### PR TITLE
[codex] Address code review followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ or:
 X-SceneWorks-Token: choose-a-private-token
 ```
 
+Event streams use a short-lived one-shot ticket instead of putting the access token in the URL. Clients should `POST /api/v1/jobs/events/ticket` with the normal auth header, then connect to `/api/v1/jobs/events?ticket=...`.
+
 This is for privacy and control over local media, model downloads, and long-running GPU work. It is not a content moderation system.
 
 ## Structure
@@ -50,7 +52,7 @@ apps/
   worker/    Placeholder worker package
 packages/
   schemas/   Shared schema placeholders
-  shared/    Cross-app shared notes/helpers placeholder
+  shared/    Cross-app Python helpers for JSON, project lookup, and project DB indexing
 config/
   manifests/ Built-in and user model/LoRA manifests
 data/

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -10,4 +10,6 @@ Current routes:
 - `GET /api/v1/projects`
 - `POST /api/v1/projects`
 - `GET /api/v1/projects/{project_id}`
+- `POST /api/v1/projects/{project_id}/reindex`
+- `POST /api/v1/jobs/events/ticket`
 - `GET /api/v1/jobs/events`

--- a/apps/api/sceneworks_api/__main__.py
+++ b/apps/api/sceneworks_api/__main__.py
@@ -1,6 +1,22 @@
+import argparse
+import json
+from pathlib import Path
+
+from sceneworks_shared import reindex_project
+
 from .settings import get_settings
 from .server import run
 
 
 if __name__ == "__main__":
-    run(get_settings())
+    parser = argparse.ArgumentParser(prog="python -m sceneworks_api")
+    subparsers = parser.add_subparsers(dest="command")
+    reindex_parser = subparsers.add_parser("reindex", help="Rebuild a project's DB index from sidecar files.")
+    reindex_parser.add_argument("--project", required=True, help="Path to a .sceneworks project folder.")
+    args = parser.parse_args()
+
+    if args.command == "reindex":
+        counts = reindex_project(Path(args.project).expanduser().resolve())
+        print(json.dumps(counts, sort_keys=True))
+    else:
+        run(get_settings())

--- a/apps/api/sceneworks_api/assets.py
+++ b/apps/api/sceneworks_api/assets.py
@@ -13,7 +13,17 @@ from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
-from .projects import find_project_path, utc_now
+from sceneworks_shared import (
+    ensure_project_db_ready,
+    find_asset_sidecar_path,
+    index_asset,
+    purge_asset,
+    read_json,
+    utc_now,
+    write_json,
+)
+
+from .projects import find_project_path
 
 
 router = APIRouter(prefix="/projects/{project_id}", tags=["assets"])
@@ -28,17 +38,6 @@ class AssetStatusUpdate(BaseModel):
     rating: int | None = Field(default=None, ge=0, le=5)
     rejected: bool | None = None
     trashed: bool | None = None
-
-
-def read_json(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def write_json(path: Path, payload: dict[str, Any]) -> None:
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(payload, handle, indent=2)
-        handle.write("\n")
 
 
 def safe_filename(value: str, fallback: str = "upload") -> str:
@@ -57,44 +56,7 @@ def media_type_for_mime(mime_type: str) -> str:
 
 
 def index_asset_db(project_path: Path, asset: dict[str, Any]) -> None:
-    db_path = project_path / "project.db"
-    with sqlite3.connect(db_path) as connection:
-        connection.execute(
-            """
-            create table if not exists assets (
-              id text primary key,
-              type text not null,
-              display_name text not null,
-              file_path text not null,
-              generation_set_id text,
-              created_at text not null,
-              favorite integer not null default 0,
-              rating integer not null default 0,
-              rejected integer not null default 0,
-              trashed integer not null default 0
-            )
-            """
-        )
-        connection.execute(
-            """
-            insert or replace into assets (
-              id, type, display_name, file_path, generation_set_id, created_at,
-              favorite, rating, rejected, trashed
-            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                asset["id"],
-                asset["type"],
-                asset["displayName"],
-                asset["file"]["path"],
-                asset.get("generationSetId"),
-                asset["createdAt"],
-                int(asset["status"]["favorite"]),
-                int(asset["status"]["rating"]),
-                int(asset["status"]["rejected"]),
-                int(asset["status"]["trashed"]),
-            ),
-        )
+    index_asset(project_path, asset, (project_path / asset["file"]["path"]).with_suffix(".sceneworks.json"))
 
 
 def normalize_asset(project_id: str, project_path: Path, sidecar_path: Path) -> dict[str, Any]:
@@ -108,14 +70,9 @@ def normalize_asset(project_id: str, project_path: Path, sidecar_path: Path) -> 
 
 
 def find_asset_sidecar(project_path: Path, asset_id: str) -> Path:
-    for folder in MEDIA_FOLDERS:
-        for sidecar_path in (project_path / folder).glob(ASSET_SIDECAR_PATTERN):
-            try:
-                payload = read_json(sidecar_path)
-            except (OSError, json.JSONDecodeError):
-                continue
-            if payload.get("id") == asset_id:
-                return sidecar_path
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is not None:
+        return sidecar_path
     raise HTTPException(status_code=404, detail="Asset not found")
 
 
@@ -128,20 +85,36 @@ def list_assets(
 ) -> list[dict[str, Any]]:
     project_path = find_project_path(request.app.state.settings, project_id)
     assets = []
-    for folder in MEDIA_FOLDERS:
-        for sidecar_path in (project_path / folder).glob(ASSET_SIDECAR_PATTERN):
+    ensure_project_db_ready(project_path)
+    with sqlite3.connect(project_path / "project.db") as connection:
+        rows = connection.execute(
+            """
+            select sidecar_path, file_path
+              from assets
+             where (? or rejected = 0)
+               and (? or trashed = 0)
+             order by created_at desc
+            """,
+            (int(includeRejected), int(includeTrashed)),
+        ).fetchall()
+
+    for sidecar_rel, file_rel in rows:
+        candidates = []
+        if sidecar_rel:
+            candidates.append(project_path / sidecar_rel)
+        if file_rel:
+            candidates.append((project_path / file_rel).with_suffix(".sceneworks.json"))
+        for sidecar_path in candidates:
+            if not sidecar_path.exists():
+                continue
             try:
                 asset = normalize_asset(project_id, project_path, sidecar_path)
             except (OSError, json.JSONDecodeError):
                 continue
-            status = asset.get("status", {})
-            if status.get("rejected") and not includeRejected:
-                continue
-            if status.get("trashed") and not includeTrashed:
-                continue
             assets.append(asset)
+            break
 
-    return sorted(assets, key=lambda item: item.get("createdAt", ""), reverse=True)
+    return assets
 
 
 @router.post("/assets", status_code=201)
@@ -245,11 +218,38 @@ def delete_asset(project_id: str, asset_id: str, request: Request) -> dict[str, 
     sidecar_path = find_asset_sidecar(project_path, asset_id)
     asset = read_json(sidecar_path)
     media_path = project_path / asset.get("file", {}).get("path", "")
+    status = asset.setdefault("status", {})
+    status["trashed"] = True
+
+    trash_dir = project_path / "trash" / asset_id
+    trash_dir.mkdir(parents=True, exist_ok=True)
+    if media_path.exists() and media_path.is_file():
+        trashed_media_path = trash_dir / media_path.name
+        shutil.move(str(media_path), trashed_media_path)
+        asset["file"]["path"] = str(trashed_media_path.relative_to(project_path)).replace("\\", "/")
+    trashed_sidecar_path = trash_dir / sidecar_path.name
+    write_json(trashed_sidecar_path, asset)
+    if sidecar_path != trashed_sidecar_path:
+        sidecar_path.unlink(missing_ok=True)
+    index_asset(project_path, asset, trashed_sidecar_path)
+    return {"id": asset_id, "status": "trashed"}
+
+
+@router.delete("/assets/{asset_id}/purge")
+def purge_deleted_asset(project_id: str, asset_id: str, request: Request) -> dict[str, str]:
+    project_path = find_project_path(request.app.state.settings, project_id)
+    sidecar_path = find_asset_sidecar(project_path, asset_id)
+    asset = read_json(sidecar_path)
+    media_path = project_path / asset.get("file", {}).get("path", "")
 
     if media_path.exists() and media_path.is_file():
         media_path.unlink()
-    sidecar_path.unlink()
-    return {"id": asset_id, "status": "deleted"}
+    sidecar_path.unlink(missing_ok=True)
+    parent = sidecar_path.parent
+    if parent.name == asset_id and parent.parent == project_path / "trash":
+        shutil.rmtree(parent, ignore_errors=True)
+    purge_asset(project_path, asset_id)
+    return {"id": asset_id, "status": "purged"}
 
 
 @router.get("/files/{relative_path:path}")

--- a/apps/api/sceneworks_api/events.py
+++ b/apps/api/sceneworks_api/events.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from typing import Any
+from uuid import uuid4
+
+from fastapi import HTTPException
 
 
 class EventHub:
@@ -37,3 +41,28 @@ def encode_sse(message: dict[str, Any]) -> str:
     event = message.get("event", "message")
     data = json.dumps(message.get("data", {}), separators=(",", ":"))
     return f"event: {event}\ndata: {data}\n\n"
+
+
+class EventTicketStore:
+    def __init__(self, ttl_seconds: int = 30) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._tickets: dict[str, float] = {}
+
+    def issue(self) -> dict[str, Any]:
+        self._prune()
+        ticket = uuid4().hex
+        expires_at = time.time() + self.ttl_seconds
+        self._tickets[ticket] = expires_at
+        return {"ticket": ticket, "expiresInSeconds": self.ttl_seconds}
+
+    def consume(self, ticket: str) -> None:
+        self._prune()
+        expires_at = self._tickets.pop(ticket, None)
+        if expires_at is None or expires_at < time.time():
+            raise HTTPException(status_code=401, detail="Invalid or expired event stream ticket")
+
+    def _prune(self) -> None:
+        now = time.time()
+        expired = [ticket for ticket, expires_at in self._tickets.items() if expires_at < now]
+        for ticket in expired:
+            self._tickets.pop(ticket, None)

--- a/apps/api/sceneworks_api/jobs.py
+++ b/apps/api/sceneworks_api/jobs.py
@@ -112,8 +112,15 @@ def create_job(payload: JobCreateRequest, request: Request) -> dict:
     return job
 
 
+@router.post("/jobs/events/ticket")
+def create_event_ticket(request: Request) -> dict[str, Any]:
+    return request.app.state.event_ticket_store.issue()
+
+
 @router.get("/jobs/events")
-async def job_events(request: Request) -> StreamingResponse:
+async def job_events(request: Request, ticket: str = Query(default="")) -> StreamingResponse:
+    if request.app.state.settings.access_token:
+        request.app.state.event_ticket_store.consume(ticket)
     queue = await request.app.state.event_hub.subscribe()
 
     async def stream():

--- a/apps/api/sceneworks_api/jobs_store.py
+++ b/apps/api/sceneworks_api/jobs_store.py
@@ -8,16 +8,13 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from sceneworks_shared import utc_now
 
 ACTIVE_STATUSES = ("preparing", "downloading", "loading_model", "running", "saving")
 TERMINAL_STATUSES = ("completed", "failed", "canceled", "interrupted")
 JOB_STATUSES = ("queued", *ACTIVE_STATUSES, *TERMINAL_STATUSES)
 NON_GPU_JOB_TYPES = ("model_download", "lora_import")
 MAX_JOB_ATTEMPTS = 5
-
-
-def utc_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def dumps(value: Any) -> str:

--- a/apps/api/sceneworks_api/main.py
+++ b/apps/api/sceneworks_api/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from .assets import router as assets_router
-from .events import EventHub
+from .events import EventHub, EventTicketStore
 from .image_generation import router as image_router
 from .jobs import router as jobs_router
 from .jobs_store import JobsStore
@@ -29,6 +29,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.state.settings = settings
     app.state.jobs_store = jobs_store
     app.state.event_hub = EventHub()
+    app.state.event_ticket_store = EventTicketStore()
 
     app.add_middleware(
         CORSMiddleware,

--- a/apps/api/sceneworks_api/projects.py
+++ b/apps/api/sceneworks_api/projects.py
@@ -1,6 +1,4 @@
-from datetime import UTC, datetime
 import json
-import re
 import sqlite3
 import tempfile
 import threading
@@ -9,6 +7,16 @@ from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
+
+from sceneworks_shared import (
+    ProjectNotFound,
+    apply_project_migrations,
+    find_project_path as shared_find_project_path,
+    load_registry as shared_load_registry,
+    reindex_project,
+    slugify,
+    utc_now,
+)
 
 from .settings import Settings
 
@@ -43,13 +51,11 @@ class ProjectSummary(BaseModel):
     createdAt: str
 
 
-def slugify(value: str) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
-    return slug or "project"
-
-
-def utc_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+class ReindexResult(BaseModel):
+    projectId: str
+    assets: int
+    generationSets: int
+    timelines: int
 
 
 def get_settings_from_request(request: Request) -> Settings:
@@ -63,11 +69,7 @@ def ensure_data_dirs(settings: Settings) -> None:
 
 
 def load_registry(settings: Settings) -> list[dict]:
-    if not settings.registry_path.exists():
-        return []
-
-    with settings.registry_path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
+    return shared_load_registry(settings.registry_path)
 
 
 def save_registry(settings: Settings, projects: list[dict]) -> None:
@@ -87,62 +89,7 @@ def save_registry(settings: Settings, projects: list[dict]) -> None:
 def create_project_db(project_path: Path) -> None:
     db_path = project_path / "project.db"
     with sqlite3.connect(db_path) as connection:
-        connection.execute(
-            """
-            create table if not exists project_metadata (
-              key text primary key,
-              value text not null
-            )
-            """
-        )
-        connection.execute(
-            "insert or replace into project_metadata (key, value) values (?, ?)",
-            ("schemaVersion", "1"),
-        )
-        connection.execute(
-            """
-            create table if not exists assets (
-              id text primary key,
-              type text not null,
-              display_name text not null,
-              file_path text not null,
-              generation_set_id text,
-              created_at text not null,
-              favorite integer not null default 0,
-              rating integer not null default 0,
-              rejected integer not null default 0,
-              trashed integer not null default 0
-            )
-            """
-        )
-        connection.execute(
-            """
-            create table if not exists generation_sets (
-              id text primary key,
-              mode text not null,
-              model text not null,
-              prompt text not null,
-              created_at text not null,
-              job_id text
-            )
-            """
-        )
-        connection.execute(
-            """
-            create table if not exists timelines (
-              id text primary key,
-              name text not null,
-              file_path text not null,
-              aspect_ratio text not null,
-              width integer not null,
-              height integer not null,
-              fps integer not null,
-              duration real not null default 0,
-              created_at text not null,
-              updated_at text not null
-            )
-            """
-        )
+        apply_project_migrations(connection)
 
 
 def write_project_file(settings: Settings, project_path: Path, project_id: str, name: str) -> dict:
@@ -178,14 +125,10 @@ def read_project_summary(project_path: Path) -> ProjectSummary:
 
 
 def find_project_path(settings: Settings, project_id: str) -> Path:
-    for item in load_registry(settings):
-        if item.get("id") == project_id:
-            project_path = Path(item["path"])
-            if project_path.exists():
-                return project_path
-            break
-
-    raise HTTPException(status_code=404, detail="Project not found")
+    try:
+        return shared_find_project_path(settings.registry_path, project_id)
+    except ProjectNotFound:
+        raise HTTPException(status_code=404, detail="Project not found") from None
 
 
 @router.get("", response_model=list[ProjectSummary])
@@ -207,10 +150,10 @@ def create_project(payload: ProjectCreateRequest, request: Request) -> ProjectSu
 
     with REGISTRY_LOCK:
         project_id = f"project_{uuid4().hex}"
-        folder_name = f"{slugify(payload.name)}.sceneworks"
+        folder_name = f"{slugify(payload.name, fallback='project')}.sceneworks"
         project_path = settings.projects_dir / folder_name
         if project_path.exists():
-            project_path = settings.projects_dir / f"{slugify(payload.name)}-{project_id[-8:]}.sceneworks"
+            project_path = settings.projects_dir / f"{slugify(payload.name, fallback='project')}-{project_id[-8:]}.sceneworks"
 
         project_path.mkdir(parents=True)
         for folder in PROJECT_FOLDERS:
@@ -230,3 +173,10 @@ def create_project(payload: ProjectCreateRequest, request: Request) -> ProjectSu
 def get_project(project_id: str, request: Request) -> ProjectSummary:
     settings = get_settings_from_request(request)
     return read_project_summary(find_project_path(settings, project_id))
+
+
+@router.post("/{project_id}/reindex", response_model=ReindexResult)
+def reindex_project_endpoint(project_id: str, request: Request) -> ReindexResult:
+    settings = get_settings_from_request(request)
+    counts = reindex_project(find_project_path(settings, project_id))
+    return ReindexResult(projectId=project_id, **counts)

--- a/apps/api/sceneworks_api/security.py
+++ b/apps/api/sceneworks_api/security.py
@@ -11,14 +11,11 @@ PUBLIC_PATHS = {
     "/api/v1/health",
     "/api/v1/access",
     "/api/v1/auth/verify",
+    "/api/v1/jobs/events",
 }
 
 
 def token_from_request(request: Request) -> str:
-    query_token = request.query_params.get("token", "").strip()
-    if query_token:
-        return query_token
-
     header_token = request.headers.get("x-sceneworks-token", "").strip()
     if header_token:
         return header_token

--- a/apps/api/sceneworks_api/timelines.py
+++ b/apps/api/sceneworks_api/timelines.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
 import json
-import re
 import sqlite3
 from pathlib import Path
 from typing import Any, Literal
@@ -10,6 +8,8 @@ from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field, model_validator
+
+from sceneworks_shared import ensure_project_db_ready, read_json, slugify, utc_now, write_json
 
 from .jobs import queue_summary
 from .projects import find_project_path
@@ -110,49 +110,12 @@ class TimelineExportRequest(BaseModel):
         return self
 
 
-def utc_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def slugify(value: str) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
-    return (slug or "timeline")[:48]
-
-
 def timeline_file_path(project_path: Path, timeline_id: str, name: str) -> Path:
-    return project_path / "timelines" / f"{slugify(name)}-{timeline_id[-8:]}.sceneworks.timeline.json"
-
-
-def read_json(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(payload, handle, indent=2)
-        handle.write("\n")
+    return project_path / "timelines" / f"{slugify(name, fallback='timeline', max_length=48)}-{timeline_id[-8:]}.sceneworks.timeline.json"
 
 
 def ensure_timeline_db(project_path: Path) -> None:
-    with sqlite3.connect(project_path / "project.db") as connection:
-        connection.execute(
-            """
-            create table if not exists timelines (
-              id text primary key,
-              name text not null,
-              file_path text not null,
-              aspect_ratio text not null,
-              width integer not null,
-              height integer not null,
-              fps integer not null,
-              duration real not null default 0,
-              created_at text not null,
-              updated_at text not null
-            )
-            """
-        )
+    ensure_project_db_ready(project_path)
 
 
 def default_tracks() -> list[TimelineTrack]:
@@ -194,18 +157,28 @@ def index_timeline(project_path: Path, timeline: TimelineDocument, rel_path: str
 
 def find_timeline_file(project_path: Path, timeline_id: str) -> Path:
     ensure_timeline_db(project_path)
+    indexed_path = None
     with sqlite3.connect(project_path / "project.db") as connection:
         row = connection.execute("select file_path from timelines where id = ?", (timeline_id,)).fetchone()
     if row is not None:
-        path = project_path / row[0]
+        indexed_path = row[0]
+        path = project_path / indexed_path
         if path.exists():
             return path
     for candidate in (project_path / "timelines").glob("*.sceneworks.timeline.json"):
         try:
             if read_json(candidate).get("id") == timeline_id:
+                rel_path = str(candidate.relative_to(project_path)).replace("\\", "/")
+                with sqlite3.connect(project_path / "project.db") as connection:
+                    connection.execute("update timelines set file_path = ? where id = ?", (rel_path, timeline_id))
                 return candidate
         except (OSError, json.JSONDecodeError):
             continue
+    if indexed_path:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Timeline file not found at indexed path {indexed_path}; reindex required",
+        )
     raise HTTPException(status_code=404, detail="Timeline not found")
 
 

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -76,10 +76,10 @@ async function apiFetch(path, token, options = {}) {
   return response.json();
 }
 
-function eventUrl(path, token) {
+function eventUrl(path, ticket) {
   const url = new URL(`${API_BASE_URL}${path}`);
-  if (token) {
-    url.searchParams.set("token", token);
+  if (ticket) {
+    url.searchParams.set("ticket", ticket);
   }
   return url.toString();
 }
@@ -315,8 +315,28 @@ function App() {
       }
     }
 
-    function connect() {
-      const source = new EventSource(eventUrl("/api/v1/jobs/events", token));
+    async function connect() {
+      let ticket = "";
+      try {
+        if (access.authRequired) {
+          const response = await apiFetch("/api/v1/jobs/events/ticket", token, { method: "POST" });
+          ticket = response.ticket;
+        }
+      } catch (err) {
+        setError(err.message);
+        if (!closed) {
+          const delay = Math.min(30000, 1000 * 2 ** reconnectAttempt);
+          reconnectAttempt += 1;
+          reconnectTimer = window.setTimeout(connect, delay);
+        }
+        return;
+      }
+
+      if (closed) {
+        return;
+      }
+
+      const source = new EventSource(eventUrl("/api/v1/jobs/events", ticket));
       events = source;
       source.addEventListener("job.updated", handleJobUpdated);
       source.addEventListener("worker.updated", handleWorkerUpdated);
@@ -344,7 +364,7 @@ function App() {
       }
       events?.close();
     };
-  }, [authenticated, token]);
+  }, [access.authRequired, authenticated, token]);
 
   async function refreshData() {
     try {
@@ -373,9 +393,10 @@ function App() {
       return;
     }
     try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true`, token);
