### PR TITLE
[codex] Address code review cleanup batch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,34 @@
+# API bind address and exposed port.
 SCENEWORKS_API_HOST=0.0.0.0
 SCENEWORKS_API_PORT=8000
+
+# Vite dev server port exposed by docker-compose.
 SCENEWORKS_WEB_PORT=5173
+
+# Leave blank for local open access, or set a private token for shared-machine/LAN use.
 SCENEWORKS_ACCESS_TOKEN=
+
+# Comma-separated browser origins allowed to call the API.
 SCENEWORKS_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
+# Local data/config roots used by API and worker outside Docker.
+SCENEWORKS_DATA_DIR=data
+SCENEWORKS_CONFIG_DIR=config
+
+# Optional API metadata and storage overrides.
+SCENEWORKS_APP_VERSION=0.1.0
+SCENEWORKS_JOBS_DB_PATH=
+SCENEWORKS_WORKER_TIMEOUT_SECONDS=90
+
+# Worker connection and polling defaults.
+SCENEWORKS_API_URL=http://localhost:8000
+SCENEWORKS_WORKER_ID=worker-local-0
+SCENEWORKS_GPU_ID=auto
+SCENEWORKS_WORKER_HEARTBEAT_SECONDS=30
+SCENEWORKS_WORKER_POLL_SECONDS=3
+
+# Worker adapter override: auto, procedural, z_image_diffusers, or qwen_image.
+SCENEWORKS_IMAGE_ADAPTER=auto
+
+# Docker/NVIDIA runtime GPU selection.
+NVIDIA_VISIBLE_DEVICES=all

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.6
 python-multipart==0.0.20
 uvicorn[standard]==0.34.0
+pytest==9.0.2

--- a/apps/api/sceneworks_api/assets.py
+++ b/apps/api/sceneworks_api/assets.py
@@ -235,6 +235,7 @@ def update_asset_status(
     changes = payload.model_dump(exclude_none=True)
     status.update(changes)
     write_json(sidecar_path, asset)
+    index_asset_db(project_path, asset)
     return normalize_asset(project_id, project_path, sidecar_path)
 
 

--- a/apps/api/sceneworks_api/jobs.py
+++ b/apps/api/sceneworks_api/jobs.py
@@ -1,21 +1,33 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from .events import encode_sse
-from .jobs_store import JOB_STATUSES, JobsStore
+from .jobs_store import JOB_STATUSES, MAX_JOB_ATTEMPTS, JobsStore
 
 
 router = APIRouter(tags=["jobs"])
 
+JobType = Literal[
+    "placeholder",
+    "image_generate",
+    "image_edit",
+    "video_generate",
+    "video_extend",
+    "video_bridge",
+    "timeline_export",
+    "model_download",
+    "lora_import",
+]
+
 
 class JobCreateRequest(BaseModel):
-    type: str = Field(default="placeholder", min_length=1, max_length=80)
+    type: JobType = "placeholder"
     projectId: str | None = None
     projectName: str | None = None
     payload: dict[str, Any] = Field(default_factory=dict)
@@ -163,6 +175,8 @@ def retry_job(job_id: str, request: Request) -> dict:
         job = get_store(request).retry_job(job_id)
     except KeyError:
         raise HTTPException(status_code=404, detail="Job not found") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     publish(request, "job.updated", job)
     publish(request, "queue.updated", queue_summary(request))
     return job
@@ -195,6 +209,7 @@ def queue_summary(request: Request) -> dict:
         "counts": counts,
         "activeJobs": [job for job in jobs if job["status"] not in ("completed", "failed", "canceled", "interrupted")],
         "workers": workers,
+        "maxJobAttempts": MAX_JOB_ATTEMPTS,
     }
 
 

