### PR TITLE
[codex] Add Video Studio first adapter

### DIFF
--- a/apps/api/sceneworks_api/main.py
+++ b/apps/api/sceneworks_api/main.py
@@ -9,6 +9,7 @@ from .models import router as models_router
 from .projects import ensure_data_dirs, router as projects_router
 from .security import access_control_middleware
 from .settings import Settings, get_settings
+from .video_generation import router as video_router
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -73,6 +74,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(assets_router, prefix="/api/v1")
     app.include_router(models_router, prefix="/api/v1")
     app.include_router(image_router, prefix="/api/v1")
+    app.include_router(video_router, prefix="/api/v1")
     app.include_router(jobs_router, prefix="/api/v1")
     return app
 

--- a/apps/api/sceneworks_api/settings.py
+++ b/apps/api/sceneworks_api/settings.py
@@ -21,6 +21,8 @@ class Settings:
                     "http://127.0.0.1:5174",
                     "http://localhost:5175",
                     "http://127.0.0.1:5175",
+                    "http://localhost:5176",
+                    "http://127.0.0.1:5176",
                 ]
             ),
         )

--- a/apps/api/sceneworks_api/video_generation.py
+++ b/apps/api/sceneworks_api/video_generation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field, model_validator
+
+from .jobs import queue_summary
+
+
+router = APIRouter(prefix="/video", tags=["video"])
+
+VideoMode = Literal["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"]
+VideoQuality = Literal["fast", "balanced", "best"]
+
+
+class VideoJobRequest(BaseModel):
+    projectId: str = Field(min_length=1)
+    projectName: str | None = None
+    mode: VideoMode = "image_to_video"
+    prompt: str = Field(min_length=1, max_length=4000)
+    negativePrompt: str = ""
+    model: str = "ltx_2_3"
+    duration: float = Field(default=6, ge=1, le=30)
+    fps: int = Field(default=25, ge=1, le=60)
+    width: int = Field(default=768, ge=256, le=1920)
+    height: int = Field(default=512, ge=256, le=1920)
+    quality: VideoQuality = "balanced"
+    seed: int | None = None
+    loras: list[dict[str, Any]] = Field(default_factory=list)
+    sourceAssetId: str | None = None
+    lastFrameAssetId: str | None = None
+    sourceClipAssetId: str | None = None
+    requestedGpu: str = "auto"
+    advanced: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_mode_inputs(self) -> "VideoJobRequest":
+        if self.mode == "image_to_video" and not self.sourceAssetId:
+            raise ValueError("Image to Video requires a source image.")
+        if self.mode == "first_last_frame" and (not self.sourceAssetId or not self.lastFrameAssetId):
+            raise ValueError("First/Last Frame requires first and last image assets.")
+        if self.mode == "extend_clip" and not self.sourceClipAssetId:
+            raise ValueError("Extend Clip requires a source clip.")
+        return self
+
+
+@router.post("/jobs", status_code=201)
+def create_video_job(payload: VideoJobRequest, request: Request) -> dict:
+    job = request.app.state.jobs_store.create_job(
+        job_type="video_generate",
+        project_id=payload.projectId,
+        project_name=payload.projectName,
+        payload=payload.model_dump(exclude={"requestedGpu"}),
+        requested_gpu=payload.requestedGpu,
+    )
+    request.app.state.event_hub.publish("job.updated", job)
+    request.app.state.event_hub.publish("queue.updated", queue_summary(request))
+    return job

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -22,11 +22,47 @@ const fallbackModels = [
     capabilities: ["edit_image"],
     ui: { description: "Image edit target." },
   },
