### PR TITLE
[codex] Complete character API parity coverage

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1368,11 +1368,6 @@ async fn create_character_test_job(
         move |store| store.get_character(&project_id, &character_id)
     })
     .await?;
-    let project_name = project_call(state.clone(), {
-        let project_id = project_id.clone();
-        move |store| store.project_stem(&project_id)
-    })
-    .await?;
     let look = payload.look_id.as_deref().and_then(|look_id| {
         character
             .get("looks")
@@ -1444,7 +1439,7 @@ async fn create_character_test_job(
         state,
         JobType::ImageGenerate,
         Some(project_id),
-        Some(project_name),
+        None,
         job_payload,
         requested_gpu_or_auto(payload.requested_gpu),
     )

--- a/tests/fixtures/python_rust_api_parity/snapshots.json
+++ b/tests/fixtures/python_rust_api_parity/snapshots.json
@@ -59,6 +59,61 @@
     "id": "asset_fixture",
     "status": "purged"
   },
+  "asset sidecar after character reference": {
+    "createdAt": "<timestamp>",
+    "displayName": "fixture image.png",
+    "file": {
+      "duration": null,
+      "fps": null,
+      "height": null,
+      "mimeType": "image/png",
+      "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+      "width": null
+    },
+    "generationSetId": null,
+    "id": "asset_fixture",
+    "lineage": {
+      "jobId": null,
+      "parents": [],
+      "sourceAssetId": null,
+      "sourceTimestamp": null
+    },
+    "metadata": {
+      "characterReferences": [
+        {
+          "approved": true,
+          "approvedAt": "<timestamp>",
+          "characterId": "character_fixture",
+          "linkedAt": "<timestamp>",
+          "role": "hero",
+          "source": "character-sidecar"
+        }
+      ]
+    },
+    "projectId": "project_fixture",
+    "recipe": {
+      "adapter": "api-upload",
+      "loras": [],
+      "mode": "upload",
+      "model": "manual-import",
+      "negativePrompt": "",
+      "normalizedSettings": {},
+      "prompt": "fixture image.png",
+      "rawAdapterSettings": {
+        "contentType": "image/png"
+      },
+      "seed": 0,
+      "stylePreset": "none"
+    },
+    "schemaVersion": 1,
+    "status": {
+      "favorite": false,
+      "rating": 0,
+      "rejected": false,
+      "trashed": false
+    },
+    "type": "image"
+  },
   "asset status project DB update response": {
     "createdAt": "<timestamp>",
     "displayName": "fixture image.png",
@@ -166,6 +221,543 @@
     ],
     "registeredAt": "<timestamp>",
     "status": "busy"
+  },
+  "character archive response": {
+    "id": "character_fixture",
+    "status": "archived"
+  },
+  "character create response": {
+    "approvedReferences": [],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character detail response": {
+    "approvedReferences": [],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character list after archive response": [],
+  "character list include archived response": [
+    {
+      "approvedReferences": [
+        {
+          "addedAt": "<timestamp>",
+          "approved": true,
+          "approvedAt": "<timestamp>",
+          "asset": {
+            "displayName": "fixture image.png",
+            "file": {
+              "duration": null,
+              "fps": null,
+              "height": null,
+              "mimeType": "image/png",
+              "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+              "width": null
+            },
+            "id": "asset_fixture",
+            "status": {
+              "favorite": false,
+              "rating": 0,
+              "rejected": false,
+              "trashed": false
+            },
+            "type": "image",
+            "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+          },
+          "assetId": "asset_fixture",
+          "notes": "Primary face",
+          "role": "hero"
+        }
+      ],
+      "createdAt": "<timestamp>",
+      "description": "Lead performer",
+      "id": "character_fixture",
+      "looks": [
+        {
+          "approvedReferenceIds": [
+            "asset_fixture"
+          ],
+          "createdAt": "<timestamp>",
+          "description": "Night exterior look",
+          "id": "look_fixture",
+          "name": "Rain coat",
+          "recipeSettings": {
+            "style": "noir"
+          },
+          "updatedAt": "<timestamp>"
+        }
+      ],
+      "loras": [
+        {
+          "category": "character",
+          "compatibility": {
+            "families": [
+              "z-image"
+            ]
+          },
+          "copiedIntoProject": true,
+          "createdAt": "<timestamp>",
+          "defaultWeight": 0.8,
+          "id": "character_lora_fixture",
+          "loraId": null,
+          "name": "Mira LoRA",
+          "projectPath": "loras/characters/character_fixture/mira.safetensors",
+          "scope": "project",
+          "sourcePath": "<runtime-root>/data/loras/mira.safetensors",
+          "triggerWords": [
+            "mira"
+          ],
+          "updatedAt": "<timestamp>"
+        }
+      ],
+      "name": "Mira",
+      "projectId": "project_fixture",
+      "references": [
+        {
+          "addedAt": "<timestamp>",
+          "approved": true,
+          "approvedAt": "<timestamp>",
+          "asset": {
+            "displayName": "fixture image.png",
+            "file": {
+              "duration": null,
+              "fps": null,
+              "height": null,
+              "mimeType": "image/png",
+              "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+              "width": null
+            },
+            "id": "asset_fixture",
+            "status": {
+              "favorite": false,
+              "rating": 0,
+              "rejected": false,
+              "trashed": false
+            },
+            "type": "image",
+            "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+          },
+          "assetId": "asset_fixture",
+          "notes": "Primary face",
+          "role": "hero"
+        }
+      ],
+      "schemaVersion": 1,
+      "status": {
+        "archived": true
+      },
+      "trainedLoras": [],
+      "type": "person",
+      "updatedAt": "<timestamp>"
+    }
+  ],
+  "character list response": [
+    {
+      "approvedReferences": [],
+      "createdAt": "<timestamp>",
+      "description": "Lead performer",
+      "id": "character_fixture",
+      "looks": [],
+      "loras": [],
+      "name": "Mira",
+      "projectId": "project_fixture",
+      "references": [],
+      "schemaVersion": 1,
+      "status": {
+        "archived": false
+      },
+      "trainedLoras": [],
+      "type": "person",
+      "updatedAt": "<timestamp>"
+    }
+  ],
+  "character look create response": {
+    "approvedReferences": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Primary face",
+        "role": "hero"
+      }
+    ],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer",
+    "id": "character_fixture",
+    "looks": [
+      {
+        "approvedReferenceIds": [
+          "asset_fixture"
+        ],
+        "createdAt": "<timestamp>",
+        "description": "Night exterior look",
+        "id": "look_fixture",
+        "name": "Rain coat",
+        "recipeSettings": {
+          "style": "noir"
+        },
+        "updatedAt": "<timestamp>"
+      }
+    ],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Primary face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character lora attach response": {
+    "approvedReferences": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Primary face",
+        "role": "hero"
+      }
+    ],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer",
+    "id": "character_fixture",
+    "looks": [
+      {
+        "approvedReferenceIds": [
+          "asset_fixture"
+        ],
+        "createdAt": "<timestamp>",
+        "description": "Night exterior look",
+        "id": "look_fixture",
+        "name": "Rain coat",
+        "recipeSettings": {
+          "style": "noir"
+        },
+        "updatedAt": "<timestamp>"
+      }
+    ],
+    "loras": [
+      {
+        "category": "character",
+        "compatibility": {
+          "families": [
+            "z-image"
+          ]
+        },
+        "copiedIntoProject": true,
+        "createdAt": "<timestamp>",
+        "defaultWeight": 0.8,
+        "id": "character_lora_fixture",
+        "loraId": null,
+        "name": "Mira LoRA",
+        "projectPath": "loras/characters/character_fixture/mira.safetensors",
+        "scope": "project",
+        "sourcePath": "<runtime-root>/data/loras/mira.safetensors",
+        "triggerWords": [
+          "mira"
+        ],
+        "updatedAt": "<timestamp>"
+      }
+    ],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Primary face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character reference attach response": {
+    "approvedReferences": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Primary face",
+        "role": "hero"
+      }
+    ],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Primary face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character test job response": {
+    "assignedGpu": null,
+    "attempts": 1,
+    "cancelRequested": false,
+    "canceledAt": null,
+    "completedAt": null,
+    "createdAt": "<timestamp>",
+    "duplicateOfJobId": null,
+    "elapsedSeconds": null,
+    "error": null,
+    "etaSeconds": null,
+    "id": "job_fixture",
+    "lastHeartbeatAt": null,
+    "message": "Waiting for an available worker.",
+    "payload": {
+      "advanced": {
+        "approvedReferenceIds": [
+          "asset_fixture"
+        ],
+        "characterName": "Mira",
+        "characterType": "person",
+        "look": {
+          "approvedReferenceIds": [
+            "asset_fixture"
+          ],
+          "createdAt": "<timestamp>",
+          "description": "Night exterior look",
+          "id": "look_fixture",
+          "name": "Rain coat",
+          "recipeSettings": {
+            "style": "noir"
+          },
+          "updatedAt": "<timestamp>"
+        }
+      },
+      "characterId": "character_fixture",
+      "characterLookId": "look_fixture",
+      "count": 2,
+      "height": 1024,
+      "loras": [
+        {
+          "category": "character",
+          "compatibility": {
+            "families": [
+              "z-image"
+            ]
+          },
+          "copiedIntoProject": true,
+          "createdAt": "<timestamp>",
+          "defaultWeight": 0.8,
+          "id": "character_lora_fixture",
+          "loraId": null,
+          "name": "Mira LoRA",
+          "projectPath": "loras/characters/character_fixture/mira.safetensors",
+          "scope": "project",
+          "sourcePath": "<runtime-root>/data/loras/mira.safetensors",
+          "triggerWords": [
+            "mira"
+          ],
+          "updatedAt": "<timestamp>"
+        }
+      ],
+      "mode": "character_image",
+      "model": "z_image_turbo",
+      "negativePrompt": "",
+      "prompt": "portrait in rain",
+      "seed": null,
+      "sourceAssetId": null,
+      "stylePreset": "character-test",
+      "width": 1024
+    },
+    "progress": 0.0,
+    "projectId": "project_fixture",
+    "projectName": null,
+    "requestedGpu": "auto",
+    "result": {},
+    "sourceJobId": null,
+    "stage": "queued",
+    "startedAt": null,
+    "status": "queued",
+    "type": "image_generate",
+    "updatedAt": "<timestamp>",
+    "workerId": null
   },
   "concurrent claim response set": [
     {
@@ -578,6 +1170,32 @@
       }
     }
   ],