--- a/apps/api/sceneworks_api/jobs_store.py
+++ b/apps/api/sceneworks_api/jobs_store.py
@@ -13,6 +13,7 @@ ACTIVE_STATUSES = ("preparing", "downloading", "loading_model", "running", "savi
 TERMINAL_STATUSES = ("completed", "failed", "canceled", "interrupted")
 JOB_STATUSES = ("queued", *ACTIVE_STATUSES, *TERMINAL_STATUSES)
 NON_GPU_JOB_TYPES = ("model_download", "lora_import")
+MAX_JOB_ATTEMPTS = 5
 
 
 def utc_now() -> str:
@@ -256,6 +257,8 @@ class JobsStore:
     def retry_job(self, job_id: str) -> dict:
         with self._lock, self.connect() as connection:
             job = self.get_job(job_id, connection=connection)
+        if job["attempts"] >= MAX_JOB_ATTEMPTS:
+            raise ValueError(f"Job retry limit reached after {MAX_JOB_ATTEMPTS} attempts.")
         return self.create_job(
             job_type=job["type"],
             project_id=job["projectId"],
@@ -406,6 +409,7 @@ class JobsStore:
         with self._lock, self.connect() as connection:
             worker = self.get_worker(worker_id, connection=connection)
             gpu_id = worker["gpuId"]
+            capabilities = set(worker["capabilities"])
             active_gpu_job = connection.execute(
                 f"""
                 select id from jobs
@@ -417,17 +421,18 @@ class JobsStore:
                 (gpu_id, *ACTIVE_STATUSES, *NON_GPU_JOB_TYPES),
             ).fetchone()
 
-            queued = connection.execute(
+            queued_rows = connection.execute(
                 f"""
                 select * from jobs
                  where status = 'queued'
                    and (type in ({','.join('?' for _ in NON_GPU_JOB_TYPES)}) or requested_gpu = 'auto' or requested_gpu = ?)
                    and (? = 0 or type in ({','.join('?' for _ in NON_GPU_JOB_TYPES)}))
                  order by created_at asc
-                 limit 1
+                 limit 50
                 """,
                 (*NON_GPU_JOB_TYPES, gpu_id, int(active_gpu_job is not None), *NON_GPU_JOB_TYPES),
-            ).fetchone()
+            ).fetchall()
+            queued = next((row for row in queued_rows if row["type"] in capabilities), None)
             if queued is None:
                 return None
             assigned_gpu = "cpu" if queued["type"] in NON_GPU_JOB_TYPES else gpu_id

--- a/apps/api/sceneworks_api/main.py
+++ b/apps/api/sceneworks_api/main.py
@@ -33,9 +33,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-SceneWorks-Token"],
     )
 
     @app.middleware("http")

--- a/apps/api/sceneworks_api/models.py
+++ b/apps/api/sceneworks_api/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -68,20 +69,29 @@ def strip_jsonc_comments(value: str) -> str:
     return "".join(output)
 
 
-def load_manifest(path: Path) -> list[dict[str, Any]]:
+def manifest_mtime(path: Path) -> int:
+    try:
+        return path.stat().st_mtime_ns
+    except FileNotFoundError:
+        return 0
+
+
+@lru_cache(maxsize=16)
+def load_manifest_cached(path_text: str, mtime_ns: int, key: str) -> tuple[dict[str, Any], ...]:
+    path = Path(path_text)
     if not path.exists():
-        return []
+        return ()
     with path.open("r", encoding="utf-8") as handle:
         payload = json.loads(strip_jsonc_comments(handle.read()))
-    return payload.get("models", [])
+    return tuple(payload.get(key, []))
+
+
+def load_manifest(path: Path) -> list[dict[str, Any]]:
+    return [dict(item) for item in load_manifest_cached(str(path), manifest_mtime(path), "models")]
 
 
 def load_lora_manifest(path: Path) -> list[dict[str, Any]]:
-    if not path.exists():
-        return []
-    with path.open("r", encoding="utf-8") as handle:
-        payload = json.loads(strip_jsonc_comments(handle.read()))
-    return payload.get("loras", [])
+    return [dict(item) for item in load_manifest_cached(str(path), manifest_mtime(path), "loras")]
 
 
 def safe_download_dir(repo: str) -> str:

--- a/apps/api/sceneworks_api/security.py
+++ b/apps/api/sceneworks_api/security.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from secrets import compare_digest
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
@@ -34,7 +35,9 @@ def is_authorized(request: Request, settings: Settings) -> bool:
     if not settings.access_token:
         return True
 
-    return token_from_request(request) == settings.access_token
+    request_token = token_from_request(request).encode("utf-8")
+    expected_token = settings.access_token.encode("utf-8")
+    return compare_digest(request_token, expected_token)
 
 
 async def access_control_middleware(

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -13,8 +13,72 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.7.0",
-        "vite": "6.4.2"
+        "jsdom": "27.3.0",
+        "vite": "6.4.2",
+        "vitest": "4.0.14"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -296,6 +360,146 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1186,6 +1390,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1231,6 +1442,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1259,6 +1488,137 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.14.tgz",
+      "integrity": "sha512-RHk63V3zvRiYOWAV0rGEBRO820ce17hz7cI2kDmEdfQsBjT2luEKB5tCOc91u1oSQoUOZkSv3ZyzkdkSLD7lKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.14",
+        "@vitest/utils": "4.0.14",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.14.tgz",
+      "integrity": "sha512-RzS5NujlCzeRPF1MK7MXLiEFpkIXeMdQ+rN3Kk3tDI9j0mtbr7Nmuq67tpkOJQpgyClbOltCXMjLZicJHsH5Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.14",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.14.tgz",
+      "integrity": "sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.14.tgz",
+      "integrity": "sha512-BsAIk3FAqxICqREbX8SetIteT8PiaUL/tgJjmhxJhCsigmzzH8xeadtp7LRnTpCVzvf0ib9BgAfKJHuhNllKLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.14",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.14.tgz",
+      "integrity": "sha512-aQVBfT1PMzDSA16Y3Fp45a0q8nKexx6N5Amw3MX55BeTeZpoC08fGqEZqVmPcqN0ueZsuUQ9rriPMhZ3Mu19Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.14",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.14.tgz",
+      "integrity": "sha512-JmAZT1UtZooO0tpY3GRyiC/8W7dCs05UOq9rfsUUgEZEdq+DuHLmWhPsrTt0TiW7WYeL/hXpaE07AZ2RCk44hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.14.tgz",
+      "integrity": "sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.14",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.30",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
@@ -1270,6 +1630,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1327,12 +1697,86 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1352,12 +1796,39 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.357",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
       "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1411,6 +1882,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1454,11 +1945,112 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.3.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.3.0.tgz",
+      "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1508,6 +2100,23 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1538,6 +2147,37 @@
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1590,6 +2230,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1619,6 +2269,16 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1670,6 +2330,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1689,6 +2369,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1698,6 +2385,41 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -1714,6 +2436,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1821,6 +2599,201 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.14.tgz",
+      "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.14",
+        "@vitest/mocker": "4.0.14",
+        "@vitest/pretty-format": "4.0.14",
+        "@vitest/runner": "4.0.14",
+        "@vitest/snapshot": "4.0.14",
+        "@vitest/spy": "4.0.14",
+        "@vitest/utils": "4.0.14",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.14",
+        "@vitest/browser-preview": "4.0.14",
+        "@vitest/browser-webdriverio": "4.0.14",
+        "@vitest/ui": "4.0.14",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "vite build",
-    "preview": "vite preview --host 0.0.0.0"
+    "preview": "vite preview --host 0.0.0.0",
+    "test": "vitest run --environment jsdom"
   },
   "dependencies": {
     "react": "18.3.1",
@@ -14,6 +15,8 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.7.0",
+    "jsdom": "27.3.0",
+    "vitest": "4.0.14",
     "vite": "6.4.2"
   }
 }

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -176,6 +176,7 @@ function App() {
   const [projectName, setProjectName] = useState("");
   const [jobs, setJobs] = useState([]);
   const [workers, setWorkers] = useState([]);
+  const [queueSummary, setQueueSummary] = useState(null);
   const [models, setModels] = useState([]);
   const [loras, setLoras] = useState([]);
   const [assets, setAssets] = useState([]);
@@ -210,6 +211,12 @@ function App() {
   const latestImageAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "image"), [latestAssets]);
   const latestVideoAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "video"), [latestAssets]);
   const queueCounts = useMemo(() => {
+    if (queueSummary?.counts) {
+      return {
+        ...queueSummary.counts,
+        active: queueSummary.activeJobs?.length ?? jobs.filter((job) => !terminalStatuses.has(job.status)).length,
+      };
+    }
     return jobs.reduce(
       (counts, job) => {
         counts[job.status] = (counts[job.status] ?? 0) + 1;
@@ -300,11 +307,20 @@ function App() {
       setWorkers((items) => [worker, ...items.filter((item) => item.id !== worker.id)].sort(sortWorkers));
     }
 
+    function handleQueueUpdated(event) {
+      const summary = JSON.parse(event.data);
+      setQueueSummary(summary);
+      if (Array.isArray(summary.workers)) {
+        setWorkers(summary.workers.sort(sortWorkers));
+      }
+    }
+
     function connect() {
       const source = new EventSource(eventUrl("/api/v1/jobs/events", token));
       events = source;
       source.addEventListener("job.updated", handleJobUpdated);
       source.addEventListener("worker.updated", handleWorkerUpdated);
+      source.addEventListener("queue.updated", handleQueueUpdated);
       source.onopen = () => {
         reconnectAttempt = 0;
       };
@@ -343,6 +359,7 @@ function App() {
       setActiveProject((current) => current ?? projectItems[0] ?? null);
       setJobs(jobItems.sort(sortNewest));
       setWorkers(workerItems.sort(sortWorkers));
+      setQueueSummary(null);
       setModels(modelItems);
       setLoras(loraItems);
       setError("");
@@ -2238,7 +2255,9 @@ function QueueScreen({
 
 function JobRow({ job, jobAction }) {
   const canCancel = !terminalStatuses.has(job.status);
-  const canRepeat = actionStatuses.has(job.status);
+  const maxAttempts = 5;
+  const attempts = job.attempts ?? 1;
+  const canRepeat = actionStatuses.has(job.status) && attempts < maxAttempts;
   return (
     <article className={`job-row ${job.status}`}>
       <div className="job-main">
@@ -2253,6 +2272,7 @@ function JobRow({ job, jobAction }) {
         <span>Stage {job.stage}</span>
         <span>Elapsed {formatSeconds(job.elapsedSeconds)}</span>
         <span>GPU {job.assignedGpu ?? job.requestedGpu}</span>
+        <span>Attempt {attempts}/{maxAttempts}</span>
       </div>
       <div className="progress-track" aria-label={`${percent(job.progress)} complete`}>
         <span style={{ width: percent(job.progress) }} />
@@ -2308,4 +2328,9 @@ function sortWorkers(a, b) {
   return `${a.gpuId}-${a.id}`.localeCompare(`${b.gpuId}-${b.id}`);
 }
 
-createRoot(document.getElementById("root")).render(<App />);
+const rootElement = typeof document === "undefined" ? null : document.getElementById("root");
+if (rootElement) {
+  createRoot(rootElement).render(<App />);
+}
+
+export { App, eventUrl };

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1,0 +1,77 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App, eventUrl } from "./main.jsx";
+
+class FakeEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+  }
+
+  addEventListener(event, handler) {
+    this.listeners[event] = handler;
+  }
+
+  close() {}
+}
+
+function response(payload) {
+  return {
+    ok: true,
+    json: async () => payload,
+  };
+}
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("SceneWorks app shell", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      return Promise.resolve(response([]));
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the app navigation against mocked API calls", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Library");
+    expect(container.textContent).toContain("Queue");
+  });
+
+  it("adds the SSE token as a query parameter", () => {
+    expect(eventUrl("/api/v1/jobs/events", "secret-token")).toContain("token=secret-token");
+  });
+});

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -1,4 +1,5 @@
 httpx==0.28.1
+pytest==9.0.2
 huggingface_hub>=0.36,<1
 pillow>=12.0.0,<13
 torch>=2.7

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import sqlite3
+import warnings
 from pathlib import Path
 from textwrap import wrap
 from typing import Any, Callable
@@ -17,6 +18,9 @@ from PIL import Image, ImageDraw, ImageFont
 
 from .settings import WorkerSettings
 
+
+Image.MAX_IMAGE_PIXELS = 64_000_000
+warnings.simplefilter("error", Image.DecompressionBombWarning)
 
 ProgressCallback = Callable[[str, str, float, str], None]
 CancelCallback = Callable[[], bool]
@@ -36,6 +40,7 @@ MODEL_TARGETS = {
         "family": "z-image",
         "supportsEdit": True,
         "steps": 8,
+        # Uses Turbo weights via ZImageImg2ImgPipeline until the dedicated Edit checkpoint is released.
         "repo": "Tongyi-MAI/Z-Image-Turbo",
         "adapter": "z_image_diffusers",
     },
@@ -411,7 +416,10 @@ def load_source_image(settings: WorkerSettings, request: ImageRequest) -> Image.
         source_path = find_asset_media_path(find_project_path(settings, request.project_id), request.source_asset_id)
     if not source_path:
         raise RuntimeError("Image edit jobs require a source image asset.")
-    image = Image.open(source_path).convert("RGB")
+    try:
+        image = Image.open(source_path).convert("RGB")
+    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise RuntimeError(f"Source image could not be loaded safely: {source_path}") from exc
     return image.resize((request.width, request.height))
 
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -42,15 +42,20 @@ class ApiClient:
         return response.json()
 
 
+def worker_capabilities(gpu: dict) -> list[str]:
+    gpu_capabilities = set(gpu["capabilities"])
+    capabilities = set(gpu["capabilities"]) | {"timeline_export", "model_download", "lora_import"}
+    if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities:
+        capabilities |= {"image_generate", "image_edit", "video_generate", "video_extend", "video_bridge"}
+    return sorted(capabilities)
+
+
 def register_worker(api: ApiClient, settings: WorkerSettings, gpu: dict) -> None:
     payload = {
         "workerId": settings.worker_id,
         "gpuId": gpu["id"],
         "gpuName": gpu["name"],
-        "capabilities": sorted(
-            set([*gpu["capabilities"], "image_generate", "image_edit", "video_generate", "video_extend", "video_bridge"])
-            | {"timeline_export", "model_download", "lora_import"}
-        ),
+        "capabilities": worker_capabilities(gpu),
         "loadedModels": [],
     }
     worker = api.post("/api/v1/workers/register", payload)
@@ -508,14 +513,27 @@ def main() -> None:
     settings = WorkerSettings()
     gpu = discover_gpu(settings.gpu_id)
     api = ApiClient(settings)
+    max_registration_attempts = 20
 
-    while True:
+    for attempt in range(1, max_registration_attempts + 1):
         try:
             register_worker(api, settings, gpu)
             break
         except httpx.HTTPError as exc:
-            emit({"event": "register_failed", "error": str(exc), "reportedAt": now()})
-            time.sleep(settings.poll_seconds)
+            delay = min(30, settings.poll_seconds * (2 ** (attempt - 1)))
+            emit(
+                {
+                    "event": "register_failed",
+                    "attempt": attempt,
+                    "maxAttempts": max_registration_attempts,
+                    "retryInSeconds": delay,
+                    "error": str(exc),
+                    "reportedAt": now(),
+                }
+            )
+            if attempt == max_registration_attempts:
+                raise RuntimeError(f"Worker registration failed after {max_registration_attempts} attempts.") from exc
+            time.sleep(delay)
 
     while True:
         try:

--- a/apps/worker/scene_worker/timeline_exporter.py
+++ b/apps/worker/scene_worker/timeline_exporter.py
@@ -334,8 +334,12 @@ def mux_with_crossfades(ffmpeg: str, segments: list[dict[str, Any]], tmp_path: P
 def run_ffmpeg(command: list[str]) -> None:
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     if result.returncode != 0:
-        stderr = result.stderr.strip().splitlines()
-        raise RuntimeError(stderr[-1] if stderr else "FFmpeg command failed.")
+        stderr = result.stderr.strip()
+        if not stderr:
+            raise RuntimeError("FFmpeg command failed.")
+        lines = stderr.splitlines()[-10:]
+        message = "\n".join(lines)
+        raise RuntimeError(message[-2000:])
 
 
 def build_render_asset(

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 import hashlib
 import re
+import warnings
 from pathlib import Path
 from textwrap import wrap
 from typing import Any, Callable
@@ -15,6 +16,9 @@ from PIL import Image, ImageDraw, ImageEnhance, ImageFont
 from .image_adapters import find_project_path, index_project_db, write_json
 from .settings import WorkerSettings
 
+
+Image.MAX_IMAGE_PIXELS = 64_000_000
+warnings.simplefilter("error", Image.DecompressionBombWarning)
 
 ProgressCallback = Callable[[str, str, float, str], None]
 CancelCallback = Callable[[], bool]
@@ -319,7 +323,7 @@ def load_source_image(project_path: Path, asset_id: str | None, width: int, heig
             media_path = project_path / payload.get("file", {}).get("path", "")
             try:
                 image = Image.open(media_path).convert("RGB")
-            except OSError:
+            except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
                 return None
             image.thumbnail((width, height), Image.Resampling.LANCZOS)
             canvas = Image.new("RGB", (width, height), (18, 17, 15))

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "check": "node scripts/check-scaffold.mjs",
     "check:health": "node scripts/check-health.mjs"
   },
-  "workspaces": [
-    "apps/web"
-  ],
   "engines": {
     "node": ">=20"
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+for package_path in (ROOT / "apps" / "api", ROOT / "apps" / "worker"):
+    sys.path.insert(0, str(package_path))

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from sceneworks_api.assets import AssetStatusUpdate, get_project_file, index_asset_db, update_asset_status, write_json
+
+
+def request_for_project(tmp_path, project_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    registry_path = data_dir / "recent-projects.json"
+    registry_path.write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    settings = SimpleNamespace(registry_path=registry_path)
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(settings=settings)))
+
+
+def test_project_file_rejects_path_traversal(tmp_path):
+    project_path = tmp_path / "project.sceneworks"
+    project_path.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("nope", encoding="utf-8")
+
+    with pytest.raises(HTTPException) as exc_info:
+        get_project_file("project-1", "../outside.txt", request_for_project(tmp_path, project_path))
+
+    assert exc_info.value.status_code == 400
+
+
+def test_status_patch_updates_project_db(tmp_path):
+    project_path = tmp_path / "project.sceneworks"
+    image_dir = project_path / "assets" / "images"
+    image_dir.mkdir(parents=True)
+    asset = {
+        "id": "asset-1",
+        "type": "image",
+        "displayName": "Image",
+        "createdAt": "2026-05-17T00:00:00Z",
+        "generationSetId": None,
+        "file": {"path": "assets/images/image.png"},
+        "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
+    }
+    write_json(image_dir / "image.sceneworks.json", asset)
+    index_asset_db(project_path, asset)
+
+    update_asset_status(
+        "project-1",
+        "asset-1",
+        AssetStatusUpdate(favorite=True, rating=4, rejected=True),
+        request_for_project(tmp_path, project_path),
+    )
+
+    with sqlite3.connect(project_path / "project.db") as connection:
+        row = connection.execute("select favorite, rating, rejected, trashed from assets where id = ?", ("asset-1",)).fetchone()
+
+    assert row == (1, 4, 1, 0)

--- a/tests/test_jobs_store.py
+++ b/tests/test_jobs_store.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from sceneworks_api.jobs_store import JobsStore
+
+
+def test_job_lifecycle_create_claim_complete(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    store.register_worker(
+        worker_id="worker-1",
+        gpu_id="gpu-0",
+        gpu_name="GPU 0",
+        capabilities=["image_generate"],
+        loaded_models=[],
+    )
+
+    created = store.create_job(
+        job_type="image_generate",
+        project_id="project-1",
+        project_name="Project 1",
+        payload={"prompt": "mist over hills"},
+        requested_gpu="auto",
+    )
+    claimed = store.claim_next_job("worker-1")
+
+    assert claimed is not None
+    assert claimed["id"] == created["id"]
+    assert claimed["status"] == "preparing"
+    assert claimed["assignedGpu"] == "gpu-0"
+
+    completed = store.update_job_progress(
+        claimed["id"],
+        status="completed",
+        stage="completed",
+        progress=1,
+        message="Done",
+        result={"assetIds": ["asset-1"]},
+    )
+    worker = store.get_worker("worker-1")
+
+    assert completed["status"] == "completed"
+    assert completed["result"] == {"assetIds": ["asset-1"]}
+    assert worker["status"] == "idle"
+    assert worker["currentJobId"] is None
+
+
+def test_non_gpu_jobs_can_claim_while_gpu_is_busy(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    store.register_worker(
+        worker_id="worker-1",
+        gpu_id="gpu-0",
+        gpu_name=None,
+        capabilities=["image_generate", "model_download"],
+        loaded_models=[],
+    )
+
+    gpu_job = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={},
+        requested_gpu="auto",
+    )
+    download_job = store.create_job(
+        job_type="model_download",
+        project_id=None,
+        project_name=None,
+        payload={"repo": "owner/model"},
+        requested_gpu="auto",
+    )
+
+    assert store.claim_next_job("worker-1")["id"] == gpu_job["id"]
+    assert store.claim_next_job("worker-1")["id"] == download_job["id"]
+
+
+def test_claim_skips_jobs_not_supported_by_worker_capabilities(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    store.register_worker(
+        worker_id="worker-1",
+        gpu_id="gpu-0",
+        gpu_name=None,
+        capabilities=["model_download"],
+        loaded_models=[],
+    )
+    store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={},
+        requested_gpu="auto",
+    )
+    download_job = store.create_job(
+        job_type="model_download",
+        project_id=None,
+        project_name=None,
+        payload={"repo": "owner/model"},
+        requested_gpu="auto",
+    )
+
+    assert store.claim_next_job("worker-1")["id"] == download_job["id"]
+
+
+def test_retry_job_is_capped(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    job = store.create_job(
+        job_type="placeholder",
+        project_id=None,
+        project_name=None,
+        payload={},
+        requested_gpu="auto",
+        attempts=5,
+    )
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        store.retry_job(job["id"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from sceneworks_api.models import load_manifest, strip_jsonc_comments
+
+
+def test_jsonc_comment_stripping_preserves_url_strings():
+    payload = '{"repo":"https://example.test/model", "name":"ok"} // trailing comment\n'
+
+    assert strip_jsonc_comments(payload) == '{"repo":"https://example.test/model", "name":"ok"} \n'
+
+
+def test_manifest_cache_reloads_when_mtime_changes(tmp_path):
+    manifest = tmp_path / "models.jsonc"
+    manifest.write_text('{"models":[{"id":"first"}]}', encoding="utf-8")
+
+    assert load_manifest(manifest) == [{"id": "first"}]
+
+    manifest.write_text('{"models":[{"id":"second"}]}', encoding="utf-8")
+    assert load_manifest(manifest) == [{"id": "second"}]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from scene_worker.runtime import worker_capabilities
+
+
+def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
+    capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
+
+    assert "image_generate" not in capabilities
+    assert "video_generate" not in capabilities
+    assert "model_download" in capabilities
+    assert "timeline_export" in capabilities
+
+
+def test_gpu_worker_advertises_generation_capabilities():
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+
+    assert "image_generate" in capabilities
+    assert "video_generate" in capabilities


### PR DESCRIPTION
## What changed

This PR continues the SceneWorks code-review cleanup sweep. It includes the earlier F-001 through F-009 cleanup commit already on the branch, plus the new batch for F-010, F-011, F-012, F-015, F-023, F-024, F-026, F-027, F-028, F-029, F-030, F-031, F-032, F-034, and F-036.

Highlights:
- Adds pytest and Vitest harnesses with focused coverage for job state transitions, capability routing, retry caps, JSONC parsing, manifest cache reloads, asset path traversal, asset DB status sync, worker capability derivation, and the React app shell.
- Tightens API auth and CORS with constant-time token comparison, explicit CORS methods/headers, and typed job type validation.
- Improves queue/runtime behavior with capability-aware dispatch, retry caps, queue.updated consumption, worker registration backoff, and mtime-keyed manifest caching.
- Adds PIL decompression-bomb guards, richer FFmpeg stderr reporting, expanded `.env.example`, and a note documenting the current Z-Image edit weights fallback.
- Removes the unused root `workspaces` declaration.

## Why

The review found drift in security defaults, queue contracts, test coverage, worker dispatch semantics, and storage consistency. This batch focuses on small-to-medium fixes that reduce risk before the next feature slice.

## Validation

- `python -m pytest tests`
- `python -m compileall apps/api/sceneworks_api apps/worker/scene_worker tests`
- `npm run test` from `apps/web`
- `npm run build` from `apps/web`