### PR TITLE
[codex] Add timeline generation hooks

### DIFF
--- a/apps/api/sceneworks_api/assets.py
+++ b/apps/api/sceneworks_api/assets.py
@@ -89,6 +89,7 @@ def list_assets(
 ) -> list[dict[str, Any]]:
     project_path = find_project_path(request.app.state.settings, project_id)
     assets = []
+    seen_asset_ids = set()
     ensure_project_db_ready(project_path)
     with sqlite3.connect(project_path / "project.db") as connection:
         total = connection.execute("select count(*) from assets").fetchone()[0]
@@ -119,6 +120,9 @@ def list_assets(
                 asset = normalize_asset(project_id, project_path, sidecar_path)
             except (OSError, json.JSONDecodeError):
                 continue
+            if asset.get("id") in seen_asset_ids:
+                break
+            seen_asset_ids.add(asset.get("id"))
             assets.append(asset)
             break
 

--- a/apps/api/sceneworks_api/jobs.py
+++ b/apps/api/sceneworks_api/jobs.py
@@ -20,6 +20,7 @@ JobType = Literal[
     "video_generate",
     "video_extend",
     "video_bridge",
+    "frame_extract",
     "timeline_export",
     "model_download",
     "lora_import",

--- a/apps/api/sceneworks_api/timelines.py
+++ b/apps/api/sceneworks_api/timelines.py
@@ -65,7 +65,7 @@ class TimelineItem(BaseModel):
     transitionOut: Transition | None = None
 
     @model_validator(mode="after")
-    def validate_ranges(self) -> "TimelineItem":
+    def validate_ranges_and_populate_version_metadata(self) -> "TimelineItem":
         if self.sourceOut <= self.sourceIn:
             raise ValueError("sourceOut must be greater than sourceIn.")
         if self.timelineEnd <= self.timelineStart:

--- a/apps/api/sceneworks_api/timelines.py
+++ b/apps/api/sceneworks_api/timelines.py
@@ -37,6 +37,14 @@ class Transition(BaseModel):
     duration: float = Field(default=0, ge=0, le=10)
 
 
+class TimelineItemVersion(BaseModel):
+    assetId: str = Field(min_length=1)
+    createdAt: str | None = None
+    source: Literal["original", "replacement", "extension", "bridge", "restore", "manual"] = "manual"
+    jobId: str | None = None
+    note: str | None = None
+
+
 class TimelineItem(BaseModel):
     id: str = Field(default_factory=lambda: f"item_{uuid4().hex}")
     trackId: str
@@ -51,6 +59,8 @@ class TimelineItem(BaseModel):
     fit: Literal["fit", "fill", "stretch"] = "fit"
     volume: float = Field(default=1, ge=0, le=2)
     versionAssetIds: list[str] = Field(default_factory=list)
+    currentVersionAssetId: str | None = None
+    versionHistory: list[TimelineItemVersion] = Field(default_factory=list)
     transitionIn: Transition | None = None
     transitionOut: Transition | None = None
 
@@ -60,6 +70,12 @@ class TimelineItem(BaseModel):
             raise ValueError("sourceOut must be greater than sourceIn.")
         if self.timelineEnd <= self.timelineStart:
             raise ValueError("timelineEnd must be greater than timelineStart.")
+        if not self.currentVersionAssetId:
+            self.currentVersionAssetId = self.assetId
+        if self.assetId not in self.versionAssetIds:
+            self.versionAssetIds.append(self.assetId)
+        if not self.versionHistory:
+            self.versionHistory.append(TimelineItemVersion(assetId=self.assetId, source="original"))
         return self
 
 
@@ -110,6 +126,12 @@ class TimelineExportRequest(BaseModel):
         return self
 
 
+class FrameExtractRequest(BaseModel):
+    playheadSeconds: float = Field(ge=0)
+    intendedUse: Literal["reuse", "first_frame", "last_frame", "video_studio", "image_studio", "bridge", "extension"] = "reuse"
+    requestedGpu: str = "auto"
+
+
 def timeline_file_path(project_path: Path, timeline_id: str, name: str) -> Path:
     return project_path / "timelines" / f"{slugify(name, fallback='timeline', max_length=48)}-{timeline_id[-8:]}.sceneworks.timeline.json"
 
@@ -129,6 +151,19 @@ def default_tracks() -> list[TimelineTrack]:
 def compute_duration(timeline: TimelineDocument) -> float:
     ends = [item.timelineEnd for track in timeline.tracks for item in track.items]
     return max(ends, default=0)
+
+
+def find_timeline_item(timeline: TimelineDocument, item_id: str) -> TimelineItem:
+    for track in timeline.tracks:
+        for item in track.items:
+            if item.id == item_id:
+                return item
+    raise HTTPException(status_code=404, detail="Timeline item not found")
+
+
+def source_timestamp_for_item(item: TimelineItem, playhead_seconds: float) -> float:
+    clamped = min(max(playhead_seconds, item.timelineStart), item.timelineEnd)
+    return item.sourceIn + ((clamped - item.timelineStart) * item.speed)
 
 
 def index_timeline(project_path: Path, timeline: TimelineDocument, rel_path: str) -> None:
@@ -285,6 +320,41 @@ def create_timeline_export(
             "timelinePath": str(timeline_path.relative_to(project_path)).replace("\\", "/"),
             "resolution": payload.resolution,
             "fps": payload.fps,
+        },
+        requested_gpu=payload.requestedGpu,
+    )
+    request.app.state.event_hub.publish("job.updated", job)
+    request.app.state.event_hub.publish("queue.updated", queue_summary(request))
+    return job
+
+
+@router.post("/{timeline_id}/items/{item_id}/frames", status_code=201)
+def extract_timeline_frame(
+    project_id: str,
+    timeline_id: str,
+    item_id: str,
+    payload: FrameExtractRequest,
+    request: Request,
+) -> dict:
+    project_path = find_project_path(request.app.state.settings, project_id)
+    timeline_path = find_timeline_file(project_path, timeline_id)
+    timeline = TimelineDocument.model_validate(read_json(timeline_path))
+    item = find_timeline_item(timeline, item_id)
+    timestamp = source_timestamp_for_item(item, payload.playheadSeconds)
+    job = request.app.state.jobs_store.create_job(
+        job_type="frame_extract",
+        project_id=project_id,
+        project_name=None,
+        payload={
+            "projectId": project_id,
+            "timelineId": timeline_id,
+            "timelineName": timeline.name,
+            "timelinePath": str(timeline_path.relative_to(project_path)).replace("\\", "/"),
+            "timelineItemId": item_id,
+            "sourceAssetId": item.assetId,
+            "sourceTimestamp": timestamp,
+            "playheadSeconds": payload.playheadSeconds,
+            "intendedUse": payload.intendedUse,
         },
         requested_gpu=payload.requestedGpu,
     )

--- a/apps/api/sceneworks_api/video_generation.py
+++ b/apps/api/sceneworks_api/video_generation.py
@@ -10,7 +10,7 @@ from .jobs import queue_summary
 
 router = APIRouter(prefix="/video", tags=["video"])
 
-VideoMode = Literal["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"]
+VideoMode = Literal["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"]
 VideoQuality = Literal["fast", "balanced", "best"]
 
 
@@ -31,6 +31,7 @@ class VideoJobRequest(BaseModel):
     sourceAssetId: str | None = None
     lastFrameAssetId: str | None = None
     sourceClipAssetId: str | None = None
+    bridgeRightClipAssetId: str | None = None
     requestedGpu: str = "auto"
     advanced: dict[str, Any] = Field(default_factory=dict)
 
@@ -42,13 +43,20 @@ class VideoJobRequest(BaseModel):
             raise ValueError("First/Last Frame requires first and last image assets.")
         if self.mode == "extend_clip" and not self.sourceClipAssetId:
             raise ValueError("Extend Clip requires a source clip.")
+        if self.mode == "video_bridge" and (not self.sourceClipAssetId or not self.bridgeRightClipAssetId):
+            raise ValueError("Bridge generation requires left and right source clips.")
         return self
 
 
 @router.post("/jobs", status_code=201)
 def create_video_job(payload: VideoJobRequest, request: Request) -> dict:
+    job_type = "video_generate"
+    if payload.mode == "extend_clip":
+        job_type = "video_extend"
+    elif payload.mode == "video_bridge":
+        job_type = "video_bridge"
     job = request.app.state.jobs_store.create_job(
-        job_type="video_generate",
+        job_type=job_type,
         project_id=payload.projectId,
         project_name=payload.projectName,
         payload=payload.model_dump(exclude={"requestedGpu"}),

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, eventUrl } from "./api.js";
 import { StatusDot } from "./components/StatusDot.jsx";
 import { FullscreenPreview } from "./components/assetPanels.jsx";
@@ -36,7 +36,10 @@ export function App() {
   const [jobPrompt, setJobPrompt] = useState("Placeholder generation");
   const [latestGenerationSetId, setLatestGenerationSetId] = useState(null);
   const [previewAsset, setPreviewAsset] = useState(null);
+  const [studioLaunch, setStudioLaunch] = useState(null);
   const [error, setError] = useState("");
+  const selectedTimelineIdRef = useRef(null);
+  const timelineApplyQueueRef = useRef(Promise.resolve());
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
@@ -91,6 +94,10 @@ export function App() {
   );
 
   useEffect(() => {
+    selectedTimelineIdRef.current = selectedTimelineId;
+  }, [selectedTimelineId]);
+
+  useEffect(() => {
     apiFetch("/api/v1/health", "")
       .then(setHealth)
       .catch((err) => setError(err.message));
@@ -143,7 +150,7 @@ export function App() {
         if (job.result?.generationSetId) {
           setLatestGenerationSetId(job.result.generationSetId);
         }
-        applyCompletedTimelineGeneration(job);
+        enqueueTimelineGenerationApply(job);
         if (job.projectId) {
           refreshAssets(job.projectId);
         }
@@ -212,7 +219,7 @@ export function App() {
       }
       events?.close();
     };
-  }, [access.authRequired, activeProject?.id, authenticated, selectedTimelineId, token]);
+  }, [access.authRequired, authenticated, token]);
 
   async function refreshData() {
     try {
@@ -241,8 +248,7 @@ export function App() {
       return;
     }
     try {
-      const fetched = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token);
-      const items = Array.from(new Map(fetched.map((asset) => [asset.id, asset])).values());
+      const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token);
       setAssets(items);
       const defaultAsset = items.find((asset) => !asset.status?.trashed && !asset.status?.rejected) ?? items[0] ?? null;
       setSelectedAssetId((current) => current ?? defaultAsset?.id ?? null);
@@ -415,7 +421,8 @@ export function App() {
     }
   }
 
