### PR TITLE
[codex] Add job queue worker foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,9 @@ apps/web/dist/
 data/projects/*
 !data/projects/.gitkeep
 data/recent-projects.json
+data/*.db
+data/*.db-shm
+data/*.db-wal
 data/models/*
 !data/models/.gitkeep
 data/loras/*

--- a/apps/api/sceneworks_api/events.py
+++ b/apps/api/sceneworks_api/events.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+
+class EventHub:
+    def __init__(self) -> None:
+        self._subscribers: dict[asyncio.Queue[dict[str, Any]], asyncio.AbstractEventLoop] = {}
+
+    async def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=100)
+        self._subscribers[queue] = asyncio.get_running_loop()
+        await queue.put({"event": "ready", "data": {"status": "connected"}})
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
+        self._subscribers.pop(queue, None)
+
+    def publish(self, event: str, data: dict[str, Any]) -> None:
+        message = {"event": event, "data": data}
+        for queue, loop in list(self._subscribers.items()):
+            try:
+                loop.call_soon_threadsafe(self._put_nowait, queue, message)
+            except RuntimeError:
+                self.unsubscribe(queue)
+
+    def _put_nowait(self, queue: asyncio.Queue[dict[str, Any]], message: dict[str, Any]) -> None:
+        try:
+            queue.put_nowait(message)
+        except asyncio.QueueFull:
+            self.unsubscribe(queue)
+
+
+def encode_sse(message: dict[str, Any]) -> str:
+    event = message.get("event", "message")
+    data = json.dumps(message.get("data", {}), separators=(",", ":"))
+    return f"event: {event}\ndata: {data}\n\n"

--- a/apps/api/sceneworks_api/jobs.py
+++ b/apps/api/sceneworks_api/jobs.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from .events import encode_sse
+from .jobs_store import JOB_STATUSES, JobsStore
+
+
+router = APIRouter(tags=["jobs"])
+
+
+class JobCreateRequest(BaseModel):
+    type: str = Field(default="placeholder", min_length=1, max_length=80)
+    projectId: str | None = None
+    projectName: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    requestedGpu: str = "auto"
+
+
+class DuplicateJobRequest(BaseModel):
+    payloadChanges: dict[str, Any] = Field(default_factory=dict)
+    requestedGpu: str | None = None
+
+
+class WorkerRegisterRequest(BaseModel):
+    workerId: str = Field(min_length=1, max_length=120)
+    gpuId: str = Field(default="auto", min_length=1, max_length=120)
+    gpuName: str | None = None
+    capabilities: list[str] = Field(default_factory=list)
+    loadedModels: list[str] = Field(default_factory=list)
+
+
+class WorkerHeartbeatRequest(BaseModel):
+    status: str = "idle"
+    currentJobId: str | None = None
+    loadedModels: list[str] = Field(default_factory=list)
+
+
+class ClaimRequest(BaseModel):
+    workerId: str = Field(min_length=1, max_length=120)
+
+
+class ProgressRequest(BaseModel):
+    status: str
+    stage: str
+    progress: float = Field(ge=0, le=1)
+    message: str = ""
+    error: str | None = None
+    result: dict[str, Any] | None = None
+    etaSeconds: float | None = None
+
+
+def get_store(request: Request) -> JobsStore:
+    return request.app.state.jobs_store
+
+
+def publish(request: Request, event: str, data: dict) -> None:
+    request.app.state.event_hub.publish(event, data)
+
+
+@router.get("/jobs")
+def list_jobs(
+    request: Request,
+    projectId: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> list[dict]:
+    if status and status not in JOB_STATUSES:
+        raise HTTPException(status_code=400, detail="Unsupported job status")
+    return get_store(request).list_jobs(project_id=projectId, status=status, limit=limit)
+
+
+@router.post("/jobs", status_code=201)
+def create_job(payload: JobCreateRequest, request: Request) -> dict:
+    job = get_store(request).create_job(
+        job_type=payload.type,
+        project_id=payload.projectId,
+        project_name=payload.projectName,
+        payload=payload.payload,
+        requested_gpu=payload.requestedGpu,
+    )
+    publish(request, "job.updated", job)
+    publish(request, "queue.updated", queue_summary(request))
+    return job
+
+
+@router.get("/jobs/events")
+async def job_events(request: Request) -> StreamingResponse:
+    queue = await request.app.state.event_hub.subscribe()
+
+    async def stream():
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    message = await asyncio.wait_for(queue.get(), timeout=15)
+                    yield encode_sse(message)
+                except asyncio.TimeoutError:
+                    yield "event: heartbeat\ndata: {}\n\n"
+        finally:
+            request.app.state.event_hub.unsubscribe(queue)
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.post("/jobs/claim")
+def claim_job(payload: ClaimRequest, request: Request) -> dict:
+    try:
+        job = get_store(request).claim_next_job(payload.workerId)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Worker not found") from None
+    if job is None:
+        return {"job": None}
+    publish(request, "job.updated", job)
+    publish(request, "queue.updated", queue_summary(request))
+    return {"job": job}
+
+
+@router.get("/jobs/{job_id}")
+def get_job(job_id: str, request: Request) -> dict:
+    try:
+        return get_store(request).get_job(job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+
+
+@router.post("/jobs/{job_id}/cancel")
+def cancel_job(job_id: str, request: Request) -> dict:
+    try:
+        job = get_store(request).cancel_job(job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+    publish(request, "job.updated", job)
+    publish(request, "queue.updated", queue_summary(request))
+    return job
+
+
+@router.post("/jobs/{job_id}/retry", status_code=201)
+def retry_job(job_id: str, request: Request) -> dict:
+    try:
+        job = get_store(request).retry_job(job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+    publish(request, "job.updated", job)
+    publish(request, "queue.updated", queue_summary(request))
+    return job
+
+
+@router.post("/jobs/{job_id}/duplicate", status_code=201)
+def duplicate_job(job_id: str, payload: DuplicateJobRequest, request: Request) -> dict:
+    try:
+        job = get_store(request).duplicate_job(
+            job_id,
+            payload_changes=payload.payloadChanges,
+            requested_gpu=payload.requestedGpu,
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+    publish(request, "job.updated", job)
+    publish(request, "queue.updated", queue_summary(request))
+    return job
+
+
+@router.get("/queue")
+def queue_summary(request: Request) -> dict:
+    jobs = get_store(request).list_jobs(limit=500)
+    workers = get_store(request).list_workers()
+    counts = {status: 0 for status in JOB_STATUSES}
+    for job in jobs:
+        counts[job["status"]] = counts.get(job["status"], 0) + 1
+    return {
+        "counts": counts,
+        "activeJobs": [job for job in jobs if job["status"] not in ("completed", "failed", "canceled", "interrupted")],
+        "workers": workers,
+    }
+
+
+@router.get("/workers")
+def list_workers(request: Request) -> list[dict]:
+    return get_store(request).list_workers()
+
+
+@router.post("/workers/register")
+def register_worker(payload: WorkerRegisterRequest, request: Request) -> dict:
+    worker = get_store(request).register_worker(
+        worker_id=payload.workerId,
+        gpu_id=payload.gpuId,
+        gpu_name=payload.gpuName,
+        capabilities=payload.capabilities,
+        loaded_models=payload.loadedModels,
+    )
+    publish(request, "worker.updated", worker)
+    publish(request, "queue.updated", queue_summary(request))
+    return worker
+
+
+@router.post("/workers/{worker_id}/heartbeat")
+def heartbeat_worker(worker_id: str, payload: WorkerHeartbeatRequest, request: Request) -> dict:
+    try:
+        worker = get_store(request).heartbeat_worker(
+            worker_id=worker_id,
+            status=payload.status,
+            current_job_id=payload.currentJobId,
+            loaded_models=payload.loadedModels,
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Worker not found") from None
+    publish(request, "worker.updated", worker)
+    return worker
+
+
+@router.post("/jobs/{job_id}/progress")
+def update_job_progress(job_id: str, payload: ProgressRequest, request: Request) -> dict:
+    try:
+        job = get_store(request).update_job_progress(
+            job_id,
+            status=payload.status,
+            stage=payload.stage,
+            progress=payload.progress,
+            message=payload.message,
+            error=payload.error,
+            result=payload.result,
+            eta_seconds=payload.etaSeconds,
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    publish(request, "job.updated", job)
+    publish(request, "queue.updated", queue_summary(request))
+    return job

--- a/apps/api/sceneworks_api/jobs_store.py
+++ b/apps/api/sceneworks_api/jobs_store.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+ACTIVE_STATUSES = ("preparing", "downloading", "loading_model", "running", "saving")
+TERMINAL_STATUSES = ("completed", "failed", "canceled", "interrupted")
+JOB_STATUSES = ("queued", *ACTIVE_STATUSES, *TERMINAL_STATUSES)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def dumps(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, separators=(",", ":"), sort_keys=True)
+
+
+def loads(value: str | None, fallback: Any) -> Any:
+    if not value:
+        return fallback
+    return json.loads(value)
+
+
+class JobsStore:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._lock = threading.RLock()
+
+    def connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.db_path, timeout=30, check_same_thread=False)
+        connection.row_factory = sqlite3.Row
+        connection.execute("pragma journal_mode = wal")
+        connection.execute("pragma foreign_keys = on")
+        return connection
+
+    def initialize(self) -> None:
+        with self._lock, self.connect() as connection:
+            connection.executescript(
+                """
+                create table if not exists jobs (
+                  id text primary key,
+                  type text not null,
+                  status text not null,
+                  project_id text,
+                  project_name text,
+                  payload_json text not null,
+                  result_json text not null default '{}',
+                  requested_gpu text not null default 'auto',
+                  assigned_gpu text,
+                  worker_id text,
+                  progress real not null default 0,
+                  stage text not null default 'queued',
+                  message text not null default '',
+                  error text,
+                  eta_seconds real,
+                  attempts integer not null default 1,
+                  source_job_id text,
+                  duplicate_of_job_id text,
+                  cancel_requested integer not null default 0,
+                  created_at text not null,
+                  updated_at text not null,
+                  started_at text,
+                  completed_at text,
+                  canceled_at text,
+                  last_heartbeat_at text
+                );
+
+                create index if not exists idx_jobs_status_created
+                  on jobs(status, created_at);
+                create index if not exists idx_jobs_project_created
+                  on jobs(project_id, created_at);
+                create index if not exists idx_jobs_assigned_gpu_status
+                  on jobs(assigned_gpu, status);
+
+                create table if not exists workers (
+                  id text primary key,
+                  gpu_id text not null,
+                  gpu_name text,
+                  status text not null,
+                  current_job_id text,
+                  capabilities_json text not null,
+                  loaded_models_json text not null,
+                  registered_at text not null,
+                  last_seen_at text not null
+                );
+                """
+            )
+
+    def mark_interrupted_on_startup(self) -> list[dict]:
+        now = utc_now()
+        with self._lock, self.connect() as connection:
+            rows = connection.execute(
+                f"select * from jobs where status in ({','.join('?' for _ in ACTIVE_STATUSES)})",
+                ACTIVE_STATUSES,
+            ).fetchall()
+            connection.execute(
+                f"""
+                update jobs
+                   set status = 'interrupted',
+                       stage = 'interrupted',
+                       message = 'Job was interrupted by a backend restart.',
+                       error = 'The backend restarted before this job finished.',
+                       completed_at = ?,
+                       updated_at = ?,
+                       worker_id = null
+                 where status in ({','.join('?' for _ in ACTIVE_STATUSES)})
+                """,
+                (now, now, *ACTIVE_STATUSES),
+            )
+            connection.execute(
+                "update workers set status = 'offline', current_job_id = null where status != 'offline'"
+            )
+            return [self.row_to_job(row) for row in rows]
+
+    def create_job(
+        self,
+        *,
+        job_type: str,
+        project_id: str | None,
+        project_name: str | None,
+        payload: dict,
+        requested_gpu: str,
+        source_job_id: str | None = None,
+        duplicate_of_job_id: str | None = None,
+        attempts: int = 1,
+    ) -> dict:
+        now = utc_now()
+        job_id = f"job_{uuid4().hex}"
+        with self._lock, self.connect() as connection:
+            connection.execute(
+                """
+                insert into jobs (
+                  id, type, status, project_id, project_name, payload_json, result_json,
+                  requested_gpu, progress, stage, message, attempts, source_job_id,
+                  duplicate_of_job_id, created_at, updated_at
+                ) values (?, ?, 'queued', ?, ?, ?, '{}', ?, 0, 'queued', ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job_id,
+                    job_type,
+                    project_id,
+                    project_name,
+                    dumps(payload),
+                    requested_gpu or "auto",
+                    "Waiting for an available worker.",
+                    attempts,
+                    source_job_id,
+                    duplicate_of_job_id,
+                    now,
+                    now,
+                ),
+            )
+            return self.get_job(job_id, connection=connection)
+
+    def list_jobs(
+        self,
+        *,
+        project_id: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        filters = []
+        params: list[Any] = []
+        if project_id:
+            filters.append("project_id = ?")
+            params.append(project_id)
+        if status:
+            filters.append("status = ?")
+            params.append(status)
+
+        where_clause = f"where {' and '.join(filters)}" if filters else ""
+        with self._lock, self.connect() as connection:
+            rows = connection.execute(
+                f"select * from jobs {where_clause} order by created_at desc limit ?",
+                (*params, max(1, min(limit, 500))),
+            ).fetchall()
+        return [self.row_to_job(row) for row in rows]
+
+    def get_job(self, job_id: str, *, connection: sqlite3.Connection | None = None) -> dict:
+        owns_connection = connection is None
+        connection = connection or self.connect()
+        try:
+            row = connection.execute("select * from jobs where id = ?", (job_id,)).fetchone()
+            if row is None:
+                raise KeyError(job_id)
+            return self.row_to_job(row)
+        finally:
+            if owns_connection:
+                connection.close()
+
+    def cancel_job(self, job_id: str) -> dict:
+        now = utc_now()
+        with self._lock, self.connect() as connection:
+            job = self.get_job(job_id, connection=connection)
+            if job["status"] in TERMINAL_STATUSES:
+                return job
+
+            if job["status"] == "queued":
+                connection.execute(
+                    """
+                    update jobs
+                       set status = 'canceled',
+                           stage = 'canceled',
+                           progress = 1,
+                           cancel_requested = 1,
+                           message = 'Canceled before a worker started.',
+                           canceled_at = ?,
+                           completed_at = ?,
+                           updated_at = ?
+                     where id = ?
+                    """,
+                    (now, now, now, job_id),
+                )
+            else:
+                connection.execute(
+                    """
+                    update jobs
+                       set cancel_requested = 1,
+                           message = 'Cancellation requested. Waiting for worker acknowledgement.',
+                           updated_at = ?
+                     where id = ?
+                    """,
+                    (now, job_id),
+                )
+            return self.get_job(job_id, connection=connection)
+
+    def retry_job(self, job_id: str) -> dict:
+        with self._lock, self.connect() as connection:
+            job = self.get_job(job_id, connection=connection)
+        return self.create_job(
+            job_type=job["type"],
+            project_id=job["projectId"],
+            project_name=job["projectName"],
+            payload=job["payload"],
+            requested_gpu=job["requestedGpu"],
+            source_job_id=job["id"],
+            attempts=job["attempts"] + 1,
+        )
+
+    def duplicate_job(self, job_id: str, *, payload_changes: dict, requested_gpu: str | None) -> dict:
+        with self._lock, self.connect() as connection:
+            job = self.get_job(job_id, connection=connection)
+        payload = {**job["payload"], **payload_changes}
+        return self.create_job(
+            job_type=job["type"],
+            project_id=job["projectId"],
+            project_name=job["projectName"],
+            payload=payload,
+            requested_gpu=requested_gpu or job["requestedGpu"],
+            duplicate_of_job_id=job["id"],
+        )
+
+    def register_worker(
+        self,
+        *,
+        worker_id: str,
+        gpu_id: str,
+        gpu_name: str | None,
+        capabilities: list[str],
+        loaded_models: list[str],
+    ) -> dict:
+        now = utc_now()
+        with self._lock, self.connect() as connection:
+            connection.execute(
+                """
+                insert into workers (
+                  id, gpu_id, gpu_name, status, current_job_id, capabilities_json,
+                  loaded_models_json, registered_at, last_seen_at
+                ) values (?, ?, ?, 'idle', null, ?, ?, ?, ?)
+                on conflict(id) do update set
+                  gpu_id = excluded.gpu_id,
+                  gpu_name = excluded.gpu_name,
+                  status = case when workers.current_job_id is null then 'idle' else workers.status end,
+                  capabilities_json = excluded.capabilities_json,
+                  loaded_models_json = excluded.loaded_models_json,
+                  last_seen_at = excluded.last_seen_at
+                """,
+                (
+                    worker_id,
+                    gpu_id,
+                    gpu_name,
+                    dumps(capabilities),
+                    dumps(loaded_models),
+                    now,
+                    now,
+                ),
+            )
+            return self.get_worker(worker_id, connection=connection)
+
+    def heartbeat_worker(
+        self,
+        *,
+        worker_id: str,
+        status: str,
+        current_job_id: str | None,
+        loaded_models: list[str],
+    ) -> dict:
+        now = utc_now()
+        with self._lock, self.connect() as connection:
+            connection.execute(
+                """
+                update workers
+                   set status = ?,
+                       current_job_id = ?,
+                       loaded_models_json = ?,
+                       last_seen_at = ?
+                 where id = ?
+                """,
+                (status, current_job_id, dumps(loaded_models), now, worker_id),
+            )
+            if current_job_id:
+                connection.execute(
+                    "update jobs set last_heartbeat_at = ?, updated_at = ? where id = ?",
+                    (now, now, current_job_id),
+                )
+            return self.get_worker(worker_id, connection=connection)
+
+    def claim_next_job(self, worker_id: str) -> dict | None:
+        now = utc_now()
+        with self._lock, self.connect() as connection:
+            worker = self.get_worker(worker_id, connection=connection)
+            gpu_id = worker["gpuId"]
+            active_gpu_job = connection.execute(
+                f"""
+                select id from jobs
+                 where assigned_gpu = ?
+                   and status in ({','.join('?' for _ in ACTIVE_STATUSES)})
+                 limit 1
+                """,
+                (gpu_id, *ACTIVE_STATUSES),
+            ).fetchone()
+            if active_gpu_job is not None:
+                return None
+
+            queued = connection.execute(
+                """
+                select * from jobs
+                 where status = 'queued'
+                   and (requested_gpu = 'auto' or requested_gpu = ?)
+                 order by created_at asc
+                 limit 1
+                """,
+                (gpu_id,),
+            ).fetchone()
+            if queued is None:
+                return None
+
+            connection.execute(
+                """
+                update jobs
+                   set status = 'preparing',
+                       assigned_gpu = ?,
+                       worker_id = ?,
+                       stage = 'preparing',
+                       message = 'Worker claimed job.',
+                       started_at = coalesce(started_at, ?),
+                       updated_at = ?
+                 where id = ? and status = 'queued'
+                """,
+                (gpu_id, worker_id, now, now, queued["id"]),
+            )
+            connection.execute(
+                "update workers set status = 'busy', current_job_id = ?, last_seen_at = ? where id = ?",
+                (queued["id"], now, worker_id),
+            )
+            return self.get_job(queued["id"], connection=connection)
+
+    def update_job_progress(
+        self,
+        job_id: str,
+        *,
+        status: str,
+        stage: str,
+        progress: float,
+        message: str,
+        error: str | None = None,
+        result: dict | None = None,
+        eta_seconds: float | None = None,
+    ) -> dict:
+        if status not in JOB_STATUSES:
+            raise ValueError(f"Unsupported job status: {status}")
+
+        now = utc_now()
+        completed_at = now if status in TERMINAL_STATUSES else None
+        canceled_at = now if status == "canceled" else None
+        with self._lock, self.connect() as connection:
+            connection.execute(
+                """
+                update jobs
+                   set status = ?,
+                       stage = ?,
+                       progress = ?,
+                       message = ?,
+                       error = ?,
+                       result_json = coalesce(?, result_json),
+                       eta_seconds = ?,
+                       completed_at = coalesce(?, completed_at),
+                       canceled_at = coalesce(?, canceled_at),
+                       updated_at = ?
+                 where id = ?
+                """,
+                (
+                    status,
+                    stage,
+                    max(0, min(1, progress)),
+                    message,
+                    error,
+                    dumps(result) if result is not None else None,
+                    eta_seconds,
+                    completed_at,
+                    canceled_at,
+                    now,
+                    job_id,
+                ),
+            )
+            job = self.get_job(job_id, connection=connection)
+            if status in TERMINAL_STATUSES and job["workerId"]:
+                connection.execute(
+                    "update workers set status = 'idle', current_job_id = null, last_seen_at = ? where id = ?",
+                    (now, job["workerId"]),
+                )
+            return job
+
+    def list_workers(self) -> list[dict]:
+        with self._lock, self.connect() as connection:
+            rows = connection.execute("select * from workers order by gpu_id, id").fetchall()
+        return [self.row_to_worker(row) for row in rows]
+
+    def get_worker(self, worker_id: str, *, connection: sqlite3.Connection | None = None) -> dict:
+        owns_connection = connection is None
+        connection = connection or self.connect()
+        try:
+            row = connection.execute("select * from workers where id = ?", (worker_id,)).fetchone()
+            if row is None:
+                raise KeyError(worker_id)
+            return self.row_to_worker(row)
+        finally:
+            if owns_connection:
+                connection.close()
+
+    def row_to_job(self, row: sqlite3.Row) -> dict:
+        created_at = row["created_at"]
+        started_at = row["started_at"]
+        completed_at = row["completed_at"]
+        elapsed_seconds = None
+        if started_at:
+            end = completed_at or utc_now()
+            elapsed_seconds = max(
+                0,
+                int(
+                    (
+                        datetime.fromisoformat(end.replace("Z", "+00:00"))
+                        - datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+                    ).total_seconds()
+                ),
+            )
+
+        return {
+            "id": row["id"],
+            "type": row["type"],
+            "status": row["status"],
+            "projectId": row["project_id"],
+            "projectName": row["project_name"],
+            "payload": loads(row["payload_json"], {}),
+            "result": loads(row["result_json"], {}),
+            "requestedGpu": row["requested_gpu"],
+            "assignedGpu": row["assigned_gpu"],
+            "workerId": row["worker_id"],
+            "progress": row["progress"],
+            "stage": row["stage"],
+            "message": row["message"],
+            "error": row["error"],
+            "etaSeconds": row["eta_seconds"],
+            "elapsedSeconds": elapsed_seconds,
+            "attempts": row["attempts"],
+            "sourceJobId": row["source_job_id"],
+            "duplicateOfJobId": row["duplicate_of_job_id"],
+            "cancelRequested": bool(row["cancel_requested"]),
+            "createdAt": created_at,
+            "updatedAt": row["updated_at"],
+            "startedAt": started_at,
+            "completedAt": completed_at,
+            "canceledAt": row["canceled_at"],
+            "lastHeartbeatAt": row["last_heartbeat_at"],
+        }
+
+    def row_to_worker(self, row: sqlite3.Row) -> dict:
+        return {
+            "id": row["id"],
+            "gpuId": row["gpu_id"],
+            "gpuName": row["gpu_name"],
+            "status": row["status"],
+            "currentJobId": row["current_job_id"],
+            "capabilities": loads(row["capabilities_json"], []),
+            "loadedModels": loads(row["loaded_models_json"], []),
+            "registeredAt": row["registered_at"],
+            "lastSeenAt": row["last_seen_at"],
+        }

--- a/apps/api/sceneworks_api/main.py
+++ b/apps/api/sceneworks_api/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
-
+from .events import EventHub
+from .jobs import router as jobs_router
+from .jobs_store import JobsStore
 from .projects import ensure_data_dirs, router as projects_router
 from .security import access_control_middleware
 from .settings import Settings, get_settings
@@ -10,6 +11,9 @@ from .settings import Settings, get_settings
 def create_app(settings: Settings | None = None) -> FastAPI:
     settings = settings or get_settings()
     ensure_data_dirs(settings)
+    jobs_store = JobsStore(settings.jobs_db_path)
+    jobs_store.initialize()
+    interrupted_jobs = jobs_store.mark_interrupted_on_startup()
 
     app = FastAPI(
         title="SceneWorks API",
@@ -18,6 +22,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         openapi_url="/api/openapi.json",
     )
     app.state.settings = settings
+    app.state.jobs_store = jobs_store
+    app.state.event_hub = EventHub()
 
     app.add_middleware(
         CORSMiddleware,
@@ -42,7 +48,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "data": str(settings.data_dir),
                 "config": str(settings.config_dir),
                 "projects": str(settings.projects_dir),
+                "jobsDb": str(settings.jobs_db_path),
             },
+            "interruptedJobsOnStartup": len(interrupted_jobs),
         }
 
     @app.get("/api/v1/access", tags=["system"])
@@ -58,15 +66,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         return {"ok": is_authorized(request, settings)}
 
-    @app.get("/api/v1/jobs/events", tags=["jobs"])
-    async def job_events() -> StreamingResponse:
-        async def stream():
-            yield "event: ready\n"
-            yield 'data: {"status":"placeholder","message":"Job event stream ready"}\n\n'
-
-        return StreamingResponse(stream(), media_type="text/event-stream")
-
     app.include_router(projects_router, prefix="/api/v1")
+    app.include_router(jobs_router, prefix="/api/v1")
     return app
 
 

--- a/apps/api/sceneworks_api/security.py
+++ b/apps/api/sceneworks_api/security.py
@@ -14,6 +14,10 @@ PUBLIC_PATHS = {
 
 
 def token_from_request(request: Request) -> str:
+    query_token = request.query_params.get("token", "").strip()
+    if query_token:
+        return query_token
+
     header_token = request.headers.get("x-sceneworks-token", "").strip()
     if header_token:
         return header_token

--- a/apps/api/sceneworks_api/settings.py
+++ b/apps/api/sceneworks_api/settings.py
@@ -13,7 +13,16 @@ class Settings:
         self.access_token = os.getenv("SCENEWORKS_ACCESS_TOKEN", "").strip()
         cors = os.getenv(
             "SCENEWORKS_CORS_ORIGINS",
-            "http://localhost:5173,http://127.0.0.1:5173",
+            ",".join(
+                [
+                    "http://localhost:5173",
+                    "http://127.0.0.1:5173",
+                    "http://localhost:5174",
+                    "http://127.0.0.1:5174",
+                    "http://localhost:5175",
+                    "http://127.0.0.1:5175",
+                ]
+            ),
         )
         self.cors_origins = [origin.strip() for origin in cors.split(",") if origin.strip()]
 
@@ -24,6 +33,10 @@ class Settings:
     @property
     def registry_path(self) -> Path:
         return self.data_dir / "recent-projects.json"
+
+    @property
+    def jobs_db_path(self) -> Path:
+        return self.data_dir / "jobs.db"
 
 
 @lru_cache(maxsize=1)

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -4,46 +4,16 @@ import "./styles.css";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
 
-const navItems = [
-  "Library",
-  "Image",
-  "Video",
-  "Characters",
-  "Editor",
-  "Queue",
-];
+const navItems = ["Library", "Image", "Video", "Characters", "Editor", "Queue"];
+const terminalStatuses = new Set(["completed", "failed", "canceled", "interrupted"]);
+const actionStatuses = new Set(["failed", "canceled", "interrupted", "completed"]);
 
 const placeholders = {
-  Library: {
-    title: "Library",
-    eyebrow: "Project assets",
-    body: "Imported and generated media will appear here with recipe metadata, ratings, lineage, and reuse actions.",
-  },
-  Image: {
-    title: "Image Studio",
-    eyebrow: "Text, edit, character, variations",
-    body: "Prompt-first image workflows land here, with model details tucked into an advanced drawer.",
-  },
-  Video: {
-    title: "Video Studio",
-    eyebrow: "Short generated shots",
-    body: "Image-to-video, text-to-video, first/last frame, extend, and replacement modes will share this surface.",
-  },
-  Characters: {
-    title: "Character Studio",
-    eyebrow: "Reusable identities",
-    body: "Characters will gather references, looks, and project LoRAs before full training arrives.",
-  },
-  Editor: {
-    title: "Editor",
-    eyebrow: "Timeline assembly",
-    body: "Generated and imported clips will be arranged, trimmed, bridged, and exported from here.",
-  },
-  Queue: {
-    title: "Queue",
-    eyebrow: "Jobs and GPUs",
-    body: "Generation, downloads, exports, tracking, and replacement jobs will show progress here.",
-  },
+  Library: ["Project assets", "Imported and generated media"],
+  Image: ["Image Studio", "Text, edit, character, variations"],
+  Video: ["Video Studio", "Short generated shots"],
+  Characters: ["Character Studio", "Reusable identities"],
+  Editor: ["Editor", "Timeline assembly"],
 };
 
 async function apiFetch(path, token, options = {}) {
@@ -53,21 +23,37 @@ async function apiFetch(path, token, options = {}) {
     headers.set("X-SceneWorks-Token", token);
   }
 
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
-    headers,
-  });
-
+  const response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
   if (!response.ok) {
     const detail = await response.json().catch(() => ({}));
     throw new Error(detail.detail ?? `Request failed with ${response.status}`);
   }
-
   return response.json();
+}
+
+function eventUrl(path, token) {
+  const url = new URL(`${API_BASE_URL}${path}`);
+  if (token) {
+    url.searchParams.set("token", token);
+  }
+  return url.toString();
 }
 
 function StatusDot({ ok }) {
   return <span className={ok ? "status-dot ok" : "status-dot"} aria-hidden="true" />;
+}
+
+function formatSeconds(seconds) {
+  if (seconds === null || seconds === undefined) {
+    return "0s";
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return minutes > 0 ? `${minutes}m ${remainder}s` : `${remainder}s`;
+}
+
+function percent(value) {
+  return `${Math.round((value ?? 0) * 100)}%`;
 }
 
 function App() {
@@ -78,9 +64,38 @@ function App() {
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
   const [projectName, setProjectName] = useState("");
+  const [jobs, setJobs] = useState([]);
+  const [workers, setWorkers] = useState([]);
+  const [projectFilter, setProjectFilter] = useState("all");
+  const [requestedGpu, setRequestedGpu] = useState("auto");
+  const [jobPrompt, setJobPrompt] = useState("Placeholder generation");
   const [error, setError] = useState("");
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
+  const queueCounts = useMemo(() => {
+    return jobs.reduce(
+      (counts, job) => {
+        counts[job.status] = (counts[job.status] ?? 0) + 1;
+        if (!terminalStatuses.has(job.status)) {
+          counts.active += 1;
+        }
+        return counts;
+      },
+      { active: 0 },
+    );
+  }, [jobs]);
+
+  const filteredJobs = useMemo(() => {
+    if (projectFilter === "all") {
+      return jobs;
+    }
+    return jobs.filter((job) => job.projectId === projectFilter);
+  }, [jobs, projectFilter]);
+
+  const gpuOptions = useMemo(() => {
+    const ids = workers.map((worker) => worker.gpuId).filter(Boolean);
+    return ["auto", ...Array.from(new Set(ids))];
+  }, [workers]);
 
   useEffect(() => {
     apiFetch("/api/v1/health", "")
@@ -97,18 +112,52 @@ function App() {
       return;
     }
 
-    apiFetch("/api/v1/projects", token)
-      .then((items) => {
-        setProjects(items);
-        setActiveProject((current) => current ?? items[0] ?? null);
-      })
-      .catch((err) => setError(err.message));
+    refreshData();
   }, [authenticated, token]);
+
+  useEffect(() => {
+    if (!authenticated) {
+      return undefined;
+    }
+
+    const events = new EventSource(eventUrl("/api/v1/jobs/events", token));
+    events.addEventListener("job.updated", (event) => {
+      const job = JSON.parse(event.data);
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    });
+    events.addEventListener("worker.updated", (event) => {
+      const worker = JSON.parse(event.data);
+      setWorkers((items) => [worker, ...items.filter((item) => item.id !== worker.id)].sort(sortWorkers));
+    });
+    events.onerror = () => {
+      events.close();
+    };
+
+    return () => events.close();
+  }, [authenticated, token]);
+
+  async function refreshData() {
+    try {
+      const [projectItems, jobItems, workerItems] = await Promise.all([
+        apiFetch("/api/v1/projects", token),
+        apiFetch("/api/v1/jobs", token),
+        apiFetch("/api/v1/workers", token),
+      ]);
+      setProjects(projectItems);
+      setActiveProject((current) => current ?? projectItems[0] ?? null);
+      setJobs(jobItems.sort(sortNewest));
+      setWorkers(workerItems.sort(sortWorkers));
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
 
   function saveToken(event) {
     event.preventDefault();
     window.localStorage.setItem("sceneworks-token", token);
     setError("");
+    refreshData();
   }
 
   async function createProject(event) {
@@ -132,7 +181,43 @@ function App() {
     }
   }
 
-  const view = placeholders[activeView];
+  async function createJob(event) {
+    event.preventDefault();
+    try {
+      await apiFetch("/api/v1/jobs", token, {
+        method: "POST",
+        body: JSON.stringify({
+          type: "placeholder",
+          projectId: activeProject?.id ?? null,
+          projectName: activeProject?.name ?? null,
+          requestedGpu,
+          payload: {
+            prompt: jobPrompt,
+            createdFrom: activeView,
+          },
+        }),
+      });
+      setActiveView("Queue");
+      setError("");
+      refreshData();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function jobAction(job, action) {
+    try {
+      const path = action === "duplicate" ? `/api/v1/jobs/${job.id}/duplicate` : `/api/v1/jobs/${job.id}/${action}`;
+      const body = action === "duplicate" ? { payloadChanges: { duplicatedAt: new Date().toISOString() } } : {};
+      await apiFetch(path, token, { method: "POST", body: JSON.stringify(body) });
+      setError("");
+      refreshData();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  const [viewTitle, viewEyebrow] = placeholders[activeView] ?? ["Queue", "Jobs and GPUs"];
 
   return (
     <main className="app">
@@ -170,8 +255,11 @@ function App() {
               <StatusDot ok={health?.status === "ok"} />
               API
             </span>
-            <span>GPU auto</span>
-            <span>Queue idle</span>
+            <span>{workers.length ? `${workers.length} worker${workers.length === 1 ? "" : "s"}` : "No workers"}</span>
+            <span>{gpuOptions.length > 1 ? `${gpuOptions.length - 1} GPU slot${gpuOptions.length === 2 ? "" : "s"}` : "GPU auto"}</span>
+            <button className="queue-chip" onClick={() => setActiveView("Queue")} type="button">
+              Queue {queueCounts.active}
+            </button>
           </div>
         </header>
 
@@ -203,7 +291,7 @@ function App() {
             </div>
             <div className="project-buttons">
               {projects.length === 0 ? (
-                <span className="empty-state">Create the first project to start the Library spine.</span>
+                <span className="empty-state">No projects yet</span>
               ) : (
                 projects.map((project) => (
                   <button
@@ -235,28 +323,189 @@ function App() {
           </form>
         </section>
 
-        <section className="main-surface">
-          <div className="section-heading">
-            <p className="eyebrow">{view.eyebrow}</p>
-            <h2>{view.title}</h2>
-          </div>
-          <p className="view-copy">{view.body}</p>
+        {activeView === "Queue" ? (
+          <QueueScreen
+            activeProject={activeProject}
+            createJob={createJob}
+            filteredJobs={filteredJobs}
+            gpuOptions={gpuOptions}
+            jobAction={jobAction}
+            jobPrompt={jobPrompt}
+            projectFilter={projectFilter}
+            projects={projects}
+            requestedGpu={requestedGpu}
+            setJobPrompt={setJobPrompt}
+            setProjectFilter={setProjectFilter}
+            setRequestedGpu={setRequestedGpu}
+            workers={workers}
+          />
+        ) : (
+          <section className="main-surface">
+            <div className="section-heading">
+              <p className="eyebrow">{viewEyebrow}</p>
+              <h2>{viewTitle}</h2>
+            </div>
 
-          <div className="media-grid" aria-label={`${view.title} preview placeholders`}>
-            <div className="media-tile wide">
-              <span>{activeProject ? activeProject.name : "Create a project"}</span>
+            <form className="job-composer compact" onSubmit={createJob}>
+              <label htmlFor="surface-job-prompt">Prompt</label>
+              <input
+                id="surface-job-prompt"
+                onChange={(event) => setJobPrompt(event.target.value)}
+                value={jobPrompt}
+              />
+              <label htmlFor="surface-gpu">GPU</label>
+              <select id="surface-gpu" onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
+                {gpuOptions.map((gpu) => (
+                  <option key={gpu} value={gpu}>
+                    {gpu === "auto" ? "Auto" : gpu}
+                  </option>
+                ))}
+              </select>
+              <button disabled={!authenticated} type="submit">
+                Start job
+              </button>
+            </form>
+
+            <div className="media-grid" aria-label={`${viewTitle} preview placeholders`}>
+              <div className="media-tile wide">
+                <span>{activeProject ? activeProject.name : "Create a project"}</span>
+              </div>
+              <div className="media-tile accent">
+                <span>{queueCounts.running ? `${queueCounts.running} running` : "Idle"}</span>
+              </div>
+              <div className="media-tile warm">
+                <span>{workers[0]?.gpuName ?? "GPU auto"}</span>
+              </div>
             </div>
-            <div className="media-tile accent">
-              <span>Recipes</span>
-            </div>
-            <div className="media-tile warm">
-              <span>Assets</span>
-            </div>
-          </div>
-        </section>
+          </section>
+        )}
       </section>
     </main>
   );
+}
+
+function QueueScreen({
+  activeProject,
+  createJob,
+  filteredJobs,
+  gpuOptions,
+  jobAction,
+  jobPrompt,
+  projectFilter,
+  projects,
+  requestedGpu,
+  setJobPrompt,
+  setProjectFilter,
+  setRequestedGpu,
+  workers,
+}) {
+  return (
+    <section className="main-surface queue-surface">
+      <div className="queue-header">
+        <div className="section-heading">
+          <p className="eyebrow">Jobs and GPUs</p>
+          <h2>Queue</h2>
+        </div>
+        <form className="job-composer" onSubmit={createJob}>
+          <label htmlFor="queue-job-prompt">Prompt</label>
+          <input id="queue-job-prompt" onChange={(event) => setJobPrompt(event.target.value)} value={jobPrompt} />
+          <label htmlFor="queue-gpu">GPU</label>
+          <select id="queue-gpu" onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
+            {gpuOptions.map((gpu) => (
+              <option key={gpu} value={gpu}>
+                {gpu === "auto" ? "Auto" : gpu}
+              </option>
+            ))}
+          </select>
+          <button disabled={!activeProject} type="submit">
+            Add job
+          </button>
+        </form>
+      </div>
+
+      <div className="queue-tools">
+        <label htmlFor="project-filter">Project</label>
+        <select id="project-filter" onChange={(event) => setProjectFilter(event.target.value)} value={projectFilter}>
+          <option value="all">All projects</option>
+          {projects.map((project) => (
+            <option key={project.id} value={project.id}>
+              {project.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="worker-grid">
+        {workers.length === 0 ? (
+          <div className="worker-card">
+            <strong>No workers registered</strong>
+            <span>Start the worker service to claim queued jobs.</span>
+          </div>
+        ) : (
+          workers.map((worker) => (
+            <div className="worker-card" key={worker.id}>
+              <strong>{worker.gpuName ?? worker.gpuId}</strong>
+              <span>{worker.status}</span>
+              <small>{worker.currentJobId ?? "Idle"}</small>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="job-list">
+        {filteredJobs.length === 0 ? (
+          <div className="empty-panel">No jobs in this view</div>
+        ) : (
+          filteredJobs.map((job) => <JobRow job={job} jobAction={jobAction} key={job.id} />)
+        )}
+      </div>
+    </section>
+  );
+}
+
+function JobRow({ job, jobAction }) {
+  const canCancel = !terminalStatuses.has(job.status);
+  const canRepeat = actionStatuses.has(job.status);
+  return (
+    <article className={`job-row ${job.status}`}>
+      <div className="job-main">
+        <div>
+          <p className="eyebrow">{job.type}</p>
+          <h3>{job.payload.prompt ?? job.id}</h3>
+        </div>
+        <span className="status-badge">{job.status}</span>
+      </div>
+      <div className="job-meta">
+        <span>{job.projectName ?? "Global"}</span>
+        <span>Stage {job.stage}</span>
+        <span>Elapsed {formatSeconds(job.elapsedSeconds)}</span>
+        <span>GPU {job.assignedGpu ?? job.requestedGpu}</span>
+      </div>
+      <div className="progress-track" aria-label={`${percent(job.progress)} complete`}>
+        <span style={{ width: percent(job.progress) }} />
+      </div>
+      <p className={job.error ? "job-message error-text" : "job-message"}>{job.error ?? job.message}</p>
+      <div className="job-actions">
+        <button disabled={!canCancel || job.cancelRequested} onClick={() => jobAction(job, "cancel")} type="button">
+          Cancel
+        </button>
+        <button disabled={!canRepeat} onClick={() => jobAction(job, "retry")} type="button">
+          Retry
+        </button>
+        <button disabled={!canRepeat} onClick={() => jobAction(job, "duplicate")} type="button">
+          Duplicate
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function sortNewest(a, b) {
+  return b.createdAt.localeCompare(a.createdAt);
+}
+
+function sortWorkers(a, b) {
+  return `${a.gpuId}-${a.id}`.localeCompare(`${b.gpuId}-${b.id}`);
 }
 
 createRoot(document.getElementById("root")).render(<App />);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -20,7 +20,8 @@ body {
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 
@@ -197,7 +198,10 @@ button {
 }
 
 .project-pill,
-.form-row button {
+.form-row button,
+.queue-chip,
+.job-composer button,
+.job-actions button {
   min-height: 38px;
   border: 1px solid #4b463d;
   background: #292722;
@@ -206,7 +210,8 @@ button {
 }
 
 .project-pill.active,
-.form-row button {
+.form-row button,
+.job-composer button {
   border-color: #6ec6b8;
   background: #183f3a;
 }
@@ -231,7 +236,16 @@ input {
   padding: 9px 10px;
 }
 
+select {
+  min-width: 0;
+  border: 1px solid #4b463d;
+  background: #191815;
+  color: #f3f0e8;
+  padding: 9px 10px;
+}
+
 input:focus,
+select:focus,
 button:focus-visible {
   outline: 2px solid #f8d78c;
   outline-offset: 2px;
@@ -248,6 +262,155 @@ button:disabled {
   gap: 18px;
   padding: 24px;
   min-height: 420px;
+}
+
+.queue-chip {
+  border-color: #6ec6b8;
+  color: #f3f0e8;
+}
+
+.job-composer {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(108px, 140px) auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.job-composer label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.job-composer.compact {
+  grid-template-columns: minmax(0, 1fr) minmax(104px, 140px) auto;
+  max-width: 760px;
+}
+
+.queue-surface {
+  gap: 16px;
+}
+
+.queue-header {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(360px, 1.4fr);
+  gap: 18px;
+  align-items: end;
+}
+
+.queue-tools {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.worker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.worker-card,
+.empty-panel,
+.job-row {
+  border: 1px solid #3c3a34;
+  background: #23221f;
+}
+
+.worker-card {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+}
+
+.worker-card span,
+.worker-card small {
+  color: #aaa397;
+}
+
+.job-list {
+  display: grid;
+  gap: 10px;
+}
+
+.empty-panel {
+  padding: 18px;
+  color: #aaa397;
+}
+
+.job-row {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+}
+
+.job-main,
+.job-meta,
+.job-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.job-main {
+  justify-content: space-between;
+}
+
+.job-main h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.job-meta {
+  color: #aaa397;
+  font-size: 13px;
+}
+
+.status-badge {
+  border: 1px solid #4b463d;
+  background: #191815;
+  color: #f8d78c;
+  padding: 4px 8px;
+  text-transform: capitalize;
+}
+
+.job-row.completed .status-badge {
+  color: #6ec6b8;
+}
+
+.job-row.failed .status-badge,
+.job-row.interrupted .status-badge {
+  color: #e28e78;
+}
+
+.progress-track {
+  height: 8px;
+  overflow: hidden;
+  background: #191815;
+  border: 1px solid #3c3a34;
+}
+
+.progress-track span {
+  display: block;
+  height: 100%;
+  background: #6ec6b8;
+  transition: width 180ms ease;
+}
+
+.job-message {
+  margin: 0;
+  color: #c7bfb2;
+}
+
+.error-text {
+  color: #e28e78;
+}
+
+.job-actions button:disabled {
+  opacity: 0.45;
 }
 
 .view-copy {
@@ -305,7 +468,10 @@ button:disabled {
 
   .nav-list,
   .project-band,
-  .media-grid {
+  .media-grid,
+  .queue-header,
+  .job-composer,
+  .job-composer.compact {
     grid-template-columns: 1fr;
   }
 

--- a/apps/worker/scene_worker/gpu.py
+++ b/apps/worker/scene_worker/gpu.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def discover_gpu(requested_gpu_id: str) -> dict:
+    if requested_gpu_id and requested_gpu_id != "auto":
+        return {
+            "id": requested_gpu_id,
+            "name": f"GPU {requested_gpu_id}",
+            "capabilities": ["placeholder", "gpu"],
+        }
+
+    visible_devices = os.getenv("NVIDIA_VISIBLE_DEVICES", "").strip()
+    if visible_devices and visible_devices not in ("all", "void", "none"):
+        gpu_id = visible_devices.split(",")[0].strip()
+        return {"id": gpu_id, "name": f"GPU {gpu_id}", "capabilities": ["placeholder", "gpu"]}
+
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,name,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        first_line = result.stdout.strip().splitlines()[0]
+        index, name, memory_mb = [part.strip() for part in first_line.split(",", maxsplit=2)]
+        return {
+            "id": index,
+            "name": f"{name} ({memory_mb} MB)",
+            "capabilities": ["placeholder", "gpu", "nvidia"],
+        }
+    except (IndexError, OSError, subprocess.SubprocessError, ValueError):
+        return {
+            "id": "cpu",
+            "name": "CPU placeholder",
+            "capabilities": ["placeholder", "cpu"],
+        }

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
 import json
 import time
+from typing import Any
 
+import httpx
+
+from .gpu import discover_gpu
 from .settings import WorkerSettings
 
 
@@ -9,41 +15,150 @@ def now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def readiness_payload(settings: WorkerSettings) -> dict:
-    return {
-        "event": "ready",
-        "workerId": settings.worker_id,
-        "gpuId": settings.gpu_id,
-        "apiUrl": settings.api_url,
-        "capabilities": ["placeholder"],
-        "directories": {
-            "data": str(settings.data_dir),
-            "config": str(settings.config_dir),
-        },
-        "reportedAt": now(),
-    }
-
-
-def heartbeat_payload(settings: WorkerSettings) -> dict:
-    return {
-        "event": "heartbeat",
-        "workerId": settings.worker_id,
-        "gpuId": settings.gpu_id,
-        "status": "idle",
-        "currentJobId": None,
-        "loadedModels": [],
-        "reportedAt": now(),
-    }
-
-
 def emit(payload: dict) -> None:
     print(json.dumps(payload, sort_keys=True), flush=True)
 
 
+class ApiClient:
+    def __init__(self, settings: WorkerSettings) -> None:
+        headers = {}
+        if settings.access_token:
+            headers["X-SceneWorks-Token"] = settings.access_token
+        self.client = httpx.Client(base_url=settings.api_url, headers=headers, timeout=20)
+
+    def post(self, path: str, payload: dict) -> dict:
+        response = self.client.post(path, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    def get(self, path: str) -> dict:
+        response = self.client.get(path)
+        response.raise_for_status()
+        return response.json()
+
+
+def register_worker(api: ApiClient, settings: WorkerSettings, gpu: dict) -> None:
+    payload = {
+        "workerId": settings.worker_id,
+        "gpuId": gpu["id"],
+        "gpuName": gpu["name"],
+        "capabilities": gpu["capabilities"],
+        "loadedModels": [],
+    }
+    worker = api.post("/api/v1/workers/register", payload)
+    emit({"event": "registered", "worker": worker, "reportedAt": now()})
+
+
+def heartbeat(
+    api: ApiClient,
+    settings: WorkerSettings,
+    status: str,
+    current_job_id: str | None = None,
+) -> None:
+    api.post(
+        f"/api/v1/workers/{settings.worker_id}/heartbeat",
+        {"status": status, "currentJobId": current_job_id, "loadedModels": []},
+    )
+
+
+def update_job(api: ApiClient, job_id: str, payload: dict[str, Any]) -> dict:
+    job = api.post(f"/api/v1/jobs/{job_id}/progress", payload)
+    emit({"event": "job_progress", "jobId": job_id, "status": job["status"], "stage": job["stage"]})
+    return job
+
+
+def job_cancel_requested(api: ApiClient, job_id: str) -> bool:
+    return bool(api.get(f"/api/v1/jobs/{job_id}")["cancelRequested"])
+
+
+def run_placeholder_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    job_id = job["id"]
+    stages = [
+        ("preparing", "preparing", 0.1, "Preparing placeholder job."),
+        ("running", "running", 0.35, "Running placeholder step 1."),
+        ("running", "running", 0.65, "Running placeholder step 2."),
+        ("saving", "saving", 0.9, "Saving placeholder result."),
+    ]
+
+    for status, stage, progress, message in stages:
+        if job_cancel_requested(api, job_id):
+            update_job(
+                api,
+                job_id,
+                {
+                    "status": "canceled",
+                    "stage": "canceled",
+                    "progress": progress,
+                    "message": "Worker canceled the job before completion.",
+                },
+            )
+            heartbeat(api, settings, "idle")
+            return
+
+        heartbeat(api, settings, "busy", job_id)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": status,
+                "stage": stage,
+                "progress": progress,
+                "message": message,
+            },
+        )
+        time.sleep(1.5)
+
+    update_job(
+        api,
+        job_id,
+        {
+            "status": "completed",
+            "stage": "completed",
+            "progress": 1,
+            "message": "Placeholder job completed.",
+            "result": {"completedAt": now(), "output": "placeholder"},
+        },
+    )
+    heartbeat(api, settings, "idle")
+
+
 def main() -> None:
     settings = WorkerSettings()
-    emit(readiness_payload(settings))
+    gpu = discover_gpu(settings.gpu_id)
+    api = ApiClient(settings)
 
     while True:
-        emit(heartbeat_payload(settings))
-        time.sleep(settings.heartbeat_seconds)
+        try:
+            register_worker(api, settings, gpu)
+            break
+        except httpx.HTTPError as exc:
+            emit({"event": "register_failed", "error": str(exc), "reportedAt": now()})
+            time.sleep(settings.poll_seconds)
+
+    while True:
+        try:
+            heartbeat(api, settings, "idle")
+            claimed = api.post("/api/v1/jobs/claim", {"workerId": settings.worker_id})
+            job = claimed.get("job")
+            if job is None:
+                time.sleep(settings.poll_seconds)
+                continue
+
+            emit({"event": "claimed", "jobId": job["id"], "gpuId": job["assignedGpu"], "reportedAt": now()})
+            if job["type"] == "placeholder":
+                run_placeholder_job(api, settings, job)
+            else:
+                update_job(
+                    api,
+                    job["id"],
+                    {
+                        "status": "failed",
+                        "stage": "failed",
+                        "progress": 1,
+                        "message": "No adapter exists for this job type yet.",
+                        "error": f"Unsupported job type: {job['type']}",
+                    },
+                )
+        except httpx.HTTPError as exc:
+            emit({"event": "api_error", "error": str(exc), "reportedAt": now()})
+            time.sleep(settings.poll_seconds)

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -11,3 +11,4 @@ class WorkerSettings:
         self.config_dir = Path(os.getenv("SCENEWORKS_CONFIG_DIR", "config")).resolve()
         self.access_token = os.getenv("SCENEWORKS_ACCESS_TOKEN", "").strip()
         self.heartbeat_seconds = int(os.getenv("SCENEWORKS_WORKER_HEARTBEAT_SECONDS", "30"))
+        self.poll_seconds = int(os.getenv("SCENEWORKS_WORKER_POLL_SECONDS", "3"))

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -43,7 +43,7 @@ for (const requiredPath of requiredPaths) {
 
 await assertContains("apps/web/src/main.jsx", "/api/v1/health");
 await assertContains("apps/api/sceneworks_api/main.py", "/api/v1/health");
-await assertContains("apps/api/sceneworks_api/main.py", "/api/v1/jobs/events");
+await assertContains("apps/api/sceneworks_api/jobs.py", "/jobs/events");
 await assertContains("docker-compose.yml", "NVIDIA_VISIBLE_DEVICES");
 await assertContains("README.md", "SCENEWORKS_ACCESS_TOKEN");
 


### PR DESCRIPTION
## Summary

Implements the SceneWorks jobs/workers/GPU dispatch epic foundation across the API, worker, and web app.

- Adds a SQLite-backed job and worker store with queued/preparing/downloading/loading_model/running/saving/completed/failed/canceled/interrupted states.
- Adds job create/list/detail/cancel/retry/duplicate APIs, worker registration/heartbeat/claim/progress APIs, startup interruption handling, and thread-safe SSE updates.
- Adds GPU discovery and worker registration/claim execution for placeholder jobs, including cancellation checks and exclusive GPU assignment.
- Replaces the placeholder Queue surface with project filtering, live job rows, progress, elapsed time, failure messages, retry/duplicate/cancel actions, top-bar queue/GPU status, and GPU selection.

## Validation

- `python -m compileall apps\api apps\worker`
- `npm run check`
- `npm --workspace apps/web run build`
- Browser smoke: created a project, queued a placeholder job, observed it complete live via SSE in the Queue UI.
- Isolated API/worker smoke: started throwaway API/worker/data directory and verified a placeholder job claimed and completed on `cpu`.

## Notes

Covers Shortcut epic 1083 and stories sc-1109 through sc-1115.