### PR TITLE
Build projects, assets, and persistence spine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SceneWorks
 
-SceneWorks is a local Docker-based AI image and video generation studio. This repository currently contains the runtime skeleton for the first epic: a Vite/React web shell, FastAPI backend, placeholder Python worker, shared config/data folders, and Docker Compose wiring.
+SceneWorks is a local Docker-based AI image and video generation studio. This repository currently contains the runtime skeleton plus the project, asset, and persistence spine: a Vite/React Library shell, FastAPI backend, placeholder Python worker, shared config/data folders, SQLite project indexes, and portable JSON sidecars.
 
 ## Quick Start
 
@@ -17,7 +17,34 @@ Run the lightweight scaffold checks:
 
 ```powershell
 npm run check
+npm run check:api
 ```
+
+Build the web app:
+
+```powershell
+npm --workspace apps/web run build
+```
+
+## Projects And Assets
+
+Projects are inspectable `.sceneworks` folders under `data/projects` by default. Each project contains `project.json`, `project.db`, and portable asset folders:
+
+```text
+assets/images
+assets/videos
+assets/uploads
+assets/frames
+assets/renders
+characters
+loras
+recipes
+timelines
+trash
+cache
+```
+
+Imported images and videos are copied into the project. Each asset gets a sidecar JSON file next to the media file, while `project.db` indexes assets for fast listing, search, filtering, curation, trash, and future repair/reindex workflows.
 
 ## Local Access Control
 
@@ -49,7 +76,7 @@ apps/
   api/       FastAPI service and backend filesystem owner
   worker/    Placeholder worker package
 packages/
-  schemas/   Shared schema placeholders
+  schemas/   Shared JSON schema contracts
   shared/    Cross-app shared notes/helpers placeholder
 config/
   manifests/ Built-in and user model/LoRA manifests

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -9,5 +9,15 @@ Current routes:
 - `POST /api/v1/auth/verify`
 - `GET /api/v1/projects`
 - `POST /api/v1/projects`
+- `POST /api/v1/projects/open`
 - `GET /api/v1/projects/{project_id}`
+- `GET /api/v1/projects/{project_id}/assets`
+- `POST /api/v1/projects/{project_id}/assets/import`
+- `GET /api/v1/projects/{project_id}/assets/{asset_id}`
+- `PATCH /api/v1/projects/{project_id}/assets/{asset_id}`
+- `DELETE /api/v1/projects/{project_id}/assets/{asset_id}`
+- `GET /api/v1/projects/{project_id}/assets/{asset_id}/content`
+- `POST /api/v1/projects/{project_id}/reindex`
 - `GET /api/v1/jobs/events`
+
+The API owns project filesystem writes. Imported media is copied into the project, sidecar JSON is validated with typed models, and SQLite indexes assets for Library list/search/filter operations.

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.115.6
+httpx==0.28.1
+python-multipart==0.0.20
 uvicorn[standard]==0.34.0

--- a/apps/api/sceneworks_api/assets.py
+++ b/apps/api/sceneworks_api/assets.py
@@ -1,0 +1,106 @@
+from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+from fastapi.responses import FileResponse
+
+from .models import (
+    AssetImportResponse,
+    AssetListResponse,
+    AssetSort,
+    AssetSummary,
+    AssetType,
+    AssetUpdateRequest,
+    ReindexResponse,
+)
+from .persistence import (
+    find_project_path,
+    get_asset,
+    get_asset_sidecar_path,
+    import_asset,
+    list_assets,
+    reindex_project,
+    trash_asset,
+    update_asset,
+)
+from .projects import get_settings_from_request
+
+
+router = APIRouter(prefix="/projects/{project_id}", tags=["assets"])
+
+
+@router.get("/assets", response_model=AssetListResponse)
+def list_project_assets(
+    project_id: str,
+    request: Request,
+    asset_type: AssetType | None = Query(default=None, alias="type"),
+    include_rejected: bool = Query(default=False, alias="includeRejected"),
+    include_trashed: bool = Query(default=False, alias="includeTrashed"),
+    favorites_only: bool = Query(default=False, alias="favoritesOnly"),
+    search: str | None = None,
+    sort: AssetSort = "newest",
+) -> AssetListResponse:
+    project_path = find_project_path(get_settings_from_request(request), project_id)
+    assets, total = list_assets(project_path, asset_type, include_rejected, include_trashed, favorites_only, search, sort)
+    return AssetListResponse(assets=assets, total=total)
+
+
+@router.post("/assets/import", response_model=AssetImportResponse, status_code=201)
+async def import_project_assets(
+    project_id: str,
+    request: Request,
+    files: list[UploadFile] = File(...),
+) -> AssetImportResponse:
+    settings = get_settings_from_request(request)
+    imported: list[AssetSummary] = []
+    for upload in files:
+        imported.append(import_asset(settings, project_id, upload))
+    return AssetImportResponse(assets=imported)
+
+
+@router.get("/assets/{asset_id}", response_model=AssetSummary)
+def get_project_asset(project_id: str, asset_id: str, request: Request) -> AssetSummary:
+    project_path = find_project_path(get_settings_from_request(request), project_id)
+    return get_asset(project_path, asset_id)
+
+
+@router.patch("/assets/{asset_id}", response_model=AssetSummary)
+def update_project_asset(
+    project_id: str,
+    asset_id: str,
+    payload: AssetUpdateRequest,
+    request: Request,
+) -> AssetSummary:
+    project_path = find_project_path(get_settings_from_request(request), project_id)
+    return update_asset(project_path, asset_id, **payload.model_dump(exclude_unset=True))
+
+
+@router.delete("/assets/{asset_id}", response_model=AssetSummary | None)
+def delete_project_asset(
+    project_id: str,
+    asset_id: str,
+    request: Request,
+    hard_delete: bool = Query(default=False, alias="hardDelete"),
+) -> AssetSummary | None:
+    project_path = find_project_path(get_settings_from_request(request), project_id)
+    return trash_asset(project_path, asset_id, hard_delete)
+
+
+@router.get("/assets/{asset_id}/content")
+def get_project_asset_content(project_id: str, asset_id: str, request: Request) -> FileResponse:
+    project_path = find_project_path(get_settings_from_request(request), project_id)
+    sidecar = get_asset(project_path, asset_id)
+    media_path = (project_path / sidecar.file.path).resolve()
+    if not media_path.exists() or project_path not in media_path.parents:
+        raise HTTPException(status_code=404, detail="Asset file not found")
+    return FileResponse(media_path, media_type=sidecar.file.mimeType, filename=media_path.name)
+
+
+@router.post("/reindex", response_model=ReindexResponse)
+def reindex_project_assets(project_id: str, request: Request) -> ReindexResponse:
+    project_path = find_project_path(get_settings_from_request(request), project_id)
+    discovered, indexed, errors, migrations = reindex_project(project_path)
+    return ReindexResponse(
+        projectId=project_id,
+        discovered=discovered,
+        indexed=indexed,
+        errors=errors,
+        migrationsApplied=migrations,
+    )

--- a/apps/api/sceneworks_api/main.py
+++ b/apps/api/sceneworks_api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
+from .assets import router as assets_router
 from .projects import ensure_data_dirs, router as projects_router
 from .security import access_control_middleware
 from .settings import Settings, get_settings
@@ -67,6 +68,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return StreamingResponse(stream(), media_type="text/event-stream")
 
     app.include_router(projects_router, prefix="/api/v1")
+    app.include_router(assets_router, prefix="/api/v1")
     return app
 
 