-  async function createVideoJob(payload) {
+  async function createVideoJob(payload, options = {}) {
+    const { navigateToQueue = true } = options;
     if (!activeProject) {
       setError("Create or open a project first.");
       return null;
@@ -430,7 +437,9 @@ export function App() {
           requestedGpu,
         }),
       });
-      setActiveView("Queue");
+      if (navigateToQueue) {
+        setActiveView("Queue");
+      }
       setError("");
       refreshData();
       return job;
@@ -440,19 +449,25 @@ export function App() {
     }
   }
 
-  function sendAssetToImage(asset) {
+  function sendAssetToImage(asset, mode = null) {
     if (!asset) {
       return;
     }
     setSelectedAssetId(asset.id);
+    if (mode) {
+      setStudioLaunch({ id: crypto.randomUUID(), view: "Image", assetId: asset.id, mode });
+    }
     setActiveView("Image");
   }
 
-  function sendAssetToVideo(asset) {
+  function sendAssetToVideo(asset, mode = null) {
     if (!asset) {
       return;
     }
     setSelectedAssetId(asset.id);
+    if (mode) {
+      setStudioLaunch({ id: crypto.randomUUID(), view: "Video", assetId: asset.id, mode });
+    }
     setActiveView("Video");
   }
 
@@ -465,7 +480,6 @@ export function App() {
         method: "POST",
         body: JSON.stringify({ playheadSeconds, intendedUse, requestedGpu }),
       });
-      setActiveView("Queue");
       setError("");
       refreshData();
       return job;
@@ -476,7 +490,7 @@ export function App() {
   }
 
   async function queueTimelineVideoJob(payload) {
-    return createVideoJob(payload);
+    return createVideoJob(payload, { navigateToQueue: false });
   }
 
   function applyTimelineGenerationResult(timeline, job) {
@@ -568,9 +582,15 @@ export function App() {
     return { ...timeline, tracks };
   }
 
+  function enqueueTimelineGenerationApply(job) {
+    timelineApplyQueueRef.current = timelineApplyQueueRef.current
+      .then(() => applyCompletedTimelineGeneration(job))
+      .catch((err) => setError(err.message));
+  }
+
   async function applyCompletedTimelineGeneration(job) {
     const timelineId = job.payload?.advanced?.timelineContext?.timelineId;
-    const projectId = job.projectId ?? activeProject?.id;
+    const projectId = job.projectId;
     if (!projectId || !timelineId || !job.result?.assetIds?.length) {
       return;
     }
@@ -584,7 +604,7 @@ export function App() {
         method: "PUT",
         body: JSON.stringify({ timeline: updated }),
       });
-      if (selectedTimelineId === timelineId) {
+      if (selectedTimelineIdRef.current === timelineId) {
         setActiveTimeline(saved);
       }
       refreshTimelines(projectId);
@@ -785,16 +805,10 @@ export function App() {
             purgeAsset={purgeAsset}
             importAsset={importAsset}
             onPreview={setPreviewAsset}
-            onSendImage={(asset) => {
-              setSelectedAssetId(asset.id);
-              setActiveView("Image");
-            }}
+            onSendImage={(asset) => sendAssetToImage(asset)}
             selectedAsset={selectedAsset}
             setSelectedAssetId={setSelectedAssetId}
-            onSendVideo={(asset) => {
-              setSelectedAssetId(asset.id);
-              setActiveView("Video");
-            }}
+            onSendVideo={(asset) => sendAssetToVideo(asset)}
             onSendEditor={(asset) => {
               setSelectedAssetId(asset.id);
               setActiveView("Editor");
@@ -811,6 +825,7 @@ export function App() {
             gpuOptions={gpuOptions}
             imageModels={imageModels}
             latestAssets={latestImageAssets}
+            launchRequest={studioLaunch}
             onPreview={setPreviewAsset}
             requestedGpu={requestedGpu}
             selectedAsset={selectedAsset}
@@ -830,6 +845,7 @@ export function App() {
             purgeAsset={purgeAsset}
             gpuOptions={gpuOptions}
             latestAssets={latestVideoAssets}
+            launchRequest={studioLaunch}
             onPreview={setPreviewAsset}
             requestedGpu={requestedGpu}
             selectedAsset={selectedAsset}
@@ -870,8 +886,8 @@ export function App() {
             extractTimelineFrame={extractTimelineFrame}
             exportTimeline={exportTimeline}
             onPreview={setPreviewAsset}
-            onSendImage={sendAssetToImage}
-            onSendVideo={sendAssetToVideo}
+            onSendImage={(asset) => sendAssetToImage(asset, "edit_image")}
+            onSendVideo={(asset) => sendAssetToVideo(asset, asset?.type === "video" ? "extend_clip" : "image_to_video")}
             queueTimelineVideoJob={queueTimelineVideoJob}
             refreshAssets={refreshAssets}
             saveTimeline={saveTimeline}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -11,6 +11,7 @@ import { EditorScreen } from "./screens/EditorScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { PlaceholderSurface } from "./screens/PlaceholderSurface.jsx";
 import { sortNewest, sortWorkers } from "./sorters.js";
+import { ensureItemVersionFields } from "./timeline.js";
 
 export function App() {
   const [health, setHealth] = useState(null);
@@ -142,6 +143,7 @@ export function App() {
         if (job.result?.generationSetId) {
           setLatestGenerationSetId(job.result.generationSetId);
         }
+        applyCompletedTimelineGeneration(job);
         if (job.projectId) {
           refreshAssets(job.projectId);
         }
@@ -210,7 +212,7 @@ export function App() {
       }
       events?.close();
     };
-  }, [access.authRequired, authenticated, token]);
+  }, [access.authRequired, activeProject?.id, authenticated, selectedTimelineId, token]);
 
   async function refreshData() {
     try {
@@ -239,7 +241,8 @@ export function App() {
       return;
     }
     try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token);
+      const fetched = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token);
+      const items = Array.from(new Map(fetched.map((asset) => [asset.id, asset])).values());
       setAssets(items);
       const defaultAsset = items.find((asset) => !asset.status?.trashed && !asset.status?.rejected) ?? items[0] ?? null;
       setSelectedAssetId((current) => current ?? defaultAsset?.id ?? null);
@@ -415,10 +418,10 @@ export function App() {
   async function createVideoJob(payload) {
     if (!activeProject) {
       setError("Create or open a project first.");
-      return;
+      return null;
     }
     try {
-      await apiFetch("/api/v1/video/jobs", token, {
+      const job = await apiFetch("/api/v1/video/jobs", token, {
         method: "POST",
         body: JSON.stringify({
           ...payload,
@@ -430,6 +433,161 @@ export function App() {
       setActiveView("Queue");
       setError("");
       refreshData();
+      return job;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  function sendAssetToImage(asset) {
+    if (!asset) {
+      return;
+    }
+    setSelectedAssetId(asset.id);
+    setActiveView("Image");
+  }
+
+  function sendAssetToVideo(asset) {
+    if (!asset) {
+      return;
+    }
+    setSelectedAssetId(asset.id);
+    setActiveView("Video");
+  }
+
+  async function extractTimelineFrame({ timeline, item, playheadSeconds, intendedUse }) {
+    if (!activeProject || !timeline || !item) {
+      return null;
+    }
+    try {
+      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}/items/${item.id}/frames`, token, {
+        method: "POST",
+        body: JSON.stringify({ playheadSeconds, intendedUse, requestedGpu }),
+      });
+      setActiveView("Queue");
+      setError("");
+      refreshData();
+      return job;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function queueTimelineVideoJob(payload) {
+    return createVideoJob(payload);
+  }
+
+  function applyTimelineGenerationResult(timeline, job) {
+    const payload = job.payload ?? {};
+    const action = payload.advanced?.timelineAction;
+    const context = payload.advanced?.timelineContext ?? {};
+    const assetId = job.result?.assetIds?.[0];
+    if (!action || !assetId || context.timelineId !== timeline.id) {
+      return timeline;
+    }
+    const resultAsset = job.result?.assets?.[0];
+    const displayName = resultAsset?.displayName ?? "Generated clip";
+    const createdAt = resultAsset?.createdAt ?? new Date().toISOString();
+    const tracks = timeline.tracks.map((track) => {
+      if (track.id !== context.trackId) {
+        return track;
+      }
+      if (action === "bridge") {
+        const bridgeItem = ensureItemVersionFields({
+          id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
+          trackId: track.id,
+          assetId,
+          type: "video",
+          displayName,
+          sourceIn: 0,
+          sourceOut: Number(payload.duration) || Math.max(0.1, Number(context.timelineEnd) - Number(context.timelineStart)),
+          timelineStart: Number(context.timelineStart),
+          timelineEnd: Number(context.timelineEnd),
+          speed: 1,
+          fit: "fit",
+          volume: 1,
+          versionAssetIds: [assetId],
+          currentVersionAssetId: assetId,
+          versionHistory: [{ assetId, createdAt, source: "bridge", jobId: job.id, note: "Generated bridge clip" }],
+          transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+          transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+        });
+        return { ...track, items: [...track.items, bridgeItem] };
+      }
+      if (action === "extend") {
+        const start = Number(context.timelineStart);
+        const duration = Number(payload.duration) || 4;
+        const extensionItem = ensureItemVersionFields({
+          id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
+          trackId: track.id,
+          assetId,
+          type: "video",
+          displayName,
+          sourceIn: 0,
+          sourceOut: duration,
+          timelineStart: start,
+          timelineEnd: start + duration,
+          speed: 1,
+          fit: "fit",
+          volume: 1,
+          versionAssetIds: [assetId],
+          currentVersionAssetId: assetId,
+          versionHistory: [{ assetId, createdAt, source: "extension", jobId: job.id, note: "Generated extension" }],
+          transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+          transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+        });
+        return { ...track, items: [...track.items, extensionItem] };
+      }
+      if (action === "replace") {
+        return {
+          ...track,
+          items: track.items.map((item) => {
+            if (item.id !== context.itemId) {
+              return item;
+            }
+            const current = ensureItemVersionFields(item);
+            return {
+              ...current,
+              assetId,
+              currentVersionAssetId: assetId,
+              type: "video",
+              displayName,
+              versionAssetIds: Array.from(new Set([...current.versionAssetIds, assetId])),
+              versionHistory: [
+                ...current.versionHistory,
+                { assetId, createdAt, source: "replacement", jobId: job.id, note: "Generated replacement" },
+              ],
+            };
+          }),
+        };
+      }
+      return track;
+    });
+    return { ...timeline, tracks };
+  }
+
+  async function applyCompletedTimelineGeneration(job) {
+    const timelineId = job.payload?.advanced?.timelineContext?.timelineId;
+    const projectId = job.projectId ?? activeProject?.id;
+    if (!projectId || !timelineId || !job.result?.assetIds?.length) {
+      return;
+    }
+    try {
+      const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
+      const updated = applyTimelineGenerationResult(timeline, job);
+      if (updated === timeline) {
+        return;
+      }
+      const saved = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token, {
+        method: "PUT",
+        body: JSON.stringify({ timeline: updated }),
+      });
+      if (selectedTimelineId === timelineId) {
+        setActiveTimeline(saved);
+      }
+      refreshTimelines(projectId);
     } catch (err) {
       setError(err.message);
     }
@@ -709,8 +867,12 @@ export function App() {
             activeTimeline={activeTimeline}
             assets={mediaAssets}
             createTimeline={createTimeline}
+            extractTimelineFrame={extractTimelineFrame}
             exportTimeline={exportTimeline}
             onPreview={setPreviewAsset}
+            onSendImage={sendAssetToImage}
+            onSendVideo={sendAssetToVideo}
+            queueTimelineVideoJob={queueTimelineVideoJob}
             refreshAssets={refreshAssets}
             saveTimeline={saveTimeline}
             selectedTimelineId={selectedTimelineId}

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -20,7 +20,7 @@ export const fallbackModels = [
     id: "ltx_2_3",
     name: "LTX-2.3",
     type: "video",
-    capabilities: ["image_to_video", "text_to_video", "first_last_frame"],
+    capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
     defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
     limits: {
       durations: [4, 6, 8, 10, 12, 15],
@@ -37,7 +37,7 @@ export const fallbackModels = [
     id: "wan_2_2",
     name: "Wan2.2",
     type: "video",
-    capabilities: ["image_to_video", "text_to_video", "first_last_frame", "replace_person"],
+    capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
     defaults: { duration: 5, fps: 24, resolution: "1280x720", quality: "balanced" },
     limits: {
       durations: [4, 5, 6, 7, 8],

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -39,6 +39,7 @@ export function EditorScreen({
   const [isPlaying, setIsPlaying] = useState(false);
   const [playheadSeconds, setPlayheadSeconds] = useState(0);
   const [generationPrompt, setGenerationPrompt] = useState("Continue the action with matching motion and lighting");
+  const [extensionDuration, setExtensionDuration] = useState(4);
   const [timelineNotice, setTimelineNotice] = useState("");
 
   const selectedItem = useMemo(() => {
@@ -272,7 +273,7 @@ export function EditorScreen({
       setTimelineNotice("Select a video clip before extending.");
       return;
     }
-    const duration = Math.min(6, Math.max(2, itemDuration(selectedItem)));
+    const duration = Math.min(15, Math.max(1, Number(extensionDuration) || itemDuration(selectedItem)));
     const job = await queueTimelineVideoJob({
       mode: "extend_clip",
       prompt: generationPrompt,
@@ -541,6 +542,17 @@ export function EditorScreen({
                   <label className="prompt-field">
                     Generation prompt
                     <textarea onChange={(event) => setGenerationPrompt(event.target.value)} value={generationPrompt} />
+                  </label>
+                  <label>
+                    Extension duration
+                    <input
+                      max="15"
+                      min="1"
+                      onChange={(event) => setExtensionDuration(Number(event.target.value))}
+                      step="0.5"
+                      type="number"
+                      value={extensionDuration}
+                    />
                   </label>
                   <div className="hook-actions">
                     <button disabled={selectedItem.type !== "video"} onClick={() => extractFrame("reuse")} type="button">

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -1,15 +1,28 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetMedia, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { formatSeconds } from "../formatting.js";
-import { aspectOptions, itemDuration, speedPresets, timelineDuration, trackItems, transitionOptions } from "../timeline.js";
+import {
+  aspectOptions,
+  ensureItemVersionFields,
+  itemDuration,
+  sourceTimestampAtPlayhead,
+  speedPresets,
+  timelineDuration,
+  trackItems,
+  transitionOptions,
+} from "../timeline.js";
 
 export function EditorScreen({
   activeProject,
   activeTimeline,
   assets,
   createTimeline,
+  extractTimelineFrame,
   exportTimeline,
   onPreview,
+  onSendImage,
+  onSendVideo,
+  queueTimelineVideoJob,
   saveTimeline,
   selectedTimelineId,
   setActiveTimeline,
@@ -24,6 +37,9 @@ export function EditorScreen({
   const [history, setHistory] = useState([]);
   const [future, setFuture] = useState([]);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [playheadSeconds, setPlayheadSeconds] = useState(0);
+  const [generationPrompt, setGenerationPrompt] = useState("Continue the action with matching motion and lighting");
+  const [timelineNotice, setTimelineNotice] = useState("");
 
   const selectedItem = useMemo(() => {
     if (!activeTimeline) {
@@ -42,6 +58,13 @@ export function EditorScreen({
     setFuture([]);
     setSelectedItemId(null);
   }, [activeTimeline?.id]);
+
+  useEffect(() => {
+    if (selectedItem) {
+      setPlayheadSeconds(Number(selectedItem.timelineStart) || 0);
+    }
+    setTimelineNotice("");
+  }, [selectedItem?.id]);
 
   useEffect(() => {
     function onKeyDown(event) {
@@ -147,6 +170,8 @@ export function EditorScreen({
       fit: "fit",
       volume: 1,
       versionAssetIds: [asset.id],
+      currentVersionAssetId: asset.id,
+      versionHistory: [{ assetId: asset.id, createdAt: null, source: "original", jobId: null, note: null }],
       transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
       transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
     });
@@ -197,13 +222,154 @@ export function EditorScreen({
     const sourceIn = Number(item.sourceIn) || 0;
     const sourceOut = Math.max(sourceIn + 0.1, Number(item.sourceOut) || sourceIn + itemDuration(item));
     return {
-      ...item,
+      ...ensureItemVersionFields(item),
       sourceIn,
       sourceOut,
       timelineStart: Math.max(0, start),
       timelineEnd: end,
       speed: Math.max(0.1, Number(item.speed) || 1),
     };
+  }
+
+  function selectedTrackItems() {
+    if (!activeTimeline || !selectedItem) {
+      return [];
+    }
+    const track = activeTimeline.tracks.find((item) => item.id === selectedItem.trackId);
+    return track ? trackItems(track) : [];
+  }
+
+  function nextItemAfterSelection() {
+    return selectedTrackItems().find((item) => item.timelineStart >= selectedItem.timelineEnd && item.id !== selectedItem.id) ?? null;
+  }
+
+  function generationBaseContext(action, extra = {}) {
+    return {
+      action,
+      timelineId: activeTimeline.id,
+      timelineName: activeTimeline.name,
+      itemId: selectedItem.id,
+      trackId: selectedItem.trackId,
+      sourceAssetId: selectedItem.assetId,
+      sourceTimestamp: sourceTimestampAtPlayhead(selectedItem, playheadSeconds),
+      ...extra,
+    };
+  }
+
+  async function extractFrame(intendedUse = "reuse") {
+    if (!selectedItem || selectedItem.type !== "video") {
+      setTimelineNotice("Select a video clip before extracting a frame.");
+      return;
+    }
+    const job = await extractTimelineFrame({ timeline: activeTimeline, item: selectedItem, playheadSeconds, intendedUse });
+    if (job) {
+      setTimelineNotice("Frame extraction queued.");
+    }
+  }
+
+  async function extendSelectedClip() {
+    if (!selectedItem || selectedItem.type !== "video") {
+      setTimelineNotice("Select a video clip before extending.");
+      return;
+    }
+    const duration = Math.min(6, Math.max(2, itemDuration(selectedItem)));
+    const job = await queueTimelineVideoJob({
+      mode: "extend_clip",
+      prompt: generationPrompt,
+      model: "ltx_2_3",
+      duration,
+      fps: activeTimeline.fps,
+      width: activeTimeline.width,
+      height: activeTimeline.height,
+      quality: "balanced",
+      sourceClipAssetId: selectedItem.assetId,
+      loras: [],
+      advanced: {
+        resolution: `${activeTimeline.width}x${activeTimeline.height}`,
+        timelineAction: "extend",
+        timelineContext: generationBaseContext("extend", {
+          endpointTimestamp: Number(selectedItem.sourceOut) || sourceTimestampAtPlayhead(selectedItem, selectedItem.timelineEnd),
+          timelineStart: Number(selectedItem.timelineEnd),
+        }),
+      },
+    });
+    if (job) {
+      setTimelineNotice("Extension job queued. The new clip will land after the selection when it completes.");
+    }
+  }
+
+  async function replaceSelectedItem() {
+    if (!selectedItem) {
+      return;
+    }
+    const isStill = selectedItem.type === "image";
+    const duration = itemDuration(selectedItem);
+    const job = await queueTimelineVideoJob({
+      mode: isStill ? "image_to_video" : "extend_clip",
+      prompt: generationPrompt,
+      model: "ltx_2_3",
+      duration,
+      fps: activeTimeline.fps,
+      width: activeTimeline.width,
+      height: activeTimeline.height,
+      quality: "balanced",
+      sourceAssetId: isStill ? selectedItem.assetId : null,
+      sourceClipAssetId: isStill ? null : selectedItem.assetId,
+      loras: [],
+      advanced: {
+        resolution: `${activeTimeline.width}x${activeTimeline.height}`,
+        timelineAction: "replace",
+        timelineContext: generationBaseContext("replace"),
+      },
+    });
+    if (job) {
+      setTimelineNotice("Replacement job queued. The prior asset will stay in this item's version history.");
+    }
+  }
+
+  async function bridgeAfterSelectedClip() {
+    if (!selectedItem || selectedItem.type !== "video") {
+      setTimelineNotice("Select the left video clip before generating a bridge.");
+      return;
+    }
+    const rightItem = nextItemAfterSelection();
+    if (!rightItem || rightItem.type !== "video") {
+      setTimelineNotice("Place another video clip after this one on the same track first.");
+      return;
+    }
+    const gap = Number(rightItem.timelineStart) - Number(selectedItem.timelineEnd);
+    if (gap <= 0.05) {
+      setTimelineNotice("Create space between the clips before generating a bridge.");
+      return;
+    }
+    const job = await queueTimelineVideoJob({
+      mode: "video_bridge",
+      prompt: generationPrompt,
+      model: "ltx_2_3",
+      duration: Number(gap.toFixed(2)),
+      fps: activeTimeline.fps,
+      width: activeTimeline.width,
+      height: activeTimeline.height,
+      quality: "balanced",
+      sourceClipAssetId: selectedItem.assetId,
+      bridgeRightClipAssetId: rightItem.assetId,
+      loras: [],
+      advanced: {
+        resolution: `${activeTimeline.width}x${activeTimeline.height}`,
+        timelineAction: "bridge",
+        timelineContext: generationBaseContext("bridge", {
+          rightItemId: rightItem.id,
+          rightAssetId: rightItem.assetId,
+          leftTimestamp: Number(selectedItem.sourceOut) || sourceTimestampAtPlayhead(selectedItem, selectedItem.timelineEnd),
+          rightTimestamp: Number(rightItem.sourceIn) || 0,
+          timelineStart: Number(selectedItem.timelineEnd),
+          timelineEnd: Number(rightItem.timelineStart),
+        }),
+      },
+    });
+    if (job) {
+      setTimelineNotice("Bridge job queued. The generated clip will land in the gap.");
+    }
   }
 
   if (!activeProject) {
@@ -360,6 +526,59 @@ export function EditorScreen({
                     value={selectedItem.speed}
                   />
                 </label>
+                <div className="generation-hook-panel">
+                  <label>
+                    Playhead
+                    <input
+                      max={selectedItem.timelineEnd}
+                      min={selectedItem.timelineStart}
+                      onChange={(event) => setPlayheadSeconds(Number(event.target.value))}
+                      step="0.1"
+                      type="number"
+                      value={playheadSeconds}
+                    />
+                  </label>
+                  <label className="prompt-field">
+                    Generation prompt
+                    <textarea onChange={(event) => setGenerationPrompt(event.target.value)} value={generationPrompt} />
+                  </label>
+                  <div className="hook-actions">
+                    <button disabled={selectedItem.type !== "video"} onClick={() => extractFrame("reuse")} type="button">
+                      Extract Frame
+                    </button>
+                    <button disabled={selectedItem.type === "video"} onClick={() => onSendImage(selectedAsset)} type="button">
+                      Send Image
+                    </button>
+                    <button onClick={() => onSendVideo(selectedAsset)} type="button">
+                      Send Video
+                    </button>
+                    <button disabled={selectedItem.type !== "video"} onClick={extendSelectedClip} type="button">
+                      Extend
+                    </button>
+                    <button onClick={replaceSelectedItem} type="button">
+                      Replace
+                    </button>
+                    <button disabled={selectedItem.type !== "video"} onClick={bridgeAfterSelectedClip} type="button">
+                      Bridge Gap
+                    </button>
+                  </div>
+                  <div className="version-list">
+                    <strong>{ensureItemVersionFields(selectedItem).versionAssetIds.length} versions</strong>
+                    {ensureItemVersionFields(selectedItem)
+                      .versionAssetIds.slice(-4)
+                      .map((assetId) => (
+                        <button
+                          className={assetId === selectedItem.assetId ? "active" : ""}
+                          key={assetId}
+                          onClick={() => updateTimelineItem(selectedItem.id, { assetId, currentVersionAssetId: assetId })}
+                          type="button"
+                        >
+                          {assetId === selectedItem.assetId ? "Current" : "Restore"} {assetId.slice(-6)}
+                        </button>
+                      ))}
+                  </div>
+                  {timelineNotice ? <p className="inline-warning">{timelineNotice}</p> : null}
+                </div>
                 <label>
                   Transition in
                   <select

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -10,6 +10,7 @@ export function ImageStudio({
   gpuOptions,
   imageModels,
   latestAssets,
+  launchRequest,
   onPreview,
   requestedGpu,
   selectedAsset,
@@ -34,13 +35,20 @@ export function ImageStudio({
   }, [imageModels, model]);
 
   useEffect(() => {
-    if ((selectedAsset?.type === "image" || selectedAsset?.type === "frame") && mode !== "edit_image") {
-      setMode("edit_image");
-    }
     if (mode === "edit_image" && selectedAsset?.id) {
       setSourceAssetId(selectedAsset.id);
     }
-  }, [mode, selectedAsset?.id, selectedAsset?.type]);
+  }, [mode, selectedAsset?.id]);
+
+  useEffect(() => {
+    if (launchRequest?.view !== "Image" || launchRequest.assetId !== selectedAsset?.id) {
+      return;
+    }
+    setMode(launchRequest.mode);
+    if (launchRequest.mode === "edit_image" && selectedAsset?.id) {
+      setSourceAssetId(selectedAsset.id);
+    }
+  }, [launchRequest?.id, selectedAsset?.id]);
 
   const availableModels = imageModels.filter((item) => {
     const caps = item.capabilities ?? [];

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -34,10 +34,13 @@ export function ImageStudio({
   }, [imageModels, model]);
 
   useEffect(() => {
+    if ((selectedAsset?.type === "image" || selectedAsset?.type === "frame") && mode !== "edit_image") {
+      setMode("edit_image");
+    }
     if (mode === "edit_image" && selectedAsset?.id) {
       setSourceAssetId(selectedAsset.id);
     }
-  }, [mode, selectedAsset?.id]);
+  }, [mode, selectedAsset?.id, selectedAsset?.type]);
 
   const availableModels = imageModels.filter((item) => {
     const caps = item.capabilities ?? [];
@@ -95,7 +98,7 @@ export function ImageStudio({
               <select onChange={(event) => setSourceAssetId(event.target.value)} value={sourceAssetId}>
                 <option value="">Select image</option>
                 {assets
-                  .filter((asset) => asset.type === "image")
+                  .filter((asset) => asset.type === "image" || asset.type === "frame")
                   .map((asset) => (
                     <option key={asset.id} value={asset.id}>
                       {asset.displayName}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -30,7 +30,7 @@ export function VideoStudio({
   const [fps, setFps] = useState(selectedModel?.defaults?.fps ?? 25);
   const [seed, setSeed] = useState("");
   const [negativePrompt, setNegativePrompt] = useState("");
-  const [sourceAssetId, setSourceAssetId] = useState(selectedAsset?.type === "image" ? selectedAsset.id : "");
+  const [sourceAssetId, setSourceAssetId] = useState(["image", "frame"].includes(selectedAsset?.type) ? selectedAsset.id : "");
   const [lastFrameAssetId, setLastFrameAssetId] = useState("");
   const [sourceClipAssetId, setSourceClipAssetId] = useState(selectedAsset?.type === "video" ? selectedAsset.id : "");
 
@@ -41,13 +41,17 @@ export function VideoStudio({
   }, [videoModels, model]);
 
   useEffect(() => {
-    if (selectedAsset?.type === "image") {
+    if (selectedAsset?.type === "image" || selectedAsset?.type === "frame") {
       setSourceAssetId(selectedAsset.id);
+      if (mode === "extend_clip") {
+        setMode("image_to_video");
+      }
     }
     if (selectedAsset?.type === "video") {
       setSourceClipAssetId(selectedAsset.id);
+      setMode("extend_clip");
     }
-  }, [selectedAsset?.id, selectedAsset?.type]);
+  }, [mode, selectedAsset?.id, selectedAsset?.type]);
 
   useEffect(() => {
     if (!selectedModel) {
@@ -76,7 +80,7 @@ export function VideoStudio({
   ];
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
-  const implementedMode = ["image_to_video", "text_to_video", "first_last_frame"].includes(mode);
+  const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip"].includes(mode);
   const hasInputs =
     mode === "text_to_video" ||
     (mode === "image_to_video" && sourceAssetId) ||

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -10,6 +10,7 @@ export function VideoStudio({
   purgeAsset,
   gpuOptions,
   latestAssets,
+  launchRequest,
   onPreview,
   requestedGpu,
   selectedAsset,
@@ -43,15 +44,24 @@ export function VideoStudio({
   useEffect(() => {
     if (selectedAsset?.type === "image" || selectedAsset?.type === "frame") {
       setSourceAssetId(selectedAsset.id);
-      if (mode === "extend_clip") {
-        setMode("image_to_video");
-      }
     }
     if (selectedAsset?.type === "video") {
       setSourceClipAssetId(selectedAsset.id);
-      setMode("extend_clip");
     }
-  }, [mode, selectedAsset?.id, selectedAsset?.type]);
+  }, [selectedAsset?.id, selectedAsset?.type]);
+
+  useEffect(() => {
+    if (launchRequest?.view !== "Video" || launchRequest.assetId !== selectedAsset?.id) {
+      return;
+    }
+    setMode(launchRequest.mode);
+    if (selectedAsset?.type === "video") {
+      setSourceClipAssetId(selectedAsset.id);
+    }
+    if (selectedAsset?.type === "image" || selectedAsset?.type === "frame") {
+      setSourceAssetId(selectedAsset.id);
+    }
+  }, [launchRequest?.id, selectedAsset?.id, selectedAsset?.type]);
 
   useEffect(() => {
     if (!selectedModel) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -753,6 +753,48 @@ button:disabled {
   background: #30211f;
 }
 
+.generation-hook-panel {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid #3c3a34;
+  background: #191815;
+}
+
+.generation-hook-panel textarea {
+  min-height: 84px;
+}
+
+.hook-actions,
+.version-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hook-actions button,
+.version-list button {
+  min-height: 34px;
+  border: 1px solid #4b463d;
+  background: #292722;
+  color: #f3f0e8;
+  padding: 7px 10px;
+}
+
+.version-list {
+  align-items: center;
+}
+
+.version-list strong {
+  color: #d8d2c7;
+  font-size: 13px;
+}
+
+.version-list button.active {
+  border-color: #6ec6b8;
+  background: #183f3a;
+}
+
 .timeline-panel,
 .export-strip {
   grid-column: 1 / -1;

--- a/apps/web/src/timeline.js
+++ b/apps/web/src/timeline.js
@@ -40,3 +40,23 @@ export function itemDuration(item) {
 export function trackItems(track) {
   return [...track.items].sort((a, b) => a.timelineStart - b.timelineStart);
 }
+
+export function sourceTimestampAtPlayhead(item, playheadSeconds) {
+  const start = Number(item.timelineStart) || 0;
+  const end = Math.max(start, Number(item.timelineEnd) || start);
+  const clamped = Math.min(Math.max(Number(playheadSeconds) || start, start), end);
+  return (Number(item.sourceIn) || 0) + (clamped - start) * (Number(item.speed) || 1);
+}
+
+export function ensureItemVersionFields(item) {
+  const versionAssetIds = Array.from(new Set([...(item.versionAssetIds ?? []), item.assetId].filter(Boolean)));
+  return {
+    ...item,
+    currentVersionAssetId: item.currentVersionAssetId ?? item.assetId,
+    versionAssetIds,
+    versionHistory:
+      item.versionHistory?.length > 0
+        ? item.versionHistory
+        : [{ assetId: item.assetId, createdAt: null, source: "original", jobId: null, note: null }],
+  };
+}

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -19,7 +19,7 @@ from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_worker_id
 from .image_adapters import ProceduralImageAdapter, ZImageDiffusersAdapter, create_image_adapter
 from .settings import WorkerSettings
 from .timeline_exporter import run_timeline_export
-from .video_adapters import ProceduralVideoAdapter
+from .video_adapters import ProceduralVideoAdapter, run_frame_extract
 
 
 def now() -> str:
@@ -53,7 +53,7 @@ def worker_capabilities(gpu: dict) -> list[str]:
     utility_jobs_enabled = os.getenv("SCENEWORKS_UTILITY_JOBS", "1").strip() != "0"
     capabilities = set(gpu["capabilities"])
     if utility_jobs_enabled:
-        capabilities |= {"timeline_export", "model_download", "lora_import"}
+        capabilities |= {"timeline_export", "model_download", "lora_import", "frame_extract"}
     if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities:
         capabilities |= {"image_generate", "image_edit", "video_generate", "video_extend", "video_bridge"}
     return sorted(capabilities)
@@ -759,6 +759,74 @@ def run_timeline_export_job(api: ApiClient, settings: WorkerSettings, job: dict)
         heartbeat(api, settings, "idle")
 
 
+def run_frame_extract_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    job_id = job["id"]
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": status,
+                "stage": stage,
+                "progress": value,
+                "message": message,
+            },
+        )
+
+    try:
+        progress("preparing", "preparing", 0.08, "Preparing frame extraction.")
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda: run_frame_extract(
+                settings=settings,
+                job=job,
+                progress=progress,
+                cancel_requested=lambda: job_cancel_requested(api, job_id),
+            ),
+        )
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "completed",
+                "stage": "completed",
+                "progress": 1,
+                "message": "Timeline frame saved as an asset.",
+                "result": result,
+            },
+        )
+    except InterruptedError as exc:
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "canceled",
+                "stage": "canceled",
+                "progress": 1,
+                "message": str(exc),
+            },
+        )
+    except Exception as exc:
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "failed",
+                "stage": "failed",
+                "progress": 1,
+                "message": "Frame extraction failed.",
+                "error": str(exc),
+            },
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def run_worker_loop(settings: WorkerSettings) -> None:
     gpu = discover_gpu(settings.gpu_id)
     api = ApiClient(settings)
@@ -804,6 +872,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
                 run_image_job(api, settings, job, image_adapters)
             elif job["type"] in ("video_generate", "video_extend", "video_bridge"):
                 run_video_job(api, settings, job)
+            elif job["type"] == "frame_extract":
+                run_frame_extract_job(api, settings, job)
             elif job["type"] == "timeline_export":
                 run_timeline_export_job(api, settings, job)
             elif job["type"] == "model_download":

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -358,7 +358,7 @@ def load_seekable_image_frame(media_path: Path, timestamp: float, duration: Any 
 def load_ffmpeg_frame(media_path: Path, timestamp: float) -> Image.Image | None:
     ffmpeg = shutil.which("ffmpeg")
     if ffmpeg is None:
-        return None
+        raise RuntimeError("ffmpeg is not available for frame extraction.")
     with tempfile.TemporaryDirectory(prefix="sceneworks-frame-") as temp_dir:
         frame_path = Path(temp_dir) / "frame.png"
         command = [
@@ -374,8 +374,11 @@ def load_ffmpeg_frame(media_path: Path, timestamp: float) -> Image.Image | None:
             "image2",
             str(frame_path),
         ]
-        result = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        result = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True, check=False)
         if result.returncode != 0 or not frame_path.exists():
+            tail = "\n".join((result.stderr or "").splitlines()[-6:]).strip()
+            if tail:
+                raise RuntimeError(f"ffmpeg could not extract a frame at {timestamp:.3f}s: {tail}")
             return None
         try:
             return Image.open(frame_path).convert("RGB")
@@ -557,7 +560,7 @@ def build_video_asset_sidecar(
                 "lastFrameAssetId": request.last_frame_asset_id,
                 "sourceClipAssetId": request.source_clip_asset_id,
                 "bridgeRightClipAssetId": request.bridge_right_clip_asset_id,
-                "timelineContext": timeline_context,
+                "timelineContextRef": "lineage.timeline",
             },
             "rawAdapterSettings": raw_settings,
         },

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import hashlib
+import shutil
+import subprocess
+import tempfile
 import warnings
 from pathlib import Path
 from textwrap import wrap
@@ -29,7 +32,7 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "label": "LTX-2.3",
         "family": "ltx-video",
         "adapter": "ltx_video",
-        "capabilities": ["image_to_video", "text_to_video", "first_last_frame"],
+        "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
         "recommendedMaxDuration": 10,
         "hardMaxDuration": 15,
         "steps": {"fast": 6, "balanced": 8, "best": 20},
@@ -39,7 +42,7 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "label": "Wan2.2",
         "family": "wan-video",
         "adapter": "wan_video",
-        "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "replace_person"],
+        "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
         "recommendedMaxDuration": 7,
         "hardMaxDuration": 8,
         "steps": {"fast": 12, "balanced": 20, "best": 30},
@@ -68,6 +71,7 @@ class VideoRequest:
     source_asset_id: str | None
     last_frame_asset_id: str | None
     source_clip_asset_id: str | None
+    bridge_right_clip_asset_id: str | None
     advanced: dict[str, Any]
 
 
@@ -161,6 +165,15 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
 
         first_image = load_source_image(project_path, request.source_asset_id, request.width, request.height)
         last_image = load_source_image(project_path, request.last_frame_asset_id, request.width, request.height)
+        context = request.advanced.get("timelineContext", {})
+        if request.mode == "extend_clip" and first_image is None:
+            timestamp = safe_float(context.get("endpointTimestamp"), 0, 0, 3600)
+            first_image = load_source_frame(project_path, request.source_clip_asset_id, timestamp, request.width, request.height)
+        if request.mode == "video_bridge":
+            left_timestamp = safe_float(context.get("leftTimestamp"), 0, 0, 3600)
+            right_timestamp = safe_float(context.get("rightTimestamp"), 0, 0, 3600)
+            first_image = load_source_frame(project_path, request.source_clip_asset_id, left_timestamp, request.width, request.height)
+            last_image = load_source_frame(project_path, request.bridge_right_clip_asset_id, right_timestamp, request.width, request.height)
         if cancel_requested():
             raise InterruptedError("Video generation canceled before rendering.")
 
@@ -252,6 +265,7 @@ def video_request_from_job(job: dict[str, Any]) -> VideoRequest:
         source_asset_id=payload.get("sourceAssetId"),
         last_frame_asset_id=payload.get("lastFrameAssetId"),
         source_clip_asset_id=payload.get("sourceClipAssetId"),
+        bridge_right_clip_asset_id=payload.get("bridgeRightClipAssetId"),
         advanced=payload.get("advanced", {}),
     )
 
@@ -298,6 +312,75 @@ def load_source_image(project_path: Path, asset_id: str | None, width: int, heig
     canvas = Image.new("RGB", (width, height), (18, 17, 15))
     canvas.paste(image, ((width - image.width) // 2, (height - image.height) // 2))
     return canvas
+
+
+def load_source_frame(project_path: Path, asset_id: str | None, timestamp: float, width: int, height: int) -> Image.Image | None:
+    if not asset_id:
+        return None
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        return None
+    payload = read_json(sidecar_path)
+    media_path = project_path / payload.get("file", {}).get("path", "")
+    if not media_path.exists():
+        return None
+
+    image = load_seekable_image_frame(media_path, timestamp, payload.get("file", {}).get("duration"))
+    if image is None:
+        image = load_ffmpeg_frame(media_path, timestamp)
+    if image is None:
+        return None
+
+    image.thumbnail((width, height), Image.Resampling.LANCZOS)
+    canvas = Image.new("RGB", (width, height), (18, 17, 15))
+    canvas.paste(image, ((width - image.width) // 2, (height - image.height) // 2))
+    return canvas
+
+
+def load_seekable_image_frame(media_path: Path, timestamp: float, duration: Any = None) -> Image.Image | None:
+    try:
+        image = Image.open(media_path)
+    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+        return None
+
+    try:
+        frame_count = getattr(image, "n_frames", 1)
+        if frame_count > 1:
+            total_duration = safe_float(duration, 0, 0, 3600)
+            if total_duration > 0:
+                frame_index = min(frame_count - 1, max(0, int(round((timestamp / total_duration) * (frame_count - 1)))))
+                image.seek(frame_index)
+        return image.convert("RGB")
+    except (EOFError, OSError):
+        return None
+
+
+def load_ffmpeg_frame(media_path: Path, timestamp: float) -> Image.Image | None:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        return None
+    with tempfile.TemporaryDirectory(prefix="sceneworks-frame-") as temp_dir:
+        frame_path = Path(temp_dir) / "frame.png"
+        command = [
+            ffmpeg,
+            "-y",
+            "-ss",
+            f"{max(0, timestamp):.3f}",
+            "-i",
+            str(media_path),
+            "-frames:v",
+            "1",
+            "-f",
+            "image2",
+            str(frame_path),
+        ]
+        result = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        if result.returncode != 0 or not frame_path.exists():
+            return None
+        try:
+            return Image.open(frame_path).convert("RGB")
+        except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+            return None
 
 
 def render_preview_frames(
@@ -422,7 +505,17 @@ def build_video_asset_sidecar(
     target: dict[str, Any],
     raw_settings: dict[str, Any],
 ) -> dict[str, Any]:
-    parents = [asset_id for asset_id in [request.source_asset_id, request.last_frame_asset_id, request.source_clip_asset_id] if asset_id]
+    parents = [
+        asset_id
+        for asset_id in [
+            request.source_asset_id,
+            request.last_frame_asset_id,
+            request.source_clip_asset_id,
+            request.bridge_right_clip_asset_id,
+        ]
+        if asset_id
+    ]
+    timeline_context = request.advanced.get("timelineContext", {})
     return {
         "schemaVersion": 1,
         "id": asset_id,
@@ -463,6 +556,8 @@ def build_video_asset_sidecar(
                 "sourceAssetId": request.source_asset_id,
                 "lastFrameAssetId": request.last_frame_asset_id,
                 "sourceClipAssetId": request.source_clip_asset_id,
+                "bridgeRightClipAssetId": request.bridge_right_clip_asset_id,
+                "timelineContext": timeline_context,
             },
             "rawAdapterSettings": raw_settings,
         },
@@ -471,7 +566,121 @@ def build_video_asset_sidecar(
             "sourceAssetId": request.source_asset_id,
             "lastFrameAssetId": request.last_frame_asset_id,
             "sourceClipAssetId": request.source_clip_asset_id,
+            "bridgeRightClipAssetId": request.bridge_right_clip_asset_id,
             "sourceTimestamp": None,
+            "timeline": timeline_context,
             "jobId": job_id,
         },
+    }
+
+
+def run_frame_extract(
+    *,
+    settings: WorkerSettings,
+    job: dict[str, Any],
+    progress: ProgressCallback,
+    cancel_requested: CancelCallback,
+) -> dict[str, Any]:
+    payload = job["payload"]
+    project_id = payload["projectId"]
+    project_path = find_project_path(settings, project_id)
+    frames_dir = project_path / "assets" / "frames"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    (project_path / "recipes").mkdir(parents=True, exist_ok=True)
+
+    source_asset_id = payload.get("sourceAssetId")
+    timestamp = safe_float(payload.get("sourceTimestamp"), 0, 0, 3600)
+    source_sidecar_path = find_asset_sidecar_path(project_path, source_asset_id)
+    if source_sidecar_path is None:
+        raise FileNotFoundError(f"Source asset not found: {source_asset_id}")
+    source_asset = read_json(source_sidecar_path)
+    source_media_path = project_path / source_asset.get("file", {}).get("path", "")
+    if not source_media_path.exists():
+        raise FileNotFoundError(f"Source media not found: {source_media_path}")
+
+    progress("running", "extracting", 0.25, "Extracting timeline frame.")
+    if cancel_requested():
+        raise InterruptedError("Frame extraction canceled before reading media.")
+
+    image = load_source_frame(project_path, source_asset_id, timestamp, 1920, 1080)
+    if image is None:
+        raise RuntimeError("Could not decode a frame from the selected clip.")
+
+    asset_id = f"asset_{uuid4().hex}"
+    created_at = utc_now()
+    filename = f"{created_at[:10]}_frame_{asset_id[-8:]}.png"
+    media_rel = f"assets/frames/{filename}"
+    media_path = project_path / media_rel
+    temp_path = media_path.with_suffix(".tmp.png")
+    image.save(temp_path, "PNG")
+    temp_path.replace(media_path)
+
+    timeline_id = payload.get("timelineId")
+    timeline_item_id = payload.get("timelineItemId")
+    intended_use = payload.get("intendedUse", "reuse")
+    asset = {
+        "schemaVersion": 1,
+        "id": asset_id,
+        "projectId": project_id,
+        "generationSetId": None,
+        "type": "frame",
+        "displayName": f"Frame {timestamp:.2f}s from {source_asset.get('displayName', 'clip')}",
+        "createdAt": created_at,
+        "file": {
+            "path": media_rel,
+            "mimeType": "image/png",
+            "width": image.width,
+            "height": image.height,
+            "duration": None,
+            "fps": None,
+        },
+        "status": {
+            "favorite": False,
+            "rating": 0,
+            "rejected": False,
+            "trashed": False,
+        },
+        "recipe": {
+            "mode": "frame_extract",
+            "model": "timeline-frame-extract",
+            "adapter": "ffmpeg-frame-extract",
+            "prompt": f"Extract frame at {timestamp:.2f}s",
+            "negativePrompt": "",
+            "seed": 0,
+            "loras": [],
+            "stylePreset": "none",
+            "normalizedSettings": {
+                "timelineId": timeline_id,
+                "timelineItemId": timeline_item_id,
+                "playheadSeconds": payload.get("playheadSeconds"),
+                "sourceTimestamp": timestamp,
+                "intendedUse": intended_use,
+            },
+            "rawAdapterSettings": {"sourcePath": str(source_media_path.relative_to(project_path)).replace("\\", "/")},
+        },
+        "lineage": {
+            "parents": [source_asset_id],
+            "sourceAssetId": source_asset_id,
+            "sourceTimestamp": timestamp,
+            "timelineId": timeline_id,
+            "timelineItemId": timeline_item_id,
+            "intendedUse": intended_use,
+            "jobId": job["id"],
+        },
+    }
+    sidecar_path = media_path.with_suffix(".sceneworks.json")
+    progress("saving", "saving", 0.85, "Saving extracted frame asset.")
+    if cancel_requested():
+        media_path.unlink(missing_ok=True)
+        raise InterruptedError("Frame extraction canceled before asset promotion.")
+    write_json(sidecar_path, asset)
+    write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
+    index_asset(project_path, asset)
+    return {
+        "assetIds": [asset_id],
+        "assets": [asset],
+        "sourceAssetId": source_asset_id,
+        "sourceTimestamp": timestamp,
+        "timelineId": timeline_id,
+        "timelineItemId": timeline_item_id,
     }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -118,7 +118,7 @@
       "family": "ltx-video",
       "type": "video",
       "adapter": "ltx_video",
-      "capabilities": ["image_to_video", "text_to_video", "first_last_frame"],
+      "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
       "downloads": [
         {
           "provider": "huggingface",
@@ -151,7 +151,7 @@
       "ui": {
         "label": "LTX-2.3",
         "description": "First-class short-shot video target for image-to-video and text-to-video.",
-        "recommendedFor": ["image_to_video", "text_to_video", "first_last_frame"],
+        "recommendedFor": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
         "durationHint": "Best for short clips. Start with 4-8 seconds; 10 seconds is the normal ceiling for the current workflow."
       }
     },
@@ -161,7 +161,7 @@
       "family": "wan-video",
       "type": "video",
       "adapter": "wan_video",
-      "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "replace_person"],
+      "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
       "downloads": [
         {
           "provider": "huggingface",

--- a/packages/schemas/timeline.schema.json
+++ b/packages/schemas/timeline.schema.json
@@ -44,6 +44,21 @@
                 "fit": { "enum": ["fit", "fill", "stretch"] },
                 "volume": { "type": "number", "minimum": 0 },
                 "versionAssetIds": { "type": "array", "items": { "type": "string" } },
+                "currentVersionAssetId": { "type": ["string", "null"] },
+                "versionHistory": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["assetId", "source"],
+                    "properties": {
+                      "assetId": { "type": "string" },
+                      "createdAt": { "type": ["string", "null"], "format": "date-time" },
+                      "source": { "enum": ["original", "replacement", "extension", "bridge", "restore", "manual"] },
+                      "jobId": { "type": ["string", "null"] },
+                      "note": { "type": ["string", "null"] }
+                    }
+                  }
+                },
                 "transitionIn": { "$ref": "#/$defs/transition" },
                 "transitionOut": { "$ref": "#/$defs/transition" }
               }

--- a/tests/test_timelines.py
+++ b/tests/test_timelines.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from sceneworks_api.jobs_store import JobsStore
+from sceneworks_api.timelines import (
+    FrameExtractRequest,
+    TimelineDocument,
+    TimelineItem,
+    TimelineTrack,
+    extract_timeline_frame,
+    save_timeline,
+)
+from sceneworks_shared import index_asset, write_json
+
+
+class EventHub:
+    def __init__(self) -> None:
+        self.events = []
+
+    def publish(self, event: str, data: dict) -> None:
+        self.events.append((event, data))
+
+
+def request_for_project(tmp_path, project_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    registry_path = data_dir / "recent-projects.json"
+    registry_path.write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    jobs_store = JobsStore(tmp_path / "jobs.db")
+    jobs_store.initialize()
+    state = SimpleNamespace(
+        settings=SimpleNamespace(registry_path=registry_path, worker_timeout_seconds=120),
+        jobs_store=jobs_store,
+        event_hub=EventHub(),
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def test_timeline_item_defaults_current_version_history():
+    item = TimelineItem(
+        trackId="track_main",
+        assetId="asset-1",
+        displayName="Clip",
+        sourceIn=0,
+        sourceOut=4,
+        timelineStart=0,
+        timelineEnd=4,
+    )
+
+    assert item.currentVersionAssetId == "asset-1"
+    assert item.versionAssetIds == ["asset-1"]
+    assert item.versionHistory[0].source == "original"
+
+
+def test_extract_timeline_frame_queues_worker_job_with_source_metadata(tmp_path):
+    project_path = tmp_path / "project.sceneworks"
+    video_dir = project_path / "assets" / "videos"
+    video_dir.mkdir(parents=True)
+    media_path = video_dir / "clip.webp"
+    media_path.write_bytes(b"webp")
+    asset = {
+        "id": "asset-1",
+        "projectId": "project-1",
+        "type": "video",
+        "displayName": "Clip",
+        "createdAt": "2026-05-17T00:00:00Z",
+        "generationSetId": None,
+        "file": {"path": "assets/videos/clip.webp", "duration": 8},
+        "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
+    }
+    write_json(video_dir / "clip.sceneworks.json", asset)
+    index_asset(project_path, asset)
+    timeline = TimelineDocument(
+        id="timeline_test",
+        projectId="project-1",
+        name="Timeline",
+        tracks=[
+            TimelineTrack(
+                id="track_main",
+                name="Main",
+                kind="video",
+                items=[
+                    TimelineItem(
+                        id="item-1",
+                        trackId="track_main",
+                        assetId="asset-1",
+                        displayName="Clip",
+                        sourceIn=2,
+                        sourceOut=6,
+                        timelineStart=10,
+                        timelineEnd=14,
+                        speed=1,
+                    )
+                ],
+            )
+        ],
+    )
+    save_timeline(project_path, timeline)
+    request = request_for_project(tmp_path, project_path)
+
+    job = extract_timeline_frame(
+        "project-1",
+        "timeline_test",
+        "item-1",
+        FrameExtractRequest(playheadSeconds=12.5, intendedUse="first_frame"),
+        request,
+    )
+
+    assert job["type"] == "frame_extract"
+    assert job["payload"]["sourceAssetId"] == "asset-1"
+    assert job["payload"]["sourceTimestamp"] == 4.5
+    assert job["payload"]["timelineId"] == "timeline_test"
+    assert request.app.state.event_hub.events[-1][0] == "queue.updated"


### PR DESCRIPTION
﻿## Summary
- Add timeline item version metadata and a frame extraction job endpoint for selected timeline clips.
- Wire editor actions for extracting frames, sending selected assets to studios, extending clips, generating bridge clips, and nondestructive replacement.
- Teach the worker to extract timeline frames and render extend/bridge jobs from source clip frames, with lineage metadata preserved.

## Validation
- `python -m pytest`
- `npm test` in `apps/web`
- `npm run build` in `apps/web`
- Browser smoke pass on `http://127.0.0.1:5173` for timeline creation, adding/selecting an item, and the new generation hook controls.
