### PR TITLE
[codex] Implement scoped LoRA catalog and selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/apps/api/sceneworks_api/characters.py
+++ b/apps/api/sceneworks_api/characters.py
@@ -224,14 +224,17 @@ def copy_lora_into_project(
     if not source_path_text:
         return None, False
     source_path = Path(source_path_text)
-    if not source_path.exists() or not source_path.is_file():
+    if not source_path.exists() or not (source_path.is_file() or source_path.is_dir()):
         raise HTTPException(status_code=400, detail=f"LoRA source path not found: {source_path_text}")
     assert_allowed_lora_source(project_path, data_dir, source_path)
     target_dir = project_path / "loras" / "characters" / character_id
     target_dir.mkdir(parents=True, exist_ok=True)
     target = target_dir / source_path.name
     if source_path.resolve() != target.resolve():
-        shutil.copy2(source_path, target)
+        if source_path.is_dir():
+            shutil.copytree(source_path, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source_path, target)
     return str(target.relative_to(project_path)).replace("\\", "/"), True
 
 

--- a/apps/api/sceneworks_api/models.py
+++ b/apps/api/sceneworks_api/models.py
@@ -13,6 +13,7 @@ from urllib.request import urlopen
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
+from sceneworks_shared import ProjectNotFound, find_project_path, slugify, utc_now, write_json
 
 
 router = APIRouter(prefix="/models", tags=["models"])
@@ -30,6 +31,8 @@ class LoraImportRequest(BaseModel):
     sourcePath: str | None = None
     files: list[str] = Field(default_factory=list)
     family: str | None = None
+    scope: str = "global"
+    projectId: str | None = None
 
 
 def strip_jsonc_comments(value: str) -> str:
@@ -100,8 +103,69 @@ def load_lora_manifest(path: Path) -> list[dict[str, Any]]:
     return [dict(item) for item in load_manifest_cached(str(path), manifest_signature(path), "loras")]
 
 
+def lora_manifest_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schemaVersion": 1, "loras": []}
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.loads(strip_jsonc_comments(handle.read()))
+    payload.setdefault("schemaVersion", 1)
+    payload.setdefault("loras", [])
+    return payload
+
+
 def safe_download_dir(repo: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_.-]+", "__", repo).strip("_") or "download"
+
+
+def project_path_for_request(request: Request, project_id: str) -> Path:
+    try:
+        return find_project_path(request.app.state.settings.registry_path, project_id)
+    except ProjectNotFound:
+        raise HTTPException(status_code=404, detail="Project not found") from None
+
+
+def project_lora_manifest_path(project_path: Path) -> Path:
+    return project_path / "loras" / "manifest.jsonc"
+
+
+def normalize_lora_entry(
+    lora: dict[str, Any],
+    *,
+    scope: str,
+    manifest_path: Path,
+    default_root: Path,
+) -> dict[str, Any]:
+    entry = dict(lora)
+    entry.setdefault("scope", scope)
+    source = entry.get("source") if isinstance(entry.get("source"), dict) else {}
+    source_path = source.get("path") or entry.get("path")
+    installed_path = None
+    if source_path:
+        installed_path = Path(source_path)
+        if not installed_path.is_absolute():
+            installed_path = default_root / source_path
+    entry["manifestPath"] = str(manifest_path)
+    entry["installedPath"] = str(installed_path) if installed_path else None
+    entry["installState"] = "installed" if installed_path and installed_path.exists() else "missing"
+    return entry
+
+
+def upsert_lora_manifest_entry(path: Path, entry: dict[str, Any]) -> None:
+    payload = lora_manifest_payload(path)
+    lora_id = entry["id"]
+    merged = []
+    found = False
+    for item in payload.get("loras", []):
+        if item.get("id") != lora_id:
+            merged.append(item)
+            continue
+        found = True
+        merged.append({**item, **entry, "createdAt": item.get("createdAt", entry.get("createdAt"))})
+    if not found:
+        merged.append(entry)
+    payload["loras"] = merged
+    write_json(path, payload)
+    load_manifest_cached.cache_clear()
 
 
 def format_bytes(value: int | float | None) -> str | None:
@@ -204,17 +268,49 @@ def model_catalog(request: Request) -> list[dict[str, Any]]:
     return sorted(models, key=lambda model: (model.get("type", ""), model.get("name", "")))
 
 
-def lora_catalog(request: Request) -> list[dict[str, Any]]:
+def lora_catalog(request: Request, project_id: str | None = None) -> list[dict[str, Any]]:
     settings = request.app.state.settings
     manifest_dir = settings.config_dir / "manifests"
     builtin = load_lora_manifest(manifest_dir / "builtin.loras.jsonc")
     user = load_lora_manifest(manifest_dir / "user.loras.jsonc")
-    by_id = {lora["id"]: lora for lora in builtin if "id" in lora}
+    by_id = {
+        lora["id"]: normalize_lora_entry(
+            lora,
+            scope=lora.get("scope", "builtin"),
+            manifest_path=manifest_dir / "builtin.loras.jsonc",
+            default_root=settings.data_dir,
+        )
+        for lora in builtin
+        if "id" in lora
+    }
     for lora in user:
         lora_id = lora.get("id")
         if lora_id:
-            by_id[lora_id] = {**by_id.get(lora_id, {}), **lora}
-    return sorted(by_id.values(), key=lambda lora: (lora.get("family", ""), lora.get("name", "")))
+            by_id[lora_id] = {
+                **by_id.get(lora_id, {}),
+                **normalize_lora_entry(
+                    lora,
+                    scope=lora.get("scope", "global"),
+                    manifest_path=manifest_dir / "user.loras.jsonc",
+                    default_root=settings.data_dir,
+                ),
+            }
+    if project_id:
+        project_path = project_path_for_request(request, project_id)
+        project_manifest = project_lora_manifest_path(project_path)
+        for lora in load_lora_manifest(project_manifest):
+            lora_id = lora.get("id")
+            if lora_id:
+                by_id[lora_id] = {
+                    **by_id.get(lora_id, {}),
+                    **normalize_lora_entry(
+                        lora,
+                        scope=lora.get("scope", "project"),
+                        manifest_path=project_manifest,
+                        default_root=project_path,
+                    ),
+                }
+    return sorted(by_id.values(), key=lambda lora: (lora.get("scope", ""), lora.get("family", ""), lora.get("name", "")))
 
 
 def lora_families(lora: dict[str, Any]) -> set[str]:
@@ -266,8 +362,12 @@ def create_model_download_job(model_id: str, payload: ModelDownloadRequest, requ
 
 
 @loras_router.get("")
-def list_loras(request: Request, modelFamily: str | None = Query(default=None)) -> list[dict[str, Any]]:
-    items = lora_catalog(request)
+def list_loras(
+    request: Request,
+    modelFamily: str | None = Query(default=None),
+    projectId: str | None = Query(default=None),
+) -> list[dict[str, Any]]:
+    items = lora_catalog(request, projectId)
     if modelFamily:
         items = [item for item in items if modelFamily in lora_families(item)]
     return items
@@ -277,11 +377,57 @@ def list_loras(request: Request, modelFamily: str | None = Query(default=None)) 
 def create_lora_import_job(payload: LoraImportRequest, request: Request) -> dict[str, Any]:
     if not payload.repo and not payload.sourcePath:
         raise HTTPException(status_code=400, detail="Provide a Hugging Face repo or source path")
+    if payload.scope not in {"global", "project"}:
+        raise HTTPException(status_code=400, detail="LoRA scope must be global or project")
+
+    settings = request.app.state.settings
+    name = payload.name or payload.repo or Path(payload.sourcePath or "Imported LoRA").stem
+    lora_id = payload.loraId or slugify(name, fallback="lora").replace("-", "_")
+    target_name = safe_download_dir(lora_id)
+    if payload.scope == "project":
+        if not payload.projectId:
+            raise HTTPException(status_code=400, detail="Project LoRA imports require projectId")
+        project_path = project_path_for_request(request, payload.projectId)
+        target_dir = project_path / "loras" / "imports" / target_name
+        manifest_path = project_lora_manifest_path(project_path)
+        source_path = f"loras/imports/{target_name}"
+        project_id = payload.projectId
+        project_name = None
+    else:
+        target_dir = settings.data_dir / "loras" / target_name
+        manifest_path = settings.config_dir / "manifests" / "user.loras.jsonc"
+        source_path = f"loras/{target_name}"
+        project_id = None
+        project_name = None
+
+    timestamp = utc_now()
+    manifest_entry = {
+        "id": lora_id,
+        "name": name,
+        "family": payload.family,
+        "scope": payload.scope,
+        "source": {
+            "provider": "huggingface" if payload.repo else "local",
+            "repo": payload.repo,
+            "path": source_path,
+        },
+        "files": payload.files,
+        "createdAt": timestamp,
+        "updatedAt": timestamp,
+    }
+    upsert_lora_manifest_entry(manifest_path, {key: value for key, value in manifest_entry.items() if value is not None})
+
+    job_payload = {
+        **payload.model_dump(exclude_none=True),
+        "loraId": lora_id,
+        "name": name,
+        "targetDir": str(target_dir),
+    }
     job = request.app.state.jobs_store.create_job(
         job_type="lora_import",
-        project_id=None,
-        project_name=None,
-        payload=payload.model_dump(exclude_none=True),
+        project_id=project_id,
+        project_name=project_name,
+        payload=job_payload,
         requested_gpu="auto",
     )
     request.app.state.event_hub.publish("job.updated", job)

--- a/apps/api/sceneworks_api/models.py
+++ b/apps/api/sceneworks_api/models.py
@@ -4,6 +4,8 @@ from fnmatch import fnmatch
 import json
 import os
 import re
+import tempfile
+import threading
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -13,11 +15,12 @@ from urllib.request import urlopen
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
-from sceneworks_shared import ProjectNotFound, find_project_path, slugify, utc_now, write_json
+from sceneworks_shared import ProjectNotFound, find_project_path, slugify, utc_now
 
 
 router = APIRouter(prefix="/models", tags=["models"])
 loras_router = APIRouter(prefix="/loras", tags=["loras"])
+LORA_MANIFEST_LOCK = threading.Lock()
 
 
 class ModelDownloadRequest(BaseModel):
@@ -146,26 +149,37 @@ def normalize_lora_entry(
             installed_path = default_root / source_path
     entry["manifestPath"] = str(manifest_path)
     entry["installedPath"] = str(installed_path) if installed_path else None
-    entry["installState"] = "installed" if installed_path and installed_path.exists() else "missing"
+    entry["installState"] = "missing" if installed_path and not installed_path.exists() else "installed"
     return entry
 
 
 def upsert_lora_manifest_entry(path: Path, entry: dict[str, Any]) -> None:
-    payload = lora_manifest_payload(path)
-    lora_id = entry["id"]
-    merged = []
-    found = False
-    for item in payload.get("loras", []):
-        if item.get("id") != lora_id:
-            merged.append(item)
-            continue
-        found = True
-        merged.append({**item, **entry, "createdAt": item.get("createdAt", entry.get("createdAt"))})
-    if not found:
-        merged.append(entry)
-    payload["loras"] = merged
-    write_json(path, payload)
-    load_manifest_cached.cache_clear()
+    with LORA_MANIFEST_LOCK:
+        payload = lora_manifest_payload(path)
+        lora_id = entry["id"]
+        merged = []
+        found = False
+        for item in payload.get("loras", []):
+            if item.get("id") != lora_id:
+                merged.append(item)
+                continue
+            found = True
+            merged.append({**item, **entry, "createdAt": item.get("createdAt", entry.get("createdAt"))})
+        if not found:
+            merged.append(entry)
+        payload["loras"] = merged
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile("w", delete=False, dir=path.parent, encoding="utf-8") as handle:
+                tmp_path = Path(handle.name)
+                json.dump(payload, handle, indent=2)
+                handle.write("\n")
+            tmp_path.replace(path)
+        finally:
+            if tmp_path and tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
+        load_manifest_cached.cache_clear()
 
 
 def format_bytes(value: int | float | None) -> str | None:
@@ -415,13 +429,15 @@ def create_lora_import_job(payload: LoraImportRequest, request: Request) -> dict
         "createdAt": timestamp,
         "updatedAt": timestamp,
     }
-    upsert_lora_manifest_entry(manifest_path, {key: value for key, value in manifest_entry.items() if value is not None})
+    manifest_entry = {key: value for key, value in manifest_entry.items() if value is not None}
 
     job_payload = {
         **payload.model_dump(exclude_none=True),
         "loraId": lora_id,
         "name": name,
         "targetDir": str(target_dir),
+        "manifestPath": str(manifest_path),
+        "manifestEntry": manifest_entry,
     }
     job = request.app.state.jobs_store.create_job(
         job_type="lora_import",

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -14,6 +14,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 sceneworks-core = { path = "../../crates/sceneworks-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+time = { version = "0.3", features = ["formatting"] }
 tokio = { version = "1.40", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["io"] }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2391,9 +2391,9 @@ fn slugify_lora_id(value: &str) -> String {
 fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .replace_nanosecond(0)
-        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+        .expect("setting nanoseconds to zero must be valid")
         .format(&Rfc3339)
-        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+        .expect("formatting a UTC timestamp as RFC3339 must succeed")
 }
 
 fn model_is_installed(path: &FsPath) -> bool {

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -33,6 +33,8 @@ use sceneworks_core::project_store::{
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 use tokio::time::{Instant as TokioInstant, MissedTickBehavior};
@@ -469,6 +471,7 @@ struct AssetsQuery {
 #[serde(rename_all = "camelCase")]
 struct LorasQuery {
     model_family: Option<String>,
+    project_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -682,6 +685,10 @@ struct LoraImportRequest {
     files: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     family: Option<String>,
+    #[serde(default = "default_lora_scope")]
+    scope: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    project_id: Option<String>,
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
@@ -1307,7 +1314,7 @@ async fn list_loras(
     State(state): State<AppState>,
     Query(query): Query<LorasQuery>,
 ) -> Result<Json<Vec<Value>>, ApiError> {
-    let mut items = lora_catalog(&state).await?;
+    let mut items = lora_catalog(&state, query.project_id.as_deref()).await?;
     if let Some(model_family) = query.model_family {
         items.retain(|item| {
             lora_families(item)
@@ -1329,12 +1336,96 @@ async fn create_lora_import_job(
             "Provide a Hugging Face repo or source path",
         ));
     }
-    let payload = to_json_object(&payload)?;
+    if !matches!(payload.scope.as_str(), "global" | "project") {
+        return Err(ApiError::bad_request(
+            "LoRA scope must be global or project",
+        ));
+    }
+    let name = payload
+        .name
+        .clone()
+        .or_else(|| payload.repo.clone())
+        .or_else(|| {
+            payload.source_path.as_deref().and_then(|path| {
+                FsPath::new(path)
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .map(str::to_owned)
+            })
+        })
+        .unwrap_or_else(|| "Imported LoRA".to_owned());
+    let lora_id = payload
+        .lora_id
+        .clone()
+        .unwrap_or_else(|| slugify_lora_id(&name));
+    let target_name = safe_download_dir(&lora_id);
+    let (target_dir, manifest_path, source_path, project_id, project_name) =
+        if payload.scope == "project" {
+            let Some(project_id) = payload.project_id.clone() else {
+                return Err(ApiError::bad_request(
+                    "Project LoRA imports require projectId",
+                ));
+            };
+            let project_path = project_path_for_id(state.clone(), &project_id).await?;
+            (
+                project_path
+                    .join("loras")
+                    .join("imports")
+                    .join(&target_name),
+                project_path.join("loras").join("manifest.jsonc"),
+                format!("loras/imports/{target_name}"),
+                Some(project_id),
+                None,
+            )
+        } else {
+            (
+                state.settings.data_dir.join("loras").join(&target_name),
+                state
+                    .settings
+                    .config_dir
+                    .join("manifests")
+                    .join("user.loras.jsonc"),
+                format!("loras/{target_name}"),
+                None,
+                None,
+            )
+        };
+    let timestamp = now_rfc3339();
+    let mut manifest_entry = json!({
+        "id": lora_id,
+        "name": name,
+        "scope": payload.scope.clone(),
+        "source": {
+            "provider": if payload.repo.is_some() { "huggingface" } else { "local" },
+            "repo": payload.repo.clone(),
+            "path": source_path,
+        },
+        "files": payload.files.clone(),
+        "createdAt": timestamp,
+        "updatedAt": timestamp,
+    });
+    if let Some(family) = payload.family.clone() {
+        if let Some(object) = manifest_entry.as_object_mut() {
+            object.insert("family".to_owned(), Value::String(family));
+        }
+    }
+    let mut payload = to_json_object(&payload)?;
+    payload.insert("loraId".to_owned(), manifest_entry["id"].clone());
+    payload.insert("name".to_owned(), manifest_entry["name"].clone());
+    payload.insert(
+        "targetDir".to_owned(),
+        Value::String(target_dir.display().to_string()),
+    );
+    payload.insert(
+        "manifestPath".to_owned(),
+        Value::String(manifest_path.display().to_string()),
+    );
+    payload.insert("manifestEntry".to_owned(), manifest_entry);
     let job = create_generation_job(
         state,
         JobType::LoraImport,
-        None,
-        None,
+        project_id,
+        project_name,
         payload,
         "auto".to_owned(),
     )
@@ -1845,21 +1936,58 @@ async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
     Ok(models)
 }
 
-async fn lora_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
+async fn lora_catalog(state: &AppState, project_id: Option<&str>) -> Result<Vec<Value>, ApiError> {
     let manifest_dir = state.settings.config_dir.join("manifests");
     let builtin =
         load_manifest_entries(state, &manifest_dir.join("builtin.loras.jsonc"), "loras").await?;
     let user =
         load_manifest_entries(state, &manifest_dir.join("user.loras.jsonc"), "loras").await?;
-    let mut loras = merge_entries_by_id(builtin, user);
+    let mut loras = Vec::new();
+    for lora in builtin {
+        loras.push(normalize_lora_entry(
+            lora,
+            "builtin",
+            &manifest_dir.join("builtin.loras.jsonc"),
+            &state.settings.data_dir,
+        )?);
+    }
+    let user = user
+        .into_iter()
+        .map(|lora| {
+            normalize_lora_entry(
+                lora,
+                "global",
+                &manifest_dir.join("user.loras.jsonc"),
+                &state.settings.data_dir,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    loras = merge_entries_by_id(loras, user);
+    if let Some(project_id) = project_id {
+        let project_path = project_path_for_id(state.clone(), project_id).await?;
+        let project_manifest = project_path.join("loras").join("manifest.jsonc");
+        let project_loras = load_manifest_entries(state, &project_manifest, "loras")
+            .await?
+            .into_iter()
+            .map(|lora| normalize_lora_entry(lora, "project", &project_manifest, &project_path))
+            .collect::<Result<Vec<_>, _>>()?;
+        loras = merge_entries_by_id(loras, project_loras);
+    }
     loras.sort_by(|left, right| {
         let left_key = (
+            left.get("scope")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
             left.get("family")
                 .and_then(Value::as_str)
                 .unwrap_or_default(),
             left.get("name").and_then(Value::as_str).unwrap_or_default(),
         );
         let right_key = (
+            right
+                .get("scope")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
             right
                 .get("family")
                 .and_then(Value::as_str)
@@ -1872,6 +2000,60 @@ async fn lora_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
         left_key.cmp(&right_key)
     });
     Ok(loras)
+}
+
+async fn project_path_for_id(state: AppState, project_id: &str) -> Result<PathBuf, ApiError> {
+    let project_id = project_id.to_owned();
+    let project = project_call(state, move |store| store.get_project(&project_id)).await?;
+    Ok(PathBuf::from(project.path))
+}
+
+fn normalize_lora_entry(
+    mut lora: Value,
+    scope: &str,
+    manifest_path: &FsPath,
+    default_root: &FsPath,
+) -> Result<Value, ApiError> {
+    let object = lora
+        .as_object_mut()
+        .ok_or_else(|| ApiError::internal("LoRA manifest entry must be an object"))?;
+    object
+        .entry("scope".to_owned())
+        .or_insert_with(|| Value::String(scope.to_owned()));
+    let source_path = object
+        .get("source")
+        .and_then(Value::as_object)
+        .and_then(|source| source.get("path"))
+        .and_then(Value::as_str)
+        .or_else(|| object.get("path").and_then(Value::as_str));
+    let installed_path = source_path.map(|source_path| {
+        let path = PathBuf::from(source_path);
+        if path.is_absolute() {
+            path
+        } else {
+            default_root.join(path)
+        }
+    });
+    let install_state = if installed_path.as_ref().is_some_and(|path| !path.exists()) {
+        "missing"
+    } else {
+        "installed"
+    };
+    object.insert(
+        "manifestPath".to_owned(),
+        Value::String(manifest_path.display().to_string()),
+    );
+    object.insert(
+        "installedPath".to_owned(),
+        installed_path
+            .map(|path| Value::String(path.display().to_string()))
+            .unwrap_or(Value::Null),
+    );
+    object.insert(
+        "installState".to_owned(),
+        Value::String(install_state.to_owned()),
+    );
+    Ok(lora)
 }
 
 async fn load_manifest_entries(
@@ -2182,6 +2364,36 @@ fn safe_download_dir(repo: &str) -> String {
     } else {
         output
     }
+}
+
+fn slugify_lora_id(value: &str) -> String {
+    let mut output = String::new();
+    let mut previous_separator = false;
+    for character in value.trim().chars() {
+        if character.is_ascii_alphanumeric() {
+            output.push(character.to_ascii_lowercase());
+            previous_separator = false;
+        } else if !previous_separator && !output.is_empty() {
+            output.push('_');
+            previous_separator = true;
+        }
+    }
+    while output.ends_with('_') {
+        output.pop();
+    }
+    if output.is_empty() {
+        "lora".to_owned()
+    } else {
+        output
+    }
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .replace_nanosecond(0)
+        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
 }
 
 fn model_is_installed(path: &FsPath) -> bool {
@@ -2500,6 +2712,10 @@ fn default_frame_intended_use() -> String {
 
 fn default_requested_gpu() -> String {
     "auto".to_owned()
+}
+
+fn default_lora_scope() -> String {
+    "global".to_owned()
 }
 
 fn default_track_name() -> String {
@@ -3390,7 +3606,13 @@ mod tests {
         assert_eq!(status, StatusCode::CREATED);
         assert_eq!(job["type"], "lora_import");
         assert_eq!(job["payload"]["repo"], "owner/lora");
-        assert!(job["payload"].get("loraId").is_none());
+        assert_eq!(job["payload"]["loraId"], "imported_lora");
+        assert_eq!(job["payload"]["scope"], "global");
+        assert!(job["payload"]["targetDir"]
+            .as_str()
+            .is_some_and(|value| value.ends_with("data/loras/imported_lora")
+                || value.ends_with("data\\loras\\imported_lora")));
+        assert_eq!(job["payload"]["manifestEntry"]["scope"], "global");
         assert!(job["payload"].get("sourcePath").is_none());
     }
 

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -2257,9 +2257,9 @@ fn quote_path(value: &str) -> String {
 fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .replace_nanosecond(0)
-        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+        .expect("setting nanoseconds to zero must be valid")
         .format(&Rfc3339)
-        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+        .expect("formatting a UTC timestamp as RFC3339 must succeed")
 }
 
 fn export_request_from_job(job: &JobSnapshot) -> WorkerResult<TimelineExportRequest> {

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -31,6 +31,7 @@ pub struct Settings {
     pub api_url: String,
     pub access_token: Option<String>,
     pub data_dir: PathBuf,
+    pub config_dir: PathBuf,
     pub worker_id: String,
     pub gpu_id: String,
     pub is_child_worker: bool,
@@ -50,6 +51,7 @@ impl Settings {
                 .map(|value| value.trim().to_owned())
                 .filter(|value| !value.is_empty()),
             data_dir: env_path("SCENEWORKS_DATA_DIR", "data"),
+            config_dir: env_path("SCENEWORKS_CONFIG_DIR", "config"),
             worker_id: env_string("SCENEWORKS_WORKER_ID", "rust-utility-worker"),
             gpu_id: env_string("SCENEWORKS_GPU_ID", "cpu"),
             is_child_worker: std::env::var("SCENEWORKS_WORKER_CHILD")
@@ -1000,9 +1002,11 @@ async fn run_lora_import_job(
                 })
                 .unwrap_or_else(|| "lora".to_owned())
         });
-    let target_dir = optional_payload_string(&job.payload, "targetDir")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| settings.data_dir.join("loras").join(target_name));
+    let target_dir = resolve_lora_import_target(
+        settings,
+        &job.payload,
+        settings.data_dir.join("loras").join(target_name),
+    )?;
 
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     update_job(
@@ -1061,6 +1065,16 @@ async fn run_lora_import_job(
             Some("Provide repo or sourcePath for LoRA import".to_owned()),
         )
         .await;
+    }
+
+    if let Some(manifest_entry) = job
+        .payload
+        .get("manifestEntry")
+        .and_then(Value::as_object)
+        .cloned()
+    {
+        let manifest_path = lora_manifest_target(settings, &job.payload)?;
+        upsert_lora_manifest_entry(&manifest_path, manifest_entry).await?;
     }
 
     let mut result = JsonObject::new();
@@ -2109,6 +2123,93 @@ fn optional_payload_string<'a>(payload: &'a JsonObject, field: &str) -> Option<&
         .filter(|value| !value.trim().is_empty())
 }
 
+fn normalize_absolute_path(path: &Path) -> WorkerResult<PathBuf> {
+    let mut output = if path.is_absolute() {
+        PathBuf::new()
+    } else {
+        std::env::current_dir()?
+    };
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => output.push(prefix.as_os_str()),
+            std::path::Component::RootDir => output.push(component.as_os_str()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !output.pop() {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "Unsafe absolute path: {}",
+                        path.display()
+                    )));
+                }
+            }
+            std::path::Component::Normal(value) => output.push(value),
+        }
+    }
+    Ok(output)
+}
+
+fn project_path_for_payload(
+    settings: &Settings,
+    payload: &JsonObject,
+) -> WorkerResult<Option<PathBuf>> {
+    let Some(project_id) = optional_payload_string(payload, "projectId") else {
+        return Ok(None);
+    };
+    let store = ProjectStore::new(settings.data_dir.clone(), "worker");
+    let project = store.get_project(project_id)?;
+    Ok(Some(PathBuf::from(project.path)))
+}
+
+fn resolve_lora_import_target(
+    settings: &Settings,
+    payload: &JsonObject,
+    fallback_target: PathBuf,
+) -> WorkerResult<PathBuf> {
+    let target = normalize_absolute_path(
+        &optional_payload_string(payload, "targetDir")
+            .map(PathBuf::from)
+            .unwrap_or(fallback_target),
+    )?;
+    let mut allowed_roots = vec![normalize_absolute_path(&settings.data_dir.join("loras"))?];
+    if let Some(project_path) = project_path_for_payload(settings, payload)? {
+        allowed_roots.push(normalize_absolute_path(
+            &project_path.join("loras").join("imports"),
+        )?);
+    }
+    if allowed_roots.iter().any(|root| target.starts_with(root)) {
+        return Ok(target);
+    }
+    Err(WorkerError::InvalidPayload(
+        "LoRA import targetDir must be inside app-managed data/loras or project/loras/imports"
+            .to_owned(),
+    ))
+}
+
+fn lora_manifest_target(settings: &Settings, payload: &JsonObject) -> WorkerResult<PathBuf> {
+    let manifest_path = normalize_absolute_path(&PathBuf::from(required_payload_string(
+        payload,
+        "manifestPath",
+    )?))?;
+    let mut allowed = vec![normalize_absolute_path(
+        &settings
+            .config_dir
+            .join("manifests")
+            .join("user.loras.jsonc"),
+    )?];
+    if let Some(project_path) = project_path_for_payload(settings, payload)? {
+        allowed.push(normalize_absolute_path(
+            &project_path.join("loras").join("manifest.jsonc"),
+        )?);
+    }
+    if allowed.iter().any(|path| path == &manifest_path) {
+        return Ok(manifest_path);
+    }
+    Err(WorkerError::InvalidPayload(
+        "LoRA manifestPath must target the global user manifest or the selected project's LoRA manifest"
+            .to_owned(),
+    ))
+}
+
 fn payload_string_array(payload: &JsonObject, field: &str) -> Vec<String> {
     payload
         .get(field)
@@ -2696,6 +2797,102 @@ fn bounded_tail(value: &str, max_lines: usize, max_chars: usize) -> String {
 
 async fn read_json_value(path: &Path) -> WorkerResult<Value> {
     Ok(serde_json::from_slice(&tokio::fs::read(path).await?)?)
+}
+
+fn strip_jsonc_comments(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(character) = chars.next() {
+        if in_string {
+            output.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if character == '"' {
+            in_string = true;
+            output.push(character);
+            continue;
+        }
+        if character == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            for next in chars.by_ref() {
+                if next == '\r' || next == '\n' {
+                    output.push(next);
+                    break;
+                }
+            }
+            continue;
+        }
+        if character == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            let mut previous = '\0';
+            for next in chars.by_ref() {
+                if previous == '*' && next == '/' {
+                    break;
+                }
+                previous = next;
+            }
+            continue;
+        }
+        output.push(character);
+    }
+    output
+}
+
+async fn upsert_lora_manifest_entry(
+    path: &Path,
+    entry: serde_json::Map<String, Value>,
+) -> WorkerResult<()> {
+    let mut manifest = match tokio::fs::read_to_string(path).await {
+        Ok(payload) => serde_json::from_str(&strip_jsonc_comments(&payload))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            json!({ "schemaVersion": 1, "loras": [] })
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let lora_id = entry
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkerError::InvalidPayload("LoRA manifest entry requires id".to_owned()))?;
+    let loras = manifest
+        .as_object_mut()
+        .ok_or_else(|| WorkerError::InvalidPayload("LoRA manifest must be an object".to_owned()))?
+        .entry("loras")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let loras = loras.as_array_mut().ok_or_else(|| {
+        WorkerError::InvalidPayload("LoRA manifest loras must be an array".to_owned())
+    })?;
+    let mut found = false;
+    for item in loras.iter_mut() {
+        if item.get("id").and_then(Value::as_str) != Some(lora_id) {
+            continue;
+        }
+        found = true;
+        let created_at = item.get("createdAt").cloned();
+        let Some(object) = item.as_object_mut() else {
+            return Err(WorkerError::InvalidPayload(
+                "LoRA manifest entry must be an object".to_owned(),
+            ));
+        };
+        for (key, value) in entry.clone() {
+            object.insert(key, value);
+        }
+        if let Some(created_at) = created_at {
+            object.insert("createdAt".to_owned(), created_at);
+        }
+    }
+    if !found {
+        loras.push(Value::Object(entry));
+    }
+    write_json_value(path, &manifest).await
 }
 
 async fn write_json_value(path: &Path, value: &Value) -> WorkerResult<()> {
@@ -3326,6 +3523,7 @@ mod tests {
             api_url: "http://127.0.0.1:8000".to_owned(),
             access_token: None,
             data_dir: PathBuf::from("data"),
+            config_dir: PathBuf::from("config"),
             worker_id: "test-worker".to_owned(),
             gpu_id: "cpu".to_owned(),
             is_child_worker: true,

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -1000,7 +1000,9 @@ async fn run_lora_import_job(
                 })
                 .unwrap_or_else(|| "lora".to_owned())
         });
-    let target_dir = settings.data_dir.join("loras").join(target_name);
+    let target_dir = optional_payload_string(&job.payload, "targetDir")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| settings.data_dir.join("loras").join(target_name));
 
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     update_job(

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -152,6 +152,7 @@ export function App() {
     }
     refreshAssets(activeProject.id);
     refreshCharacters(activeProject.id);
+    refreshLoras(activeProject.id);
     refreshPersonTracks(activeProject.id);
     refreshTimelines(activeProject.id);
   }, [activeProject?.id, authenticated, token]);
@@ -301,6 +302,17 @@ export function App() {
     try {
       const items = await apiFetch(`/api/v1/projects/${projectId}/characters`, token);
       setCharacters(items);
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function refreshLoras(projectId = activeProject?.id) {
+    try {
+      const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+      const items = await apiFetch(`/api/v1/loras${query}`, token);
+      setLoras(items);
       setError("");
     } catch (err) {
       setError(err.message);
@@ -1106,6 +1118,7 @@ export function App() {
             imageModels={imageModels}
             latestAssets={latestImageAssets}
             launchRequest={studioLaunch}
+            loras={loras}
             onPreview={setPreviewAsset}
             requestedGpu={requestedGpu}
             selectedAsset={selectedAsset}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2,6 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
+import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 
 class FakeEventSource {
@@ -282,5 +283,63 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Waiting for model download Qwen Image Edit to finish.");
     expect(container.textContent).toContain("Waiting for dependency job-dependency to finish.");
     expect(container.textContent).toContain("Warm: z_image_turbo");
+  });
+
+  it("submits compatible image LoRAs while capping simple user selections at two", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={createImageJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
+          latestAssets={[]}
+          loras={[
+            { id: "built_in", name: "Built In", family: "z-image", scope: "builtin", defaultWeight: 0.6 },
+            { id: "global_style", name: "Global Style", family: "z-image", scope: "global" },
+            { id: "project_mira", name: "Project Mira", family: "z-image", scope: "project" },
+            { id: "third_user", name: "Third User", family: "z-image", scope: "global" },
+            { id: "qwen_only", name: "Qwen Only", family: "qwen-image", scope: "global" },
+          ]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Built In");
+    expect(container.textContent).not.toContain("Qwen Only");
+
+    const checkboxes = [...container.querySelectorAll('.lora-choice input[type="checkbox"]')];
+    await act(async () => {
+      checkboxes[0].click();
+      checkboxes[1].click();
+      checkboxes[2].click();
+    });
+
+    expect(checkboxes[3].disabled).toBe(true);
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loras: [
+          expect.objectContaining({ id: "built_in", scope: "builtin", weight: 0.6 }),
+          expect.objectContaining({ id: "global_style", scope: "global" }),
+          expect.objectContaining({ id: "project_mira", scope: "project" }),
+        ],
+      }),
+    );
   });
 });

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -305,6 +305,7 @@ describe("SceneWorks app shell", () => {
             { id: "project_mira", name: "Project Mira", family: "z-image", scope: "project" },
             { id: "third_user", name: "Third User", family: "z-image", scope: "global" },
             { id: "qwen_only", name: "Qwen Only", family: "qwen-image", scope: "global" },
+            { id: "missing_lora", name: "Missing LoRA", family: "z-image", scope: "global", installState: "missing" },
           ]}
           onPreview={() => {}}
           purgeAsset={() => {}}
@@ -318,6 +319,7 @@ describe("SceneWorks app shell", () => {
 
     expect(container.textContent).toContain("Built In");
     expect(container.textContent).not.toContain("Qwen Only");
+    expect(container.textContent).not.toContain("Missing LoRA");
 
     const checkboxes = [...container.querySelectorAll('.lora-choice input[type="checkbox"]')];
     await act(async () => {
@@ -327,6 +329,16 @@ describe("SceneWorks app shell", () => {
     });
 
     expect(checkboxes[3].disabled).toBe(true);
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+    await act(async () => {
+      container.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
+    });
+
+    expect(container.textContent).toContain("Qwen Only");
+    expect(container.textContent).not.toContain("Missing LoRA");
 
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -151,6 +151,7 @@ export function CharacterStudio({
     await attachCharacterLora(selectedCharacter.id, {
       loraId: lora.id,
       name: lora.name ?? lora.id,
+      sourcePath: lora.installedPath ?? lora.source?.path ?? null,
       triggerWords: lora.triggerWords ?? [],
       defaultWeight: lora.defaultWeight ?? 0.8,
       compatibility: { families: compatibleFamilies(lora) },

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -154,7 +154,7 @@ export function CharacterStudio({
       triggerWords: lora.triggerWords ?? [],
       defaultWeight: lora.defaultWeight ?? 0.8,
       compatibility: { families: compatibleFamilies(lora) },
-      scope: "global",
+      scope: lora.scope ?? "global",
     });
     setLoraId("");
   }

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -12,6 +12,7 @@ export function ImageStudio({
   imageModels,
   latestAssets,
   launchRequest,
+  loras = [],
   onPreview,
   requestedGpu,
   selectedAsset,
@@ -30,6 +31,23 @@ export function ImageStudio({
   const [sourceAssetId, setSourceAssetId] = useState(selectedAsset?.id ?? "");
   const [characterId, setCharacterId] = useState("");
   const [characterLookId, setCharacterLookId] = useState("");
+  const [selectedLoraIds, setSelectedLoraIds] = useState([]);
+
+  function loraFamilies(lora) {
+    const compatibility = lora.compatibility ?? {};
+    const values =
+      lora.families ??
+      lora.compatibleFamilies ??
+      lora.modelFamilies ??
+      compatibility.families ??
+      (lora.family ? [lora.family] : []);
+    return Array.isArray(values) ? values : [values].filter(Boolean);
+  }
+
+  function loraWeight(lora) {
+    const value = Number(lora.defaultWeight ?? lora.weight ?? 0.8);
+    return Number.isFinite(value) ? value : 0.8;
+  }
 
   useEffect(() => {
     if (!imageModels.some((item) => item.id === model)) {
@@ -76,7 +94,33 @@ export function ImageStudio({
     }
     return item.type === "image";
   });
+  const selectedModel = imageModels.find((item) => item.id === model);
+  const selectedModelFamily = selectedModel?.family ?? null;
+  const compatibleLoras = loras.filter((lora) => {
+    const families = loraFamilies(lora);
+    return !selectedModelFamily || families.length === 0 || families.includes(selectedModelFamily);
+  });
+  const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
+  const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
   const [width, height] = resolution.split("x").map((value) => Number(value));
+
+  useEffect(() => {
+    setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
+  }, [compatibleLoras.map((lora) => lora.id).join("|")]);
+
+  function toggleLora(lora) {
+    setSelectedLoraIds((ids) => {
+      if (ids.includes(lora.id)) {
+        return ids.filter((id) => id !== lora.id);
+      }
+      const selected = ids.map((id) => compatibleLoras.find((item) => item.id === id)).filter(Boolean);
+      const userCount = selected.filter((item) => item.scope !== "builtin").length;
+      if (lora.scope !== "builtin" && userCount >= 2) {
+        return ids;
+      }
+      return [...ids, lora.id];
+    });
+  }
 
   function submit(event) {
     event.preventDefault();
@@ -93,7 +137,14 @@ export function ImageStudio({
       characterId: mode === "character_image" ? characterId || null : null,
       characterLookId: mode === "character_image" ? characterLookId || null : null,
       sourceAssetId: mode === "edit_image" ? sourceAssetId || null : null,
-      loras: [],
+      loras: selectedLoras.map((lora) => ({
+        id: lora.id,
+        name: lora.name ?? lora.id,
+        scope: lora.scope ?? "global",
+        weight: loraWeight(lora),
+        triggerWords: lora.triggerWords ?? [],
+        compatibility: lora.compatibility ?? {},
+      })),
       advanced: { resolution },
     });
   }
@@ -201,6 +252,39 @@ export function ImageStudio({
               </select>
             </label>
           </div>
+
+          <section className="lora-picker" aria-label="LoRA selection">
+            <div>
+              <strong>LoRAs</strong>
+              <span>{selectedLoras.length ? `${selectedLoras.length} selected` : "Compatible with selected model"}</span>
+            </div>
+            {compatibleLoras.length ? (
+              <div className="lora-choice-list">
+                {compatibleLoras.map((lora) => {
+                  const checked = selectedLoraIds.includes(lora.id);
+                  const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
+                  return (
+                    <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
+                      <input
+                        checked={checked}
+                        disabled={userLimitReached}
+                        onChange={() => toggleLora(lora)}
+                        type="checkbox"
+                      />
+                      <span>
+                        <strong>{lora.name ?? lora.id}</strong>
+                        <small>
+                          {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
+                        </small>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="empty-panel compact-panel">No compatible LoRAs</div>
+            )}
+          </section>
 
           <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
             {advancedOpen ? "Hide advanced" : "Advanced"}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { AssetCard } from "../components/assetPanels.jsx";
 
 export function ImageStudio({
@@ -32,6 +32,7 @@ export function ImageStudio({
   const [characterId, setCharacterId] = useState("");
   const [characterLookId, setCharacterLookId] = useState("");
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
+  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
 
   function loraFamilies(lora) {
     const compatibility = lora.compatibility ?? {};
@@ -96,17 +97,24 @@ export function ImageStudio({
   });
   const selectedModel = imageModels.find((item) => item.id === model);
   const selectedModelFamily = selectedModel?.family ?? null;
-  const compatibleLoras = loras.filter((lora) => {
+  const compatibleLoras = useMemo(() => loras.filter((lora) => {
+    if (lora.installState === "missing") {
+      return false;
+    }
+    if (showIncompatibleLoras) {
+      return true;
+    }
     const families = loraFamilies(lora);
     return !selectedModelFamily || families.length === 0 || families.includes(selectedModelFamily);
-  });
+  }), [loras, selectedModelFamily, showIncompatibleLoras]);
+  const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
   const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
   const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
   const [width, height] = resolution.split("x").map((value) => Number(value));
 
   useEffect(() => {
     setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
-  }, [compatibleLoras.map((lora) => lora.id).join("|")]);
+  }, [compatibleLoraKey]);
 
   function toggleLora(lora) {
     setSelectedLoraIds((ids) => {
@@ -258,6 +266,16 @@ export function ImageStudio({
               <strong>LoRAs</strong>
               <span>{selectedLoras.length ? `${selectedLoras.length} selected` : "Compatible with selected model"}</span>
             </div>
+            {advancedOpen ? (
+              <label className="checkline">
+                <input
+                  checked={showIncompatibleLoras}
+                  onChange={(event) => setShowIncompatibleLoras(event.target.checked)}
+                  type="checkbox"
+                />
+                Show incompatible
+              </label>
+            ) : null}
             {compatibleLoras.length ? (
               <div className="lora-choice-list">
                 {compatibleLoras.map((lora) => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -98,7 +98,7 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel }) {
             {visibleLoras.map((lora) => (
               <article className="lora-row" key={lora.id ?? lora.name}>
                 <strong>{lora.name ?? lora.id}</strong>
-                <span>{lora.family ?? "compatible"}</span>
+                <span>{[lora.scope, lora.family ?? "compatible"].filter(Boolean).join(" | ")}</span>
               </article>
             ))}
           </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -755,6 +755,7 @@ button:disabled {
 }
 
 .guidance-strip,
+.lora-picker,
 .inline-warning {
   border: 1px solid #4b463d;
   background: #191815;
@@ -764,6 +765,51 @@ button:disabled {
   display: grid;
   gap: 4px;
   padding: 10px;
+}
+
+.lora-picker {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.lora-picker > div:first-child,
+.lora-choice {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.lora-picker > div:first-child span,
+.lora-choice small {
+  color: #aaa397;
+}
+
+.lora-choice-list {
+  display: grid;
+  gap: 8px;
+}
+
+.lora-choice {
+  align-items: center;
+  border: 1px solid #3c3a34;
+  background: #23221f;
+  padding: 9px 10px;
+}
+
+.lora-choice.active {
+  border-color: #6ec6b8;
+  background: #183f3a;
+}
+
+.lora-choice input {
+  width: auto;
+}
+
+.lora-choice span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
 }
 
 .guidance-strip span,

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 from PIL import Image, ImageDraw, ImageFont
 
 from sceneworks_shared import (
-    ProjectNotFound,
     find_asset_sidecar_path,
     find_project_path as shared_find_project_path,
     index_asset,
@@ -115,13 +114,6 @@ def load_registry(data_dir: Path) -> list[dict[str, Any]]:
         return json.load(handle)
 
 
-def find_project_path(settings: WorkerSettings, project_id: str) -> Path:
-    try:
-        return shared_find_project_path(settings.data_dir / "recent-projects.json", project_id)
-    except ProjectNotFound as exc:
-        raise RuntimeError(str(exc)) from exc
-
-
 def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
     payload = job["payload"]
     return ImageRequest(
@@ -157,7 +149,7 @@ class ImageAssetWriter:
         raw_settings: dict[str, Any],
     ) -> dict[str, Any]:
         request = image_request_from_job(job)
-        project_path = find_project_path(settings, request.project_id)
+        project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
         for folder in ("assets/images", "generation-sets", "recipes"):
             (project_path / folder).mkdir(parents=True, exist_ok=True)
 
@@ -472,7 +464,8 @@ def select_torch_dtype(torch: Any, device: str, requested: Any) -> Any:
 def load_source_image(settings: WorkerSettings, request: ImageRequest) -> Image.Image:
     source_path = request.advanced.get("sourceImagePath")
     if not source_path and request.source_asset_id:
-        source_path = find_asset_media_path(find_project_path(settings, request.project_id), request.source_asset_id)
+        project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
+        source_path = find_asset_media_path(project_path, request.source_asset_id)
     if not source_path:
         raise RuntimeError("Image edit jobs require a source image asset.")
     try:

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -15,6 +15,7 @@ import time
 from typing import Any, Callable
 
 import httpx
+from sceneworks_shared import find_project_path
 
 from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_worker_id
 from .image_adapters import ProceduralImageAdapter, ZImageDiffusersAdapter, create_image_adapter
@@ -231,7 +232,7 @@ def resolve_lora_import_target(settings: WorkerSettings, payload: dict[str, Any]
     allowed_roots = [(settings.data_dir / "loras").resolve()]
     project_id = payload.get("projectId")
     if project_id:
-        project_path = find_project_path(settings, project_id)
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", project_id)
         allowed_roots.append((project_path / "loras" / "imports").resolve())
     for root in allowed_roots:
         try:
@@ -251,7 +252,8 @@ def lora_manifest_target(settings: WorkerSettings, payload: dict[str, Any]) -> P
     allowed = [(settings.config_dir / "manifests" / "user.loras.jsonc").resolve()]
     project_id = payload.get("projectId")
     if project_id:
-        allowed.append((find_project_path(settings, project_id) / "loras" / "manifest.jsonc").resolve())
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", project_id)
+        allowed.append((project_path / "loras" / "manifest.jsonc").resolve())
     if manifest_path not in allowed:
         raise ValueError("LoRA manifestPath must target the global user manifest or the selected project's LoRA manifest")
     return manifest_path

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -491,7 +491,7 @@ def run_lora_import_job(api: ApiClient, settings: WorkerSettings, job: dict) -> 
     repo = payload.get("repo")
     source_path = payload.get("sourcePath")
     target_name = safe_download_dir(payload.get("loraId") or payload.get("name") or repo or Path(source_path or "lora").stem)
-    target_dir = settings.data_dir / "loras" / target_name
+    target_dir = Path(payload.get("targetDir") or settings.data_dir / "loras" / target_name).expanduser().resolve()
 
     try:
         heartbeat(api, settings, "busy", job_id)

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from typing import Any, Callable
@@ -23,6 +24,7 @@ from .video_adapters import ProceduralVideoAdapter, run_frame_extract, run_perso
 
 
 LoadedModelsSource = Callable[[], list[str]] | None
+LORA_MANIFEST_LOCK = threading.Lock()
 
 
 def now() -> str:
@@ -183,6 +185,109 @@ def job_cancel_requested(api: ApiClient, job_id: str) -> bool:
 def safe_download_dir(value: str) -> str:
     normalized = "".join(char if char.isalnum() or char in "._-" else "__" for char in value)
     return normalized.strip("_") or "download"
+
+
+def strip_jsonc_comments(value: str) -> str:
+    output = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(value):
+        char = value[index]
+        next_char = value[index + 1] if index + 1 < len(value) else ""
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            index += 1
+            continue
+        if char == "/" and next_char == "/":
+            index += 2
+            while index < len(value) and value[index] not in "\r\n":
+                index += 1
+            continue
+        if char == "/" and next_char == "*":
+            index += 2
+            while index + 1 < len(value) and not (value[index] == "*" and value[index + 1] == "/"):
+                index += 1
+            index += 2
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def resolve_lora_import_target(settings: WorkerSettings, payload: dict[str, Any], fallback_target: Path) -> Path:
+    target = Path(payload.get("targetDir") or fallback_target).expanduser().resolve()
+    allowed_roots = [(settings.data_dir / "loras").resolve()]
+    project_id = payload.get("projectId")
+    if project_id:
+        project_path = find_project_path(settings, project_id)
+        allowed_roots.append((project_path / "loras" / "imports").resolve())
+    for root in allowed_roots:
+        try:
+            target.relative_to(root)
+            return target
+        except ValueError:
+            continue
+    raise ValueError("LoRA import targetDir must be inside app-managed data/loras or project/loras/imports")
+
+
+def lora_manifest_target(settings: WorkerSettings, payload: dict[str, Any]) -> Path | None:
+    manifest_path_text = payload.get("manifestPath")
+    manifest_entry = payload.get("manifestEntry")
+    if not manifest_path_text or not isinstance(manifest_entry, dict):
+        return None
+    manifest_path = Path(manifest_path_text).expanduser().resolve()
+    allowed = [(settings.config_dir / "manifests" / "user.loras.jsonc").resolve()]
+    project_id = payload.get("projectId")
+    if project_id:
+        allowed.append((find_project_path(settings, project_id) / "loras" / "manifest.jsonc").resolve())
+    if manifest_path not in allowed:
+        raise ValueError("LoRA manifestPath must target the global user manifest or the selected project's LoRA manifest")
+    return manifest_path
+
+
+def upsert_lora_manifest_entry(path: Path, entry: dict[str, Any]) -> None:
+    with LORA_MANIFEST_LOCK:
+        if path.exists():
+            with path.open("r", encoding="utf-8") as handle:
+                payload = json.loads(strip_jsonc_comments(handle.read()))
+        else:
+            payload = {"schemaVersion": 1, "loras": []}
+        payload.setdefault("schemaVersion", 1)
+        lora_id = entry["id"]
+        loras = []
+        found = False
+        for item in payload.get("loras", []):
+            if item.get("id") == lora_id:
+                found = True
+                loras.append({**item, **entry, "createdAt": item.get("createdAt", entry.get("createdAt"))})
+            else:
+                loras.append(item)
+        if not found:
+            loras.append(entry)
+        payload["loras"] = loras
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile("w", delete=False, dir=path.parent, encoding="utf-8") as handle:
+                tmp_path = Path(handle.name)
+                json.dump(payload, handle, indent=2)
+                handle.write("\n")
+            tmp_path.replace(path)
+        finally:
+            if tmp_path and tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
 
 
 def write_model_install_marker(target_dir: Path, payload: dict, repo: str, job_id: str) -> None:
@@ -491,7 +596,7 @@ def run_lora_import_job(api: ApiClient, settings: WorkerSettings, job: dict) -> 
     repo = payload.get("repo")
     source_path = payload.get("sourcePath")
     target_name = safe_download_dir(payload.get("loraId") or payload.get("name") or repo or Path(source_path or "lora").stem)
-    target_dir = Path(payload.get("targetDir") or settings.data_dir / "loras" / target_name).expanduser().resolve()
+    target_dir = resolve_lora_import_target(settings, payload, settings.data_dir / "loras" / target_name)
 
     try:
         heartbeat(api, settings, "busy", job_id)
@@ -527,6 +632,9 @@ def run_lora_import_job(api: ApiClient, settings: WorkerSettings, job: dict) -> 
                 shutil.copy2(source, target_dir / source.name)
         else:
             raise ValueError("Provide repo or sourcePath for LoRA import")
+        manifest_path = lora_manifest_target(settings, payload)
+        if manifest_path:
+            upsert_lora_manifest_entry(manifest_path, payload["manifestEntry"])
         update_job(
             api,
             job_id,

--- a/apps/worker/scene_worker/timeline_exporter.py
+++ b/apps/worker/scene_worker/timeline_exporter.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
 
-from sceneworks_shared import find_asset_sidecar_path, index_asset, read_json, safe_float, slugify, utc_now
+from sceneworks_shared import find_asset_sidecar_path, find_project_path, index_asset, read_json, safe_float, slugify, utc_now
 
-from .image_adapters import find_project_path, write_json
+from .image_adapters import write_json
 from .settings import WorkerSettings
 
 
@@ -53,7 +53,7 @@ def run_timeline_export(
     cancel_requested: CancelCallback,
 ) -> dict[str, Any]:
     request = export_request_from_job(job)
-    project_path = find_project_path(settings, request.project_id)
+    project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
     timeline = read_json(project_path / request.timeline_path)
     ffmpeg = shutil.which("ffmpeg")
     if ffmpeg is None:

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -16,6 +16,7 @@ from PIL import Image, ImageDraw, ImageEnhance, ImageFont
 
 from sceneworks_shared import (
     find_asset_sidecar_path,
+    find_project_path,
     index_asset,
     load_asset_with_media,
     read_json,
@@ -25,7 +26,7 @@ from sceneworks_shared import (
     utc_now,
 )
 
-from .image_adapters import find_project_path, write_json
+from .image_adapters import write_json
 from .settings import WorkerSettings
 
 
@@ -163,7 +164,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
-        project_path = find_project_path(settings, request.project_id)
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
         for folder in ("assets/videos", "generation-sets", "recipes"):
             (project_path / folder).mkdir(parents=True, exist_ok=True)
 
@@ -692,7 +693,7 @@ def run_person_detect(
     payload = job["payload"]
     project_id = payload["projectId"]
     source_asset_id = payload["sourceAssetId"]
-    project_path = find_project_path(settings, project_id)
+    project_path = find_project_path(settings.data_dir / "recent-projects.json", project_id)
     frames_dir = project_path / "assets" / "frames"
     frames_dir.mkdir(parents=True, exist_ok=True)
     (project_path / "recipes").mkdir(parents=True, exist_ok=True)
@@ -815,7 +816,7 @@ def run_person_track(
     payload = job["payload"]
     project_id = payload["projectId"]
     source_asset_id = payload["sourceAssetId"]
-    project_path = find_project_path(settings, project_id)
+    project_path = find_project_path(settings.data_dir / "recent-projects.json", project_id)
     track_dir = project_path / "person-tracks"
     track_dir.mkdir(parents=True, exist_ok=True)
     source_asset, _ = source_asset_payload(project_path, source_asset_id)
@@ -882,7 +883,7 @@ def run_frame_extract(
 ) -> dict[str, Any]:
     payload = job["payload"]
     project_id = payload["projectId"]
-    project_path = find_project_path(settings, project_id)
+    project_path = find_project_path(settings.data_dir / "recent-projects.json", project_id)
     frames_dir = project_path / "assets" / "frames"
     frames_dir.mkdir(parents=True, exist_ok=True)
     (project_path / "recipes").mkdir(parents=True, exist_ok=True)

--- a/tests/fixtures/python_rust_api_parity/snapshots.json
+++ b/tests/fixtures/python_rust_api_parity/snapshots.json
@@ -276,7 +276,7 @@
     "completedAt": null,
     "createdAt": "<timestamp>",
     "duplicateOfJobId": null,
-    "elapsedSeconds": 1,
+    "elapsedSeconds": 0,
     "error": null,
     "etaSeconds": null,
     "id": "job_fixture",
@@ -368,7 +368,7 @@
     "completedAt": "<timestamp>",
     "createdAt": "<timestamp>",
     "duplicateOfJobId": null,
-    "elapsedSeconds": 1,
+    "elapsedSeconds": 0,
     "error": null,
     "etaSeconds": null,
     "id": "job_fixture",
@@ -423,8 +423,27 @@
       "files": [
         "adapter.safetensors"
       ],
+      "loraId": "imported_lora",
+      "manifestEntry": {
+        "createdAt": "<timestamp>",
+        "files": [
+          "adapter.safetensors"
+        ],
+        "id": "imported_lora",
+        "name": "Imported LoRA",
+        "scope": "global",
+        "source": {
+          "path": "loras/imported_lora",
+          "provider": "huggingface",
+          "repo": "owner/style-lora"
+        },
+        "updatedAt": "<timestamp>"
+      },
+      "manifestPath": "<runtime-root>/config/manifests/user.loras.jsonc",
       "name": "Imported LoRA",
-      "repo": "owner/style-lora"
+      "repo": "owner/style-lora",
+      "scope": "global",
+      "targetDir": "<runtime-root>/data/loras/imported_lora"
     },
     "progress": 0.0,
     "projectId": null,
@@ -449,7 +468,11 @@
       },
       "family": "z-image",
       "id": "style-lora",
+      "installState": "missing",
+      "installedPath": "<runtime-root>/data/loras/style.safetensors",
+      "manifestPath": "<runtime-root>/config/manifests/builtin.loras.jsonc",
       "name": "Style LoRA",
+      "scope": "builtin",
       "source": {
         "path": "loras/style.safetensors",
         "provider": "local"

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -131,6 +131,19 @@ def test_character_looks_and_lora_copy(tmp_path):
     assert link["projectPath"].startswith(f"loras/characters/{character['id']}/")
     assert (project_path / link["projectPath"]).read_bytes() == b"lora"
 
+    lora_package = lora_dir / "package"
+    lora_package.mkdir()
+    (lora_package / "adapter.safetensors").write_bytes(b"adapter")
+    with_lora_dir = attach_lora(
+        "project-1",
+        character["id"],
+        CharacterLoraRequest(name="Packaged LoRA", sourcePath=str(lora_package)),
+        request,
+    )
+    dir_link = with_lora_dir["loras"][0]
+    assert dir_link["copiedIntoProject"] is True
+    assert (project_path / dir_link["projectPath"] / "adapter.safetensors").read_bytes() == b"adapter"
+
 
 def test_lora_copy_rejects_missing_and_outside_source_paths(tmp_path):
     project_path = tmp_path / "project.sceneworks"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -108,7 +108,9 @@ def test_lora_catalog_merges_global_and_project_scopes(tmp_path):
 
     scopes = {lora["id"]: lora["scope"] for lora in loras}
     assert scopes == {"built_in": "builtin", "global_style": "global", "mira": "project"}
-    assert {lora["id"]: lora["installState"] for lora in loras}["mira"] == "installed"
+    install_states = {lora["id"]: lora["installState"] for lora in loras}
+    assert install_states["built_in"] == "installed"
+    assert install_states["mira"] == "installed"
 
 
 def test_project_lora_import_targets_project_manifest_and_folder(tmp_path):
@@ -179,7 +181,9 @@ def test_project_lora_import_targets_project_manifest_and_folder(tmp_path):
     )
 
     assert job["projectId"] == "project-1"
-    assert jobs_store.created["payload"]["targetDir"] == str(project_path / "loras" / "imports" / "mira_style")
-    manifest = json.loads((project_path / "loras" / "manifest.jsonc").read_text(encoding="utf-8"))
-    assert manifest["loras"][0]["scope"] == "project"
-    assert manifest["loras"][0]["source"]["path"] == "loras/imports/mira_style"
+    payload = jobs_store.created["payload"]
+    assert payload["targetDir"] == str(project_path / "loras" / "imports" / "mira_style")
+    assert payload["manifestPath"] == str(project_path / "loras" / "manifest.jsonc")
+    assert payload["manifestEntry"]["scope"] == "project"
+    assert payload["manifestEntry"]["source"]["path"] == "loras/imports/mira_style"
+    assert not (project_path / "loras" / "manifest.jsonc").exists()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+
 from sceneworks_api.models import (
+    LoraImportRequest,
+    create_lora_import_job,
     download_size_from_siblings,
     format_bytes,
+    lora_catalog,
     load_manifest,
     model_is_installed,
     model_install_marker,
@@ -60,3 +66,120 @@ def test_format_bytes_for_model_catalog():
     assert format_bytes(None) is None
     assert format_bytes(0) == "0 B"
     assert format_bytes(1024 * 1024 * 1024) == "1.0 GB"
+
+
+def test_lora_catalog_merges_global_and_project_scopes(tmp_path):
+    config_dir = tmp_path / "config"
+    manifest_dir = config_dir / "manifests"
+    manifest_dir.mkdir(parents=True)
+    data_dir = tmp_path / "data"
+    project_path = data_dir / "projects" / "noir.sceneworks"
+    project_path.mkdir(parents=True)
+    (data_dir / "loras" / "global_style").mkdir(parents=True)
+    (project_path / "loras" / "imports" / "mira").mkdir(parents=True)
+    (manifest_dir / "builtin.loras.jsonc").write_text(
+        '{"schemaVersion":1,"loras":[{"id":"built_in","name":"Built In","family":"z-image"}]}',
+        encoding="utf-8",
+    )
+    (manifest_dir / "user.loras.jsonc").write_text(
+        '{"schemaVersion":1,"loras":[{"id":"global_style","name":"Global Style","family":"z-image","source":{"path":"loras/global_style"}}]}',
+        encoding="utf-8",
+    )
+    (project_path / "loras").mkdir(exist_ok=True)
+    (project_path / "loras" / "manifest.jsonc").write_text(
+        '{"schemaVersion":1,"loras":[{"id":"mira","name":"Mira","family":"z-image","source":{"path":"loras/imports/mira"}}]}',
+        encoding="utf-8",
+    )
+    registry_path = data_dir / "recent-projects.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps([{"id": "project-1", "name": "Noir", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                settings=SimpleNamespace(config_dir=config_dir, data_dir=data_dir, registry_path=registry_path),
+            ),
+        ),
+    )
+
+    loras = lora_catalog(request, "project-1")
+
+    scopes = {lora["id"]: lora["scope"] for lora in loras}
+    assert scopes == {"built_in": "builtin", "global_style": "global", "mira": "project"}
+    assert {lora["id"]: lora["installState"] for lora in loras}["mira"] == "installed"
+
+
+def test_project_lora_import_targets_project_manifest_and_folder(tmp_path):
+    class FakeJobsStore:
+        def __init__(self):
+            self.created = None
+
+        def create_job(self, **kwargs):
+            self.created = kwargs
+            return {
+                "id": "job-1",
+                "type": kwargs["job_type"],
+                "status": "queued",
+                "payload": kwargs["payload"],
+                "projectId": kwargs["project_id"],
+            }
+
+        def list_jobs(self, limit=500):
+            return []
+
+        def list_workers(self):
+            return []
+
+        def mark_stale_workers_interrupted(self, _timeout):
+            return {"jobs": [], "workers": []}
+
+    class FakeEventHub:
+        def publish(self, *_args):
+            pass
+
+    config_dir = tmp_path / "config"
+    (config_dir / "manifests").mkdir(parents=True)
+    (config_dir / "manifests" / "user.loras.jsonc").write_text('{"schemaVersion":1,"loras":[]}', encoding="utf-8")
+    data_dir = tmp_path / "data"
+    project_path = data_dir / "projects" / "noir.sceneworks"
+    (project_path / "loras").mkdir(parents=True)
+    registry_path = data_dir / "recent-projects.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps([{"id": "project-1", "name": "Noir", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    jobs_store = FakeJobsStore()
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                settings=SimpleNamespace(
+                    config_dir=config_dir,
+                    data_dir=data_dir,
+                    registry_path=registry_path,
+                    worker_timeout_seconds=90,
+                ),
+                jobs_store=jobs_store,
+                event_hub=FakeEventHub(),
+            ),
+        ),
+    )
+
+    job = create_lora_import_job(
+        LoraImportRequest(
+            name="Mira Style",
+            sourcePath=str(tmp_path / "mira.safetensors"),
+            family="z-image",
+            scope="project",
+            projectId="project-1",
+        ),
+        request,
+    )
+
+    assert job["projectId"] == "project-1"
+    assert jobs_store.created["payload"]["targetDir"] == str(project_path / "loras" / "imports" / "mira_style")
+    manifest = json.loads((project_path / "loras" / "manifest.jsonc").read_text(encoding="utf-8"))
+    assert manifest["loras"][0]["scope"] == "project"
+    assert manifest["loras"][0]["source"]["path"] == "loras/imports/mira_style"

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -18,6 +18,7 @@ from scene_worker.runtime import (
     friendly_failure,
     heartbeat,
     keep_job_alive,
+    lora_manifest_target,
     loaded_models_from_adapters,
     resolve_loaded_models,
     resolve_lora_import_target,
@@ -83,7 +84,7 @@ def test_python_worker_can_advertise_legacy_ffmpeg_jobs(monkeypatch):
 
 
 def test_lora_import_target_must_stay_under_allowed_roots(tmp_path):
-    settings = SimpleNamespace(data_dir=tmp_path / "data", registry_path=tmp_path / "data" / "recent-projects.json")
+    settings = SimpleNamespace(data_dir=tmp_path / "data", config_dir=tmp_path / "config")
     target = resolve_lora_import_target(settings, {"targetDir": str(tmp_path / "data" / "loras" / "style")}, tmp_path / "fallback")
 
     assert target == (tmp_path / "data" / "loras" / "style").resolve()
@@ -94,6 +95,35 @@ def test_lora_import_target_must_stay_under_allowed_roots(tmp_path):
         assert "targetDir" in str(exc)
     else:
         raise AssertionError("outside targetDir should reject")
+
+
+def test_project_lora_import_target_and_manifest_are_allowed(tmp_path):
+    settings = SimpleNamespace(data_dir=tmp_path / "data", config_dir=tmp_path / "config")
+    project_path = tmp_path / "projects" / "demo"
+    project_path.mkdir(parents=True)
+    settings.data_dir.mkdir()
+    (settings.data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+
+    target_dir = project_path / "loras" / "imports" / "style"
+    target = resolve_lora_import_target(
+        settings,
+        {"projectId": "project-1", "targetDir": str(target_dir)},
+        tmp_path / "fallback",
+    )
+    manifest = lora_manifest_target(
+        settings,
+        {
+            "projectId": "project-1",
+            "manifestPath": str(project_path / "loras" / "manifest.jsonc"),
+            "manifestEntry": {"id": "style"},
+        },
+    )
+
+    assert target == target_dir.resolve()
+    assert manifest == (project_path / "loras" / "manifest.jsonc").resolve()
 
 
 def test_lora_manifest_upsert_is_atomic_and_preserves_created_at(tmp_path):

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 from scene_worker.image_adapters import (
@@ -19,8 +20,10 @@ from scene_worker.runtime import (
     keep_job_alive,
     loaded_models_from_adapters,
     resolve_loaded_models,
+    resolve_lora_import_target,
     run_placeholder_job,
     run_video_job,
+    upsert_lora_manifest_entry,
     worker_capabilities,
 )
 from scene_worker.video_adapters import VIDEO_MODEL_TARGETS, build_video_asset_sidecar, video_request_from_job
@@ -77,6 +80,29 @@ def test_python_worker_can_advertise_legacy_ffmpeg_jobs(monkeypatch):
 
     assert "frame_extract" in capabilities
     assert "timeline_export" in capabilities
+
+
+def test_lora_import_target_must_stay_under_allowed_roots(tmp_path):
+    settings = SimpleNamespace(data_dir=tmp_path / "data", registry_path=tmp_path / "data" / "recent-projects.json")
+    target = resolve_lora_import_target(settings, {"targetDir": str(tmp_path / "data" / "loras" / "style")}, tmp_path / "fallback")
+
+    assert target == (tmp_path / "data" / "loras" / "style").resolve()
+
+    try:
+        resolve_lora_import_target(settings, {"targetDir": str(tmp_path / "outside")}, tmp_path / "fallback")
+    except ValueError as exc:
+        assert "targetDir" in str(exc)
+    else:
+        raise AssertionError("outside targetDir should reject")
+
+
+def test_lora_manifest_upsert_is_atomic_and_preserves_created_at(tmp_path):
+    manifest = tmp_path / "user.loras.jsonc"
+    upsert_lora_manifest_entry(manifest, {"id": "style", "name": "Style", "createdAt": "first"})
+    upsert_lora_manifest_entry(manifest, {"id": "style", "name": "Style Updated", "createdAt": "second"})
+
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert payload["loras"] == [{"id": "style", "name": "Style Updated", "createdAt": "first"}]
 
 
 def test_python_cpu_child_honors_explicit_utility_disable(monkeypatch):


### PR DESCRIPTION
﻿## Summary

Implements the completed scoped LoRA slice for `sc-1167`, with the related import and generation-selection foundations needed by the dependent stories.

- Merge builtin, global, and project LoRA manifests through `/api/v1/loras?projectId=...`.
- Route project LoRA imports into `project/loras/imports/...` and `project/loras/manifest.jsonc`, while preserving global imports under `data/loras` and the user manifest.
- Teach both Python and Rust workers to honor `targetDir` for LoRA imports.
- Refresh the web LoRA catalog per active project and expose compatible Image Studio LoRA selection with the simple-mode cap of builtin LoRAs plus up to 2 user/project LoRAs.
- Preserve LoRA scope in character attachment and show scope in the Models LoRA list.

## Story Scope

Primary completed story: `sc-1167` Implement global and project LoRA scopes.

Related partial progress: `sc-1168` import flow foundation and `sc-1169` selection/payload foundation. Runtime adapter-level LoRA loading and metadata editing remain tracked in Shortcut tasks.

## Validation

- `python -m pytest tests/test_models.py tests/test_image_generation.py`
- `npm --prefix apps/web test`
- `rustfmt --check apps/rust-worker/src/lib.rs`
- `cargo test -p sceneworks-rust-worker lora_file_and_directory_import_preserve_copy_semantics`
- Browser sanity check at `http://127.0.0.1:5173` for Image Studio rendering and console errors

Note: workspace-wide `cargo fmt --all -- --check` is currently blocked by pre-existing newline-style issues in unrelated Rust files.
