### PR TITLE
[codex] Complete multi-GPU polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,10 @@ SCENEWORKS_LEGACY_FFMPEG_JOBS=0
 # Optional Hugging Face token for gated model or LoRA repos.
 HF_TOKEN=
 
+# Persist Diffusers/Hugging Face model caches inside the mounted data volume.
+SCENEWORKS_HF_HOME=/sceneworks/data/cache/huggingface
+SCENEWORKS_HUGGINGFACE_HUB_CACHE=/sceneworks/data/cache/huggingface/hub
+
 # Worker adapter override: auto, procedural, z_image_diffusers, or qwen_image.
 SCENEWORKS_IMAGE_ADAPTER=auto
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ API volume contracts are shared across Python and Rust:
 - `${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data` read/write for projects, models, LoRAs, and cache-backed app data.
 - `${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config:ro` read-only for manifests and app configuration.
 - `./data/cache/jobs.db` is the shared queue database for both runtimes, preserving existing compose queue history across migration flips and rollback.
+- `./data/cache/huggingface` persists Diffusers/Hugging Face model downloads across worker container rebuilds and restarts.
 
 Both API runtimes expose `GET /api/v1/health`; Compose checks it with `curl`
 inside the container so dependent services wait for the selected implementation.
@@ -125,6 +126,10 @@ owns the model, LoRA, and FFmpeg utility families. Set
 The Python worker ID changed from `worker-gpu-auto-0` to
 `python-inference-worker-0`; existing queue databases may retain the old worker
 row until the stale-worker sweep marks it offline.
+When multiple GPU children are registered, auto GPU jobs may be claimed by a
+worker that already reports the requested model as warm before falling back to
+FIFO order. Explicit GPU selections and utility jobs keep their normal FIFO
+claim order.
 Both Docker worker images install Debian Bookworm `ffmpeg`; host-mode workers
 use the `ffmpeg` found on `PATH`. Set `HF_TOKEN` when downloading from gated
 Hugging Face repositories.

