### PR TITLE
[codex] fix Rust worker GPU count

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ SCENEWORKS_WORKER_POLL_SECONDS=3
 # Keep this enabled so procedural person detection/tracking jobs are claimed by
 # Python while Rust owns model/LoRA/FFmpeg utility jobs.
 SCENEWORKS_PYTHON_UTILITY_JOBS=1
+SCENEWORKS_RUST_WORKER_GPU_ID=cpu
 
 # Enable these only while rolling a specific Rust utility family back to Python.
 SCENEWORKS_LEGACY_MODEL_LORA_JOBS=0

--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ Compose, workers are wired to the selected `api` service automatically. The
 Compose `worker` service is the Python inference worker and the `rust-worker`
 service is the Rust utility worker; both use the same HTTP contract.
 The `sceneworks-rust-worker` binary handles CPU utility jobs for model downloads,
-LoRA imports, FFmpeg frame extraction, and timeline MP4 exports. Set
-`SCENEWORKS_GPU_ID=auto` to let the Rust worker supervise one child per visible
+LoRA imports, FFmpeg frame extraction, and timeline MP4 exports. The Rust worker
+defaults to `SCENEWORKS_GPU_ID=cpu` so it registers one CPU utility worker and
+does not duplicate the Python inference GPU workers. Set
+`SCENEWORKS_RUST_WORKER_GPU_ID=auto` in Compose, or `SCENEWORKS_GPU_ID=auto` in
+host mode, only if you want the Rust worker to supervise one child per visible
 NVIDIA GPU plus a CPU utility child; use `NVIDIA_VISIBLE_DEVICES=none` for a CPU
-fallback-only worker or a comma-separated list to constrain the GPU children.
-The Rust worker defaults to auto mode, matching the Python worker. Shutdown waits
-up to 10 seconds for child workers by default; set
+fallback-only worker or a comma-separated list to constrain GPU children.
+Shutdown waits up to 10 seconds for child workers by default; set
 `SCENEWORKS_WORKER_SHUTDOWN_TIMEOUT_SECONDS` to tune that grace period. On
 Windows, Rust listens for Ctrl+C; Unix workers also handle SIGTERM.
 

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -51,7 +51,7 @@ impl Settings {
                 .filter(|value| !value.is_empty()),
             data_dir: env_path("SCENEWORKS_DATA_DIR", "data"),
             worker_id: env_string("SCENEWORKS_WORKER_ID", "rust-utility-worker"),
-            gpu_id: env_string("SCENEWORKS_GPU_ID", "auto"),
+            gpu_id: env_string("SCENEWORKS_GPU_ID", "cpu"),
             is_child_worker: std::env::var("SCENEWORKS_WORKER_CHILD")
                 .is_ok_and(|value| value.trim() == "1"),
             poll_seconds: env_u64_any(

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -13,6 +13,26 @@ import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { sortNewest, sortWorkers } from "./sorters.js";
 import { ensureItemVersionFields } from "./timeline.js";
 
+function isActiveWorker(worker) {
+  return worker.status !== "offline";
+}
+
+function hasCapability(worker, capability) {
+  return Array.isArray(worker.capabilities) && worker.capabilities.includes(capability);
+}
+
+function isPlaceholderOnlyGpuWorker(worker) {
+  if (!hasCapability(worker, "gpu")) {
+    return false;
+  }
+  const capabilities = Array.isArray(worker.capabilities) ? worker.capabilities : [];
+  return capabilities.every((capability) => ["placeholder", "gpu", "nvidia"].includes(capability));
+}
+
+function isSelectableGpuWorker(worker) {
+  return worker.gpuId && worker.gpuId !== "cpu" && hasCapability(worker, "gpu") && !isPlaceholderOnlyGpuWorker(worker);
+}
+
 export function App() {
   const [health, setHealth] = useState(null);
   const [access, setAccess] = useState({ authRequired: false });
@@ -86,10 +106,14 @@ export function App() {
     }
     return jobs.filter((job) => job.projectId === projectFilter);
   }, [jobs, projectFilter]);
+  const visibleWorkers = useMemo(
+    () => workers.filter((worker) => isActiveWorker(worker) && !isPlaceholderOnlyGpuWorker(worker)),
+    [workers],
+  );
   const gpuOptions = useMemo(() => {
-    const ids = workers.map((worker) => worker.gpuId).filter(Boolean);
+    const ids = visibleWorkers.filter(isSelectableGpuWorker).map((worker) => worker.gpuId);
     return ["auto", ...Array.from(new Set(ids))];
-  }, [workers]);
+  }, [visibleWorkers]);
   const mediaAssets = useMemo(
     () => assets.filter((asset) => ["image", "video", "upload", "frame", "render"].includes(asset.type)),
     [assets],
@@ -983,7 +1007,9 @@ export function App() {
               <StatusDot ok={health?.status === "ok"} />
               API
             </span>
-            <span>{workers.length ? `${workers.length} worker${workers.length === 1 ? "" : "s"}` : "No workers"}</span>
+            <span>
+              {visibleWorkers.length ? `${visibleWorkers.length} worker${visibleWorkers.length === 1 ? "" : "s"}` : "No workers"}
+            </span>
             <span>{gpuOptions.length > 1 ? `${gpuOptions.length - 1} GPU slot${gpuOptions.length === 2 ? "" : "s"}` : "GPU auto"}</span>
             <button className="queue-chip" onClick={() => setActiveView("Queue")} type="button">
               Queue {queueCounts.active}
@@ -1128,7 +1154,7 @@ export function App() {
             setJobPrompt={setJobPrompt}
             setProjectFilter={setProjectFilter}
             setRequestedGpu={setRequestedGpu}
-            workers={workers}
+            workers={visibleWorkers}
           />
         ) : null}
 

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -97,4 +97,71 @@ describe("SceneWorks app shell", () => {
   it("adds the SSE ticket as a query parameter", () => {
     expect(eventUrl("/api/v1/jobs/events", "stream-ticket")).toContain("ticket=stream-ticket");
   });
+
+  it("filters stale and placeholder-only GPU workers from the queue view", async () => {
+    global.fetch.mockImplementation((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/workers")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "python-gpu-0",
+              gpuId: "0",
+              gpuName: "Fixture GPU 0",
+              status: "idle",
+              capabilities: ["placeholder", "gpu", "image_generate"],
+            },
+            {
+              id: "rust-gpu-1",
+              gpuId: "1",
+              gpuName: "Rust placeholder GPU",
+              status: "idle",
+              capabilities: ["placeholder", "gpu", "nvidia"],
+            },
+            {
+              id: "stale-gpu-2",
+              gpuId: "2",
+              gpuName: "Stale GPU",
+              status: "offline",
+              capabilities: ["placeholder", "gpu", "image_generate"],
+            },
+            {
+              id: "rust-cpu",
+              gpuId: "cpu",
+              gpuName: "Rust CPU utility worker",
+              status: "idle",
+              capabilities: ["placeholder", "cpu", "model_download"],
+            },
+          ]),
+        );
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Fixture GPU 0");
+    expect(container.textContent).toContain("Rust CPU utility worker");
+    expect(container.textContent).not.toContain("Rust placeholder GPU");
+    expect(container.textContent).not.toContain("Stale GPU");
+    expect([...container.querySelector("#queue-gpu").options].map((option) => option.value)).toEqual(["auto", "0"]);
+  });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8000}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_WORKER_ID: rust-utility-worker-0
-      SCENEWORKS_GPU_ID: ${SCENEWORKS_RUST_WORKER_GPU_ID:-auto}
+      SCENEWORKS_GPU_ID: ${SCENEWORKS_RUST_WORKER_GPU_ID:-cpu}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       HF_TOKEN: ${HF_TOKEN:-}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
@@ -71,8 +71,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
-    # Rust GPU children currently report device presence for migration parity.
-    # Keep GPU visibility here so auto discovery behaves like the Python worker.
+    # Keep GPU visibility available for explicit Rust GPU auto mode.
     deploy:
       resources:
         reservations:

