### PR TITLE
[codex] Fix LTX video failures and preset model overrides

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1735,13 +1735,15 @@ async fn apply_recipe_preset_to_image_payload(
 
     let expanded_prompt = preset_prompt(&payload.prompt, preset);
     job_payload.insert("prompt".to_owned(), Value::String(expanded_prompt));
-    if let Some(model) = preset
-        .get("model")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
+    if payload.model == default_image_model() {
+        if let Some(model) = preset
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
+        }
     }
     apply_recipe_preset_defaults(preset, job_payload)?;
     job_payload.insert(
@@ -4530,7 +4532,7 @@ mod tests {
             "city at night, cinematic lighting"
         );
         assert_eq!(image_job["payload"]["loras"][0]["id"], "style-lora");
-        assert_eq!(image_job["payload"]["model"], "preset-model");
+        assert_eq!(image_job["payload"]["model"], "client-model");
         assert_eq!(image_job["payload"]["count"], 2);
         assert_eq!(image_job["payload"]["seeds"].as_array().unwrap().len(), 2);
         assert_eq!(image_job["payload"]["width"], 1280);
@@ -4541,6 +4543,23 @@ mod tests {
             image_job["payload"]["advanced"]["recipePresetId"],
             "cinematic"
         );
+
+        let (status, preset_model_job) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/image/jobs",
+            json!({
+                "projectId": project_id,
+                "prompt": "city at dawn",
+                "count": 1,
+                "width": 512,
+                "height": 512,
+                "recipePresetId": "cinematic"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(preset_model_job["payload"]["model"], "preset-model");
 
         let (status, job) = request(
             app.clone(),

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -33,6 +33,12 @@ function isSelectableGpuWorker(worker) {
   return worker.gpuId && worker.gpuId !== "cpu" && hasCapability(worker, "gpu") && !isPlaceholderOnlyGpuWorker(worker);
 }
 
+function failedJobNotice(job) {
+  const label = String(job.type ?? "job").replaceAll("_", " ");
+  const detail = job.error || job.message || "Failed without additional worker detail.";
+  return `${label}: ${detail}`;
+}
+
 export function App() {
   const [health, setHealth] = useState(null);
   const [access, setAccess] = useState({ authRequired: false });
@@ -194,6 +200,9 @@ export function App() {
       }
       if (job.status === "completed" && job.projectId && job.type === "person_detect") {
         refreshAssets(job.projectId);
+      }
+      if (job.status === "failed") {
+        setError(failedJobNotice(job));
       }
     }
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -144,6 +144,23 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
                 f"or a different GPU. Technical detail: {detail}"
             ),
         )
+    ltx_frame_markers = (
+        "num_frames",
+        "frame count",
+        "divisible by 8",
+        "multiple of 8",
+        "8 + 1",
+        "8n+1",
+    )
+    if ("ltx" in lowered or job_kind.lower().startswith("video")) and any(marker in lowered for marker in ltx_frame_markers):
+        return (
+            f"{job_kind} failed because LTX requires a compatible frame count.",
+            (
+                "LTX video frame counts must satisfy (frames - 1) being divisible by 8. "
+                "Try a standard SceneWorks duration/FPS preset or shorten the clip. "
+                f"Technical detail: {detail}"
+            ),
+        )
     missing_model_markers = (
         "repo id",
         "repository not found",

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -41,7 +41,7 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "label": "LTX-2.3",
         "family": "ltx-video",
         "adapter": "ltx_video",
-        "repo": "Lightricks/LTX-2",
+        "repo": "Lightricks/LTX-2.3",
         "fallbackRepo": "Lightricks/LTX-Video",
         "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
         "recommendedMaxDuration": 10,
@@ -286,8 +286,11 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
     def estimate_requirements(self, request: VideoRequest) -> dict[str, Any]:
         target = model_target(request.model)
+        raw_frames = max(1, int(round(request.duration * request.fps)))
+        estimated_frames = self._num_frames(request)
         return {
-            "estimatedFrames": max(1, int(round(request.duration * request.fps))),
+            "estimatedFrames": estimated_frames,
+            "requestedFrames": raw_frames,
             "pixelCount": request.width * request.height,
             "recommendedMaxDuration": target["recommendedMaxDuration"],
             "gpuPreference": request.advanced.get("gpuPreference", "auto"),
@@ -517,7 +520,10 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
     def _num_frames(self, request: VideoRequest) -> int:
         raw_frames = max(1, int(round(request.duration * request.fps)))
-        if model_target(request.model)["adapter"] == "wan_video":
+        adapter = model_target(request.model)["adapter"]
+        if adapter == "ltx_video":
+            return ltx_frame_count(raw_frames)
+        if adapter == "wan_video":
             return max(5, raw_frames - ((raw_frames - 1) % 4))
         return raw_frames
 
@@ -670,6 +676,17 @@ def preview_frame_count(request: VideoRequest) -> int:
     if request.quality == "best":
         return max(18, min(80, raw_frames))
     return max(16, min(60, raw_frames))
+
+
+def ltx_frame_count(raw_frames: int) -> int:
+    frame_count = max(9, int(raw_frames))
+    lower = frame_count - ((frame_count - 1) % 8)
+    upper = lower + 8
+    if lower < 9:
+        return upper
+    lower_delta = abs(frame_count - lower)
+    upper_delta = abs(upper - frame_count)
+    return lower if lower_delta <= upper_delta else upper
 
 
 def load_source_image(project_path: Path, asset_id: str | None, width: int, height: int) -> Image.Image | None:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -158,7 +158,7 @@
       "downloads": [
         {
           "provider": "huggingface",
-          "repo": "Lightricks/LTX-2",
+          "repo": "Lightricks/LTX-2.3",
           "files": []
         },
         {
@@ -168,7 +168,7 @@
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Lightricks/LTX-2",
+        "model": "${HF_CACHE}/Lightricks/LTX-2.3",
         "imageToVideoModel": "${HF_CACHE}/Lightricks/LTX-Video"
       },
       "defaults": {

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -36,6 +36,7 @@ from scene_worker.video_adapters import (
     create_video_adapter,
     evenly_spaced_indices,
     frames_from_output,
+    ltx_frame_count,
     load_seekable_image_frame,
     person_track_masks,
     video_request_from_job,
@@ -165,6 +166,14 @@ def test_friendly_failure_identifies_missing_model_files():
     assert "Model Manager" in error
     assert "Rust utility worker" in error
     assert "HF_TOKEN" in error
+
+
+def test_friendly_failure_identifies_ltx_frame_count_errors():
+    message, error = friendly_failure("Video generation", RuntimeError("num_frames must be divisible by 8 + 1"))
+
+    assert message == "Video generation failed because LTX requires a compatible frame count."
+    assert "(frames - 1)" in error
+    assert "Technical detail" in error
 
 
 def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
@@ -428,6 +437,37 @@ def test_video_pipeline_evicts_previous_pipeline_and_loaded_models():
     assert adapter._pipeline_key_value is None
     assert adapter.loaded_models() == []
     assert Torch.cuda.emptied is True
+
+
+def test_ltx_frame_count_uses_nearest_8n_plus_one_value():
+    assert ltx_frame_count(100) == 97
+    assert ltx_frame_count(150) == 153
+    assert ltx_frame_count(200) == 201
+    assert ltx_frame_count(250) == 249
+
+
+def test_ltx_video_requirements_report_normalized_frame_count():
+    adapter = DiffusersVideoAdapter()
+    request = video_request_from_job(
+        {
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "duration": 6,
+                "fps": 25,
+                "advanced": {},
+            },
+        }
+    )
+
+    requirements = adapter.estimate_requirements(request)
+
+    assert requirements["requestedFrames"] == 150
+    assert requirements["estimatedFrames"] == 153
+    assert requirements["repo"] == "Lightricks/LTX-2.3"
 
 
 def test_evenly_spaced_indices_are_bounded():


### PR DESCRIPTION
﻿## Summary

This PR fixes two generation issues found during local testing:

- LTX-2.3 text-to-video jobs could fail with a vague `Failed` state because the adapter sent invalid frame counts and targeted the older `Lightricks/LTX-2` repo for text-to-video.
- Image presets could silently override an explicitly selected model, so a Qwen Image request using a preset was rewritten into a Z-Image job.

## Changes

- Point LTX text-to-video at `Lightricks/LTX-2.3` in the worker target and built-in model manifest.
- Normalize LTX frame counts to the nearest valid `(frames - 1) % 8 == 0` value before inference.
- Add LTX frame-count-specific failure messaging and surface failed job details in the app notice area.
- Preserve explicit image model selections when applying recipe presets; preset model is only used as a default.
- Add tests for LTX frame normalization, clearer failure messaging, and preset/model behavior.

## Validation

- `cargo test -p sceneworks-rust-api model_and_lora_routes_match_manifest_behavior`
- `python -m pytest tests/test_worker_runtime.py`
- `npm test -- --run` in `apps/web`
- `git diff --check`