--- a/apps/api/sceneworks_api/models.py
+++ b/apps/api/sceneworks_api/models.py
@@ -1,0 +1,244 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+SCHEMA_VERSION = 1
+
+AssetType = Literal["image", "video", "upload", "frame", "render", "character_reference"]
+AssetSort = Literal["newest", "oldest", "rating", "type", "name"]
+JobStatus = Literal[
+    "queued",
+    "preparing",
+    "downloading",
+    "loading_model",
+    "running",
+    "saving",
+    "completed",
+    "failed",
+    "canceled",
+    "interrupted",
+]
+
+
+class ProjectCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+
+
+class ProjectOpenRequest(BaseModel):
+    path: str = Field(min_length=1)
+
+
+class ProjectSummary(BaseModel):
+    id: str
+    name: str
+    path: str
+    createdAt: str
+    updatedAt: str | None = None
+    assetCount: int = 0
+
+
+class ProjectDocument(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    appVersion: str
+    id: str
+    name: str
+    createdAt: str
+    updatedAt: str
+    folders: dict[str, str]
+
+
+class AssetFileMetadata(BaseModel):
+    path: str
+    mimeType: str
+    sizeBytes: int
+    width: int | None = None
+    height: int | None = None
+    duration: float | None = None
+    fps: float | None = None
+
+
+class AssetStatus(BaseModel):
+    favorite: bool = False
+    rating: int = Field(default=0, ge=0, le=5)
+    rejected: bool = False
+    trashed: bool = False
+
+
+class Recipe(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    appVersion: str
+    id: str | None = None
+    mode: str | None = None
+    model: str | None = None
+    prompt: str | None = None
+    negativePrompt: str | None = None
+    seed: int | None = None
+    loras: list[dict[str, Any]] = Field(default_factory=list)
+    normalizedSettings: dict[str, Any] = Field(default_factory=dict)
+    rawAdapterSettings: dict[str, Any] = Field(default_factory=dict)
+
+
+class AssetLineage(BaseModel):
+    parents: list[str] = Field(default_factory=list)
+    sourceAssetId: str | None = None
+    sourceTimestamp: float | None = None
+    sourceTimelineId: str | None = None
+    jobId: str | None = None
+
+
+class AssetSidecar(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    appVersion: str
+    id: str
+    projectId: str
+    generationSetId: str | None = None
+    type: AssetType
+    displayName: str
+    createdAt: str
+    updatedAt: str
+    file: AssetFileMetadata
+    status: AssetStatus = Field(default_factory=AssetStatus)
+    notes: str = ""
+    recipe: Recipe | None = None
+    lineage: AssetLineage = Field(default_factory=AssetLineage)
+
+
+class AssetSummary(BaseModel):
+    id: str
+    projectId: str
+    generationSetId: str | None = None
+    type: AssetType
+    displayName: str
+    createdAt: str
+    updatedAt: str
+    file: AssetFileMetadata
+    status: AssetStatus
+    notes: str = ""
+    recipe: Recipe | None = None
+    lineage: AssetLineage
+    previewUrl: str
+
+
+class AssetUpdateRequest(BaseModel):
+    displayName: str | None = Field(default=None, min_length=1, max_length=180)
+    favorite: bool | None = None
+    rating: int | None = Field(default=None, ge=0, le=5)
+    rejected: bool | None = None
+    notes: str | None = Field(default=None, max_length=4000)
+
+
+class AssetListResponse(BaseModel):
+    assets: list[AssetSummary]
+    total: int
+
+
+class AssetImportResponse(BaseModel):
+    assets: list[AssetSummary]
+
+
+class GenerationSet(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    appVersion: str
+    id: str
+    projectId: str
+    createdAt: str
+    mode: str
+    recipeId: str | None = None
+    assetIds: list[str] = Field(default_factory=list)
+
+
+class Job(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    appVersion: str
+    id: str
+    projectId: str | None = None
+    type: str
+    status: JobStatus = "queued"
+    progress: float = Field(default=0, ge=0, le=1)
+    createdAt: str
+    updatedAt: str
+    error: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class ModelManifest(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    id: str
+    name: str
+    family: str
+    type: Literal["image", "video", "utility"]
+    adapter: str
+    capabilities: list[str] = Field(default_factory=list)
+    downloads: list[dict[str, Any]] = Field(default_factory=list)
+    paths: dict[str, str] = Field(default_factory=dict)
+    defaults: dict[str, Any] = Field(default_factory=dict)
+    limits: dict[str, Any] = Field(default_factory=dict)
+    loraCompatibility: dict[str, Any] = Field(default_factory=dict)
+    ui: dict[str, Any] = Field(default_factory=dict)
+
+
+class LoRAManifest(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    id: str
+    name: str
+    scope: Literal["global", "project"]
+    category: Literal["style", "enhance", "character", "motion", "clothing_object", "experimental"]
+    compatibleFamilies: list[str] = Field(default_factory=list)
+    path: str
+    triggerWords: list[str] = Field(default_factory=list)
+    defaultWeight: float = 1.0
+    builtIn: bool = False
+    ui: dict[str, Any] = Field(default_factory=dict)
+
+
+class Character(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    appVersion: str
+    id: str
+    projectId: str
+    name: str
+    type: Literal["person", "creature", "object"]
+    createdAt: str
+    updatedAt: str
+    referenceAssetIds: list[str] = Field(default_factory=list)
+    approvedReferenceAssetIds: list[str] = Field(default_factory=list)
+    lookIds: list[str] = Field(default_factory=list)
+    loraIds: list[str] = Field(default_factory=list)
+    notes: str = ""
+
+
+class TimelineItem(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    id: str
+    timelineId: str
+    assetId: str
+    track: str = "main"
+    sourceIn: float = 0
+    sourceOut: float | None = None
+    timelineStart: float
+    timelineEnd: float
+    speed: float = 1
+    activeVersionAssetId: str | None = None
+    versionAssetIds: list[str] = Field(default_factory=list)
+
+
+class Timeline(BaseModel):
+    schemaVersion: int = SCHEMA_VERSION
+    appVersion: str
+    id: str
+    projectId: str
+    name: str
+    createdAt: str
+    updatedAt: str
+    aspectRatio: Literal["16:9", "9:16", "1:1", "source"] = "16:9"
+    fps: int = 24
+    items: list[TimelineItem] = Field(default_factory=list)
+
+
+class ReindexResponse(BaseModel):
+    projectId: str
+    discovered: int
+    indexed: int
+    errors: list[str] = Field(default_factory=list)
+    migrationsApplied: list[str] = Field(default_factory=list)

--- a/apps/api/sceneworks_api/persistence.py
+++ b/apps/api/sceneworks_api/persistence.py
@@ -1,0 +1,578 @@
+from datetime import UTC, datetime
+from contextlib import contextmanager
+import json
+import mimetypes
+import re
+import shutil
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import HTTPException, UploadFile
+from pydantic import ValidationError
+
+from .models import (
+    SCHEMA_VERSION,
+    AssetFileMetadata,
+    AssetLineage,
+    AssetSidecar,
+    AssetStatus,
+    AssetSummary,
+    ProjectDocument,
+    ProjectSummary,
+    Recipe,
+)
+from .settings import Settings
+
+
+PROJECT_FOLDERS = [
+    "assets/images",
+    "assets/videos",
+    "assets/uploads",
+    "assets/frames",
+    "assets/renders",
+    "characters",
+    "loras",
+    "recipes",
+    "timelines",
+    "trash",
+    "cache",
+]
+
+ASSET_DIR_BY_TYPE = {
+    "image": "assets/images",
+    "video": "assets/videos",
+    "upload": "assets/uploads",
+    "frame": "assets/frames",
+    "render": "assets/renders",
+    "character_reference": "characters",
+}
+
+IMAGE_EXTENSIONS = {".apng", ".avif", ".bmp", ".gif", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+VIDEO_EXTENSIONS = {".avi", ".m4v", ".mkv", ".mov", ".mp4", ".mpeg", ".mpg", ".webm", ".wmv"}
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
+    return slug or "asset"
+
+
+def read_json(path: Path) -> dict:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail=f"{path.name} contains invalid JSON: {exc.msg}") from exc
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def relative_to_project(project_path: Path, path: Path) -> str:
+    return path.relative_to(project_path).as_posix()
+
+
+def ensure_data_dirs(settings: Settings) -> None:
+    settings.projects_dir.mkdir(parents=True, exist_ok=True)
+    for folder in ("models", "loras", "cache"):
+        (settings.data_dir / folder).mkdir(parents=True, exist_ok=True)
+
+
+def ensure_project_structure(project_path: Path) -> None:
+    project_path.mkdir(parents=True, exist_ok=True)
+    for folder in PROJECT_FOLDERS:
+        (project_path / folder).mkdir(parents=True, exist_ok=True)
+
+
+def load_registry(settings: Settings) -> list[dict]:
+    if not settings.registry_path.exists():
+        return []
+    payload = read_json(settings.registry_path)
+    if isinstance(payload, list):
+        return payload
+    raise HTTPException(status_code=422, detail="Recent projects registry must be a list")
+
+
+def save_registry(settings: Settings, projects: list[dict]) -> None:
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    write_json(settings.registry_path, projects[:20])
+
+
+def touch_registry(settings: Settings, project: ProjectSummary) -> None:
+    registry = [item for item in load_registry(settings) if item.get("id") != project.id]
+    registry.insert(
+        0,
+        {
+            "id": project.id,
+            "name": project.name,
+            "path": project.path,
+            "lastOpenedAt": utc_now(),
+        },
+    )
+    save_registry(settings, registry)
+
+
+def db_path(project_path: Path) -> Path:
+    return project_path / "project.db"
+
+
+@contextmanager
+def connect_project_db(project_path: Path):
+    connection = sqlite3.connect(db_path(project_path))
+    connection.row_factory = sqlite3.Row
+    try:
+        yield connection
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def migrate_project_db(project_path: Path) -> list[str]:
+    applied: list[str] = []
+    with connect_project_db(project_path) as connection:
+        connection.execute(
+            """
+            create table if not exists project_metadata (
+              key text primary key,
+              value text not null
+            )
+            """
+        )
+        connection.execute(
+            """
+            create table if not exists assets (
+              id text primary key,
+              project_id text not null,
+              generation_set_id text,
+              type text not null,
+              display_name text not null,
+              relative_path text not null unique,
+              sidecar_path text not null unique,
+              mime_type text not null,
+              size_bytes integer not null,
+              created_at text not null,
+              updated_at text not null,
+              favorite integer not null default 0,
+              rating integer not null default 0,
+              rejected integer not null default 0,
+              trashed integer not null default 0,
+              notes text not null default '',
+              prompt text,
+              model text,
+              lineage_json text not null default '{}'
+            )
+            """
+        )
+        connection.execute(
+            """
+            create table if not exists generation_sets (
+              id text primary key,
+              project_id text not null,
+              created_at text not null,
+              mode text not null,
+              recipe_id text
+            )
+            """
+        )
+        connection.execute(
+            """
+            create table if not exists jobs (
+              id text primary key,
+              project_id text,
+              type text not null,
+              status text not null,
+              progress real not null default 0,
+              payload_json text not null default '{}',
+              error text,
+              created_at text not null,
+              updated_at text not null
+            )
+            """
+        )
+        connection.execute(
+            """
+            create table if not exists characters (
+              id text primary key,
+              project_id text not null,
+              name text not null,
+              type text not null,
+              document_json text not null,
+              created_at text not null,
+              updated_at text not null
+            )
+            """
+        )
+        connection.execute(
+            """
+            create table if not exists timelines (
+              id text primary key,
+              project_id text not null,
+              name text not null,
+              document_json text not null,
+              created_at text not null,
+              updated_at text not null
+            )
+            """
+        )
+        connection.execute("create index if not exists idx_assets_type on assets(type)")
+        connection.execute("create index if not exists idx_assets_status on assets(rejected, trashed, favorite)")
+        connection.execute("create index if not exists idx_assets_created_at on assets(created_at)")
+        connection.execute(
+            "insert or replace into project_metadata (key, value) values (?, ?)",
+            ("schemaVersion", str(SCHEMA_VERSION)),
+        )
+        connection.execute("pragma user_version = 1")
+        applied.append("sqlite_schema_v1")
+    return applied
+
+
+def create_project_document(settings: Settings, project_path: Path, project_id: str, name: str) -> ProjectDocument:
+    now = utc_now()
+    document = ProjectDocument(
+        appVersion=settings.app_version,
+        id=project_id,
+        name=name,
+        createdAt=now,
+        updatedAt=now,
+        folders={folder.replace("/", "_").replace("-", "_"): folder for folder in PROJECT_FOLDERS},
+    )
+    write_json(project_path / "project.json", document.model_dump(mode="json"))
+    return document
+
+
+def load_project_document(project_path: Path) -> ProjectDocument:
+    project_file = project_path / "project.json"
+    if not project_file.exists():
+        raise HTTPException(status_code=404, detail="Project file not found")
+    try:
+        return ProjectDocument.model_validate(read_json(project_file))
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=f"Invalid project.json: {exc}") from exc
+
+
+def project_asset_count(project_path: Path) -> int:
+    if not db_path(project_path).exists():
+        return 0
+    with connect_project_db(project_path) as connection:
+        row = connection.execute("select count(*) as count from assets where trashed = 0").fetchone()
+    return int(row["count"])
+
+
+def read_project_summary(project_path: Path) -> ProjectSummary:
+    document = load_project_document(project_path)
+    return ProjectSummary(
+        id=document.id,
+        name=document.name,
+        path=str(project_path),
+        createdAt=document.createdAt,
+        updatedAt=document.updatedAt,
+        assetCount=project_asset_count(project_path),
+    )
+
+
+def create_project(settings: Settings, name: str) -> ProjectSummary:
+    ensure_data_dirs(settings)
+    project_id = f"project_{uuid4().hex}"
+    project_path = settings.projects_dir / f"{slugify(name)}.sceneworks"
+    if project_path.exists():
+        project_path = settings.projects_dir / f"{slugify(name)}-{project_id[-8:]}.sceneworks"
+    ensure_project_structure(project_path)
+    create_project_document(settings, project_path, project_id, name)
+    migrate_project_db(project_path)
+    summary = read_project_summary(project_path)
+    touch_registry(settings, summary)
+    return summary
+
+
+def open_project(settings: Settings, project_path: Path) -> ProjectSummary:
+    resolved = project_path.expanduser().resolve()
+    if not resolved.exists():
+        raise HTTPException(status_code=404, detail="Project folder not found")
+    ensure_project_structure(resolved)
+    summary = read_project_summary(resolved)
+    migrate_project_db(resolved)
+    touch_registry(settings, summary)
+    return read_project_summary(resolved)
+
+
+def find_project_path(settings: Settings, project_id: str) -> Path:
+    for item in load_registry(settings):
+        if item.get("id") == project_id:
+            path = Path(item["path"])
+            if path.exists():
+                return path
+    raise HTTPException(status_code=404, detail="Project not found")
+
+
+def classify_upload(filename: str, content_type: str | None) -> tuple[str, str]:
+    suffix = Path(filename).suffix.lower()
+    mime_type = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    if mime_type.startswith("image/") or suffix in IMAGE_EXTENSIONS:
+        return "image", mime_type
+    if mime_type.startswith("video/") or suffix in VIDEO_EXTENSIONS:
+        return "video", mime_type
+    return "upload", mime_type
+
+
+def asset_summary_from_sidecar(project_id: str, sidecar: AssetSidecar) -> AssetSummary:
+    return AssetSummary(
+        id=sidecar.id,
+        projectId=project_id,
+        generationSetId=sidecar.generationSetId,
+        type=sidecar.type,
+        displayName=sidecar.displayName,
+        createdAt=sidecar.createdAt,
+        updatedAt=sidecar.updatedAt,
+        file=sidecar.file,
+        status=sidecar.status,
+        notes=sidecar.notes,
+        recipe=sidecar.recipe,
+        lineage=sidecar.lineage,
+        previewUrl=f"/api/v1/projects/{project_id}/assets/{sidecar.id}/content",
+    )
+
+
+def load_sidecar(path: Path) -> AssetSidecar:
+    try:
+        return AssetSidecar.model_validate(read_json(path))
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=f"Invalid asset sidecar {path.name}: {exc}") from exc
+
+
+def sidecar_path_for_media(media_path: Path) -> Path:
+    return media_path.with_suffix(".sceneworks.json")
+
+
+def upsert_asset_index(project_path: Path, sidecar: AssetSidecar) -> None:
+    with connect_project_db(project_path) as connection:
+        connection.execute(
+            """
+            insert into assets (
+              id, project_id, generation_set_id, type, display_name, relative_path, sidecar_path,
+              mime_type, size_bytes, created_at, updated_at, favorite, rating, rejected, trashed,
+              notes, prompt, model, lineage_json
+            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            on conflict(id) do update set
+              generation_set_id = excluded.generation_set_id,
+              type = excluded.type,
+              display_name = excluded.display_name,
+              relative_path = excluded.relative_path,
+              sidecar_path = excluded.sidecar_path,
+              mime_type = excluded.mime_type,
+              size_bytes = excluded.size_bytes,
+              updated_at = excluded.updated_at,
+              favorite = excluded.favorite,
+              rating = excluded.rating,
+              rejected = excluded.rejected,
+              trashed = excluded.trashed,
+              notes = excluded.notes,
+              prompt = excluded.prompt,
+              model = excluded.model,
+              lineage_json = excluded.lineage_json
+            """,
+            (
+                sidecar.id,
+                sidecar.projectId,
+                sidecar.generationSetId,
+                sidecar.type,
+                sidecar.displayName,
+                sidecar.file.path,
+                f"{sidecar.file.path.rsplit('.', 1)[0]}.sceneworks.json",
+                sidecar.file.mimeType,
+                sidecar.file.sizeBytes,
+                sidecar.createdAt,
+                sidecar.updatedAt,
+                int(sidecar.status.favorite),
+                sidecar.status.rating,
+                int(sidecar.status.rejected),
+                int(sidecar.status.trashed),
+                sidecar.notes,
+                sidecar.recipe.prompt if sidecar.recipe else None,
+                sidecar.recipe.model if sidecar.recipe else None,
+                json.dumps(sidecar.lineage.model_dump(mode="json")),
+            ),
+        )
+
+
+def import_asset(settings: Settings, project_id: str, upload: UploadFile) -> AssetSummary:
+    project_path = find_project_path(settings, project_id)
+    project = load_project_document(project_path)
+    migrate_project_db(project_path)
+
+    asset_type, mime_type = classify_upload(upload.filename or "upload.bin", upload.content_type)
+    destination_dir = project_path / ASSET_DIR_BY_TYPE[asset_type]
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    original_name = Path(upload.filename or "upload").stem
+    extension = Path(upload.filename or "").suffix.lower() or mimetypes.guess_extension(mime_type) or ".bin"
+    asset_id = f"asset_{uuid4().hex}"
+    date_prefix = datetime.now(UTC).strftime("%Y-%m-%d")
+    filename = f"{date_prefix}_{slugify(original_name)}_{asset_id[-8:]}{extension}"
+    media_path = destination_dir / filename
+    with media_path.open("wb") as handle:
+        shutil.copyfileobj(upload.file, handle)
+
+    relative_path = relative_to_project(project_path, media_path)
+    now = utc_now()
+    sidecar = AssetSidecar(
+        appVersion=settings.app_version,
+        id=asset_id,
+        projectId=project.id,
+        type=asset_type,
+        displayName=Path(upload.filename or filename).stem,
+        createdAt=now,
+        updatedAt=now,
+        file=AssetFileMetadata(
+            path=relative_path,
+            mimeType=mime_type,
+            sizeBytes=media_path.stat().st_size,
+        ),
+        status=AssetStatus(),
+        notes="",
+        recipe=Recipe(appVersion=settings.app_version, id=None),
+        lineage=AssetLineage(),
+    )
+    write_json(sidecar_path_for_media(media_path), sidecar.model_dump(mode="json"))
+    upsert_asset_index(project_path, sidecar)
+    update_project_timestamp(project_path)
+    return asset_summary_from_sidecar(project.id, sidecar)
+
+
+def update_project_timestamp(project_path: Path) -> None:
+    document = load_project_document(project_path)
+    document.updatedAt = utc_now()
+    write_json(project_path / "project.json", document.model_dump(mode="json"))
+
+
+def get_asset_sidecar_path(project_path: Path, asset_id: str) -> Path:
+    with connect_project_db(project_path) as connection:
+        row = connection.execute("select sidecar_path from assets where id = ?", (asset_id,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return project_path / row["sidecar_path"]
+
+
+def get_asset(project_path: Path, asset_id: str) -> AssetSummary:
+    sidecar = load_sidecar(get_asset_sidecar_path(project_path, asset_id))
+    return asset_summary_from_sidecar(sidecar.projectId, sidecar)
+
+
+def list_assets(
+    project_path: Path,
+    asset_type: str | None,
+    include_rejected: bool,
+    include_trashed: bool,
+    favorites_only: bool,
+    search: str | None,
+    sort: str,
+) -> tuple[list[AssetSummary], int]:
+    query = "select sidecar_path from assets where 1 = 1"
+    params: list[object] = []
+    if asset_type:
+        query += " and type = ?"
+        params.append(asset_type)
+    if not include_rejected:
+        query += " and rejected = 0"
+    if not include_trashed:
+        query += " and trashed = 0"
+    if favorites_only:
+        query += " and favorite = 1"
+    if search:
+        query += " and (display_name like ? or notes like ? or prompt like ? or model like ?)"
+        needle = f"%{search}%"
+        params.extend([needle, needle, needle, needle])
+
+    order_by = {
+        "oldest": "created_at asc",
+        "rating": "rating desc, created_at desc",
+        "type": "type asc, created_at desc",
+        "name": "display_name collate nocase asc",
+    }.get(sort, "created_at desc")
+    query += f" order by {order_by}"
+
+    with connect_project_db(project_path) as connection:
+        rows = connection.execute(query, params).fetchall()
+
+    assets: list[AssetSummary] = []
+    for row in rows:
+        sidecar = load_sidecar(project_path / row["sidecar_path"])
+        assets.append(asset_summary_from_sidecar(sidecar.projectId, sidecar))
+    return assets, len(assets)
+
+
+def update_asset(project_path: Path, asset_id: str, **updates: object) -> AssetSummary:
+    sidecar_path = get_asset_sidecar_path(project_path, asset_id)
+    sidecar = load_sidecar(sidecar_path)
+    if updates.get("displayName") is not None:
+        sidecar.displayName = str(updates["displayName"])
+    if updates.get("favorite") is not None:
+        sidecar.status.favorite = bool(updates["favorite"])
+    if updates.get("rating") is not None:
+        sidecar.status.rating = int(updates["rating"])
+    if updates.get("rejected") is not None:
+        sidecar.status.rejected = bool(updates["rejected"])
+    if updates.get("notes") is not None:
+        sidecar.notes = str(updates["notes"])
+    sidecar.updatedAt = utc_now()
+    write_json(sidecar_path, sidecar.model_dump(mode="json"))
+    upsert_asset_index(project_path, sidecar)
+    update_project_timestamp(project_path)
+    return asset_summary_from_sidecar(sidecar.projectId, sidecar)
+
+
+def trash_asset(project_path: Path, asset_id: str, hard_delete: bool = False) -> AssetSummary | None:
+    sidecar_path = get_asset_sidecar_path(project_path, asset_id)
+    sidecar = load_sidecar(sidecar_path)
+    media_path = project_path / sidecar.file.path
+    if hard_delete and not sidecar.lineage.parents and not sidecar.generationSetId:
+        media_path.unlink(missing_ok=True)
+        sidecar_path.unlink(missing_ok=True)
+        with connect_project_db(project_path) as connection:
+            connection.execute("delete from assets where id = ?", (asset_id,))
+        update_project_timestamp(project_path)
+        return None
+
+    trash_dir = project_path / "trash" / sidecar.type
+    trash_dir.mkdir(parents=True, exist_ok=True)
+    trashed_media = trash_dir / media_path.name
+    trashed_sidecar = sidecar_path_for_media(trashed_media)
+    if media_path.exists():
+        shutil.move(str(media_path), str(trashed_media))
+    if sidecar_path.exists():
+        shutil.move(str(sidecar_path), str(trashed_sidecar))
+    sidecar.file.path = relative_to_project(project_path, trashed_media)
+    sidecar.status.trashed = True
+    sidecar.updatedAt = utc_now()
+    write_json(trashed_sidecar, sidecar.model_dump(mode="json"))
+    upsert_asset_index(project_path, sidecar)
+    update_project_timestamp(project_path)
+    return asset_summary_from_sidecar(sidecar.projectId, sidecar)
+
+
+def reindex_project(project_path: Path) -> tuple[int, int, list[str], list[str]]:
+    migrations = migrate_project_db(project_path)
+    discovered = 0
+    indexed = 0
+    errors: list[str] = []
+    for sidecar_path in project_path.glob("**/*.sceneworks.json"):
+        if sidecar_path.name == "project.sceneworks.json":
+            continue
+        discovered += 1
+        try:
+            sidecar = load_sidecar(sidecar_path)
+            media_path = project_path / sidecar.file.path
+            if media_path.exists():
+                sidecar.file.sizeBytes = media_path.stat().st_size
+            upsert_asset_index(project_path, sidecar)
+            indexed += 1
+        except HTTPException as exc:
+            errors.append(f"{relative_to_project(project_path, sidecar_path)}: {exc.detail}")
+    return discovered, indexed, errors, migrations

--- a/apps/api/sceneworks_api/projects.py
+++ b/apps/api/sceneworks_api/projects.py
@@ -1,132 +1,31 @@
-from datetime import UTC, datetime
-import json
-import re
-import sqlite3
 from pathlib import Path
-from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Request
 
+from .models import ProjectCreateRequest, ProjectOpenRequest, ProjectSummary
+from .persistence import (
+    create_project as create_project_on_disk,
+    ensure_data_dirs,
+    find_project_path,
+    load_registry,
+    open_project as open_project_on_disk,
+    read_project_summary,
+)
 from .settings import Settings
 
 
 router = APIRouter(prefix="/projects", tags=["projects"])
-
-PROJECT_FOLDERS = [
-    "assets/images",
-    "assets/videos",
-    "assets/uploads",
-    "assets/frames",
-    "assets/renders",
-    "characters",
-    "loras",
-    "recipes",
-    "timelines",
-    "trash",
-    "cache",
-]
-
-
-class ProjectCreateRequest(BaseModel):
-    name: str = Field(min_length=1, max_length=120)
-
-
-class ProjectSummary(BaseModel):
-    id: str
-    name: str
-    path: str
-    createdAt: str
-
-
-def slugify(value: str) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
-    return slug or "project"
-
-
-def utc_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def get_settings_from_request(request: Request) -> Settings:
     return request.app.state.settings
 
 
-def ensure_data_dirs(settings: Settings) -> None:
-    settings.projects_dir.mkdir(parents=True, exist_ok=True)
-    for folder in ("models", "loras", "cache"):
-        (settings.data_dir / folder).mkdir(parents=True, exist_ok=True)
-
-
-def load_registry(settings: Settings) -> list[dict]:
-    if not settings.registry_path.exists():
-        return []
-
-    with settings.registry_path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def save_registry(settings: Settings, projects: list[dict]) -> None:
-    settings.data_dir.mkdir(parents=True, exist_ok=True)
-    with settings.registry_path.open("w", encoding="utf-8") as handle:
-        json.dump(projects, handle, indent=2)
-        handle.write("\n")
-
-
-def create_project_db(project_path: Path) -> None:
-    db_path = project_path / "project.db"
-    with sqlite3.connect(db_path) as connection:
-        connection.execute(
-            """
-            create table if not exists project_metadata (
-              key text primary key,
-              value text not null
-            )
-            """
-        )
-        connection.execute(
-            "insert or replace into project_metadata (key, value) values (?, ?)",
-            ("schemaVersion", "1"),
-        )
-
-
-def write_project_file(settings: Settings, project_path: Path, project_id: str, name: str) -> dict:
-    created_at = utc_now()
-    project_file = {
-        "schemaVersion": 1,
-        "appVersion": settings.app_version,
-        "id": project_id,
-        "name": name,
-        "createdAt": created_at,
-        "folders": {folder.replace("/", "_"): folder for folder in PROJECT_FOLDERS},
-    }
-    with (project_path / "project.json").open("w", encoding="utf-8") as handle:
-        json.dump(project_file, handle, indent=2)
-        handle.write("\n")
-    return project_file
-
-
-def read_project_summary(project_path: Path) -> ProjectSummary:
-    project_file = project_path / "project.json"
-    if not project_file.exists():
-        raise HTTPException(status_code=404, detail="Project file not found")
-
-    with project_file.open("r", encoding="utf-8") as handle:
-        payload = json.load(handle)
-
-    return ProjectSummary(
-        id=payload["id"],
-        name=payload["name"],
-        path=str(project_path),
-        createdAt=payload["createdAt"],
-    )
-
-
 @router.get("", response_model=list[ProjectSummary])
 def list_projects(request: Request) -> list[ProjectSummary]:
     settings = get_settings_from_request(request)
     ensure_data_dirs(settings)
-    projects = []
+    projects: list[ProjectSummary] = []
     for item in load_registry(settings):
         path = Path(item["path"])
         if path.exists():
@@ -136,34 +35,14 @@ def list_projects(request: Request) -> list[ProjectSummary]:
 
 @router.post("", response_model=ProjectSummary, status_code=201)
 def create_project(payload: ProjectCreateRequest, request: Request) -> ProjectSummary:
-    settings = get_settings_from_request(request)
-    ensure_data_dirs(settings)
+    return create_project_on_disk(get_settings_from_request(request), payload.name)
 
-    project_id = f"project_{uuid4().hex}"
-    folder_name = f"{slugify(payload.name)}.sceneworks"
-    project_path = settings.projects_dir / folder_name
-    if project_path.exists():
-        project_path = settings.projects_dir / f"{slugify(payload.name)}-{project_id[-8:]}.sceneworks"
 
-    project_path.mkdir(parents=True)
-    for folder in PROJECT_FOLDERS:
-        (project_path / folder).mkdir(parents=True, exist_ok=True)
-
-    write_project_file(settings, project_path, project_id, payload.name)
-    create_project_db(project_path)
-
-    registry = [item for item in load_registry(settings) if item.get("id") != project_id]
-    registry.insert(0, {"id": project_id, "name": payload.name, "path": str(project_path)})
-    save_registry(settings, registry)
-
-    return read_project_summary(project_path)
+@router.post("/open", response_model=ProjectSummary)
+def open_project(payload: ProjectOpenRequest, request: Request) -> ProjectSummary:
+    return open_project_on_disk(get_settings_from_request(request), Path(payload.path))
 
 
 @router.get("/{project_id}", response_model=ProjectSummary)
 def get_project(project_id: str, request: Request) -> ProjectSummary:
-    settings = get_settings_from_request(request)
-    for item in load_registry(settings):
-        if item.get("id") == project_id:
-            return read_project_summary(Path(item["path"]))
-
-    raise HTTPException(status_code=404, detail="Project not found")
+    return read_project_summary(find_project_path(get_settings_from_request(request), project_id))

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -4,70 +4,108 @@ import "./styles.css";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
 
-const navItems = [
-  "Library",
-  "Image",
-  "Video",
-  "Characters",
-  "Editor",
-  "Queue",
+const navItems = ["Library", "Image", "Video", "Characters", "Editor", "Queue"];
+const assetTypes = [
+  ["", "All"],
+  ["image", "Images"],
+  ["video", "Videos"],
+  ["upload", "Uploads"],
+  ["frame", "Frames"],
+  ["render", "Renders"],
+  ["character_reference", "Characters"],
+];
+const sortOptions = [
+  ["newest", "Newest"],
+  ["rating", "Rating"],
+  ["type", "Type"],
+  ["name", "Name"],
 ];
 
 const placeholders = {
-  Library: {
-    title: "Library",
-    eyebrow: "Project assets",
-    body: "Imported and generated media will appear here with recipe metadata, ratings, lineage, and reuse actions.",
-  },
-  Image: {
-    title: "Image Studio",
-    eyebrow: "Text, edit, character, variations",
-    body: "Prompt-first image workflows land here, with model details tucked into an advanced drawer.",
-  },
-  Video: {
-    title: "Video Studio",
-    eyebrow: "Short generated shots",
-    body: "Image-to-video, text-to-video, first/last frame, extend, and replacement modes will share this surface.",
-  },
-  Characters: {
-    title: "Character Studio",
-    eyebrow: "Reusable identities",
-    body: "Characters will gather references, looks, and project LoRAs before full training arrives.",
-  },
-  Editor: {
-    title: "Editor",
-    eyebrow: "Timeline assembly",
-    body: "Generated and imported clips will be arranged, trimmed, bridged, and exported from here.",
-  },
-  Queue: {
-    title: "Queue",
-    eyebrow: "Jobs and GPUs",
-    body: "Generation, downloads, exports, tracking, and replacement jobs will show progress here.",
-  },
+  Image: "Prompt workflows will reuse selected Library assets here.",
+  Video: "Generated shots will land in the Library and asset tray.",
+  Characters: "Character references will be project assets with approved picks.",
+  Editor: "Timeline items will reference assets by id, not by file path.",
+  Queue: "Generation, imports, exports, and repair work will share job state.",
 };
 
-async function apiFetch(path, token, options = {}) {
+async function readError(response) {
+  const detail = await response.json().catch(() => ({}));
+  if (Array.isArray(detail.detail)) {
+    return detail.detail.map((item) => item.msg).join("; ");
+  }
+  return detail.detail ?? `Request failed with ${response.status}`;
+}
+
+async function apiJson(path, token, options = {}) {
   const headers = new Headers(options.headers ?? {});
   headers.set("Content-Type", "application/json");
   if (token) {
     headers.set("X-SceneWorks-Token", token);
   }
-
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
-    headers,
-  });
-
+  const response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
   if (!response.ok) {
-    const detail = await response.json().catch(() => ({}));
-    throw new Error(detail.detail ?? `Request failed with ${response.status}`);
+    throw new Error(await readError(response));
   }
+  return response.status === 204 ? null : response.json();
+}
 
+async function apiForm(path, token, formData) {
+  const headers = new Headers();
+  if (token) {
+    headers.set("X-SceneWorks-Token", token);
+  }
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: formData,
+  });
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
   return response.json();
 }
 
 function StatusDot({ ok }) {
   return <span className={ok ? "status-dot ok" : "status-dot"} aria-hidden="true" />;
+}
+
+function assetUrl(asset) {
+  return `${API_BASE_URL}${asset.previewUrl}`;
+}
+
+function AssetPreview({ asset, size = "normal" }) {
+  if (!asset) {
+    return <div className={`asset-preview ${size}`} />;
+  }
+  if (asset.type === "image" || asset.type === "frame" || asset.type === "render" || asset.type === "character_reference") {
+    return <img className={`asset-preview ${size}`} src={assetUrl(asset)} alt={asset.displayName} />;
+  }
+  if (asset.type === "video") {
+    return <video className={`asset-preview ${size}`} src={assetUrl(asset)} muted controls={size === "large"} />;
+  }
+  return (
+    <div className={`asset-preview ${size} file-preview`}>
+      <span>{asset.file.mimeType}</span>
+    </div>
+  );
+}
+
+function RatingControl({ value, onChange }) {
+  return (
+    <div className="segmented compact" aria-label="Rating">
+      {[0, 1, 2, 3, 4, 5].map((rating) => (
+        <button
+          className={value === rating ? "active" : ""}
+          key={rating}
+          onClick={() => onChange(rating)}
+          type="button"
+        >
+          {rating}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 function App() {
@@ -76,18 +114,31 @@ function App() {
   const [token, setToken] = useState(() => window.localStorage.getItem("sceneworks-token") ?? "");
   const [projects, setProjects] = useState([]);
   const [activeProject, setActiveProject] = useState(null);
+  const [assets, setAssets] = useState([]);
+  const [selectedAssetId, setSelectedAssetId] = useState(null);
   const [activeView, setActiveView] = useState("Library");
   const [projectName, setProjectName] = useState("");
+  const [openPath, setOpenPath] = useState("");
+  const [assetType, setAssetType] = useState("");
+  const [sort, setSort] = useState("newest");
+  const [search, setSearch] = useState("");
+  const [showRejected, setShowRejected] = useState(false);
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [trayOpen, setTrayOpen] = useState(true);
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
+  const selectedAsset = useMemo(
+    () => assets.find((asset) => asset.id === selectedAssetId) ?? assets[0] ?? null,
+    [assets, selectedAssetId],
+  );
 
   useEffect(() => {
-    apiFetch("/api/v1/health", "")
+    apiJson("/api/v1/health", "")
       .then(setHealth)
       .catch((err) => setError(err.message));
-
-    apiFetch("/api/v1/access", "")
+    apiJson("/api/v1/access", "")
       .then(setAccess)
       .catch((err) => setError(err.message));
   }, []);
@@ -96,19 +147,58 @@ function App() {
     if (!authenticated) {
       return;
     }
-
-    apiFetch("/api/v1/projects", token)
-      .then((items) => {
-        setProjects(items);
-        setActiveProject((current) => current ?? items[0] ?? null);
-      })
-      .catch((err) => setError(err.message));
+    loadProjects();
   }, [authenticated, token]);
+
+  useEffect(() => {
+    if (!activeProject || !authenticated) {
+      setAssets([]);
+      return;
+    }
+    loadAssets(activeProject.id);
+  }, [activeProject?.id, assetType, sort, showRejected, favoritesOnly, authenticated]);
+
+  async function loadProjects() {
+    try {
+      const items = await apiJson("/api/v1/projects", token);
+      setProjects(items);
+      setActiveProject((current) => current ?? items[0] ?? null);
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function loadAssets(projectId = activeProject?.id) {
+    if (!projectId) {
+      return;
+    }
+    const params = new URLSearchParams({
+      sort,
+      includeRejected: String(showRejected),
+      favoritesOnly: String(favoritesOnly),
+    });
+    if (assetType) {
+      params.set("type", assetType);
+    }
+    if (search.trim()) {
+      params.set("search", search.trim());
+    }
+    try {
+      const payload = await apiJson(`/api/v1/projects/${projectId}/assets?${params}`, token);
+      setAssets(payload.assets);
+      setSelectedAssetId((current) => (payload.assets.some((asset) => asset.id === current) ? current : payload.assets[0]?.id ?? null));
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
 
   function saveToken(event) {
     event.preventDefault();
     window.localStorage.setItem("sceneworks-token", token);
     setError("");
+    loadProjects();
   }
 
   async function createProject(event) {
@@ -116,9 +206,9 @@ function App() {
     if (!projectName.trim()) {
       return;
     }
-
+    setBusy(true);
     try {
-      const created = await apiFetch("/api/v1/projects", token, {
+      const created = await apiJson("/api/v1/projects", token, {
         method: "POST",
         body: JSON.stringify({ name: projectName }),
       });
@@ -129,10 +219,101 @@ function App() {
       setError("");
     } catch (err) {
       setError(err.message);
+    } finally {
+      setBusy(false);
     }
   }
 
-  const view = placeholders[activeView];
+  async function openProject(event) {
+    event.preventDefault();
+    if (!openPath.trim()) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const opened = await apiJson("/api/v1/projects/open", token, {
+        method: "POST",
+        body: JSON.stringify({ path: openPath }),
+      });
+      setProjects((items) => [opened, ...items.filter((item) => item.id !== opened.id)]);
+      setActiveProject(opened);
+      setOpenPath("");
+      setActiveView("Library");
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function importAssets(event) {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = "";
+    if (!activeProject || files.length === 0) {
+      return;
+    }
+    const formData = new FormData();
+    files.forEach((file) => formData.append("files", file));
+    setBusy(true);
+    try {
+      const payload = await apiForm(`/api/v1/projects/${activeProject.id}/assets/import`, token, formData);
+      await loadAssets(activeProject.id);
+      setSelectedAssetId(payload.assets[0]?.id ?? null);
+      await loadProjects();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function patchAsset(asset, patch) {
+    try {
+      const updated = await apiJson(`/api/v1/projects/${activeProject.id}/assets/${asset.id}`, token, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      });
+      setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function trashSelected() {
+    if (!selectedAsset || !activeProject) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await apiJson(`/api/v1/projects/${activeProject.id}/assets/${selectedAsset.id}`, token, { method: "DELETE" });
+      await loadAssets(activeProject.id);
+      await loadProjects();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function reindexProject() {
+    if (!activeProject) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await apiJson(`/api/v1/projects/${activeProject.id}/reindex`, token, { method: "POST" });
+      await loadAssets(activeProject.id);
+      setError(result.errors.length ? result.errors.join("; ") : `Reindexed ${result.indexed} assets`);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const workspaceClass = trayOpen ? "workspace with-tray" : "workspace";
 
   return (
     <main className="app">
@@ -159,23 +340,26 @@ function App() {
         </nav>
       </aside>
 
-      <section className="workspace">
+      <section className={workspaceClass}>
         <header className="topbar">
-          <div>
+          <div className="topbar-project">
             <p className="eyebrow">Project</p>
             <strong>{activeProject?.name ?? "No project open"}</strong>
+            {activeProject ? <span>{activeProject.path}</span> : null}
           </div>
           <div className="topbar-status">
             <span>
               <StatusDot ok={health?.status === "ok"} />
               API
             </span>
-            <span>GPU auto</span>
-            <span>Queue idle</span>
+            <span>{busy ? "Working" : "Idle"}</span>
+            <button className="icon-button" onClick={() => setTrayOpen((value) => !value)} type="button">
+              {trayOpen ? "Hide tray" : "Show tray"}
+            </button>
           </div>
         </header>
 
-        {error ? <p className="notice error">{error}</p> : null}
+        {error ? <p className={error.startsWith("Reindexed") ? "notice ok" : "notice error"}>{error}</p> : null}
 
         {access.authRequired && !window.localStorage.getItem("sceneworks-token") ? (
           <section className="auth-band">
@@ -199,62 +383,256 @@ function App() {
           <div className="project-list">
             <div className="section-heading">
               <p className="eyebrow">Recent projects</p>
-              <h2>Open a workspace</h2>
+              <h2>Projects</h2>
             </div>
             <div className="project-buttons">
               {projects.length === 0 ? (
-                <span className="empty-state">Create the first project to start the Library spine.</span>
+                <span className="empty-state">No recent projects</span>
               ) : (
                 projects.map((project) => (
                   <button
                     className={activeProject?.id === project.id ? "project-pill active" : "project-pill"}
                     key={project.id}
-                    onClick={() => setActiveProject(project)}
+                    onClick={() => {
+                      setActiveProject(project);
+                      setActiveView("Library");
+                    }}
                     type="button"
                   >
-                    {project.name}
+                    <span>{project.name}</span>
+                    <small>{project.assetCount} assets</small>
                   </button>
                 ))
               )}
             </div>
           </div>
 
-          <form className="create-project" onSubmit={createProject}>
-            <label htmlFor="project-name">New project</label>
-            <div className="form-row">
-              <input
-                id="project-name"
-                onChange={(event) => setProjectName(event.target.value)}
-                placeholder="Noir Alley"
-                value={projectName}
-              />
-              <button disabled={!authenticated} type="submit">
-                Create
-              </button>
-            </div>
-          </form>
-        </section>
-
-        <section className="main-surface">
-          <div className="section-heading">
-            <p className="eyebrow">{view.eyebrow}</p>
-            <h2>{view.title}</h2>
-          </div>
-          <p className="view-copy">{view.body}</p>
-
-          <div className="media-grid" aria-label={`${view.title} preview placeholders`}>
-            <div className="media-tile wide">
-              <span>{activeProject ? activeProject.name : "Create a project"}</span>
-            </div>
-            <div className="media-tile accent">
-              <span>Recipes</span>
-            </div>
-            <div className="media-tile warm">
-              <span>Assets</span>
-            </div>
+          <div className="project-forms">
+            <form className="compact-form" onSubmit={createProject}>
+              <label htmlFor="project-name">New project</label>
+              <div className="form-row">
+                <input
+                  id="project-name"
+                  onChange={(event) => setProjectName(event.target.value)}
+                  placeholder="Noir Alley"
+                  value={projectName}
+                />
+                <button disabled={!authenticated || busy} type="submit">
+                  Create
+                </button>
+              </div>
+            </form>
+            <form className="compact-form" onSubmit={openProject}>
+              <label htmlFor="project-path">Open folder</label>
+              <div className="form-row">
+                <input
+                  id="project-path"
+                  onChange={(event) => setOpenPath(event.target.value)}
+                  placeholder="D:\\Projects\\Noir Alley.sceneworks"
+                  value={openPath}
+                />
+                <button disabled={!authenticated || busy} type="submit">
+                  Open
+                </button>
+              </div>
+            </form>
           </div>
         </section>
+
+        {activeView === "Library" ? (
+          <section className="library-shell">
+            <div className="library-main">
+              <div className="library-toolbar">
+                <div className="section-heading">
+                  <p className="eyebrow">Library</p>
+                  <h2>{assets.length} assets</h2>
+                </div>
+                <div className="toolbar-controls">
+                  <label className="file-button">
+                    Import
+                    <input accept="image/*,video/*" disabled={!activeProject || busy} multiple onChange={importAssets} type="file" />
+                  </label>
+                  <button disabled={!activeProject || busy} onClick={reindexProject} type="button">
+                    Reindex
+                  </button>
+                </div>
+              </div>
+
+              <div className="filters">
+                <div className="segmented">
+                  {assetTypes.map(([value, label]) => (
+                    <button className={assetType === value ? "active" : ""} key={value || "all"} onClick={() => setAssetType(value)} type="button">
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                <input
+                  aria-label="Search assets"
+                  onChange={(event) => setSearch(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      loadAssets();
+                    }
+                  }}
+                  placeholder="Search prompt, model, notes"
+                  value={search}
+                />
+                <select aria-label="Sort assets" onChange={(event) => setSort(event.target.value)} value={sort}>
+                  {sortOptions.map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+                <label className="toggle">
+                  <input checked={showRejected} onChange={(event) => setShowRejected(event.target.checked)} type="checkbox" />
+                  Rejected
+                </label>
+                <label className="toggle">
+                  <input checked={favoritesOnly} onChange={(event) => setFavoritesOnly(event.target.checked)} type="checkbox" />
+                  Favorites
+                </label>
+              </div>
+
+              <div className="asset-grid" aria-label="Project assets">
+                {assets.length === 0 ? (
+                  <div className="empty-panel">No matching assets</div>
+                ) : (
+                  assets.map((asset) => (
+                    <button
+                      className={selectedAsset?.id === asset.id ? "asset-card active" : "asset-card"}
+                      key={asset.id}
+                      onClick={() => setSelectedAssetId(asset.id)}
+                      type="button"
+                    >
+                      <AssetPreview asset={asset} />
+                      <span>{asset.displayName}</span>
+                      <small>
+                        {asset.type} {asset.status.rating ? `${asset.status.rating}/5` : ""}
+                      </small>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <aside className="detail-panel" aria-label="Asset detail">
+              {selectedAsset ? (
+                <>
+                  <AssetPreview asset={selectedAsset} size="large" />
+                  <div className="detail-heading">
+                    <input
+                      aria-label="Asset display name"
+                      onBlur={(event) => {
+                        if (event.target.value !== selectedAsset.displayName) {
+                          patchAsset(selectedAsset, { displayName: event.target.value });
+                        }
+                      }}
+                      defaultValue={selectedAsset.displayName}
+                      key={selectedAsset.id}
+                    />
+                    <span>{selectedAsset.file.path}</span>
+                  </div>
+                  <div className="detail-actions">
+                    <button
+                      className={selectedAsset.status.favorite ? "active" : ""}
+                      onClick={() => patchAsset(selectedAsset, { favorite: !selectedAsset.status.favorite })}
+                      type="button"
+                    >
+                      Favorite
+                    </button>
+                    <button
+                      className={selectedAsset.status.rejected ? "active danger" : ""}
+                      onClick={() => patchAsset(selectedAsset, { rejected: !selectedAsset.status.rejected })}
+                      type="button"
+                    >
+                      Reject
+                    </button>
+                    <button className="danger" disabled={busy} onClick={trashSelected} type="button">
+                      Trash
+                    </button>
+                  </div>
+                  <RatingControl value={selectedAsset.status.rating} onChange={(rating) => patchAsset(selectedAsset, { rating })} />
+                  <textarea
+                    aria-label="Asset notes"
+                    defaultValue={selectedAsset.notes}
+                    key={`${selectedAsset.id}-notes`}
+                    onBlur={(event) => patchAsset(selectedAsset, { notes: event.target.value })}
+                    placeholder="Notes"
+                  />
+                  <dl className="metadata-list">
+                    <div>
+                      <dt>Type</dt>
+                      <dd>{selectedAsset.type}</dd>
+                    </div>
+                    <div>
+                      <dt>Mime</dt>
+                      <dd>{selectedAsset.file.mimeType}</dd>
+                    </div>
+                    <div>
+                      <dt>Size</dt>
+                      <dd>{Math.max(1, Math.round(selectedAsset.file.sizeBytes / 1024))} KB</dd>
+                    </div>
+                    <div>
+                      <dt>Prompt</dt>
+                      <dd>{selectedAsset.recipe?.prompt ?? "None"}</dd>
+                    </div>
+                    <div>
+                      <dt>Model</dt>
+                      <dd>{selectedAsset.recipe?.model ?? "None"}</dd>
+                    </div>
+                    <div>
+                      <dt>Lineage</dt>
+                      <dd>{selectedAsset.lineage.parents.length ? selectedAsset.lineage.parents.join(", ") : "None"}</dd>
+                    </div>
+                  </dl>
+                  <div className="send-row">
+                    <button type="button">Reuse</button>
+                    <button type="button">Video</button>
+                    <button type="button">Editor</button>
+                  </div>
+                </>
+              ) : (
+                <div className="empty-panel">Select an asset</div>
+              )}
+            </aside>
+          </section>
+        ) : (
+          <section className="main-surface">
+            <div className="section-heading">
+              <p className="eyebrow">{activeView}</p>
+              <h2>{activeView}</h2>
+            </div>
+            <p className="view-copy">{placeholders[activeView]}</p>
+          </section>
+        )}
       </section>
+
+      {trayOpen ? (
+        <aside className="asset-tray" aria-label="Asset tray">
+          <div className="section-heading">
+            <p className="eyebrow">Tray</p>
+            <h2>Recent</h2>
+          </div>
+          <div className="tray-list">
+            {assets.slice(0, 8).map((asset) => (
+              <button
+                className={selectedAsset?.id === asset.id ? "tray-item active" : "tray-item"}
+                key={asset.id}
+                onClick={() => {
+                  setActiveView("Library");
+                  setSelectedAssetId(asset.id);
+                }}
+                type="button"
+              >
+                <AssetPreview asset={asset} size="thumb" />
+                <span>{asset.displayName}</span>
+              </button>
+            ))}
+            {assets.length === 0 ? <span className="empty-state">No assets</span> : null}
+          </div>
+        </aside>
+      ) : null}
     </main>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -20,7 +20,9 @@ body {
 }
 
 button,
-input {
+input,
+select,
+textarea {
   font: inherit;
 }
 
@@ -30,11 +32,9 @@ button {
 
 .app {
   display: grid;
-  grid-template-columns: 252px minmax(0, 1fr);
+  grid-template-columns: 244px minmax(0, 1fr) 292px;
   min-height: 100vh;
-  background:
-    linear-gradient(90deg, rgba(255, 255, 255, 0.03), transparent 34%),
-    #171716;
+  background: #171716;
 }
 
 .sidebar {
@@ -76,7 +76,12 @@ button {
 .eyebrow,
 .notice,
 .view-copy,
-.empty-state {
+.empty-state,
+.topbar-project span,
+.metadata-list dt,
+.asset-card small,
+.project-pill small,
+.detail-heading span {
   margin: 0;
   color: #aaa397;
 }
@@ -105,16 +110,20 @@ button {
 .workspace {
   display: grid;
   grid-template-rows: auto auto auto 1fr;
-  gap: 18px;
-  padding: 22px;
+  gap: 16px;
+  min-width: 0;
+  padding: 20px;
 }
 
 .topbar,
 .project-band,
 .main-surface,
-.auth-band {
+.auth-band,
+.library-main,
+.detail-panel,
+.asset-tray {
   border: 1px solid #39362f;
-  background: rgba(36, 34, 30, 0.82);
+  background: rgba(36, 34, 30, 0.9);
 }
 
 .topbar {
@@ -125,10 +134,24 @@ button {
   padding: 14px 18px;
 }
 
+.topbar-project {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.topbar-project strong,
+.topbar-project span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .topbar-status {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  align-items: center;
   color: #c7bfb2;
   font-size: 14px;
 }
@@ -156,9 +179,14 @@ button {
   background: #30211f;
 }
 
+.notice.ok {
+  border-color: #426f66;
+  background: #1c302d;
+}
+
 .project-band {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 380px);
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 430px);
   gap: 24px;
   padding: 18px;
 }
@@ -173,7 +201,7 @@ button {
 }
 
 .section-heading h2 {
-  font-size: 26px;
+  font-size: 24px;
 }
 
 .eyebrow {
@@ -184,7 +212,8 @@ button {
 }
 
 .project-list,
-.create-project,
+.project-forms,
+.compact-form,
 .auth-band form {
   display: grid;
   gap: 12px;
@@ -196,17 +225,28 @@ button {
   gap: 8px;
 }
 
-.project-pill,
-.form-row button {
-  min-height: 38px;
+.project-pill {
+  display: grid;
+  gap: 2px;
+  min-height: 44px;
+  max-width: 220px;
   border: 1px solid #4b463d;
   background: #292722;
   color: #f3f0e8;
   padding: 8px 12px;
+  text-align: left;
+}
+
+.project-pill span,
+.project-pill small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .project-pill.active,
-.form-row button {
+.form-row button,
+.file-button {
   border-color: #6ec6b8;
   background: #183f3a;
 }
@@ -223,7 +263,9 @@ label {
   font-weight: 700;
 }
 
-input {
+input,
+select,
+textarea {
   min-width: 0;
   border: 1px solid #4b463d;
   background: #191815;
@@ -231,22 +273,269 @@ input {
   padding: 9px 10px;
 }
 
+textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+
 input:focus,
+select:focus,
+textarea:focus,
 button:focus-visible {
   outline: 2px solid #f8d78c;
   outline-offset: 2px;
 }
 
-button:disabled {
+button:disabled,
+input:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
+.library-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(292px, 360px);
+  gap: 16px;
+  min-height: 0;
+}
+
+.library-main,
+.detail-panel,
 .main-surface {
   display: grid;
   align-content: start;
-  gap: 18px;
-  padding: 24px;
+  gap: 16px;
+  min-width: 0;
+  padding: 18px;
+}
+
+.library-toolbar,
+.filters,
+.detail-actions,
+.send-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toolbar-controls,
+.detail-actions,
+.send-row {
+  justify-content: flex-start;
+}
+
+.filters {
+  justify-content: flex-start;
+}
+
+.filters input {
+  flex: 1 1 220px;
+}
+
+.segmented {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid #4b463d;
+}
+
+.segmented button,
+.detail-actions button,
+.send-row button,
+.toolbar-controls button,
+.icon-button,
+.file-button,
+.form-row button {
+  min-height: 38px;
+  border: 1px solid #4b463d;
+  background: #292722;
+  color: #f3f0e8;
+  padding: 8px 12px;
+}
+
+.segmented button {
+  border-width: 0 1px 0 0;
+}
+
+.segmented button:last-child {
+  border-right: 0;
+}
+
+.segmented button.active,
+.detail-actions button.active,
+.send-row button:hover,
+.toolbar-controls button:hover,
+.icon-button:hover,
+.file-button:hover {
+  background: #183f3a;
+  color: #ffffff;
+}
+
+.segmented.compact {
+  grid-auto-columns: minmax(38px, 1fr);
+}
+
+.toggle {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  min-height: 38px;
+}
+
+.toggle input {
+  min-width: auto;
+}
+
+.file-button {
+  display: inline-grid;
+  place-items: center;
+  position: relative;
+}
+
+.file-button input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.asset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  gap: 12px;
+}
+
+.asset-card {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  border: 1px solid #3c3a34;
+  background: #23221f;
+  color: #f3f0e8;
+  padding: 8px;
+  text-align: left;
+}
+
+.asset-card.active,
+.tray-item.active {
+  border-color: #f8d78c;
+}
+
+.asset-card span,
+.asset-card small,
+.tray-item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-preview {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  background: #171716;
+  border: 1px solid #37332d;
+}
+
+.asset-preview.large {
+  aspect-ratio: 16 / 10;
+}
+
+.asset-preview.thumb {
+  width: 54px;
+  height: 54px;
+  aspect-ratio: auto;
+  flex: 0 0 auto;
+}
+
+.file-preview {
+  display: grid;
+  place-items: center;
+  padding: 10px;
+  color: #c7bfb2;
+  text-align: center;
+}
+
+.detail-panel {
+  position: sticky;
+  top: 20px;
+  max-height: calc(100vh - 40px);
+  overflow: auto;
+}
+
+.detail-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.detail-heading input {
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.detail-actions .danger,
+button.danger {
+  border-color: #8f4f42;
+}
+
+.detail-actions .danger.active,
+button.danger:hover {
+  background: #3d211e;
+}
+
+.metadata-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.metadata-list div {
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr);
+  gap: 8px;
+}
+
+.metadata-list dt,
+.metadata-list dd {
+  margin: 0;
+  min-width: 0;
+}
+
+.metadata-list dd {
+  overflow-wrap: anywhere;
+}
+
+.asset-tray {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  padding: 18px;
+  border-width: 0 0 0 1px;
+}
+
+.tray-list {
+  display: grid;
+  gap: 8px;
+}
+
+.tray-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid #3c3a34;
+  background: #23221f;
+  color: #f3f0e8;
+  padding: 8px;
+  text-align: left;
+}
+
+.main-surface {
   min-height: 420px;
 }
 
@@ -255,46 +544,39 @@ button:disabled {
   line-height: 1.6;
 }
 
-.media-grid {
+.empty-panel {
   display: grid;
-  grid-template-columns: 1.35fr 1fr 1fr;
-  gap: 12px;
-  min-height: 240px;
+  min-height: 180px;
+  place-items: center;
+  border: 1px dashed #4b463d;
+  color: #aaa397;
 }
 
-.media-tile {
-  display: grid;
-  place-items: end start;
-  min-height: 220px;
-  padding: 16px;
-  border: 1px solid #3c3a34;
-  background:
-    linear-gradient(135deg, rgba(110, 198, 184, 0.18), transparent 42%),
-    #23221f;
-  color: #f3f0e8;
-  font-weight: 800;
-}
-
-.media-tile.wide {
-  background:
-    linear-gradient(135deg, rgba(248, 215, 140, 0.22), transparent 48%),
-    #25231f;
-}
-
-.media-tile.accent {
-  background:
-    linear-gradient(135deg, rgba(128, 181, 226, 0.18), transparent 48%),
-    #222528;
-}
-
-.media-tile.warm {
-  background:
-    linear-gradient(135deg, rgba(210, 117, 87, 0.2), transparent 48%),
-    #28221f;
-}
-
-@media (max-width: 860px) {
+@media (max-width: 1180px) {
   .app {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .asset-tray {
+    display: none;
+  }
+}
+
+@media (max-width: 1320px) {
+  .library-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-panel {
+    position: static;
+    max-height: none;
+  }
+}
+
+@media (max-width: 940px) {
+  .app,
+  .project-band,
+  .library-shell {
     grid-template-columns: 1fr;
   }
 
@@ -303,14 +585,33 @@ button:disabled {
     border-bottom: 1px solid #34312b;
   }
 
-  .nav-list,
-  .project-band,
-  .media-grid {
-    grid-template-columns: 1fr;
+  .nav-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .topbar {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .detail-panel {
+    position: static;
+    max-height: none;
+  }
+}
+
+@media (max-width: 620px) {
+  .workspace,
+  .sidebar {
+    padding: 14px;
+  }
+
+  .nav-list,
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading h2 {
+    font-size: 21px;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,940 @@
+{
+  "name": "sceneworks",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sceneworks",
+      "version": "0.1.0",
+      "workspaces": [
+        "apps/web"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/web": {
+      "name": "@sceneworks/web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@vitejs/plugin-react": "latest",
+        "react": "latest",
+        "react-dom": "latest",
+        "typescript": "latest",
+        "vite": "latest"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@sceneworks/web": {
+      "resolved": "apps/web",
+      "link": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "stack:up": "docker compose up --build",
     "stack:down": "docker compose down",
     "check": "node scripts/check-scaffold.mjs",
+    "check:api": "python scripts/check-api.py",
     "check:health": "node scripts/check-health.mjs"
   },
   "workspaces": [

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -1,3 +1,5 @@
 # SceneWorks Schemas
 
 Shared JSON schema contracts live here so the API, worker, and web app can agree on project, asset, recipe, job, model, LoRA, character, and timeline shapes.
+
+The FastAPI models in `apps/api/sceneworks_api/models.py` are the runtime contract for API responses and sidecar validation. These JSON schemas mirror those shapes for portable project data and future worker/web validation.

--- a/packages/schemas/asset.schema.json
+++ b/packages/schemas/asset.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/asset.schema.json",
+  "title": "SceneWorks Asset Sidecar",
+  "type": "object",
+  "required": ["schemaVersion", "appVersion", "id", "projectId", "type", "displayName", "createdAt", "updatedAt", "file", "status", "lineage"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "appVersion": { "type": "string" },
+    "id": { "type": "string", "pattern": "^asset_[a-z0-9_]+$" },
+    "projectId": { "type": "string", "pattern": "^project_[a-z0-9_]+$" },
+    "generationSetId": { "type": ["string", "null"], "pattern": "^genset_[a-z0-9_]+$" },
+    "type": { "enum": ["image", "video", "upload", "frame", "render", "character_reference"] },
+    "displayName": { "type": "string", "minLength": 1 },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "file": { "$ref": "#/$defs/file" },
+    "status": { "$ref": "#/$defs/status" },
+    "notes": { "type": "string" },
+    "recipe": { "anyOf": [{ "$ref": "recipe.schema.json" }, { "type": "null" }] },
+    "lineage": { "$ref": "#/$defs/lineage" }
+  },
+  "$defs": {
+    "file": {
+      "type": "object",
+      "required": ["path", "mimeType", "sizeBytes"],
+      "properties": {
+        "path": { "type": "string" },
+        "mimeType": { "type": "string" },
+        "sizeBytes": { "type": "integer", "minimum": 0 },
+        "width": { "type": ["integer", "null"], "minimum": 1 },
+        "height": { "type": ["integer", "null"], "minimum": 1 },
+        "duration": { "type": ["number", "null"], "minimum": 0 },
+        "fps": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "status": {
+      "type": "object",
+      "required": ["favorite", "rating", "rejected", "trashed"],
+      "properties": {
+        "favorite": { "type": "boolean" },
+        "rating": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "rejected": { "type": "boolean" },
+        "trashed": { "type": "boolean" }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "required": ["parents"],
+      "properties": {
+        "parents": { "type": "array", "items": { "type": "string" } },
+        "sourceAssetId": { "type": ["string", "null"] },
+        "sourceTimestamp": { "type": ["number", "null"] },
+        "sourceTimelineId": { "type": ["string", "null"] },
+        "jobId": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/packages/schemas/character.schema.json
+++ b/packages/schemas/character.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/character.schema.json",
+  "title": "SceneWorks Character",
+  "type": "object",
+  "required": ["schemaVersion", "appVersion", "id", "projectId", "name", "type", "createdAt", "updatedAt"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "appVersion": { "type": "string" },
+    "id": { "type": "string", "pattern": "^character_[a-z0-9_]+$" },
+    "projectId": { "type": "string", "pattern": "^project_[a-z0-9_]+$" },
+    "name": { "type": "string", "minLength": 1 },
+    "type": { "enum": ["person", "creature", "object"] },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "referenceAssetIds": { "type": "array", "items": { "type": "string" } },
+    "approvedReferenceAssetIds": { "type": "array", "items": { "type": "string" } },
+    "lookIds": { "type": "array", "items": { "type": "string" } },
+    "loraIds": { "type": "array", "items": { "type": "string" } },
+    "notes": { "type": "string" }
+  }
+}

--- a/packages/schemas/generation-set.schema.json
+++ b/packages/schemas/generation-set.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/generation-set.schema.json",
+  "title": "SceneWorks Generation Set",
+  "type": "object",
+  "required": ["schemaVersion", "appVersion", "id", "projectId", "createdAt", "mode", "assetIds"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "appVersion": { "type": "string" },
+    "id": { "type": "string", "pattern": "^genset_[a-z0-9_]+$" },
+    "projectId": { "type": "string", "pattern": "^project_[a-z0-9_]+$" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "mode": { "type": "string" },
+    "recipeId": { "type": ["string", "null"] },
+    "assetIds": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/packages/schemas/job.schema.json
+++ b/packages/schemas/job.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/job.schema.json",
+  "title": "SceneWorks Job",
+  "type": "object",
+  "required": ["schemaVersion", "appVersion", "id", "type", "status", "progress", "createdAt", "updatedAt", "payload"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "appVersion": { "type": "string" },
+    "id": { "type": "string", "pattern": "^job_[a-z0-9_]+$" },
+    "projectId": { "type": ["string", "null"] },
+    "type": { "type": "string" },
+    "status": { "enum": ["queued", "preparing", "downloading", "loading_model", "running", "saving", "completed", "failed", "canceled", "interrupted"] },
+    "progress": { "type": "number", "minimum": 0, "maximum": 1 },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "error": { "type": ["string", "null"] },
+    "payload": { "type": "object" }
+  }
+}

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -8,7 +8,22 @@
     "schemaVersion": { "type": "integer", "minimum": 1 },
     "loras": {
       "type": "array",
-      "items": { "type": "object" }
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "scope", "category", "compatibleFamilies", "path"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "scope": { "enum": ["global", "project"] },
+          "category": { "enum": ["style", "enhance", "character", "motion", "clothing_object", "experimental"] },
+          "compatibleFamilies": { "type": "array", "items": { "type": "string" } },
+          "path": { "type": "string" },
+          "triggerWords": { "type": "array", "items": { "type": "string" } },
+          "defaultWeight": { "type": "number" },
+          "builtIn": { "type": "boolean" },
+          "ui": { "type": "object" }
+        }
+      }
     }
   }
 }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -8,7 +8,24 @@
     "schemaVersion": { "type": "integer", "minimum": 1 },
     "models": {
       "type": "array",
-      "items": { "type": "object" }
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "family", "type", "adapter"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "family": { "type": "string" },
+          "type": { "enum": ["image", "video", "utility"] },
+          "adapter": { "type": "string" },
+          "capabilities": { "type": "array", "items": { "type": "string" } },
+          "downloads": { "type": "array", "items": { "type": "object" } },
+          "paths": { "type": "object" },
+          "defaults": { "type": "object" },
+          "limits": { "type": "object" },
+          "loraCompatibility": { "type": "object" },
+          "ui": { "type": "object" }
+        }
+      }
     }
   }
 }

--- a/packages/schemas/project.schema.json
+++ b/packages/schemas/project.schema.json
@@ -3,13 +3,14 @@
   "$id": "https://sceneworks.local/schemas/project.schema.json",
   "title": "SceneWorks Project",
   "type": "object",
-  "required": ["schemaVersion", "appVersion", "id", "name", "createdAt", "folders"],
+  "required": ["schemaVersion", "appVersion", "id", "name", "createdAt", "updatedAt", "folders"],
   "properties": {
     "schemaVersion": { "type": "integer", "minimum": 1 },
     "appVersion": { "type": "string" },
     "id": { "type": "string", "pattern": "^project_[a-z0-9_]+$" },
     "name": { "type": "string", "minLength": 1 },
     "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
     "folders": {
       "type": "object",
       "additionalProperties": { "type": "string" }

--- a/packages/schemas/recipe.schema.json
+++ b/packages/schemas/recipe.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/recipe.schema.json",
+  "title": "SceneWorks Recipe",
+  "type": "object",
+  "required": ["schemaVersion", "appVersion", "loras", "normalizedSettings", "rawAdapterSettings"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "appVersion": { "type": "string" },
+    "id": { "type": ["string", "null"] },
+    "mode": { "type": ["string", "null"] },
+    "model": { "type": ["string", "null"] },
+    "prompt": { "type": ["string", "null"] },
+    "negativePrompt": { "type": ["string", "null"] },
+    "seed": { "type": ["integer", "null"] },
+    "loras": { "type": "array", "items": { "type": "object" } },
+    "normalizedSettings": { "type": "object" },
+    "rawAdapterSettings": { "type": "object" }
+  }
+}

--- a/packages/schemas/timeline-item.schema.json
+++ b/packages/schemas/timeline-item.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/timeline-item.schema.json",
+  "title": "SceneWorks Timeline Item",
+  "type": "object",
+  "required": ["schemaVersion", "id", "timelineId", "assetId", "track", "sourceIn", "timelineStart", "timelineEnd", "speed", "versionAssetIds"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "id": { "type": "string", "pattern": "^timeline_item_[a-z0-9_]+$" },
+    "timelineId": { "type": "string", "pattern": "^timeline_[a-z0-9_]+$" },
+    "assetId": { "type": "string", "pattern": "^asset_[a-z0-9_]+$" },
+    "track": { "type": "string" },
+    "sourceIn": { "type": "number", "minimum": 0 },
+    "sourceOut": { "type": ["number", "null"], "minimum": 0 },
+    "timelineStart": { "type": "number", "minimum": 0 },
+    "timelineEnd": { "type": "number", "minimum": 0 },
+    "speed": { "type": "number", "exclusiveMinimum": 0 },
+    "activeVersionAssetId": { "type": ["string", "null"] },
+    "versionAssetIds": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/packages/schemas/timeline.schema.json
+++ b/packages/schemas/timeline.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/timeline.schema.json",
+  "title": "SceneWorks Timeline",
+  "type": "object",
+  "required": ["schemaVersion", "appVersion", "id", "projectId", "name", "createdAt", "updatedAt", "aspectRatio", "fps", "items"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "appVersion": { "type": "string" },
+    "id": { "type": "string", "pattern": "^timeline_[a-z0-9_]+$" },
+    "projectId": { "type": "string", "pattern": "^project_[a-z0-9_]+$" },
+    "name": { "type": "string", "minLength": 1 },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "aspectRatio": { "enum": ["16:9", "9:16", "1:1", "source"] },
+    "fps": { "type": "integer", "minimum": 1 },
+    "items": { "type": "array", "items": { "$ref": "timeline-item.schema.json" } }
+  }
+}

--- a/scripts/check-api.py
+++ b/scripts/check-api.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+import sqlite3
+import sys
+import tempfile
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from apps.api.sceneworks_api.main import create_app
+from apps.api.sceneworks_api.persistence import PROJECT_FOLDERS
+from apps.api.sceneworks_api.settings import Settings
+
+
+def assert_status(response, status_code):
+    if response.status_code != status_code:
+        raise AssertionError(f"Expected {status_code}, got {response.status_code}: {response.text}")
+
+
+with tempfile.TemporaryDirectory() as temp_dir:
+    root = Path(temp_dir)
+    settings = Settings()
+    settings.data_dir = root / "data"
+    settings.config_dir = root / "config"
+    settings.access_token = ""
+
+    client = TestClient(create_app(settings))
+
+    created_response = client.post("/api/v1/projects", json={"name": "Epic Spine"})
+    assert_status(created_response, 201)
+    project = created_response.json()
+    project_path = Path(project["path"])
+    assert (project_path / "project.json").exists()
+    assert (project_path / "project.db").exists()
+    for folder in PROJECT_FOLDERS:
+        assert (project_path / folder).is_dir(), folder
+
+    opened_response = client.post("/api/v1/projects/open", json={"path": str(project_path)})
+    assert_status(opened_response, 200)
+    assert opened_response.json()["id"] == project["id"]
+
+    import_response = client.post(
+        f"/api/v1/projects/{project['id']}/assets/import",
+        files=[
+            ("files", ("noir still.png", b"\x89PNG\r\n\x1a\nsceneworks", "image/png")),
+            ("files", ("alley shot.mp4", b"\x00\x00\x00\x18ftypmp42", "video/mp4")),
+        ],
+    )
+    assert_status(import_response, 201)
+    imported_assets = import_response.json()["assets"]
+    assert len(imported_assets) == 2
+    assert {asset["type"] for asset in imported_assets} == {"image", "video"}
+    for asset in imported_assets:
+        media_path = project_path / asset["file"]["path"]
+        sidecar_path = media_path.with_suffix(".sceneworks.json")
+        assert media_path.exists()
+        assert sidecar_path.exists()
+
+    connection = sqlite3.connect(project_path / "project.db")
+    try:
+        count = connection.execute("select count(*) from assets").fetchone()[0]
+    finally:
+        connection.close()
+    assert count == 2
+
+    first_asset = imported_assets[0]
+    patch_response = client.patch(
+        f"/api/v1/projects/{project['id']}/assets/{first_asset['id']}",
+        json={"rating": 5, "favorite": True, "rejected": True, "notes": "keeper after review"},
+    )
+    assert_status(patch_response, 200)
+    updated_asset = patch_response.json()
+    assert updated_asset["status"]["rating"] == 5
+    assert updated_asset["status"]["favorite"] is True
+    assert updated_asset["status"]["rejected"] is True
+    assert updated_asset["notes"] == "keeper after review"
+
+    hidden_response = client.get(f"/api/v1/projects/{project['id']}/assets")
+    assert_status(hidden_response, 200)
+    assert hidden_response.json()["total"] == 1
+
+    shown_response = client.get(f"/api/v1/projects/{project['id']}/assets?includeRejected=true")
+    assert_status(shown_response, 200)
+    assert shown_response.json()["total"] == 2
+
+    delete_response = client.delete(f"/api/v1/projects/{project['id']}/assets/{first_asset['id']}")
+    assert_status(delete_response, 200)
+    trashed_asset = delete_response.json()
+    assert trashed_asset["status"]["trashed"] is True
+    assert trashed_asset["file"]["path"].startswith("trash/")
+
+    reindex_response = client.post(f"/api/v1/projects/{project['id']}/reindex")
+    assert_status(reindex_response, 200)
+    reindex = reindex_response.json()
+    assert reindex["discovered"] == 2
+    assert reindex["indexed"] == 2
+    assert reindex["errors"] == []
+
+print("SceneWorks API persistence check passed.")

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -9,10 +9,20 @@ const requiredPaths = [
   "apps/web/src/main.jsx",
   "apps/web/src/styles.css",
   "apps/api/sceneworks_api/main.py",
+  "apps/api/sceneworks_api/models.py",
+  "apps/api/sceneworks_api/persistence.py",
   "apps/api/sceneworks_api/projects.py",
+  "apps/api/sceneworks_api/assets.py",
   "apps/api/sceneworks_api/security.py",
   "apps/worker/scene_worker/runtime.py",
   "packages/schemas/project.schema.json",
+  "packages/schemas/asset.schema.json",
+  "packages/schemas/recipe.schema.json",
+  "packages/schemas/generation-set.schema.json",
+  "packages/schemas/job.schema.json",
+  "packages/schemas/character.schema.json",
+  "packages/schemas/timeline.schema.json",
+  "packages/schemas/timeline-item.schema.json",
   "config/manifests/builtin.models.jsonc",
   "config/manifests/builtin.loras.jsonc",
   "data/projects/.gitkeep",
@@ -44,6 +54,9 @@ for (const requiredPath of requiredPaths) {
 await assertContains("apps/web/src/main.jsx", "/api/v1/health");
 await assertContains("apps/api/sceneworks_api/main.py", "/api/v1/health");
 await assertContains("apps/api/sceneworks_api/main.py", "/api/v1/jobs/events");
+await assertContains("apps/api/sceneworks_api/assets.py", "/assets/import");
+await assertContains("apps/api/sceneworks_api/persistence.py", "project.db");
+await assertContains("packages/schemas/asset.schema.json", "generationSetId");
 await assertContains("docker-compose.yml", "NVIDIA_VISIBLE_DEVICES");
 await assertContains("README.md", "SCENEWORKS_ACCESS_TOKEN");
 


### PR DESCRIPTION
## Summary
- Add typed FastAPI contracts plus project persistence helpers for inspectable `.sceneworks` folders, `project.json`, SQLite migrations, recent projects, and open-project behavior.
- Add asset import/list/detail/update/content/trash/reindex APIs with sidecar JSON validation and SQLite indexes.
- Expand JSON schemas for project, asset, generation set, recipe, job, model, LoRA, character, timeline, and timeline item contracts.
- Replace the Library placeholder with project create/open, media import, filters/search/sort, asset grid, detail panel, curation controls, and desktop asset tray.

## Validation
- `npm run check`
- `npm run check:api`
- `python -m compileall apps/api/sceneworks_api scripts/check-api.py`
- `npm --workspace apps/web run build`
- Browser smoke test at `http://127.0.0.1:5173` with API/web Docker services rebuilt