+  "persisted character sidecar": {
+    "createdAt": "<timestamp>",
+    "description": "Lead performer",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "assetId": "asset_fixture",
+        "notes": "Primary face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
   "persisted upload sidecar": {
     "createdAt": "<timestamp>",
     "displayName": "fixture image.png",

--- a/tests/fixtures/python_rust_api_parity/snapshots.json
+++ b/tests/fixtures/python_rust_api_parity/snapshots.json
@@ -114,6 +114,52 @@
     },
     "type": "image"
   },
+  "asset sidecar after character reference removal": {
+    "createdAt": "<timestamp>",
+    "displayName": "fixture image.png",
+    "file": {
+      "duration": null,
+      "fps": null,
+      "height": null,
+      "mimeType": "image/png",
+      "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+      "width": null
+    },
+    "generationSetId": null,
+    "id": "asset_fixture",
+    "lineage": {
+      "jobId": null,
+      "parents": [],
+      "sourceAssetId": null,
+      "sourceTimestamp": null
+    },
+    "metadata": {
+      "characterReferences": []
+    },
+    "projectId": "project_fixture",
+    "recipe": {
+      "adapter": "api-upload",
+      "loras": [],
+      "mode": "upload",
+      "model": "manual-import",
+      "negativePrompt": "",
+      "normalizedSettings": {},
+      "prompt": "fixture image.png",
+      "rawAdapterSettings": {
+        "contentType": "image/png"
+      },
+      "seed": 0,
+      "stylePreset": "none"
+    },
+    "schemaVersion": 1,
+    "status": {
+      "favorite": false,
+      "rating": 0,
+      "rejected": false,
+      "trashed": false
+    },
+    "type": "image"
+  },
   "asset status project DB update response": {
     "createdAt": "<timestamp>",
     "displayName": "fixture image.png",
@@ -244,6 +290,10 @@
     "type": "person",
     "updatedAt": "<timestamp>"
   },