+  {
+    id: "ltx_2_3",
+    name: "LTX-2.3",
+    type: "video",
+    capabilities: ["image_to_video", "text_to_video", "first_last_frame"],
+    defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+    limits: {
+      durations: [4, 6, 8, 10, 12, 15],
+      recommendedMaxDuration: 10,
+      fps: [24, 25, 30],
+      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+    },
+    ui: {
+      description: "First-class short-shot video target.",
+      durationHint: "Best at 10s or less for the current workflow.",
+    },
+  },
+  {
+    id: "wan_2_2",
+    name: "Wan2.2",
+    type: "video",
+    capabilities: ["image_to_video", "text_to_video", "first_last_frame", "replace_person"],
+    defaults: { duration: 5, fps: 24, resolution: "1280x720", quality: "balanced" },
+    limits: {
+      durations: [4, 5, 6, 7, 8],
+      recommendedMaxDuration: 7,
+      fps: [16, 24],
+      resolutions: ["832x480", "1280x720", "720x1280"],
+    },
+    ui: {
+      description: "Fallback video family.",
+      durationHint: "Keep clips short until local looping behavior is validated.",
+    },
+  },
 ];
 
 async function apiFetch(path, token, options = {}) {
   const headers = new Headers(options.headers ?? {});
-  headers.set("Content-Type", "application/json");
+  if (options.body) {
+    headers.set("Content-Type", "application/json");
+  }
   if (token) {
     headers.set("X-SceneWorks-Token", token);
   }
@@ -49,6 +85,24 @@ function eventUrl(path, token) {
 
 function assetUrl(asset) {
   return asset?.url ? `${API_BASE_URL}${asset.url}` : "";
+}
+
+function assetCanRenderAsImage(asset) {
+  return asset?.type === "image" || asset?.file?.mimeType?.startsWith("image/");
+}
+
+function AssetMedia({ asset, className = "" }) {
+  if (!asset) {
+    return null;
+  }
+  const src = assetUrl(asset);
+  if (asset.type === "video" && asset.file?.mimeType?.startsWith("video/")) {
+    return <video className={className} controls muted playsInline src={src} />;
+  }
+  if (assetCanRenderAsImage(asset)) {
+    return <img alt="" className={className} src={src} />;
+  }
+  return <span className={className}>{asset.type}</span>;
 }
 
 function StatusDot({ ok }) {
@@ -91,7 +145,11 @@ function App() {
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
     const items = models.filter((model) => model.type === "image");
-    return items.length ? items : fallbackModels;
+    return items.length ? items : fallbackModels.filter((model) => model.type === "image");
+  }, [models]);
+  const videoModels = useMemo(() => {
+    const items = models.filter((model) => model.type === "video");
+    return items.length ? items : fallbackModels.filter((model) => model.type === "video");
   }, [models]);
   const selectedAsset = useMemo(
     () => assets.find((asset) => asset.id === selectedAssetId) ?? assets[0] ?? null,
@@ -101,6 +159,8 @@ function App() {
     () => assets.filter((asset) => asset.generationSetId === latestGenerationSetId),
     [assets, latestGenerationSetId],
   );
+  const latestImageAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "image"), [latestAssets]);
+  const latestVideoAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "video"), [latestAssets]);
   const queueCounts = useMemo(() => {
     return jobs.reduce(
       (counts, job) => {
@@ -284,6 +344,29 @@ function App() {
     }
   }
 
+  async function createVideoJob(payload) {
+    if (!activeProject) {
+      setError("Create or open a project first.");
+      return;
+    }
+    try {
+      await apiFetch("/api/v1/video/jobs", token, {
+        method: "POST",
+        body: JSON.stringify({
+          ...payload,
+          projectId: activeProject.id,
+          projectName: activeProject.name,
+          requestedGpu,
+        }),
+      });
+      setActiveView("Queue");
+      setError("");
+      refreshData();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
   async function updateAssetStatus(asset, changes) {
     try {
       const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/status`, token, {
@@ -435,6 +518,14 @@ function App() {
             }}
             selectedAsset={selectedAsset}
             setSelectedAssetId={setSelectedAssetId}
+            onSendVideo={(asset) => {
+              setSelectedAssetId(asset.id);
+              setActiveView("Video");
+            }}
+            onSendEditor={(asset) => {
+              setSelectedAssetId(asset.id);
+              setActiveView("Editor");
+            }}
             updateAssetStatus={updateAssetStatus}
           />
         ) : null}
@@ -446,13 +537,30 @@ function App() {
             createImageJob={createImageJob}
             gpuOptions={gpuOptions}
             imageModels={imageModels}
-            latestAssets={latestAssets}
+            latestAssets={latestImageAssets}
             onPreview={setPreviewAsset}
             requestedGpu={requestedGpu}
             selectedAsset={selectedAsset}
             setRequestedGpu={setRequestedGpu}
             updateAssetStatus={updateAssetStatus}
             deleteAsset={deleteAsset}
+          />
+        ) : null}
+
+        {activeView === "Video" ? (
+          <VideoStudio
+            activeProject={activeProject}
+            assets={assets}
+            createVideoJob={createVideoJob}
+            deleteAsset={deleteAsset}
+            gpuOptions={gpuOptions}
+            latestAssets={latestVideoAssets}
+            onPreview={setPreviewAsset}
+            requestedGpu={requestedGpu}
+            selectedAsset={selectedAsset}
+            setRequestedGpu={setRequestedGpu}
+            updateAssetStatus={updateAssetStatus}
+            videoModels={videoModels}
           />
         ) : null}
 
@@ -474,7 +582,7 @@ function App() {
           />
         ) : null}
 
-        {["Video", "Characters", "Editor"].includes(activeView) ? (
+        {["Characters", "Editor"].includes(activeView) ? (
           <PlaceholderSurface activeView={activeView} assets={assets} createJob={createPlaceholderJob} />
         ) : null}
       </section>
@@ -489,6 +597,8 @@ function LibraryScreen({
   deleteAsset,
   onPreview,
   onSendImage,
+  onSendVideo,
+  onSendEditor,
   selectedAsset,
   setSelectedAssetId,
   updateAssetStatus,
@@ -538,6 +648,8 @@ function LibraryScreen({
           deleteAsset={deleteAsset}
           onPreview={onPreview}
           onSendImage={onSendImage}
+          onSendVideo={onSendVideo}
+          onSendEditor={onSendEditor}
           updateAssetStatus={updateAssetStatus}
         />
       </div>
@@ -747,6 +859,323 @@ function ImageStudio({
   );
 }
 
+function VideoStudio({
+  activeProject,
+  assets,
+  createVideoJob,
+  deleteAsset,
+  gpuOptions,
+  latestAssets,
+  onPreview,
+  requestedGpu,
+  selectedAsset,
+  setRequestedGpu,
+  updateAssetStatus,
+  videoModels,
+}) {
+  const imageAssets = assets.filter((asset) => asset.type === "image" || asset.type === "frame");
+  const videoAssets = assets.filter((asset) => asset.type === "video");
+  const [mode, setMode] = useState("image_to_video");
+  const [prompt, setPrompt] = useState("Camera slowly pushes in while the scene comes alive");
+  const [quality, setQuality] = useState("balanced");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [model, setModel] = useState(videoModels[0]?.id ?? "ltx_2_3");
+  const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
+  const [duration, setDuration] = useState(selectedModel?.defaults?.duration ?? 6);
+  const [resolution, setResolution] = useState(selectedModel?.defaults?.resolution ?? "768x512");
+  const [fps, setFps] = useState(selectedModel?.defaults?.fps ?? 25);
+  const [seed, setSeed] = useState("");
+  const [negativePrompt, setNegativePrompt] = useState("");
+  const [sourceAssetId, setSourceAssetId] = useState(selectedAsset?.type === "image" ? selectedAsset.id : "");
+  const [lastFrameAssetId, setLastFrameAssetId] = useState("");
+  const [sourceClipAssetId, setSourceClipAssetId] = useState(selectedAsset?.type === "video" ? selectedAsset.id : "");
+
+  useEffect(() => {
+    if (!videoModels.some((item) => item.id === model)) {
+      setModel(videoModels[0]?.id ?? "ltx_2_3");
+    }
+  }, [videoModels, model]);
+
+  useEffect(() => {
+    if (selectedAsset?.type === "image") {
+      setSourceAssetId(selectedAsset.id);
+    }
+    if (selectedAsset?.type === "video") {
+      setSourceClipAssetId(selectedAsset.id);
+    }
+  }, [selectedAsset?.id, selectedAsset?.type]);
+
+  useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
+    setDuration((current) => {
+      const options = selectedModel.limits?.durations ?? [4, 6, 8, 10];
+      return options.includes(Number(current)) ? current : selectedModel.defaults?.duration ?? options[0];
+    });
+    setResolution((current) => {
+      const options = selectedModel.limits?.resolutions ?? ["768x512"];
+      return options.includes(current) ? current : selectedModel.defaults?.resolution ?? options[0];
+    });
+    setFps((current) => {
+      const options = selectedModel.limits?.fps ?? [24, 25, 30];
+      return options.includes(Number(current)) ? current : selectedModel.defaults?.fps ?? options[0];
+    });
+  }, [selectedModel?.id]);
+
+  const modeOptions = [
+    ["image_to_video", "Image to Video"],
+    ["text_to_video", "Text to Video"],
+    ["first_last_frame", "First/Last Frame"],
+    ["extend_clip", "Extend Clip"],
+    ["replace_person", "Replace Person"],
+  ];
+  const capabilities = selectedModel?.capabilities ?? [];
+  const supportsMode = capabilities.includes(mode);
+  const implementedMode = ["image_to_video", "text_to_video", "first_last_frame"].includes(mode);
+  const hasInputs =
+    mode === "text_to_video" ||
+    (mode === "image_to_video" && sourceAssetId) ||
+    (mode === "first_last_frame" && sourceAssetId && lastFrameAssetId) ||
+    (mode === "extend_clip" && sourceClipAssetId) ||
+    mode === "replace_person";
+  const canSubmit = Boolean(activeProject && prompt.trim() && supportsMode && implementedMode && hasInputs);
+  const [width, height] = resolution.split("x").map((value) => Number(value));
+  const durationOptions = selectedModel?.limits?.durations ?? [4, 6, 8, 10];
+  const resolutionOptions = selectedModel?.limits?.resolutions ?? ["768x512", "640x640", "1280x720", "720x1280"];
+  const fpsOptions = selectedModel?.limits?.fps ?? [24, 25, 30];
+  const durationHint =
+    selectedModel?.ui?.durationHint ??
+    (selectedModel?.limits?.recommendedMaxDuration ? `Recommended: ${selectedModel.limits.recommendedMaxDuration}s or less.` : "");
+  const blockedMessage = !supportsMode
+    ? `${selectedModel?.name ?? "Selected model"} does not support this mode.`
+    : !implementedMode
+      ? "This entry point is reserved for the next runtime slice."
+      : !hasInputs
+        ? "Required inputs are missing."
+        : "";
+
+  function submit(event) {
+    event.preventDefault();
+    createVideoJob({
+      mode,
+      prompt,
+      negativePrompt,
+      model,
+      duration: Number(duration),
+      fps: Number(fps),
+      width,
+      height,
+      quality,
+      seed: seed === "" ? null : Number(seed),
+      sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,
+      lastFrameAssetId: mode === "first_last_frame" ? lastFrameAssetId || null : null,
+      sourceClipAssetId: mode === "extend_clip" ? sourceClipAssetId || null : null,
+      loras: [],
+      advanced: { resolution, durationHint },
+    });
+  }
+
+  return (
+    <section className="main-surface video-studio">
+      <div className="surface-header">
+        <div className="section-heading">
+          <p className="eyebrow">Video Studio</p>
+          <h2>{activeProject ? activeProject.name : "Create a project"}</h2>
+        </div>
+        <div className="segmented-control mode-control" role="tablist" aria-label="Video mode">
+          {modeOptions.map(([value, label]) => (
+            <button className={mode === value ? "active" : ""} key={value} onClick={() => setMode(value)} type="button">
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <form className="studio-layout video-layout" onSubmit={submit}>
+        <section className="studio-controls">
+          {mode === "image_to_video" || mode === "first_last_frame" ? (
+            <label>
+              First frame
+              <select onChange={(event) => setSourceAssetId(event.target.value)} value={sourceAssetId}>
+                <option value="">Select image</option>
+                {imageAssets.map((asset) => (
+                  <option key={asset.id} value={asset.id}>
+                    {asset.displayName}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+
+          {mode === "first_last_frame" ? (
+            <label>
+              Last frame
+              <select onChange={(event) => setLastFrameAssetId(event.target.value)} value={lastFrameAssetId}>
+                <option value="">Select image</option>
+                {imageAssets.map((asset) => (
+                  <option key={asset.id} value={asset.id}>
+                    {asset.displayName}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+
+          {mode === "extend_clip" ? (
+            <label>
+              Source clip
+              <select onChange={(event) => setSourceClipAssetId(event.target.value)} value={sourceClipAssetId}>
+                <option value="">Select clip</option>
+                {videoAssets.map((asset) => (
+                  <option key={asset.id} value={asset.id}>
+                    {asset.displayName}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+
+          {mode === "replace_person" ? (
+            <div className="empty-panel compact-panel">Replacement is staged as a placeholder mode.</div>
+          ) : null}
+
+          <label className="prompt-field">
+            Prompt
+            <textarea onChange={(event) => setPrompt(event.target.value)} value={prompt} />
+          </label>
+
+          <div className="control-grid">
+            <label>
+              Duration
+              <select onChange={(event) => setDuration(Number(event.target.value))} value={duration}>
+                {durationOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {value}s
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Quality
+              <select onChange={(event) => setQuality(event.target.value)} value={quality}>
+                <option value="fast">Fast</option>
+                <option value="balanced">Balanced</option>
+                <option value="best">Best</option>
+              </select>
+            </label>
+            <label>
+              GPU
+              <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
+                {gpuOptions.map((gpu) => (
+                  <option key={gpu} value={gpu}>
+                    {gpu === "auto" ? "Auto" : gpu}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="guidance-strip">
+            <strong>{selectedModel?.name ?? "Video model"}</strong>
+            <span>{durationHint}</span>
+          </div>
+
+          <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
+            {advancedOpen ? "Hide advanced" : "Advanced"}
+          </button>
+
+          {advancedOpen ? (
+            <div className="advanced-panel">
+              <label>
+                Model
+                <select onChange={(event) => setModel(event.target.value)} value={model}>
+                  {videoModels.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Resolution
+                <select onChange={(event) => setResolution(event.target.value)} value={resolution}>
+                  {resolutionOptions.map((value) => (
+                    <option key={value} value={value}>
+                      {value.replace("x", " x ")}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                FPS
+                <select onChange={(event) => setFps(Number(event.target.value))} value={fps}>
+                  {fpsOptions.map((value) => (
+                    <option key={value} value={value}>
+                      {value}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Seed
+                <input onChange={(event) => setSeed(event.target.value)} placeholder="Random" type="number" value={seed} />
+              </label>
+              <label className="prompt-field">
+                Negative prompt
+                <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
+              </label>
+            </div>
+          ) : null}
+
+          {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
+          <button className="primary-action" disabled={!canSubmit} type="submit">
+            Generate Clip
+          </button>
+        </section>
+
+        <section className="review-panel video-review">
+          <div className="section-heading">
+            <p className="eyebrow">Fresh clip</p>
+            <h2>Review</h2>
+          </div>
+          {latestAssets.length ? (
+            <div className="review-grid video-review-grid">
+              {latestAssets.map((asset) => (
+                <AssetCard
+                  asset={asset}
+                  deleteAsset={deleteAsset}
+                  key={asset.id}
+                  onPreview={onPreview}
+                  updateAssetStatus={updateAssetStatus}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="empty-panel">No fresh video clip</div>
+          )}
+
+          <div className="asset-tray">
+            <div className="section-heading">
+              <p className="eyebrow">Asset tray</p>
+              <h2>Recent videos</h2>
+            </div>
+            <div className="tray-grid">
+              {videoAssets.slice(0, 4).map((asset) => (
+                <button className="tray-item" key={asset.id} onClick={() => onPreview(asset)} type="button">
+                  <AssetMedia asset={asset} />
+                  <span>{asset.displayName}</span>
+                </button>
+              ))}
+              {videoAssets.length === 0 ? <div className="empty-panel compact-panel">No video assets</div> : null}
+            </div>
+          </div>
+        </section>
+      </form>
+    </section>
+  );
+}
+
 function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
   if (!assets.length) {
     return <div className="empty-panel">No assets in this view</div>;
@@ -762,7 +1191,7 @@ function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
           onDoubleClick={() => onPreview(asset)}
           type="button"
         >
-          {asset.type === "image" ? <img alt="" src={assetUrl(asset)} /> : <span>{asset.type}</span>}
+          <AssetMedia asset={asset} />
           <strong>{asset.displayName}</strong>
         </button>
       ))}
@@ -770,7 +1199,7 @@ function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
   );
 }
 
-function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, updateAssetStatus }) {
+function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, onSendVideo, onSendEditor, updateAssetStatus }) {
   if (!asset) {
     return <aside className="asset-detail empty-panel">No asset selected</aside>;
   }
@@ -778,7 +1207,7 @@ function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, updateAssetSt
   return (
     <aside className="asset-detail">
       <button className="preview-button" onClick={() => onPreview(asset)} type="button">
-        {asset.type === "image" ? <img alt="" src={assetUrl(asset)} /> : <span>{asset.type}</span>}
+        <AssetMedia asset={asset} />
       </button>
       <h3>{asset.displayName}</h3>
       <p>{asset.recipe?.prompt ?? "No prompt"}</p>
@@ -801,9 +1230,21 @@ function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, updateAssetSt
         <button onClick={() => updateAssetStatus(asset, { rejected: !asset.status?.rejected })} type="button">
           {asset.status?.rejected ? "Restore" : "Reject"}
         </button>
-        <button onClick={() => onSendImage(asset)} type="button">
-          Send to Image
-        </button>
+        {asset.type === "image" ? (
+          <button onClick={() => onSendImage(asset)} type="button">
+            Send to Image
+          </button>
+        ) : null}
+        {asset.type === "image" ? (
+          <button onClick={() => onSendVideo(asset)} type="button">
+            Send to Video
+          </button>
+        ) : null}
+        {asset.type === "video" ? (
+          <button onClick={() => onSendEditor(asset)} type="button">
+            Send to Editor
+          </button>
+        ) : null}
         <button onClick={() => deleteAsset(asset)} type="button">
           Discard
         </button>
@@ -812,6 +1253,10 @@ function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, updateAssetSt
         <div>
           <dt>Model</dt>
           <dd>{asset.recipe?.model ?? "Unknown"}</dd>
+        </div>
+        <div>
+          <dt>Duration</dt>
+          <dd>{asset.file?.duration ? `${asset.file.duration}s` : "Still"}</dd>
         </div>
         <div>
           <dt>Generation set</dt>
@@ -826,7 +1271,7 @@ function AssetCard({ asset, deleteAsset, onPreview, updateAssetStatus }) {
   return (
     <article className={asset.status?.rejected ? "review-card rejected" : "review-card"}>
       <button className="preview-button" onClick={() => onPreview(asset)} type="button">
-        <img alt="" src={assetUrl(asset)} />
+        <AssetMedia asset={asset} />
       </button>
       <div className="review-actions">
         <button onClick={() => updateAssetStatus(asset, { favorite: !asset.status?.favorite })} type="button">
@@ -850,7 +1295,7 @@ function FullscreenPreview({ asset, onClose }) {
         <button className="modal-close" onClick={onClose} type="button">
           Close
         </button>
-        {asset.type === "image" ? <img alt="" src={assetUrl(asset)} /> : <div>{asset.type}</div>}
+        <AssetMedia asset={asset} />
         <footer>
           <strong>{asset.displayName}</strong>
           <span>{asset.recipe?.model}</span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -366,15 +366,22 @@ button:disabled {
 }
 
 .asset-tile img,
+.asset-tile video,
 .preview-button img,
+.preview-button video,
 .review-card img,
-.preview-modal img {
+.review-card video,
+.preview-modal img,
+.preview-modal video,
+.tray-item img,
+.tray-item video {
   display: block;
   width: 100%;
   object-fit: cover;
 }
 
-.asset-tile img {
+.asset-tile img,
+.asset-tile video {
   aspect-ratio: 1;
   background: #191815;
 }
@@ -432,7 +439,8 @@ button:disabled {
   color: #f3f0e8;
 }
 
-.preview-button img {
+.preview-button img,
+.preview-button video {
   aspect-ratio: 16 / 11;
 }
 
@@ -490,6 +498,88 @@ button:disabled {
   opacity: 0.58;
 }
 
+.mode-control {
+  max-width: min(720px, 100%);
+}
+
+.video-layout {
+  grid-template-columns: minmax(320px, 460px) minmax(0, 1fr);
+}
+
+.guidance-strip,
+.inline-warning {
+  border: 1px solid #4b463d;
+  background: #191815;
+}
+
+.guidance-strip {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+}
+
+.guidance-strip span,
+.inline-warning {
+  color: #c7bfb2;
+  line-height: 1.45;
+}
+
+.inline-warning {
+  margin: 0;
+  padding: 10px;
+}
+
+.compact-panel {
+  min-height: auto;
+  padding: 12px;
+}
+
+.video-review {
+  align-content: start;
+}
+
+.video-review-grid {
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.asset-tray {
+  display: grid;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.tray-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.tray-item {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  min-height: 154px;
+  border: 1px solid #3c3a34;
+  background: #23221f;
+  color: #f3f0e8;
+  padding: 8px;
+  text-align: left;
+}
+
+.tray-item img,
+.tray-item video {
+  aspect-ratio: 16 / 10;
+  background: #191815;
+}
+
+.tray-item span {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 13px;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -510,7 +600,8 @@ button:disabled {
   background: #191815;
 }
 
-.preview-modal img {
+.preview-modal img,
+.preview-modal video {
   max-height: 78vh;
   object-fit: contain;
   background: #0f0f0e;

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -10,6 +10,7 @@ import httpx
 from .gpu import discover_gpu
 from .image_adapters import ProceduralImageAdapter
 from .settings import WorkerSettings
+from .video_adapters import ProceduralVideoAdapter
 
 
 def now() -> str:
@@ -43,7 +44,9 @@ def register_worker(api: ApiClient, settings: WorkerSettings, gpu: dict) -> None
         "workerId": settings.worker_id,
         "gpuId": gpu["id"],
         "gpuName": gpu["name"],
-        "capabilities": sorted(set([*gpu["capabilities"], "image_generate", "image_edit"])),
+        "capabilities": sorted(
+            set([*gpu["capabilities"], "image_generate", "image_edit", "video_generate", "video_extend", "video_bridge"])
+        ),
         "loadedModels": [],
     }
     worker = api.post("/api/v1/workers/register", payload)
@@ -187,6 +190,82 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
         heartbeat(api, settings, "idle")
 
 
+def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    job_id = job["id"]
+    adapter = ProceduralVideoAdapter()
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": status,
+                "stage": stage,
+                "progress": value,
+                "message": message,
+            },
+        )
+
+    try:
+        progress("preparing", "preparing", 0.06, "Preparing Video Studio request.")
+        request = adapter.prepare(settings=settings, job=job)
+        progress("loading_model", "loading_model", 0.14, "Resolving video adapter target.")
+        adapter.ensure_models(request)
+        requirements = adapter.estimate_requirements(request)
+        progress(
+            "running",
+            "estimating",
+            0.18,
+            f"Estimated {requirements['previewFrames']} preview frames for this clip.",
+        )
+        result = adapter.run(
+            settings=settings,
+            job=job,
+            request=request,
+            progress=progress,
+            cancel_requested=lambda: job_cancel_requested(api, job_id),
+        )
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "completed",
+                "stage": "completed",
+                "progress": 1,
+                "message": "Video generation asset saved.",
+                "result": result,
+            },
+        )
+    except InterruptedError as exc:
+        adapter.cancel(job_id)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "canceled",
+                "stage": "canceled",
+                "progress": 1,
+                "message": str(exc),
+            },
+        )
+    except Exception as exc:
+        adapter.cleanup(job_id)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "failed",
+                "stage": "failed",
+                "progress": 1,
+                "message": "Video generation failed.",
+                "error": str(exc),
+            },
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def main() -> None:
     settings = WorkerSettings()
     gpu = discover_gpu(settings.gpu_id)
@@ -214,6 +293,8 @@ def main() -> None:
                 run_placeholder_job(api, settings, job)
             elif job["type"] in ("image_generate", "image_edit"):
                 run_image_job(api, settings, job)
+            elif job["type"] in ("video_generate", "video_extend", "video_bridge"):
+                run_video_job(api, settings, job)
             else:
                 update_job(
                     api,

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import re
+from pathlib import Path
+from textwrap import wrap
+from typing import Any, Callable
+from uuid import uuid4
+
+from PIL import Image, ImageDraw, ImageEnhance, ImageFont
+
+from .image_adapters import find_project_path, index_project_db, write_json
+from .settings import WorkerSettings
+
+
+ProgressCallback = Callable[[str, str, float, str], None]
+CancelCallback = Callable[[], bool]
+
+
+VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
+    "ltx_2_3": {
+        "label": "LTX-2.3",
+        "family": "ltx-video",
+        "adapter": "ltx_video",
+        "capabilities": ["image_to_video", "text_to_video", "first_last_frame"],
+        "recommendedMaxDuration": 10,
+        "hardMaxDuration": 15,
+        "steps": {"fast": 6, "balanced": 8, "best": 20},
+        "durationHint": "Best as short shots. Start with 4-8 seconds; 10 seconds is the current workflow ceiling.",
+    },
+    "wan_2_2": {
+        "label": "Wan2.2",
+        "family": "wan-video",
+        "adapter": "wan_video",
+        "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "replace_person"],
+        "recommendedMaxDuration": 7,
+        "hardMaxDuration": 8,
+        "steps": {"fast": 12, "balanced": 20, "best": 30},
+        "durationHint": "Keep clips shorter until local looping behavior is validated.",
+    },
+}
+
+
+ASSET_FOLDERS = ("assets/images", "assets/videos", "assets/uploads", "assets/frames", "assets/renders")
+
+
+@dataclass(frozen=True)
+class VideoRequest:
+    project_id: str
+    mode: str
+    prompt: str
+    negative_prompt: str
+    model: str
+    duration: float
+    fps: int
+    width: int
+    height: int
+    quality: str
+    seed: int | None
+    loras: list[dict[str, Any]]
+    source_asset_id: str | None
+    last_frame_asset_id: str | None
+    source_clip_asset_id: str | None
+    advanced: dict[str, Any]
+
+
+class VideoGenerationAdapter(ABC):
+    id: str
+
+    @abstractmethod
+    def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
+        raise NotImplementedError
+
+    @abstractmethod
+    def ensure_models(self, request: VideoRequest) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def estimate_requirements(self, request: VideoRequest) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: VideoRequest,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def cancel(self, job_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def cleanup(self, job_id: str) -> None:
+        raise NotImplementedError
+
+
+class ProceduralVideoAdapter(VideoGenerationAdapter):
+    id = "procedural_video"
+
+    def __init__(self) -> None:
+        self._temporary_outputs: dict[str, list[Path]] = {}
+
+    def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
+        return video_request_from_job(job)
+
+    def ensure_models(self, request: VideoRequest) -> None:
+        target = model_target(request.model)
+        if request.mode not in target["capabilities"]:
+            raise RuntimeError(f"{target['label']} does not support {request.mode.replace('_', ' ')}.")
+        if request.duration > target["hardMaxDuration"]:
+            raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
+
+    def estimate_requirements(self, request: VideoRequest) -> dict[str, Any]:
+        pixels = request.width * request.height
+        raw_frames = max(1, int(round(request.duration * request.fps)))
+        return {
+            "estimatedFrames": raw_frames,
+            "previewFrames": preview_frame_count(request),
+            "pixelCount": pixels,
+            "recommendedMaxDuration": model_target(request.model)["recommendedMaxDuration"],
+            "gpuPreference": request.advanced.get("gpuPreference", "auto"),
+        }
+
+    def run(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: VideoRequest,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        project_path = find_project_path(settings, request.project_id)
+        for folder in ("assets/videos", "generation-sets", "recipes"):
+            (project_path / folder).mkdir(parents=True, exist_ok=True)
+
+        generation_set_id = f"genset_{uuid4().hex}"
+        asset_id = f"asset_{uuid4().hex}"
+        created_at = utc_now()
+        seed = resolve_seed(request.seed, request.prompt)
+        target = model_target(request.model)
+        raw_settings = self.map_settings(request, target)
+        filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt)}"
+        media_rel = f"assets/videos/{filename_base}.webp"
+        media_path = project_path / media_rel
+        temp_path = media_path.with_suffix(".tmp.webp")
+        self._temporary_outputs.setdefault(job["id"], []).append(temp_path)
+
+        first_image = load_source_image(project_path, request.source_asset_id, request.width, request.height)
+        last_image = load_source_image(project_path, request.last_frame_asset_id, request.width, request.height)
+        if cancel_requested():
+            raise InterruptedError("Video generation canceled before rendering.")
+
+        frames = render_preview_frames(request, target, seed, first_image, last_image, progress, cancel_requested)
+        save_animated_preview(frames, temp_path, request.duration)
+        temp_path.replace(media_path)
+
+        sidecar_path = media_path.with_suffix(".sceneworks.json")
+        generation_set = {
+            "schemaVersion": 1,
+            "id": generation_set_id,
+            "projectId": request.project_id,
+            "jobId": job["id"],
+            "mode": request.mode,
+            "model": request.model,
+            "prompt": request.prompt,
+            "negativePrompt": request.negative_prompt,
+            "count": 1,
+            "createdAt": created_at,
+        }
+        asset = build_video_asset_sidecar(
+            asset_id=asset_id,
+            project_id=request.project_id,
+            generation_set_id=generation_set_id,
+            request=request,
+            job_id=job["id"],
+            media_rel=media_rel,
+            created_at=created_at,
+            seed=seed,
+            target=target,
+            raw_settings=raw_settings,
+        )
+
+        progress("saving", "saving", 0.9, "Saving video asset and recipe.")
+        if cancel_requested():
+            media_path.unlink(missing_ok=True)
+            raise InterruptedError("Video generation canceled before asset promotion.")
+
+        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
+        write_json(sidecar_path, asset)
+        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
+        index_project_db(project_path, asset)
+        return {
+            "generationSetId": generation_set_id,
+            "assetIds": [asset_id],
+            "assets": [asset],
+            "adapter": self.id,
+            "model": request.model,
+            "requirements": self.estimate_requirements(request),
+        }
+
+    def cancel(self, job_id: str) -> None:
+        self.cleanup(job_id)
+
+    def cleanup(self, job_id: str) -> None:
+        for path in self._temporary_outputs.pop(job_id, []):
+            path.unlink(missing_ok=True)
+
+    def map_settings(self, request: VideoRequest, target: dict[str, Any]) -> dict[str, Any]:
+        steps = target["steps"].get(request.quality, target["steps"]["balanced"])
+        return {
+            **request.advanced,
+            "adapterFamily": target["family"],
+            "targetAdapter": target["adapter"],
+            "steps": steps,
+            "frameCount": max(1, int(round(request.duration * request.fps))),
+            "previewFrameCount": preview_frame_count(request),
+            "recommendedMaxDuration": target["recommendedMaxDuration"],
+            "previewRenderer": True,
+        }
+
+
+def video_request_from_job(job: dict[str, Any]) -> VideoRequest:
+    payload = job["payload"]
+    width, height = normalized_dimensions(payload.get("width", 768), payload.get("height", 512))
+    return VideoRequest(
+        project_id=payload["projectId"],
+        mode=payload.get("mode", "image_to_video"),
+        prompt=payload.get("prompt", ""),
+        negative_prompt=payload.get("negativePrompt", ""),
+        model=payload.get("model", "ltx_2_3"),
+        duration=safe_float(payload.get("duration"), 6, 1, 30),
+        fps=safe_int(payload.get("fps"), 25, 1, 60),
+        width=width,
+        height=height,
+        quality=payload.get("quality", "balanced"),
+        seed=payload.get("seed"),
+        loras=payload.get("loras", []),
+        source_asset_id=payload.get("sourceAssetId"),
+        last_frame_asset_id=payload.get("lastFrameAssetId"),
+        source_clip_asset_id=payload.get("sourceClipAssetId"),
+        advanced=payload.get("advanced", {}),
+    )
+
+
+def model_target(model_id: str) -> dict[str, Any]:
+    return VIDEO_MODEL_TARGETS.get(model_id, VIDEO_MODEL_TARGETS["ltx_2_3"])
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
+    return (slug or "video")[:42]
+
+
+def safe_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def safe_float(value: Any, default: float, minimum: float, maximum: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def normalized_dimensions(width: Any, height: Any) -> tuple[int, int]:
+    parsed_width = safe_int(width, 768, 256, 1920)
+    parsed_height = safe_int(height, 512, 256, 1920)
+    return max(256, parsed_width - (parsed_width % 32)), max(256, parsed_height - (parsed_height % 32))
+
+
+def resolve_seed(seed: int | None, prompt: str) -> int:
+    if seed is not None:
+        return int(seed)
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16)
+
+
+def preview_frame_count(request: VideoRequest) -> int:
+    raw_frames = int(round(request.duration * request.fps))
+    if request.quality == "fast":
+        return max(12, min(40, raw_frames // 2))
+    if request.quality == "best":
+        return max(18, min(80, raw_frames))
+    return max(16, min(60, raw_frames))
+
+
+def load_source_image(project_path: Path, asset_id: str | None, width: int, height: int) -> Image.Image | None:
+    if not asset_id:
+        return None
+    for folder in ASSET_FOLDERS:
+        for sidecar_path in (project_path / folder).glob("*.sceneworks.json"):
+            try:
+                import json
+
+                payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if payload.get("id") != asset_id:
+                continue
+            media_path = project_path / payload.get("file", {}).get("path", "")
+            try:
+                image = Image.open(media_path).convert("RGB")
+            except OSError:
+                return None
+            image.thumbnail((width, height), Image.Resampling.LANCZOS)
+            canvas = Image.new("RGB", (width, height), (18, 17, 15))
+            canvas.paste(image, ((width - image.width) // 2, (height - image.height) // 2))
+            return canvas
+    return None
+
+
+def render_preview_frames(
+    request: VideoRequest,
+    target: dict[str, Any],
+    seed: int,
+    first_image: Image.Image | None,
+    last_image: Image.Image | None,
+    progress: ProgressCallback,
+    cancel_requested: CancelCallback,
+) -> list[Image.Image]:
+    frame_count = preview_frame_count(request)
+    digest = hashlib.sha256(f"{request.prompt}:{request.mode}:{seed}".encode("utf-8")).digest()
+    base = first_image or gradient_frame(request.width, request.height, digest)
+    end = last_image or ImageEnhance.Color(base.copy()).enhance(1.35)
+    frames: list[Image.Image] = []
+
+    for index in range(frame_count):
+        if cancel_requested():
+            raise InterruptedError("Video generation canceled by user.")
+
+        t = index / max(1, frame_count - 1)
+        frame = Image.blend(base, end, t * 0.55 if last_image else t * 0.24)
+        draw_motion(frame, digest, index, frame_count)
+        draw_caption(frame, request, target, seed, index, frame_count)
+        frames.append(frame)
+        if index % max(1, frame_count // 8) == 0 or index == frame_count - 1:
+            progress("running", "generating", 0.2 + ((index + 1) / frame_count) * 0.62, "Rendering preview clip frames.")
+    return frames
+
+
+def gradient_frame(width: int, height: int, digest: bytes) -> Image.Image:
+    base = (digest[0], digest[1], digest[2])
+    accent = (digest[10], digest[11], digest[12])
+    image = Image.new("RGB", (width, height), base)
+    pixels = image.load()
+    for y in range(height):
+        for x in range(width):
+            mix = (x / max(1, width - 1) * 0.58) + (y / max(1, height - 1) * 0.42)
+            wave = ((x * digest[3] + y * digest[4]) % 255) / 255
+            pixels[x, y] = tuple(
+                int(base[channel] * (1 - mix) + accent[channel] * mix * 0.88 + wave * 28)
+                for channel in range(3)
+            )
+    return image
+
+
+def draw_motion(frame: Image.Image, digest: bytes, index: int, frame_count: int) -> None:
+    draw = ImageDraw.Draw(frame, "RGBA")
+    width, height = frame.size
+    t = index / max(1, frame_count - 1)
+    sweep_x = int((width + 180) * t) - 120
+    draw.rectangle((sweep_x, 0, sweep_x + 70, height), fill=(255, 255, 255, 26))
+    draw.ellipse(
+        (
+            int(width * (0.18 + 0.58 * t)),
+            int(height * (0.22 + (digest[5] % 20) / 100)),
+            int(width * (0.3 + 0.58 * t)),
+            int(height * (0.34 + (digest[6] % 20) / 100)),
+        ),
+        outline=(110, 198, 184, 150),
+        width=max(2, width // 220),
+    )
+    draw.line(
+        (
+            int(width * 0.08),
+            int(height * (0.78 - t * 0.16)),
+            int(width * 0.92),
+            int(height * (0.68 + t * 0.12)),
+        ),
+        fill=(248, 215, 140, 90),
+        width=max(2, width // 180),
+    )
+
+
+def draw_caption(
+    frame: Image.Image,
+    request: VideoRequest,
+    target: dict[str, Any],
+    seed: int,
+    index: int,
+    frame_count: int,
+) -> None:
+    draw = ImageDraw.Draw(frame, "RGBA")
+    width, height = frame.size
+    font = ImageFont.load_default()
+    draw.rectangle((0, 0, width, 72), fill=(12, 12, 12, 124))
+    draw.rectangle((0, int(height * 0.72), width, height), fill=(12, 12, 12, 156))
+    draw.text((24, 18), f"{target['label']} preview | {request.mode.replace('_', ' ')}", fill=(255, 244, 214, 255), font=font)
+    draw.text((24, 42), f"{request.duration:g}s {request.fps}fps {request.width}x{request.height} seed {seed}", fill=(194, 235, 226, 255), font=font)
+    draw.text((width - 92, 18), f"{index + 1}/{frame_count}", fill=(255, 255, 255, 220), font=font)
+
+    y = int(height * 0.74)
+    for line in wrap(request.prompt.strip() or "Untitled video prompt", width=max(28, width // 14))[:5]:
+        draw.text((24, y), line, fill=(255, 255, 255, 238), font=font)
+        y += 18
+
+
+def save_animated_preview(frames: list[Image.Image], path: Path, duration: float) -> None:
+    frame_ms = max(40, int((duration * 1000) / max(1, len(frames))))
+    frames[0].save(
+        path,
+        "WEBP",
+        save_all=True,
+        append_images=frames[1:],
+        duration=frame_ms,
+        loop=0,
+        quality=82,
+        method=4,
+    )
+
+
+def build_video_asset_sidecar(
+    *,
+    asset_id: str,
+    project_id: str,
+    generation_set_id: str,
+    request: VideoRequest,
+    job_id: str,
+    media_rel: str,
+    created_at: str,
+    seed: int,
+    target: dict[str, Any],
+    raw_settings: dict[str, Any],
+) -> dict[str, Any]:
+    parents = [asset_id for asset_id in [request.source_asset_id, request.last_frame_asset_id, request.source_clip_asset_id] if asset_id]
+    return {
+        "schemaVersion": 1,
+        "id": asset_id,
+        "projectId": project_id,
+        "generationSetId": generation_set_id,
+        "type": "video",
+        "displayName": f"{request.prompt[:56] or 'Generated video'}",
+        "createdAt": created_at,
+        "file": {
+            "path": media_rel,
+            "mimeType": "image/webp",
+            "width": request.width,
+            "height": request.height,
+            "duration": request.duration,
+            "fps": request.fps,
+        },
+        "status": {
+            "favorite": False,
+            "rating": 0,
+            "rejected": False,
+            "trashed": False,
+        },
+        "recipe": {
+            "mode": request.mode,
+            "model": request.model,
+            "adapter": "procedural_video",
+            "prompt": request.prompt,
+            "negativePrompt": request.negative_prompt,
+            "seed": seed,
+            "loras": request.loras,
+            "normalizedSettings": {
+                "duration": request.duration,
+                "fps": request.fps,
+                "width": request.width,
+                "height": request.height,
+                "quality": request.quality,
+                "family": target["family"],
+                "sourceAssetId": request.source_asset_id,
+                "lastFrameAssetId": request.last_frame_asset_id,
+                "sourceClipAssetId": request.source_clip_asset_id,
+            },
+            "rawAdapterSettings": raw_settings,
+        },
+        "lineage": {
+            "parents": parents,
+            "sourceAssetId": request.source_asset_id,
+            "lastFrameAssetId": request.last_frame_asset_id,
+            "sourceClipAssetId": request.source_clip_asset_id,
+            "sourceTimestamp": None,
+            "jobId": job_id,
+        },
+    }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -111,6 +111,90 @@
         "description": "Higher-control image edit target kept behind the same adapter contract.",
         "recommendedFor": ["edit_image"]
       }
+    },
+    {
+      "id": "ltx_2_3",
+      "name": "LTX-2.3",
+      "family": "ltx-video",
+      "type": "video",
+      "adapter": "ltx_video",
+      "capabilities": ["image_to_video", "text_to_video", "first_last_frame"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "Lightricks/LTX-2.3",
+          "files": []
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/Lightricks/LTX-2.3"
+      },
+      "defaults": {
+        "duration": 6,
+        "fps": 25,
+        "resolution": "768x512",
+        "quality": "balanced",
+        "steps": 8
+      },
+      "limits": {
+        "durations": [4, 6, 8, 10, 12, 15],
+        "recommendedMaxDuration": 10,
+        "hardMaxDuration": 15,
+        "fps": [24, 25, 30],
+        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+        "requiresDimensionsMultipleOf": 32
+      },
+      "loraCompatibility": {
+        "families": ["ltx-video"],
+        "types": ["style", "motion", "character", "enhance"]
+      },
+      "ui": {
+        "label": "LTX-2.3",
+        "description": "First-class short-shot video target for image-to-video and text-to-video.",
+        "recommendedFor": ["image_to_video", "text_to_video", "first_last_frame"],
+        "durationHint": "Best for short clips. Start with 4-8 seconds; 10 seconds is the normal ceiling for the current workflow."
+      }
+    },
+    {
+      "id": "wan_2_2",
+      "name": "Wan2.2",
+      "family": "wan-video",
+      "type": "video",
+      "adapter": "wan_video",
+      "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "replace_person"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "Wan-AI/Wan2.2-TI2V-5B",
+          "files": []
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/Wan-AI/Wan2.2-TI2V-5B"
+      },
+      "defaults": {
+        "duration": 5,
+        "fps": 24,
+        "resolution": "1280x720",
+        "quality": "balanced"
+      },
+      "limits": {
+        "durations": [4, 5, 6, 7, 8],
+        "recommendedMaxDuration": 7,
+        "hardMaxDuration": 8,
+        "fps": [16, 24],
+        "resolutions": ["832x480", "1280x720", "720x1280"]
+      },
+      "loraCompatibility": {
+        "families": ["wan-video"],
+        "types": ["style", "motion", "character", "enhance"]
+      },
+      "ui": {
+        "label": "Wan2.2",
+        "description": "Fallback video family kept behind the adapter contract for future runtime support.",
+        "recommendedFor": ["image_to_video", "text_to_video"],
+        "durationHint": "Use shorter clips until local looping behavior is validated."
+      }
     }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
-      SCENEWORKS_CORS_ORIGINS: ${SCENEWORKS_CORS_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173}
+      SCENEWORKS_CORS_ORIGINS: ${SCENEWORKS_CORS_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176}
     ports:
       - "8000:8000"
     volumes:

--- a/documents/VIDEO_MODEL_RESEARCH.md
+++ b/documents/VIDEO_MODEL_RESEARCH.md
@@ -1,0 +1,43 @@
+# SceneWorks Video Model Research
+
+Use `ltx_2_3` as the first SceneWorks video target, with Wan2.2 present as the next fallback family once the adapter boundary can host multiple runtimes.
+
+## Recommendation
+
+- First adapter: LTX-2.3.
+- Runtime path: start with the official Lightricks PyTorch/ComfyUI-compatible path and keep the worker contract isolated behind a SceneWorks adapter.
+- First shipped implementation in this repo: `procedural_video`, which produces deterministic preview clips while exercising the real Video Studio, job, recipe, lineage, and Library asset contracts.
+- Fallback family: Wan2.2, exposed in the manifest so UI and payload settings can already express Wan-aware limits.
+
+## Why LTX-2.3 First
+
+- Lightricks documents LTX-2.3 as an open-weights DiT audio-video model with multimodal inputs including text, image, video, audio, depth, and LoRA-based customization.
+- The Hugging Face model card provides the practical local entry point, model IDs, checkpoint variants, and PyTorch repository requirements.
+- The official usage guides support both image-to-video and text-to-video, with resolution and frame count guidance that maps well to SceneWorks controls.
+- It is a better first SceneWorks target than Wan2.2 for the current product slice because it supports a single family for I2V, T2V, first/last-frame style conditioning, and future audio-aware workflows.
+
+## Encoded Product Limits
+
+- Keep SceneWorks oriented around short shots assembled later in the editor.
+- Simple UI should recommend 4-8 seconds for fast iteration and keep 10 seconds as the normal LTX-2.3 ceiling.
+- The broader product assumption from the plan says LTX2.3 is best at 15 seconds or less. Current official guides list 257 frames, roughly 10 seconds at 25fps, for the common I2V/T2V workflows, so the UI should favor 10 seconds for now and reserve longer durations for future adapter-specific support.
+- Resolution dimensions must be divisible by 32 for LTX-2.3. Favor 768x512, 640x640, 1280x720, and 720x1280 presets.
+- FPS controls should default to 25fps for LTX-2.3, with 24fps and 30fps available in advanced mode.
+- Quality should map to raw adapter settings:
+  - Fast: fewer frames/steps for iteration.
+  - Balanced: default distilled settings.
+  - Best: higher step budget and future multiscale/upscale path.
+
+## Wan2.2 Notes
+
+- Wan2.2 has official T2V, I2V, TI2V, and S2V model entries with 480P/720P support.
+- Wan2.2 is valuable as a fallback and later adapter because it has broad video modes and Diffusers/ComfyUI ecosystem support.
+- Keep Wan-aware UI guidance conservative: shorter clips around 5-7 seconds are recommended until local looping behavior is validated against the exact runtime.
+
+## Sources
+
+- LTX open source overview: https://docs.ltx.video/open-source-model/getting-started/overview
+- LTX-2.3 Hugging Face model card: https://huggingface.co/Lightricks/LTX-2.3
+- LTX image-to-video guide: https://docs.ltx.video/open-source-model/usage-guides/image-to-video
+- LTX text-to-video guide: https://docs.ltx.video/open-source-model/usage-guides/text-to-video
+- Wan2.2 Hugging Face model card: https://huggingface.co/Wan-AI/Wan2.2-S2V-14B


### PR DESCRIPTION
## What changed

- Adds first-video-model research and manifest entries for LTX-2.3 and Wan2.2.
- Adds /api/v1/video/jobs with validated Video Studio payloads.
- Adds a video generation adapter boundary with prepare, model checks, requirement estimates, run, cancel, cleanup, progress, cancellation, recipe, lineage, and asset promotion behavior.
- Wires the worker to video_generate jobs and emits deterministic animated preview clips as video assets while the real model runtime remains isolated behind the adapter.
- Replaces the Video placeholder with mode-aware Video Studio controls for I2V, T2V, FFLF, extension, replacement placeholder, duration, quality, resolution, FPS, model, seed, negative prompt, GPU, review, and asset tray.
- Improves media preview handling for future MP4-style video assets and current animated preview assets.

## Why

This lands the Phase 8-9 vertical slice for the SceneWorks video epic without entangling UI/API/job/asset contracts with a heavyweight model runtime. LTX-2.3 is the recommended first real adapter target based on current official docs, with Wan2.2 represented as the next adapter family.

## Validation

- npm run check
- npm --workspace apps/web run build
- python -m compileall apps/api apps/worker
- Worker adapter smoke test generated a video asset sidecar and animated preview clip.
- In-app browser verified Video Studio loads against the API with model-aware controls and no fetch error.
