### PR TITLE
[codex] Add character store persistence

### DIFF
--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -1,0 +1,1762 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{params, Connection, OptionalExtension, Row};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
+
+pub const CHARACTER_SIDECAR_PATTERN: &str = ".sceneworks.character.json";
+
+const ASSET_SIDECAR_PATTERN: &str = "*.sceneworks.json";
+const CHARACTER_INDEX_FINGERPRINT_KEY: &str = "characterIndexFingerprint";
+const ASSET_FOLDERS: &[&str] = &[
+    "assets/images",
+    "assets/videos",
+    "assets/uploads",
+    "assets/frames",
+    "assets/renders",
+    "trash",
+];
+
+#[derive(Debug, Clone)]
+pub struct CharacterCreateInput {
+    pub name: String,
+    pub character_type: String,
+    pub description: String,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CharacterUpdateInput {
+    pub name: Option<String>,
+    pub character_type: Option<String>,
+    pub description: Option<String>,
+    pub archived: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CharacterReferenceInput {
+    pub asset_id: String,
+    pub approved: bool,
+    pub role: String,
+    pub notes: String,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CharacterReferenceUpdateInput {
+    pub approved: Option<bool>,
+    pub role: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CharacterLookInput {
+    pub name: String,
+    pub description: String,
+    pub approved_reference_ids: Vec<String>,
+    pub recipe_settings: Map<String, Value>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CharacterLookUpdateInput {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub approved_reference_ids: Option<Vec<String>>,
+    pub recipe_settings: Option<Map<String, Value>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CharacterLoraInput {
+    pub lora_id: Option<String>,
+    pub name: String,
+    pub source_path: Option<String>,
+    pub trigger_words: Vec<String>,
+    pub default_weight: f64,
+    pub compatibility: Map<String, Value>,
+    pub scope: String,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CharacterLoraUpdateInput {
+    pub name: Option<String>,
+    pub trigger_words: Option<Vec<String>>,
+    pub default_weight: Option<f64>,
+    pub compatibility: Option<Map<String, Value>>,
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CharacterMutationResult {
+    pub id: String,
+    pub status: String,
+}
+
+#[derive(Debug)]
+pub struct CharacterStore<'a> {
+    data_dir: &'a Path,
+    project_path: PathBuf,
+}
+
+impl<'a> CharacterStore<'a> {
+    pub fn new(data_dir: &'a Path, project_path: impl Into<PathBuf>) -> Self {
+        Self {
+            data_dir,
+            project_path: project_path.into(),
+        }
+    }
+
+    pub fn list_characters(
+        &self,
+        project_id: &str,
+        include_archived: bool,
+    ) -> ProjectStoreResult<Vec<Value>> {
+        ensure_character_index(&self.project_path)?;
+        let connection = connect_project_db(&self.project_path)?;
+        let mut statement = connection.prepare("select sidecar_path from characters")?;
+        let rows = statement
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut characters = Vec::new();
+        for sidecar_rel in rows {
+            let sidecar_path = self.project_path.join(sidecar_rel);
+            if !sidecar_path.exists() {
+                continue;
+            }
+            let Ok(character) = read_json(&sidecar_path) else {
+                continue;
+            };
+            if character
+                .pointer("/status/archived")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+                && !include_archived
+            {
+                continue;
+            }
+            characters.push(hydrate_character(
+                project_id,
+                &self.project_path,
+                character,
+            )?);
+        }
+        characters.sort_by(|left, right| {
+            right
+                .get("updatedAt")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .cmp(
+                    left.get("updatedAt")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                )
+        });
+        Ok(characters)
+    }
+
+    pub fn get_character(&self, project_id: &str, character_id: &str) -> ProjectStoreResult<Value> {
+        let character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn create_character(
+        &self,
+        project_id: &str,
+        input: CharacterCreateInput,
+    ) -> ProjectStoreResult<Value> {
+        validate_character_name(&input.name)?;
+        validate_character_type(&input.character_type)?;
+        validate_text_length(&input.description, "description", 2000)?;
+
+        let now = utc_now();
+        let character_id = format!("character_{}", random_hex(16)?);
+        let mut character = json!({
+            "schemaVersion": 1,
+            "id": character_id,
+            "projectId": project_id,
+            "name": input.name.trim(),
+            "type": input.character_type,
+            "description": input.description.trim(),
+            "createdAt": now,
+            "updatedAt": now,
+            "status": { "archived": false },
+            "references": [],
+            "looks": [],
+            "loras": [],
+            "trainedLoras": []
+        });
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, false)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn update_character(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        input: CharacterUpdateInput,
+    ) -> ProjectStoreResult<Value> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let object = value_object_mut(&mut character, "Character sidecar")?;
+        if let Some(name) = input.name {
+            validate_character_name(&name)?;
+            object.insert("name".to_owned(), Value::String(name.trim().to_owned()));
+        }
+        if let Some(character_type) = input.character_type {
+            validate_character_type(&character_type)?;
+            object.insert("type".to_owned(), Value::String(character_type));
+        }
+        if let Some(description) = input.description {
+            validate_text_length(&description, "description", 2000)?;
+            object.insert(
+                "description".to_owned(),
+                Value::String(description.trim().to_owned()),
+            );
+        }
+        if let Some(archived) = input.archived {
+            object
+                .entry("status".to_owned())
+                .or_insert_with(|| json!({}))
+                .as_object_mut()
+                .ok_or_else(|| {
+                    ProjectStoreError::BadRequest("Character status must be an object".to_owned())
+                })?
+                .insert("archived".to_owned(), Value::Bool(archived));
+        }
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn archive_character(
+        &self,
+        character_id: &str,
+    ) -> ProjectStoreResult<CharacterMutationResult> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        value_object_mut(&mut character, "Character sidecar")?
+            .entry("status".to_owned())
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+            .ok_or_else(|| {
+                ProjectStoreError::BadRequest("Character status must be an object".to_owned())
+            })?
+            .insert("archived".to_owned(), Value::Bool(true));
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        Ok(CharacterMutationResult {
+            id: character_id.to_owned(),
+            status: "archived".to_owned(),
+        })
+    }
+
+    pub fn purge_character(
+        &self,
+        character_id: &str,
+    ) -> ProjectStoreResult<CharacterMutationResult> {
+        let path = find_character_file(&self.project_path, character_id)?;
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        purge_character_on_connection(&transaction, character_id)?;
+        fs::remove_file(path)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        Ok(CharacterMutationResult {
+            id: character_id.to_owned(),
+            status: "purged".to_owned(),
+        })
+    }
+
+    pub fn add_reference(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        input: CharacterReferenceInput,
+    ) -> ProjectStoreResult<Value> {
+        validate_required_text(&input.asset_id, "assetId")?;
+        validate_text_length(&input.role, "role", 80)?;
+        validate_text_length(&input.notes, "notes", 1000)?;
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let now = utc_now();
+        let reference = json!({
+            "assetId": input.asset_id,
+            "approved": input.approved,
+            "role": if input.role.trim().is_empty() { "reference" } else { input.role.trim() },
+            "notes": input.notes,
+            "addedAt": now,
+            "approvedAt": if input.approved { Value::String(now) } else { Value::Null }
+        });
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        update_asset_character_link(
+            &transaction,
+            &self.project_path,
+            character_id,
+            &reference,
+            false,
+        )?;
+        let object = value_object_mut(&mut character, "Character sidecar")?;
+        let mut references = object
+            .remove("references")
+            .and_then(|value| value.as_array().cloned())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|item| {
+                item.get("assetId")
+                    .and_then(Value::as_str)
+                    .is_some_and(|asset_id| asset_id != input.asset_id)
+            })
+            .collect::<Vec<_>>();
+        references.insert(0, reference);
+        object.insert("references".to_owned(), Value::Array(references));
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn update_reference(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        asset_id: &str,
+        input: CharacterReferenceUpdateInput,
+    ) -> ProjectStoreResult<Value> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let references = character
+            .get_mut("references")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| {
+                ProjectStoreError::BadRequest("Character references must be an array".to_owned())
+            })?;
+        let reference = references
+            .iter_mut()
+            .find(|item| item.get("assetId").and_then(Value::as_str) == Some(asset_id))
+            .ok_or_else(|| ProjectStoreError::NotFound("Reference not found".to_owned()))?;
+        if let Some(approved) = input.approved {
+            value_object_mut(reference, "Character reference")?
+                .insert("approved".to_owned(), Value::Bool(approved));
+            value_object_mut(reference, "Character reference")?.insert(
+                "approvedAt".to_owned(),
+                if approved {
+                    Value::String(utc_now())
+                } else {
+                    Value::Null
+                },
+            );
+        }
+        if let Some(role) = input.role {
+            validate_text_length(&role, "role", 80)?;
+            value_object_mut(reference, "Character reference")?.insert(
+                "role".to_owned(),
+                Value::String(if role.trim().is_empty() {
+                    "reference".to_owned()
+                } else {
+                    role
+                }),
+            );
+        }
+        if let Some(notes) = input.notes {
+            validate_text_length(&notes, "notes", 1000)?;
+            value_object_mut(reference, "Character reference")?
+                .insert("notes".to_owned(), Value::String(notes));
+        }
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        update_asset_character_link(
+            &transaction,
+            &self.project_path,
+            character_id,
+            reference,
+            false,
+        )?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn remove_reference(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        asset_id: &str,
+    ) -> ProjectStoreResult<Value> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let references = character
+            .get("references")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let reference = references
+            .iter()
+            .find(|item| item.get("assetId").and_then(Value::as_str) == Some(asset_id))
+            .ok_or_else(|| ProjectStoreError::NotFound("Reference not found".to_owned()))?;
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        update_asset_character_link(
+            &transaction,
+            &self.project_path,
+            character_id,
+            reference,
+            true,
+        )?;
+        value_object_mut(&mut character, "Character sidecar")?.insert(
+            "references".to_owned(),
+            Value::Array(
+                references
+                    .into_iter()
+                    .filter(|item| item.get("assetId").and_then(Value::as_str) != Some(asset_id))
+                    .collect(),
+            ),
+        );
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn create_look(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        input: CharacterLookInput,
+    ) -> ProjectStoreResult<Value> {
+        validate_character_name(&input.name)?;
+        validate_text_length(&input.description, "description", 1000)?;
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let now = utc_now();
+        let look = json!({
+            "id": format!("look_{}", random_hex(16)?),
+            "name": input.name.trim(),
+            "description": input.description.trim(),
+            "approvedReferenceIds": input.approved_reference_ids,
+            "recipeSettings": input.recipe_settings,
+            "createdAt": now,
+            "updatedAt": now
+        });
+        prepend_array_field(&mut character, "looks", look)?;
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn update_look(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        look_id: &str,
+        input: CharacterLookUpdateInput,
+    ) -> ProjectStoreResult<Value> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let looks = character
+            .get_mut("looks")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| {
+                ProjectStoreError::BadRequest("Character looks must be an array".to_owned())
+            })?;
+        let look = looks
+            .iter_mut()
+            .find(|item| item.get("id").and_then(Value::as_str) == Some(look_id))
+            .ok_or_else(|| ProjectStoreError::NotFound("Look not found".to_owned()))?;
+        let object = value_object_mut(look, "Character look")?;
+        if let Some(name) = input.name {
+            validate_character_name(&name)?;
+            object.insert("name".to_owned(), Value::String(name.trim().to_owned()));
+        }
+        if let Some(description) = input.description {
+            validate_text_length(&description, "description", 1000)?;
+            object.insert(
+                "description".to_owned(),
+                Value::String(description.trim().to_owned()),
+            );
+        }
+        if let Some(approved_reference_ids) = input.approved_reference_ids {
+            object.insert(
+                "approvedReferenceIds".to_owned(),
+                json!(approved_reference_ids),
+            );
+        }
+        if let Some(recipe_settings) = input.recipe_settings {
+            object.insert("recipeSettings".to_owned(), Value::Object(recipe_settings));
+        }
+        object.insert("updatedAt".to_owned(), Value::String(utc_now()));
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn delete_look(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        look_id: &str,
+    ) -> ProjectStoreResult<Value> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let looks = character
+            .get("looks")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        value_object_mut(&mut character, "Character sidecar")?.insert(
+            "looks".to_owned(),
+            Value::Array(
+                looks
+                    .into_iter()
+                    .filter(|item| item.get("id").and_then(Value::as_str) != Some(look_id))
+                    .collect(),
+            ),
+        );
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn attach_lora(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        input: CharacterLoraInput,
+    ) -> ProjectStoreResult<Value> {
+        validate_character_name(&input.name)?;
+        validate_lora_weight(input.default_weight)?;
+        validate_lora_scope(&input.scope, true)?;
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let (project_lora_path, copied) = copy_lora_into_project(
+            &self.project_path,
+            self.data_dir,
+            character_id,
+            input.source_path.as_deref(),
+        )?;
+        let now = utc_now();
+        let link = json!({
+            "id": format!("character_lora_{}", random_hex(16)?),
+            "loraId": input.lora_id,
+            "name": input.name.trim(),
+            "sourcePath": input.source_path,
+            "projectPath": project_lora_path,
+            "copiedIntoProject": copied,
+            "category": "character",
+            "scope": input.scope,
+            "triggerWords": input.trigger_words,
+            "defaultWeight": input.default_weight,
+            "compatibility": input.compatibility,
+            "createdAt": now,
+            "updatedAt": now
+        });
+        prepend_array_field(&mut character, "loras", link)?;
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn update_lora_link(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        link_id: &str,
+        input: CharacterLoraUpdateInput,
+    ) -> ProjectStoreResult<Value> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let loras = character
+            .get_mut("loras")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| {
+                ProjectStoreError::BadRequest("Character LoRAs must be an array".to_owned())
+            })?;
+        let lora = loras
+            .iter_mut()
+            .find(|item| item.get("id").and_then(Value::as_str) == Some(link_id))
+            .ok_or_else(|| ProjectStoreError::NotFound("Character LoRA not found".to_owned()))?;
+        let object = value_object_mut(lora, "Character LoRA")?;
+        if let Some(name) = input.name {
+            validate_character_name(&name)?;
+            object.insert("name".to_owned(), Value::String(name.trim().to_owned()));
+        }
+        if let Some(trigger_words) = input.trigger_words {
+            object.insert("triggerWords".to_owned(), json!(trigger_words));
+        }
+        if let Some(default_weight) = input.default_weight {
+            validate_lora_weight(default_weight)?;
+            object.insert("defaultWeight".to_owned(), json!(default_weight));
+        }
+        if let Some(compatibility) = input.compatibility {
+            object.insert("compatibility".to_owned(), Value::Object(compatibility));
+        }
+        if let Some(scope) = input.scope {
+            validate_lora_scope(&scope, true)?;
+            object.insert("scope".to_owned(), Value::String(scope));
+        }
+        object.insert("updatedAt".to_owned(), Value::String(utc_now()));
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+
+    pub fn detach_lora(
+        &self,
+        project_id: &str,
+        character_id: &str,
+        link_id: &str,
+    ) -> ProjectStoreResult<Value> {
+        let mut character = read_json(&find_character_file(&self.project_path, character_id)?)?;
+        let loras = character
+            .get("loras")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        value_object_mut(&mut character, "Character sidecar")?.insert(
+            "loras".to_owned(),
+            Value::Array(
+                loras
+                    .into_iter()
+                    .filter(|item| item.get("id").and_then(Value::as_str) != Some(link_id))
+                    .collect(),
+            ),
+        );
+
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        write_character(&self.project_path, &mut character, true)?;
+        index_character_on_connection(&transaction, &self.project_path, &character)?;
+        store_character_index_fingerprint(&transaction, &self.project_path)?;
+        transaction.commit()?;
+
+        hydrate_character(project_id, &self.project_path, character)
+    }
+}
+
+pub fn apply_character_migrations(connection: &Connection) -> ProjectStoreResult<()> {
+    connection.execute_batch(
+        "
+        create table if not exists characters (
+          id text primary key,
+          project_id text not null,
+          name text not null,
+          type text not null,
+          description text not null default '',
+          sidecar_path text not null,
+          created_at text not null,
+          updated_at text not null,
+          archived integer not null default 0
+        );
+        create table if not exists character_references (
+          character_id text not null,
+          asset_id text not null,
+          approved integer not null default 0,
+          role text not null default 'reference',
+          notes text not null default '',
+          added_at text not null,
+          approved_at text,
+          primary key (character_id, asset_id)
+        );
+        create table if not exists character_looks (
+          id text primary key,
+          character_id text not null,
+          name text not null,
+          description text not null default '',
+          approved_reference_ids text not null default '[]',
+          recipe_settings text not null default '{}',
+          created_at text not null,
+          updated_at text not null
+        );
+        create table if not exists character_loras (
+          id text primary key,
+          character_id text not null,
+          lora_id text,
+          name text not null,
+          source_path text,
+          project_path text,
+          copied_into_project integer not null default 0,
+          category text not null default 'character',
+          scope text not null default 'project',
+          trigger_words text not null default '[]',
+          default_weight real not null default 1.0,
+          compatibility text not null default '{}',
+          created_at text not null,
+          updated_at text not null
+        );
+        ",
+    )?;
+    Ok(())
+}
+
+pub fn clear_character_tables(connection: &Connection) -> ProjectStoreResult<()> {
+    connection.execute("delete from character_loras", [])?;
+    connection.execute("delete from character_looks", [])?;
+    connection.execute("delete from character_references", [])?;
+    connection.execute("delete from characters", [])?;
+    Ok(())
+}
+
+pub fn reindex_characters_on_connection(
+    connection: &Connection,
+    project_path: &Path,
+) -> ProjectStoreResult<u32> {
+    let mut count = 0;
+    for sidecar_path in character_sidecars(project_path)? {
+        let Ok(character) = read_json(&sidecar_path) else {
+            continue;
+        };
+        if character.get("id").is_none() {
+            continue;
+        }
+        index_character_sidecar_on_connection(connection, project_path, &sidecar_path, &character)?;
+        count += 1;
+    }
+    store_character_index_fingerprint(connection, project_path)?;
+    Ok(count)
+}
+
+pub fn write_character_sidecar(project_path: &Path, character: &Value) -> ProjectStoreResult<()> {
+    let character_id = required_str(character, "id")?.to_owned();
+    write_character_json(&character_file(project_path, &character_id), character)
+}
+
+fn ensure_character_index(project_path: &Path) -> ProjectStoreResult<()> {
+    let (fingerprint, sidecar_count) = character_index_fingerprint(project_path)?;
+    let mut connection = connect_project_db(project_path)?;
+    let indexed_count = connection.query_row("select count(*) from characters", [], |row| {
+        row.get::<_, u64>(0)
+    })?;
+    let stored_fingerprint = connection
+        .query_row(
+            "select value from project_metadata where key = ?1",
+            params![CHARACTER_INDEX_FINGERPRINT_KEY],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    if stored_fingerprint.as_deref() == Some(fingerprint.as_str()) && indexed_count == sidecar_count
+    {
+        return Ok(());
+    }
+
+    // Sidecars are authoritative. If a previous commit failed after an atomic sidecar write,
+    // or files changed outside the DB path, rebuild only when the sidecar fingerprint changes.
+    let transaction = connection.transaction()?;
+    clear_character_tables(&transaction)?;
+    reindex_characters_on_connection(&transaction, project_path)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn store_character_index_fingerprint(
+    connection: &Connection,
+    project_path: &Path,
+) -> ProjectStoreResult<()> {
+    let (fingerprint, _) = character_index_fingerprint(project_path)?;
+    connection.execute(
+        "insert or replace into project_metadata (key, value) values (?1, ?2)",
+        params![CHARACTER_INDEX_FINGERPRINT_KEY, fingerprint],
+    )?;
+    Ok(())
+}
+
+fn character_index_fingerprint(project_path: &Path) -> ProjectStoreResult<(String, u64)> {
+    let mut entries = Vec::new();
+    for path in character_sidecars(project_path)? {
+        let metadata = fs::metadata(&path)?;
+        let modified_ns = metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        entries.push(format!(
+            "{}:{}:{}",
+            relative_string(project_path, &path)?,
+            metadata.len(),
+            modified_ns
+        ));
+    }
+    entries.sort();
+    Ok((entries.join("|"), entries.len() as u64))
+}
+
+fn index_character_on_connection(
+    connection: &Connection,
+    project_path: &Path,
+    character: &Value,
+) -> ProjectStoreResult<()> {
+    let sidecar_path = character_file(project_path, required_str(character, "id")?);
+    index_character_sidecar_on_connection(connection, project_path, &sidecar_path, character)
+}
+
+fn index_character_sidecar_on_connection(
+    connection: &Connection,
+    project_path: &Path,
+    sidecar_path: &Path,
+    character: &Value,
+) -> ProjectStoreResult<()> {
+    let character_id = required_str(character, "id")?;
+    purge_character_on_connection(connection, character_id)?;
+    let sidecar_rel = relative_string(project_path, sidecar_path)?;
+    connection.execute(
+        "
+        insert or replace into characters (
+          id, project_id, name, type, description, sidecar_path, created_at, updated_at, archived
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ",
+        params![
+            character_id,
+            required_str(character, "projectId")?,
+            required_str(character, "name")?,
+            required_str(character, "type")?,
+            optional_str(character, "description").unwrap_or(""),
+            sidecar_rel,
+            required_str(character, "createdAt")?,
+            optional_str(character, "updatedAt")
+                .or_else(|| optional_str(character, "createdAt"))
+                .unwrap_or(""),
+            optional_bool(character.get("status").unwrap_or(&Value::Null), "archived")
+                .unwrap_or(false),
+        ],
+    )?;
+
+    for reference in character
+        .get("references")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+    {
+        connection.execute(
+            "
+            insert or replace into character_references (
+              character_id, asset_id, approved, role, notes, added_at, approved_at
+            ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            ",
+            params![
+                character_id,
+                required_str(&reference, "assetId")?,
+                optional_bool(&reference, "approved").unwrap_or(false),
+                optional_str(&reference, "role").unwrap_or("reference"),
+                optional_str(&reference, "notes").unwrap_or(""),
+                optional_str(&reference, "addedAt").unwrap_or(""),
+                optional_str(&reference, "approvedAt"),
+            ],
+        )?;
+    }
+
+    for look in character
+        .get("looks")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+    {
+        connection.execute(
+            "
+            insert or replace into character_looks (
+              id, character_id, name, description, approved_reference_ids, recipe_settings,
+              created_at, updated_at
+            ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            ",
+            params![
+                required_str(&look, "id")?,
+                character_id,
+                required_str(&look, "name")?,
+                optional_str(&look, "description").unwrap_or(""),
+                to_json_string(look.get("approvedReferenceIds").unwrap_or(&json!([])))?,
+                to_json_string(look.get("recipeSettings").unwrap_or(&json!({})))?,
+                optional_str(&look, "createdAt").unwrap_or(""),
+                optional_str(&look, "updatedAt")
+                    .or_else(|| optional_str(&look, "createdAt"))
+                    .unwrap_or(""),
+            ],
+        )?;
+    }
+
+    for lora in character
+        .get("loras")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+    {
+        connection.execute(
+            "
+            insert or replace into character_loras (
+              id, character_id, lora_id, name, source_path, project_path, copied_into_project,
+              category, scope, trigger_words, default_weight, compatibility, created_at, updated_at
+            ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            ",
+            params![
+                required_str(&lora, "id")?,
+                character_id,
+                optional_str(&lora, "loraId"),
+                required_str(&lora, "name")?,
+                optional_str(&lora, "sourcePath"),
+                optional_str(&lora, "projectPath"),
+                optional_bool(&lora, "copiedIntoProject").unwrap_or(false),
+                optional_str(&lora, "category").unwrap_or("character"),
+                optional_str(&lora, "scope").unwrap_or("project"),
+                to_json_string(lora.get("triggerWords").unwrap_or(&json!([])))?,
+                optional_f64(&lora, "defaultWeight").unwrap_or(1.0),
+                to_json_string(lora.get("compatibility").unwrap_or(&json!({})))?,
+                optional_str(&lora, "createdAt").unwrap_or(""),
+                optional_str(&lora, "updatedAt")
+                    .or_else(|| optional_str(&lora, "createdAt"))
+                    .unwrap_or(""),
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn purge_character_on_connection(
+    connection: &Connection,
+    character_id: &str,
+) -> ProjectStoreResult<()> {
+    connection.execute(
+        "delete from character_references where character_id = ?1",
+        params![character_id],
+    )?;
+    connection.execute(
+        "delete from character_looks where character_id = ?1",
+        params![character_id],
+    )?;
+    connection.execute(
+        "delete from character_loras where character_id = ?1",
+        params![character_id],
+    )?;
+    connection.execute(
+        "delete from characters where id = ?1",
+        params![character_id],
+    )?;
+    Ok(())
+}
+
+fn connect_project_db(project_path: &Path) -> ProjectStoreResult<Connection> {
+    fs::create_dir_all(project_path)?;
+    let connection = Connection::open(project_path.join("project.db"))?;
+    apply_project_migrations(&connection)?;
+    Ok(connection)
+}
+
+fn character_sidecars(project_path: &Path) -> ProjectStoreResult<Vec<PathBuf>> {
+    let character_dir = project_path.join("characters");
+    let mut sidecars = Vec::new();
+    if !character_dir.exists() {
+        return Ok(sidecars);
+    }
+    for entry in fs::read_dir(character_dir)? {
+        let path = entry?.path();
+        if path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name.ends_with(CHARACTER_SIDECAR_PATTERN))
+        {
+            sidecars.push(path);
+        }
+    }
+    Ok(sidecars)
+}
+
+fn character_file(project_path: &Path, character_id: &str) -> PathBuf {
+    project_path
+        .join("characters")
+        .join(format!("{character_id}.sceneworks.character.json"))
+}
+
+fn find_character_file(project_path: &Path, character_id: &str) -> ProjectStoreResult<PathBuf> {
+    let path = character_file(project_path, character_id);
+    if path.exists() {
+        return Ok(path);
+    }
+    for candidate in character_sidecars(project_path)? {
+        let Ok(character) = read_json(&candidate) else {
+            continue;
+        };
+        if character.get("id").and_then(Value::as_str) == Some(character_id) {
+            return Ok(candidate);
+        }
+    }
+    Err(ProjectStoreError::NotFound(
+        "Character not found".to_owned(),
+    ))
+}
+
+fn write_character(
+    project_path: &Path,
+    character: &mut Value,
+    touch_updated_at: bool,
+) -> ProjectStoreResult<()> {
+    if touch_updated_at {
+        value_object_mut(character, "Character sidecar")?
+            .insert("updatedAt".to_owned(), Value::String(utc_now()));
+    }
+    write_character_sidecar(project_path, character)
+}
+
+fn hydrate_character(
+    project_id: &str,
+    project_path: &Path,
+    mut character: Value,
+) -> ProjectStoreResult<Value> {
+    let references = character
+        .get("references")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|mut reference| {
+            let asset = reference
+                .get("assetId")
+                .and_then(Value::as_str)
+                .and_then(|asset_id| {
+                    character_asset_summary(project_id, project_path, asset_id)
+                        .ok()
+                        .flatten()
+                })
+                .unwrap_or(Value::Null);
+            if let Some(object) = reference.as_object_mut() {
+                object.insert("asset".to_owned(), asset);
+            }
+            reference
+        })
+        .collect::<Vec<_>>();
+    let approved_references = references
+        .iter()
+        .filter(|reference| {
+            reference
+                .get("approved")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let object = value_object_mut(&mut character, "Character sidecar")?;
+    object.insert("references".to_owned(), Value::Array(references));
+    object.insert(
+        "approvedReferences".to_owned(),
+        Value::Array(approved_references),
+    );
+    Ok(character)
+}
+
+fn character_asset_summary(
+    project_id: &str,
+    project_path: &Path,
+    asset_id: &str,
+) -> ProjectStoreResult<Option<Value>> {
+    let Some(sidecar_path) = find_asset_sidecar_path(project_path, asset_id)? else {
+        return Ok(None);
+    };
+    let asset = normalize_asset(project_id, project_path, &sidecar_path)?;
+    Ok(Some(json!({
+        "id": asset.get("id").cloned().unwrap_or(Value::Null),
+        "type": asset.get("type").cloned().unwrap_or(Value::Null),
+        "displayName": asset.get("displayName").cloned().unwrap_or(Value::Null),
+        "url": asset.get("url").cloned().unwrap_or(Value::Null),
+        "status": asset.get("status").cloned().unwrap_or_else(|| json!({})),
+        "file": asset.get("file").cloned().unwrap_or_else(|| json!({}))
+    })))
+}
+
+fn update_asset_character_link(
+    connection: &Connection,
+    project_path: &Path,
+    character_id: &str,
+    reference: &Value,
+    remove: bool,
+) -> ProjectStoreResult<()> {
+    let asset_id = required_str(reference, "assetId")?;
+    let sidecar_path =
+        find_asset_sidecar_path_on_connection(connection, project_path, asset_id)?
+            .ok_or_else(|| ProjectStoreError::NotFound("Reference asset not found".to_owned()))?;
+    let mut asset = read_json(&sidecar_path)?;
+    let metadata = value_object_mut(&mut asset, "Asset sidecar")?
+        .entry("metadata".to_owned())
+        .or_insert_with(|| json!({}));
+    let metadata = metadata.as_object_mut().ok_or_else(|| {
+        ProjectStoreError::BadRequest("Asset metadata must be an object".to_owned())
+    })?;
+    let mut links = metadata
+        .remove("characterReferences")
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|item| item.get("characterId").and_then(Value::as_str) != Some(character_id))
+        .collect::<Vec<_>>();
+    if !remove {
+        links.push(json!({
+            "characterId": character_id,
+            "source": "character-sidecar",
+            "approved": reference.get("approved").and_then(Value::as_bool).unwrap_or(false),
+            "role": reference.get("role").and_then(Value::as_str).unwrap_or("reference"),
+            "linkedAt": reference.get("addedAt").and_then(Value::as_str).unwrap_or("").to_owned(),
+            "approvedAt": reference.get("approvedAt").cloned().unwrap_or(Value::Null)
+        }));
+    }
+    metadata.insert("characterReferences".to_owned(), Value::Array(links));
+    write_json(&sidecar_path, &asset)?;
+    index_asset_on_connection(connection, project_path, &asset, Some(&sidecar_path))
+}
+
+fn find_asset_sidecar_path(
+    project_path: &Path,
+    asset_id: &str,
+) -> ProjectStoreResult<Option<PathBuf>> {
+    let connection = connect_project_db(project_path)?;
+    apply_project_migrations(&connection)?;
+    find_asset_sidecar_path_on_connection(&connection, project_path, asset_id)
+}
+
+fn find_asset_sidecar_path_on_connection(
+    connection: &Connection,
+    project_path: &Path,
+    asset_id: &str,
+) -> ProjectStoreResult<Option<PathBuf>> {
+    if let Some(record) = connection
+        .query_row(
+            "select file_path, sidecar_path from assets where id = ?1",
+            params![asset_id],
+            row_to_asset_record,
+        )
+        .optional()?
+    {
+        let mut candidates = Vec::new();
+        if let Some(sidecar_path) = record.sidecar_path {
+            candidates.push(project_path.join(sidecar_path));
+        }
+        if let Some(file_path) = record.file_path {
+            candidates.push(
+                project_path
+                    .join(file_path)
+                    .with_extension("sceneworks.json"),
+            );
+        }
+        for candidate in candidates {
+            if candidate.exists() {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+    for sidecar_path in asset_sidecars(project_path)? {
+        let Ok(asset) = read_json(&sidecar_path) else {
+            continue;
+        };
+        if asset.get("id").and_then(Value::as_str) == Some(asset_id) {
+            return Ok(Some(sidecar_path));
+        }
+    }
+    Ok(None)
+}
+
+#[derive(Debug)]
+struct AssetRecord {
+    file_path: Option<String>,
+    sidecar_path: Option<String>,
+}
+
+fn row_to_asset_record(row: &Row<'_>) -> rusqlite::Result<AssetRecord> {
+    Ok(AssetRecord {
+        file_path: row.get(0)?,
+        sidecar_path: row.get(1)?,
+    })
+}
+
+fn asset_sidecars(project_path: &Path) -> ProjectStoreResult<Vec<PathBuf>> {
+    let mut sidecars = Vec::new();
+    for folder in ASSET_FOLDERS {
+        collect_sidecars(&project_path.join(folder), &mut sidecars)?;
+    }
+    let timeline_dir = project_path.join("timelines");
+    sidecars.retain(|path| !path.starts_with(&timeline_dir));
+    Ok(sidecars)
+}
+
+fn collect_sidecars(path: &Path, sidecars: &mut Vec<PathBuf>) -> ProjectStoreResult<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(path)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_sidecars(&path, sidecars)?;
+        } else if path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name.ends_with(ASSET_SIDECAR_PATTERN.trim_start_matches('*')))
+        {
+            sidecars.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn normalize_asset(
+    project_id: &str,
+    project_path: &Path,
+    sidecar_path: &Path,
+) -> ProjectStoreResult<Value> {
+    let mut asset = read_json(sidecar_path)?;
+    if let Some(path) = asset.pointer("/file/path").and_then(Value::as_str) {
+        let normalized_path = path.replace('\\', "/");
+        if let Some(object) = asset.as_object_mut() {
+            object.insert(
+                "url".to_owned(),
+                Value::String(format!(
+                    "/api/v1/projects/{project_id}/files/{normalized_path}"
+                )),
+            );
+        }
+    }
+    let sidecar_rel = relative_string(project_path, sidecar_path)?;
+    if let Some(object) = asset.as_object_mut() {
+        object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));
+    }
+    Ok(asset)
+}
+
+fn index_asset_on_connection(
+    connection: &Connection,
+    project_path: &Path,
+    asset: &Value,
+    sidecar_path: Option<&Path>,
+) -> ProjectStoreResult<()> {
+    let sidecar_rel = match sidecar_path {
+        Some(path) => Some(relative_string(project_path, path)?),
+        None => None,
+    };
+    let status = asset.get("status").unwrap_or(&Value::Null);
+    connection.execute(
+        "
+        insert or replace into assets (
+          id, type, display_name, file_path, generation_set_id, created_at,
+          favorite, rating, rejected, trashed, sidecar_path
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+        ",
+        params![
+            required_str(asset, "id")?,
+            required_str(asset, "type")?,
+            required_str(asset, "displayName")?,
+            asset
+                .get("file")
+                .and_then(|file| optional_str(file, "path"))
+                .ok_or_else(|| ProjectStoreError::BadRequest(
+                    "Asset file path is required".to_owned()
+                ))?,
+            optional_str(asset, "generationSetId"),
+            required_str(asset, "createdAt")?,
+            optional_bool(status, "favorite").unwrap_or(false),
+            optional_u64(status, "rating").unwrap_or(0),
+            optional_bool(status, "rejected").unwrap_or(false),
+            optional_bool(status, "trashed").unwrap_or(false),
+            sidecar_rel,
+        ],
+    )?;
+    Ok(())
+}
+
+fn copy_lora_into_project(
+    project_path: &Path,
+    data_dir: &Path,
+    character_id: &str,
+    source_path: Option<&str>,
+) -> ProjectStoreResult<(Option<String>, bool)> {
+    let Some(source_path) = source_path.filter(|value| !value.trim().is_empty()) else {
+        return Ok((None, false));
+    };
+    let source_path = PathBuf::from(source_path);
+    if !source_path.exists() || !(source_path.is_file() || source_path.is_dir()) {
+        return Err(ProjectStoreError::BadRequest(format!(
+            "LoRA source path not found: {}",
+            source_path.display()
+        )));
+    }
+    assert_allowed_lora_source(project_path, data_dir, &source_path)?;
+    let target_dir = project_path
+        .join("loras")
+        .join("characters")
+        .join(character_id);
+    fs::create_dir_all(&target_dir)?;
+    let target = target_dir.join(
+        source_path
+            .file_name()
+            .ok_or_else(|| ProjectStoreError::BadRequest("Invalid LoRA source path".to_owned()))?,
+    );
+    if fs::canonicalize(&source_path).ok() != fs::canonicalize(&target).ok() {
+        if source_path.is_dir() {
+            copy_dir_recursive(&source_path, &target)?;
+        } else {
+            fs::copy(&source_path, &target)?;
+        }
+    }
+    Ok((Some(relative_string(project_path, &target)?), true))
+}
+
+fn assert_allowed_lora_source(
+    project_path: &Path,
+    data_dir: &Path,
+    source_path: &Path,
+) -> ProjectStoreResult<()> {
+    let resolved = fs::canonicalize(source_path)?;
+    let roots = [data_dir.join("loras"), project_path.join("loras")];
+    for root in roots {
+        if let Ok(root) = fs::canonicalize(root) {
+            if resolved.starts_with(root) {
+                return Ok(());
+            }
+        }
+    }
+    Err(ProjectStoreError::BadRequest(
+        "LoRA source path must be inside the app-managed data/loras or project/loras folders"
+            .to_owned(),
+    ))
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> ProjectStoreResult<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn prepend_array_field(payload: &mut Value, field: &str, item: Value) -> ProjectStoreResult<()> {
+    let object = value_object_mut(payload, "Character sidecar")?;
+    let mut items = object
+        .remove(field)
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default();
+    items.insert(0, item);
+    object.insert(field.to_owned(), Value::Array(items));
+    Ok(())
+}
+
+fn read_json(path: &Path) -> ProjectStoreResult<Value> {
+    let payload = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&payload)?)
+}
+
+fn write_json(path: &Path, payload: &Value) -> ProjectStoreResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut output = serde_json::to_string_pretty(payload)?;
+    output.push('\n');
+    let tmp_path = path.with_extension(format!(
+        "{}.tmp",
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("json")
+    ));
+    fs::write(&tmp_path, output)?;
+    fs::rename(tmp_path, path)?;
+    Ok(())
+}
+
+fn write_character_json(path: &Path, payload: &Value) -> ProjectStoreResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut output = String::new();
+    write_character_value(payload, 0, None, &mut output)?;
+    output.push('\n');
+    let tmp_path = path.with_extension(format!(
+        "{}.tmp",
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("json")
+    ));
+    fs::write(&tmp_path, output)?;
+    fs::rename(tmp_path, path)?;
+    Ok(())
+}
+
+fn write_character_value(
+    value: &Value,
+    indent: usize,
+    key_hint: Option<&str>,
+    output: &mut String,
+) -> ProjectStoreResult<()> {
+    match value {
+        Value::Object(object) if should_inline_object(key_hint) => {
+            write_inline_value(&Value::Object(object.clone()), output)?;
+        }
+        Value::Object(object) => {
+            if object.is_empty() {
+                output.push_str("{}");
+                return Ok(());
+            }
+            output.push_str("{\n");
+            let keys = ordered_character_keys(object);
+            for (index, key) in keys.iter().enumerate() {
+                output.push_str(&" ".repeat(indent + 2));
+                output.push_str(&serde_json::to_string(key)?);
+                output.push_str(": ");
+                write_character_value(&object[*key], indent + 2, Some(key), output)?;
+                if index + 1 != keys.len() {
+                    output.push(',');
+                }
+                output.push('\n');
+            }
+            output.push_str(&" ".repeat(indent));
+            output.push('}');
+        }
+        Value::Array(items) if items.is_empty() || items.iter().all(is_inline_json_value) => {
+            write_inline_value(value, output)?;
+        }
+        Value::Array(items) => {
+            output.push_str("[\n");
+            for (index, item) in items.iter().enumerate() {
+                output.push_str(&" ".repeat(indent + 2));
+                write_character_value(item, indent + 2, key_hint, output)?;
+                if index + 1 != items.len() {
+                    output.push(',');
+                }
+                output.push('\n');
+            }
+            output.push_str(&" ".repeat(indent));
+            output.push(']');
+        }
+        _ => write_inline_value(value, output)?,
+    }
+    Ok(())
+}
+
+fn should_inline_object(key_hint: Option<&str>) -> bool {
+    matches!(key_hint, Some("recipeSettings" | "compatibility"))
+}
+
+fn is_inline_json_value(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
+    )
+}
+
+fn write_inline_value(value: &Value, output: &mut String) -> ProjectStoreResult<()> {
+    match value {
+        Value::Object(object) => {
+            output.push_str("{ ");
+            let keys = ordered_character_keys(object);
+            for (index, key) in keys.iter().enumerate() {
+                output.push_str(&serde_json::to_string(key)?);
+                output.push_str(": ");
+                write_inline_value(&object[*key], output)?;
+                if index + 1 != keys.len() {
+                    output.push_str(", ");
+                }
+            }
+            output.push_str(" }");
+        }
+        Value::Array(items) => {
+            output.push('[');
+            for (index, item) in items.iter().enumerate() {
+                write_inline_value(item, output)?;
+                if index + 1 != items.len() {
+                    output.push_str(", ");
+                }
+            }
+            output.push(']');
+        }
+        _ => output.push_str(&serde_json::to_string(value)?),
+    }
+    Ok(())
+}
+
+fn ordered_character_keys(object: &Map<String, Value>) -> Vec<&str> {
+    let preferred: &[&str] =
+        if object.contains_key("schemaVersion") && object.contains_key("trainedLoras") {
+            &[
+                "schemaVersion",
+                "id",
+                "projectId",
+                "name",
+                "type",
+                "description",
+                "createdAt",
+                "updatedAt",
+                "status",
+                "references",
+                "looks",
+                "loras",
+                "trainedLoras",
+            ]
+        } else if object.contains_key("assetId") && object.contains_key("addedAt") {
+            &[
+                "assetId",
+                "approved",
+                "role",
+                "notes",
+                "addedAt",
+                "approvedAt",
+                "asset",
+            ]
+        } else if object.contains_key("approvedReferenceIds") {
+            &[
+                "id",
+                "name",
+                "description",
+                "approvedReferenceIds",
+                "recipeSettings",
+                "createdAt",
+                "updatedAt",
+            ]
+        } else if object.contains_key("loraId") || object.contains_key("copiedIntoProject") {
+            &[
+                "id",
+                "loraId",
+                "name",
+                "sourcePath",
+                "projectPath",
+                "copiedIntoProject",
+                "category",
+                "scope",
+                "triggerWords",
+                "defaultWeight",
+                "compatibility",
+                "createdAt",
+                "updatedAt",
+            ]
+        } else if object.contains_key("archived") {
+            &["archived"]
+        } else {
+            &[]
+        };
+
+    let mut keys = Vec::new();
+    for key in preferred {
+        if object.contains_key(*key) {
+            keys.push(*key);
+        }
+    }
+    for key in object.keys() {
+        if !keys.iter().any(|existing| existing == key) {
+            keys.push(key.as_str());
+        }
+    }
+    keys
+}
+
+fn relative_string(root: &Path, path: &Path) -> ProjectStoreResult<String> {
+    Ok(path
+        .strip_prefix(root)
+        .map_err(|_| ProjectStoreError::BadRequest("Path is outside project".to_owned()))?
+        .to_string_lossy()
+        .replace('\\', "/"))
+}
+
+fn to_json_string(value: &Value) -> ProjectStoreResult<String> {
+    serde_json::to_string(value).map_err(Into::into)
+}
+
+fn required_str<'a>(value: &'a Value, key: &str) -> ProjectStoreResult<&'a str> {
+    optional_str(value, key).ok_or_else(|| {
+        ProjectStoreError::BadRequest(format!(
+            "{} is required",
+            camel_to_title(key).unwrap_or_else(|| key.to_owned())
+        ))
+    })
+}
+
+fn optional_str<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(Value::as_str)
+}
+
+fn optional_bool(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(Value::as_bool)
+}
+
+fn optional_u64(value: &Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(Value::as_u64)
+}
+
+fn optional_f64(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64)
+}
+
+fn value_object_mut<'a>(
+    value: &'a mut Value,
+    label: &str,
+) -> ProjectStoreResult<&'a mut Map<String, Value>> {
+    value
+        .as_object_mut()
+        .ok_or_else(|| ProjectStoreError::BadRequest(format!("{label} must be an object")))
+}
+
+fn validate_required_text(value: &str, key: &str) -> ProjectStoreResult<()> {
+    if value.trim().is_empty() {
+        return Err(ProjectStoreError::BadRequest(format!(
+            "{} is required",
+            camel_to_title(key).unwrap_or_else(|| key.to_owned())
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text_length(value: &str, key: &str, max: usize) -> ProjectStoreResult<()> {
+    if value.chars().count() > max {
+        return Err(ProjectStoreError::BadRequest(format!(
+            "{key} must be at most {max} characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_character_name(value: &str) -> ProjectStoreResult<()> {
+    validate_required_text(value, "name")?;
+    let max = 120;
+    if value.chars().count() > max {
+        return Err(ProjectStoreError::BadRequest(format!(
+            "name must be at most {max} characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_character_type(value: &str) -> ProjectStoreResult<()> {
+    if matches!(value, "person" | "creature" | "object") {
+        return Ok(());
+    }
+    Err(ProjectStoreError::BadRequest(
+        "Character type must be person, creature, or object".to_owned(),
+    ))
+}
+
+fn validate_lora_weight(value: f64) -> ProjectStoreResult<()> {
+    if !value.is_finite() || !(-2.0..=2.0).contains(&value) {
+        return Err(ProjectStoreError::BadRequest(
+            "defaultWeight must be between -2 and 2".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_lora_scope(value: &str, allow_empty: bool) -> ProjectStoreResult<()> {
+    if allow_empty && value.trim().is_empty() {
+        return Ok(());
+    }
+    if matches!(value, "project" | "global") {
+        return Ok(());
+    }
+    Err(ProjectStoreError::BadRequest(
+        "scope must be project or global".to_owned(),
+    ))
+}
+
+fn camel_to_title(value: &str) -> Option<String> {
+    if value.is_empty() {
+        return None;
+    }
+    let mut output = String::new();
+    for character in value.chars() {
+        if character.is_uppercase() && !output.is_empty() {
+            output.push(' ');
+        }
+        output.push(character);
+    }
+    let mut characters = output.chars();
+    let first = characters.next()?.to_uppercase().collect::<String>();
+    Some(format!("{first}{}", characters.as_str()))
+}
+
+fn random_hex(bytes: usize) -> ProjectStoreResult<String> {
+    let connection = Connection::open_in_memory()?;
+    Ok(connection.query_row(
+        &format!("select lower(hex(randomblob({bytes})))"),
+        [],
+        |row| row.get(0),
+    )?)
+}
+
+fn utc_now() -> String {
+    format_unix_seconds(now_unix_seconds())
+}
+
+fn now_unix_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| i64::try_from(duration.as_secs()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+fn format_unix_seconds(timestamp: i64) -> String {
+    let days = timestamp.div_euclid(86_400);
+    let seconds_of_day = timestamp.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = (seconds_of_day % 3_600) / 60;
+    let second = seconds_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let adjusted_days = days + 719_468;
+    let era = adjusted_days.div_euclid(146_097);
+    let day_of_era = adjusted_days - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (year, month, day)
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod character_store;
 pub mod contracts;
 pub mod jobs_store;
 pub mod project_store;

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -7,8 +7,17 @@ use rusqlite::{params, Connection, OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
+use crate::character_store::{
+    apply_character_migrations, clear_character_tables, reindex_characters_on_connection,
+    CharacterStore,
+};
+pub use crate::character_store::{
+    CharacterCreateInput, CharacterLookInput, CharacterLookUpdateInput, CharacterLoraInput,
+    CharacterLoraUpdateInput, CharacterMutationResult, CharacterReferenceInput,
+    CharacterReferenceUpdateInput, CharacterUpdateInput, CHARACTER_SIDECAR_PATTERN,
+};
+
 pub const ASSET_SIDECAR_PATTERN: &str = "*.sceneworks.json";
-pub const CHARACTER_SIDECAR_PATTERN: &str = ".sceneworks.character.json";
 pub const PROJECT_FOLDERS: &[&str] = &[
     "assets/images",
     "assets/videos",
@@ -134,78 +143,6 @@ pub struct AssetStatusPatch {
     pub rating: Option<u8>,
     pub rejected: Option<bool>,
     pub trashed: Option<bool>,
-}
-
-#[derive(Debug, Clone)]
-pub struct CharacterCreateInput {
-    pub name: String,
-    pub character_type: String,
-    pub description: String,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct CharacterUpdateInput {
-    pub name: Option<String>,
-    pub character_type: Option<String>,
-    pub description: Option<String>,
-    pub archived: Option<bool>,
-}
-
-#[derive(Debug, Clone)]
-pub struct CharacterReferenceInput {
-    pub asset_id: String,
-    pub approved: bool,
-    pub role: String,
-    pub notes: String,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct CharacterReferenceUpdateInput {
-    pub approved: Option<bool>,
-    pub role: Option<String>,
-    pub notes: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct CharacterLookInput {
-    pub name: String,
-    pub description: String,
-    pub approved_reference_ids: Vec<String>,
-    pub recipe_settings: Map<String, Value>,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct CharacterLookUpdateInput {
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub approved_reference_ids: Option<Vec<String>>,
-    pub recipe_settings: Option<Map<String, Value>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct CharacterLoraInput {
-    pub lora_id: Option<String>,
-    pub name: String,
-    pub source_path: Option<String>,
-    pub trigger_words: Vec<String>,
-    pub default_weight: f64,
-    pub compatibility: Map<String, Value>,
-    pub scope: String,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct CharacterLoraUpdateInput {
-    pub name: Option<String>,
-    pub trigger_words: Option<Vec<String>>,
-    pub default_weight: Option<f64>,
-    pub compatibility: Option<Map<String, Value>>,
-    pub scope: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CharacterMutationResult {
-    pub id: String,
-    pub status: String,
 }
 
 #[derive(Debug, Clone)]
@@ -587,33 +524,8 @@ impl ProjectStore {
         include_archived: bool,
     ) -> ProjectStoreResult<Vec<Value>> {
         let project_path = self.find_project_path(project_id)?;
-        let mut characters = Vec::new();
-        for path in character_sidecars(&project_path)? {
-            let Ok(character) = read_json(&path) else {
-                continue;
-            };
-            if character
-                .pointer("/status/archived")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-                && !include_archived
-            {
-                continue;
-            }
-            characters.push(hydrate_character(project_id, &project_path, character)?);
-        }
-        characters.sort_by(|left, right| {
-            right
-                .get("updatedAt")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .cmp(
-                    left.get("updatedAt")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default(),
-                )
-        });
-        Ok(characters)
+        CharacterStore::new(&self.data_dir, project_path)
+            .list_characters(project_id, include_archived)
     }
 
     pub fn create_character(
@@ -621,38 +533,13 @@ impl ProjectStore {
         project_id: &str,
         input: CharacterCreateInput,
     ) -> ProjectStoreResult<Value> {
-        validate_character_name(&input.name)?;
-        validate_character_type(&input.character_type)?;
-        validate_text_length(&input.description, "description", 2000)?;
         let project_path = self.find_project_path(project_id)?;
-        let now = utc_now();
-        let character_id = format!("character_{}", random_hex(16)?);
-        let character = json!({
-            "schemaVersion": 1,
-            "id": character_id,
-            "projectId": project_id,
-            "name": input.name.trim(),
-            "type": input.character_type,
-            "description": input.description.trim(),
-            "createdAt": now,
-            "updatedAt": now,
-            "status": { "archived": false },
-            "references": [],
-            "looks": [],
-            "loras": [],
-            "trainedLoras": []
-        });
-        write_json(
-            &character_file(&project_path, required_str(&character, "id")?),
-            &character,
-        )?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).create_character(project_id, input)
     }
 
     pub fn get_character(&self, project_id: &str, character_id: &str) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let character = read_json(&find_character_file(&project_path, character_id)?)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).get_character(project_id, character_id)
     }
 
     pub fn update_character(
@@ -662,35 +549,11 @@ impl ProjectStore {
         input: CharacterUpdateInput,
     ) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let object = value_object_mut(&mut character, "Character sidecar")?;
-        if let Some(name) = input.name {
-            validate_character_name(&name)?;
-            object.insert("name".to_owned(), Value::String(name.trim().to_owned()));
-        }
-        if let Some(character_type) = input.character_type {
-            validate_character_type(&character_type)?;
-            object.insert("type".to_owned(), Value::String(character_type));
-        }
-        if let Some(description) = input.description {
-            validate_text_length(&description, "description", 2000)?;
-            object.insert(
-                "description".to_owned(),
-                Value::String(description.trim().to_owned()),
-            );
-        }
-        if let Some(archived) = input.archived {
-            object
-                .entry("status".to_owned())
-                .or_insert_with(|| json!({}))
-                .as_object_mut()
-                .ok_or_else(|| {
-                    ProjectStoreError::BadRequest("Character status must be an object".to_owned())
-                })?
-                .insert("archived".to_owned(), Value::Bool(archived));
-        }
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).update_character(
+            project_id,
+            character_id,
+            input,
+        )
     }
 
     pub fn archive_character(
@@ -699,20 +562,7 @@ impl ProjectStore {
         character_id: &str,
     ) -> ProjectStoreResult<CharacterMutationResult> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        value_object_mut(&mut character, "Character sidecar")?
-            .entry("status".to_owned())
-            .or_insert_with(|| json!({}))
-            .as_object_mut()
-            .ok_or_else(|| {
-                ProjectStoreError::BadRequest("Character status must be an object".to_owned())
-            })?
-            .insert("archived".to_owned(), Value::Bool(true));
-        write_character(&project_path, &mut character)?;
-        Ok(CharacterMutationResult {
-            id: character_id.to_owned(),
-            status: "archived".to_owned(),
-        })
+        CharacterStore::new(&self.data_dir, project_path).archive_character(character_id)
     }
 
     pub fn purge_character(
@@ -721,12 +571,7 @@ impl ProjectStore {
         character_id: &str,
     ) -> ProjectStoreResult<CharacterMutationResult> {
         let project_path = self.find_project_path(project_id)?;
-        let path = find_character_file(&project_path, character_id)?;
-        fs::remove_file(path)?;
-        Ok(CharacterMutationResult {
-            id: character_id.to_owned(),
-            status: "purged".to_owned(),
-        })
+        CharacterStore::new(&self.data_dir, project_path).purge_character(character_id)
     }
 
     pub fn add_character_reference(
@@ -735,37 +580,12 @@ impl ProjectStore {
         character_id: &str,
         input: CharacterReferenceInput,
     ) -> ProjectStoreResult<Value> {
-        validate_required_text(&input.asset_id, "assetId")?;
-        validate_text_length(&input.role, "role", 80)?;
-        validate_text_length(&input.notes, "notes", 1000)?;
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let now = utc_now();
-        let reference = json!({
-            "assetId": input.asset_id,
-            "approved": input.approved,
-            "role": if input.role.trim().is_empty() { "reference" } else { input.role.trim() },
-            "notes": input.notes,
-            "addedAt": now,
-            "approvedAt": if input.approved { Value::String(now) } else { Value::Null }
-        });
-        update_asset_character_link(&project_path, character_id, &reference, false)?;
-        let object = value_object_mut(&mut character, "Character sidecar")?;
-        let mut references = object
-            .remove("references")
-            .and_then(|value| value.as_array().cloned())
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|item| {
-                item.get("assetId")
-                    .and_then(Value::as_str)
-                    .is_some_and(|asset_id| asset_id != input.asset_id)
-            })
-            .collect::<Vec<_>>();
-        references.insert(0, reference);
-        object.insert("references".to_owned(), Value::Array(references));
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).add_reference(
+            project_id,
+            character_id,
+            input,
+        )
     }
 
     pub fn update_character_reference(
@@ -776,48 +596,12 @@ impl ProjectStore {
         input: CharacterReferenceUpdateInput,
     ) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let references = character
-            .get_mut("references")
-            .and_then(Value::as_array_mut)
-            .ok_or_else(|| {
-                ProjectStoreError::BadRequest("Character references must be an array".to_owned())
-            })?;
-        let reference = references
-            .iter_mut()
-            .find(|item| item.get("assetId").and_then(Value::as_str) == Some(asset_id))
-            .ok_or_else(|| ProjectStoreError::NotFound("Reference not found".to_owned()))?;
-        if let Some(approved) = input.approved {
-            value_object_mut(reference, "Character reference")?
-                .insert("approved".to_owned(), Value::Bool(approved));
-            value_object_mut(reference, "Character reference")?.insert(
-                "approvedAt".to_owned(),
-                if approved {
-                    Value::String(utc_now())
-                } else {
-                    Value::Null
-                },
-            );
-        }
-        if let Some(role) = input.role {
-            validate_text_length(&role, "role", 80)?;
-            value_object_mut(reference, "Character reference")?.insert(
-                "role".to_owned(),
-                Value::String(if role.trim().is_empty() {
-                    "reference".to_owned()
-                } else {
-                    role
-                }),
-            );
-        }
-        if let Some(notes) = input.notes {
-            validate_text_length(&notes, "notes", 1000)?;
-            value_object_mut(reference, "Character reference")?
-                .insert("notes".to_owned(), Value::String(notes));
-        }
-        update_asset_character_link(&project_path, character_id, reference, false)?;
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).update_reference(
+            project_id,
+            character_id,
+            asset_id,
+            input,
+        )
     }
 
     pub fn remove_character_reference(
@@ -827,28 +611,11 @@ impl ProjectStore {
         asset_id: &str,
     ) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let references = character
-            .get("references")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        let reference = references
-            .iter()
-            .find(|item| item.get("assetId").and_then(Value::as_str) == Some(asset_id))
-            .ok_or_else(|| ProjectStoreError::NotFound("Reference not found".to_owned()))?;
-        update_asset_character_link(&project_path, character_id, reference, true)?;
-        value_object_mut(&mut character, "Character sidecar")?.insert(
-            "references".to_owned(),
-            Value::Array(
-                references
-                    .into_iter()
-                    .filter(|item| item.get("assetId").and_then(Value::as_str) != Some(asset_id))
-                    .collect(),
-            ),
-        );
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).remove_reference(
+            project_id,
+            character_id,
+            asset_id,
+        )
     }
 
     pub fn create_character_look(
@@ -857,23 +624,12 @@ impl ProjectStore {
         character_id: &str,
         input: CharacterLookInput,
     ) -> ProjectStoreResult<Value> {
-        validate_character_name(&input.name)?;
-        validate_text_length(&input.description, "description", 1000)?;
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let now = utc_now();
-        let look = json!({
-            "id": format!("look_{}", random_hex(16)?),
-            "name": input.name.trim(),
-            "description": input.description.trim(),
-            "approvedReferenceIds": input.approved_reference_ids,
-            "recipeSettings": input.recipe_settings,
-            "createdAt": now,
-            "updatedAt": now
-        });
-        prepend_array_field(&mut character, "looks", look)?;
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).create_look(
+            project_id,
+            character_id,
+            input,
+        )
     }
 
     pub fn update_character_look(
@@ -884,41 +640,12 @@ impl ProjectStore {
         input: CharacterLookUpdateInput,
     ) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let looks = character
-            .get_mut("looks")
-            .and_then(Value::as_array_mut)
-            .ok_or_else(|| {
-                ProjectStoreError::BadRequest("Character looks must be an array".to_owned())
-            })?;
-        let look = looks
-            .iter_mut()
-            .find(|item| item.get("id").and_then(Value::as_str) == Some(look_id))
-            .ok_or_else(|| ProjectStoreError::NotFound("Look not found".to_owned()))?;
-        let object = value_object_mut(look, "Character look")?;
-        if let Some(name) = input.name {
-            validate_character_name(&name)?;
-            object.insert("name".to_owned(), Value::String(name.trim().to_owned()));
-        }
-        if let Some(description) = input.description {
-            validate_text_length(&description, "description", 1000)?;
-            object.insert(
-                "description".to_owned(),
-                Value::String(description.trim().to_owned()),
-            );
-        }
-        if let Some(approved_reference_ids) = input.approved_reference_ids {
-            object.insert(
-                "approvedReferenceIds".to_owned(),
-                json!(approved_reference_ids),
-            );
-        }
-        if let Some(recipe_settings) = input.recipe_settings {
-            object.insert("recipeSettings".to_owned(), Value::Object(recipe_settings));
-        }
-        object.insert("updatedAt".to_owned(), Value::String(utc_now()));
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).update_look(
+            project_id,
+            character_id,
+            look_id,
+            input,
+        )
     }
 
     pub fn delete_character_look(
@@ -928,23 +655,11 @@ impl ProjectStore {
         look_id: &str,
     ) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let looks = character
-            .get("looks")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        value_object_mut(&mut character, "Character sidecar")?.insert(
-            "looks".to_owned(),
-            Value::Array(
-                looks
-                    .into_iter()
-                    .filter(|item| item.get("id").and_then(Value::as_str) != Some(look_id))
-                    .collect(),
-            ),
-        );
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).delete_look(
+            project_id,
+            character_id,
+            look_id,
+        )
     }
 
     pub fn attach_character_lora(
@@ -953,36 +668,12 @@ impl ProjectStore {
         character_id: &str,
         input: CharacterLoraInput,
     ) -> ProjectStoreResult<Value> {
-        validate_character_name(&input.name)?;
-        validate_lora_weight(input.default_weight)?;
-        validate_lora_scope(&input.scope, true)?;
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let (project_lora_path, copied) = copy_lora_into_project(
-            &project_path,
-            &self.data_dir,
+        CharacterStore::new(&self.data_dir, project_path).attach_lora(
+            project_id,
             character_id,
-            input.source_path.as_deref(),
-        )?;
-        let now = utc_now();
-        let link = json!({
-            "id": format!("character_lora_{}", random_hex(16)?),
-            "loraId": input.lora_id,
-            "name": input.name.trim(),
-            "sourcePath": input.source_path,
-            "projectPath": project_lora_path,
-            "copiedIntoProject": copied,
-            "category": "character",
-            "scope": input.scope,
-            "triggerWords": input.trigger_words,
-            "defaultWeight": input.default_weight,
-            "compatibility": input.compatibility,
-            "createdAt": now,
-            "updatedAt": now
-        });
-        prepend_array_field(&mut character, "loras", link)?;
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+            input,
+        )
     }
 
     pub fn update_character_lora(
@@ -993,39 +684,12 @@ impl ProjectStore {
         input: CharacterLoraUpdateInput,
     ) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let loras = character
-            .get_mut("loras")
-            .and_then(Value::as_array_mut)
-            .ok_or_else(|| {
-                ProjectStoreError::BadRequest("Character LoRAs must be an array".to_owned())
-            })?;
-        let lora = loras
-            .iter_mut()
-            .find(|item| item.get("id").and_then(Value::as_str) == Some(link_id))
-            .ok_or_else(|| ProjectStoreError::NotFound("Character LoRA not found".to_owned()))?;
-        let object = value_object_mut(lora, "Character LoRA")?;
-        if let Some(name) = input.name {
-            validate_character_name(&name)?;
-            object.insert("name".to_owned(), Value::String(name.trim().to_owned()));
-        }
-        if let Some(trigger_words) = input.trigger_words {
-            object.insert("triggerWords".to_owned(), json!(trigger_words));
-        }
-        if let Some(default_weight) = input.default_weight {
-            validate_lora_weight(default_weight)?;
-            object.insert("defaultWeight".to_owned(), json!(default_weight));
-        }
-        if let Some(compatibility) = input.compatibility {
-            object.insert("compatibility".to_owned(), Value::Object(compatibility));
-        }
-        if let Some(scope) = input.scope {
-            validate_lora_scope(&scope, true)?;
-            object.insert("scope".to_owned(), Value::String(scope));
-        }
-        object.insert("updatedAt".to_owned(), Value::String(utc_now()));
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).update_lora_link(
+            project_id,
+            character_id,
+            link_id,
+            input,
+        )
     }
 
     pub fn detach_character_lora(
@@ -1035,23 +699,11 @@ impl ProjectStore {
         link_id: &str,
     ) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
-        let mut character = read_json(&find_character_file(&project_path, character_id)?)?;
-        let loras = character
-            .get("loras")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        value_object_mut(&mut character, "Character sidecar")?.insert(
-            "loras".to_owned(),
-            Value::Array(
-                loras
-                    .into_iter()
-                    .filter(|item| item.get("id").and_then(Value::as_str) != Some(link_id))
-                    .collect(),
-            ),
-        );
-        write_character(&project_path, &mut character)?;
-        hydrate_character(project_id, &project_path, character)
+        CharacterStore::new(&self.data_dir, project_path).detach_lora(
+            project_id,
+            character_id,
+            link_id,
+        )
     }
 
     pub fn list_person_tracks(&self, project_id: &str) -> ProjectStoreResult<Vec<Value>> {
@@ -1461,7 +1113,7 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
           key text primary key,
           value text not null
         );
-        insert or replace into project_metadata (key, value) values ('schemaVersion', '1');
+        insert or ignore into project_metadata (key, value) values ('schemaVersion', '1');
         create table if not exists assets (
           id text primary key,
           type text not null,
@@ -1497,6 +1149,7 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
         ",
     )?;
     ensure_column(connection, "assets", "sidecar_path", "text")?;
+    apply_character_migrations(connection)?;
     Ok(())
 }
 
@@ -1511,6 +1164,7 @@ fn reindex_project_path(project_path: &Path) -> ProjectStoreResult<ReindexCounts
     transaction.execute("delete from assets", [])?;
     transaction.execute("delete from generation_sets", [])?;
     transaction.execute("delete from timelines", [])?;
+    clear_character_tables(&transaction)?;
 
     let mut counts = ReindexCounts::default();
     for sidecar_path in asset_sidecars(project_path)? {
@@ -1592,6 +1246,8 @@ fn reindex_project_path(project_path: &Path) -> ProjectStoreResult<ReindexCounts
         )?;
         counts.timelines += 1;
     }
+
+    reindex_characters_on_connection(&transaction, project_path)?;
 
     transaction.commit()?;
     Ok(counts)
@@ -2288,302 +1944,6 @@ fn asset_sidecars(project_path: &Path) -> ProjectStoreResult<Vec<PathBuf>> {
     let timeline_dir = project_path.join("timelines");
     sidecars.retain(|path| !path.starts_with(&timeline_dir));
     Ok(sidecars)
-}
-
-fn character_sidecars(project_path: &Path) -> ProjectStoreResult<Vec<PathBuf>> {
-    let character_dir = project_path.join("characters");
-    let mut sidecars = Vec::new();
-    if !character_dir.exists() {
-        return Ok(sidecars);
-    }
-    for entry in fs::read_dir(character_dir)? {
-        let path = entry?.path();
-        if path
-            .file_name()
-            .and_then(|value| value.to_str())
-            .is_some_and(|name| name.ends_with(CHARACTER_SIDECAR_PATTERN))
-        {
-            sidecars.push(path);
-        }
-    }
-    Ok(sidecars)
-}
-
-fn character_file(project_path: &Path, character_id: &str) -> PathBuf {
-    project_path
-        .join("characters")
-        .join(format!("{character_id}.sceneworks.character.json"))
-}
-
-fn find_character_file(project_path: &Path, character_id: &str) -> ProjectStoreResult<PathBuf> {
-    let path = character_file(project_path, character_id);
-    if path.exists() {
-        return Ok(path);
-    }
-    for candidate in character_sidecars(project_path)? {
-        let Ok(character) = read_json(&candidate) else {
-            continue;
-        };
-        if character.get("id").and_then(Value::as_str) == Some(character_id) {
-            return Ok(candidate);
-        }
-    }
-    Err(ProjectStoreError::NotFound(
-        "Character not found".to_owned(),
-    ))
-}
-
-fn write_character(project_path: &Path, character: &mut Value) -> ProjectStoreResult<()> {
-    let character_id = required_str(character, "id")?.to_owned();
-    value_object_mut(character, "Character sidecar")?
-        .insert("updatedAt".to_owned(), Value::String(utc_now()));
-    write_json(&character_file(project_path, &character_id), character)
-}
-
-fn hydrate_character(
-    project_id: &str,
-    project_path: &Path,
-    mut character: Value,
-) -> ProjectStoreResult<Value> {
-    let references = character
-        .get("references")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|mut reference| {
-            let asset = reference
-                .get("assetId")
-                .and_then(Value::as_str)
-                .and_then(|asset_id| {
-                    character_asset_summary(project_id, project_path, asset_id)
-                        .ok()
-                        .flatten()
-                })
-                .unwrap_or(Value::Null);
-            if let Some(object) = reference.as_object_mut() {
-                object.insert("asset".to_owned(), asset);
-            }
-            reference
-        })
-        .collect::<Vec<_>>();
-    let approved_references = references
-        .iter()
-        .filter(|reference| {
-            reference
-                .get("approved")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    let object = value_object_mut(&mut character, "Character sidecar")?;
-    object.insert("references".to_owned(), Value::Array(references));
-    object.insert(
-        "approvedReferences".to_owned(),
-        Value::Array(approved_references),
-    );
-    Ok(character)
-}
-
-fn character_asset_summary(
-    project_id: &str,
-    project_path: &Path,
-    asset_id: &str,
-) -> ProjectStoreResult<Option<Value>> {
-    let Some(sidecar_path) = find_asset_sidecar_path(project_path, asset_id)? else {
-        return Ok(None);
-    };
-    let asset = normalize_asset(project_id, project_path, &sidecar_path)?;
-    Ok(Some(json!({
-        "id": asset.get("id").cloned().unwrap_or(Value::Null),
-        "type": asset.get("type").cloned().unwrap_or(Value::Null),
-        "displayName": asset.get("displayName").cloned().unwrap_or(Value::Null),
-        "url": asset.get("url").cloned().unwrap_or(Value::Null),
-        "status": asset.get("status").cloned().unwrap_or_else(|| json!({})),
-        "file": asset.get("file").cloned().unwrap_or_else(|| json!({}))
-    })))
-}
-
-fn update_asset_character_link(
-    project_path: &Path,
-    character_id: &str,
-    reference: &Value,
-    remove: bool,
-) -> ProjectStoreResult<()> {
-    let asset_id = required_str(reference, "assetId")?;
-    let sidecar_path = find_asset_sidecar_path(project_path, asset_id)?
-        .ok_or_else(|| ProjectStoreError::NotFound("Reference asset not found".to_owned()))?;
-    let mut asset = read_json(&sidecar_path)?;
-    let metadata = value_object_mut(&mut asset, "Asset sidecar")?
-        .entry("metadata".to_owned())
-        .or_insert_with(|| json!({}));
-    let metadata = metadata.as_object_mut().ok_or_else(|| {
-        ProjectStoreError::BadRequest("Asset metadata must be an object".to_owned())
-    })?;
-    let mut links = metadata
-        .remove("characterReferences")
-        .and_then(|value| value.as_array().cloned())
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|item| item.get("characterId").and_then(Value::as_str) != Some(character_id))
-        .collect::<Vec<_>>();
-    if !remove {
-        links.push(json!({
-            "characterId": character_id,
-            "source": "character-sidecar",
-            "approved": reference.get("approved").and_then(Value::as_bool).unwrap_or(false),
-            "role": reference.get("role").and_then(Value::as_str).unwrap_or("reference"),
-            "linkedAt": reference.get("addedAt").and_then(Value::as_str).unwrap_or("").to_owned(),
-            "approvedAt": reference.get("approvedAt").cloned().unwrap_or(Value::Null)
-        }));
-    }
-    metadata.insert("characterReferences".to_owned(), Value::Array(links));
-    write_json(&sidecar_path, &asset)?;
-    index_asset(project_path, &asset, Some(&sidecar_path))
-}
-
-fn copy_lora_into_project(
-    project_path: &Path,
-    data_dir: &Path,
-    character_id: &str,
-    source_path: Option<&str>,
-) -> ProjectStoreResult<(Option<String>, bool)> {
-    let Some(source_path) = source_path.filter(|value| !value.trim().is_empty()) else {
-        return Ok((None, false));
-    };
-    let source_path = PathBuf::from(source_path);
-    if !source_path.exists() || !(source_path.is_file() || source_path.is_dir()) {
-        return Err(ProjectStoreError::BadRequest(format!(
-            "LoRA source path not found: {}",
-            source_path.display()
-        )));
-    }
-    assert_allowed_lora_source(project_path, data_dir, &source_path)?;
-    let target_dir = project_path
-        .join("loras")
-        .join("characters")
-        .join(character_id);
-    fs::create_dir_all(&target_dir)?;
-    let target = target_dir.join(
-        source_path
-            .file_name()
-            .ok_or_else(|| ProjectStoreError::BadRequest("Invalid LoRA source path".to_owned()))?,
-    );
-    if fs::canonicalize(&source_path).ok() != fs::canonicalize(&target).ok() {
-        if source_path.is_dir() {
-            copy_dir_recursive(&source_path, &target)?;
-        } else {
-            fs::copy(&source_path, &target)?;
-        }
-    }
-    Ok((Some(relative_string(project_path, &target)?), true))
-}
-
-fn assert_allowed_lora_source(
-    project_path: &Path,
-    data_dir: &Path,
-    source_path: &Path,
-) -> ProjectStoreResult<()> {
-    let resolved = fs::canonicalize(source_path)?;
-    let roots = [data_dir.join("loras"), project_path.join("loras")];
-    for root in roots {
-        if let Ok(root) = fs::canonicalize(root) {
-            if resolved.starts_with(root) {
-                return Ok(());
-            }
-        }
-    }
-    Err(ProjectStoreError::BadRequest(
-        "LoRA source path must be inside the app-managed data/loras or project/loras folders"
-            .to_owned(),
-    ))
-}
-
-fn copy_dir_recursive(source: &Path, target: &Path) -> ProjectStoreResult<()> {
-    fs::create_dir_all(target)?;
-    for entry in fs::read_dir(source)? {
-        let entry = entry?;
-        let source_path = entry.path();
-        let target_path = target.join(entry.file_name());
-        if source_path.is_dir() {
-            copy_dir_recursive(&source_path, &target_path)?;
-        } else {
-            fs::copy(&source_path, &target_path)?;
-        }
-    }
-    Ok(())
-}
-
-fn prepend_array_field(payload: &mut Value, field: &str, value: Value) -> ProjectStoreResult<()> {
-    let object = value_object_mut(payload, "Character sidecar")?;
-    let mut values = object
-        .remove(field)
-        .and_then(|value| value.as_array().cloned())
-        .unwrap_or_default();
-    values.insert(0, value);
-    object.insert(field.to_owned(), Value::Array(values));
-    Ok(())
-}
-
-fn value_object_mut<'a>(
-    value: &'a mut Value,
-    label: &str,
-) -> ProjectStoreResult<&'a mut Map<String, Value>> {
-    value
-        .as_object_mut()
-        .ok_or_else(|| ProjectStoreError::BadRequest(format!("{label} must be an object")))
-}
-
-fn validate_required_text(value: &str, key: &str) -> ProjectStoreResult<()> {
-    if value.trim().is_empty() {
-        return Err(ProjectStoreError::BadRequest(format!("{key} is required")));
-    }
-    Ok(())
-}
-
-fn validate_character_name(value: &str) -> ProjectStoreResult<()> {
-    validate_required_text(value, "name")?;
-    validate_text_length(value, "name", 120)
-}
-
-fn validate_text_length(value: &str, key: &str, max: usize) -> ProjectStoreResult<()> {
-    if value.chars().count() > max {
-        return Err(ProjectStoreError::BadRequest(format!(
-            "{key} must be at most {max} characters"
-        )));
-    }
-    Ok(())
-}
-
-fn validate_character_type(value: &str) -> ProjectStoreResult<()> {
-    if matches!(value, "person" | "creature" | "object") {
-        Ok(())
-    } else {
-        Err(ProjectStoreError::BadRequest(
-            "Character type must be person, creature, or object".to_owned(),
-        ))
-    }
-}
-
-fn validate_lora_scope(value: &str, allow_external: bool) -> ProjectStoreResult<()> {
-    if matches!(value, "project" | "global") || (allow_external && value == "external") {
-        Ok(())
-    } else {
-        Err(ProjectStoreError::BadRequest(
-            "LoRA scope must be project, global, or external".to_owned(),
-        ))
-    }
-}
-
-fn validate_lora_weight(value: f64) -> ProjectStoreResult<()> {
-    if value.is_finite() && (-2.0..=2.0).contains(&value) {
-        Ok(())
-    } else {
-        Err(ProjectStoreError::BadRequest(
-            "defaultWeight must be between -2 and 2".to_owned(),
-        ))
-    }
 }
 
 fn collect_sidecars(path: &Path, sidecars: &mut Vec<PathBuf>) -> ProjectStoreResult<()> {

--- a/crates/sceneworks-core/tests/character_store.rs
+++ b/crates/sceneworks-core/tests/character_store.rs
@@ -1,0 +1,394 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{params, Connection};
+use sceneworks_core::character_store::write_character_sidecar;
+use sceneworks_core::project_store::{
+    CharacterCreateInput, CharacterLookInput, CharacterLookUpdateInput, CharacterLoraInput,
+    CharacterLoraUpdateInput, CharacterReferenceInput, CharacterReferenceUpdateInput, ProjectStore,
+    UploadAsset,
+};
+use serde_json::{json, Map, Value};
+
+fn fixture_path(relative_path: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests")
+        .join("fixtures")
+        .join("rust_migration_contracts")
+        .join(relative_path)
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).expect("json reads")).expect("json parses")
+}
+
+#[test]
+fn character_sidecar_writer_byte_matches_fixture() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let fixture_path = fixture_path("sidecars/character.sceneworks.character.json");
+    let expected = fs::read_to_string(&fixture_path)
+        .expect("fixture reads")
+        .replace("\r\n", "\n");
+    let character: Value = serde_json::from_str(&expected).expect("fixture parses");
+
+    write_character_sidecar(temp_dir.path(), &character).expect("sidecar writes");
+
+    let actual = fs::read_to_string(
+        temp_dir
+            .path()
+            .join("characters/character_fixture.sceneworks.character.json"),
+    )
+    .expect("written sidecar reads");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn character_sidecar_writer_preserves_string_newlines_as_json_escapes() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let character = json!({
+        "schemaVersion": 1,
+        "id": "character_multiline",
+        "projectId": "project_fixture",
+        "name": "Mira",
+        "type": "person",
+        "description": "line one\nline two",
+        "createdAt": "2026-05-17T13:00:00Z",
+        "updatedAt": "2026-05-17T13:00:00Z",
+        "status": { "archived": false },
+        "references": [],
+        "looks": [],
+        "loras": [],
+        "trainedLoras": []
+    });
+
+    write_character_sidecar(temp_dir.path(), &character).expect("sidecar writes");
+
+    let bytes = fs::read(
+        temp_dir
+            .path()
+            .join("characters/character_multiline.sceneworks.character.json"),
+    )
+    .expect("written sidecar reads");
+    assert!(!bytes.contains(&b'\r'));
+    assert!(String::from_utf8(bytes)
+        .expect("utf8")
+        .contains(r#""description": "line one\nline two""#));
+}
+
+#[test]
+fn character_crud_updates_sidecars_and_project_index() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+    let project = store.create_project("Characters").expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+
+    let character = store
+        .create_character(
+            &project.id,
+            CharacterCreateInput {
+                name: "Mira".to_owned(),
+                character_type: "person".to_owned(),
+                description: "Lead".to_owned(),
+            },
+        )
+        .expect("character creates");
+    let character_id = character["id"].as_str().expect("character id").to_owned();
+    let character_path = project_path.join(format!(
+        "characters/{character_id}.sceneworks.character.json"
+    ));
+    assert!(character_path.exists());
+
+    let connection = Connection::open(project_path.join("project.db")).expect("db opens");
+    let indexed_name: String = connection
+        .query_row(
+            "select name from characters where id = ?1",
+            params![character_id],
+            |row| row.get(0),
+        )
+        .expect("character indexed");
+    assert_eq!(indexed_name, "Mira");
+
+    store
+        .archive_character(&project.id, &character_id)
+        .expect("character archives");
+    assert_eq!(
+        store
+            .list_characters(&project.id, false)
+            .expect("characters list")
+            .len(),
+        0
+    );
+    assert_eq!(
+        store
+            .list_characters(&project.id, true)
+            .expect("archived characters list")
+            .len(),
+        1
+    );
+
+    store
+        .purge_character(&project.id, &character_id)
+        .expect("character purges");
+    let remaining: i64 = connection
+        .query_row("select count(*) from characters", [], |row| row.get(0))
+        .expect("count reads");
+    assert_eq!(remaining, 0);
+    assert!(!character_path.exists());
+}
+
+#[test]
+fn references_sync_asset_metadata_and_character_reference_table() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+    let project = store.create_project("References").expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+    let source = temp_dir.path().join("reference.png");
+    fs::write(&source, b"png-bytes").expect("source writes");
+    let asset = store
+        .import_asset(
+            &project.id,
+            UploadAsset {
+                filename: "reference.png".to_owned(),
+                content_type: Some("image/png".to_owned()),
+                source_path: source,
+            },
+        )
+        .expect("asset imports");
+    let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+    let character = store
+        .create_character(
+            &project.id,
+            CharacterCreateInput {
+                name: "Mira".to_owned(),
+                character_type: "person".to_owned(),
+                description: String::new(),
+            },
+        )
+        .expect("character creates");
+    let character_id = character["id"].as_str().expect("character id").to_owned();
+
+    store
+        .add_character_reference(
+            &project.id,
+            &character_id,
+            CharacterReferenceInput {
+                asset_id: asset_id.clone(),
+                approved: false,
+                role: "reference".to_owned(),
+                notes: "front".to_owned(),
+            },
+        )
+        .expect("reference adds");
+    store
+        .update_character_reference(
+            &project.id,
+            &character_id,
+            &asset_id,
+            CharacterReferenceUpdateInput {
+                approved: Some(true),
+                role: Some("hero".to_owned()),
+                notes: None,
+            },
+        )
+        .expect("reference updates");
+
+    let sidecar_path = project_path.join(
+        asset["sidecarPath"]
+            .as_str()
+            .expect("sidecar path")
+            .replace('/', std::path::MAIN_SEPARATOR_STR),
+    );
+    let asset_sidecar = read_json(&sidecar_path);
+    assert_eq!(
+        asset_sidecar["metadata"]["characterReferences"][0]["characterId"],
+        character_id
+    );
+    assert_eq!(
+        asset_sidecar["metadata"]["characterReferences"][0]["approved"],
+        true
+    );
+
+    let connection = Connection::open(project_path.join("project.db")).expect("db opens");
+    let approved: i64 = connection
+        .query_row(
+            "select approved from character_references where character_id = ?1 and asset_id = ?2",
+            params![character_id, asset_id],
+            |row| row.get(0),
+        )
+        .expect("reference indexed");
+    assert_eq!(approved, 1);
+
+    store
+        .remove_character_reference(&project.id, &character_id, &asset_id)
+        .expect("reference removes");
+    let asset_sidecar = read_json(&sidecar_path);
+    assert_eq!(
+        asset_sidecar["metadata"]["characterReferences"]
+            .as_array()
+            .expect("metadata links"),
+        &Vec::<Value>::new()
+    );
+}
+
+#[test]
+fn looks_loras_and_reindex_are_persisted() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+    let project = store.create_project("Looks").expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+    let character = store
+        .create_character(
+            &project.id,
+            CharacterCreateInput {
+                name: "Mira".to_owned(),
+                character_type: "person".to_owned(),
+                description: String::new(),
+            },
+        )
+        .expect("character creates");
+    let character_id = character["id"].as_str().expect("character id").to_owned();
+
+    let with_look = store
+        .create_character_look(
+            &project.id,
+            &character_id,
+            CharacterLookInput {
+                name: "Rain coat".to_owned(),
+                description: "Wet hair".to_owned(),
+                approved_reference_ids: vec!["asset_1".to_owned()],
+                recipe_settings: Map::from_iter([("style".to_owned(), json!("noir"))]),
+            },
+        )
+        .expect("look creates");
+    let look_id = with_look["looks"][0]["id"]
+        .as_str()
+        .expect("look id")
+        .to_owned();
+    let updated = store
+        .update_character_look(
+            &project.id,
+            &character_id,
+            &look_id,
+            CharacterLookUpdateInput {
+                name: Some("Blue coat".to_owned()),
+                ..CharacterLookUpdateInput::default()
+            },
+        )
+        .expect("look updates");
+    assert_eq!(updated["looks"][0]["name"], "Blue coat");
+    let without_look = store
+        .delete_character_look(&project.id, &character_id, &look_id)
+        .expect("look deletes");
+    assert_eq!(without_look["looks"].as_array().expect("looks").len(), 0);
+
+    let lora_dir = temp_dir.path().join("data/loras");
+    fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    let lora_source = lora_dir.join("mira.safetensors");
+    fs::write(&lora_source, b"lora").expect("lora source writes");
+    let with_lora = store
+        .attach_character_lora(
+            &project.id,
+            &character_id,
+            CharacterLoraInput {
+                lora_id: Some("lora_fixture".to_owned()),
+                name: "Mira LoRA".to_owned(),
+                source_path: Some(lora_source.display().to_string()),
+                trigger_words: vec!["mira".to_owned()],
+                default_weight: 0.8,
+                compatibility: Map::from_iter([("families".to_owned(), json!(["z-image"]))]),
+                scope: "project".to_owned(),
+            },
+        )
+        .expect("lora attaches");
+    let link_id = with_lora["loras"][0]["id"]
+        .as_str()
+        .expect("link id")
+        .to_owned();
+    let project_lora_path = project_path.join(
+        with_lora["loras"][0]["projectPath"]
+            .as_str()
+            .expect("project lora path")
+            .replace('/', std::path::MAIN_SEPARATOR_STR),
+    );
+    assert_eq!(fs::read(project_lora_path).expect("lora copied"), b"lora");
+    let with_updated_lora = store
+        .update_character_lora(
+            &project.id,
+            &character_id,
+            &link_id,
+            CharacterLoraUpdateInput {
+                default_weight: Some(-0.5),
+                ..CharacterLoraUpdateInput::default()
+            },
+        )
+        .expect("lora updates");
+    assert_eq!(with_updated_lora["loras"][0]["defaultWeight"], -0.5);
+    let without_lora = store
+        .detach_character_lora(&project.id, &character_id, &link_id)
+        .expect("lora detaches");
+    assert_eq!(without_lora["loras"].as_array().expect("loras").len(), 0);
+
+    store.reindex_project(&project.id).expect("reindex works");
+    let connection = Connection::open(project_path.join("project.db")).expect("db opens");
+    let count: i64 = connection
+        .query_row("select count(*) from characters", [], |row| row.get(0))
+        .expect("characters count reads");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn list_characters_recovers_stale_character_index_from_sidecars() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+    let project = store.create_project("Recovery").expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+    let character = store
+        .create_character(
+            &project.id,
+            CharacterCreateInput {
+                name: "Original".to_owned(),
+                character_type: "person".to_owned(),
+                description: String::new(),
+            },
+        )
+        .expect("character creates");
+    let character_id = character["id"].as_str().expect("character id").to_owned();
+    let sidecar_path = project_path.join(format!(
+        "characters/{character_id}.sceneworks.character.json"
+    ));
+    let mut sidecar = read_json(&sidecar_path);
+    sidecar["name"] = json!("Recovered");
+    sidecar["status"]["archived"] = json!(true);
+    write_character_sidecar(&project_path, &sidecar).expect("sidecar rewrites");
+
+    let connection = Connection::open(project_path.join("project.db")).expect("db opens");
+    connection
+        .execute(
+            "update characters set name = 'Stale', archived = 0 where id = ?1",
+            params![character_id],
+        )
+        .expect("index made stale");
+
+    assert_eq!(
+        store
+            .list_characters(&project.id, false)
+            .expect("visible list")
+            .len(),
+        0
+    );
+    let archived = store
+        .list_characters(&project.id, true)
+        .expect("archived list");
+    assert_eq!(archived[0]["name"], "Recovered");
+
+    let indexed: (String, i64) = connection
+        .query_row(
+            "select name, archived from characters where id = ?1",
+            params![character_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("index refreshed");
+    assert_eq!(indexed, ("Recovered".to_owned(), 1));
+}


### PR DESCRIPTION
﻿## Summary

Implements the remaining story 1283 core persistence work by moving character persistence into a dedicated `sceneworks-core` character store module while preserving the existing `ProjectStore` API surface through re-exports and delegation.

## What changed

- Added `crates/sceneworks-core/src/character_store.rs` with character CRUD, reference, look, and LoRA mutation support.
- Added SQLite migrations and reindex support for `characters`, `character_references`, `character_looks`, and `character_loras`.
- Wrapped character mutations in SQLite transactions and kept asset character-reference metadata sync inside the same transaction path.
- Added atomic character sidecar writing with golden fixture byte parity.
- Added focused tests covering create/archive/purge, reference add/update/remove metadata sync, look CRUD, LoRA copy/update/detach, reindex, and golden sidecar output.

## Validation

- `cargo test -p sceneworks-core`
- `cargo clippy -p sceneworks-core -- -D warnings`
- `cargo check -p sceneworks-rust-api`