+  "character delete archive response": {
+    "id": "character_fixture",
+    "status": "archived"
+  },
   "character detail response": {
     "approvedReferences": [],
     "createdAt": "<timestamp>",
@@ -291,51 +341,15 @@
             "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
           },
           "assetId": "asset_fixture",
-          "notes": "Primary face",
+          "notes": "Approved face",
           "role": "hero"
         }
       ],
       "createdAt": "<timestamp>",
-      "description": "Lead performer",
+      "description": "Lead performer, updated",
       "id": "character_fixture",
-      "looks": [
-        {
-          "approvedReferenceIds": [
-            "asset_fixture"
-          ],
-          "createdAt": "<timestamp>",
-          "description": "Night exterior look",
-          "id": "look_fixture",
-          "name": "Rain coat",
-          "recipeSettings": {
-            "style": "noir"
-          },
-          "updatedAt": "<timestamp>"
-        }
-      ],
-      "loras": [
-        {
-          "category": "character",
-          "compatibility": {
-            "families": [
-              "z-image"
-            ]
-          },
-          "copiedIntoProject": true,
-          "createdAt": "<timestamp>",
-          "defaultWeight": 0.8,
-          "id": "character_lora_fixture",
-          "loraId": null,
-          "name": "Mira LoRA",
-          "projectPath": "loras/characters/character_fixture/mira.safetensors",
-          "scope": "project",
-          "sourcePath": "<runtime-root>/data/loras/mira.safetensors",
-          "triggerWords": [
-            "mira"
-          ],
-          "updatedAt": "<timestamp>"
-        }
-      ],
+      "looks": [],
+      "loras": [],
       "name": "Mira",
       "projectId": "project_fixture",
       "references": [
@@ -364,7 +378,7 @@
             "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
           },
           "assetId": "asset_fixture",
-          "notes": "Primary face",
+          "notes": "Approved face",
           "role": "hero"
         }
       ],
@@ -424,12 +438,12 @@
           "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
         },
         "assetId": "asset_fixture",
-        "notes": "Primary face",
+        "notes": "Approved face",
         "role": "hero"
       }
     ],
     "createdAt": "<timestamp>",
-    "description": "Lead performer",
+    "description": "Lead performer, updated",
     "id": "character_fixture",
     "looks": [
       {
@@ -475,7 +489,198 @@
           "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
         },
         "assetId": "asset_fixture",
-        "notes": "Primary face",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character look delete response": {
+    "approvedReferences": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer, updated",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [
+      {
+        "category": "character",
+        "compatibility": {
+          "families": [
+            "z-image"
+          ],
+          "notes": "parity"
+        },
+        "copiedIntoProject": true,
+        "createdAt": "<timestamp>",
+        "defaultWeight": 0.65,
+        "id": "character_lora_fixture",
+        "loraId": null,
+        "name": "Mira LoRA revised",
+        "projectPath": "loras/characters/character_fixture/mira.safetensors",
+        "scope": "project",
+        "sourcePath": "<runtime-root>/data/loras/mira.safetensors",
+        "triggerWords": [
+          "mira",
+          "rain"
+        ],
+        "updatedAt": "<timestamp>"
+      }
+    ],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character look update response": {
+    "approvedReferences": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer, updated",
+    "id": "character_fixture",
+    "looks": [
+      {
+        "approvedReferenceIds": [
+          "asset_fixture"
+        ],
+        "createdAt": "<timestamp>",
+        "description": "Night exterior hero look",
+        "id": "look_fixture",
+        "name": "Rain coat revised",
+        "recipeSettings": {
+          "lens": "85mm",
+          "style": "noir"
+        },
+        "updatedAt": "<timestamp>"
+      }
+    ],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
         "role": "hero"
       }
     ],