--- a/apps/api/sceneworks_api/jobs_store.py
+++ b/apps/api/sceneworks_api/jobs_store.py
@@ -49,6 +49,13 @@ def choose_claimable_job(rows: list[sqlite3.Row], capabilities: set[str], loaded
     if first["type"] in NON_GPU_JOB_TYPES or first["requested_gpu"] != "auto":
         return first
 
+    explicit_gpu_job = next(
+        (row for row in compatible if row["type"] not in NON_GPU_JOB_TYPES and row["requested_gpu"] != "auto"),
+        None,
+    )
+    if explicit_gpu_job is not None:
+        return explicit_gpu_job
+
     return next((row for row in compatible if job_matches_loaded_model(row, loaded_models)), first)
 
 

--- a/apps/api/sceneworks_api/jobs_store.py
+++ b/apps/api/sceneworks_api/jobs_store.py
@@ -17,6 +17,41 @@ NON_GPU_JOB_TYPES = ("model_download", "lora_import")
 MAX_JOB_ATTEMPTS = 5
 
 
+def desired_model_keys(payload: dict) -> set[str]:
+    keys: set[str] = set()
+    model = payload.get("model")
+    if isinstance(model, str) and model:
+        keys.add(model)
+    repo = payload.get("repo")
+    if isinstance(repo, str) and repo:
+        keys.add(repo)
+    advanced = payload.get("advanced")
+    if isinstance(advanced, dict):
+        for field in ("modelRepo", "repo"):
+            value = advanced.get(field)
+            if isinstance(value, str) and value:
+                keys.add(value)
+    return keys
+
+
+def job_matches_loaded_model(row: sqlite3.Row, loaded_models: set[str]) -> bool:
+    if row["requested_gpu"] != "auto" or row["type"] in NON_GPU_JOB_TYPES or not loaded_models:
+        return False
+    return bool(desired_model_keys(loads(row["payload_json"], {})) & loaded_models)
+
+
+def choose_claimable_job(rows: list[sqlite3.Row], capabilities: set[str], loaded_models: set[str]) -> sqlite3.Row | None:
+    compatible = [row for row in rows if row["type"] in capabilities]
+    if not compatible:
+        return None
+
+    first = compatible[0]
+    if first["type"] in NON_GPU_JOB_TYPES or first["requested_gpu"] != "auto":
+        return first
+
+    return next((row for row in compatible if job_matches_loaded_model(row, loaded_models)), first)
+
+
 def dumps(value: Any) -> str:
     return json.dumps(value if value is not None else {}, separators=(",", ":"), sort_keys=True)
 
@@ -426,6 +461,7 @@ class JobsStore:
             worker = self.get_worker(worker_id, connection=connection)
             gpu_id = worker["gpuId"]
             capabilities = set(worker["capabilities"])
+            loaded_models = set(worker["loadedModels"])
             active_gpu_job = connection.execute(
                 f"""
                 select id from jobs
@@ -450,7 +486,7 @@ class JobsStore:
             ).fetchall()
             # Keep this bounded while the queue is still small; revisit before large multi-tenant queues
             # so capability-incompatible jobs cannot hide a later compatible job indefinitely.
-            queued = next((row for row in queued_rows if row["type"] in capabilities), None)
+            queued = choose_claimable_job(queued_rows, capabilities, loaded_models)
             if queued is None:
                 return None
             assigned_gpu = "cpu" if queued["type"] in NON_GPU_JOB_TYPES else gpu_id

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -12,7 +12,7 @@ use axum::extract::{
 };
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode};
 use axum::middleware::{self, Next};
-use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::sse::{Event, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, patch, post};
 use axum::{Json, Router};
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
+use tokio::time::{Instant as TokioInstant, MissedTickBehavior};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 use tokio_util::io::ReaderStream;
@@ -54,7 +55,9 @@ const DEFAULT_CORS_ORIGINS: &str = concat!(
     "http://localhost:5176,http://127.0.0.1:5176"
 );
 const EVENT_BUFFER_SIZE: usize = 100;
-const HEARTBEAT_SSE_TEXT: &str = "{}";
+const HEARTBEAT_SSE_DATA: &str = "{}";
+#[cfg(test)]
+const HEARTBEAT_SSE_WIRE: &str = "event: heartbeat\ndata: {}\n\n";
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MANIFEST_CACHE_LIMIT: usize = 16;
 const MODEL_SIZE_CACHE_LIMIT: usize = 64;
@@ -1550,18 +1553,47 @@ async fn job_events(
             .event_tickets
             .consume(query.ticket.as_deref().unwrap_or_default())?;
     }
-    let ready = tokio_stream::iter([Ok(Event::default()
+    Ok(Sse::new(sse_event_stream(state.events.subscribe())))
+}
+
+fn sse_event_stream(
+    messages: ReceiverStream<EventMessage>,
+) -> impl futures_util::Stream<Item = Result<Event, Infallible>> {
+    let mut heartbeat = tokio::time::interval_at(
+        TokioInstant::now() + Duration::from_secs(15),
+        Duration::from_secs(15),
+    );
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    futures_util::stream::unfold(
+        (messages, heartbeat, true),
+        |(mut messages, mut heartbeat, send_ready)| async move {
+            if send_ready {
+                return Some((Ok(ready_event()), (messages, heartbeat, false)));
+            }
+            tokio::select! {
+                message = messages.next() => {
+                    message.map(|message| (Ok(sse_message_event(message)), (messages, heartbeat, false)))
+                }
+                _ = heartbeat.tick() => {
+                    Some((Ok(heartbeat_event()), (messages, heartbeat, false)))
+                }
+            }
+        },
+    )
+}
+
+fn ready_event() -> Event {
+    Event::default()
         .event("ready")
-        .data(json!({ "status": "connected" }).to_string()))]);
-    let messages = state
-        .events
-        .subscribe()
-        .map(|message| Ok(Event::default().event(message.event).data(message.data)));
-    Ok(Sse::new(ready.chain(messages)).keep_alive(
-        KeepAlive::new()
-            .interval(Duration::from_secs(15))
-            .text(HEARTBEAT_SSE_TEXT),
-    ))
+        .data(json!({ "status": "connected" }).to_string())
+}
+
+fn sse_message_event(message: EventMessage) -> Event {
+    Event::default().event(message.event).data(message.data)
+}
+
+fn heartbeat_event() -> Event {
+    Event::default().event("heartbeat").data(HEARTBEAT_SSE_DATA)
 }
 
 async fn access_control(
@@ -2622,7 +2654,8 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_app, EventHub, EventMessage, Settings, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_TEXT,
+        create_app, EventHub, EventMessage, Settings, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
+        HEARTBEAT_SSE_WIRE,
     };
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
@@ -3769,9 +3802,9 @@ mod tests {
     }
 
     #[test]
-    fn heartbeat_keepalive_text_is_axum_safe() {
-        assert_eq!(HEARTBEAT_SSE_TEXT, "{}");
-        assert!(!HEARTBEAT_SSE_TEXT.contains(['\r', '\n']));
+    fn heartbeat_event_matches_python_wire_shape() {
+        assert_eq!(HEARTBEAT_SSE_DATA, "{}");
+        assert_eq!(HEARTBEAT_SSE_WIRE, "event: heartbeat\ndata: {}\n\n");
     }
 
     #[tokio::test]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -54,7 +54,7 @@ const DEFAULT_CORS_ORIGINS: &str = concat!(
     "http://localhost:5176,http://127.0.0.1:5176"
 );
 const EVENT_BUFFER_SIZE: usize = 100;
-const HEARTBEAT_SSE_TEXT: &str = "event: heartbeat\ndata: {}\n\n";
+const HEARTBEAT_SSE_TEXT: &str = "{}";
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MANIFEST_CACHE_LIMIT: usize = 16;
 const MODEL_SIZE_CACHE_LIMIT: usize = 64;
@@ -3769,8 +3769,9 @@ mod tests {
     }
 
     #[test]
-    fn heartbeat_event_matches_python_wire_shape() {
-        assert_eq!(HEARTBEAT_SSE_TEXT, "event: heartbeat\ndata: {}\n\n");
+    fn heartbeat_keepalive_text_is_axum_safe() {
+        assert_eq!(HEARTBEAT_SSE_TEXT, "{}");
+        assert!(!HEARTBEAT_SSE_TEXT.contains(['\r', '\n']));
     }
 
     #[tokio::test]

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1147,6 +1147,7 @@ export function App() {
             filteredJobs={filteredJobs}
             gpuOptions={gpuOptions}
             jobAction={jobAction}
+            jobs={jobs}
             jobPrompt={jobPrompt}
             projectFilter={projectFilter}
             projects={projects}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -198,6 +198,60 @@ describe("SceneWorks app shell", () => {
               payload: { prompt: "clip" },
               attempts: 1,
             },
+            {
+              id: "job-download",
+              type: "model_download",
+              status: "downloading",
+              stage: "downloading",
+              progress: 0.4,
+              projectId: null,
+              projectName: null,
+              requestedGpu: "auto",
+              assignedGpu: "cpu",
+              payload: {
+                modelId: "qwen_image_edit",
+                modelName: "Qwen Image Edit",
+                repo: "Qwen/Qwen-Image-Edit",
+              },
+              attempts: 1,
+            },
+            {
+              id: "job-waiting-download",
+              type: "image_generate",
+              status: "queued",
+              stage: "queued",
+              progress: 0,
+              projectId: "project-1",
+              projectName: "Project 1",
+              requestedGpu: "auto",
+              payload: { prompt: "edit", model: "qwen_image_edit" },
+              attempts: 1,
+            },
+            {
+              id: "job-dependency",
+              type: "image_generate",
+              status: "running",
+              stage: "generating",
+              progress: 0.5,
+              projectId: "project-1",
+              projectName: "Project 1",
+              requestedGpu: "0",
+              assignedGpu: "0",
+              payload: { prompt: "source" },
+              attempts: 1,
+            },
+            {
+              id: "job-waiting-dependency",
+              type: "image_generate",
+              status: "queued",
+              stage: "queued",
+              progress: 0,
+              projectId: "project-1",
+              projectName: "Project 1",
+              requestedGpu: "auto",
+              payload: { prompt: "dependent", dependsOnJobId: "job-dependency" },
+              attempts: 1,
+            },
           ]}
           gpuOptions={["auto", "0"]}
           jobAction={() => {}}
@@ -225,6 +279,8 @@ describe("SceneWorks app shell", () => {
 
     expect(container.textContent).toContain("Waiting: an eligible worker is busy.");
     expect(container.textContent).toContain("Blocked: no active worker supports video generate.");
+    expect(container.textContent).toContain("Waiting for model download Qwen Image Edit to finish.");
+    expect(container.textContent).toContain("Waiting for dependency job-dependency to finish.");
     expect(container.textContent).toContain("Warm: z_image_turbo");
   });
 });

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2,6 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
+import { QueueScreen } from "./screens/QueueScreen.jsx";
 
 class FakeEventSource {
   constructor(url) {
@@ -163,5 +164,67 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Rust placeholder GPU");
     expect(container.textContent).not.toContain("Stale GPU");
     expect([...container.querySelector("#queue-gpu").options].map((option) => option.value)).toEqual(["auto", "0"]);
+  });
+
+  it("explains queued GPU jobs that are waiting on capability or busy workers", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueueScreen
+          activeProject={{ id: "project-1", name: "Project 1" }}
+          createJob={(event) => event.preventDefault()}
+          filteredJobs={[
+            {
+              id: "job-waiting",
+              type: "image_generate",
+              status: "queued",
+              stage: "queued",
+              progress: 0,
+              projectId: "project-1",
+              projectName: "Project 1",
+              requestedGpu: "auto",
+              payload: { prompt: "mist", model: "z_image_turbo" },
+              attempts: 1,
+            },
+            {
+              id: "job-blocked",
+              type: "video_generate",
+              status: "queued",
+              stage: "queued",
+              progress: 0,
+              projectId: "project-1",
+              projectName: "Project 1",
+              requestedGpu: "auto",
+              payload: { prompt: "clip" },
+              attempts: 1,
+            },
+          ]}
+          gpuOptions={["auto", "0"]}
+          jobAction={() => {}}
+          jobPrompt="Placeholder generation"
+          projectFilter="all"
+          projects={[{ id: "project-1", name: "Project 1" }]}
+          requestedGpu="auto"
+          setJobPrompt={() => {}}
+          setProjectFilter={() => {}}
+          setRequestedGpu={() => {}}
+          workers={[
+            {
+              id: "python-gpu-0",
+              gpuId: "0",
+              gpuName: "Fixture GPU 0",
+              status: "busy",
+              currentJobId: "job-active",
+              capabilities: ["placeholder", "gpu", "image_generate"],
+              loadedModels: ["z_image_turbo"],
+            },
+          ]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Waiting: an eligible worker is busy.");
+    expect(container.textContent).toContain("Blocked: no active worker supports video generate.");
+    expect(container.textContent).toContain("Warm: z_image_turbo");
   });
 });

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -3,6 +3,7 @@ import { actionStatuses, terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
 
 const nonGpuJobTypes = new Set(["model_download", "lora_import"]);
+const terminalStatusesForBlocking = new Set(["completed", "failed", "canceled", "interrupted"]);
 
 function formatJobType(type) {
   return String(type ?? "job").replaceAll("_", " ");
@@ -22,9 +23,60 @@ function workerCanClaim(job, worker) {
   return job.requestedGpu === "auto" || job.requestedGpu === worker.gpuId;
 }
 
-function jobWaitingMessage(job, workers) {
+function modelKeys(job) {
+  const keys = new Set();
+  if (job.payload?.model) {
+    keys.add(job.payload.model);
+  }
+  if (job.payload?.repo) {
+    keys.add(job.payload.repo);
+  }
+  if (job.payload?.advanced?.modelRepo) {
+    keys.add(job.payload.advanced.modelRepo);
+  }
+  if (job.payload?.advanced?.repo) {
+    keys.add(job.payload.advanced.repo);
+  }
+  return keys;
+}
+
+function activeModelDownloadFor(job, jobs) {
+  const keys = modelKeys(job);
+  if (!keys.size) {
+    return null;
+  }
+  return jobs.find(
+    (candidate) =>
+      candidate.type === "model_download" &&
+      !terminalStatusesForBlocking.has(candidate.status) &&
+      (keys.has(candidate.payload?.modelId) || keys.has(candidate.payload?.repo)),
+  );
+}
+
+function dependencyJobId(job) {
+  return job.payload?.dependsOnJobId ?? job.payload?.dependencyJobId ?? job.dependsOnJobId ?? job.sourceJobId ?? null;
+}
+
+function activeDependencyFor(job, jobs) {
+  const id = dependencyJobId(job);
+  if (!id) {
+    return null;
+  }
+  const dependency = jobs.find((candidate) => candidate.id === id);
+  return dependency && !terminalStatusesForBlocking.has(dependency.status) ? dependency : null;
+}
+
+function jobWaitingMessage(job, workers, jobs) {
   if (job.status !== "queued") {
     return job.error ?? job.message;
+  }
+  const dependency = activeDependencyFor(job, jobs);
+  if (dependency) {
+    return `Waiting for dependency ${dependency.id} to finish.`;
+  }
+  const download = activeModelDownloadFor(job, jobs);
+  if (download) {
+    return `Waiting for model download ${download.payload?.modelName ?? download.payload?.modelId ?? download.id} to finish.`;
   }
   const candidates = workers.filter((worker) => workerCanClaim(job, worker));
   if (!candidates.length) {
@@ -56,6 +108,7 @@ export function QueueScreen({
   filteredJobs,
   gpuOptions,
   jobAction,
+  jobs = filteredJobs,
   jobPrompt,
   projectFilter,
   projects,
@@ -129,6 +182,7 @@ export function QueueScreen({
               job={job}
               jobAction={jobAction}
               key={job.id}
+              jobs={jobs}
               workers={workers}
             />
           ))
@@ -138,12 +192,12 @@ export function QueueScreen({
   );
 }
 
-function JobRow({ assignedWorker, job, jobAction, workers }) {
+function JobRow({ assignedWorker, job, jobAction, jobs, workers }) {
   const canCancel = !terminalStatuses.has(job.status);
   const maxAttempts = 5;
   const attempts = job.attempts ?? 1;
   const canRepeat = actionStatuses.has(job.status) && attempts < maxAttempts;
-  const displayMessage = jobWaitingMessage(job, workers);
+  const displayMessage = jobWaitingMessage(job, workers, jobs);
   return (
     <article className={`job-row ${job.status}`}>
       <div className="job-main">

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -1,6 +1,54 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { actionStatuses, terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
+
+const nonGpuJobTypes = new Set(["model_download", "lora_import"]);
+
+function formatJobType(type) {
+  return String(type ?? "job").replaceAll("_", " ");
+}
+
+function workerSupports(worker, type) {
+  return Array.isArray(worker.capabilities) && worker.capabilities.includes(type);
+}
+
+function workerCanClaim(job, worker) {
+  if (!workerSupports(worker, job.type)) {
+    return false;
+  }
+  if (nonGpuJobTypes.has(job.type)) {
+    return true;
+  }
+  return job.requestedGpu === "auto" || job.requestedGpu === worker.gpuId;
+}
+
+function jobWaitingMessage(job, workers) {
+  if (job.status !== "queued") {
+    return job.error ?? job.message;
+  }
+  const candidates = workers.filter((worker) => workerCanClaim(job, worker));
+  if (!candidates.length) {
+    if (job.requestedGpu && job.requestedGpu !== "auto") {
+      return `Blocked: no active worker can run ${formatJobType(job.type)} on GPU ${job.requestedGpu}.`;
+    }
+    return `Blocked: no active worker supports ${formatJobType(job.type)}.`;
+  }
+  if (candidates.every((worker) => worker.status === "busy")) {
+    const target = job.requestedGpu && job.requestedGpu !== "auto" ? `GPU ${job.requestedGpu}` : "an eligible worker";
+    return `Waiting: ${target} is busy.`;
+  }
+  if (job.requestedGpu && job.requestedGpu !== "auto") {
+    return `Waiting for GPU ${job.requestedGpu} to claim the job.`;
+  }
+  return nonGpuJobTypes.has(job.type) ? "Waiting for a utility worker." : "Waiting for an available GPU worker.";
+}
+
+function workerStatusLine(worker) {
+  if (worker.status === "busy") {
+    return `Busy${worker.currentJobId ? ` with ${worker.currentJobId}` : ""}`;
+  }
+  return worker.status === "idle" ? "Ready" : worker.status;
+}
 
 export function QueueScreen({
   activeProject,
@@ -17,6 +65,7 @@ export function QueueScreen({
   setRequestedGpu,
   workers,
 }) {
+  const workersById = useMemo(() => new Map(workers.map((worker) => [worker.id, worker])), [workers]);
   return (
     <section className="main-surface queue-surface">
       <div className="queue-header">
@@ -63,8 +112,8 @@ export function QueueScreen({
           workers.map((worker) => (
             <div className="worker-card" key={worker.id}>
               <strong>{worker.gpuName ?? worker.gpuId}</strong>
-              <span>{worker.status}</span>
-              <small>{worker.currentJobId ?? "Idle"}</small>
+              <span>{workerStatusLine(worker)}</span>
+              <small>{worker.loadedModels?.length ? `Warm: ${worker.loadedModels.join(", ")}` : "No warm model"}</small>
             </div>
           ))
         )}
@@ -74,18 +123,27 @@ export function QueueScreen({
         {filteredJobs.length === 0 ? (
           <div className="empty-panel">No jobs in this view</div>
         ) : (
-          filteredJobs.map((job) => <JobRow job={job} jobAction={jobAction} key={job.id} />)
+          filteredJobs.map((job) => (
+            <JobRow
+              assignedWorker={workersById.get(job.workerId)}
+              job={job}
+              jobAction={jobAction}
+              key={job.id}
+              workers={workers}
+            />
+          ))
         )}
       </div>
     </section>
   );
 }
 
-function JobRow({ job, jobAction }) {
+function JobRow({ assignedWorker, job, jobAction, workers }) {
   const canCancel = !terminalStatuses.has(job.status);
   const maxAttempts = 5;
   const attempts = job.attempts ?? 1;
   const canRepeat = actionStatuses.has(job.status) && attempts < maxAttempts;
+  const displayMessage = jobWaitingMessage(job, workers);
   return (
     <article className={`job-row ${job.status}`}>
       <div className="job-main">
@@ -100,12 +158,13 @@ function JobRow({ job, jobAction }) {
         <span>Stage {job.stage}</span>
         <span>Elapsed {formatSeconds(job.elapsedSeconds)}</span>
         <span>GPU {job.assignedGpu ?? job.requestedGpu}</span>
+        {assignedWorker ? <span>{assignedWorker.gpuName ?? assignedWorker.id}</span> : null}
         <span>Attempt {attempts}/{maxAttempts}</span>
       </div>
       <div className="progress-track" aria-label={`${percent(job.progress)} complete`}>
         <span style={{ width: percent(job.progress) }} />
       </div>
-      <p className={job.error ? "job-message error-text" : "job-message"}>{job.error ?? job.message}</p>
+      <p className={job.error ? "job-message error-text" : "job-message"}>{displayMessage}</p>
       <div className="job-actions">
         <button disabled={!canCancel || job.cancelRequested} onClick={() => jobAction(job, "cancel")} type="button">
           Cancel

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1312,11 +1312,13 @@ button:disabled {
   display: grid;
   gap: 6px;
   padding: 12px;
+  min-width: 0;
 }
 
 .worker-card span,
 .worker-card small {
   color: #aaa397;
+  overflow-wrap: anywhere;
 }
 
 .job-list {

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -36,11 +36,26 @@ CancelCallback = Callable[[], bool]
 
 
 def huggingface_repo_cache_exists(repo: str) -> bool:
+    repo_cache = huggingface_repo_cache_path(repo)
+    if repo_cache is None:
+        return False
+    return (repo_cache / "snapshots").is_dir() or (repo_cache / "blobs").is_dir()
+
+
+def huggingface_repo_cache_path(repo: str) -> Path | None:
     default_home = Path.home() / ".cache" / "huggingface"
     hf_home = Path(os.getenv("HF_HOME") or default_home)
     cache_root = Path(os.getenv("HUGGINGFACE_HUB_CACHE") or hf_home / "hub")
-    repo_cache = cache_root / f"models--{repo.replace('/', '--')}"
-    return (repo_cache / "snapshots").exists() or (repo_cache / "blobs").exists()
+    safe_repo = "".join(char if char.isalnum() or char in "._-" else "--" for char in repo).strip("-")
+    if not safe_repo:
+        return None
+    try:
+        root = cache_root.resolve()
+        repo_cache = (root / f"models--{safe_repo}").resolve()
+        repo_cache.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return repo_cache
 
 
 MODEL_TARGETS = {

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -35,6 +35,14 @@ ProgressCallback = Callable[[str, str, float, str], None]
 CancelCallback = Callable[[], bool]
 
 
+def huggingface_repo_cache_exists(repo: str) -> bool:
+    default_home = Path.home() / ".cache" / "huggingface"
+    hf_home = Path(os.getenv("HF_HOME") or default_home)
+    cache_root = Path(os.getenv("HUGGINGFACE_HUB_CACHE") or hf_home / "hub")
+    repo_cache = cache_root / f"models--{repo.replace('/', '--')}"
+    return (repo_cache / "snapshots").exists() or (repo_cache / "blobs").exists()
+
+
 MODEL_TARGETS = {
     "z_image_turbo": {
         "label": "Z-Image-Turbo",
@@ -212,9 +220,10 @@ class ZImageDiffusersAdapter:
         self._text_pipe: Any | None = None
         self._img2img_pipe: Any | None = None
         self._loaded_repo: str | None = None
+        self._loaded_model: str | None = None
 
     def loaded_models(self) -> list[str]:
-        return [self._loaded_repo] if self._loaded_repo else []
+        return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
 
     def generate(
         self,
@@ -233,7 +242,7 @@ class ZImageDiffusersAdapter:
             raise RuntimeError(f"{request.model} is not a Z-Image Diffusers target.")
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
-        pipe = self._load_pipeline(request, model_target)
+        pipe = self._load_pipeline(request, model_target, progress=progress)
         images = []
         total = request.count
         for index in range(total):
@@ -259,7 +268,7 @@ class ZImageDiffusersAdapter:
             },
         )
 
-    def _load_pipeline(self, request: ImageRequest, model_target: dict[str, Any]) -> Any:
+    def _load_pipeline(self, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = request.advanced.get("modelRepo") or model_target["repo"]
@@ -268,6 +277,8 @@ class ZImageDiffusersAdapter:
         use_img2img = request.mode == "edit_image"
         cached_pipe = self._img2img_pipe if use_img2img else self._text_pipe
         if cached_pipe is not None and self._loaded_repo == repo:
+            self._loaded_model = request.model
+            progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
             return cached_pipe
 
         if self._loaded_repo and self._loaded_repo != repo:
@@ -289,11 +300,14 @@ class ZImageDiffusersAdapter:
         if pipeline_class is None:
             pipeline_class = getattr(diffusers, "DiffusionPipeline")
 
+        cache_action = "Loading cached" if huggingface_repo_cache_exists(repo) else "Downloading"
+        progress("loading_model", "loading_model", 0.2, f"{cache_action} {model_target['label']} model files.")
         pipe = pipeline_class.from_pretrained(
             repo,
             torch_dtype=dtype,
             low_cpu_mem_usage=bool(request.advanced.get("lowCpuMemUsage", False)),
         )
+        progress("loading_model", "loading_model", 0.22, f"Moving {model_target['label']} to {device}.")
         if bool(request.advanced.get("cpuOffload", False)) and hasattr(pipe, "enable_model_cpu_offload"):
             pipe.enable_model_cpu_offload()
         else:
@@ -304,12 +318,14 @@ class ZImageDiffusersAdapter:
         else:
             self._text_pipe = pipe
         self._loaded_repo = repo
+        self._loaded_model = request.model
         return pipe
 
     def _evict_pipelines(self, torch: Any) -> None:
         self._text_pipe = None
         self._img2img_pipe = None
         self._loaded_repo = None
+        self._loaded_model = None
         self._empty_cuda_cache(torch)
 
     def _empty_cuda_cache(self, torch: Any) -> None:

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -159,15 +159,18 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
         "repository not found",
         "is not a local folder",
         "couldn't connect to 'https://huggingface.co'",
-        "model not found",
-        "model files",
+        "no file named model_index.json",
+        "error no file named",
+        "cannot load model",
+        "missing model file",
     )
     if any(marker in lowered for marker in missing_model_markers):
         return (
             f"{job_kind} failed because required model files were not available.",
             (
                 "The worker could not find or download the model files. Check that the model is installed, "
-                f"the Hugging Face repo is reachable, and HF_TOKEN is set for gated repos. Technical detail: {detail}"
+                "open Model Manager or queue a model_download job to install it, and verify HF_TOKEN for gated repos. "
+                f"Technical detail: {detail}"
             ),
         )
     return (f"{job_kind} failed.", detail)

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -142,6 +142,37 @@ def update_job(api: ApiClient, job_id: str, payload: dict[str, Any]) -> dict:
     return job
 
 
+def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
+    detail = str(exc).strip() or exc.__class__.__name__
+    lowered = detail.lower()
+    exc_name = exc.__class__.__name__.lower()
+    if "outofmemory" in exc_name or "out of memory" in lowered or "cuda error: out of memory" in lowered:
+        return (
+            f"{job_kind} failed because the GPU ran out of memory.",
+            (
+                "GPU memory was exhausted. Try a lower resolution, shorter clip, smaller batch count, "
+                f"or a different GPU. Technical detail: {detail}"
+            ),
+        )
+    missing_model_markers = (
+        "repo id",
+        "repository not found",
+        "is not a local folder",
+        "couldn't connect to 'https://huggingface.co'",
+        "model not found",
+        "model files",
+    )
+    if any(marker in lowered for marker in missing_model_markers):
+        return (
+            f"{job_kind} failed because required model files were not available.",
+            (
+                "The worker could not find or download the model files. Check that the model is installed, "
+                f"the Hugging Face repo is reachable, and HF_TOKEN is set for gated repos. Technical detail: {detail}"
+            ),
+        )
+    return (f"{job_kind} failed.", detail)
+
+
 def job_cancel_requested(api: ApiClient, job_id: str) -> bool:
     return bool(api.get(f"/api/v1/jobs/{job_id}")["cancelRequested"])
 
@@ -641,6 +672,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
             },
         )
     except Exception as exc:
+        message, error = friendly_failure("Image generation", exc)
         update_job(
             api,
             job_id,
@@ -648,8 +680,8 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
                 "status": "failed",
                 "stage": "failed",
                 "progress": 1,
-                "message": "Image generation failed.",
-                "error": str(exc),
+                "message": message,
+                "error": error,
             },
         )
     finally:
@@ -727,6 +759,7 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
         )
     except Exception as exc:
         adapter.cleanup(job_id)
+        message, error = friendly_failure("Video generation", exc)
         update_job(
             api,
             job_id,
@@ -734,8 +767,8 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
                 "status": "failed",
                 "stage": "failed",
                 "progress": 1,
-                "message": "Video generation failed.",
-                "error": str(exc),
+                "message": message,
+                "error": error,
             },
         )
     finally:

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1130,6 +1130,13 @@ fn choose_claimable_job(rows: Vec<JobSnapshot>, worker: &WorkerSnapshot) -> Opti
     if is_non_gpu_job_type(first.job_type.as_str()) || first.requested_gpu != "auto" {
         return compatible.into_iter().next();
     }
+    if let Some(explicit_gpu_job) = compatible
+        .iter()
+        .find(|job| !is_non_gpu_job_type(job.job_type.as_str()) && job.requested_gpu != "auto")
+        .cloned()
+    {
+        return Some(explicit_gpu_job);
+    }
     compatible
         .iter()
         .find(|job| job_matches_loaded_model(job, worker))

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -602,14 +602,9 @@ impl JobsStore {
             params![worker.gpu_id, i64::from(has_active_gpu_job)],
             row_to_job,
         )?)?;
-        // Faithful to the current Python queue behavior. Revisit before large multi-tenant queues so
-        // capability-incompatible jobs cannot hide a later compatible job indefinitely.
-        let queued = queued_rows.into_iter().find(|job| {
-            worker
-                .capabilities
-                .iter()
-                .any(|capability| capability.as_str() == job.job_type.as_str())
-        });
+        // Keep this bounded while the queue is still small; revisit before large multi-tenant
+        // queues so capability-incompatible jobs cannot hide a later compatible job indefinitely.
+        let queued = choose_claimable_job(queued_rows, &worker);
         let Some(queued) = queued else {
             return Ok(None);
         };
@@ -1119,6 +1114,63 @@ fn is_terminal_status(status: &str) -> bool {
 
 fn is_non_gpu_job_type(job_type: &str) -> bool {
     NON_GPU_JOB_TYPES.contains(&job_type)
+}
+
+fn choose_claimable_job(rows: Vec<JobSnapshot>, worker: &WorkerSnapshot) -> Option<JobSnapshot> {
+    let compatible = rows
+        .into_iter()
+        .filter(|job| {
+            worker
+                .capabilities
+                .iter()
+                .any(|capability| capability.as_str() == job.job_type.as_str())
+        })
+        .collect::<Vec<_>>();
+    let first = compatible.first()?;
+    if is_non_gpu_job_type(first.job_type.as_str()) || first.requested_gpu != "auto" {
+        return compatible.into_iter().next();
+    }
+    compatible
+        .iter()
+        .find(|job| job_matches_loaded_model(job, worker))
+        .cloned()
+        .or_else(|| compatible.into_iter().next())
+}
+
+fn job_matches_loaded_model(job: &JobSnapshot, worker: &WorkerSnapshot) -> bool {
+    if job.requested_gpu != "auto"
+        || is_non_gpu_job_type(job.job_type.as_str())
+        || worker.loaded_models.is_empty()
+    {
+        return false;
+    }
+    let keys = desired_model_keys(&job.payload);
+    worker
+        .loaded_models
+        .iter()
+        .any(|loaded_model| keys.iter().any(|key| key == loaded_model))
+}
+
+fn desired_model_keys(payload: &Map<String, Value>) -> Vec<String> {
+    let mut keys = Vec::new();
+    push_string_value(&mut keys, payload.get("model"));
+    push_string_value(&mut keys, payload.get("repo"));
+    if let Some(advanced) = payload.get("advanced").and_then(Value::as_object) {
+        push_string_value(&mut keys, advanced.get("modelRepo"));
+        push_string_value(&mut keys, advanced.get("repo"));
+    }
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+fn push_string_value(output: &mut Vec<String>, value: Option<&Value>) {
+    if let Some(value) = value
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        output.push(value.to_owned());
+    }
 }
 
 fn placeholders_from(start: usize, count: usize) -> String {

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -248,6 +248,53 @@ fn loaded_model_preference_does_not_skip_explicit_gpu_job() {
 }
 
 #[test]
+fn explicit_gpu_job_beats_younger_warm_auto_match() {
+    let store = store("explicit-gpu-before-warm-auto");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-1".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: None,
+            capabilities: vec![WorkerCapability::ImageGenerate],
+            loaded_models: vec!["model-x".to_owned()],
+        })
+        .expect("worker registers");
+    let auto_other = store
+        .create_job(image_job(object(json!({ "model": "model-y" }))))
+        .expect("auto other job creates");
+    let explicit_job = store
+        .create_job(CreateJob {
+            requested_gpu: "gpu-0".to_owned(),
+            ..image_job(object(json!({ "model": "model-y" })))
+        })
+        .expect("explicit job creates");
+    let warm_auto = store
+        .create_job(image_job(object(json!({ "model": "model-x" }))))
+        .expect("warm auto job creates");
+
+    let claimed = store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+
+    assert_eq!(claimed.id, explicit_job.id);
+    assert_eq!(
+        store
+            .get_job(&auto_other.id)
+            .expect("auto other job loads")
+            .status,
+        JobStatus::Queued
+    );
+    assert_eq!(
+        store
+            .get_job(&warm_auto.id)
+            .expect("warm auto job loads")
+            .status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
 fn cpu_utility_worker_does_not_claim_gpu_generation_job() {
     let store = store("cpu-utility-no-gpu-jobs");
     store

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -179,6 +179,75 @@ fn claim_skips_jobs_not_supported_by_worker_capabilities() {
 }
 
 #[test]
+fn auto_claim_prefers_job_matching_loaded_model() {
+    let store = store("loaded-model-preference");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-1".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: None,
+            capabilities: vec![WorkerCapability::ImageGenerate],
+            loaded_models: vec![
+                "z_image_turbo".to_owned(),
+                "Tongyi-MAI/Z-Image-Turbo".to_owned(),
+            ],
+        })
+        .expect("worker registers");
+    let other_model_job = store
+        .create_job(image_job(object(json!({ "model": "qwen_image_edit" }))))
+        .expect("other model job creates");
+    let warm_model_job = store
+        .create_job(image_job(object(json!({ "model": "z_image_turbo" }))))
+        .expect("warm model job creates");
+
+    let claimed = store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+
+    assert_eq!(claimed.id, warm_model_job.id);
+    assert_eq!(
+        store
+            .get_job(&other_model_job.id)
+            .expect("other model job loads")
+            .status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
+fn loaded_model_preference_does_not_skip_explicit_gpu_job() {
+    let store = store("loaded-model-explicit-gpu");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-1".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: None,
+            capabilities: vec![WorkerCapability::ImageGenerate],
+            loaded_models: vec!["z_image_turbo".to_owned()],
+        })
+        .expect("worker registers");
+    let explicit_job = store
+        .create_job(CreateJob {
+            requested_gpu: "gpu-0".to_owned(),
+            ..image_job(object(json!({ "model": "qwen_image_edit" })))
+        })
+        .expect("explicit job creates");
+    store
+        .create_job(image_job(object(json!({ "model": "z_image_turbo" }))))
+        .expect("warm model job creates");
+
+    assert_eq!(
+        store
+            .claim_next_job("worker-1")
+            .expect("claim succeeds")
+            .expect("job claimed")
+            .id,
+        explicit_job.id
+    );
+}
+
+#[test]
 fn cpu_utility_worker_does_not_claim_gpu_generation_job() {
     let store = store("cpu-utility-no-gpu-jobs");
     store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       SCENEWORKS_GPU_ID: auto
       SCENEWORKS_UTILITY_JOBS: ${SCENEWORKS_PYTHON_UTILITY_JOBS:-1}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
+      HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
+      HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data

--- a/scripts/check-compose-config.mjs
+++ b/scripts/check-compose-config.mjs
@@ -29,6 +29,12 @@ function assertRuntimeDefaults(config, label) {
   assertEqual(api?.environment?.SCENEWORKS_API_RUNTIME, "rust", `${label} api runtime`);
   assertEqual(worker?.environment?.SCENEWORKS_UTILITY_JOBS, "1", `${label} python utility jobs`);
   assertEqual(worker?.environment?.SCENEWORKS_WORKER_ID, "python-inference-worker-0", `${label} python worker id`);
+  assertEqual(worker?.environment?.HF_HOME, "/sceneworks/data/cache/huggingface", `${label} python HF home`);
+  assertEqual(
+    worker?.environment?.HUGGINGFACE_HUB_CACHE,
+    "/sceneworks/data/cache/huggingface/hub",
+    `${label} python HF hub cache`,
+  );
   assertEqual(rustWorker?.environment?.SCENEWORKS_GPU_ID, "cpu", `${label} rust worker gpu mode`);
 }
 

--- a/tests/test_jobs_store.py
+++ b/tests/test_jobs_store.py
@@ -161,6 +161,45 @@ def test_loaded_model_preference_does_not_skip_explicit_gpu_job(tmp_path):
     assert store.claim_next_job("worker-1")["id"] == explicit_job["id"]
 
 
+def test_explicit_gpu_job_beats_younger_warm_auto_match(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    store.register_worker(
+        worker_id="worker-1",
+        gpu_id="gpu-0",
+        gpu_name=None,
+        capabilities=["image_generate"],
+        loaded_models=["model-x"],
+    )
+    auto_other = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={"model": "model-y"},
+        requested_gpu="auto",
+    )
+    explicit_job = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={"model": "model-y"},
+        requested_gpu="gpu-0",
+    )
+    warm_auto = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={"model": "model-x"},
+        requested_gpu="auto",
+    )
+
+    claimed = store.claim_next_job("worker-1")
+
+    assert claimed["id"] == explicit_job["id"]
+    assert store.get_job(auto_other["id"])["status"] == "queued"
+    assert store.get_job(warm_auto["id"])["status"] == "queued"
+
+
 def test_idle_heartbeat_interrupts_previous_active_job(tmp_path):
     store = JobsStore(tmp_path / "jobs.db")
     store.initialize()

--- a/tests/test_jobs_store.py
+++ b/tests/test_jobs_store.py
@@ -102,6 +102,65 @@ def test_claim_skips_jobs_not_supported_by_worker_capabilities(tmp_path):
     assert store.claim_next_job("worker-1")["id"] == download_job["id"]
 
 
+def test_auto_claim_prefers_job_matching_loaded_model(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    store.register_worker(
+        worker_id="worker-1",
+        gpu_id="gpu-0",
+        gpu_name=None,
+        capabilities=["image_generate"],
+        loaded_models=["z_image_turbo", "Tongyi-MAI/Z-Image-Turbo"],
+    )
+    other_model_job = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={"model": "qwen_image_edit"},
+        requested_gpu="auto",
+    )
+    warm_model_job = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={"model": "z_image_turbo"},
+        requested_gpu="auto",
+    )
+
+    claimed = store.claim_next_job("worker-1")
+
+    assert claimed["id"] == warm_model_job["id"]
+    assert store.get_job(other_model_job["id"])["status"] == "queued"
+
+
+def test_loaded_model_preference_does_not_skip_explicit_gpu_job(tmp_path):
+    store = JobsStore(tmp_path / "jobs.db")
+    store.initialize()
+    store.register_worker(
+        worker_id="worker-1",
+        gpu_id="gpu-0",
+        gpu_name=None,
+        capabilities=["image_generate"],
+        loaded_models=["z_image_turbo"],
+    )
+    explicit_job = store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={"model": "qwen_image_edit"},
+        requested_gpu="gpu-0",
+    )
+    store.create_job(
+        job_type="image_generate",
+        project_id=None,
+        project_name=None,
+        payload={"model": "z_image_turbo"},
+        requested_gpu="auto",
+    )
+
+    assert store.claim_next_job("worker-1")["id"] == explicit_job["id"]
+
+
 def test_idle_heartbeat_interrupts_previous_active_job(tmp_path):
     store = JobsStore(tmp_path / "jobs.db")
     store.initialize()

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from scene_worker.image_adapters import MODEL_TARGETS, ZImageDiffusersAdapter, build_asset_sidecar, image_request_from_job, resolve_seed
+from scene_worker.image_adapters import (
+    MODEL_TARGETS,
+    ZImageDiffusersAdapter,
+    build_asset_sidecar,
+    huggingface_repo_cache_path,
+    image_request_from_job,
+    resolve_seed,
+)
 from scene_worker.runtime import (
     download_progress_payload,
     format_bytes,
@@ -102,7 +109,17 @@ def test_z_image_loaded_models_include_repo_and_model_id():
     adapter._loaded_repo = "Tongyi-MAI/Z-Image-Turbo"
     adapter._loaded_model = "z_image_turbo"
 
-    assert adapter.loaded_models() == ["Tongyi-MAI/Z-Image-Turbo", "z_image_turbo"]
+    assert set(adapter.loaded_models()) == {"Tongyi-MAI/Z-Image-Turbo", "z_image_turbo"}
+
+
+def test_huggingface_repo_cache_path_stays_under_cache_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(tmp_path / "hub"))
+
+    path = huggingface_repo_cache_path(r"..\outside/../../model")
+
+    assert path is not None
+    path.relative_to((tmp_path / "hub").resolve())
+    assert path.name.startswith("models--")
 
 
 def test_friendly_failure_identifies_gpu_oom():
@@ -117,6 +134,8 @@ def test_friendly_failure_identifies_missing_model_files():
     message, error = friendly_failure("Image generation", RuntimeError("Repository not found: owner/model"))
 
     assert message == "Image generation failed because required model files were not available."
+    assert "Model Manager" in error
+    assert "model_download" in error
     assert "HF_TOKEN" in error
 
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from scene_worker.image_adapters import MODEL_TARGETS, build_asset_sidecar, image_request_from_job, resolve_seed
+from scene_worker.image_adapters import MODEL_TARGETS, ZImageDiffusersAdapter, build_asset_sidecar, image_request_from_job, resolve_seed
 from scene_worker.runtime import (
     download_progress_payload,
     format_bytes,
     child_environment,
+    friendly_failure,
     heartbeat,
     keep_job_alive,
     loaded_models_from_adapters,
@@ -94,6 +95,29 @@ def test_loaded_models_are_collected_from_adapter_cache():
             return ["Tongyi-MAI/Z-Image-Turbo"]
 
     assert loaded_models_from_adapters({"z": Adapter()}) == ["Tongyi-MAI/Z-Image-Turbo"]
+
+
+def test_z_image_loaded_models_include_repo_and_model_id():
+    adapter = ZImageDiffusersAdapter()
+    adapter._loaded_repo = "Tongyi-MAI/Z-Image-Turbo"
+    adapter._loaded_model = "z_image_turbo"
+
+    assert adapter.loaded_models() == ["Tongyi-MAI/Z-Image-Turbo", "z_image_turbo"]
+
+
+def test_friendly_failure_identifies_gpu_oom():
+    message, error = friendly_failure("Image generation", RuntimeError("CUDA error: out of memory"))
+
+    assert message == "Image generation failed because the GPU ran out of memory."
+    assert "lower resolution" in error
+    assert "Technical detail" in error
+
+
+def test_friendly_failure_identifies_missing_model_files():
+    message, error = friendly_failure("Image generation", RuntimeError("Repository not found: owner/model"))
+
+    assert message == "Image generation failed because required model files were not available."
+    assert "HF_TOKEN" in error
 
 
 def test_heartbeat_loaded_models_are_not_sent_as_current_job():


### PR DESCRIPTION
## Summary

Completes the SceneWorks Multi-GPU Polish epic by tightening worker-per-GPU behavior and improving queue visibility.

- Adds loaded-model-aware auto GPU claiming in both Python and Rust queue stores while preserving FIFO for explicit GPU selections and utility jobs.
- Reports warm model IDs from the Z-Image worker cache and improves loading progress around cached/downloaded model files.
- Improves image/video failure messages for GPU OOM and missing Hugging Face model-file cases.
- Makes the Queue screen show clearer worker warmth, busy state, and queued job waiting/blocked reasons.
- Includes the current branch's HF cache persistence, compose defaults, and Rust SSE keepalive safety change.

## Validation

- `python -m pytest tests/test_jobs_store.py tests/test_worker_runtime.py tests/test_worker_gpu.py -q`
- `npm --prefix apps/web test -- --run`
- `node scripts/check-compose-config.mjs`
- `cargo test -p sceneworks-core --test jobs_store`
- `cargo test -p sceneworks-rust-api`
- `cargo test -p sceneworks-rust-worker`
- `python -m pytest tests/test_python_rust_api_parity.py tests/test_rust_api_worker_smoke.py -q`