### PR TITLE
[codex] Fix worker scheduling and model downloads

### DIFF
--- a/apps/api/sceneworks_api/image_generation.py
+++ b/apps/api/sceneworks_api/image_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from typing import Any, Literal
 
 from fastapi import APIRouter, Request
@@ -31,6 +32,17 @@ class ImageJobRequest(BaseModel):
     advanced: dict[str, Any] = Field(default_factory=dict)
 
 
+def random_image_seeds(count: int) -> list[int]:
+    return [secrets.randbits(32) for _ in range(count)]
+
+
+def image_job_payload(payload: ImageJobRequest) -> dict[str, Any]:
+    job_payload = payload.model_dump(exclude={"requestedGpu"})
+    if job_payload["seed"] is None:
+        job_payload["seeds"] = random_image_seeds(payload.count)
+    return job_payload
+
+
 @router.post("/jobs", status_code=201)
 def create_image_job(payload: ImageJobRequest, request: Request) -> dict:
     job_type = "image_edit" if payload.mode == "edit_image" else "image_generate"
@@ -38,7 +50,7 @@ def create_image_job(payload: ImageJobRequest, request: Request) -> dict:
         job_type=job_type,
         project_id=payload.projectId,
         project_name=payload.projectName,
-        payload=payload.model_dump(exclude={"requestedGpu"}),
+        payload=image_job_payload(payload),
         requested_gpu=payload.requestedGpu,
     )
     request.app.state.event_hub.publish("job.updated", job)

--- a/apps/api/sceneworks_api/jobs_store.py
+++ b/apps/api/sceneworks_api/jobs_store.py
@@ -326,6 +326,25 @@ class JobsStore:
     ) -> dict:
         now = utc_now()
         with self._lock, self.connect() as connection:
+            worker = self.get_worker(worker_id, connection=connection)
+            previous_job_id = worker["currentJobId"]
+            if not current_job_id and previous_job_id:
+                previous_job = self.get_job(previous_job_id, connection=connection)
+                if previous_job["status"] in ACTIVE_STATUSES:
+                    connection.execute(
+                        """
+                        update jobs
+                           set status = 'interrupted',
+                               stage = 'interrupted',
+                               message = 'Job was interrupted after its worker restarted.',
+                               error = 'Worker heartbeat no longer referenced the active job.',
+                               completed_at = ?,
+                               updated_at = ?,
+                               worker_id = null
+                         where id = ?
+                        """,
+                        (now, now, previous_job_id),
+                    )
             connection.execute(
                 """
                 update workers

--- a/apps/api/sceneworks_api/models.py
+++ b/apps/api/sceneworks_api/models.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from fnmatch import fnmatch
 import json
 import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import urlopen
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -99,6 +103,60 @@ def safe_download_dir(repo: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_.-]+", "__", repo).strip("_") or "download"
 
 
+def format_bytes(value: int | float | None) -> str | None:
+    if value is None:
+        return None
+    size = float(max(0, value))
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
+
+
+def allow_pattern_matches(path: str, patterns: list[str]) -> bool:
+    if not patterns:
+        return True
+    return any(fnmatch(path, pattern) for pattern in patterns)
+
+
+def download_size_from_siblings(siblings: list[dict[str, Any]], files: list[str] | None = None) -> int | None:
+    patterns = files or []
+    total = 0
+    found_size = False
+    for sibling in siblings:
+        filename = sibling.get("rfilename", "")
+        if not allow_pattern_matches(filename, patterns):
+            continue
+        size = sibling.get("size")
+        if size is None:
+            continue
+        found_size = True
+        total += int(size)
+    return total if found_size else None
+
+
+@lru_cache(maxsize=64)
+def estimate_huggingface_download_size(repo: str, files_key: tuple[str, ...]) -> int | None:
+    url = f"https://huggingface.co/api/models/{quote(repo, safe='/')}?blobs=true"
+    try:
+        with urlopen(url, timeout=8) as response:
+            payload = json.load(response)
+    except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
+        return None
+    return download_size_from_siblings(payload.get("siblings", []), list(files_key))
+
+
+def model_install_marker(path: Path) -> Path:
+    return path / ".sceneworks-download-complete.json"
+
+
+def model_is_installed(path: Path) -> bool:
+    return path.is_dir() and model_install_marker(path).is_file()
+
+
 def model_download(model: dict[str, Any]) -> dict[str, Any] | None:
     for download in model.get("downloads", []):
         if download.get("provider") == "huggingface" and download.get("repo"):
@@ -122,13 +180,20 @@ def model_catalog(request: Request) -> list[dict[str, Any]]:
         download = model_download(model)
         installed_path = None
         installed = False
+        download_size_bytes = None
         if download:
             installed_path = settings.data_dir / "models" / safe_download_dir(download["repo"])
-            installed = installed_path.is_dir() and any(installed_path.iterdir())
+            installed = model_is_installed(installed_path)
+            download_size_bytes = estimate_huggingface_download_size(
+                download["repo"],
+                tuple(download.get("files", [])),
+            )
         models.append(
             {
                 **model,
                 "downloadable": bool(download),
+                "downloadSizeBytes": download_size_bytes,
+                "downloadSizeLabel": format_bytes(download_size_bytes),
                 "installState": "installed" if installed else "missing",
                 "installedPath": str(installed_path) if installed_path else None,
             }

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -75,9 +75,13 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel }) {
                   <dt>Repo</dt>
                   <dd>{model.downloads?.[0]?.repo ?? "none"}</dd>
                 </div>
+                <div>
+                  <dt>Download</dt>
+                  <dd>{model.downloadSizeLabel ?? "unknown"}</dd>
+                </div>
               </dl>
               <button disabled={installed || !model.downloadable || Boolean(downloadJob)} onClick={() => onDownloadModel(model)} type="button">
-                {downloadJob ? downloadJob.status : installed ? "Ready" : "Download"}
+                {downloadJob ? downloadJob.status : installed ? "Ready" : model.downloadSizeLabel ? `Download ${model.downloadSizeLabel}` : "Download"}
               </button>
             </article>
           );

--- a/apps/worker/scene_worker/gpu.py
+++ b/apps/worker/scene_worker/gpu.py
@@ -1,22 +1,42 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 
 
-def discover_gpu(requested_gpu_id: str) -> dict:
-    if requested_gpu_id and requested_gpu_id != "auto":
-        return {
-            "id": requested_gpu_id,
-            "name": f"GPU {requested_gpu_id}",
-            "capabilities": ["placeholder", "gpu"],
-        }
+def gpu_worker_id(base_worker_id: str, gpu_id: str) -> str:
+    safe_gpu_id = re.sub(r"[^a-zA-Z0-9_.-]+", "-", gpu_id).strip("-") or "gpu"
+    if safe_gpu_id == "0" and base_worker_id.endswith("-0"):
+        return base_worker_id
+    if base_worker_id.endswith("-0") and safe_gpu_id.isdigit():
+        return f"{base_worker_id[:-1]}{safe_gpu_id}"
+    return f"{base_worker_id}-gpu-{safe_gpu_id}"
 
-    visible_devices = os.getenv("NVIDIA_VISIBLE_DEVICES", "").strip()
-    if visible_devices and visible_devices not in ("all", "void", "none"):
-        gpu_id = visible_devices.split(",")[0].strip()
-        return {"id": gpu_id, "name": f"GPU {gpu_id}", "capabilities": ["placeholder", "gpu"]}
 
+def cpu_worker_id(base_worker_id: str) -> str:
+    base = base_worker_id[:-2] if base_worker_id.endswith("-0") else base_worker_id
+    return f"{base}-cpu"
+
+
+def parse_nvidia_smi_gpus(output: str) -> list[dict]:
+    gpus = []
+    for line in output.strip().splitlines():
+        parts = [part.strip() for part in line.split(",", maxsplit=2)]
+        if len(parts) != 3:
+            continue
+        index, name, memory_mb = parts
+        gpus.append(
+            {
+                "id": index,
+                "name": f"{name} ({memory_mb} MB)",
+                "capabilities": ["placeholder", "gpu", "nvidia"],
+            }
+        )
+    return gpus
+
+
+def query_nvidia_gpus() -> list[dict]:
     try:
         result = subprocess.run(
             [
@@ -29,16 +49,58 @@ def discover_gpu(requested_gpu_id: str) -> dict:
             text=True,
             timeout=3,
         )
-        first_line = result.stdout.strip().splitlines()[0]
-        index, name, memory_mb = [part.strip() for part in first_line.split(",", maxsplit=2)]
-        return {
-            "id": index,
-            "name": f"{name} ({memory_mb} MB)",
-            "capabilities": ["placeholder", "gpu", "nvidia"],
-        }
-    except (IndexError, OSError, subprocess.SubprocessError, ValueError):
+        return parse_nvidia_smi_gpus(result.stdout)
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+
+def visible_gpu_ids() -> list[str] | None:
+    visible_devices = os.getenv("NVIDIA_VISIBLE_DEVICES", "").strip()
+    if not visible_devices or visible_devices == "all":
+        return None
+    if visible_devices in ("void", "none"):
+        return []
+    return [device.strip() for device in visible_devices.split(",") if device.strip()]
+
+
+def discover_gpus() -> list[dict]:
+    ids = visible_gpu_ids()
+    if ids == []:
+        return []
+
+    gpus = query_nvidia_gpus()
+    if ids is not None:
+        by_id = {gpu["id"]: gpu for gpu in gpus}
+        return [
+            by_id.get(gpu_id, {"id": gpu_id, "name": f"GPU {gpu_id}", "capabilities": ["placeholder", "gpu"]})
+            for gpu_id in ids
+        ]
+    return gpus
+
+
+def discover_gpu(requested_gpu_id: str) -> dict:
+    if requested_gpu_id == "cpu":
         return {
             "id": "cpu",
-            "name": "CPU placeholder",
+            "name": "CPU utility worker",
             "capabilities": ["placeholder", "cpu"],
         }
+
+    gpus = discover_gpus()
+    if requested_gpu_id and requested_gpu_id != "auto":
+        for gpu in gpus:
+            if gpu["id"] == requested_gpu_id:
+                return gpu
+        return {
+            "id": requested_gpu_id,
+            "name": f"GPU {requested_gpu_id}",
+            "capabilities": ["placeholder", "gpu"],
+        }
+
+    if gpus:
+        return gpus[0]
+    return {
+        "id": "cpu",
+        "name": "CPU utility worker",
+        "capabilities": ["placeholder", "cpu"],
+    }

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -73,6 +73,7 @@ class ImageRequest:
     model: str
     count: int
     seed: int | None
+    seeds: list[int]
     width: int
     height: int
     style_preset: str
@@ -106,6 +107,7 @@ def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
         model=payload.get("model", "z_image_turbo"),
         count=safe_int(payload.get("count"), 4, 1, 8),
         seed=payload.get("seed"),
+        seeds=[int(seed) for seed in payload.get("seeds", []) if seed is not None],
         width=safe_int(payload.get("width"), 1024, 256, 2048),
         height=safe_int(payload.get("height"), 1024, 256, 2048),
         style_preset=payload.get("stylePreset", "cinematic"),
@@ -158,7 +160,7 @@ class ImageAssetWriter:
                 raise InterruptedError("Image generation canceled by user.")
 
             asset_id = f"asset_{uuid4().hex}"
-            seed = resolve_seed(request.seed, request.prompt, index)
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
             filename = f"{date_slug}_{request.model}_{prompt_slug}_{index + 1:04d}.png"
             media_rel = f"assets/images/{filename}"
             media_path = project_path / media_rel
@@ -233,7 +235,7 @@ class ZImageDiffusersAdapter:
         for index in range(total):
             if cancel_requested():
                 raise InterruptedError("Image generation canceled by user.")
-            seed = resolve_seed(request.seed, request.prompt, index)
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
             progress("running", "generating", 0.24 + (index / total) * 0.48, f"Running Z-Image {index + 1} of {total}.")
             images.append(self._run_pipeline(settings, pipe, request, seed))
 
@@ -365,7 +367,7 @@ class ProceduralImageAdapter:
         for index in range(request.count):
             if cancel_requested():
                 raise InterruptedError("Image generation canceled by user.")
-            seed = resolve_seed(request.seed, request.prompt, index)
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
             images.append(render_preview_image(request, model_target, seed, index))
             progress(
                 "running",
@@ -407,9 +409,11 @@ def model_supports_edit(model_id: str) -> bool:
     return bool(MODEL_TARGETS.get(model_id, {}).get("supportsEdit"))
 
 
-def resolve_seed(seed: int | None, prompt: str, index: int) -> int:
+def resolve_seed(seed: int | None, prompt: str, index: int, seeds: list[int] | None = None) -> int:
     if seed is not None:
         return int(seed) + index
+    if seeds and index < len(seeds):
+        return int(seeds[index])
     digest = hashlib.sha256(f"{prompt}:{index}".encode("utf-8")).hexdigest()
     return int(digest[:8], 16)
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from fnmatch import fnmatch
 import json
+import os
 from pathlib import Path
 import shutil
+import signal
+import subprocess
+import sys
+import threading
 import time
 from typing import Any
 
 import httpx
 
-from .gpu import discover_gpu
+from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_worker_id
 from .image_adapters import ProceduralImageAdapter, ZImageDiffusersAdapter, create_image_adapter
 from .settings import WorkerSettings
 from .timeline_exporter import run_timeline_export
@@ -44,7 +50,10 @@ class ApiClient:
 
 def worker_capabilities(gpu: dict) -> list[str]:
     gpu_capabilities = set(gpu["capabilities"])
-    capabilities = set(gpu["capabilities"]) | {"timeline_export", "model_download", "lora_import"}
+    utility_jobs_enabled = os.getenv("SCENEWORKS_UTILITY_JOBS", "1").strip() != "0"
+    capabilities = set(gpu["capabilities"])
+    if utility_jobs_enabled:
+        capabilities |= {"timeline_export", "model_download", "lora_import"}
     if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities:
         capabilities |= {"image_generate", "image_edit", "video_generate", "video_extend", "video_bridge"}
     return sorted(capabilities)
@@ -99,6 +108,114 @@ def safe_download_dir(value: str) -> str:
     return normalized.strip("_") or "download"
 
 
+def write_model_install_marker(target_dir: Path, payload: dict, repo: str, job_id: str) -> None:
+    marker = {
+        "repo": repo,
+        "modelId": payload.get("modelId"),
+        "modelName": payload.get("modelName"),
+        "jobId": job_id,
+        "completedAt": now(),
+    }
+    with (target_dir / ".sceneworks-download-complete.json").open("w", encoding="utf-8") as handle:
+        json.dump(marker, handle, indent=2, sort_keys=True)
+
+
+def format_bytes(value: int | float | None) -> str:
+    if value is None:
+        return "unknown"
+    size = float(max(0, value))
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
+
+
+def directory_size(path: Path) -> int:
+    if not path.exists():
+        return 0
+    total = 0
+    for item in path.rglob("*"):
+        if not item.is_file() or item.name == ".sceneworks-download-complete.json":
+            continue
+        try:
+            total += item.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def allow_pattern_matches(path: str, patterns: list[str]) -> bool:
+    if not patterns:
+        return True
+    return any(fnmatch(path, pattern) for pattern in patterns)
+
+
+def estimate_huggingface_repo_size(repo: str, files: list[str] | None = None) -> int | None:
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        return None
+
+    try:
+        info = HfApi().model_info(repo, files_metadata=True)
+    except Exception as exc:
+        emit({"event": "download_size_unavailable", "repo": repo, "error": str(exc), "reportedAt": now()})
+        return None
+
+    patterns = files or []
+    total = 0
+    found_size = False
+    for sibling in getattr(info, "siblings", []):
+        filename = getattr(sibling, "rfilename", "")
+        if not allow_pattern_matches(filename, patterns):
+            continue
+        size = getattr(sibling, "size", None)
+        if size is None:
+            continue
+        found_size = True
+        total += int(size)
+    return total if found_size else None
+
+
+def download_progress_payload(
+    repo: str,
+    downloaded_bytes: int,
+    total_bytes: int | None,
+    *,
+    started_bytes: int,
+    started_at: float,
+) -> dict[str, Any]:
+    elapsed_seconds = max(0.001, time.monotonic() - started_at)
+    transferred_bytes = max(0, downloaded_bytes - started_bytes)
+    rate = transferred_bytes / elapsed_seconds
+    eta_seconds = None
+    if total_bytes and rate > 0:
+        eta_seconds = max(0, (max(0, total_bytes - downloaded_bytes)) / rate)
+
+    if total_bytes:
+        ratio = min(max(downloaded_bytes / total_bytes, 0), 1)
+        progress = 0.1 + ratio * 0.85
+        remaining_bytes = max(0, total_bytes - downloaded_bytes)
+        message = (
+            f"Downloading {repo}: {format_bytes(downloaded_bytes)} of {format_bytes(total_bytes)} "
+            f"({format_bytes(remaining_bytes)} left)."
+        )
+    else:
+        progress = 0.1
+        message = f"Downloading {repo}: {format_bytes(downloaded_bytes)} written."
+
+    return {
+        "status": "downloading",
+        "stage": "downloading",
+        "progress": progress,
+        "message": message,
+        "etaSeconds": eta_seconds,
+    }
+
+
 def snapshot_huggingface_repo(repo: str, target_dir: Path, files: list[str] | None = None) -> Path:
     try:
         from huggingface_hub import snapshot_download
@@ -113,6 +230,95 @@ def snapshot_huggingface_repo(repo: str, target_dir: Path, files: list[str] | No
         local_dir_use_symlinks=False,
     )
     return target_dir
+
+
+def monitor_download_progress(
+    api: ApiClient,
+    settings: WorkerSettings,
+    job_id: str,
+    repo: str,
+    target_dir: Path,
+    total_bytes: int | None,
+    stop_event: threading.Event,
+) -> None:
+    interval = max(5, min(settings.heartbeat_seconds, 15))
+    started_bytes = directory_size(target_dir)
+    started_at = time.monotonic()
+    while not stop_event.wait(interval):
+        try:
+            heartbeat(api, settings, "busy", job_id)
+            update_job(
+                api,
+                job_id,
+                download_progress_payload(
+                    repo,
+                    directory_size(target_dir),
+                    total_bytes,
+                    started_bytes=started_bytes,
+                    started_at=started_at,
+                ),
+            )
+        except httpx.HTTPError as exc:
+            emit({"event": "download_progress_failed", "jobId": job_id, "error": str(exc), "reportedAt": now()})
+
+
+def run_monitored_download(
+    api: ApiClient,
+    settings: WorkerSettings,
+    job_id: str,
+    repo: str,
+    target_dir: Path,
+    files: list[str] | None,
+    total_bytes: int | None,
+) -> Path:
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=monitor_download_progress,
+        args=(api, settings, job_id, repo, target_dir, total_bytes, stop_event),
+        daemon=True,
+    )
+    thread.start()
+    try:
+        return snapshot_huggingface_repo(repo, target_dir, files)
+    finally:
+        stop_event.set()
+        thread.join(timeout=1)
+
+
+def keep_job_alive(
+    api: ApiClient,
+    settings: WorkerSettings,
+    job_id: str,
+    status: str,
+    stop_event: threading.Event,
+) -> None:
+    interval = max(5, min(settings.heartbeat_seconds, 30))
+    while not stop_event.wait(interval):
+        try:
+            heartbeat(api, settings, status, job_id)
+        except httpx.HTTPError as exc:
+            emit({"event": "heartbeat_failed", "jobId": job_id, "error": str(exc), "reportedAt": now()})
+
+
+def run_blocking_job_step(
+    api: ApiClient,
+    settings: WorkerSettings,
+    job_id: str,
+    status: str,
+    callback: Any,
+) -> Any:
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=keep_job_alive,
+        args=(api, settings, job_id, status, stop_event),
+        daemon=True,
+    )
+    thread.start()
+    try:
+        return callback()
+    finally:
+        stop_event.set()
+        thread.join(timeout=1)
 
 
 def run_model_download_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
@@ -137,6 +343,7 @@ def run_model_download_job(api: ApiClient, settings: WorkerSettings, job: dict) 
     target_dir = Path(payload.get("targetDir") or settings.data_dir / "models" / safe_download_dir(repo))
     try:
         heartbeat(api, settings, "busy", job_id)
+        total_bytes = estimate_huggingface_repo_size(repo, payload.get("files") or [])
         update_job(
             api,
             job_id,
@@ -144,12 +351,17 @@ def run_model_download_job(api: ApiClient, settings: WorkerSettings, job: dict) 
                 "status": "downloading",
                 "stage": "downloading",
                 "progress": 0.1,
-                "message": f"Downloading {repo}.",
+                "message": (
+                    f"Downloading {repo}: 0 B of {format_bytes(total_bytes)}."
+                    if total_bytes
+                    else f"Downloading {repo}: estimating size."
+                ),
             },
         )
         if job_cancel_requested(api, job_id):
             raise InterruptedError("Model download canceled before transfer started.")
-        snapshot_huggingface_repo(repo, target_dir, payload.get("files") or [])
+        run_monitored_download(api, settings, job_id, repo, target_dir, payload.get("files") or [], total_bytes)
+        write_model_install_marker(target_dir, payload, repo, job_id)
         update_job(
             api,
             job_id,
@@ -216,7 +428,13 @@ def run_lora_import_job(api: ApiClient, settings: WorkerSettings, job: dict) -> 
         if job_cancel_requested(api, job_id):
             raise InterruptedError("LoRA import canceled before transfer started.")
         if repo:
-            snapshot_huggingface_repo(repo, target_dir, payload.get("files") or [])
+            run_blocking_job_step(
+                api,
+                settings,
+                job_id,
+                "busy",
+                lambda: snapshot_huggingface_repo(repo, target_dir, payload.get("files") or []),
+            )
         elif source_path:
             source = Path(source_path).expanduser().resolve()
             if not source.exists():
@@ -341,11 +559,17 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
     try:
         progress("preparing", "preparing", 0.08, "Preparing Image Studio request.")
         progress("loading_model", "loading_model", 0.16, "Resolving image adapter target.")
-        result = adapter.generate(
-            settings=settings,
-            job=job,
-            progress=progress,
-            cancel_requested=lambda: job_cancel_requested(api, job_id),
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda: adapter.generate(
+                settings=settings,
+                job=job,
+                progress=progress,
+                cancel_requested=lambda: job_cancel_requested(api, job_id),
+            ),
         )
         update_job(
             api,
@@ -382,7 +606,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
             },
         )
     finally:
-        heartbeat(api, settings, "idle", loaded_models_from_adapters(image_adapters))
+        heartbeat(api, settings, "idle", loaded_models=loaded_models_from_adapters(image_adapters))
 
 
 def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
@@ -414,12 +638,18 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             0.18,
             f"Estimated {requirements['previewFrames']} preview frames for this clip.",
         )
-        result = adapter.run(
-            settings=settings,
-            job=job,
-            request=request,
-            progress=progress,
-            cancel_requested=lambda: job_cancel_requested(api, job_id),
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda: adapter.run(
+                settings=settings,
+                job=job,
+                request=request,
+                progress=progress,
+                cancel_requested=lambda: job_cancel_requested(api, job_id),
+            ),
         )
         update_job(
             api,
@@ -479,11 +709,17 @@ def run_timeline_export_job(api: ApiClient, settings: WorkerSettings, job: dict)
 
     try:
         progress("preparing", "preparing", 0.06, "Preparing timeline export.")
-        result = run_timeline_export(
-            settings=settings,
-            job=job,
-            progress=progress,
-            cancel_requested=lambda: job_cancel_requested(api, job_id),
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda: run_timeline_export(
+                settings=settings,
+                job=job,
+                progress=progress,
+                cancel_requested=lambda: job_cancel_requested(api, job_id),
+            ),
         )
         update_job(
             api,
@@ -523,8 +759,7 @@ def run_timeline_export_job(api: ApiClient, settings: WorkerSettings, job: dict)
         heartbeat(api, settings, "idle")
 
 
-def main() -> None:
-    settings = WorkerSettings()
+def run_worker_loop(settings: WorkerSettings) -> None:
     gpu = discover_gpu(settings.gpu_id)
     api = ApiClient(settings)
     image_adapters: dict[str, object] = {
@@ -590,3 +825,84 @@ def main() -> None:
         except httpx.HTTPError as exc:
             emit({"event": "api_error", "error": str(exc), "reportedAt": now()})
             time.sleep(settings.poll_seconds)
+
+
+def child_environment(settings: WorkerSettings, *, worker_id: str, gpu_id: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["SCENEWORKS_WORKER_CHILD"] = "1"
+    env["SCENEWORKS_WORKER_ID"] = worker_id
+    env["SCENEWORKS_GPU_ID"] = gpu_id
+    if gpu_id == "cpu":
+        env["CUDA_VISIBLE_DEVICES"] = ""
+        env["SCENEWORKS_UTILITY_JOBS"] = "1"
+    else:
+        env["CUDA_VISIBLE_DEVICES"] = gpu_id
+        env["SCENEWORKS_UTILITY_JOBS"] = "0"
+    return env
+
+
+def start_child_worker(settings: WorkerSettings, *, worker_id: str, gpu_id: str) -> subprocess.Popen:
+    emit({"event": "starting_worker", "workerId": worker_id, "gpuId": gpu_id, "reportedAt": now()})
+    return subprocess.Popen(
+        [sys.executable, "-m", "scene_worker"],
+        env=child_environment(settings, worker_id=worker_id, gpu_id=gpu_id),
+    )
+
+
+def supervise_auto_workers(settings: WorkerSettings) -> None:
+    gpus = discover_gpus()
+    if not gpus:
+        run_worker_loop(settings.for_worker(worker_id=cpu_worker_id(settings.worker_id), gpu_id="cpu"))
+        return
+
+    worker_specs = [(gpu_worker_id(settings.worker_id, gpu["id"]), gpu["id"]) for gpu in gpus]
+    worker_specs.append((cpu_worker_id(settings.worker_id), "cpu"))
+    children = {
+        worker_id: start_child_worker(settings, worker_id=worker_id, gpu_id=gpu_id)
+        for worker_id, gpu_id in worker_specs
+    }
+    shutting_down = False
+
+    def stop_children(_signum: int, _frame: object) -> None:
+        nonlocal shutting_down
+        shutting_down = True
+        for child in children.values():
+            if child.poll() is None:
+                child.terminate()
+
+    signal.signal(signal.SIGTERM, stop_children)
+    signal.signal(signal.SIGINT, stop_children)
+
+    while True:
+        for worker_id, child in list(children.items()):
+            exit_code = child.poll()
+            if exit_code is None:
+                continue
+            if shutting_down:
+                children.pop(worker_id)
+                continue
+            gpu_id = next(gpu_id for candidate_worker_id, gpu_id in worker_specs if candidate_worker_id == worker_id)
+            emit(
+                {
+                    "event": "worker_exited",
+                    "workerId": worker_id,
+                    "gpuId": gpu_id,
+                    "exitCode": exit_code,
+                    "restartInSeconds": settings.poll_seconds,
+                    "reportedAt": now(),
+                }
+            )
+            time.sleep(settings.poll_seconds)
+            children[worker_id] = start_child_worker(settings, worker_id=worker_id, gpu_id=gpu_id)
+
+        if shutting_down and not children:
+            return
+        time.sleep(1)
+
+
+def main() -> None:
+    settings = WorkerSettings()
+    if settings.gpu_id == "auto" and os.getenv("SCENEWORKS_WORKER_CHILD") != "1":
+        supervise_auto_workers(settings)
+        return
+    run_worker_loop(settings)

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -12,3 +12,15 @@ class WorkerSettings:
         self.access_token = os.getenv("SCENEWORKS_ACCESS_TOKEN", "").strip()
         self.heartbeat_seconds = int(os.getenv("SCENEWORKS_WORKER_HEARTBEAT_SECONDS", "30"))
         self.poll_seconds = int(os.getenv("SCENEWORKS_WORKER_POLL_SECONDS", "3"))
+
+    def for_worker(self, *, worker_id: str, gpu_id: str) -> "WorkerSettings":
+        settings = object.__new__(WorkerSettings)
+        settings.worker_id = worker_id
+        settings.gpu_id = gpu_id
+        settings.api_url = self.api_url
+        settings.data_dir = self.data_dir
+        settings.config_dir = self.config_dir
+        settings.access_token = self.access_token
+        settings.heartbeat_seconds = self.heartbeat_seconds
+        settings.poll_seconds = self.poll_seconds
+        return settings

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -41,7 +41,7 @@ for (const requiredPath of requiredPaths) {
   await assertReadable(requiredPath);
 }
 
-await assertContains("apps/web/src/main.jsx", "/api/v1/health");
+await assertContains("apps/web/src/App.jsx", "/api/v1/health");
 await assertContains("apps/api/sceneworks_api/main.py", "/api/v1/health");
 await assertContains("apps/api/sceneworks_api/jobs.py", "/jobs/events");
 await assertContains("docker-compose.yml", "NVIDIA_VISIBLE_DEVICES");

--- a/tests/test_image_generation.py
+++ b/tests/test_image_generation.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sceneworks_api import image_generation
+from sceneworks_api.image_generation import ImageJobRequest, image_job_payload
+
+
+def test_blank_image_seed_gets_independent_batch_seeds(monkeypatch):
+    values = iter([101, 202, 303, 404])
+    monkeypatch.setattr(image_generation.secrets, "randbits", lambda _bits: next(values))
+
+    request = ImageJobRequest(projectId="project-1", prompt="city at night", seed=None, count=4)
+    payload = image_job_payload(request)
+
+    assert payload["seed"] is None
+    assert payload["seeds"] == [101, 202, 303, 404]
+
+
+def test_explicit_image_seed_is_preserved():
+    request = ImageJobRequest(projectId="project-1", prompt="city at night", seed=1234)
+
+    payload = image_job_payload(request)
+
+    assert payload["seed"] == 1234
+    assert "seeds" not in payload

--- a/tests/test_jobs_store.py
+++ b/tests/test_jobs_store.py
@@ -102,6 +102,41 @@ def test_claim_skips_jobs_not_supported_by_worker_capabilities(tmp_path):
     assert store.claim_next_job("worker-1")["id"] == download_job["id"]
 
 
+def test_idle_heartbeat_interrupts_previous_active_job(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    store.register_worker(
+        worker_id="worker-1",
+        gpu_id="gpu-0",
+        gpu_name=None,
+        capabilities=["image_generate"],
+        loaded_models=[],
+    )
+    created = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={},
+        requested_gpu="auto",
+    )
+    claimed = store.claim_next_job("worker-1")
+
+    assert claimed["id"] == created["id"]
+
+    worker = store.heartbeat_worker(
+        worker_id="worker-1",
+        status="idle",
+        current_job_id=None,
+        loaded_models=[],
+    )
+    job = store.get_job(created["id"])
+
+    assert worker["status"] == "idle"
+    assert worker["currentJobId"] is None
+    assert job["status"] == "interrupted"
+    assert job["workerId"] is None
+
+
 def test_retry_job_is_capped(tmp_path):
     store = JobsStore(tmp_path / "jobs.db")
     store.initialize()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from sceneworks_api.models import load_manifest, strip_jsonc_comments
+from sceneworks_api.models import (
+    download_size_from_siblings,
+    format_bytes,
+    load_manifest,
+    model_is_installed,
+    model_install_marker,
+    strip_jsonc_comments,
+)
 
 
 def test_jsonc_comment_stripping_preserves_url_strings():
@@ -17,3 +24,39 @@ def test_manifest_cache_reloads_when_mtime_changes(tmp_path):
 
     manifest.write_text('{"models":[{"id":"second"}]}', encoding="utf-8")
     assert load_manifest(manifest) == [{"id": "second"}]
+
+
+def test_partial_model_directory_is_not_installed(tmp_path):
+    model_dir = tmp_path / "models" / "owner__model"
+    model_dir.mkdir(parents=True)
+    (model_dir / "partial.bin").write_bytes(b"partial")
+
+    assert not model_is_installed(model_dir)
+
+
+def test_model_directory_with_completion_marker_is_installed(tmp_path):
+    model_dir = tmp_path / "models" / "owner__model"
+    model_dir.mkdir(parents=True)
+    model_install_marker(model_dir).write_text("{}", encoding="utf-8")
+
+    assert model_is_installed(model_dir)
+
+
+def test_download_size_from_siblings_respects_allow_patterns():
+    siblings = [
+        {"rfilename": "model-00001.safetensors", "size": 100},
+        {"rfilename": "model-00002.safetensors", "size": 200},
+        {"rfilename": "README.md", "size": 50},
+    ]
+
+    assert download_size_from_siblings(siblings, ["*.safetensors"]) == 300
+
+
+def test_download_size_from_siblings_returns_none_when_unknown():
+    assert download_size_from_siblings([{"rfilename": "model.bin"}]) is None
+
+
+def test_format_bytes_for_model_catalog():
+    assert format_bytes(None) is None
+    assert format_bytes(0) == "0 B"
+    assert format_bytes(1024 * 1024 * 1024) == "1.0 GB"

--- a/tests/test_worker_gpu.py
+++ b/tests/test_worker_gpu.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from scene_worker.gpu import cpu_worker_id, gpu_worker_id, parse_nvidia_smi_gpus
+
+
+def test_parse_nvidia_smi_gpus_returns_all_devices():
+    gpus = parse_nvidia_smi_gpus(
+        "0, NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, 97887\n"
+        "1, NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, 97887\n"
+    )
+
+    assert [gpu["id"] for gpu in gpus] == ["0", "1"]
+    assert gpus[0]["name"] == "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition (97887 MB)"
+    assert "nvidia" in gpus[1]["capabilities"]
+
+
+def test_gpu_worker_id_preserves_existing_first_worker_id():
+    assert gpu_worker_id("worker-gpu-auto-0", "0") == "worker-gpu-auto-0"
+    assert gpu_worker_id("worker-gpu-auto-0", "1") == "worker-gpu-auto-1"
+
+
+def test_cpu_worker_id_uses_same_worker_family():
+    assert cpu_worker_id("worker-gpu-auto-0") == "worker-gpu-auto-cpu"

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from scene_worker.runtime import loaded_models_from_adapters, worker_capabilities
+from scene_worker.image_adapters import resolve_seed
+from scene_worker.runtime import download_progress_payload, format_bytes, heartbeat, loaded_models_from_adapters, worker_capabilities
 
 
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
@@ -19,9 +20,87 @@ def test_gpu_worker_advertises_generation_capabilities():
     assert "video_generate" in capabilities
 
 
+def test_auto_gpu_worker_can_disable_utility_capabilities(monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_UTILITY_JOBS", "0")
+
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+
+    assert "image_generate" in capabilities
+    assert "model_download" not in capabilities
+    assert "lora_import" not in capabilities
+
+
 def test_loaded_models_are_collected_from_adapter_cache():
     class Adapter:
         def loaded_models(self):
             return ["Tongyi-MAI/Z-Image-Turbo"]
 
     assert loaded_models_from_adapters({"z": Adapter()}) == ["Tongyi-MAI/Z-Image-Turbo"]
+
+
+def test_heartbeat_loaded_models_are_not_sent_as_current_job():
+    class Api:
+        def __init__(self):
+            self.path = None
+            self.payload = None
+
+        def post(self, path, payload):
+            self.path = path
+            self.payload = payload
+            return {}
+
+    class Settings:
+        worker_id = "worker-1"
+
+    api = Api()
+    heartbeat(api, Settings(), "idle", loaded_models=["model-a"])
+
+    assert api.path == "/api/v1/workers/worker-1/heartbeat"
+    assert api.payload == {"status": "idle", "currentJobId": None, "loadedModels": ["model-a"]}
+
+
+def test_random_batch_seeds_are_used_per_image():
+    assert resolve_seed(None, "city at night", 2, [101, 202, 303, 404]) == 303
+
+
+def test_explicit_seed_uses_reproducible_ladder():
+    assert resolve_seed(1234, "city at night", 2, [101, 202, 303, 404]) == 1236
+
+
+def test_download_progress_payload_reports_remaining_bytes(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.time.monotonic", lambda: 20.0)
+
+    payload = download_progress_payload(
+        "owner/model",
+        downloaded_bytes=512 * 1024 * 1024,
+        total_bytes=1024 * 1024 * 1024,
+        started_bytes=0,
+        started_at=10.0,
+    )
+
+    assert payload["status"] == "downloading"
+    assert payload["stage"] == "downloading"
+    assert payload["progress"] == 0.525
+    assert payload["message"] == "Downloading owner/model: 512.0 MB of 1.0 GB (512.0 MB left)."
+    assert payload["etaSeconds"] == 10.0
+
+
+def test_download_progress_payload_handles_unknown_total(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.time.monotonic", lambda: 20.0)
+
+    payload = download_progress_payload(
+        "owner/model",
+        downloaded_bytes=128 * 1024 * 1024,
+        total_bytes=None,
+        started_bytes=0,
+        started_at=10.0,
+    )
+
+    assert payload["progress"] == 0.1
+    assert payload["message"] == "Downloading owner/model: 128.0 MB written."
+    assert payload["etaSeconds"] is None
+
+
+def test_format_bytes_uses_readable_units():
+    assert format_bytes(0) == "0 B"
+    assert format_bytes(1024 * 1024) == "1.0 MB"


### PR DESCRIPTION
﻿## Summary

This PR fixes the worker and model-management issues found while testing the local generation queue.

- Starts one worker per detected GPU plus a CPU utility worker for downloads/imports.
- Keeps long-running model downloads and generation jobs alive with heartbeat keepalives.
- Prevents GPU workers from claiming model downloads.
- Treats models as installed only after a completed download marker is written.
- Adds Hugging Face download size estimates to the model catalog and Model Manager.
- Adds monitored model download progress payloads for future worker restarts.
- Uses independent random per-image seeds for blank-seed batches while preserving explicit seed reproducibility.

## Root Cause

The queue could look stuck because workers were either not registered per GPU, were busy inside blocking Hugging Face/Diffusers calls without heartbeats, or partial download directories were being treated as complete installs. Model downloads also reported only a static 10% progress message, so large downloads looked frozen.

## Validation

- `python -m pytest -q` -> 32 passed
- `npm run check` -> passed
- `npm test -- --run` in `apps/web` -> 2 passed