@@ -514,12 +719,12 @@
           "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
         },
         "assetId": "asset_fixture",
-        "notes": "Primary face",
+        "notes": "Approved face",
         "role": "hero"
       }
     ],
     "createdAt": "<timestamp>",
-    "description": "Lead performer",
+    "description": "Lead performer, updated",
     "id": "character_fixture",
     "looks": [
       {
@@ -527,10 +732,11 @@
           "asset_fixture"
         ],
         "createdAt": "<timestamp>",
-        "description": "Night exterior look",
+        "description": "Night exterior hero look",
         "id": "look_fixture",
-        "name": "Rain coat",
+        "name": "Rain coat revised",
         "recipeSettings": {
+          "lens": "85mm",
           "style": "noir"
         },
         "updatedAt": "<timestamp>"
@@ -587,7 +793,7 @@
           "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
         },
         "assetId": "asset_fixture",
-        "notes": "Primary face",
+        "notes": "Approved face",
         "role": "hero"
       }
     ],
@@ -599,7 +805,7 @@
     "type": "person",
     "updatedAt": "<timestamp>"
   },
-  "character reference attach response": {
+  "character lora delete response": {
     "approvedReferences": [
       {
         "addedAt": "<timestamp>",
@@ -626,12 +832,12 @@
           "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
         },
         "assetId": "asset_fixture",
-        "notes": "Primary face",
+        "notes": "Approved face",
         "role": "hero"
       }
     ],
     "createdAt": "<timestamp>",
-    "description": "Lead performer",
+    "description": "Lead performer, updated",
     "id": "character_fixture",
     "looks": [],
     "loras": [],
@@ -663,7 +869,267 @@
           "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
         },
         "assetId": "asset_fixture",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character lora update response": {
+    "approvedReferences": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer, updated",
+    "id": "character_fixture",
+    "looks": [
+      {
+        "approvedReferenceIds": [
+          "asset_fixture"
+        ],
+        "createdAt": "<timestamp>",
+        "description": "Night exterior hero look",
+        "id": "look_fixture",
+        "name": "Rain coat revised",
+        "recipeSettings": {
+          "lens": "85mm",
+          "style": "noir"
+        },
+        "updatedAt": "<timestamp>"
+      }
+    ],
+    "loras": [
+      {
+        "category": "character",
+        "compatibility": {
+          "families": [
+            "z-image"
+          ],
+          "notes": "parity"
+        },
+        "copiedIntoProject": true,
+        "createdAt": "<timestamp>",
+        "defaultWeight": 0.65,
+        "id": "character_lora_fixture",
+        "loraId": null,
+        "name": "Mira LoRA revised",
+        "projectPath": "loras/characters/character_fixture/mira.safetensors",
+        "scope": "project",
+        "sourcePath": "<runtime-root>/data/loras/mira.safetensors",
+        "triggerWords": [
+          "mira",
+          "rain"
+        ],
+        "updatedAt": "<timestamp>"
+      }
+    ],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character purge response": {
+    "id": "character_fixture",
+    "status": "purged"
+  },
+  "character reference attach response": {
+    "approvedReferences": [],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer, updated",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": false,
+        "approvedAt": null,
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
         "notes": "Primary face",
+        "role": "reference"
+      }
+    ],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character reference delete response": {
+    "approvedReferences": [],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer, updated",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
+  },
+  "character reference update response": {
+    "approvedReferences": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
+        "role": "hero"
+      }
+    ],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer, updated",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [
+      {
+        "addedAt": "<timestamp>",
+        "approved": true,
+        "approvedAt": "<timestamp>",
+        "asset": {
+          "displayName": "fixture image.png",
+          "file": {
+            "duration": null,
+            "fps": null,
+            "height": null,
+            "mimeType": "image/png",
+            "path": "assets/uploads/fixture-image-<upload-suffix>.png",
+            "width": null
+          },
+          "id": "asset_fixture",
+          "status": {
+            "favorite": false,
+            "rating": 0,
+            "rejected": false,
+            "trashed": false
+          },
+          "type": "image",
+          "url": "/api/v1/projects/project_fixture/files/assets/uploads/fixture-image-<upload-suffix>.png"
+        },
+        "assetId": "asset_fixture",
+        "notes": "Approved face",
         "role": "hero"
       }
     ],
@@ -701,10 +1167,11 @@
             "asset_fixture"
           ],
           "createdAt": "<timestamp>",
-          "description": "Night exterior look",
+          "description": "Night exterior hero look",
           "id": "look_fixture",
-          "name": "Rain coat",
+          "name": "Rain coat revised",
           "recipeSettings": {
+            "lens": "85mm",
             "style": "noir"
           },
           "updatedAt": "<timestamp>"
@@ -720,19 +1187,21 @@
           "compatibility": {
             "families": [
               "z-image"
-            ]
+            ],
+            "notes": "parity"
           },
           "copiedIntoProject": true,
           "createdAt": "<timestamp>",
-          "defaultWeight": 0.8,
+          "defaultWeight": 0.65,
           "id": "character_lora_fixture",
           "loraId": null,
