### PR TITLE
[codex] Add editor timelines and MP4 export

### DIFF
--- a/apps/api/sceneworks_api/main.py
+++ b/apps/api/sceneworks_api/main.py
@@ -9,6 +9,7 @@ from .models import router as models_router
 from .projects import ensure_data_dirs, router as projects_router
 from .security import access_control_middleware
 from .settings import Settings, get_settings
+from .timelines import router as timelines_router
 from .video_generation import router as video_router
 
 
@@ -73,6 +74,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(projects_router, prefix="/api/v1")
     app.include_router(assets_router, prefix="/api/v1")
     app.include_router(models_router, prefix="/api/v1")
+    app.include_router(timelines_router, prefix="/api/v1")
     app.include_router(image_router, prefix="/api/v1")
     app.include_router(video_router, prefix="/api/v1")
     app.include_router(jobs_router, prefix="/api/v1")

--- a/apps/api/sceneworks_api/projects.py
+++ b/apps/api/sceneworks_api/projects.py
@@ -117,6 +117,22 @@ def create_project_db(project_path: Path) -> None:
             )
             """
         )
+        connection.execute(
+            """
+            create table if not exists timelines (
+              id text primary key,
+              name text not null,
+              file_path text not null,
+              aspect_ratio text not null,
+              width integer not null,
+              height integer not null,
+              fps integer not null,
+              duration real not null default 0,
+              created_at text not null,
+              updated_at text not null
+            )
+            """
+        )
 
 
 def write_project_file(settings: Settings, project_path: Path, project_id: str, name: str) -> dict:

--- a/apps/api/sceneworks_api/timelines.py
+++ b/apps/api/sceneworks_api/timelines.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Literal
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field, model_validator
+
+from .jobs import queue_summary
+from .projects import find_project_path
+
+
+router = APIRouter(prefix="/projects/{project_id}/timelines", tags=["timelines"])
+
+AspectRatio = Literal["16:9", "9:16", "1:1"]
+TrackKind = Literal["video", "overlay", "audio"]
+TimelineItemKind = Literal["video", "image", "audio"]
+TransitionKind = Literal["cut", "crossfade", "fade_from_black", "fade_to_black"]
+
+ASPECT_DIMENSIONS = {
+    "16:9": (1280, 720),
+    "9:16": (720, 1280),
+    "1:1": (1024, 1024),
+}
+
+
+class Transition(BaseModel):
+    id: str = Field(default_factory=lambda: f"transition_{uuid4().hex}")
+    type: TransitionKind = "cut"
+    fromItemId: str | None = None
+    toItemId: str | None = None
+    duration: float = Field(default=0, ge=0, le=10)
+
+
+class TimelineItem(BaseModel):
+    id: str = Field(default_factory=lambda: f"item_{uuid4().hex}")
+    trackId: str
+    assetId: str = Field(min_length=1)
+    type: TimelineItemKind = "video"
+    displayName: str = Field(min_length=1, max_length=160)
+    sourceIn: float = Field(default=0, ge=0)
+    sourceOut: float = Field(default=4, gt=0)
+    timelineStart: float = Field(default=0, ge=0)
+    timelineEnd: float = Field(default=4, gt=0)
+    speed: float = Field(default=1, ge=0.1, le=8)
+    fit: Literal["fit", "fill", "stretch"] = "fit"
+    volume: float = Field(default=1, ge=0, le=2)
+    versionAssetIds: list[str] = Field(default_factory=list)
+    transitionIn: Transition | None = None
+    transitionOut: Transition | None = None
+
+    @model_validator(mode="after")
+    def validate_ranges(self) -> "TimelineItem":
+        if self.sourceOut <= self.sourceIn:
+            raise ValueError("sourceOut must be greater than sourceIn.")
+        if self.timelineEnd <= self.timelineStart:
+            raise ValueError("timelineEnd must be greater than timelineStart.")
+        return self
+
+
+class TimelineTrack(BaseModel):
+    id: str
+    name: str
+    kind: TrackKind
+    locked: bool = False
+    muted: bool = False
+    items: list[TimelineItem] = Field(default_factory=list)
+
+
+class TimelineDocument(BaseModel):
+    schemaVersion: int = 1
+    id: str = Field(default_factory=lambda: f"timeline_{uuid4().hex}")
+    projectId: str
+    name: str = Field(min_length=1, max_length=120)
+    aspectRatio: AspectRatio = "16:9"
+    width: int = Field(default=1280, ge=256, le=3840)
+    height: int = Field(default=720, ge=256, le=3840)
+    fps: int = Field(default=30, ge=1, le=60)
+    duration: float = Field(default=0, ge=0)
+    tracks: list[TimelineTrack] = Field(default_factory=list)
+    transitions: list[Transition] = Field(default_factory=list)
+    createdAt: str | None = None
+    updatedAt: str | None = None
+
+
+class TimelineCreateRequest(BaseModel):
+    name: str = Field(default="Main timeline", min_length=1, max_length=120)
+    aspectRatio: AspectRatio = "16:9"
+    fps: int = Field(default=30, ge=1, le=60)
+
+
+class TimelineSaveRequest(BaseModel):
+    timeline: TimelineDocument
+
+
+class TimelineExportRequest(BaseModel):
+    resolution: int = Field(default=720)
+    fps: int = Field(default=30, ge=1, le=60)
+    requestedGpu: str = "auto"
+
+    @model_validator(mode="after")
+    def validate_resolution(self) -> "TimelineExportRequest":
+        if self.resolution not in {640, 720, 1024, 1280}:
+            raise ValueError("Resolution must be one of 640, 720, 1024, or 1280.")
+        return self
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
+    return (slug or "timeline")[:48]
+
+
+def timeline_file_path(project_path: Path, timeline_id: str, name: str) -> Path:
+    return project_path / "timelines" / f"{slugify(name)}-{timeline_id[-8:]}.sceneworks.timeline.json"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def ensure_timeline_db(project_path: Path) -> None:
+    with sqlite3.connect(project_path / "project.db") as connection:
+        connection.execute(
+            """
+            create table if not exists timelines (
+              id text primary key,
+              name text not null,
+              file_path text not null,
+              aspect_ratio text not null,
+              width integer not null,
+              height integer not null,
+              fps integer not null,
+              duration real not null default 0,
+              created_at text not null,
+              updated_at text not null
+            )
+            """
+        )
+
+
+def default_tracks() -> list[TimelineTrack]:
+    return [
+        TimelineTrack(id="track_main", name="Main", kind="video"),
+        TimelineTrack(id="track_overlay", name="Overlay", kind="overlay"),
+        TimelineTrack(id="track_audio", name="Audio", kind="audio"),
+    ]
+
+
+def compute_duration(timeline: TimelineDocument) -> float:
+    ends = [item.timelineEnd for track in timeline.tracks for item in track.items]
+    return max(ends, default=0)
+
+
+def index_timeline(project_path: Path, timeline: TimelineDocument, rel_path: str) -> None:
+    ensure_timeline_db(project_path)
+    with sqlite3.connect(project_path / "project.db") as connection:
+        connection.execute(
+            """
+            insert or replace into timelines (
+              id, name, file_path, aspect_ratio, width, height, fps, duration, created_at, updated_at
+            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                timeline.id,
+                timeline.name,
+                rel_path,
+                timeline.aspectRatio,
+                timeline.width,
+                timeline.height,
+                timeline.fps,
+                timeline.duration,
+                timeline.createdAt,
+                timeline.updatedAt,
+            ),
+        )
+
+
+def find_timeline_file(project_path: Path, timeline_id: str) -> Path:
+    ensure_timeline_db(project_path)
+    with sqlite3.connect(project_path / "project.db") as connection:
+        row = connection.execute("select file_path from timelines where id = ?", (timeline_id,)).fetchone()
+    if row is not None:
+        path = project_path / row[0]
+        if path.exists():
+            return path
+    for candidate in (project_path / "timelines").glob("*.sceneworks.timeline.json"):
+        try:
+            if read_json(candidate).get("id") == timeline_id:
+                return candidate
+        except (OSError, json.JSONDecodeError):
+            continue
+    raise HTTPException(status_code=404, detail="Timeline not found")
+
+
+def save_timeline(project_path: Path, timeline: TimelineDocument) -> TimelineDocument:
+    now = utc_now()
+    if timeline.createdAt is None:
+        timeline.createdAt = now
+    timeline.updatedAt = now
+    timeline.duration = compute_duration(timeline)
+    if not timeline.tracks:
+        timeline.tracks = default_tracks()
+    path = timeline_file_path(project_path, timeline.id, timeline.name)
+    rel_path = str(path.relative_to(project_path)).replace("\\", "/")
+    write_json(path, timeline.model_dump())
+    index_timeline(project_path, timeline, rel_path)
+    return timeline
+
+
+@router.get("")
+def list_timelines(project_id: str, request: Request) -> list[dict[str, Any]]:
+    project_path = find_project_path(request.app.state.settings, project_id)
+    ensure_timeline_db(project_path)
+    with sqlite3.connect(project_path / "project.db") as connection:
+        rows = connection.execute(
+            """
+            select id, name, file_path, aspect_ratio, width, height, fps, duration, created_at, updated_at
+              from timelines
+             order by updated_at desc
+            """
+        ).fetchall()
+    return [
+        {
+            "id": row[0],
+            "name": row[1],
+            "filePath": row[2],
+            "aspectRatio": row[3],
+            "width": row[4],
+            "height": row[5],
+            "fps": row[6],
+            "duration": row[7],
+            "createdAt": row[8],
+            "updatedAt": row[9],
+        }
+        for row in rows
+    ]
+
+
+@router.post("", status_code=201)
+def create_timeline(project_id: str, payload: TimelineCreateRequest, request: Request) -> TimelineDocument:
+    project_path = find_project_path(request.app.state.settings, project_id)
+    width, height = ASPECT_DIMENSIONS[payload.aspectRatio]
+    timeline = TimelineDocument(
+        projectId=project_id,
+        name=payload.name,
+        aspectRatio=payload.aspectRatio,
+        width=width,
+        height=height,
+        fps=payload.fps,
+        tracks=default_tracks(),
+    )
+    return save_timeline(project_path, timeline)
+
+
+@router.get("/{timeline_id}")
+def get_timeline(project_id: str, timeline_id: str, request: Request) -> dict[str, Any]:
+    project_path = find_project_path(request.app.state.settings, project_id)
+    return read_json(find_timeline_file(project_path, timeline_id))
+
+
+@router.put("/{timeline_id}")
+def update_timeline(
+    project_id: str,
+    timeline_id: str,
+    payload: TimelineSaveRequest,
+    request: Request,
+) -> TimelineDocument:
+    project_path = find_project_path(request.app.state.settings, project_id)
+    timeline = payload.timeline
+    if timeline_id != timeline.id:
+        raise HTTPException(status_code=400, detail="Timeline ID mismatch")
+    if timeline.projectId != project_id:
+        raise HTTPException(status_code=400, detail="Project ID mismatch")
+    return save_timeline(project_path, timeline)
+
+
+@router.post("/{timeline_id}/exports", status_code=201)
+def create_timeline_export(
+    project_id: str,
+    timeline_id: str,
+    payload: TimelineExportRequest,
+    request: Request,
+) -> dict:
+    project_path = find_project_path(request.app.state.settings, project_id)
+    timeline_path = find_timeline_file(project_path, timeline_id)
+    timeline = read_json(timeline_path)
+    job = request.app.state.jobs_store.create_job(
+        job_type="timeline_export",
+        project_id=project_id,
+        project_name=None,
+        payload={
+            "projectId": project_id,
+            "timelineId": timeline_id,
+            "timelineName": timeline.get("name", "Timeline"),
+            "timelinePath": str(timeline_path.relative_to(project_path)).replace("\\", "/"),
+            "resolution": payload.resolution,
+            "fps": payload.fps,
+        },
+        requested_gpu=payload.requestedGpu,
+    )
+    request.app.state.event_hub.publish("job.updated", job)
+    request.app.state.event_hub.publish("queue.updated", queue_summary(request))
+    return job

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -96,7 +96,7 @@ function AssetMedia({ asset, className = "" }) {
     return null;
   }
   const src = assetUrl(asset);
