### PR TITLE
[codex] Add real Diffusers adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,12 @@ HF_TOKEN=
 SCENEWORKS_HF_HOME=/sceneworks/data/cache/huggingface
 SCENEWORKS_HUGGINGFACE_HUB_CACHE=/sceneworks/data/cache/huggingface/hub
 
-# Worker adapter override: auto, procedural, z_image_diffusers, or qwen_image.
+# Worker image adapter override: auto, procedural_preview, z_image_diffusers, or qwen_image.
 SCENEWORKS_IMAGE_ADAPTER=auto
+
+# Worker video adapter override. Leave blank for real Diffusers adapters; set
+# procedural_video only for lightweight adapter-development checks.
+SCENEWORKS_VIDEO_ADAPTER=
 
 # Docker/NVIDIA runtime GPU selection.
 NVIDIA_VISIBLE_DEVICES=all

--- a/.env.example
+++ b/.env.example
@@ -48,11 +48,12 @@ HF_TOKEN=
 SCENEWORKS_HF_HOME=/sceneworks/data/cache/huggingface
 SCENEWORKS_HUGGINGFACE_HUB_CACHE=/sceneworks/data/cache/huggingface/hub
 
-# Worker image adapter override: auto, procedural_preview, z_image_diffusers, or qwen_image.
+# Worker image adapter override: auto, procedural/procedural_preview, z_image_diffusers, or qwen_image.
 SCENEWORKS_IMAGE_ADAPTER=auto
 
-# Worker video adapter override. Leave blank for real Diffusers adapters; set
-# procedural_video only for lightweight adapter-development checks.
+# Worker video adapter override. Leave blank or set diffusers_video for real
+# Diffusers adapters; set procedural/procedural_video only for lightweight
+# adapter-development checks.
 SCENEWORKS_VIDEO_ADAPTER=
 
 # Docker/NVIDIA runtime GPU selection.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install contract test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==9.0.2 httpx==0.28.1
+          python -m pip install pytest==9.0.2 httpx==0.28.1 "pillow>=12.0.0,<13"
       - name: Run scaffold and compose checks
         run: |
           npm run check
@@ -34,6 +34,6 @@ jobs:
       - name: Build Rust API before contract tests
         run: cargo build -q -p sceneworks-rust-api
       - name: Run Rust API contract snapshot tests
-        run: python -m pytest -q tests/test_rust_api_contract_snapshots.py -m parity --strict-markers
+        run: python -m pytest -q -m parity --strict-markers
       - name: Smoke default Rust API Docker runtime
         run: npm run check:docker:rust-api

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Build Rust API before contract tests
         run: cargo build -q -p sceneworks-rust-api
       - name: Run Rust API contract snapshot tests