-          "name": "Mira LoRA",
+          "name": "Mira LoRA revised",
           "projectPath": "loras/characters/character_fixture/mira.safetensors",
           "scope": "project",
           "sourcePath": "<runtime-root>/data/loras/mira.safetensors",
           "triggerWords": [
-            "mira"
+            "mira",
+            "rain"
           ],
           "updatedAt": "<timestamp>"
         }
@@ -758,6 +1227,24 @@
     "type": "image_generate",
     "updatedAt": "<timestamp>",
     "workerId": null
+  },
+  "character update response": {
+    "approvedReferences": [],
+    "createdAt": "<timestamp>",
+    "description": "Lead performer, updated",
+    "id": "character_fixture",
+    "looks": [],
+    "loras": [],
+    "name": "Mira",
+    "projectId": "project_fixture",
+    "references": [],
+    "schemaVersion": 1,
+    "status": {
+      "archived": false
+    },
+    "trainedLoras": [],
+    "type": "person",
+    "updatedAt": "<timestamp>"
   },
   "concurrent claim response set": [
     {
@@ -856,6 +1343,9 @@
     "type": "image_generate",
     "updatedAt": "<timestamp>",
     "workerId": null
+  },
+  "invalid character lora source error response": {
+    "detail": "LoRA source path not found: <runtime-root>/data/loras/missing.safetensors"
   },
   "invalid job status error response": {
     "detail": "Unsupported job status"
@@ -1090,6 +1580,15 @@
       }
     ]
   },
+  "missing character error response": {
+    "detail": "Character not found"
+  },
+  "missing character look error response": {
+    "detail": "Look not found"
+  },
+  "missing character lora error response": {
+    "detail": "Character LoRA not found"
+  },
   "missing project error response": {
     "detail": "Project not found"
   },
@@ -1172,7 +1671,7 @@
   ],
   "persisted character sidecar": {
     "createdAt": "<timestamp>",
-    "description": "Lead performer",
+    "description": "Lead performer, updated",
     "id": "character_fixture",
     "looks": [],
     "loras": [],
@@ -1184,7 +1683,7 @@
         "approved": true,
         "approvedAt": "<timestamp>",
         "assetId": "asset_fixture",
-        "notes": "Primary face",
+        "notes": "Approved face",
         "role": "hero"
       }
     ],

--- a/tests/test_python_rust_api_parity.py
+++ b/tests/test_python_rust_api_parity.py
@@ -38,7 +38,7 @@ PNG_1X1 = (
 TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z")
 PREFIXED_ID_RE = re.compile(
     r"\b(project|asset|job|timeline|track|transition|genset|generation_set|"
-    r"look|character|lora|worker)_[0-9a-f]{8,32}\b"
+    r"look|character_lora|character|lora|worker)_[0-9a-f]{8,32}\b"
 )
 UPLOAD_SUFFIX_RE = re.compile(r"\b([a-z0-9]+(?:-[a-z0-9]+)*)-[0-9a-f]{8}(?=\.)")
 HEX_TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
@@ -455,6 +455,14 @@ def sidecar_payload(project_path: Path, asset_id: str) -> dict[str, Any]:
     raise AssertionError(f"Missing sidecar for {asset_id} under {project_path}")
 
 
+def character_sidecar_payload(project_path: Path, character_id: str) -> dict[str, Any]:
+    for sidecar in project_path.glob("characters/*.sceneworks.character.json"):
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        if payload.get("id") == character_id:
+            return payload
+    raise AssertionError(f"Missing character sidecar for {character_id} under {project_path}")
+
+
 def write_person_track_sidecar(runtime: ParityRuntime) -> None:
     assert runtime.project_id is not None
     assert runtime.project_path is not None
@@ -607,6 +615,210 @@ def test_project_asset_sidecar_delete_and_db_contracts(parity_runtimes):
         for runtime in parity_runtimes
     ]
     assert_response_parity("asset purge response", python_runtime, rust_runtime, purged[0], purged[1], expected_status=200, snapshot=True)