-  if (asset.type === "video" && asset.file?.mimeType?.startsWith("video/")) {
+  if (asset.file?.mimeType?.startsWith("video/")) {
     return <video className={className} controls muted playsInline src={src} />;
   }
   if (assetCanRenderAsImage(asset)) {
@@ -122,6 +122,49 @@ function percent(value) {
   return `${Math.round((value ?? 0) * 100)}%`;
 }
 
+const aspectOptions = {
+  "16:9": { width: 1280, height: 720, label: "16:9" },
+  "9:16": { width: 720, height: 1280, label: "9:16" },
+  "1:1": { width: 1024, height: 1024, label: "1:1" },
+};
+const transitionOptions = ["cut", "crossfade", "fade_from_black", "fade_to_black"];
+const speedPresets = [0.25, 0.5, 1, 2];
+
+function createLocalTimeline(project, name = "Main timeline", aspectRatio = "16:9") {
+  const dimensions = aspectOptions[aspectRatio] ?? aspectOptions["16:9"];
+  return {
+    schemaVersion: 1,
+    id: `timeline_${crypto.randomUUID().replaceAll("-", "")}`,
+    projectId: project.id,
+    name,
+    aspectRatio,
+    width: dimensions.width,
+    height: dimensions.height,
+    fps: 30,
+    duration: 0,
+    tracks: [
+      { id: "track_main", name: "Main", kind: "video", locked: false, muted: false, items: [] },
+      { id: "track_overlay", name: "Overlay", kind: "overlay", locked: false, muted: false, items: [] },
+      { id: "track_audio", name: "Audio", kind: "audio", locked: false, muted: false, items: [] },
+    ],
+    transitions: [],
+    createdAt: null,
+    updatedAt: null,
+  };
+}
+
+function timelineDuration(timeline) {
+  return Math.max(0, ...timeline.tracks.flatMap((track) => track.items.map((item) => Number(item.timelineEnd) || 0)));
+}
+
+function itemDuration(item) {
+  return Math.max(0.1, Number(item.timelineEnd) - Number(item.timelineStart));
+}
+
+function trackItems(track) {
+  return [...track.items].sort((a, b) => a.timelineStart - b.timelineStart);
+}
+
 function App() {
   const [health, setHealth] = useState(null);
   const [access, setAccess] = useState({ authRequired: false });
@@ -134,6 +177,9 @@ function App() {
   const [workers, setWorkers] = useState([]);
   const [models, setModels] = useState([]);
   const [assets, setAssets] = useState([]);
+  const [timelines, setTimelines] = useState([]);
+  const [selectedTimelineId, setSelectedTimelineId] = useState(null);
+  const [activeTimeline, setActiveTimeline] = useState(null);
   const [selectedAssetId, setSelectedAssetId] = useState(null);
   const [projectFilter, setProjectFilter] = useState("all");
   const [requestedGpu, setRequestedGpu] = useState("auto");
@@ -183,6 +229,10 @@ function App() {
     const ids = workers.map((worker) => worker.gpuId).filter(Boolean);
     return ["auto", ...Array.from(new Set(ids))];
   }, [workers]);
+  const mediaAssets = useMemo(
+    () => assets.filter((asset) => ["image", "video", "upload", "frame", "render"].includes(asset.type)),
+    [assets],
+  );
 
   useEffect(() => {
     apiFetch("/api/v1/health", "")
@@ -204,10 +254,21 @@ function App() {
   useEffect(() => {
     if (!activeProject || !authenticated) {
       setAssets([]);
+      setTimelines([]);
+      setSelectedTimelineId(null);
+      setActiveTimeline(null);
       return;
     }
     refreshAssets(activeProject.id);
+    refreshTimelines(activeProject.id);
   }, [activeProject?.id, authenticated, token]);
+
+  useEffect(() => {
+    if (!activeProject || !selectedTimelineId) {
+      return;
+    }
+    loadTimeline(activeProject.id, selectedTimelineId);
+  }, [activeProject?.id, selectedTimelineId]);
 
   useEffect(() => {
     if (!authenticated) {
@@ -218,8 +279,10 @@ function App() {
     events.addEventListener("job.updated", (event) => {
       const job = JSON.parse(event.data);
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      if (job.status === "completed" && job.result?.generationSetId) {
-        setLatestGenerationSetId(job.result.generationSetId);
+      if (job.status === "completed" && (job.result?.generationSetId || job.result?.assetIds?.length)) {
+        if (job.result?.generationSetId) {
+          setLatestGenerationSetId(job.result.generationSetId);
+        }
         if (job.projectId) {
           refreshAssets(job.projectId);
         }
@@ -264,6 +327,94 @@ function App() {
       setAssets(items);
       setSelectedAssetId((current) => current ?? items[0]?.id ?? null);
       setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function refreshTimelines(projectId = activeProject?.id) {
+    if (!projectId) {
+      return;
+    }
+    try {
+      const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token);
+      setTimelines(items);
+      setSelectedTimelineId((current) => current ?? items[0]?.id ?? null);
+      if (!items.length) {
+        setActiveTimeline(null);
+      }
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function loadTimeline(projectId, timelineId) {
+    try {
+      const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
+      setActiveTimeline(timeline);
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function createTimeline(payload) {
+    if (!activeProject) {
+      setError("Create or open a project first.");
+      return null;
+    }
+    try {
+      const created = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines`, token, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      setTimelines((items) => [created, ...items.filter((item) => item.id !== created.id)]);
+      setSelectedTimelineId(created.id);
+      setActiveTimeline(created);
+      setError("");
+      return created;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function saveTimeline(timeline) {
+    if (!activeProject || !timeline) {
+      return null;
+    }
+    try {
+      const saved = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}`, token, {
+        method: "PUT",
+        body: JSON.stringify({ timeline }),
+      });
+      setActiveTimeline(saved);
+      refreshTimelines(activeProject.id);
+      setError("");
+      return saved;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function exportTimeline(timeline, options) {
+    if (!activeProject || !timeline) {
+      return;
+    }
+    const saved = await saveTimeline(timeline);
+    if (!saved) {
+      return;
+    }
+    try {
+      await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${saved.id}/exports`, token, {
+        method: "POST",
+        body: JSON.stringify({ ...options, requestedGpu }),
+      });
+      setActiveView("Queue");
+      setError("");
+      refreshData();
     } catch (err) {
       setError(err.message);
     }
@@ -582,7 +733,24 @@ function App() {
           />
         ) : null}
 
-        {["Characters", "Editor"].includes(activeView) ? (
+        {activeView === "Editor" ? (
+          <EditorScreen
+            activeProject={activeProject}
+            activeTimeline={activeTimeline}
+            assets={mediaAssets}
+            createTimeline={createTimeline}
+            exportTimeline={exportTimeline}
+            onPreview={setPreviewAsset}
+            refreshAssets={refreshAssets}
+            saveTimeline={saveTimeline}
+            selectedTimelineId={selectedTimelineId}
+            setActiveTimeline={setActiveTimeline}
+            setSelectedTimelineId={setSelectedTimelineId}
+            timelines={timelines}
+          />
+        ) : null}
+
+        {activeView === "Characters" ? (
           <PlaceholderSurface activeView={activeView} assets={assets} createJob={createPlaceholderJob} />
         ) : null}
       </section>
@@ -1176,6 +1344,495 @@ function VideoStudio({
   );
 }
 
+function EditorScreen({
+  activeProject,
+  activeTimeline,
+  assets,
+  createTimeline,
+  exportTimeline,
+  onPreview,
+  saveTimeline,
+  selectedTimelineId,
+  setActiveTimeline,
+  setSelectedTimelineId,
+  timelines,
+}) {
+  const [newTimelineName, setNewTimelineName] = useState("Main timeline");
+  const [newAspectRatio, setNewAspectRatio] = useState("16:9");
+  const [selectedItemId, setSelectedItemId] = useState(null);
+  const [addDuration, setAddDuration] = useState(4);
+  const [exportResolution, setExportResolution] = useState(720);
+  const [history, setHistory] = useState([]);
+  const [future, setFuture] = useState([]);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const selectedItem = useMemo(() => {
+    if (!activeTimeline) {
+      return null;
+    }
+    return activeTimeline.tracks.flatMap((track) => track.items).find((item) => item.id === selectedItemId) ?? null;
+  }, [activeTimeline, selectedItemId]);
+  const selectedAsset = useMemo(() => assets.find((asset) => asset.id === selectedItem?.assetId) ?? null, [assets, selectedItem]);
+  const duration = activeTimeline ? timelineDuration(activeTimeline) : 0;
+  const timelineScale = Math.max(12, duration + 4);
+  const mainAssets = assets.filter((asset) => asset.type === "video" || asset.file?.mimeType?.startsWith("video/"));
+  const stillAssets = assets.filter((asset) => assetCanRenderAsImage(asset));
+
+  useEffect(() => {
+    setHistory([]);
+    setFuture([]);
+    setSelectedItemId(null);
+  }, [activeTimeline?.id]);
+
+  useEffect(() => {
+    function onKeyDown(event) {
+      const target = event.target;
+      const isTyping = ["INPUT", "TEXTAREA", "SELECT"].includes(target?.tagName);
+      if (isTyping) {
+        return;
+      }
+      if (event.code === "Space") {
+        event.preventDefault();
+        setIsPlaying((value) => !value);
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "z") {
+        event.preventDefault();
+        if (event.shiftKey) {
+          redo();
+        } else {
+          undo();
+        }
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "y") {
+        event.preventDefault();
+        redo();
+      }
+      if (event.key === "Delete" || event.key === "Backspace") {
+        if (selectedItemId) {
+          event.preventDefault();
+          removeSelectedItem();
+        }
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeTimeline, history, future, selectedItemId]);
+
+  async function submitNewTimeline(event) {
+    event.preventDefault();
+    await createTimeline({ name: newTimelineName, aspectRatio: newAspectRatio, fps: 30 });
+  }
+
+  function commit(nextTimeline) {
+    if (!activeTimeline) {
+      return;
+    }
+    setHistory((items) => [...items.slice(-24), activeTimeline]);
+    setFuture([]);
+    setActiveTimeline({ ...nextTimeline, duration: timelineDuration(nextTimeline) });
+  }
+
+  function updateTimelineItem(itemId, changes) {
+    if (!activeTimeline) {
+      return;
+    }
+    commit({
+      ...activeTimeline,
+      tracks: activeTimeline.tracks.map((track) => ({
+        ...track,
+        items: track.items.map((item) => (item.id === itemId ? normalizeTimelineItem({ ...item, ...changes }) : item)),
+      })),
+    });
+  }
+
+  function undo() {
+    if (!history.length || !activeTimeline) {
+      return;
+    }
+    const previous = history[history.length - 1];
+    setHistory((items) => items.slice(0, -1));
+    setFuture((items) => [activeTimeline, ...items]);
+    setActiveTimeline(previous);
+  }
+
+  function redo() {
+    if (!future.length || !activeTimeline) {
+      return;
+    }
+    const next = future[0];
+    setFuture((items) => items.slice(1));
+    setHistory((items) => [...items, activeTimeline]);
+    setActiveTimeline(next);
+  }
+
+  function addAssetToTrack(asset, trackId = "track_main") {
+    if (!activeTimeline) {
+      return;
+    }
+    const isStill = asset.type !== "video" && assetCanRenderAsImage(asset);
+    const track = activeTimeline.tracks.find((item) => item.id === trackId) ?? activeTimeline.tracks[0];
+    const start = Math.max(0, ...track.items.map((item) => item.timelineEnd));
+    const sourceDuration = Number(asset.file?.duration) || Number(addDuration) || 4;
+    const durationSeconds = isStill ? Number(addDuration) || 4 : sourceDuration;
+    const item = normalizeTimelineItem({
+      id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
+      trackId: track.id,
+      assetId: asset.id,
+      type: isStill ? "image" : "video",
+      displayName: asset.displayName,
+      sourceIn: 0,
+      sourceOut: Math.max(0.1, sourceDuration),
+      timelineStart: start,
+      timelineEnd: start + Math.max(0.1, durationSeconds),
+      speed: 1,
+      fit: "fit",
+      volume: 1,
+      versionAssetIds: [asset.id],
+      transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+      transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+    });
+    commit({
+      ...activeTimeline,
+      tracks: activeTimeline.tracks.map((current) =>
+        current.id === track.id ? { ...current, items: [...current.items, item] } : current,
+      ),
+    });
+    setSelectedItemId(item.id);
+  }
+
+  function removeSelectedItem() {
+    if (!activeTimeline || !selectedItemId) {
+      return;
+    }
+    commit({
+      ...activeTimeline,
+      tracks: activeTimeline.tracks.map((track) => ({
+        ...track,
+        items: track.items.filter((item) => item.id !== selectedItemId),
+      })),
+    });
+    setSelectedItemId(null);
+  }
+
+  function changeItemTrack(trackId) {
+    if (!activeTimeline || !selectedItem) {
+      return;
+    }
+    commit({
+      ...activeTimeline,
+      tracks: activeTimeline.tracks.map((track) => {
+        if (track.id === selectedItem.trackId) {
+          return { ...track, items: track.items.filter((item) => item.id !== selectedItem.id) };
+        }
+        if (track.id === trackId) {
+          return { ...track, items: [...track.items, normalizeTimelineItem({ ...selectedItem, trackId })] };
+        }
+        return track;
+      }),
+    });
+  }
+
+  function normalizeTimelineItem(item) {
+    const start = Number(item.timelineStart) || 0;
+    const end = Math.max(start + 0.1, Number(item.timelineEnd) || start + 0.1);
+    const sourceIn = Number(item.sourceIn) || 0;
+    const sourceOut = Math.max(sourceIn + 0.1, Number(item.sourceOut) || sourceIn + itemDuration(item));
+    return {
+      ...item,
+      sourceIn,
+      sourceOut,
+      timelineStart: Math.max(0, start),
+      timelineEnd: end,
+      speed: Math.max(0.1, Number(item.speed) || 1),
+    };
+  }
+
+  if (!activeProject) {
+    return (
+      <section className="main-surface">
+        <div className="section-heading">
+          <p className="eyebrow">Editor</p>
+          <h2>Create a project</h2>
+        </div>
+        <div className="empty-panel">Open a project before assembling a timeline.</div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="main-surface editor-surface">
+      <div className="surface-header editor-header">
+        <div className="section-heading">
+          <p className="eyebrow">Editor</p>
+          <h2>{activeTimeline?.name ?? "Timelines"}</h2>
+        </div>
+        <div className="editor-actions">
+          <select onChange={(event) => setSelectedTimelineId(event.target.value)} value={selectedTimelineId ?? ""}>
+            <option value="">Select timeline</option>
+            {timelines.map((timeline) => (
+              <option key={timeline.id} value={timeline.id}>
+                {timeline.name}
+              </option>
+            ))}
+          </select>
+          <button disabled={!activeTimeline} onClick={() => saveTimeline(activeTimeline)} type="button">
+            Save
+          </button>
+          <button disabled={!history.length} onClick={undo} type="button">
+            Undo
+          </button>
+          <button disabled={!future.length} onClick={redo} type="button">
+            Redo
+          </button>
+        </div>
+      </div>
+
+      <form className="timeline-create" onSubmit={submitNewTimeline}>
+        <label>
+          Timeline
+          <input onChange={(event) => setNewTimelineName(event.target.value)} value={newTimelineName} />
+        </label>
+        <label>
+          Aspect
+          <select onChange={(event) => setNewAspectRatio(event.target.value)} value={newAspectRatio}>
+            {Object.entries(aspectOptions).map(([value, option]) => (
+              <option key={value} value={value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button type="submit">New Timeline</button>
+      </form>
+
+      {activeTimeline ? (
+        <div className="editor-layout">
+          <section className="editor-preview">
+            <div className={`preview-canvas aspect-${activeTimeline.aspectRatio.replace(":", "-")}`}>
+              {selectedAsset ? <AssetMedia asset={selectedAsset} /> : <span>Select a timeline item</span>}
+            </div>
+            <div className="playback-bar">
+              <button onClick={() => setIsPlaying((value) => !value)} type="button">
+                {isPlaying ? "Pause" : "Play"}
+              </button>
+              <span>{formatSeconds(Math.round(duration))}</span>
+              <span>{activeTimeline.aspectRatio}</span>
+              <span>{activeTimeline.fps} fps</span>
+            </div>
+          </section>
+
+          <aside className="editor-inspector">
+            {selectedItem ? (
+              <>
+                <div className="section-heading">
+                  <p className="eyebrow">Clip</p>
+                  <h2>{selectedItem.displayName}</h2>
+                </div>
+                <label>
+                  Track
+                  <select onChange={(event) => changeItemTrack(event.target.value)} value={selectedItem.trackId}>
+                    {activeTimeline.tracks.map((track) => (
+                      <option key={track.id} value={track.id}>
+                        {track.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <div className="control-grid compact-controls">
+                  <label>
+                    Start
+                    <input
+                      min="0"
+                      onChange={(event) => updateTimelineItem(selectedItem.id, { timelineStart: Number(event.target.value) })}
+                      step="0.1"
+                      type="number"
+                      value={selectedItem.timelineStart}
+                    />
+                  </label>
+                  <label>
+                    End
+                    <input
+                      min="0.1"
+                      onChange={(event) => updateTimelineItem(selectedItem.id, { timelineEnd: Number(event.target.value) })}
+                      step="0.1"
+                      type="number"
+                      value={selectedItem.timelineEnd}
+                    />
+                  </label>
+                  <label>
+                    Source In
+                    <input
+                      min="0"
+                      onChange={(event) => updateTimelineItem(selectedItem.id, { sourceIn: Number(event.target.value) })}
+                      step="0.1"
+                      type="number"
+                      value={selectedItem.sourceIn}
+                    />
+                  </label>
+                  <label>
+                    Source Out
+                    <input
+                      min="0.1"
+                      onChange={(event) => updateTimelineItem(selectedItem.id, { sourceOut: Number(event.target.value) })}
+                      step="0.1"
+                      type="number"
+                      value={selectedItem.sourceOut}
+                    />
+                  </label>
+                </div>
+                <label>
+                  Speed
+                  <select onChange={(event) => updateTimelineItem(selectedItem.id, { speed: Number(event.target.value) })} value={selectedItem.speed}>
+                    {speedPresets.map((speed) => (
+                      <option key={speed} value={speed}>
+                        {speed}x
+                      </option>
+                    ))}
+                    {!speedPresets.includes(Number(selectedItem.speed)) ? <option value={selectedItem.speed}>Custom {selectedItem.speed}x</option> : null}
+                  </select>
+                </label>
+                <label>
+                  Custom speed
+                  <input
+                    min="0.1"
+                    onChange={(event) => updateTimelineItem(selectedItem.id, { speed: Number(event.target.value) })}
+                    step="0.05"
+                    type="number"
+                    value={selectedItem.speed}
+                  />
+                </label>
+                <label>
+                  Transition in
+                  <select
+                    onChange={(event) =>
+                      updateTimelineItem(selectedItem.id, {
+                        transitionIn: { ...(selectedItem.transitionIn ?? {}), type: event.target.value },
+                      })
+                    }
+                    value={selectedItem.transitionIn?.type ?? "cut"}
+                  >
+                    {transitionOptions.map((transition) => (
+                      <option key={transition} value={transition}>
+                        {transition.replaceAll("_", " ")}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  Transition out
+                  <select
+                    onChange={(event) =>
+                      updateTimelineItem(selectedItem.id, {
+                        transitionOut: { ...(selectedItem.transitionOut ?? {}), type: event.target.value },
+                      })
+                    }
+                    value={selectedItem.transitionOut?.type ?? "cut"}
+                  >
+                    {transitionOptions.map((transition) => (
+                      <option key={transition} value={transition}>
+                        {transition.replaceAll("_", " ")}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button className="danger-action" onClick={removeSelectedItem} type="button">
+                  Delete Clip
+                </button>
+              </>
+            ) : (
+              <div className="empty-panel compact-panel">No clip selected</div>
+            )}
+          </aside>
+
+          <section className="timeline-panel">
+            <div className="timeline-ruler">
+              <span>0s</span>
+              <span>{formatSeconds(Math.ceil(timelineScale / 2))}</span>
+              <span>{formatSeconds(Math.ceil(timelineScale))}</span>
+            </div>
+            <div className="timeline-tracks">
+              {activeTimeline.tracks.map((track) => (
+                <div className="timeline-track" key={track.id}>
+                  <strong>{track.name}</strong>
+                  <div className="track-lane">
+                    {trackItems(track).map((item) => (
+                      <button
+                        className={selectedItemId === item.id ? "timeline-item active" : "timeline-item"}
+                        key={item.id}
+                        onClick={() => setSelectedItemId(item.id)}
+                        style={{
+                          left: `${(item.timelineStart / timelineScale) * 100}%`,
+                          width: `${Math.max(4, (itemDuration(item) / timelineScale) * 100)}%`,
+                        }}
+                        type="button"
+                      >
+                        <span>{item.displayName}</span>
+                        <small>{item.speed}x</small>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <aside className="asset-bin">
+            <div className="bin-controls">
+              <label>
+                Still duration
+                <input min="0.5" onChange={(event) => setAddDuration(Number(event.target.value))} step="0.5" type="number" value={addDuration} />
+              </label>
+            </div>
+            <div className="asset-bin-list">
+              {[...mainAssets, ...stillAssets].slice(0, 18).map((asset) => (
+                <article className="bin-asset" key={asset.id}>
+                  <button onClick={() => onPreview(asset)} type="button">
+                    <AssetMedia asset={asset} />
+                  </button>
+                  <strong>{asset.displayName}</strong>
+                  <div className="bin-actions">
+                    <button onClick={() => addAssetToTrack(asset, "track_main")} type="button">
+                      Main
+                    </button>
+                    <button onClick={() => addAssetToTrack(asset, "track_overlay")} type="button">
+                      Overlay
+                    </button>
+                  </div>
+                </article>
+              ))}
+              {assets.length === 0 ? <div className="empty-panel compact-panel">No media assets</div> : null}
+            </div>
+          </aside>
+
+          <form
+            className="export-strip"
+            onSubmit={(event) => {
+              event.preventDefault();
+              exportTimeline(activeTimeline, { resolution: Number(exportResolution), fps: activeTimeline.fps });
+            }}
+          >
+            <label>
+              MP4 height
+              <select onChange={(event) => setExportResolution(Number(event.target.value))} value={exportResolution}>
+                {[640, 720, 1024, 1280].map((resolution) => (
+                  <option key={resolution} value={resolution}>
+                    {resolution}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button className="primary-action" disabled={!activeTimeline.tracks.some((track) => track.items.length)} type="submit">
+              Export MP4
+            </button>
+          </form>
+        </div>
+      ) : (
+        <div className="empty-panel">Create a timeline to start editing.</div>
+      )}
+    </section>
+  );
+}
+
 function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
   if (!assets.length) {
     return <div className="empty-panel">No assets in this view</div>;
@@ -1240,7 +1897,7 @@ function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, onSendVideo, 
             Send to Video
           </button>
         ) : null}
-        {asset.type === "video" ? (
+        {["image", "video", "upload", "frame"].includes(asset.type) ? (
           <button onClick={() => onSendEditor(asset)} type="button">
             Send to Editor
           </button>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -542,6 +542,261 @@ button:disabled {
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 }
 
+.editor-surface {
+  gap: 16px;
+}
+
+.editor-header,
+.editor-actions,
+.timeline-create,
+.playback-bar,
+.bin-actions,
+.export-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: end;
+}
+
+.editor-actions button,
+.timeline-create button,
+.playback-bar button,
+.bin-actions button,
+.danger-action {
+  min-height: 36px;
+  border: 1px solid #4b463d;
+  background: #292722;
+  color: #f3f0e8;
+  padding: 7px 10px;
+}
+
+.timeline-create {
+  padding: 12px;
+  border: 1px solid #3c3a34;
+  background: #23221f;
+}
+
+.timeline-create label,
+.export-strip label,
+.bin-controls label {
+  display: grid;
+  gap: 6px;
+}
+
+.editor-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 1.25fr) minmax(260px, 0.75fr);
+  gap: 14px;
+}
+
+.editor-preview,
+.editor-inspector,
+.timeline-panel,
+.asset-bin,
+.export-strip {
+  border: 1px solid #3c3a34;
+  background: #23221f;
+}
+
+.editor-preview,
+.editor-inspector,
+.asset-bin,
+.export-strip {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 14px;
+}
+
+.preview-canvas {
+  display: grid;
+  place-items: center;
+  width: min(100%, 760px);
+  max-height: 58vh;
+  overflow: hidden;
+  background: #0f0f0e;
+  color: #aaa397;
+}
+
+.preview-canvas.aspect-16-9 {
+  aspect-ratio: 16 / 9;
+}
+
+.preview-canvas.aspect-9-16 {
+  aspect-ratio: 9 / 16;
+  width: min(54vh, 100%);
+  justify-self: center;
+}
+
+.preview-canvas.aspect-1-1 {
+  aspect-ratio: 1;
+  width: min(58vh, 100%);
+  justify-self: center;
+}
+
+.preview-canvas img,
+.preview-canvas video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.playback-bar {
+  color: #c7bfb2;
+}
+
+.editor-inspector {
+  grid-template-columns: 1fr;
+}
+
+.editor-inspector label {
+  display: grid;
+  gap: 6px;
+}
+
+.compact-controls {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.danger-action {
+  border-color: #7f4d47;
+  background: #30211f;
+}
+
+.timeline-panel,
+.export-strip {
+  grid-column: 1 / -1;
+}
+
+.timeline-panel {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  overflow-x: auto;
+}
+
+.timeline-ruler {
+  display: flex;
+  justify-content: space-between;
+  min-width: 680px;
+  color: #aaa397;
+  font-size: 12px;
+}
+
+.timeline-tracks {
+  display: grid;
+  gap: 8px;
+  min-width: 680px;
+}
+
+.timeline-track {
+  display: grid;
+  grid-template-columns: 84px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.timeline-track strong {
+  color: #d8d2c7;
+  font-size: 13px;
+}
+
+.track-lane {
+  position: relative;
+  min-height: 58px;
+  border: 1px solid #3c3a34;
+  background:
+    repeating-linear-gradient(90deg, transparent 0 79px, rgba(255, 255, 255, 0.05) 80px),
+    #191815;
+}
+
+.timeline-item {
+  position: absolute;
+  top: 7px;
+  display: grid;
+  gap: 2px;
+  align-content: center;
+  height: 42px;
+  min-width: 52px;
+  overflow: hidden;
+  border: 1px solid #6ec6b8;
+  background: #183f3a;
+  color: #ffffff;
+  padding: 5px 7px;
+  text-align: left;
+}
+
+.timeline-item.active {
+  border-color: #f8d78c;
+}
+
+.timeline-item span,
+.timeline-item small,
+.bin-asset strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeline-item span {
+  font-size: 12px;
+}
+
+.timeline-item small {
+  color: #c7bfb2;
+  font-size: 11px;
+}
+
+.asset-bin {
+  max-height: 650px;
+  overflow: auto;
+}
+
+.asset-bin-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 10px;
+}
+
+.bin-asset {
+  display: grid;
+  gap: 7px;
+  align-content: start;
+  border: 1px solid #3c3a34;
+  background: #191815;
+  padding: 8px;
+}
+
+.bin-asset > button {
+  min-height: 80px;
+  border: 0;
+  background: #0f0f0e;
+  padding: 0;
+}
+
+.bin-asset img,
+.bin-asset video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+}
+
+.bin-asset strong {
+  color: #f3f0e8;
+  font-size: 13px;
+}
+
+.bin-actions {
+  gap: 6px;
+}
+
+.bin-actions button {
+  min-height: 30px;
+  padding: 5px 7px;
+  font-size: 12px;
+}
+
 .asset-tray {
   display: grid;
   gap: 12px;
@@ -842,11 +1097,18 @@ button:disabled {
   }
 
   .control-grid,
-  .advanced-panel {
+  .advanced-panel,
+  .editor-layout,
+  .compact-controls {
     grid-template-columns: 1fr;
   }
 
   .asset-detail {
     position: static;
+  }
+
+  .timeline-panel,
+  .export-strip {
+    grid-column: auto;
   }
 }

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -10,6 +10,7 @@ import httpx
 from .gpu import discover_gpu
 from .image_adapters import create_image_adapter
 from .settings import WorkerSettings
+from .timeline_exporter import run_timeline_export
 from .video_adapters import ProceduralVideoAdapter
 
 
@@ -46,6 +47,7 @@ def register_worker(api: ApiClient, settings: WorkerSettings, gpu: dict) -> None
         "gpuName": gpu["name"],
         "capabilities": sorted(
             set([*gpu["capabilities"], "image_generate", "image_edit", "video_generate", "video_extend", "video_bridge"])
+            | {"timeline_export"}
         ),
         "loadedModels": [],
     }
@@ -266,6 +268,68 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
         heartbeat(api, settings, "idle")
 
 
+def run_timeline_export_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    job_id = job["id"]
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": status,
+                "stage": stage,
+                "progress": value,
+                "message": message,
+            },
+        )
+
+    try:
+        progress("preparing", "preparing", 0.06, "Preparing timeline export.")
+        result = run_timeline_export(
+            settings=settings,
+            job=job,
+            progress=progress,
+            cancel_requested=lambda: job_cancel_requested(api, job_id),
+        )
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "completed",
+                "stage": "completed",
+                "progress": 1,
+                "message": "Timeline MP4 export saved.",
+                "result": result,
+            },
+        )
+    except InterruptedError as exc:
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "canceled",
+                "stage": "canceled",
+                "progress": 1,
+                "message": str(exc),
+            },
+        )
+    except Exception as exc:
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "failed",
+                "stage": "failed",
+                "progress": 1,
+                "message": "Timeline export failed.",
+                "error": str(exc),
+            },
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def main() -> None:
     settings = WorkerSettings()
     gpu = discover_gpu(settings.gpu_id)
@@ -295,6 +359,8 @@ def main() -> None:
                 run_image_job(api, settings, job)
             elif job["type"] in ("video_generate", "video_extend", "video_bridge"):
                 run_video_job(api, settings, job)
+            elif job["type"] == "timeline_export":
+                run_timeline_export_job(api, settings, job)
             else:
                 update_job(
                     api,

--- a/apps/worker/scene_worker/timeline_exporter.py
+++ b/apps/worker/scene_worker/timeline_exporter.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+import math
+import re
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+from uuid import uuid4
+
+from .image_adapters import find_project_path, index_project_db, write_json
+from .settings import WorkerSettings
+
+
+ProgressCallback = Callable[[str, str, float, str], None]
+CancelCallback = Callable[[], bool]
+
+ASSET_FOLDERS = ("assets/images", "assets/videos", "assets/uploads", "assets/frames", "assets/renders")
+
+
+@dataclass(frozen=True)
+class ExportRequest:
+    project_id: str
+    timeline_id: str
+    timeline_name: str
+    timeline_path: str
+    resolution: int
+    fps: int
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
+    return (slug or "timeline-export")[:48]
+
+
+def export_request_from_job(job: dict[str, Any]) -> ExportRequest:
+    payload = job["payload"]
+    return ExportRequest(
+        project_id=payload["projectId"],
+        timeline_id=payload["timelineId"],
+        timeline_name=payload.get("timelineName", "Timeline"),
+        timeline_path=payload["timelinePath"],
+        resolution=int(payload.get("resolution", 720)),
+        fps=int(payload.get("fps", 30)),
+    )
+
+
+def run_timeline_export(
+    *,
+    settings: WorkerSettings,
+    job: dict[str, Any],
+    progress: ProgressCallback,
+    cancel_requested: CancelCallback,
+) -> dict[str, Any]:
+    request = export_request_from_job(job)
+    project_path = find_project_path(settings, request.project_id)
+    timeline = read_json(project_path / request.timeline_path)
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("FFmpeg is required for timeline export but was not found on PATH.")
+
+    width, height = output_dimensions(timeline.get("aspectRatio", "16:9"), request.resolution)
+    items = sorted(main_track_items(timeline), key=lambda item: item.get("timelineStart", 0))
+    if not items:
+        raise RuntimeError("Timeline has no main video items to export.")
+
+    with tempfile.TemporaryDirectory(prefix=f"sceneworks_export_{job['id']}_") as tmp:
+        tmp_path = Path(tmp)
+        segments: list[dict[str, Any]] = []
+        cursor = 0.0
+        total = len(items)
+        for index, item in enumerate(items):
+            if cancel_requested():
+                raise InterruptedError("Timeline export canceled by user.")
+            start = safe_float(item.get("timelineStart"), 0)
+            if start > cursor:
+                gap_duration = start - cursor
+                gap_path = tmp_path / f"segment_{len(segments):04d}_gap.mp4"
+                render_black_segment(ffmpeg, gap_path, gap_duration, width, height, request.fps)
+                segments.append({"path": gap_path, "duration": gap_duration, "transition": None})
+                cursor = start
+
+            asset = find_asset(project_path, item["assetId"])
+            segment_path = tmp_path / f"segment_{len(segments):04d}_{slugify(item.get('displayName', 'item'))}.mp4"
+            duration = render_item_segment(
+                ffmpeg=ffmpeg,
+                project_path=project_path,
+                item=item,
+                asset=asset,
+                output_path=segment_path,
+                width=width,
+                height=height,
+                fps=request.fps,
+            )
+            segments.append(
+                {
+                    "path": segment_path,
+                    "duration": duration,
+                    "transition": (item.get("transitionIn") or {}).get("type"),
+                    "transitionDuration": safe_float((item.get("transitionIn") or {}).get("duration"), 0),
+                }
+            )
+            cursor = max(cursor, safe_float(item.get("timelineEnd"), start + duration))
+            progress("running", "rendering", 0.12 + ((index + 1) / total) * 0.58, "Rendering timeline segments.")
+
+        output_rel = f"assets/renders/{utc_now()[:10]}_{slugify(request.timeline_name)}_{job['id'][-8:]}.mp4"
+        output_path = project_path / output_rel
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        progress("saving", "muxing", 0.78, "Muxing MP4 export.")
+        mux_segments(ffmpeg, segments, tmp_path, output_path)
+
+    asset = build_render_asset(
+        project_id=request.project_id,
+        job_id=job["id"],
+        request=request,
+        timeline=timeline,
+        media_rel=output_rel,
+        width=width,
+        height=height,
+        duration=round(cursor, 3),
+    )
+    sidecar_path = output_path.with_suffix(".sceneworks.json")
+    write_json(sidecar_path, asset)
+    write_json(project_path / "recipes" / f"{asset['id']}.recipe.json", asset["recipe"])
+    index_project_db(project_path, asset)
+    return {
+        "assetIds": [asset["id"]],
+        "assets": [asset],
+        "timelineId": request.timeline_id,
+        "renderPath": output_rel,
+        "adapter": "ffmpeg_timeline",
+    }
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main_track_items(timeline: dict[str, Any]) -> list[dict[str, Any]]:
+    for track in timeline.get("tracks", []):
+        if track.get("id") == "track_main" or track.get("kind") == "video":
+            return list(track.get("items", []))
+    return []
+
+
+def output_dimensions(aspect_ratio: str, resolution: int) -> tuple[int, int]:
+    if aspect_ratio == "9:16":
+        width, height = resolution, math.ceil(resolution * 16 / 9)
+    elif aspect_ratio == "1:1":
+        width, height = resolution, resolution
+    else:
+        width, height = math.ceil(resolution * 16 / 9), resolution
+    return even(width), even(height)
+
+
+def even(value: float) -> int:
+    parsed = int(round(value))
+    return parsed if parsed % 2 == 0 else parsed + 1
+
+
+def safe_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, parsed)
+
+
+def find_asset(project_path: Path, asset_id: str) -> dict[str, Any]:
+    for folder in ASSET_FOLDERS:
+        for sidecar_path in (project_path / folder).glob("*.sceneworks.json"):
+            try:
+                asset = read_json(sidecar_path)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if asset.get("id") == asset_id:
+                return asset
+    raise RuntimeError(f"Timeline asset not found: {asset_id}")
+
+
+def render_black_segment(ffmpeg: str, output_path: Path, duration: float, width: int, height: int, fps: int) -> None:
+    run_ffmpeg(
+        [
+            ffmpeg,
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=black:s={width}x{height}:r={fps}",
+            "-t",
+            f"{duration:.3f}",
+            "-pix_fmt",
+            "yuv420p",
+            str(output_path),
+        ]
+    )
+
+
+def render_item_segment(
+    *,
+    ffmpeg: str,
+    project_path: Path,
+    item: dict[str, Any],
+    asset: dict[str, Any],
+    output_path: Path,
+    width: int,
+    height: int,
+    fps: int,
+) -> float:
+    media_path = project_path / asset.get("file", {}).get("path", "")
+    if not media_path.exists():
+        raise RuntimeError(f"Timeline source file is missing: {media_path}")
+
+    source_in = safe_float(item.get("sourceIn"), 0)
+    source_out = safe_float(item.get("sourceOut"), safe_float(item.get("timelineEnd"), 4))
+    timeline_duration = safe_float(item.get("timelineEnd"), 4) - safe_float(item.get("timelineStart"), 0)
+    source_duration = max(0.1, source_out - source_in)
+    speed = max(0.1, float(item.get("speed") or 1))
+    duration = max(0.1, timeline_duration or source_duration / speed)
+    media_type = asset.get("type")
+    mime_type = asset.get("file", {}).get("mimeType", "")
+    vf = [
+        f"scale={width}:{height}:force_original_aspect_ratio=decrease",
+        f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color=black",
+        f"fps={fps}",
+        "format=yuv420p",
+    ]
+    transition_in = item.get("transitionIn") or {}
+    transition_out = item.get("transitionOut") or {}
+    if transition_in.get("type") == "fade_from_black":
+        vf.append(f"fade=t=in:st=0:d={min(duration, safe_float(transition_in.get('duration'), 0.5)):.3f}")
+    if transition_out.get("type") == "fade_to_black":
+        fade_duration = min(duration, safe_float(transition_out.get("duration"), 0.5))
+        vf.append(f"fade=t=out:st={max(0, duration - fade_duration):.3f}:d={fade_duration:.3f}")
+
+    if media_type != "video" and (media_type == "image" or mime_type.startswith("image/")):
+        run_ffmpeg(
+            [
+                ffmpeg,
+                "-y",
+                "-loop",
+                "1",
+                "-i",
+                str(media_path),
+                "-t",
+                f"{duration:.3f}",
+                "-vf",
+                ",".join(vf),
+                "-an",
+                str(output_path),
+            ]
+        )
+        return duration
+
+    setpts = f"setpts={1 / speed:.6f}*PTS"
+    run_ffmpeg(
+        [
+            ffmpeg,
+            "-y",
+            "-ss",
+            f"{source_in:.3f}",
+            "-i",
+            str(media_path),
+            "-t",
+            f"{source_duration:.3f}",
+            "-vf",
+            ",".join([setpts, *vf]),
+            "-an",
+            str(output_path),
+        ]
+    )
+    return duration
+
+
+def mux_segments(ffmpeg: str, segments: list[dict[str, Any]], tmp_path: Path, output_path: Path) -> None:
+    crossfades = [segment for segment in segments[1:] if segment.get("transition") == "crossfade"]
+    if crossfades:
+        mux_with_crossfades(ffmpeg, segments, tmp_path, output_path)
+        return
+    list_path = tmp_path / "concat.txt"
+    list_path.write_text(
+        "".join(f"file '{segment['path'].as_posix()}'\n" for segment in segments),
+        encoding="utf-8",
+    )
+    run_ffmpeg([ffmpeg, "-y", "-f", "concat", "-safe", "0", "-i", str(list_path), "-c", "copy", str(output_path)])
+
+
+def mux_with_crossfades(ffmpeg: str, segments: list[dict[str, Any]], tmp_path: Path, output_path: Path) -> None:
+    current = segments[0]["path"]
+    current_duration = segments[0]["duration"]
+    for index, segment in enumerate(segments[1:], start=1):
+        next_path = segment["path"]
+        next_duration = segment["duration"]
+        transition = segment.get("transition")
+        duration = min(1.5, max(0.1, safe_float(segment.get("transitionDuration"), 0.5)))
+        merged = tmp_path / f"xfade_{index:04d}.mp4"
+        if transition == "crossfade":
+            offset = max(0, current_duration - duration)
+            run_ffmpeg(
+                [
+                    ffmpeg,
+                    "-y",
+                    "-i",
+                    str(current),
+                    "-i",
+                    str(next_path),
+                    "-filter_complex",
+                    f"[0:v][1:v]xfade=transition=fade:duration={duration:.3f}:offset={offset:.3f},format=yuv420p[v]",
+                    "-map",
+                    "[v]",
+                    str(merged),
+                ]
+            )
+            current_duration = current_duration + next_duration - duration
+        else:
+            list_path = tmp_path / f"concat_{index:04d}.txt"
+            list_path.write_text(f"file '{current.as_posix()}'\nfile '{next_path.as_posix()}'\n", encoding="utf-8")
+            run_ffmpeg([ffmpeg, "-y", "-f", "concat", "-safe", "0", "-i", str(list_path), "-c", "copy", str(merged)])
+            current_duration += next_duration
+        current = merged
+    current.replace(output_path)
+
+
+def run_ffmpeg(command: list[str]) -> None:
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        stderr = result.stderr.strip().splitlines()
+        raise RuntimeError(stderr[-1] if stderr else "FFmpeg command failed.")
+
+
+def build_render_asset(
+    *,
+    project_id: str,
+    job_id: str,
+    request: ExportRequest,
+    timeline: dict[str, Any],
+    media_rel: str,
+    width: int,
+    height: int,
+    duration: float,
+) -> dict[str, Any]:
+    asset_id = f"asset_{uuid4().hex}"
+    created_at = utc_now()
+    source_asset_ids = [
+        item["assetId"]
+        for track in timeline.get("tracks", [])
+        for item in track.get("items", [])
+        if item.get("assetId")
+    ]
+    return {
+        "schemaVersion": 1,
+        "id": asset_id,
+        "projectId": project_id,
+        "generationSetId": None,
+        "type": "render",
+        "displayName": f"{request.timeline_name} export",
+        "createdAt": created_at,
+        "file": {
+            "path": media_rel,
+            "mimeType": "video/mp4",
+            "width": width,
+            "height": height,
+            "duration": duration,
+            "fps": request.fps,
+        },
+        "status": {
+            "favorite": False,
+            "rating": 0,
+            "rejected": False,
+            "trashed": False,
+        },
+        "recipe": {
+            "mode": "timeline_export",
+            "model": "ffmpeg",
+            "adapter": "ffmpeg_timeline",
+            "prompt": request.timeline_name,
+            "negativePrompt": "",
+            "seed": None,
+            "loras": [],
+            "normalizedSettings": {
+                "timelineId": request.timeline_id,
+                "resolution": request.resolution,
+                "width": width,
+                "height": height,
+                "fps": request.fps,
+                "aspectRatio": timeline.get("aspectRatio", "16:9"),
+            },
+            "rawAdapterSettings": {
+                "timelinePath": request.timeline_path,
+                "renderer": "ffmpeg segment concat",
+            },
+        },
+        "lineage": {
+            "parents": source_asset_ids,
+            "sourceAssetId": request.timeline_id,
+            "sourceTimestamp": None,
+            "jobId": job_id,
+        },
+    }

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git \
+    && apt-get install -y --no-install-recommends ffmpeg git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY apps/worker/requirements.txt ./requirements.txt

--- a/documents/TIMELINE_LIBRARY_RESEARCH.md
+++ b/documents/TIMELINE_LIBRARY_RESEARCH.md
@@ -1,0 +1,73 @@
+# Timeline Library Research
+
+Source: Shortcut story sc-1136 and Phase 10 of `documents/IMPLEMENTATION_PLAN.md`.
+
+## Recommendation
+
+Use a SceneWorks-owned timeline data model and lightweight in-app React editor for the first Phase 10 slice, with FFmpeg as the authoritative export renderer.
+
+This keeps timeline JSON portable, avoids adopting a young or license-sensitive editor SDK before the product model settles, and gives SceneWorks a direct mapping from saved timeline items to MP4 output.
+
+## Candidates Reviewed
+
+### React Video Editor Timeline
+
+Docs: https://docs.reactvideoeditor.com/core/components/timeline
+
+Fit:
+- Strongest conceptual match for CapCut-like interactions.
+- Supports tracks, item movement/resizing, scrubbing, zooming, keyboard shortcuts, and undo/redo.
+- Its documented example is a copyable component approach, which is useful later if SceneWorks wants a richer timeline surface without surrendering its data model.
+
+Gaps:
+- Active development and performance caveats are called out in the docs.
+- Would need adaptation from its `start`/`end` item shape into SceneWorks `sourceIn`/`sourceOut` plus `timelineStart`/`timelineEnd`.
+- Phase 10 can satisfy core acceptance criteria with less dependency risk.
+
+### Remotion
+
+Repo: https://github.com/remotion-dev/remotion
+
+Fit:
+- Mature React video rendering ecosystem.
+- Useful for programmatic video composition and preview/render pipelines.
+
+Gaps:
+- It is primarily a renderer/framework, not a drop-in interactive editor timeline.
+- License has commercial considerations.
+- SceneWorks final export is already planned as backend FFmpeg, so Remotion is not needed for this slice.
+
+### Twick
+
+Repo: https://github.com/ncounterspecialist/twick
+
+Fit:
+- Full React editor SDK with timeline editing, canvas tools, and MP4 export.
+- Interesting reference for a future richer editing surface.
+
+Gaps:
+- Larger product-shaped SDK than SceneWorks needs right now.
+- Browser export support is browser-limited, while SceneWorks wants backend rendering.
+- Its license and cloud-oriented architecture need a dedicated review before adoption.
+
+## SceneWorks V1 Mapping
+
+Timeline item fields:
+- `assetId` points to a project asset sidecar rather than a media path.
+- `sourceIn` and `sourceOut` describe the trim range.
+- `timelineStart` and `timelineEnd` describe placement.
+- `speed`, `transitionIn`, and `transitionOut` live on the item.
+
+Export mapping:
+- Main-track items are normalized into FFmpeg segments.
+- Still images use `-loop 1` and a target duration.
+- Video clips use `-ss`, `-t`, `setpts`, scale, pad, fps, and yuv420p normalization.
+- `fade_from_black` and `fade_to_black` map to FFmpeg `fade`.
+- `crossfade` maps to FFmpeg `xfade` when adjacent segments request it.
+- Render outputs become `render` assets under `assets/renders` with lineage to the timeline and source assets.
+
+Known deferred work:
+- Rich multi-track compositing.
+- Audio mixing UI.
+- Persistent undo stack.
+- Generation-aware timeline hooks such as bridge clips, frame extraction, extension, and nondestructive replacement.

--- a/packages/schemas/timeline.schema.json
+++ b/packages/schemas/timeline.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/timeline.schema.json",
+  "title": "SceneWorks Timeline",
+  "type": "object",
+  "required": ["schemaVersion", "id", "projectId", "name", "aspectRatio", "width", "height", "fps", "tracks"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "id": { "type": "string", "pattern": "^timeline_[a-z0-9_]+$" },
+    "projectId": { "type": "string", "pattern": "^project_[a-z0-9_]+$" },
+    "name": { "type": "string", "minLength": 1 },
+    "aspectRatio": { "enum": ["16:9", "9:16", "1:1"] },
+    "width": { "type": "integer", "minimum": 256 },
+    "height": { "type": "integer", "minimum": 256 },
+    "fps": { "type": "integer", "minimum": 1, "maximum": 60 },
+    "duration": { "type": "number", "minimum": 0 },
+    "tracks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "kind", "items"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "kind": { "enum": ["video", "overlay", "audio"] },
+          "locked": { "type": "boolean" },
+          "muted": { "type": "boolean" },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "trackId", "assetId", "type", "displayName", "sourceIn", "sourceOut", "timelineStart", "timelineEnd", "speed"],
+              "properties": {
+                "id": { "type": "string" },
+                "trackId": { "type": "string" },
+                "assetId": { "type": "string" },
+                "type": { "enum": ["video", "image", "audio"] },
+                "displayName": { "type": "string" },
+                "sourceIn": { "type": "number", "minimum": 0 },
+                "sourceOut": { "type": "number", "exclusiveMinimum": 0 },
+                "timelineStart": { "type": "number", "minimum": 0 },
+                "timelineEnd": { "type": "number", "exclusiveMinimum": 0 },
+                "speed": { "type": "number", "minimum": 0.1 },
+                "fit": { "enum": ["fit", "fill", "stretch"] },
+                "volume": { "type": "number", "minimum": 0 },
+                "versionAssetIds": { "type": "array", "items": { "type": "string" } },
+                "transitionIn": { "$ref": "#/$defs/transition" },
+                "transitionOut": { "$ref": "#/$defs/transition" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "transitions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/transition" }
+    },
+    "createdAt": { "type": ["string", "null"], "format": "date-time" },
+    "updatedAt": { "type": ["string", "null"], "format": "date-time" }
+  },
+  "$defs": {
+    "transition": {
+      "type": ["object", "null"],
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "enum": ["cut", "crossfade", "fade_from_black", "fade_to_black"] },
+        "fromItemId": { "type": ["string", "null"] },
+        "toItemId": { "type": ["string", "null"] },
+        "duration": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
﻿## Summary

Implements Shortcut epic 1087 / Phase 10 as one editor and export slice:

- Adds a timeline persistence API with portable JSON files under `timelines/` and SQLite indexing.
- Adds the first real Editor surface: timeline creation, aspect ratios, main/overlay/audio tracks, asset insertion, trim/placement controls, speed controls, transitions, active-session undo/redo, and keyboard basics.
- Adds worker-side `timeline_export` handling with FFmpeg segment normalization, MP4 muxing, render asset sidecars, and lineage back to timeline/source assets.
- Documents the React timeline library research and why the first pass keeps the timeline UI owned by SceneWorks.

## Validation

- `npm run check`
- `npm run build --workspace apps/web`
- `python -m compileall apps\api apps\worker`
- Timeline API smoke test with FastAPI `TestClient`
- Browser smoke on `http://127.0.0.1:5180`: Editor loads and creates a timeline against the new API

Note: host Windows does not currently have `ffmpeg` on PATH, so full local export execution was not run outside Docker. The worker image now installs FFmpeg for the export path.