--- a/scripts/check-compose-config.mjs
+++ b/scripts/check-compose-config.mjs
@@ -24,10 +24,12 @@ function assertEqual(actual, expected, label) {
 function assertRuntimeDefaults(config, label) {
   const api = config.services?.api;
   const worker = config.services?.worker;
+  const rustWorker = config.services?.["rust-worker"];
   assertEqual(api?.build?.dockerfile, "docker/rust-api.Dockerfile", `${label} api dockerfile`);
   assertEqual(api?.environment?.SCENEWORKS_API_RUNTIME, "rust", `${label} api runtime`);
   assertEqual(worker?.environment?.SCENEWORKS_UTILITY_JOBS, "1", `${label} python utility jobs`);
   assertEqual(worker?.environment?.SCENEWORKS_WORKER_ID, "python-inference-worker-0", `${label} python worker id`);
+  assertEqual(rustWorker?.environment?.SCENEWORKS_GPU_ID, "cpu", `${label} rust worker gpu mode`);
 }
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "sceneworks-compose-config-"));


### PR DESCRIPTION
﻿## Summary

Fixes the inflated GPU count after the Rust worker conversion by making the Rust utility worker CPU-only by default and keeping GPU ownership with the Python inference worker.

## Root Cause

The Rust utility worker defaulted to GPU auto mode, so it spawned GPU child workers in addition to the Python inference worker's GPU children. Those Rust GPU children only advertised placeholder device presence, but the queue UI still rendered them as extra GPUs. Offline stale worker rows could also continue to appear in the queue.

## Changes

- Default the Rust worker to `SCENEWORKS_GPU_ID=cpu` in code and Docker Compose.
- Add `SCENEWORKS_RUST_WORKER_GPU_ID=cpu` to `.env.example` and document how to opt into Rust GPU auto mode explicitly.
- Filter offline workers and placeholder-only GPU workers from the queue UI and GPU picker.
- Extend compose config and web tests to guard the behavior.

## Validation

- `npm run check:compose`
- `cargo test -p sceneworks-rust-worker --lib`
- `npm --prefix apps/web test`
- `npm run check`
- `git diff --check`