+
+
+def test_character_subsystem_contracts(parity_runtimes):
+    python_runtime, rust_runtime = parity_runtimes
+    create_projects(parity_runtimes, python_runtime, rust_runtime)
+    upload_assets(parity_runtimes, python_runtime, rust_runtime)
+
+    created_characters = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters",
+            json_payload={"name": "Mira", "type": "person", "description": "Lead performer"},
+        )
+        for runtime in parity_runtimes
+    ]
+    character_ids = [response.body["id"] for response in created_characters]
+    assert_response_parity(
+        "character create response",
+        python_runtime,
+        rust_runtime,
+        created_characters[0],
+        created_characters[1],
+        expected_status=201,
+        snapshot=True,
+    )
+
+    listed_characters = [
+        runtime.request("GET", f"/api/v1/projects/{runtime.project_id}/characters")
+        for runtime in parity_runtimes
+    ]
+    assert_response_parity(
+        "character list response",
+        python_runtime,
+        rust_runtime,
+        listed_characters[0],
+        listed_characters[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
+    fetched_characters = [
+        runtime.request("GET", f"/api/v1/projects/{runtime.project_id}/characters/{character_id}")
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "character detail response",
+        python_runtime,
+        rust_runtime,
+        fetched_characters[0],
+        fetched_characters[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
+    referenced_characters = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/references",
+            json_payload={"assetId": runtime.asset_id, "approved": True, "role": "hero", "notes": "Primary face"},
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "character reference attach response",
+        python_runtime,
+        rust_runtime,
+        referenced_characters[0],
+        referenced_characters[1],
+        expected_status=201,
+        snapshot=True,
+    )
+
+    sidecars = [
+        character_sidecar_payload(runtime.project_path, character_id)
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    normalized_sidecar = assert_parity("persisted character sidecar", python_runtime, rust_runtime, sidecars[0], sidecars[1])
+    assert_snapshot("persisted character sidecar", normalized_sidecar)
+
+    asset_sidecars = [sidecar_payload(runtime.project_path, runtime.asset_id) for runtime in parity_runtimes]
+    normalized_asset_sidecar = assert_parity(
+        "asset sidecar after character reference",
+        python_runtime,
+        rust_runtime,
+        asset_sidecars[0],
+        asset_sidecars[1],
+    )
+    assert_snapshot("asset sidecar after character reference", normalized_asset_sidecar)
+
+    created_looks = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/looks",
+            json_payload={
+                "name": "Rain coat",
+                "description": "Night exterior look",
+                "approvedReferenceIds": [runtime.asset_id],
+                "recipeSettings": {"style": "noir"},
+            },
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    normalized_look_response = assert_response_parity(
+        "character look create response",
+        python_runtime,
+        rust_runtime,
+        created_looks[0],
+        created_looks[1],
+        expected_status=201,
+        snapshot=True,
+    )
+    look_ids = [response.body["looks"][0]["id"] for response in created_looks]
+
+    lora_sources = []
+    for runtime in parity_runtimes:
+        lora_dir = runtime.roots[0] / "data" / "loras"
+        lora_dir.mkdir(parents=True, exist_ok=True)
+        lora_source = lora_dir / "mira.safetensors"
+        lora_source.write_bytes(b"lora")
+        lora_sources.append(lora_source)
+    attached_loras = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/loras",
+            json_payload={
+                "name": "Mira LoRA",
+                "sourcePath": str(lora_source),
+                "triggerWords": ["mira"],
+                "compatibility": {"families": ["z-image"]},
+            },
+        )
+        for runtime, character_id, lora_source in zip(parity_runtimes, character_ids, lora_sources)
+    ]
+    assert_response_parity(
+        "character lora attach response",
+        python_runtime,
+        rust_runtime,
+        attached_loras[0],
+        attached_loras[1],
+        expected_status=201,
+        snapshot=True,
+    )
+
+    test_jobs = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/test-jobs",
+            json_payload={"prompt": "portrait in rain", "lookId": look_id, "count": 2},
+        )
+        for runtime, character_id, look_id in zip(parity_runtimes, character_ids, look_ids)
+    ]
+    assert_response_parity(
+        "character test job response",
+        python_runtime,
+        rust_runtime,
+        test_jobs[0],
+        test_jobs[1],
+        expected_status=201,
+        snapshot=True,
+    )
+
+    archived_characters = [
+        runtime.request("POST", f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/archive")
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "character archive response",
+        python_runtime,
+        rust_runtime,
+        archived_characters[0],
+        archived_characters[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
+    hidden_archived = [
+        runtime.request("GET", f"/api/v1/projects/{runtime.project_id}/characters")
+        for runtime in parity_runtimes
+    ]
+    assert_response_parity(
+        "character list after archive response",
+        python_runtime,
+        rust_runtime,
+        hidden_archived[0],
+        hidden_archived[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
+    visible_archived = [
+        runtime.request("GET", f"/api/v1/projects/{runtime.project_id}/characters?includeArchived=true")
+        for runtime in parity_runtimes
+    ]
+    assert_response_parity(
+        "character list include archived response",
+        python_runtime,
+        rust_runtime,
+        visible_archived[0],
+        visible_archived[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
+    assert normalized_look_response["looks"][0]["approvedReferenceIds"] == ["asset_fixture"]
 
 
 def test_timeline_and_worker_job_creation_contracts(parity_runtimes):

--- a/tests/test_python_rust_api_parity.py
+++ b/tests/test_python_rust_api_parity.py
@@ -669,11 +669,29 @@ def test_character_subsystem_contracts(parity_runtimes):
         snapshot=True,
     )
 
+    updated_characters = [
+        runtime.request(
+            "PATCH",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}",
+            json_payload={"description": "Lead performer, updated", "archived": False},
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "character update response",
+        python_runtime,
+        rust_runtime,
+        updated_characters[0],
+        updated_characters[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
     referenced_characters = [
         runtime.request(
             "POST",
             f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/references",
-            json_payload={"assetId": runtime.asset_id, "approved": True, "role": "hero", "notes": "Primary face"},
+            json_payload={"assetId": runtime.asset_id, "approved": False, "role": "reference", "notes": "Primary face"},
         )
         for runtime, character_id in zip(parity_runtimes, character_ids)
     ]
@@ -684,6 +702,24 @@ def test_character_subsystem_contracts(parity_runtimes):
         referenced_characters[0],
         referenced_characters[1],
         expected_status=201,
+        snapshot=True,
+    )
+
+    updated_references = [
+        runtime.request(
+            "PATCH",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/references/{runtime.asset_id}",
+            json_payload={"approved": True, "role": "hero", "notes": "Approved face"},
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "character reference update response",
+        python_runtime,
+        rust_runtime,
+        updated_references[0],
+        updated_references[1],
+        expected_status=200,
         snapshot=True,
     )
 
@@ -703,6 +739,52 @@ def test_character_subsystem_contracts(parity_runtimes):
         asset_sidecars[1],
     )
     assert_snapshot("asset sidecar after character reference", normalized_asset_sidecar)
+
+    removed_references = [
+        runtime.request(
+            "DELETE",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/references/{runtime.asset_id}",
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "character reference delete response",
+        python_runtime,
+        rust_runtime,
+        removed_references[0],
+        removed_references[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
+    cleaned_asset_sidecars = [sidecar_payload(runtime.project_path, runtime.asset_id) for runtime in parity_runtimes]
+    normalized_cleaned_asset_sidecar = assert_parity(
+        "asset sidecar after character reference removal",
+        python_runtime,
+        rust_runtime,
+        cleaned_asset_sidecars[0],
+        cleaned_asset_sidecars[1],
+    )
+    assert_snapshot("asset sidecar after character reference removal", normalized_cleaned_asset_sidecar)
+    for asset_sidecar in cleaned_asset_sidecars:
+        assert asset_sidecar["metadata"]["characterReferences"] == []
+
+    reattached_references = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/references",
+            json_payload={"assetId": runtime.asset_id, "approved": True, "role": "hero", "notes": "Approved face"},
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "character reference reattach response",
+        python_runtime,
+        rust_runtime,
+        reattached_references[0],
+        reattached_references[1],
+        expected_status=201,
+    )
 
     created_looks = [
         runtime.request(
@@ -728,8 +810,33 @@ def test_character_subsystem_contracts(parity_runtimes):
     )
     look_ids = [response.body["looks"][0]["id"] for response in created_looks]
 
+    updated_looks = [
+        runtime.request(
+            "PATCH",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/looks/{look_id}",
+            json_payload={
+                "name": "Rain coat revised",
+                "description": "Night exterior hero look",
+                "approvedReferenceIds": [runtime.asset_id],
+                "recipeSettings": {"style": "noir", "lens": "85mm"},
+            },
+        )
+        for runtime, character_id, look_id in zip(parity_runtimes, character_ids, look_ids)
+    ]
+    normalized_look_update_response = assert_response_parity(
+        "character look update response",
+        python_runtime,
+        rust_runtime,
+        updated_looks[0],
+        updated_looks[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
     lora_sources = []
     for runtime in parity_runtimes:
+        # The parity harness root contains each runtime's data dir, so sourcePath is both valid
+        # for the API and normalized to <runtime-root> in snapshots.
         lora_dir = runtime.roots[0] / "data" / "loras"
         lora_dir.mkdir(parents=True, exist_ok=True)
         lora_source = lora_dir / "mira.safetensors"
@@ -757,6 +864,31 @@ def test_character_subsystem_contracts(parity_runtimes):
         expected_status=201,
         snapshot=True,
     )
+    lora_link_ids = [response.body["loras"][0]["id"] for response in attached_loras]
+
+    updated_loras = [
+        runtime.request(
+            "PATCH",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/loras/{link_id}",
+            json_payload={
+                "name": "Mira LoRA revised",
+                "triggerWords": ["mira", "rain"],
+                "defaultWeight": 0.65,
+                "compatibility": {"families": ["z-image"], "notes": "parity"},
+                "scope": "project",
+            },
+        )
+        for runtime, character_id, link_id in zip(parity_runtimes, character_ids, lora_link_ids)
+    ]
+    assert_response_parity(
+        "character lora update response",
+        python_runtime,
+        rust_runtime,
+        updated_loras[0],
+        updated_loras[1],
+        expected_status=200,
+        snapshot=True,
+    )
 
     test_jobs = [
         runtime.request(
@@ -776,11 +908,45 @@ def test_character_subsystem_contracts(parity_runtimes):
         snapshot=True,
     )
 
+    deleted_looks = [
+        runtime.request(
+            "DELETE",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/looks/{look_id}",
+        )
+        for runtime, character_id, look_id in zip(parity_runtimes, character_ids, look_ids)
+    ]
+    assert_response_parity(
+        "character look delete response",
+        python_runtime,
+        rust_runtime,
+        deleted_looks[0],
+        deleted_looks[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
+    detached_loras = [
+        runtime.request(
+            "DELETE",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/loras/{link_id}",
+        )
+        for runtime, character_id, link_id in zip(parity_runtimes, character_ids, lora_link_ids)
+    ]
+    assert_response_parity(
+        "character lora delete response",
+        python_runtime,
+        rust_runtime,
+        detached_loras[0],
+        detached_loras[1],
+        expected_status=200,
+        snapshot=True,
+    )
+
     archived_characters = [
         runtime.request("POST", f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/archive")
         for runtime, character_id in zip(parity_runtimes, character_ids)
     ]
-    assert_response_parity(
+    normalized_post_archive_response = assert_response_parity(
         "character archive response",
         python_runtime,
         rust_runtime,
@@ -818,7 +984,57 @@ def test_character_subsystem_contracts(parity_runtimes):
         snapshot=True,
     )
 
+    delete_archive_characters = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters",
+            json_payload={"name": "Delete Archive", "type": "object"},
+        )
+        for runtime in parity_runtimes
+    ]
+    delete_archive_ids = [response.body["id"] for response in delete_archive_characters]
+    delete_archive_responses = [
+        runtime.request("DELETE", f"/api/v1/projects/{runtime.project_id}/characters/{character_id}")
+        for runtime, character_id in zip(parity_runtimes, delete_archive_ids)
+    ]
+    normalized_delete_archive_response = assert_response_parity(
+        "character delete archive response",
+        python_runtime,
+        rust_runtime,
+        delete_archive_responses[0],
+        delete_archive_responses[1],
+        expected_status=200,
+        snapshot=True,
+    )
+    assert normalized_delete_archive_response == normalized_post_archive_response
+
+    purge_characters = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters",
+            json_payload={"name": "Purge Me", "type": "object"},
+        )
+        for runtime in parity_runtimes
+    ]
+    purge_ids = [response.body["id"] for response in purge_characters]
+    purge_responses = [
+        runtime.request("DELETE", f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/purge")
+        for runtime, character_id in zip(parity_runtimes, purge_ids)
+    ]
+    assert_response_parity(
+        "character purge response",
+        python_runtime,
+        rust_runtime,
+        purge_responses[0],
+        purge_responses[1],
+        expected_status=200,
+        snapshot=True,
+    )
+    for runtime, character_id in zip(parity_runtimes, purge_ids):
+        assert not (runtime.project_path / "characters" / f"{character_id}.sceneworks.character.json").exists()
+
     assert normalized_look_response["looks"][0]["approvedReferenceIds"] == ["asset_fixture"]
+    assert normalized_look_update_response["looks"][0]["recipeSettings"]["lens"] == "85mm"
 
 
 def test_timeline_and_worker_job_creation_contracts(parity_runtimes):
@@ -1131,3 +1347,82 @@ def test_error_case_contracts(parity_runtimes):
         for runtime in parity_runtimes
     ]
     assert_response_parity("malformed json error response", python_runtime, rust_runtime, malformed_bodies[0], malformed_bodies[1], expected_status=422, snapshot=True)
+
+    create_projects(parity_runtimes, python_runtime, rust_runtime)
+    characters = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters",
+            json_payload={"name": "Errors", "type": "person"},
+        )
+        for runtime in parity_runtimes
+    ]
+    character_ids = [response.body["id"] for response in characters]
+
+    missing_characters = [
+        runtime.request("GET", f"/api/v1/projects/{runtime.project_id}/characters/character_missing")
+        for runtime in parity_runtimes
+    ]
+    assert_response_parity(
+        "missing character error response",
+        python_runtime,
+        rust_runtime,
+        missing_characters[0],
+        missing_characters[1],
+        expected_status=404,
+        snapshot=True,
+    )
+
+    missing_looks = [
+        runtime.request(
+            "PATCH",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/looks/look_missing",
+            json_payload={"name": "Missing"},
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "missing character look error response",
+        python_runtime,
+        rust_runtime,
+        missing_looks[0],
+        missing_looks[1],
+        expected_status=404,
+        snapshot=True,
+    )
+
+    missing_loras = [
+        runtime.request(
+            "PATCH",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/loras/character_lora_missing",
+            json_payload={"name": "Missing"},
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "missing character lora error response",
+        python_runtime,
+        rust_runtime,
+        missing_loras[0],
+        missing_loras[1],
+        expected_status=404,
+        snapshot=True,
+    )
+
+    invalid_lora_sources = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/characters/{character_id}/loras",
+            json_payload={"name": "Missing source", "sourcePath": str(runtime.roots[0] / "data" / "loras" / "missing.safetensors")},
+        )
+        for runtime, character_id in zip(parity_runtimes, character_ids)
+    ]
+    assert_response_parity(
+        "invalid character lora source error response",
+        python_runtime,
+        rust_runtime,
+        invalid_lora_sources[0],
+        invalid_lora_sources[1],
+        expected_status=400,
+        snapshot=True,
+    )


### PR DESCRIPTION
﻿## Summary

Adds a dedicated Python/Rust parity test for the characters subsystem and records the new snapshots. The flow now covers all 17 character routes: create/list/get/update, both soft-archive paths, purge, reference attach/update/delete with asset metadata back-link cleanup, look create/update/delete, LoRA attach/update/delete with project copy behavior, and character test-job creation.

Also fixes a parity drift in the Rust character test-job handler: Python returns `projectName: null` for these jobs, so Rust now passes `None` instead of the project stem.

## Impact

This gives sc-1282/sc-1284 a real parity gate for the character API work, reducing the risk of deleting the Python API while character routes still drift.

## Review follow-up

Addressed the PR review coverage gap and nits:

- Added PATCH/DELETE/purge coverage for the remaining character routes.
- Verified reference deletion cleans up asset-sidecar `metadata.characterReferences`.
- Verified `DELETE /characters/:id/purge` removes the character sidecar file.
- Verified `POST /archive` and `DELETE /:id` produce equivalent archive responses.
- Added a comment explaining the LoRA source path relationship to the parity harness root.
- Added character-path error parity for missing character/look/lora IDs and invalid LoRA source payloads.

## Validation

- `python -m pytest tests/test_python_rust_api_parity.py -q` -> 9 passed
- `cargo test -p sceneworks-rust-api` -> 21 passed
- `cargo test -p sceneworks-core --test contract_roundtrip` -> 6 passed
- `cargo clippy -- -D warnings` -> clean
- `git diff --check` -> clean

Manual web Character Studio exercise was not run in this pass.