+      const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token);
       setAssets(items);
-      setSelectedAssetId((current) => current ?? items[0]?.id ?? null);
+      const defaultAsset = items.find((asset) => !asset.status?.trashed && !asset.status?.rejected) ?? items[0] ?? null;
+      setSelectedAssetId((current) => current ?? defaultAsset?.id ?? null);
       setError("");
     } catch (err) {
       setError(err.message);
@@ -592,6 +613,17 @@ function App() {
     }
   }
 
+  async function purgeAsset(asset) {
+    try {
+      await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge`, token, { method: "DELETE" });
+      setAssets((items) => items.filter((item) => item.id !== asset.id));
+      setSelectedAssetId((current) => (current === asset.id ? null : current));
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
   async function importAsset(file) {
     if (!activeProject || !file) {
       setError("Create or open a project first.");
@@ -746,6 +778,7 @@ function App() {
           <LibraryScreen
             assets={assets}
             deleteAsset={deleteAsset}
+            purgeAsset={purgeAsset}
             importAsset={importAsset}
             onPreview={setPreviewAsset}
             onSendImage={(asset) => {
@@ -780,6 +813,7 @@ function App() {
             setRequestedGpu={setRequestedGpu}
             updateAssetStatus={updateAssetStatus}
             deleteAsset={deleteAsset}
+            purgeAsset={purgeAsset}
           />
         ) : null}
 
@@ -789,6 +823,7 @@ function App() {
             assets={assets}
             createVideoJob={createVideoJob}
             deleteAsset={deleteAsset}
+            purgeAsset={purgeAsset}
             gpuOptions={gpuOptions}
             latestAssets={latestVideoAssets}
             onPreview={setPreviewAsset}
@@ -852,6 +887,7 @@ function App() {
 function LibraryScreen({
   assets,
   deleteAsset,
+  purgeAsset,
   importAsset,
   onPreview,
   onSendImage,
@@ -863,12 +899,16 @@ function LibraryScreen({
 }) {
   const [typeFilter, setTypeFilter] = useState("all");
   const [showRejected, setShowRejected] = useState(false);
+  const [showTrashed, setShowTrashed] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const visibleAssets = assets.filter((asset) => {
     if (typeFilter !== "all" && asset.type !== typeFilter) {
       return false;
     }
     if (!showRejected && asset.status?.rejected) {
+      return false;
+    }
+    if (!showTrashed && asset.status?.trashed) {
       return false;
     }
     return true;
@@ -908,6 +948,10 @@ function LibraryScreen({
             <input checked={showRejected} onChange={(event) => setShowRejected(event.target.checked)} type="checkbox" />
             Rejected
           </label>
+          <label className="checkline">
+            <input checked={showTrashed} onChange={(event) => setShowTrashed(event.target.checked)} type="checkbox" />
+            Trash
+          </label>
         </div>
       </div>
 
@@ -921,6 +965,7 @@ function LibraryScreen({
         <AssetDetail
           asset={selectedAsset}
           deleteAsset={deleteAsset}
+          purgeAsset={purgeAsset}
           onPreview={onPreview}
           onSendImage={onSendImage}
           onSendVideo={onSendVideo}
@@ -1042,6 +1087,7 @@ function ImageStudio({
   assets,
   createImageJob,
   deleteAsset,
+  purgeAsset,
   gpuOptions,
   imageModels,
   latestAssets,
@@ -1226,6 +1272,7 @@ function ImageStudio({
                   deleteAsset={deleteAsset}
                   key={asset.id}
                   onPreview={onPreview}
+                  purgeAsset={purgeAsset}
                   updateAssetStatus={updateAssetStatus}
                 />
               ))}
@@ -1244,6 +1291,7 @@ function VideoStudio({
   assets,
   createVideoJob,
   deleteAsset,
+  purgeAsset,
   gpuOptions,
   latestAssets,
   onPreview,
@@ -1527,6 +1575,7 @@ function VideoStudio({
                   deleteAsset={deleteAsset}
                   key={asset.id}
                   onPreview={onPreview}
+                  purgeAsset={purgeAsset}
                   updateAssetStatus={updateAssetStatus}
                 />
               ))}
@@ -2068,7 +2117,7 @@ function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
   );
 }
 
-function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, onSendVideo, onSendEditor, updateAssetStatus }) {
+function AssetDetail({ asset, deleteAsset, purgeAsset, onPreview, onSendImage, onSendVideo, onSendEditor, updateAssetStatus }) {
   if (!asset) {
     return <aside className="asset-detail empty-panel">No asset selected</aside>;
   }
@@ -2114,9 +2163,15 @@ function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, onSendVideo, 
             Send to Editor
           </button>
         ) : null}
-        <button onClick={() => deleteAsset(asset)} type="button">
-          Discard
-        </button>
+        {asset.status?.trashed ? (
+          <button onClick={() => purgeAsset(asset)} type="button">
+            Purge
+          </button>
+        ) : (
+          <button onClick={() => deleteAsset(asset)} type="button">
+            Discard
+          </button>
+        )}
       </div>
       <dl>
         <div>
@@ -2136,9 +2191,12 @@ function AssetDetail({ asset, deleteAsset, onPreview, onSendImage, onSendVideo, 
   );
 }
 
-function AssetCard({ asset, deleteAsset, onPreview, updateAssetStatus }) {
+function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAssetStatus }) {
+  const classes = ["review-card", asset.status?.rejected ? "rejected" : "", asset.status?.trashed ? "trashed" : ""]
+    .filter(Boolean)
+    .join(" ");
   return (
-    <article className={asset.status?.rejected ? "review-card rejected" : "review-card"}>
+    <article className={classes}>
       <button className="preview-button" onClick={() => onPreview(asset)} type="button">
         <AssetMedia asset={asset} />
       </button>
@@ -2149,9 +2207,15 @@ function AssetCard({ asset, deleteAsset, onPreview, updateAssetStatus }) {
         <button onClick={() => updateAssetStatus(asset, { rejected: !asset.status?.rejected })} type="button">
           {asset.status?.rejected ? "Restore" : "Reject"}
         </button>
-        <button onClick={() => deleteAsset(asset)} type="button">
-          Discard
-        </button>
+        {asset.status?.trashed ? (
+          <button onClick={() => purgeAsset(asset)} type="button">
+            Purge
+          </button>
+        ) : (
+          <button onClick={() => deleteAsset(asset)} type="button">
+            Discard
+          </button>
+        )}
       </div>
     </article>
   );

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -48,6 +48,9 @@ describe("SceneWorks app shell", () => {
       if (path.endsWith("/access")) {
         return Promise.resolve(response({ authRequired: false }));
       }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
       return Promise.resolve(response([]));
     });
   });
@@ -71,7 +74,7 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Queue");
   });
 
-  it("adds the SSE token as a query parameter", () => {
-    expect(eventUrl("/api/v1/jobs/events", "secret-token")).toContain("token=secret-token");
+  it("adds the SSE ticket as a query parameter", () => {
+    expect(eventUrl("/api/v1/jobs/events", "stream-ticket")).toContain("ticket=stream-ticket");
   });
 });

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -2,6 +2,7 @@ httpx==0.28.1
 pytest==9.0.2
 huggingface_hub>=0.36,<1
 pillow>=12.0.0,<13
+numpy>=2.0,<3
 torch>=2.7
 transformers>=4.57
 accelerate>=1.11

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
 import hashlib
 import importlib
 import json
 import os
-import re
-import sqlite3
 import warnings
 from pathlib import Path
 from textwrap import wrap
@@ -15,6 +12,18 @@ from typing import Any, Callable
 from uuid import uuid4
 
 from PIL import Image, ImageDraw, ImageFont
+
+from sceneworks_shared import (
+    ProjectNotFound,
+    find_asset_sidecar_path,
+    find_project_path as shared_find_project_path,
+    index_asset,
+    read_json,
+    safe_int,
+    slugify,
+    utc_now,
+    write_json,
+)
 
 from .settings import WorkerSettings
 
@@ -72,23 +81,6 @@ class ImageRequest:
     advanced: dict[str, Any]
 
 
-def utc_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def slugify(value: str) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
-    return (slug or "image")[:42]
-
-
-def safe_int(value: Any, default: int, minimum: int, maximum: int) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return default
-    return max(minimum, min(maximum, parsed))
-
-
 def load_registry(data_dir: Path) -> list[dict[str, Any]]:
     registry_path = data_dir / "recent-projects.json"
     if not registry_path.exists():
@@ -98,10 +90,10 @@ def load_registry(data_dir: Path) -> list[dict[str, Any]]:
 
 
 def find_project_path(settings: WorkerSettings, project_id: str) -> Path:
-    for project in load_registry(settings.data_dir):
-        if project.get("id") == project_id:
-            return Path(project["path"])
-    raise RuntimeError(f"Project not found: {project_id}")
+    try:
+        return shared_find_project_path(settings.data_dir / "recent-projects.json", project_id)
+    except ProjectNotFound as exc:
+        raise RuntimeError(str(exc)) from exc
 
 
 def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
@@ -143,7 +135,7 @@ class ImageAssetWriter:
         created_at = utc_now()
         generation_set_id = f"genset_{uuid4().hex}"
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
-        prompt_slug = slugify(request.prompt)
+        prompt_slug = slugify(request.prompt, fallback="image", max_length=42)
         date_slug = created_at[:10]
         assets = []
 
@@ -189,7 +181,7 @@ class ImageAssetWriter:
             )
             write_json(sidecar_path, asset)
             write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
-            index_project_db(project_path, asset)
+            index_project_db(project_path, asset, sidecar_path)
             assets.append(asset)
             progress(
                 "saving",
@@ -214,6 +206,9 @@ class ZImageDiffusersAdapter:
         self._text_pipe: Any | None = None
         self._img2img_pipe: Any | None = None
         self._loaded_repo: str | None = None
+
+    def loaded_models(self) -> list[str]:
+        return [self._loaded_repo] if self._loaded_repo else []
 
     def generate(
         self,
@@ -269,6 +264,15 @@ class ZImageDiffusersAdapter:
         if cached_pipe is not None and self._loaded_repo == repo:
             return cached_pipe
 
+        if self._loaded_repo and self._loaded_repo != repo:
+            self._evict_pipelines(torch)
+        elif use_img2img and self._text_pipe is not None:
+            self._text_pipe = None
+            self._empty_cuda_cache(torch)
+        elif not use_img2img and self._img2img_pipe is not None:
+            self._img2img_pipe = None
+            self._empty_cuda_cache(torch)
+
         pipeline_name = "ZImageImg2ImgPipeline" if use_img2img else "ZImagePipeline"
         pipeline_class = getattr(diffusers, pipeline_name, None)
         if pipeline_class is None and use_img2img:
@@ -295,6 +299,16 @@ class ZImageDiffusersAdapter:
             self._text_pipe = pipe
         self._loaded_repo = repo
         return pipe
+
+    def _evict_pipelines(self, torch: Any) -> None:
+        self._text_pipe = None
+        self._img2img_pipe = None
+        self._loaded_repo = None
+        self._empty_cuda_cache(torch)
+
+    def _empty_cuda_cache(self, torch: Any) -> None:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
         torch = importlib.import_module("torch")
@@ -330,6 +344,9 @@ class ZImageDiffusersAdapter:
 
 class ProceduralImageAdapter:
     id = "procedural_preview"
+
+    def loaded_models(self) -> list[str]:
+        return []
 
     def generate(
         self,
@@ -372,15 +389,18 @@ class ProceduralImageAdapter:
         )
 
 
-def create_image_adapter(job: dict[str, Any]) -> ProceduralImageAdapter | ZImageDiffusersAdapter:
+def create_image_adapter(
+    job: dict[str, Any],
+    adapters: dict[str, object] | None = None,
+) -> ProceduralImageAdapter | ZImageDiffusersAdapter:
     payload = job.get("payload", {})
     requested = os.getenv("SCENEWORKS_IMAGE_ADAPTER", payload.get("adapter", "")).strip()
     if requested == "procedural_preview":
-        return ProceduralImageAdapter()
+        return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
     model_target = MODEL_TARGETS.get(payload.get("model", "z_image_turbo"), {})
     if model_target.get("adapter") == ZImageDiffusersAdapter.id:
-        return ZImageDiffusersAdapter()
-    return ProceduralImageAdapter()
+        return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
+    return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
 
 
 def model_supports_edit(model_id: str) -> bool:
@@ -424,36 +444,32 @@ def load_source_image(settings: WorkerSettings, request: ImageRequest) -> Image.
 
 
 def find_asset_media_path(project_path: Path, asset_id: str) -> Path:
-    for sidecar_path in (project_path / "assets" / "images").glob("*.sceneworks.json"):
-        try:
-            with sidecar_path.open("r", encoding="utf-8") as handle:
-                asset = json.load(handle)
-        except (OSError, json.JSONDecodeError):
-            continue
-        if asset.get("id") == asset_id:
-            media_path = project_path / asset.get("file", {}).get("path", "")
-            if media_path.exists():
-                return media_path
-            raise RuntimeError(f"Source image file is missing for asset {asset_id}.")
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is not None:
+        asset = read_json(sidecar_path)
+        media_path = project_path / asset.get("file", {}).get("path", "")
+        if media_path.exists():
+            return media_path
+        raise RuntimeError(f"Source image file is missing for asset {asset_id}.")
     raise RuntimeError(f"Source image asset not found: {asset_id}.")
 
 
 def render_preview_image(request: ImageRequest, model_target: dict[str, Any], seed: int, index: int) -> Image.Image:
+    import numpy as np
+
     width = min(request.width, 1280)
     height = min(request.height, 1280)
     digest = hashlib.sha256(f"{request.prompt}:{request.style_preset}:{seed}".encode("utf-8")).digest()
-    base = (digest[0], digest[1], digest[2])
-    accent = (digest[9], digest[10], digest[11])
-    image = Image.new("RGB", (width, height), base)
-    pixels = image.load()
-    for y in range(height):
-        for x in range(width):
-            mix = (x / max(1, width - 1) * 0.56) + (y / max(1, height - 1) * 0.44)
-            wave = ((x * digest[3] + y * digest[4] + seed) % 255) / 255
-            pixels[x, y] = tuple(
-                int(base[channel] * (1 - mix) + accent[channel] * mix * 0.85 + wave * 34)
-                for channel in range(3)
-            )
+    base = np.array([digest[0], digest[1], digest[2]], dtype=np.float32)
+    accent = np.array([digest[9], digest[10], digest[11]], dtype=np.float32)
+    x = np.linspace(0, 1, width, dtype=np.float32)[None, :]
+    y = np.linspace(0, 1, height, dtype=np.float32)[:, None]
+    mix = x * 0.56 + y * 0.44
+    xi = np.arange(width, dtype=np.uint32)[None, :]
+    yi = np.arange(height, dtype=np.uint32)[:, None]
+    wave = ((xi * digest[3] + yi * digest[4] + seed) % 255).astype(np.float32) / 255
+    pixels = base * (1 - mix[..., None]) + accent * mix[..., None] * 0.85 + wave[..., None] * 34
+    image = Image.fromarray(np.clip(pixels, 0, 255).astype(np.uint8), "RGB")
 
     draw = ImageDraw.Draw(image, "RGBA")
     draw.rectangle((0, height * 0.68, width, height), fill=(12, 12, 12, 168))
@@ -534,48 +550,5 @@ def build_asset_sidecar(
     }
 
 
-def write_json(path: Path, payload: dict[str, Any]) -> None:
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(payload, handle, indent=2)
-        handle.write("\n")
-
-
-def index_project_db(project_path: Path, asset: dict[str, Any]) -> None:
-    db_path = project_path / "project.db"
-    with sqlite3.connect(db_path) as connection:
-        connection.execute(
-            """
-            create table if not exists assets (
-              id text primary key,
-              type text not null,
-              display_name text not null,
-              file_path text not null,
-              generation_set_id text,
-              created_at text not null,
-              favorite integer not null default 0,
-              rating integer not null default 0,
-              rejected integer not null default 0,
-              trashed integer not null default 0
-            )
-            """
-        )
-        connection.execute(
-            """
-            insert or replace into assets (
-              id, type, display_name, file_path, generation_set_id, created_at,
-              favorite, rating, rejected, trashed
-            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                asset["id"],
-                asset["type"],
-                asset["displayName"],
-                asset["file"]["path"],
-                asset["generationSetId"],
-                asset["createdAt"],
-                int(asset["status"]["favorite"]),
-                int(asset["status"]["rating"]),
-                int(asset["status"]["rejected"]),
-                int(asset["status"]["trashed"]),
-            ),
-        )
+def index_project_db(project_path: Path, asset: dict[str, Any], sidecar_path: Path | None = None) -> None:
+    index_asset(project_path, asset, sidecar_path or (project_path / asset["file"]["path"]).with_suffix(".sceneworks.json"))

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -10,7 +10,7 @@ from typing import Any
 import httpx
 
 from .gpu import discover_gpu
-from .image_adapters import create_image_adapter
+from .image_adapters import ProceduralImageAdapter, ZImageDiffusersAdapter, create_image_adapter
 from .settings import WorkerSettings
 from .timeline_exporter import run_timeline_export
 from .video_adapters import ProceduralVideoAdapter
@@ -50,13 +50,22 @@ def worker_capabilities(gpu: dict) -> list[str]:
     return sorted(capabilities)
 
 
-def register_worker(api: ApiClient, settings: WorkerSettings, gpu: dict) -> None:
+def loaded_models_from_adapters(adapters: dict[str, object]) -> list[str]:
+    models: set[str] = set()
+    for adapter in adapters.values():
+        loaded_models = getattr(adapter, "loaded_models", None)
+        if callable(loaded_models):
+            models.update(loaded_models())
+    return sorted(models)
+
+
+def register_worker(api: ApiClient, settings: WorkerSettings, gpu: dict, loaded_models: list[str] | None = None) -> None:
     payload = {
         "workerId": settings.worker_id,
         "gpuId": gpu["id"],
         "gpuName": gpu["name"],
         "capabilities": worker_capabilities(gpu),
-        "loadedModels": [],
+        "loadedModels": loaded_models or [],
     }
     worker = api.post("/api/v1/workers/register", payload)
     emit({"event": "registered", "worker": worker, "reportedAt": now()})
@@ -67,10 +76,11 @@ def heartbeat(
     settings: WorkerSettings,
     status: str,
     current_job_id: str | None = None,
+    loaded_models: list[str] | None = None,
 ) -> None:
     api.post(
         f"/api/v1/workers/{settings.worker_id}/heartbeat",
-        {"status": status, "currentJobId": current_job_id, "loadedModels": []},
+        {"status": status, "currentJobId": current_job_id, "loadedModels": loaded_models or []},
     )
 
 
@@ -307,12 +317,16 @@ def run_placeholder_job(api: ApiClient, settings: WorkerSettings, job: dict) -> 
     heartbeat(api, settings, "idle")
 
 
-def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_adapters: dict[str, object]) -> None:
     job_id = job["id"]
-    adapter = create_image_adapter(job)
+    adapter = create_image_adapter(job, image_adapters)
+
+    def adapter_loaded_models() -> list[str]:
+        loaded_models = getattr(adapter, "loaded_models", None)
+        return loaded_models() if callable(loaded_models) else []
 
     def progress(status: str, stage: str, value: float, message: str) -> None:
-        heartbeat(api, settings, "busy", job_id)
+        heartbeat(api, settings, "busy", job_id, adapter_loaded_models())
         update_job(
             api,
             job_id,
@@ -368,7 +382,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             },
         )
     finally:
-        heartbeat(api, settings, "idle")
+        heartbeat(api, settings, "idle", loaded_models_from_adapters(image_adapters))
 
 
 def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
@@ -513,11 +527,15 @@ def main() -> None:
     settings = WorkerSettings()
     gpu = discover_gpu(settings.gpu_id)
     api = ApiClient(settings)
+    image_adapters: dict[str, object] = {
+        "procedural_preview": ProceduralImageAdapter(),
+        "z_image_diffusers": ZImageDiffusersAdapter(),
+    }
     max_registration_attempts = 20
 
     for attempt in range(1, max_registration_attempts + 1):
         try:
-            register_worker(api, settings, gpu)
+            register_worker(api, settings, gpu, loaded_models_from_adapters(image_adapters))
             break
         except httpx.HTTPError as exc:
             delay = min(30, settings.poll_seconds * (2 ** (attempt - 1)))
@@ -537,7 +555,7 @@ def main() -> None:
 
     while True:
         try:
-            heartbeat(api, settings, "idle")
+            heartbeat(api, settings, "idle", loaded_models=loaded_models_from_adapters(image_adapters))
             claimed = api.post("/api/v1/jobs/claim", {"workerId": settings.worker_id})
             job = claimed.get("job")
             if job is None:
@@ -548,7 +566,7 @@ def main() -> None:
             if job["type"] == "placeholder":
                 run_placeholder_job(api, settings, job)
             elif job["type"] in ("image_generate", "image_edit"):
-                run_image_job(api, settings, job)
+                run_image_job(api, settings, job, image_adapters)
             elif job["type"] in ("video_generate", "video_extend", "video_bridge"):
                 run_video_job(api, settings, job)
             elif job["type"] == "timeline_export":

--- a/apps/worker/scene_worker/timeline_exporter.py
+++ b/apps/worker/scene_worker/timeline_exporter.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
 import json
 import math
-import re
 import shutil
 import sqlite3
 import subprocess
@@ -12,6 +10,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
+
+from sceneworks_shared import find_asset_sidecar_path, read_json, safe_float, slugify, utc_now
 
 from .image_adapters import find_project_path, index_project_db, write_json
 from .settings import WorkerSettings
@@ -31,15 +31,6 @@ class ExportRequest:
     timeline_path: str
     resolution: int
     fps: int
-
-
-def utc_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def slugify(value: str) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
-    return (slug or "timeline-export")[:48]
 
 
 def export_request_from_job(job: dict[str, Any]) -> ExportRequest:
@@ -90,7 +81,7 @@ def run_timeline_export(
                 cursor = start
 
             asset = find_asset(project_path, item["assetId"])
-            segment_path = tmp_path / f"segment_{len(segments):04d}_{slugify(item.get('displayName', 'item'))}.mp4"
+            segment_path = tmp_path / f"segment_{len(segments):04d}_{slugify(item.get('displayName', 'item'), fallback='timeline-export', max_length=48)}.mp4"
             duration = render_item_segment(
                 ffmpeg=ffmpeg,
                 project_path=project_path,
@@ -112,7 +103,7 @@ def run_timeline_export(
             cursor = max(cursor, safe_float(item.get("timelineEnd"), start + duration))
             progress("running", "rendering", 0.12 + ((index + 1) / total) * 0.58, "Rendering timeline segments.")
 
-        output_rel = f"assets/renders/{utc_now()[:10]}_{slugify(request.timeline_name)}_{job['id'][-8:]}.mp4"
+        output_rel = f"assets/renders/{utc_now()[:10]}_{slugify(request.timeline_name, fallback='timeline-export', max_length=48)}_{job['id'][-8:]}.mp4"
         output_path = project_path / output_rel
         output_path.parent.mkdir(parents=True, exist_ok=True)
         progress("saving", "muxing", 0.78, "Muxing MP4 export.")
@@ -141,11 +132,6 @@ def run_timeline_export(
     }
 
 
-def read_json(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
 def main_track_items(timeline: dict[str, Any]) -> list[dict[str, Any]]:
     for track in timeline.get("tracks", []):
         if track.get("id") == "track_main" or track.get("kind") == "video":
@@ -168,23 +154,10 @@ def even(value: float) -> int:
     return parsed if parsed % 2 == 0 else parsed + 1
 
 
-def safe_float(value: Any, default: float) -> float:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return default
-    return max(0, parsed)
-
-
 def find_asset(project_path: Path, asset_id: str) -> dict[str, Any]:
-    for folder in ASSET_FOLDERS:
-        for sidecar_path in (project_path / folder).glob("*.sceneworks.json"):
-            try:
-                asset = read_json(sidecar_path)
-            except (OSError, json.JSONDecodeError):
-                continue
-            if asset.get("id") == asset_id:
-                return asset
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is not None:
+        return read_json(sidecar_path)
     raise RuntimeError(f"Timeline asset not found: {asset_id}")
 
 

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import UTC, datetime
 import hashlib
-import re
 import warnings
 from pathlib import Path
 from textwrap import wrap
@@ -12,6 +10,8 @@ from typing import Any, Callable
 from uuid import uuid4
 
 from PIL import Image, ImageDraw, ImageEnhance, ImageFont
+
+from sceneworks_shared import find_asset_sidecar_path, read_json, safe_float, safe_int, slugify, utc_now
 
 from .image_adapters import find_project_path, index_project_db, write_json
 from .settings import WorkerSettings
@@ -153,7 +153,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         seed = resolve_seed(request.seed, request.prompt)
         target = model_target(request.model)
         raw_settings = self.map_settings(request, target)
-        filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt)}"
+        filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
         media_rel = f"assets/videos/{filename_base}.webp"
         media_path = project_path / media_rel
         temp_path = media_path.with_suffix(".tmp.webp")
@@ -260,31 +260,6 @@ def model_target(model_id: str) -> dict[str, Any]:
     return VIDEO_MODEL_TARGETS.get(model_id, VIDEO_MODEL_TARGETS["ltx_2_3"])
 
 
-def utc_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def slugify(value: str) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower()
-    return (slug or "video")[:42]
-
-
-def safe_int(value: Any, default: int, minimum: int, maximum: int) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return default
-    return max(minimum, min(maximum, parsed))
-
-
-def safe_float(value: Any, default: float, minimum: float, maximum: float) -> float:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return default
-    return max(minimum, min(maximum, parsed))
-
-
 def normalized_dimensions(width: Any, height: Any) -> tuple[int, int]:
     parsed_width = safe_int(width, 768, 256, 1920)
     parsed_height = safe_int(height, 512, 256, 1920)
@@ -310,25 +285,19 @@ def preview_frame_count(request: VideoRequest) -> int:
 def load_source_image(project_path: Path, asset_id: str | None, width: int, height: int) -> Image.Image | None:
     if not asset_id:
         return None
-    for folder in ASSET_FOLDERS:
-        for sidecar_path in (project_path / folder).glob("*.sceneworks.json"):
-            try:
-                import json
-
-                payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
-            except (OSError, ValueError):
-                continue
-            if payload.get("id") != asset_id:
-                continue
-            media_path = project_path / payload.get("file", {}).get("path", "")
-            try:
-                image = Image.open(media_path).convert("RGB")
-            except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
-                return None
-            image.thumbnail((width, height), Image.Resampling.LANCZOS)
-            canvas = Image.new("RGB", (width, height), (18, 17, 15))
-            canvas.paste(image, ((width - image.width) // 2, (height - image.height) // 2))
-            return canvas
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        return None
+    payload = read_json(sidecar_path)
+    media_path = project_path / payload.get("file", {}).get("path", "")
+    try:
+        image = Image.open(media_path).convert("RGB")
+    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+        return None
+    image.thumbnail((width, height), Image.Resampling.LANCZOS)
+    canvas = Image.new("RGB", (width, height), (18, 17, 15))
+    canvas.paste(image, ((width - image.width) // 2, (height - image.height) // 2))
+    return canvas
     return None
 
 
@@ -362,19 +331,18 @@ def render_preview_frames(
 
 
 def gradient_frame(width: int, height: int, digest: bytes) -> Image.Image:
-    base = (digest[0], digest[1], digest[2])
-    accent = (digest[10], digest[11], digest[12])
-    image = Image.new("RGB", (width, height), base)
-    pixels = image.load()
-    for y in range(height):
-        for x in range(width):
-            mix = (x / max(1, width - 1) * 0.58) + (y / max(1, height - 1) * 0.42)
-            wave = ((x * digest[3] + y * digest[4]) % 255) / 255
-            pixels[x, y] = tuple(
-                int(base[channel] * (1 - mix) + accent[channel] * mix * 0.88 + wave * 28)
-                for channel in range(3)
-            )
-    return image
+    import numpy as np
+
+    base = np.array([digest[0], digest[1], digest[2]], dtype=np.float32)
+    accent = np.array([digest[10], digest[11], digest[12]], dtype=np.float32)
+    x = np.linspace(0, 1, width, dtype=np.float32)[None, :]
+    y = np.linspace(0, 1, height, dtype=np.float32)[:, None]
+    mix = x * 0.58 + y * 0.42
+    xi = np.arange(width, dtype=np.uint32)[None, :]
+    yi = np.arange(height, dtype=np.uint32)[:, None]
+    wave = ((xi * digest[3] + yi * digest[4]) % 255).astype(np.float32) / 255
+    pixels = base * (1 - mix[..., None]) + accent * mix[..., None] * 0.88 + wave[..., None] * 28
+    return Image.fromarray(np.clip(pixels, 0, 255).astype(np.uint8), "RGB")
 
 
 def draw_motion(frame: Image.Image, digest: bytes, index: int, frame_count: int) -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       SCENEWORKS_API_PORT: ${SCENEWORKS_API_PORT:-8000}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
+      SCENEWORKS_JOBS_DB_PATH: /sceneworks/runtime/jobs.db
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       SCENEWORKS_CORS_ORIGINS: ${SCENEWORKS_CORS_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176}
     ports:
@@ -15,6 +16,7 @@ services:
     volumes:
       - ./data:/sceneworks/data
       - ./config:/sceneworks/config:ro
+      - api-runtime:/sceneworks/runtime
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v1/health', timeout=3).read()"]
       interval: 20s
@@ -68,3 +70,6 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
+
+volumes:
+  api-runtime:

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -9,7 +9,8 @@ COPY apps/api/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY apps/api ./apps/api
-ENV PYTHONPATH=/app/apps/api
+COPY packages/shared ./packages/shared
+ENV PYTHONPATH=/app/apps/api:/app/packages/shared
 
 EXPOSE 8000
 

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -13,6 +13,7 @@ COPY apps/worker/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY apps/worker ./apps/worker
-ENV PYTHONPATH=/app/apps/worker
+COPY packages/shared ./packages/shared
+ENV PYTHONPATH=/app/apps/worker:/app/packages/shared
 
 CMD ["python", "-m", "scene_worker"]

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,3 +1,7 @@
 # SceneWorks Shared Package
 
-Reserved for small cross-app helpers that are not tied to a single runtime.
+Small Python helpers shared by the API and worker runtimes:
+
+- JSON/time/slug parsing utilities.
+- Registry-backed project lookup with a shared `ProjectNotFound` contract.
+- Project SQLite migrations, asset indexing, sidecar lookup, purge, and reindex helpers.

--- a/packages/shared/sceneworks_shared/__init__.py
+++ b/packages/shared/sceneworks_shared/__init__.py
@@ -1,0 +1,39 @@
+from .project_db import (
+    apply_project_migrations,
+    ensure_project_db_ready,
+    find_asset_record,
+    find_asset_sidecar_path,
+    index_asset,
+    purge_asset,
+    reindex_project,
+)
+from .utils import (
+    ProjectNotFound,
+    find_project_path,
+    load_registry,
+    read_json,
+    safe_float,
+    safe_int,
+    slugify,
+    utc_now,
+    write_json,
+)
+
+__all__ = [
+    "ProjectNotFound",
+    "apply_project_migrations",
+    "ensure_project_db_ready",
+    "find_asset_record",
+    "find_asset_sidecar_path",
+    "find_project_path",
+    "index_asset",
+    "load_registry",
+    "purge_asset",
+    "read_json",
+    "reindex_project",
+    "safe_float",
+    "safe_int",
+    "slugify",
+    "utc_now",
+    "write_json",
+]

--- a/packages/shared/sceneworks_shared/project_db.py
+++ b/packages/shared/sceneworks_shared/project_db.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from .utils import read_json
+
+
+ASSET_SIDECAR_PATTERN = "*.sceneworks.json"
+ASSET_FOLDERS = ("assets/images", "assets/videos", "assets/uploads", "assets/frames", "assets/renders", "trash")
+
+
+def apply_project_migrations(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        create table if not exists project_metadata (
+          key text primary key,
+          value text not null
+        )
+        """
+    )
+    connection.execute("insert or replace into project_metadata (key, value) values (?, ?)", ("schemaVersion", "1"))
+    connection.execute(
+        """
+        create table if not exists assets (
+          id text primary key,
+          type text not null,
+          display_name text not null,
+          file_path text not null,
+          generation_set_id text,
+          created_at text not null,
+          favorite integer not null default 0,
+          rating integer not null default 0,
+          rejected integer not null default 0,
+          trashed integer not null default 0
+        )
+        """
+    )
+    connection.execute(
+        """
+        create table if not exists generation_sets (
+          id text primary key,
+          mode text not null,
+          model text not null,
+          prompt text not null,
+          created_at text not null,
+          job_id text
+        )
+        """
+    )
+    connection.execute(
+        """
+        create table if not exists timelines (
+          id text primary key,
+          name text not null,
+          file_path text not null,
+          aspect_ratio text not null,
+          width integer not null,
+          height integer not null,
+          fps integer not null,
+          duration real not null default 0,
+          created_at text not null,
+          updated_at text not null
+        )
+        """
+    )
+    _ensure_column(connection, "assets", "sidecar_path", "text")
+
+
+def ensure_project_db_ready(project_path: Path) -> None:
+    with sqlite3.connect(project_path / "project.db") as connection:
+        apply_project_migrations(connection)
+
+
+def _ensure_column(connection: sqlite3.Connection, table: str, column: str, definition: str) -> None:
+    columns = {row[1] for row in connection.execute(f"pragma table_info({table})").fetchall()}
+    if column not in columns:
+        connection.execute(f"alter table {table} add column {column} {definition}")
+
+
+def index_asset(project_path: Path, asset: dict[str, Any], sidecar_path: Path | None = None) -> None:
+    sidecar_rel = None
+    if sidecar_path is not None:
+        sidecar_rel = str(sidecar_path.relative_to(project_path)).replace("\\", "/")
+    with sqlite3.connect(project_path / "project.db") as connection:
+        apply_project_migrations(connection)
+        _index_asset_on_connection(connection, asset, sidecar_rel)
+
+
+def _index_asset_on_connection(connection: sqlite3.Connection, asset: dict[str, Any], sidecar_rel: str | None) -> None:
+    connection.execute(
+        """
+        insert or replace into assets (
+          id, type, display_name, file_path, generation_set_id, created_at,
+          favorite, rating, rejected, trashed, sidecar_path
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            asset["id"],
+            asset["type"],
+            asset["displayName"],
+            asset["file"]["path"],
+            asset.get("generationSetId"),
+            asset["createdAt"],
+            int(asset.get("status", {}).get("favorite", False)),
+            int(asset.get("status", {}).get("rating", 0)),
+            int(asset.get("status", {}).get("rejected", False)),
+            int(asset.get("status", {}).get("trashed", False)),
+            sidecar_rel,
+        ),
+    )
+
+
+def find_asset_record(project_path: Path, asset_id: str) -> dict[str, Any] | None:
+    ensure_project_db_ready(project_path)
+    with sqlite3.connect(project_path / "project.db") as connection:
+        row = connection.execute(
+            """
+            select id, type, display_name, file_path, generation_set_id, created_at,
+                   favorite, rating, rejected, trashed, sidecar_path
+              from assets
+             where id = ?
+            """,
+            (asset_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "type": row[1],
+        "displayName": row[2],
+        "filePath": row[3],
+        "generationSetId": row[4],
+        "createdAt": row[5],
+        "favorite": bool(row[6]),
+        "rating": row[7],
+        "rejected": bool(row[8]),
+        "trashed": bool(row[9]),
+        "sidecarPath": row[10],
+    }
+
+
+def find_asset_sidecar_path(project_path: Path, asset_id: str) -> Path | None:
+    record = find_asset_record(project_path, asset_id)
+    if record is not None:
+        candidates = []
+        if record.get("sidecarPath"):
+            candidates.append(project_path / record["sidecarPath"])
+        if record.get("filePath"):
+            candidates.append((project_path / record["filePath"]).with_suffix(".sceneworks.json"))
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+    return _find_asset_sidecar_by_glob(project_path, asset_id)
+
+
+def _find_asset_sidecar_by_glob(project_path: Path, asset_id: str) -> Path | None:
+    for folder in ASSET_FOLDERS:
+        for sidecar_path in (project_path / folder).rglob(ASSET_SIDECAR_PATTERN):
+            try:
+                if read_json(sidecar_path).get("id") == asset_id:
+                    return sidecar_path
+            except (OSError, json.JSONDecodeError):
+                continue
+    return None
+
+
+def purge_asset(project_path: Path, asset_id: str) -> None:
+    with sqlite3.connect(project_path / "project.db") as connection:
+        apply_project_migrations(connection)
+        connection.execute("delete from assets where id = ?", (asset_id,))
+
+
+def reindex_project(project_path: Path) -> dict[str, int]:
+    db_path = project_path / "project.db"
+    counts = {"assets": 0, "generationSets": 0, "timelines": 0}
+    with sqlite3.connect(db_path) as connection:
+        apply_project_migrations(connection)
+        connection.execute("delete from assets")
+        connection.execute("delete from generation_sets")
+        connection.execute("delete from timelines")
+
+        for sidecar_path in _asset_sidecars(project_path):
+            try:
+                asset = read_json(sidecar_path)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not asset.get("id") or not asset.get("file", {}).get("path"):
+                continue
+            sidecar_rel = str(sidecar_path.relative_to(project_path)).replace("\\", "/")
+            _index_asset_on_connection(connection, asset, sidecar_rel)
+            counts["assets"] += 1
+
+        for genset_path in (project_path / "generation-sets").glob("*.json"):
+            try:
+                generation_set = read_json(genset_path)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not generation_set.get("id"):
+                continue
+            connection.execute(
+                """
+                insert or replace into generation_sets (id, mode, model, prompt, created_at, job_id)
+                values (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    generation_set["id"],
+                    generation_set.get("mode", "unknown"),
+                    generation_set.get("model", "unknown"),
+                    generation_set.get("prompt", ""),
+                    generation_set.get("createdAt", ""),
+                    generation_set.get("jobId"),
+                ),
+            )
+            counts["generationSets"] += 1
+
+        for timeline_path in (project_path / "timelines").glob("*.sceneworks.timeline.json"):
+            try:
+                timeline = read_json(timeline_path)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not timeline.get("id"):
+                continue
+            rel_path = str(timeline_path.relative_to(project_path)).replace("\\", "/")
+            connection.execute(
+                """
+                insert or replace into timelines (
+                  id, name, file_path, aspect_ratio, width, height, fps, duration, created_at, updated_at
+                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    timeline["id"],
+                    timeline.get("name", "Timeline"),
+                    rel_path,
+                    timeline.get("aspectRatio", "16:9"),
+                    int(timeline.get("width") or 1280),
+                    int(timeline.get("height") or 720),
+                    int(timeline.get("fps") or 30),
+                    float(timeline.get("duration") or 0),
+                    timeline.get("createdAt") or "",
+                    timeline.get("updatedAt") or timeline.get("createdAt") or "",
+                ),
+            )
+            counts["timelines"] += 1
+    return counts
+
+
+def _asset_sidecars(project_path: Path) -> list[Path]:
+    sidecars: list[Path] = []
+    for folder in ASSET_FOLDERS:
+        sidecars.extend((project_path / folder).rglob(ASSET_SIDECAR_PATTERN))
+    timeline_dir = project_path / "timelines"
+    return [path for path in sidecars if timeline_dir not in path.parents]

--- a/packages/shared/sceneworks_shared/utils.py
+++ b/packages/shared/sceneworks_shared/utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+class ProjectNotFound(RuntimeError):
+    pass
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def slugify(value: str, *, fallback: str = "item", max_length: int | None = None) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip()).strip("-").lower() or fallback
+    return slug[:max_length] if max_length else slug
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def safe_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def safe_float(value: Any, default: float, minimum: float = 0, maximum: float | None = None) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    parsed = max(minimum, parsed)
+    return min(maximum, parsed) if maximum is not None else parsed
+
+
+def load_registry(registry_path: Path) -> list[dict[str, Any]]:
+    if not registry_path.exists():
+        return []
+    with registry_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def find_project_path(registry_path: Path, project_id: str) -> Path:
+    for project in load_registry(registry_path):
+        if project.get("id") == project_id:
+            project_path = Path(project["path"])
+            if project_path.exists():
+                return project_path
+            break
+    raise ProjectNotFound(f"Project not found: {project_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,5 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-for package_path in (ROOT / "apps" / "api", ROOT / "apps" / "worker"):
+for package_path in (ROOT / "apps" / "api", ROOT / "apps" / "worker", ROOT / "packages" / "shared"):
     sys.path.insert(0, str(package_path))

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -7,7 +7,15 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from sceneworks_api.assets import AssetStatusUpdate, get_project_file, index_asset_db, update_asset_status, write_json
+from sceneworks_api.assets import (
+    AssetStatusUpdate,
+    delete_asset,
+    get_project_file,
+    index_asset_db,
+    purge_deleted_asset,
+    update_asset_status,
+    write_json,
+)
 
 
 def request_for_project(tmp_path, project_path):
@@ -61,3 +69,44 @@ def test_status_patch_updates_project_db(tmp_path):
         row = connection.execute("select favorite, rating, rejected, trashed from assets where id = ?", ("asset-1",)).fetchone()
 
     assert row == (1, 4, 1, 0)
+
+
+def test_delete_soft_trashes_asset_and_purge_removes_it(tmp_path):
+    project_path = tmp_path / "project.sceneworks"
+    image_dir = project_path / "assets" / "images"
+    image_dir.mkdir(parents=True)
+    media_path = image_dir / "image.png"
+    media_path.write_bytes(b"image")
+    asset = {
+        "id": "asset-1",
+        "projectId": "project-1",
+        "type": "image",
+        "displayName": "Image",
+        "createdAt": "2026-05-17T00:00:00Z",
+        "generationSetId": None,
+        "file": {"path": "assets/images/image.png"},
+        "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
+    }
+    sidecar_path = image_dir / "image.sceneworks.json"
+    write_json(sidecar_path, asset)
+    index_asset_db(project_path, asset)
+    request = request_for_project(tmp_path, project_path)
+
+    deleted = delete_asset("project-1", "asset-1", request)
+
+    assert deleted == {"id": "asset-1", "status": "trashed"}
+    assert not media_path.exists()
+    trash_sidecar = project_path / "trash" / "asset-1" / "image.sceneworks.json"
+    assert trash_sidecar.exists()
+    with sqlite3.connect(project_path / "project.db") as connection:
+        row = connection.execute("select file_path, trashed, sidecar_path from assets where id = ?", ("asset-1",)).fetchone()
+    assert row[0] == "trash/asset-1/image.png"
+    assert row[1] == 1
+    assert row[2] == "trash/asset-1/image.sceneworks.json"
+
+    purged = purge_deleted_asset("project-1", "asset-1", request)
+
+    assert purged == {"id": "asset-1", "status": "purged"}
+    assert not (project_path / "trash" / "asset-1").exists()
+    with sqlite3.connect(project_path / "project.db") as connection:
+        assert connection.execute("select count(*) from assets where id = ?", ("asset-1",)).fetchone()[0] == 0

--- a/tests/test_project_index.py
+++ b/tests/test_project_index.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from sceneworks_api.timelines import find_timeline_file
+from sceneworks_shared import reindex_project, write_json
+
+
+def test_find_timeline_file_heals_stale_db_path(tmp_path):
+    project_path = tmp_path / "project.sceneworks"
+    timeline_dir = project_path / "timelines"
+    timeline_dir.mkdir(parents=True)
+    actual_path = timeline_dir / "renamed.sceneworks.timeline.json"
+    write_json(
+        actual_path,
+        {
+            "id": "timeline-1",
+            "projectId": "project-1",
+            "name": "Main",
+            "aspectRatio": "16:9",
+            "width": 1280,
+            "height": 720,
+            "fps": 30,
+            "duration": 0,
+            "tracks": [],
+            "createdAt": "2026-05-17T00:00:00Z",
+            "updatedAt": "2026-05-17T00:00:00Z",
+        },
+    )
+    with sqlite3.connect(project_path / "project.db") as connection:
+        connection.execute(
+            """
+            create table timelines (
+              id text primary key,
+              name text not null,
+              file_path text not null,
+              aspect_ratio text not null,
+              width integer not null,
+              height integer not null,
+              fps integer not null,
+              duration real not null default 0,
+              created_at text not null,
+              updated_at text not null
+            )
+            """
+        )
+        connection.execute(
+            """
+            insert into timelines (
+              id, name, file_path, aspect_ratio, width, height, fps, duration, created_at, updated_at
+            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("timeline-1", "Main", "timelines/missing.sceneworks.timeline.json", "16:9", 1280, 720, 30, 0, "x", "x"),
+        )
+
+    assert find_timeline_file(project_path, "timeline-1") == actual_path
+
+    with sqlite3.connect(project_path / "project.db") as connection:
+        row = connection.execute("select file_path from timelines where id = ?", ("timeline-1",)).fetchone()
+    assert row[0] == "timelines/renamed.sceneworks.timeline.json"
+
+
+def test_reindex_project_rebuilds_asset_generation_set_and_timeline_tables(tmp_path):
+    project_path = tmp_path / "project.sceneworks"
+    image_dir = project_path / "assets" / "images"
+    genset_dir = project_path / "generation-sets"
+    timeline_dir = project_path / "timelines"
+    image_dir.mkdir(parents=True)
+    genset_dir.mkdir()
+    timeline_dir.mkdir()
+    write_json(
+        image_dir / "image.sceneworks.json",
+        {
+            "id": "asset-1",
+            "type": "image",
+            "displayName": "Image",
+            "createdAt": "2026-05-17T00:00:00Z",
+            "generationSetId": "genset-1",
+            "file": {"path": "assets/images/image.png"},
+            "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
+        },
+    )
+    write_json(
+        genset_dir / "genset-1.json",
+        {
+            "id": "genset-1",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "test",
+            "createdAt": "2026-05-17T00:00:00Z",
+            "jobId": "job-1",
+        },
+    )
+    timeline = {
+        "id": "timeline-1",
+        "name": "Main",
+        "aspectRatio": "16:9",
+        "width": 1280,
+        "height": 720,
+        "fps": 30,
+        "duration": 3.5,
+        "createdAt": "2026-05-17T00:00:00Z",
+        "updatedAt": "2026-05-17T00:00:00Z",
+    }
+    (timeline_dir / "main.sceneworks.timeline.json").write_text(json.dumps(timeline), encoding="utf-8")
+
+    counts = reindex_project(project_path)
+
+    assert counts == {"assets": 1, "generationSets": 1, "timelines": 1}
+    with sqlite3.connect(project_path / "project.db") as connection:
+        assert connection.execute("select count(*) from assets").fetchone()[0] == 1
+        assert connection.execute("select count(*) from generation_sets").fetchone()[0] == 1
+        assert connection.execute("select count(*) from timelines").fetchone()[0] == 1

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from scene_worker.runtime import worker_capabilities
+from scene_worker.runtime import loaded_models_from_adapters, worker_capabilities
 
 
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
@@ -17,3 +17,11 @@ def test_gpu_worker_advertises_generation_capabilities():
 
     assert "image_generate" in capabilities
     assert "video_generate" in capabilities
+
+
+def test_loaded_models_are_collected_from_adapter_cache():
+    class Adapter:
+        def loaded_models(self):
+            return ["Tongyi-MAI/Z-Image-Turbo"]
+
+    assert loaded_models_from_adapters({"z": Adapter()}) == ["Tongyi-MAI/Z-Image-Turbo"]


### PR DESCRIPTION
﻿## Summary

Addresses the next batch of SceneWorks code-review follow-ups from Shortcut epic 1197.

- Add shared Python helpers for project lookup, JSON/time/slug utilities, project DB migrations, asset indexing, purge, and reindex.
- Replace SSE access-token query auth with short-lived one-shot stream tickets.
- Add soft-delete trash flow, purge support, and Library UI controls for trashed assets.
- Add project reindex CLI/API and timeline DB path healing.
- Move asset source lookups toward DB-backed sidecar paths across API and worker paths.
- Vectorize procedural image/video preview gradients with NumPy and improve Z-Image adapter cache reporting/eviction.
- Update docs, Docker Python paths, and focused tests.

## Why

The review found duplicated utilities, DB/sidecar source-of-truth drift, slow sidecar globbing, token leakage risk through SSE URLs, destructive discard behavior, and worker cache/reporting gaps. This PR centralizes the shared pieces and closes the backend/worker-heavy findings while leaving the large web module split as its own follow-up.

## Validation

- `python -m pytest tests`
- `python -m compileall apps\api\sceneworks_api apps\worker\scene_worker packages\shared\sceneworks_shared tests`
- `npm run test --prefix apps/web`
- `npm run build --prefix apps/web`
- `git diff --cached --check`

Shortcut epic 1197 is updated; only F-021 remains open.