-        run: python -m pytest -q -m parity --strict-markers
+        run: python -m pytest -q tests/test_rust_api_contract_snapshots.py -m parity --strict-markers
       - name: Smoke default Rust API Docker runtime
         run: npm run check:docker:rust-api

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -24,6 +24,13 @@ export const fallbackModels = [
     ui: { description: "Image edit target." },
   },
   {
+    id: "qwen_image_edit",
+    name: "Qwen Image Edit",
+    type: "image",
+    capabilities: ["edit_image"],
+    ui: { description: "Qwen image edit target." },
+  },
+  {
     id: "ltx_2_3",
     name: "LTX-2.3",
     type: "video",

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -10,6 +10,13 @@ export const fallbackModels = [
     ui: { description: "Fast local text-to-image target." },
   },
   {
+    id: "qwen_image",
+    name: "Qwen Image",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    ui: { description: "Qwen text-to-image target." },
+  },
+  {
     id: "z_image_edit",
     name: "Z-Image-Edit",
     type: "image",

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -2,6 +2,8 @@ httpx==0.28.1
 huggingface_hub>=0.36,<1
 pillow>=12.0.0,<13
 numpy>=2.0,<3
+imageio>=2.37,<3
+imageio-ffmpeg>=0.6,<1
 torch>=2.7
 transformers>=4.57
 accelerate>=1.11

--- a/apps/worker/scene_worker/adapter_utils.py
+++ b/apps/worker/scene_worker/adapter_utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+
+def accepted_call_parameters(callable_owner: Any) -> set[str]:
+    try:
+        return set(inspect.signature(callable_owner.__call__).parameters)
+    except (TypeError, ValueError):
+        return set()
+
+
+def filter_call_kwargs(callable_owner: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    accepted = accepted_call_parameters(callable_owner)
+    if not accepted:
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in accepted}

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import importlib
+import inspect
 import json
 import os
 import warnings
@@ -74,6 +75,14 @@ MODEL_TARGETS = {
         # Uses Turbo weights via ZImageImg2ImgPipeline until the dedicated Edit checkpoint is released.
         "repo": "Tongyi-MAI/Z-Image-Turbo",
         "adapter": "z_image_diffusers",
+    },
+    "qwen_image": {
+        "label": "Qwen Image",
+        "family": "qwen-image",
+        "supportsEdit": False,
+        "steps": 20,
+        "repo": "Qwen/Qwen-Image",
+        "adapter": "qwen_image",
     },
     "qwen_image_edit": {
         "label": "Qwen Image Edit",
@@ -371,6 +380,128 @@ class ZImageDiffusersAdapter:
             return 0.0
 
 
+class QwenImageAdapter:
+    id = "qwen_image"
+
+    def __init__(self) -> None:
+        self._text_pipe: Any | None = None
+        self._edit_pipe: Any | None = None
+        self._loaded_repo: str | None = None
+        self._loaded_model: str | None = None
+
+    def loaded_models(self) -> list[str]:
+        return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
+
+    def generate(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        request = image_request_from_job(job)
+        model_target = MODEL_TARGETS.get(request.model, {})
+        if model_target.get("adapter") != self.id:
+            raise RuntimeError(f"{request.model} is not a Qwen Image target.")
+        if request.mode == "edit_image" and not model_supports_edit(request.model):
+            raise RuntimeError(f"{request.model} does not support image editing.")
+
+        progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
+        pipe = self._load_pipeline(request, model_target, progress=progress)
+        images = []
+        for index in range(request.count):
+            if cancel_requested():
+                raise InterruptedError("Image generation canceled by user.")
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            progress("running", "generating", 0.24 + (index / request.count) * 0.48, f"Running Qwen Image {index + 1} of {request.count}.")
+            images.append(self._run_pipeline(settings, pipe, request, seed))
+
+        return ImageAssetWriter().write_outputs(
+            settings=settings,
+            job=job,
+            images=images,
+            adapter_id=self.id,
+            progress=progress,
+            cancel_requested=cancel_requested,
+            raw_settings={
+                **request.advanced,
+                "repo": self._repo_for_request(request, model_target),
+                "numInferenceSteps": self._num_inference_steps(request, model_target),
+                "guidanceScale": self._guidance_scale(request),
+                "realModelInference": True,
+            },
+        )
+
+    def _load_pipeline(self, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
+        torch = importlib.import_module("torch")
+        diffusers = importlib.import_module("diffusers")
+        repo = self._repo_for_request(request, model_target)
+        device = select_torch_device(torch)
+        dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+        use_edit = request.mode == "edit_image"
+        cached_pipe = self._edit_pipe if use_edit else self._text_pipe
+        if cached_pipe is not None and self._loaded_repo == repo:
+            self._loaded_model = request.model
+            progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
+            return cached_pipe
+
+        pipeline_name = "QwenImageEditPipeline" if use_edit else "QwenImagePipeline"
+        pipeline_class = getattr(diffusers, pipeline_name, None)
+        if pipeline_class is None:
+            raise RuntimeError(f"The installed diffusers package does not expose {pipeline_name}. Install the latest diffusers build.")
+
+        progress("loading_model", "loading_model", 0.2, f"Loading {model_target['label']} model files.")
+        pipe = pipeline_class.from_pretrained(repo, torch_dtype=dtype)
+        if bool(request.advanced.get("cpuOffload", False)) and hasattr(pipe, "enable_model_cpu_offload"):
+            pipe.enable_model_cpu_offload()
+        else:
+            pipe.to(device)
+        if hasattr(pipe, "enable_vae_tiling"):
+            pipe.enable_vae_tiling()
+
+        if use_edit:
+            self._edit_pipe = pipe
+        else:
+            self._text_pipe = pipe
+        self._loaded_repo = repo
+        self._loaded_model = request.model
+        return pipe
+
+    def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch)
+        generator = torch.Generator("cuda" if device == "cuda" else "cpu").manual_seed(seed)
+        kwargs = {
+            "prompt": request.prompt,
+            "height": request.height,
+            "width": request.width,
+            "num_inference_steps": self._num_inference_steps(request, MODEL_TARGETS[request.model]),
+            "guidance_scale": self._guidance_scale(request),
+            "generator": generator,
+        }
+        if request.negative_prompt:
+            kwargs["negative_prompt"] = request.negative_prompt
+        if request.mode == "edit_image":
+            kwargs["image"] = load_source_image(settings, request)
+            kwargs["strength"] = float(request.advanced.get("strength", 0.6))
+            kwargs["true_cfg_scale"] = float(request.advanced.get("trueCfgScale", 4.0))
+        output = pipe(**filter_call_kwargs(pipe, kwargs))
+        return output.images[0].convert("RGB")
+
+    def _repo_for_request(self, request: ImageRequest, model_target: dict[str, Any]) -> str:
+        return request.advanced.get("modelRepo") or model_target["repo"]
+
+    def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        return safe_int(request.advanced.get("steps"), model_target["steps"], 1, 80)
+
+    def _guidance_scale(self, request: ImageRequest) -> float:
+        try:
+            return float(request.advanced.get("guidanceScale", 4.0))
+        except (TypeError, ValueError):
+            return 4.0
+
+
 class ProceduralImageAdapter:
     id = "procedural_preview"
 
@@ -421,7 +552,7 @@ class ProceduralImageAdapter:
 def create_image_adapter(
     job: dict[str, Any],
     adapters: dict[str, object] | None = None,
-) -> ProceduralImageAdapter | ZImageDiffusersAdapter:
+) -> ProceduralImageAdapter | ZImageDiffusersAdapter | QwenImageAdapter:
     payload = job.get("payload", {})
     requested = os.getenv("SCENEWORKS_IMAGE_ADAPTER", payload.get("adapter", "")).strip()
     if requested == "procedural_preview":
@@ -429,11 +560,23 @@ def create_image_adapter(
     model_target = MODEL_TARGETS.get(payload.get("model", "z_image_turbo"), {})
     if model_target.get("adapter") == ZImageDiffusersAdapter.id:
         return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
+    if model_target.get("adapter") == QwenImageAdapter.id:
+        return adapters.get("qwen_image") if adapters else QwenImageAdapter()
     return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
 
 
 def model_supports_edit(model_id: str) -> bool:
     return bool(MODEL_TARGETS.get(model_id, {}).get("supportsEdit"))
+
+
+def filter_call_kwargs(pipe: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    try:
+        accepted = set(inspect.signature(pipe.__call__).parameters)
+    except (TypeError, ValueError):
+        return kwargs
+    if not accepted:
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in accepted and value is not None}
 
 
 def resolve_seed(seed: int | None, prompt: str, index: int, seeds: list[int] | None = None) -> int:

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import importlib
-import inspect
 import json
 import os
 import warnings
@@ -25,6 +24,7 @@ from sceneworks_shared import (
     write_json,
 )
 
+from .adapter_utils import filter_call_kwargs
 from .settings import WorkerSettings
 
 
@@ -386,11 +386,12 @@ class QwenImageAdapter:
     def __init__(self) -> None:
         self._text_pipe: Any | None = None
         self._edit_pipe: Any | None = None
-        self._loaded_repo: str | None = None
+        self._text_repo: str | None = None
+        self._edit_repo: str | None = None
         self._loaded_model: str | None = None
 
     def loaded_models(self) -> list[str]:
-        return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
+        return sorted({value for value in (self._text_repo, self._edit_repo, self._loaded_model) if value})
 
     def generate(
         self,
@@ -441,10 +442,19 @@ class QwenImageAdapter:
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         use_edit = request.mode == "edit_image"
         cached_pipe = self._edit_pipe if use_edit else self._text_pipe
-        if cached_pipe is not None and self._loaded_repo == repo:
+        cached_repo = self._edit_repo if use_edit else self._text_repo
+        if cached_pipe is not None and cached_repo == repo:
             self._loaded_model = request.model
             progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
             return cached_pipe
+        if cached_pipe is not None:
+            if use_edit:
+                self._edit_pipe = None
+                self._edit_repo = None
+            else:
+                self._text_pipe = None
+                self._text_repo = None
+            self._empty_cuda_cache(torch)
 
         pipeline_name = "QwenImageEditPipeline" if use_edit else "QwenImagePipeline"
         pipeline_class = getattr(diffusers, pipeline_name, None)
@@ -462,11 +472,16 @@ class QwenImageAdapter:
 
         if use_edit:
             self._edit_pipe = pipe
+            self._edit_repo = repo
         else:
             self._text_pipe = pipe
-        self._loaded_repo = repo
+            self._text_repo = repo
         self._loaded_model = request.model
         return pipe
+
+    def _empty_cuda_cache(self, torch: Any) -> None:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
         torch = importlib.import_module("torch")
@@ -555,8 +570,16 @@ def create_image_adapter(
 ) -> ProceduralImageAdapter | ZImageDiffusersAdapter | QwenImageAdapter:
     payload = job.get("payload", {})
     requested = os.getenv("SCENEWORKS_IMAGE_ADAPTER", payload.get("adapter", "")).strip()
-    if requested == "procedural_preview":
+    if requested == "auto":
+        requested = ""
+    if requested in {"procedural", "procedural_preview"}:
         return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
+    if requested and requested not in {ZImageDiffusersAdapter.id, QwenImageAdapter.id}:
+        raise RuntimeError(f"Unsupported SCENEWORKS_IMAGE_ADAPTER value: {requested}.")
+    if requested == ZImageDiffusersAdapter.id:
+        return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
+    if requested == QwenImageAdapter.id:
+        return adapters.get("qwen_image") if adapters else QwenImageAdapter()
     model_target = MODEL_TARGETS.get(payload.get("model", "z_image_turbo"), {})
     if model_target.get("adapter") == ZImageDiffusersAdapter.id:
         return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
@@ -567,16 +590,6 @@ def create_image_adapter(
 
 def model_supports_edit(model_id: str) -> bool:
     return bool(MODEL_TARGETS.get(model_id, {}).get("supportsEdit"))
-
-
-def filter_call_kwargs(pipe: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
-    try:
-        accepted = set(inspect.signature(pipe.__call__).parameters)
-    except (TypeError, ValueError):
-        return kwargs
-    if not accepted:
-        return kwargs
-    return {key: value for key, value in kwargs.items() if key in accepted and value is not None}
 
 
 def resolve_seed(seed: int | None, prompt: str, index: int, seeds: list[int] | None = None) -> int:

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -13,9 +13,9 @@ from typing import Any, Callable
 import httpx
 
 from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_worker_id
-from .image_adapters import ProceduralImageAdapter, ZImageDiffusersAdapter, create_image_adapter
+from .image_adapters import ProceduralImageAdapter, QwenImageAdapter, ZImageDiffusersAdapter, create_image_adapter
 from .settings import WorkerSettings
-from .video_adapters import ProceduralVideoAdapter
+from .video_adapters import create_video_adapter
 
 
 LoadedModelsSource = Callable[[], list[str]] | None
@@ -286,7 +286,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
 
 def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     job_id = job["id"]
-    adapter = ProceduralVideoAdapter()
+    adapter = create_video_adapter()
 
     def adapter_loaded_models() -> list[str]:
         return loaded_models_from_adapter(adapter, job_id=job_id)
@@ -376,6 +376,7 @@ def run_worker_loop(settings: WorkerSettings) -> None:
     api = ApiClient(settings)
     image_adapters: dict[str, object] = {
         "procedural_preview": ProceduralImageAdapter(),
+        "qwen_image": QwenImageAdapter(),
         "z_image_diffusers": ZImageDiffusersAdapter(),
     }
     max_registration_attempts = 20

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import hashlib
+import importlib
+import inspect
+import os
 import warnings
 from pathlib import Path
 from textwrap import wrap
@@ -22,7 +25,7 @@ from sceneworks_shared import (
     utc_now,
 )
 
-from .image_adapters import write_json
+from .image_adapters import select_torch_device, select_torch_dtype, write_json
 from .settings import WorkerSettings
 
 
@@ -38,6 +41,8 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "label": "LTX-2.3",
         "family": "ltx-video",
         "adapter": "ltx_video",
+        "repo": "Lightricks/LTX-2",
+        "fallbackRepo": "Lightricks/LTX-Video",
         "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
         "recommendedMaxDuration": 10,
         "hardMaxDuration": 15,
@@ -48,6 +53,7 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "label": "Wan2.2",
         "family": "wan-video",
         "adapter": "wan_video",
+        "repo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
         "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
         "recommendedMaxDuration": 7,
         "hardMaxDuration": 8,
@@ -213,6 +219,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
             created_at=created_at,
             seed=seed,
             target=target,
+            adapter_id=self.id,
             raw_settings=raw_settings,
         )
 
@@ -253,6 +260,337 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
             "recommendedMaxDuration": target["recommendedMaxDuration"],
             "previewRenderer": True,
         }
+
+
+class DiffusersVideoAdapter(VideoGenerationAdapter):
+    id = "diffusers_video"
+
+    def __init__(self) -> None:
+        self._pipelines: dict[str, Any] = {}
+        self._loaded_models: set[str] = set()
+
+    def loaded_models(self) -> list[str]:
+        return sorted(self._loaded_models)
+
+    def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
+        return video_request_from_job(job)
+
+    def ensure_models(self, request: VideoRequest) -> None:
+        target = model_target(request.model)
+        if request.mode not in target["capabilities"]:
+            raise RuntimeError(f"{target['label']} does not support {request.mode.replace('_', ' ')}.")
+        if request.duration > target["hardMaxDuration"]:
+            raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
+
+    def estimate_requirements(self, request: VideoRequest) -> dict[str, Any]:
+        target = model_target(request.model)
+        return {
+            "estimatedFrames": max(1, int(round(request.duration * request.fps))),
+            "pixelCount": request.width * request.height,
+            "recommendedMaxDuration": target["recommendedMaxDuration"],
+            "gpuPreference": request.advanced.get("gpuPreference", "auto"),
+            "adapter": target["adapter"],
+            "repo": self._repo_for_request(request, target),
+        }
+
+    def run(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: VideoRequest,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
+        for folder in ("assets/videos", "generation-sets", "recipes"):
+            (project_path / folder).mkdir(parents=True, exist_ok=True)
+
+        target = model_target(request.model)
+        progress("loading_model", "loading_model", 0.2, f"Loading {target['label']} Diffusers pipeline.")
+        pipe = self._load_pipeline(request, target)
+
+        first_image = self._first_condition_image(project_path, request)
+        last_image = self._last_condition_image(project_path, request)
+        self._validate_inputs(request, first_image, last_image)
+        if cancel_requested():
+            raise InterruptedError("Video generation canceled before inference.")
+
+        seed = resolve_seed(request.seed, request.prompt)
+        num_frames = self._num_frames(request)
+        kwargs = self._pipeline_kwargs(
+            pipe=pipe,
+            project_path=project_path,
+            request=request,
+            target=target,
+            first_image=first_image,
+            last_image=last_image,
+            seed=seed,
+            num_frames=num_frames,
+        )
+        progress("running", "generating", 0.32, f"Running {target['label']} inference.")
+        torch = importlib.import_module("torch")
+        with torch.inference_mode():
+            output = pipe(**kwargs)
+        if cancel_requested():
+            raise InterruptedError("Video generation canceled before saving.")
+
+        frames = frames_from_output(output)
+        if not frames:
+            raise RuntimeError(f"{target['label']} returned no video frames.")
+
+        generation_set_id = f"genset_{uuid4().hex}"
+        asset_id = f"asset_{uuid4().hex}"
+        created_at = utc_now()
+        raw_settings = self.map_settings(request, target)
+        filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
+        media_rel = f"assets/videos/{filename_base}.mp4"
+        media_path = project_path / media_rel
+        temp_path = media_path.with_suffix(".tmp.mp4")
+
+        progress("saving", "saving", 0.9, "Saving generated MP4 asset and recipe.")
+        diffusers_utils = importlib.import_module("diffusers.utils")
+        diffusers_utils.export_to_video(frames, str(temp_path), fps=request.fps)
+        temp_path.replace(media_path)
+
+        generation_set = {
+            "schemaVersion": 1,
+            "id": generation_set_id,
+            "projectId": request.project_id,
+            "jobId": job["id"],
+            "mode": request.mode,
+            "model": request.model,
+            "prompt": request.prompt,
+            "negativePrompt": request.negative_prompt,
+            "count": 1,
+            "createdAt": created_at,
+        }
+        asset = build_video_asset_sidecar(
+            asset_id=asset_id,
+            project_id=request.project_id,
+            generation_set_id=generation_set_id,
+            request=request,
+            job_id=job["id"],
+            media_rel=media_rel,
+            created_at=created_at,
+            seed=seed,
+            target=target,
+            adapter_id=target["adapter"],
+            raw_settings=raw_settings,
+        )
+        asset["file"]["mimeType"] = "video/mp4"
+
+        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
+        write_json(media_path.with_suffix(".sceneworks.json"), asset)
+        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
+        index_asset(project_path, asset)
+        return {
+            "generationSetId": generation_set_id,
+            "assetIds": [asset_id],
+            "assets": [asset],
+            "adapter": target["adapter"],
+            "model": request.model,
+            "requirements": self.estimate_requirements(request),
+        }
+
+    def cancel(self, _job_id: str) -> None:
+        return
+
+    def cleanup(self, _job_id: str) -> None:
+        return
+
+    def map_settings(self, request: VideoRequest, target: dict[str, Any]) -> dict[str, Any]:
+        return {
+            **request.advanced,
+            "adapterFamily": target["family"],
+            "targetAdapter": target["adapter"],
+            "repo": self._repo_for_request(request, target),
+            "steps": self._num_inference_steps(request, target),
+            "frameCount": self._num_frames(request),
+            "recommendedMaxDuration": target["recommendedMaxDuration"],
+            "previewRenderer": False,
+            "realModelInference": True,
+        }
+
+    def _load_pipeline(self, request: VideoRequest, target: dict[str, Any]) -> Any:
+        key = self._pipeline_key(request, target)
+        if key in self._pipelines:
+            self._loaded_models.update({request.model, self._repo_for_request(request, target)})
+            return self._pipelines[key]
+
+        torch = importlib.import_module("torch")
+        diffusers = importlib.import_module("diffusers")
+        repo = self._repo_for_request(request, target)
+        device = select_torch_device(torch)
+        dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+        pipeline_class = self._pipeline_class(diffusers, request, target)
+        kwargs: dict[str, Any] = {"torch_dtype": dtype}
+
+        if target["adapter"] == "wan_video":
+            vae_class = getattr(diffusers, "AutoencoderKLWan", None)
+            if vae_class is not None:
+                kwargs["vae"] = vae_class.from_pretrained(repo, subfolder="vae", torch_dtype=torch.float32)
+            if request.mode != "text_to_video":
+                transformers = importlib.import_module("transformers")
+                image_encoder_class = getattr(transformers, "CLIPVisionModel", None)
+                if image_encoder_class is not None:
+                    kwargs["image_encoder"] = image_encoder_class.from_pretrained(repo, subfolder="image_encoder", torch_dtype=torch.float32)
+
+        pipe = pipeline_class.from_pretrained(repo, **kwargs)
+        if bool(request.advanced.get("cpuOffload", False)) and hasattr(pipe, "enable_model_cpu_offload"):
+            pipe.enable_model_cpu_offload()
+        else:
+            pipe.to(device)
+        if hasattr(pipe, "enable_vae_tiling"):
+            pipe.enable_vae_tiling()
+        elif getattr(pipe, "vae", None) is not None and hasattr(pipe.vae, "enable_tiling"):
+            pipe.vae.enable_tiling()
+
+        self._pipelines[key] = pipe
+        self._loaded_models.update({request.model, repo})
+        return pipe
+
+    def _pipeline_class(self, diffusers: Any, request: VideoRequest, target: dict[str, Any]) -> Any:
+        if target["adapter"] == "wan_video":
+            if request.mode == "text_to_video":
+                return getattr(diffusers, "WanPipeline")
+            if request.mode == "replace_person" and hasattr(diffusers, "WanVACEPipeline"):
+                return getattr(diffusers, "WanVACEPipeline")
+            return getattr(diffusers, "WanImageToVideoPipeline")
+
+        if request.mode in {"first_last_frame", "video_bridge"}:
+            try:
+                ltx_condition = importlib.import_module("diffusers.pipelines.ltx.pipeline_ltx_condition")
+                return getattr(ltx_condition, "LTXConditionPipeline")
+            except (ImportError, AttributeError):
+                pass
+        if request.mode == "text_to_video":
+            pipeline_class = getattr(diffusers, "LTX2Pipeline", None) or getattr(diffusers, "LTXPipeline", None)
+            if pipeline_class is None:
+                raise RuntimeError("The installed diffusers package does not expose LTX2Pipeline or LTXPipeline.")
+            return pipeline_class
+        return getattr(diffusers, "LTXImageToVideoPipeline")
+
+    def _pipeline_key(self, request: VideoRequest, target: dict[str, Any]) -> str:
+        return f"{self._repo_for_request(request, target)}:{self._pipeline_kind(request, target)}"
+
+    def _pipeline_kind(self, request: VideoRequest, target: dict[str, Any]) -> str:
+        if target["adapter"] == "wan_video":
+            if request.mode == "text_to_video":
+                return "text"
+            if request.mode == "replace_person":
+                return "vace"
+            return "image"
+        if request.mode in {"first_last_frame", "video_bridge"}:
+            return "condition"
+        if request.mode == "text_to_video":
+            return "text"
+        return "image"
+
+    def _repo_for_request(self, request: VideoRequest, target: dict[str, Any]) -> str:
+        if request.advanced.get("modelRepo"):
+            return str(request.advanced["modelRepo"])
+        if target["adapter"] == "ltx_video" and request.mode != "text_to_video":
+            return target.get("fallbackRepo") or target["repo"]
+        return target["repo"]
+
+    def _num_inference_steps(self, request: VideoRequest, target: dict[str, Any]) -> int:
+        default_steps = target["steps"].get(request.quality, target["steps"]["balanced"])
+        return safe_int(request.advanced.get("steps"), default_steps, 1, 80)
+
+    def _guidance_scale(self, request: VideoRequest, fallback: float) -> float:
+        try:
+            return float(request.advanced.get("guidanceScale", fallback))
+        except (TypeError, ValueError):
+            return fallback
+
+    def _num_frames(self, request: VideoRequest) -> int:
+        raw_frames = max(1, int(round(request.duration * request.fps)))
+        if model_target(request.model)["adapter"] == "wan_video":
+            return max(5, raw_frames - ((raw_frames - 1) % 4))
+        return raw_frames
+
+    def _pipeline_kwargs(
+        self,
+        *,
+        pipe: Any,
+        project_path: Path,
+        request: VideoRequest,
+        target: dict[str, Any],
+        first_image: Image.Image | None,
+        last_image: Image.Image | None,
+        seed: int,
+        num_frames: int,
+    ) -> dict[str, Any]:
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch)
+        generator = torch.Generator("cuda" if device == "cuda" else "cpu").manual_seed(seed)
+        kwargs: dict[str, Any] = {
+            "prompt": request.prompt,
+            "negative_prompt": request.negative_prompt or default_negative_prompt(target),
+            "height": request.height,
+            "width": request.width,
+            "num_frames": num_frames,
+            "num_inference_steps": self._num_inference_steps(request, target),
+            "generator": generator,
+        }
+        if target["adapter"] == "wan_video":
+            kwargs["guidance_scale"] = self._guidance_scale(request, 5.0)
+            if request.mode == "replace_person":
+                kwargs["video"] = load_source_video_frames(project_path, request.source_clip_asset_id, request.width, request.height, num_frames)
+                kwargs["mask"] = person_track_masks(project_path, request.person_track_id, request.width, request.height, num_frames)
+                reference_images = character_reference_images(project_path, request.character_id, request.character_look_id, request.width, request.height)
+                if reference_images:
+                    kwargs["reference_images"] = reference_images
+                kwargs["conditioning_scale"] = float(request.advanced.get("conditioningScale", 1.0))
+            elif request.mode != "text_to_video" and first_image is not None:
+                kwargs["image"] = first_image.resize((request.width, request.height))
+            if last_image is not None:
+                kwargs["last_image"] = last_image.resize((request.width, request.height))
+        else:
+            kwargs["guidance_scale"] = self._guidance_scale(request, 3.0)
+            if request.mode in {"first_last_frame", "video_bridge"}:
+                conditions = ltx_conditions(first_image, last_image, num_frames, request.width, request.height)
+                if conditions:
+                    kwargs["conditions"] = conditions
+            elif first_image is not None:
+                kwargs["image"] = first_image.resize((request.width, request.height))
+            kwargs["frame_rate"] = request.fps
+        return filter_call_kwargs(pipe, kwargs)
+
+    def _first_condition_image(self, project_path: Path, request: VideoRequest) -> Image.Image | None:
+        if request.mode in {"image_to_video", "first_last_frame"}:
+            return load_source_image(project_path, request.source_asset_id, request.width, request.height)
+        if request.mode in {"extend_clip", "video_bridge", "replace_person"}:
+            context = request.advanced.get("timelineContext", {})
+            timestamp = safe_float(context.get("endpointTimestamp") or context.get("leftTimestamp"), 0, 0, 3600)
+            return load_source_frame(project_path, request.source_clip_asset_id, timestamp, request.width, request.height)
+        return None
+
+    def _last_condition_image(self, project_path: Path, request: VideoRequest) -> Image.Image | None:
+        if request.mode == "first_last_frame":
+            return load_source_image(project_path, request.last_frame_asset_id, request.width, request.height)
+        if request.mode == "video_bridge":
+            context = request.advanced.get("timelineContext", {})
+            timestamp = safe_float(context.get("rightTimestamp"), 0, 0, 3600)
+            return load_source_frame(project_path, request.bridge_right_clip_asset_id, timestamp, request.width, request.height)
+        return None
+
+    def _validate_inputs(self, request: VideoRequest, first_image: Image.Image | None, last_image: Image.Image | None) -> None:
+        if request.mode in {"image_to_video", "first_last_frame"} and first_image is None:
+            raise RuntimeError(f"{request.mode.replace('_', ' ').title()} requires a readable source image.")
+        if request.mode == "first_last_frame" and last_image is None:
+            raise RuntimeError("First/Last Frame requires a readable last frame image.")
+        if request.mode in {"extend_clip", "video_bridge", "replace_person"} and first_image is None:
+            raise RuntimeError(f"{request.mode.replace('_', ' ').title()} requires a readable source clip frame.")
+        if request.mode == "video_bridge" and last_image is None:
+            raise RuntimeError("Bridge generation requires a readable right clip frame.")
+
+
+def create_video_adapter() -> VideoGenerationAdapter:
+    if os.getenv("SCENEWORKS_VIDEO_ADAPTER", "").strip() == "procedural_video":
+        return ProceduralVideoAdapter()
+    return DiffusersVideoAdapter()
 
 
 def video_request_from_job(job: dict[str, Any]) -> VideoRequest:
@@ -348,11 +686,77 @@ def load_source_frame(project_path: Path, asset_id: str | None, timestamp: float
     return canvas
 
 
+def load_source_video_frames(project_path: Path, asset_id: str | None, width: int, height: int, count: int) -> list[Image.Image]:
+    if not asset_id:
+        return [gradient_frame(width, height, hashlib.sha256(b"missing-video").digest()) for _ in range(count)]
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        return [gradient_frame(width, height, hashlib.sha256(asset_id.encode("utf-8")).digest()) for _ in range(count)]
+    payload = read_json(sidecar_path)
+    media_path = project_path / payload.get("file", {}).get("path", "")
+    if not media_path.exists():
+        return [gradient_frame(width, height, hashlib.sha256(asset_id.encode("utf-8")).digest()) for _ in range(count)]
+
+    frames = load_pil_video_frames(media_path, width, height, count)
+    if not frames:
+        frames = load_imageio_video_frames(media_path, width, height, count)
+    if not frames:
+        first = load_source_frame(project_path, asset_id, 0, width, height) or gradient_frame(width, height, hashlib.sha256(asset_id.encode("utf-8")).digest())
+        frames = [first.copy() for _ in range(count)]
+    if len(frames) < count:
+        frames.extend(frames[-1].copy() for _ in range(count - len(frames)))
+    return frames[:count]
+
+
+def load_pil_video_frames(media_path: Path, width: int, height: int, count: int) -> list[Image.Image]:
+    try:
+        image = Image.open(media_path)
+    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+        return []
+    frame_total = max(1, getattr(image, "n_frames", 1))
+    frames = []
+    for index in evenly_spaced_indices(frame_total, count):
+        try:
+            image.seek(index)
+            frames.append(fit_frame(image.convert("RGB"), width, height))
+        except (EOFError, OSError):
+            break
+    return frames
+
+
+def load_imageio_video_frames(media_path: Path, width: int, height: int, count: int) -> list[Image.Image]:
+    try:
+        imageio = importlib.import_module("imageio.v3")
+        metadata = imageio.immeta(media_path)
+        duration = safe_float(metadata.get("duration"), 0, 0, 3600)
+        fps = safe_float(metadata.get("fps"), 24, 1, 240)
+        frame_total = max(count, int(round(duration * fps))) if duration > 0 else count
+        return [
+            fit_frame(Image.fromarray(imageio.imread(media_path, index=index)).convert("RGB"), width, height)
+            for index in evenly_spaced_indices(frame_total, count)
+        ]
+    except Exception:
+        return []
+
+
+def evenly_spaced_indices(total: int, count: int) -> list[int]:
+    if count <= 1:
+        return [0]
+    return [min(total - 1, max(0, round((total - 1) * index / (count - 1)))) for index in range(count)]
+
+
+def fit_frame(image: Image.Image, width: int, height: int) -> Image.Image:
+    image.thumbnail((width, height), Image.Resampling.LANCZOS)
+    canvas = Image.new("RGB", (width, height), (18, 17, 15))
+    canvas.paste(image, ((width - image.width) // 2, (height - image.height) // 2))
+    return canvas
+
+
 def load_seekable_image_frame(media_path: Path, timestamp: float, duration: Any = None) -> Image.Image | None:
     try:
         image = Image.open(media_path)
     except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
-        return None
+        return load_seekable_video_frame(media_path, timestamp)
 
     try:
         frame_count = getattr(image, "n_frames", 1)
@@ -363,6 +767,18 @@ def load_seekable_image_frame(media_path: Path, timestamp: float, duration: Any 
                 image.seek(frame_index)
         return image.convert("RGB")
     except (EOFError, OSError):
+        return None
+
+
+def load_seekable_video_frame(media_path: Path, timestamp: float) -> Image.Image | None:
+    try:
+        imageio = importlib.import_module("imageio.v3")
+        metadata = imageio.immeta(media_path)
+        fps = safe_float(metadata.get("fps"), 24, 1, 240)
+        frame_index = max(0, int(round(timestamp * fps)))
+        frame = imageio.imread(media_path, index=frame_index)
+        return Image.fromarray(frame).convert("RGB")
+    except Exception:
         return None
 
 
@@ -506,6 +922,168 @@ def save_animated_preview(frames: list[Image.Image], path: Path, duration: float
     )
 
 
+def frames_from_output(output: Any) -> list[Image.Image]:
+    frames = getattr(output, "frames", None)
+    if frames is None and isinstance(output, tuple) and output:
+        frames = output[0]
+    if frames is None:
+        frames = getattr(output, "images", None)
+    if frames is None:
+        return []
+    if hasattr(frames, "ndim"):
+        import numpy as np
+
+        array = np.asarray(frames)
+        if array.ndim == 5:
+            array = array[0]
+        return [Image.fromarray(frame).convert("RGB") for frame in array]
+    if isinstance(frames, list) and frames and isinstance(frames[0], list):
+        return [frame.convert("RGB") if hasattr(frame, "convert") else Image.fromarray(frame).convert("RGB") for frame in frames[0]]
+    if isinstance(frames, list):
+        return [frame.convert("RGB") if hasattr(frame, "convert") else Image.fromarray(frame).convert("RGB") for frame in frames]
+    return []
+
+
+def accepted_call_parameters(pipe: Any) -> set[str]:
+    try:
+        return set(inspect.signature(pipe.__call__).parameters)
+    except (TypeError, ValueError):
+        return set()
+
+
+def filter_call_kwargs(pipe: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    accepted = accepted_call_parameters(pipe)
+    if not accepted:
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in accepted and value is not None}
+
+
+def ltx_conditions(
+    first_image: Image.Image | None,
+    last_image: Image.Image | None,
+    num_frames: int,
+    width: int,
+    height: int,
+) -> list[Any]:
+    try:
+        ltx_condition = importlib.import_module("diffusers.pipelines.ltx.pipeline_ltx_condition")
+        condition_class = getattr(ltx_condition, "LTXVideoCondition")
+    except (ImportError, AttributeError):
+        return []
+
+    conditions = []
+    if first_image is not None:
+        conditions.append(condition_class(image=first_image.resize((width, height)), frame_index=0))
+    if last_image is not None:
+        conditions.append(condition_class(image=last_image.resize((width, height)), frame_index=max(0, num_frames - 1)))
+    return conditions
+
+
+def person_track_masks(project_path: Path, track_id: str | None, width: int, height: int, count: int) -> list[Image.Image]:
+    track = read_person_track(project_path, track_id)
+    boxes = []
+    if track:
+        boxes = [frame.get("box") for frame in track.get("frames", []) if isinstance(frame, dict) and isinstance(frame.get("box"), dict)]
+        selected_box = track.get("selectedDetection", {}).get("box")
+        if not boxes and isinstance(selected_box, dict):
+            boxes = [selected_box]
+    if not boxes:
+        boxes = [{"x": 0.32, "y": 0.12, "width": 0.36, "height": 0.76}]
+
+    masks = []
+    for index in range(count):
+        box = boxes[min(len(boxes) - 1, round(index * (len(boxes) - 1) / max(1, count - 1)))]
+        mask = Image.new("L", (width, height), 0)
+        draw = ImageDraw.Draw(mask)
+        left = int(safe_float(box.get("x"), 0, 0, 1) * width)
+        top = int(safe_float(box.get("y"), 0, 0, 1) * height)
+        right = int((safe_float(box.get("x"), 0, 0, 1) + safe_float(box.get("width"), 0, 0, 1)) * width)
+        bottom = int((safe_float(box.get("y"), 0, 0, 1) + safe_float(box.get("height"), 0, 0, 1)) * height)
+        padding_x = max(8, int(width * 0.03))
+        padding_y = max(8, int(height * 0.03))
+        draw.rectangle(
+            (
+                max(0, left - padding_x),
+                max(0, top - padding_y),
+                min(width, right + padding_x),
+                min(height, bottom + padding_y),
+            ),
+            fill=255,
+        )
+        masks.append(mask)
+    return masks
+
+
+def read_person_track(project_path: Path, track_id: str | None) -> dict[str, Any] | None:
+    if not track_id:
+        return None
+    tracks_dir = project_path / "person-tracks"
+    candidates = [tracks_dir / f"{track_id}.sceneworks.person-track.json"]
+    if tracks_dir.exists():
+        candidates.extend(tracks_dir.glob("*.sceneworks.person-track.json"))
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = read_json(path)
+        except (OSError, ValueError):
+            continue
+        if payload.get("id") == track_id:
+            return payload
+    return None
+
+
+def character_reference_images(project_path: Path, character_id: str | None, look_id: str | None, width: int, height: int) -> list[Image.Image]:
+    character = read_character(project_path, character_id)
+    if not character:
+        return []
+    approved_ids = []
+    for look in character.get("looks", []):
+        if isinstance(look, dict) and look.get("id") == look_id:
+            approved_ids.extend(look.get("approvedReferenceIds", []))
+    if not approved_ids:
+        approved_ids.extend(
+            reference.get("assetId")
+            for reference in character.get("references", [])
+            if isinstance(reference, dict) and reference.get("approved")
+        )
+    images = []
+    for asset_id in [asset_id for asset_id in approved_ids if asset_id]:
+        image = load_source_image(project_path, asset_id, width, height)
+        if image is not None:
+            images.append(image)
+    return images
+
+
+def read_character(project_path: Path, character_id: str | None) -> dict[str, Any] | None:
+    if not character_id:
+        return None
+    characters_dir = project_path / "characters"
+    candidates = [characters_dir / f"{character_id}.sceneworks.character.json"]
+    if characters_dir.exists():
+        candidates.extend(characters_dir.glob("*.sceneworks.character.json"))
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = read_json(path)
+        except (OSError, ValueError):
+            continue
+        if payload.get("id") == character_id:
+            return payload
+    return None
+
+
+def default_negative_prompt(target: dict[str, Any]) -> str:
+    if target["adapter"] == "wan_video":
+        return (
+            "Bright tones, overexposed, static, blurred details, subtitles, paintings, still picture, "
+            "overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, "
+            "deformed, disfigured, messy background"
+        )
+    return "worst quality, inconsistent motion, blurry, jittery, distorted"
+
+
 def build_video_asset_sidecar(
     *,
     asset_id: str,
@@ -518,6 +1096,7 @@ def build_video_asset_sidecar(
     seed: int,
     target: dict[str, Any],
     raw_settings: dict[str, Any],
+    adapter_id: str = "procedural_video",
 ) -> dict[str, Any]:
     parents = [
         asset_id
@@ -580,7 +1159,7 @@ def build_video_asset_sidecar(
         "recipe": {
             "mode": request.mode,
             "model": request.model,
-            "adapter": "procedural_video",
+            "adapter": adapter_id,
             "prompt": request.prompt,
             "negativePrompt": request.negative_prompt,
             "seed": seed,

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import hashlib
 import importlib
-import inspect
 import os
 import warnings
 from pathlib import Path
@@ -12,7 +11,7 @@ from textwrap import wrap
 from typing import Any, Callable
 from uuid import uuid4
 
-from PIL import Image, ImageDraw, ImageEnhance, ImageFont
+from PIL import Image, ImageDraw, ImageEnhance, ImageFont, UnidentifiedImageError
 
 from sceneworks_shared import (
     find_asset_sidecar_path,
@@ -25,6 +24,7 @@ from sceneworks_shared import (
     utc_now,
 )
 
+from .adapter_utils import filter_call_kwargs
 from .image_adapters import select_torch_device, select_torch_dtype, write_json
 from .settings import WorkerSettings
 
@@ -220,6 +220,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
             seed=seed,
             target=target,
             adapter_id=self.id,
+            mime_type="image/webp",
             raw_settings=raw_settings,
         )
 
@@ -266,7 +267,8 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
     id = "diffusers_video"
 
     def __init__(self) -> None:
-        self._pipelines: dict[str, Any] = {}
+        self._pipeline: Any | None = None
+        self._pipeline_key_value: str | None = None
         self._loaded_models: set[str] = set()
 
     def loaded_models(self) -> list[str]:
@@ -312,7 +314,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
         first_image = self._first_condition_image(project_path, request)
         last_image = self._last_condition_image(project_path, request)
-        self._validate_inputs(request, first_image, last_image)
+        self._validate_inputs(project_path, request, first_image, last_image)
         if cancel_requested():
             raise InterruptedError("Video generation canceled before inference.")
 
@@ -376,9 +378,9 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             seed=seed,
             target=target,
             adapter_id=target["adapter"],
+            mime_type="video/mp4",
             raw_settings=raw_settings,
         )
-        asset["file"]["mimeType"] = "video/mp4"
 
         write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
         write_json(media_path.with_suffix(".sceneworks.json"), asset)
@@ -414,27 +416,28 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
     def _load_pipeline(self, request: VideoRequest, target: dict[str, Any]) -> Any:
         key = self._pipeline_key(request, target)
-        if key in self._pipelines:
+        repo = self._repo_for_request(request, target)
+        if self._pipeline is not None and self._pipeline_key_value == key:
             self._loaded_models.update({request.model, self._repo_for_request(request, target)})
-            return self._pipelines[key]
+            return self._pipeline
 
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
-        repo = self._repo_for_request(request, target)
         device = select_torch_device(torch)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+        self._evict_pipeline(torch)
         pipeline_class = self._pipeline_class(diffusers, request, target)
         kwargs: dict[str, Any] = {"torch_dtype": dtype}
 
         if target["adapter"] == "wan_video":
             vae_class = getattr(diffusers, "AutoencoderKLWan", None)
             if vae_class is not None:
-                kwargs["vae"] = vae_class.from_pretrained(repo, subfolder="vae", torch_dtype=torch.float32)
+                kwargs["vae"] = vae_class.from_pretrained(repo, subfolder="vae", torch_dtype=dtype)
             if request.mode != "text_to_video":
                 transformers = importlib.import_module("transformers")
                 image_encoder_class = getattr(transformers, "CLIPVisionModel", None)
                 if image_encoder_class is not None:
-                    kwargs["image_encoder"] = image_encoder_class.from_pretrained(repo, subfolder="image_encoder", torch_dtype=torch.float32)
+                    kwargs["image_encoder"] = image_encoder_class.from_pretrained(repo, subfolder="image_encoder", torch_dtype=dtype)
 
         pipe = pipeline_class.from_pretrained(repo, **kwargs)
         if bool(request.advanced.get("cpuOffload", False)) and hasattr(pipe, "enable_model_cpu_offload"):
@@ -446,9 +449,17 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         elif getattr(pipe, "vae", None) is not None and hasattr(pipe.vae, "enable_tiling"):
             pipe.vae.enable_tiling()
 
-        self._pipelines[key] = pipe
+        self._pipeline = pipe
+        self._pipeline_key_value = key
         self._loaded_models.update({request.model, repo})
         return pipe
+
+    def _evict_pipeline(self, torch: Any) -> None:
+        self._pipeline = None
+        self._pipeline_key_value = None
+        self._loaded_models.clear()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def _pipeline_class(self, diffusers: Any, request: VideoRequest, target: dict[str, Any]) -> Any:
         if target["adapter"] == "wan_video":
@@ -576,7 +587,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             return load_source_frame(project_path, request.bridge_right_clip_asset_id, timestamp, request.width, request.height)
         return None
 
-    def _validate_inputs(self, request: VideoRequest, first_image: Image.Image | None, last_image: Image.Image | None) -> None:
+    def _validate_inputs(self, project_path: Path, request: VideoRequest, first_image: Image.Image | None, last_image: Image.Image | None) -> None:
         if request.mode in {"image_to_video", "first_last_frame"} and first_image is None:
             raise RuntimeError(f"{request.mode.replace('_', ' ').title()} requires a readable source image.")
         if request.mode == "first_last_frame" and last_image is None:
@@ -585,12 +596,26 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             raise RuntimeError(f"{request.mode.replace('_', ' ').title()} requires a readable source clip frame.")
         if request.mode == "video_bridge" and last_image is None:
             raise RuntimeError("Bridge generation requires a readable right clip frame.")
+        if request.mode == "replace_person":
+            if not request.person_track_id:
+                raise RuntimeError("Replace Person requires a selected person track.")
+            if not request.character_id:
+                raise RuntimeError("Replace Person requires a character.")
+            if read_person_track(project_path, request.person_track_id) is None:
+                raise RuntimeError(f"Replace Person track not found: {request.person_track_id}.")
+            if read_character(project_path, request.character_id) is None:
+                raise RuntimeError(f"Replace Person character not found: {request.character_id}.")
+            if not character_reference_images(project_path, request.character_id, request.character_look_id, request.width, request.height):
+                raise RuntimeError("Replace Person requires at least one readable approved character reference image.")
 
 
 def create_video_adapter() -> VideoGenerationAdapter:
-    if os.getenv("SCENEWORKS_VIDEO_ADAPTER", "").strip() == "procedural_video":
+    requested = os.getenv("SCENEWORKS_VIDEO_ADAPTER", "").strip()
+    if not requested or requested == "diffusers_video":
+        return DiffusersVideoAdapter()
+    if requested in {"procedural", "procedural_video"}:
         return ProceduralVideoAdapter()
-    return DiffusersVideoAdapter()
+    raise RuntimeError(f"Unsupported SCENEWORKS_VIDEO_ADAPTER value: {requested}.")
 
 
 def video_request_from_job(job: dict[str, Any]) -> VideoRequest:
@@ -688,21 +713,20 @@ def load_source_frame(project_path: Path, asset_id: str | None, timestamp: float
 
 def load_source_video_frames(project_path: Path, asset_id: str | None, width: int, height: int, count: int) -> list[Image.Image]:
     if not asset_id:
-        return [gradient_frame(width, height, hashlib.sha256(b"missing-video").digest()) for _ in range(count)]
+        raise RuntimeError("Replace Person requires a source clip asset.")
     sidecar_path = find_asset_sidecar_path(project_path, asset_id)
     if sidecar_path is None:
-        return [gradient_frame(width, height, hashlib.sha256(asset_id.encode("utf-8")).digest()) for _ in range(count)]
+        raise RuntimeError(f"Source clip asset not found: {asset_id}.")
     payload = read_json(sidecar_path)
     media_path = project_path / payload.get("file", {}).get("path", "")
     if not media_path.exists():
-        return [gradient_frame(width, height, hashlib.sha256(asset_id.encode("utf-8")).digest()) for _ in range(count)]
+        raise RuntimeError(f"Source clip file is missing for asset {asset_id}.")
 
     frames = load_pil_video_frames(media_path, width, height, count)
     if not frames:
         frames = load_imageio_video_frames(media_path, width, height, count)
     if not frames:
-        first = load_source_frame(project_path, asset_id, 0, width, height) or gradient_frame(width, height, hashlib.sha256(asset_id.encode("utf-8")).digest())
-        frames = [first.copy() for _ in range(count)]
+        raise RuntimeError(f"Source clip frames could not be read for asset {asset_id}.")
     if len(frames) < count:
         frames.extend(frames[-1].copy() for _ in range(count - len(frames)))
     return frames[:count]
@@ -711,7 +735,9 @@ def load_source_video_frames(project_path: Path, asset_id: str | None, width: in
 def load_pil_video_frames(media_path: Path, width: int, height: int, count: int) -> list[Image.Image]:
     try:
         image = Image.open(media_path)
-    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise RuntimeError(f"Source media exceeds the safe image pixel limit: {media_path}") from exc
+    except (UnidentifiedImageError, OSError):
         return []
     frame_total = max(1, getattr(image, "n_frames", 1))
     frames = []
@@ -731,10 +757,14 @@ def load_imageio_video_frames(media_path: Path, width: int, height: int, count: 
         duration = safe_float(metadata.get("duration"), 0, 0, 3600)
         fps = safe_float(metadata.get("fps"), 24, 1, 240)
         frame_total = max(count, int(round(duration * fps))) if duration > 0 else count
-        return [
-            fit_frame(Image.fromarray(imageio.imread(media_path, index=index)).convert("RGB"), width, height)
-            for index in evenly_spaced_indices(frame_total, count)
-        ]
+        target_indices = set(evenly_spaced_indices(frame_total, count))
+        frames = []
+        for index, frame in enumerate(imageio.imiter(media_path)):
+            if index in target_indices:
+                frames.append(fit_frame(Image.fromarray(frame).convert("RGB"), width, height))
+                if len(frames) == len(target_indices):
+                    break
+        return frames
     except Exception:
         return []
 
@@ -755,8 +785,12 @@ def fit_frame(image: Image.Image, width: int, height: int) -> Image.Image:
 def load_seekable_image_frame(media_path: Path, timestamp: float, duration: Any = None) -> Image.Image | None:
     try:
         image = Image.open(media_path)
-    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning):
+        return None
+    except UnidentifiedImageError:
         return load_seekable_video_frame(media_path, timestamp)
+    except OSError:
+        return None
 
     try:
         frame_count = getattr(image, "n_frames", 1)
@@ -944,20 +978,6 @@ def frames_from_output(output: Any) -> list[Image.Image]:
     return []
 
 
-def accepted_call_parameters(pipe: Any) -> set[str]:
-    try:
-        return set(inspect.signature(pipe.__call__).parameters)
-    except (TypeError, ValueError):
-        return set()
-
-
-def filter_call_kwargs(pipe: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
-    accepted = accepted_call_parameters(pipe)
-    if not accepted:
-        return kwargs
-    return {key: value for key, value in kwargs.items() if key in accepted and value is not None}
-
-
 def ltx_conditions(
     first_image: Image.Image | None,
     last_image: Image.Image | None,
@@ -988,7 +1008,7 @@ def person_track_masks(project_path: Path, track_id: str | None, width: int, hei
         if not boxes and isinstance(selected_box, dict):
             boxes = [selected_box]
     if not boxes:
-        boxes = [{"x": 0.32, "y": 0.12, "width": 0.36, "height": 0.76}]
+        raise RuntimeError(f"Person track has no usable boxes: {track_id}.")
 
     masks = []
     for index in range(count):
@@ -1048,7 +1068,7 @@ def character_reference_images(project_path: Path, character_id: str | None, loo
             if isinstance(reference, dict) and reference.get("approved")
         )
     images = []
-    for asset_id in [asset_id for asset_id in approved_ids if asset_id]:
+    for asset_id in [asset_id for asset_id in approved_ids if asset_id][:4]:
         image = load_source_image(project_path, asset_id, width, height)
         if image is not None:
             images.append(image)
@@ -1096,7 +1116,8 @@ def build_video_asset_sidecar(
     seed: int,
     target: dict[str, Any],
     raw_settings: dict[str, Any],
-    adapter_id: str = "procedural_video",
+    adapter_id: str,
+    mime_type: str,
 ) -> dict[str, Any]:
     parents = [
         asset_id
@@ -1144,7 +1165,7 @@ def build_video_asset_sidecar(
         "createdAt": created_at,
         "file": {
             "path": media_rel,
-            "mimeType": "image/webp",
+            "mimeType": mime_type,
             "width": request.width,
             "height": request.height,
             "duration": request.duration,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -160,10 +160,16 @@
           "provider": "huggingface",
           "repo": "Lightricks/LTX-2",
           "files": []
+        },
+        {
+          "provider": "huggingface",
+          "repo": "Lightricks/LTX-Video",
+          "files": []
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Lightricks/LTX-2"
+        "model": "${HF_CACHE}/Lightricks/LTX-2",
+        "imageToVideoModel": "${HF_CACHE}/Lightricks/LTX-Video"
       },
       "defaults": {
         "duration": 6,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -77,12 +77,48 @@
       }
     },
     {
+      "id": "qwen_image",
+      "name": "Qwen Image",
+      "family": "qwen-image",
+      "type": "image",
+      "adapter": "qwen_image",
+      "capabilities": ["text_to_image", "style_variations"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "Qwen/Qwen-Image",
+          "files": []
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/Qwen/Qwen-Image"
+      },
+      "defaults": {
+        "resolution": "1024x1024",
+        "steps": 20,
+        "count": 4
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        "families": ["qwen-image"],
+        "types": ["style", "enhance", "character"]
+      },
+      "ui": {
+        "label": "Qwen Image",
+        "description": "Higher-control Qwen text-to-image target backed by Diffusers.",
+        "recommendedFor": ["text_to_image", "style_variations"]
+      }
+    },
+    {
       "id": "qwen_image_edit",
       "name": "Qwen Image Edit",
       "family": "qwen-image",
       "type": "image",
       "adapter": "qwen_image",
-      "capabilities": ["text_to_image", "edit_image", "style_variations"],
+      "capabilities": ["edit_image"],
       "downloads": [
         {
           "provider": "huggingface",
@@ -122,12 +158,12 @@
       "downloads": [
         {
           "provider": "huggingface",
-          "repo": "Lightricks/LTX-2.3",
-          "files": ["ltx-2.3-22b-dev.safetensors"]
+          "repo": "Lightricks/LTX-2",
+          "files": []
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Lightricks/LTX-2.3"
+        "model": "${HF_CACHE}/Lightricks/LTX-2"
       },
       "defaults": {
         "duration": 6,
@@ -165,12 +201,12 @@
       "downloads": [
         {
           "provider": "huggingface",
-          "repo": "Wan-AI/Wan2.2-TI2V-5B",
+          "repo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
           "files": []
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Wan-AI/Wan2.2-TI2V-5B"
+        "model": "${HF_CACHE}/Wan-AI/Wan2.2-TI2V-5B-Diffusers"
       },
       "defaults": {
         "duration": 5,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
+from PIL import Image
+
+from scene_worker.adapter_utils import filter_call_kwargs
 from scene_worker.image_adapters import (
     MODEL_TARGETS,
+    QwenImageAdapter,
     ZImageDiffusersAdapter,
     build_asset_sidecar,
+    create_image_adapter,
     huggingface_repo_cache_path,
     image_request_from_job,
     resolve_seed,
@@ -22,7 +28,23 @@ from scene_worker.runtime import (
     run_video_job,
     worker_capabilities,
 )
-from scene_worker.video_adapters import VIDEO_MODEL_TARGETS, build_video_asset_sidecar, video_request_from_job
+from scene_worker.video_adapters import (
+    DiffusersVideoAdapter,
+    VIDEO_MODEL_TARGETS,
+    build_video_asset_sidecar,
+    character_reference_images,
+    create_video_adapter,
+    evenly_spaced_indices,
+    frames_from_output,
+    load_seekable_image_frame,
+    person_track_masks,
+    video_request_from_job,
+)
+
+
+class AcceptsNone:
+    def __call__(self, *, prompt, image=None):
+        return prompt, image
 
 
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
@@ -87,6 +109,35 @@ def test_z_image_loaded_models_include_repo_and_model_id():
     adapter._loaded_model = "z_image_turbo"
 
     assert set(adapter.loaded_models()) == {"Tongyi-MAI/Z-Image-Turbo", "z_image_turbo"}
+
+
+def test_qwen_loaded_models_track_text_and_edit_repos_independently():
+    adapter = QwenImageAdapter()
+    adapter._text_repo = "Qwen/Qwen-Image"
+    adapter._edit_repo = "Qwen/Qwen-Image-Edit"
+    adapter._loaded_model = "qwen_image_edit"
+
+    assert set(adapter.loaded_models()) == {"Qwen/Qwen-Image", "Qwen/Qwen-Image-Edit", "qwen_image_edit"}
+
+
+def test_filter_call_kwargs_preserves_none_for_accepted_parameters():
+    assert filter_call_kwargs(AcceptsNone(), {"prompt": "city", "image": None, "extra": 1}) == {
+        "prompt": "city",
+        "image": None,
+    }
+
+
+def test_image_adapter_env_aliases_and_unknown_values(monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "procedural")
+    assert create_image_adapter({"payload": {"model": "z_image_turbo"}}).__class__.__name__ == "ProceduralImageAdapter"
+
+    monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "typo")
+    try:
+        create_image_adapter({"payload": {"model": "z_image_turbo"}})
+    except RuntimeError as exc:
+        assert "Unsupported SCENEWORKS_IMAGE_ADAPTER" in str(exc)
+    else:
+        raise AssertionError("Unknown image adapter override should fail loudly.")
 
 
 def test_huggingface_repo_cache_path_stays_under_cache_root(monkeypatch, tmp_path):
@@ -340,6 +391,112 @@ def test_explicit_seed_uses_reproducible_ladder():
     assert resolve_seed(1234, "city at night", 2, [101, 202, 303, 404]) == 1236
 
 
+def test_video_adapter_override_aliases_and_unknown_values(monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "procedural")
+    assert create_video_adapter().__class__.__name__ == "ProceduralVideoAdapter"
+
+    monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "typo")
+    try:
+        create_video_adapter()
+    except RuntimeError as exc:
+        assert "Unsupported SCENEWORKS_VIDEO_ADAPTER" in str(exc)
+    else:
+        raise AssertionError("Unknown video adapter override should fail loudly.")
+
+
+def test_video_pipeline_evicts_previous_pipeline_and_loaded_models():
+    adapter = DiffusersVideoAdapter()
+    adapter._pipeline = object()
+    adapter._pipeline_key_value = "old"
+    adapter._loaded_models = {"old-model"}
+
+    class Torch:
+        class cuda:
+            emptied = False
+
+            @classmethod
+            def is_available(cls):
+                return True
+
+            @classmethod
+            def empty_cache(cls):
+                cls.emptied = True
+
+    adapter._evict_pipeline(Torch)
+
+    assert adapter._pipeline is None
+    assert adapter._pipeline_key_value is None
+    assert adapter.loaded_models() == []
+    assert Torch.cuda.emptied is True
+
+
+def test_evenly_spaced_indices_are_bounded():
+    assert evenly_spaced_indices(10, 4) == [0, 3, 6, 9]
+    assert evenly_spaced_indices(1, 4) == [0, 0, 0, 0]
+
+
+def test_frames_from_output_accepts_nested_frames():
+    red = Image.new("RGB", (2, 2), "red")
+    blue = Image.new("RGB", (2, 2), "blue")
+
+    frames = frames_from_output(SimpleNamespace(frames=[[red, blue]]))
+
+    assert len(frames) == 2
+    assert frames[0].getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_load_seekable_image_frame_does_not_fallback_on_decompression_bomb(monkeypatch, tmp_path):
+    path = tmp_path / "bomb.png"
+    path.write_bytes(b"not really used")
+
+    monkeypatch.setattr("scene_worker.video_adapters.Image.open", lambda _path: (_ for _ in ()).throw(Image.DecompressionBombError("too large")))
+    monkeypatch.setattr(
+        "scene_worker.video_adapters.load_seekable_video_frame",
+        lambda _path, _timestamp: (_ for _ in ()).throw(AssertionError("video fallback should not run")),
+    )
+
+    assert load_seekable_image_frame(path, 0) is None
+
+
+def test_person_track_masks_fail_without_track_boxes(tmp_path):
+    project_path = tmp_path
+    track_dir = project_path / "person-tracks"
+    track_dir.mkdir()
+    (track_dir / "track_empty.sceneworks.person-track.json").write_text(
+        json.dumps({"id": "track_empty", "frames": [], "selectedDetection": {}}),
+        encoding="utf-8",
+    )
+
+    try:
+        person_track_masks(project_path, "track_empty", 64, 64, 2)
+    except RuntimeError as exc:
+        assert "no usable boxes" in str(exc)
+    else:
+        raise AssertionError("Empty person tracks should fail loudly.")
+
+
+def test_character_reference_images_are_capped(tmp_path):
+    project_path = tmp_path
+    (project_path / "characters").mkdir()
+    (project_path / "assets" / "images").mkdir(parents=True)
+    references = []
+    for index in range(5):
+        asset_id = f"asset_ref_{index}"
+        media_rel = f"assets/images/ref_{index}.png"
+        Image.new("RGB", (4, 4), (index, 0, 0)).save(project_path / media_rel)
+        (project_path / f"assets/images/ref_{index}.sceneworks.json").write_text(
+            json.dumps({"id": asset_id, "file": {"path": media_rel}}),
+            encoding="utf-8",
+        )
+        references.append({"assetId": asset_id, "approved": True})
+    (project_path / "characters" / "character_1.sceneworks.character.json").write_text(
+        json.dumps({"id": "character_1", "references": references, "looks": []}),
+        encoding="utf-8",
+    )
+
+    assert len(character_reference_images(project_path, "character_1", None, 16, 16)) == 4
+
+
 def test_character_image_recipe_marks_conditioning_inactive():
     job = {
         "id": "job-1",
@@ -404,10 +561,13 @@ def test_replace_person_video_sidecar_preserves_lineage():
         created_at="2026-05-17T00:00:00Z",
         seed=44,
         target=VIDEO_MODEL_TARGETS["wan_2_2"],
+        adapter_id="wan_video",
+        mime_type="video/mp4",
         raw_settings={},
     )
 
     assert asset["recipe"]["mode"] == "replace_person"
+    assert asset["file"]["mimeType"] == "video/mp4"
     assert asset["recipe"]["normalizedSettings"]["personTrackId"] == "track-1"
     assert asset["recipe"]["normalizedSettings"]["replacementMode"] == "full_person_keep_outfit"
     assert asset["recipe"]["normalizedSettings"]["personDetectionActive"] is False

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -313,7 +313,7 @@ def test_video_job_reports_dynamic_loaded_models_on_progress_and_keepalive(monke
         blocking_models.append(loaded_models())
         return result
 
-    monkeypatch.setattr("scene_worker.runtime.ProceduralVideoAdapter", VideoAdapter)
+    monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda: VideoAdapter())
     monkeypatch.setattr("scene_worker.runtime.run_blocking_job_step", run_immediately)
 
     run_video_job(


### PR DESCRIPTION
﻿## Summary

Replaces the fake/default procedural generation path for non-Z-image work with real Diffusers-backed adapter wiring.

- Adds Qwen Image and Qwen Image Edit pipeline support in the Python worker.
- Adds Diffusers-backed LTX/Wan video generation that saves MP4 assets.
- Routes replace-person jobs through Wan with source frames, person-track masks, and character reference images.
- Updates model manifests, web fallback catalog, worker dependencies, and adapter override docs.

## Why

Several v1 surfaces were advertising model-backed behavior while the worker still produced procedural preview assets. This keeps the product surface intact and moves the runtime toward the real adapter implementations instead of hiding those features.

## Validation

- `python -m py_compile apps\worker\scene_worker\image_adapters.py apps\worker\scene_worker\video_adapters.py apps\worker\scene_worker\runtime.py`
- `python -m pytest tests -q` -> 39 passed, 1 skipped
- `npm --prefix apps/web test` -> 8 passed
- `cargo test --workspace` -> passed before the final Python-only replace-person conditioning additions; no Rust files changed after that

## Notes

I did not run live model inference because it requires downloading multi-GB model weights and a suitable GPU. CI may still expose parity/contract failures, which we should inspect next.
