### PR TITLE
[codex] support LoRA URL imports and preset compatibility checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "url",
 ]
 
 [[package]]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -27,6 +27,7 @@ use sceneworks_core::jobs_store::{
     CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker,
     WorkerHeartbeat, JOB_STATUSES,
 };
+use sceneworks_core::lora_url::{lora_source_url_file_stem, parse_lora_source_url, LoraUrlError};
 use sceneworks_core::project_store::{
     AssetStatusPatch, CharacterCreateInput, CharacterLookInput, CharacterLookUpdateInput,
     CharacterLoraInput, CharacterLoraUpdateInput, CharacterReferenceInput,
@@ -2277,7 +2278,7 @@ async fn duplicate_recipe_preset(
 
 async fn create_lora_import_job(
     State(state): State<AppState>,
-    ApiJson(payload): ApiJson<LoraImportRequest>,
+    ApiJson(mut payload): ApiJson<LoraImportRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
     if option_str_is_empty(payload.repo.as_deref())
         && option_str_is_empty(payload.source_url.as_deref())
@@ -2295,11 +2296,20 @@ async fn create_lora_import_job(
             "LoRA scope must be global or project",
         ));
     }
+    if let Some(family) = payload.family.take() {
+        let models = model_catalog(&state).await?;
+        payload.family = Some(validate_lora_family(&models, &family)?);
+    }
     let name = payload
         .name
         .clone()
         .or_else(|| payload.repo.clone())
-        .or_else(|| payload.source_url.as_deref().and_then(source_url_file_stem))
+        .or_else(|| {
+            payload
+                .source_url
+                .as_deref()
+                .and_then(|value| lora_source_url_file_stem(value).ok())
+        })
         .or_else(|| {
             payload.source_path.as_deref().and_then(|path| {
                 FsPath::new(path)
@@ -3602,6 +3612,11 @@ fn validate_recipe_preset_lora_compatibility(
         return Ok(());
     };
     let model_families = model_lora_families(model);
+    if model_families.is_empty() {
+        return Err(ApiError::bad_request(format!(
+            "Model {model_id} has no declared LoRA families"
+        )));
+    }
     for preset_lora in recipe_preset_loras(preset) {
         let Some(lora_id) = preset_lora_id(&preset_lora) else {
             continue;
@@ -3612,9 +3627,17 @@ fn validate_recipe_preset_lora_compatibility(
             .ok_or_else(|| {
                 ApiError::bad_request(format!("Recipe preset LoRA not found: {lora_id}"))
             })?;
+        if lora.get("installState").and_then(Value::as_str) != Some("installed") {
+            return Err(ApiError::bad_request(format!(
+                "Recipe preset LoRA is not installed: {lora_id}"
+            )));
+        }
+        validate_lora_safetensors_header(lora_id, lora)?;
         let families = lora_families(lora);
-        if model_families.is_empty() || families.is_empty() {
-            continue;
+        if families.is_empty() {
+            return Err(ApiError::bad_request(format!(
+                "LoRA {lora_id} has no declared family; cannot verify compatibility with model {model_id}"
+            )));
         }
         if !families.iter().any(|family| {
             model_families
@@ -3629,20 +3652,114 @@ fn validate_recipe_preset_lora_compatibility(
     Ok(())
 }
 
+fn validate_lora_safetensors_header(lora_id: &str, lora: &Value) -> Result<(), ApiError> {
+    let Some(path) = lora.get("installedPath").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let path = PathBuf::from(path);
+    let Some(safetensors_path) = first_safetensors_path(&path) else {
+        return Ok(());
+    };
+    let metadata = std::fs::metadata(&safetensors_path).map_err(|error| {
+        ApiError::bad_request(format!("Unable to inspect LoRA {lora_id}: {error}"))
+    })?;
+    if metadata.len() < 8 {
+        return Err(ApiError::bad_request(format!(
+            "LoRA {lora_id} has an invalid safetensors header"
+        )));
+    }
+    let mut file = std::fs::File::open(&safetensors_path).map_err(|error| {
+        ApiError::bad_request(format!("Unable to inspect LoRA {lora_id}: {error}"))
+    })?;
+    let mut length_bytes = [0_u8; 8];
+    std::io::Read::read_exact(&mut file, &mut length_bytes).map_err(|_| {
+        ApiError::bad_request(format!("LoRA {lora_id} has an invalid safetensors header"))
+    })?;
+    let header_len = u64::from_le_bytes(length_bytes);
+    if header_len == 0 || header_len > 16 * 1024 * 1024 || header_len + 8 > metadata.len() {
+        return Err(ApiError::bad_request(format!(
+            "LoRA {lora_id} has an invalid safetensors header"
+        )));
+    }
+    let mut header = vec![
+        0_u8;
+        usize::try_from(header_len).map_err(|_| ApiError::bad_request(
+            format!("LoRA {lora_id} has an invalid safetensors header")
+        ))?
+    ];
+    std::io::Read::read_exact(&mut file, &mut header).map_err(|_| {
+        ApiError::bad_request(format!("LoRA {lora_id} has an invalid safetensors header"))
+    })?;
+    serde_json::from_slice::<Value>(&header).map_err(|_| {
+        ApiError::bad_request(format!("LoRA {lora_id} has an invalid safetensors header"))
+    })?;
+    Ok(())
+}
+
+fn first_safetensors_path(path: &FsPath) -> Option<PathBuf> {
+    if path.is_file()
+        && path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
+    {
+        return Some(path.to_path_buf());
+    }
+    if !path.is_dir() {
+        return None;
+    }
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let entries = std::fs::read_dir(path).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
+            {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
 fn model_lora_families(model: &Value) -> Vec<String> {
-    let compatibility = model.get("loraCompatibility").unwrap_or(&Value::Null);
-    let values = compatibility
-        .get("families")
-        .or_else(|| model.get("family"));
-    match values {
+    families_from_value_chain(
+        model,
+        &["families", "compatibleFamilies", "modelFamilies"],
+        Some("loraCompatibility"),
+    )
+}
+
+fn families_from_value_chain(
+    value: &Value,
+    direct_fields: &[&str],
+    compatibility_field: Option<&str>,
+) -> Vec<String> {
+    let compatibility = compatibility_field
+        .and_then(|field| value.get(field))
+        .unwrap_or(&Value::Null);
+    let values = direct_fields
+        .iter()
+        .find_map(|field| value.get(*field))
+        .or_else(|| compatibility.get("families"))
+        .or_else(|| value.get("family"));
+    let mut families = match values {
         Some(Value::Array(items)) => items
             .iter()
             .filter_map(Value::as_str)
-            .map(str::to_owned)
+            .map(normalize_lora_family)
             .collect(),
-        Some(Value::String(value)) => vec![value.clone()],
+        Some(Value::String(value)) => vec![normalize_lora_family(value)],
         _ => Vec::new(),
-    }
+    };
+    families.sort();
+    families.dedup();
+    families
 }
 
 fn validate_recipe_preset_prompt(value: Option<&Value>) -> Result<(), ApiError> {
@@ -4073,37 +4190,9 @@ fn safe_download_dir(repo: &str) -> String {
 }
 
 fn validate_source_url(source_url: &str) -> Result<(), ApiError> {
-    let url = reqwest::Url::parse(source_url)
-        .map_err(|_| ApiError::bad_request("LoRA sourceUrl must be a valid URL"))?;
-    if !matches!(url.scheme(), "http" | "https") {
-        return Err(ApiError::bad_request(
-            "LoRA sourceUrl must use http or https",
-        ));
-    }
-    if source_url_file_name(source_url).is_none() {
-        return Err(ApiError::bad_request(
-            "LoRA sourceUrl must include a filename",
-        ));
-    }
-    Ok(())
-}
-
-fn source_url_file_name(source_url: &str) -> Option<String> {
-    let url = reqwest::Url::parse(source_url).ok()?;
-    url.path_segments()?
-        .next_back()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-fn source_url_file_stem(source_url: &str) -> Option<String> {
-    source_url_file_name(source_url).and_then(|file_name| {
-        FsPath::new(&file_name)
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .map(str::to_owned)
-    })
+    parse_lora_source_url(source_url)
+        .map(|_| ())
+        .map_err(|error| ApiError::bad_request(lora_url_error_message(error)))
 }
 
 fn lora_source_provider(payload: &LoraImportRequest) -> &'static str {
@@ -4114,6 +4203,40 @@ fn lora_source_provider(payload: &LoraImportRequest) -> &'static str {
     } else {
         "local"
     }
+}
+
+fn lora_url_error_message(error: LoraUrlError) -> &'static str {
+    error.message()
+}
+
+fn validate_lora_family(models: &[Value], family: &str) -> Result<String, ApiError> {
+    let normalized = normalize_lora_family(family);
+    if normalized.is_empty() {
+        return Err(ApiError::bad_request(
+            "LoRA family is required when provided",
+        ));
+    }
+    let known = known_lora_families(models);
+    if !known.is_empty() && !known.iter().any(|known_family| known_family == &normalized) {
+        return Err(ApiError::bad_request(format!(
+            "Unsupported LoRA family: {family}"
+        )));
+    }
+    Ok(normalized)
+}
+
+fn normalize_lora_family(family: &str) -> String {
+    family.trim().to_ascii_lowercase().replace('_', "-")
+}
+
+fn known_lora_families(models: &[Value]) -> Vec<String> {
+    let mut families = Vec::new();
+    for model in models {
+        families.extend(model_lora_families(model));
+    }
+    families.sort();
+    families.dedup();
+    families
 }
 
 fn slugify_lora_id(value: &str) -> String {
@@ -4201,22 +4324,11 @@ fn model_is_installed(path: &FsPath) -> bool {
 }
 
 fn lora_families(lora: &Value) -> Vec<String> {
-    let compatibility = lora.get("compatibility").unwrap_or(&Value::Null);
-    let values = lora
-        .get("families")
-        .or_else(|| lora.get("compatibleFamilies"))
-        .or_else(|| lora.get("modelFamilies"))
-        .or_else(|| compatibility.get("families"))
-        .or_else(|| lora.get("family"));
-    match values {
-        Some(Value::Array(items)) => items
-            .iter()
-            .filter_map(Value::as_str)
-            .map(str::to_owned)
-            .collect(),
-        Some(Value::String(value)) => vec![value.clone()],
-        _ => Vec::new(),
-    }
+    families_from_value_chain(
+        lora,
+        &["families", "compatibleFamilies", "modelFamilies"],
+        Some("compatibility"),
+    )
 }
 
 fn requested_gpu_or_auto(value: String) -> String {
@@ -4724,6 +4836,15 @@ mod tests {
             worker_timeout_seconds: 90,
             jobs_db_path: temp_dir.path().join("jobs.db"),
         }
+    }
+
+    fn write_test_safetensors(path: &std::path::Path) {
+        let header = br#"{"__metadata__":{"format":"pt"}}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header);
+        bytes.extend_from_slice(b"tensor-bytes");
+        std::fs::write(path, bytes).expect("test safetensors writes");
     }
 
     async fn request(
@@ -5575,6 +5696,46 @@ mod tests {
             "https://example.com/loras/detail.safetensors"
         );
         assert_eq!(url_job["payload"]["manifestEntry"]["family"], "z-image");
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (bad_status, bad_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/loras/import",
+            json!({ "sourceUrl": "file:///tmp/detail.safetensors" }),
+        )
+        .await;
+        assert_eq!(bad_status, StatusCode::BAD_REQUEST);
+        assert_eq!(bad_error["detail"], "LoRA sourceUrl must use http or https");
+
+        let (bad_status, bad_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/loras/import",
+            json!({ "sourceUrl": "https://example.com/loras/detail.safetensors", "family": "unknown-family" }),
+        )
+        .await;
+        assert_eq!(bad_status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            bad_error["detail"],
+            "Unsupported LoRA family: unknown-family"
+        );
+
+        let (status, normalized_family) = request(
+            app,
+            "POST",
+            "/api/v1/loras/import",
+            json!({
+                "sourceUrl": "https://example.com/loras/z-detail.safetensors",
+                "family": "Z_Image"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            normalized_family["payload"]["manifestEntry"]["family"],
+            "z-image"
+        );
     }
 
     #[tokio::test]
@@ -5669,14 +5830,34 @@ mod tests {
                   "triggerWords": [],
                   "compatibility": { "families": ["qwen-image"] },
                   "source": { "provider": "local", "path": "loras/qwen.safetensors" }
+                },
+                {
+                  "id": "deleted_style",
+                  "name": "Deleted Style",
+                  "family": "z-image",
+                  "triggerWords": [],
+                  "compatibility": { "families": ["z-image"] },
+                  "source": { "provider": "local", "path": "loras/deleted.safetensors" }
+                },
+                {
+                  "id": "unknown_family",
+                  "name": "Unknown Family",
+                  "triggerWords": [],
+                  "compatibility": {},
+                  "source": { "provider": "builtin" }
                 }
               ]
             }
             "#,
         )
         .expect("user loras writes");
+        let lora_dir = temp_dir.path().join("data/loras");
+        std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+        write_test_safetensors(&lora_dir.join("style.safetensors"));
+        write_test_safetensors(&lora_dir.join("qwen.safetensors"));
 
         let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        // This also pins the positive compatibility path: style_lora is installed and compatible with z_image_turbo.
         let (status, created) = request(
             app.clone(),
             "POST",
@@ -6032,6 +6213,42 @@ mod tests {
         assert_eq!(
             bad_error["detail"],
             "Recipe preset LoRA not found: missing_lora"
+        );
+
+        let (bad_status, bad_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/recipe-presets",
+            json!({
+                "name": "Deleted LoRA",
+                "model": "z_image_turbo",
+                "workflow": "text_to_image",
+                "loras": [{ "id": "deleted_style" }]
+            }),
+        )
+        .await;
+        assert_eq!(bad_status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            bad_error["detail"],
+            "Recipe preset LoRA is not installed: deleted_style"
+        );
+
+        let (bad_status, bad_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/recipe-presets",
+            json!({
+                "name": "Unknown Family LoRA",
+                "model": "z_image_turbo",
+                "workflow": "text_to_image",
+                "loras": [{ "id": "unknown_family" }]
+            }),
+        )
+        .await;
+        assert_eq!(bad_status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            bad_error["detail"],
+            "LoRA unknown_family has no declared family; cannot verify compatibility with model z_image_turbo"
         );
 
         let (bad_status, bad_error) = request(

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2125,9 +2125,11 @@ async fn create_recipe_preset(
         .or_insert_with(|| Value::String(timestamp.clone()));
     object.insert("updatedAt".to_owned(), Value::String(timestamp));
     let models = model_catalog(&state).await?;
+    let loras = lora_catalog(&state, project_id.as_deref()).await?;
     let preset = mutate_manifest_entries(&state, &manifest_path, "presets", |mut entries| {
         let preset = normalize_recipe_preset_for_write(preset, &scope, true)?;
         validate_recipe_preset_model_workflow(&models, &preset)?;
+        validate_recipe_preset_lora_compatibility(&models, &loras, &preset)?;
         if entries
             .iter()
             .any(|entry| entry.get("id").and_then(Value::as_str) == Some(id.as_str()))
@@ -2159,6 +2161,7 @@ async fn update_recipe_preset(
     )
     .await?;
     let models = model_catalog(&state).await?;
+    let loras = lora_catalog(&state, project_id.as_deref()).await?;
     let preset =
         mutate_manifest_entries(&state, &location.manifest_path, "presets", |mut entries| {
             let Some(index) = entries.iter().position(|entry| {
@@ -2174,6 +2177,7 @@ async fn update_recipe_preset(
             }
             let preset = normalize_recipe_preset_for_write(preset, &location.scope, false)?;
             validate_recipe_preset_model_workflow(&models, &preset)?;
+            validate_recipe_preset_lora_compatibility(&models, &loras, &preset)?;
             entries[index] = preset.clone();
             Ok((entries, preset))
         })
@@ -2228,6 +2232,7 @@ async fn duplicate_recipe_preset(
     )
     .await?;
     let models = model_catalog(&state).await?;
+    let loras = lora_catalog(&state, query.project_id.as_deref()).await?;
     let preset =
         mutate_manifest_entries(&state, &location.manifest_path, "presets", |mut entries| {
             let Some(source) = entries
@@ -2262,6 +2267,7 @@ async fn duplicate_recipe_preset(
             }
             let duplicate = normalize_recipe_preset_for_write(duplicate, &location.scope, true)?;
             validate_recipe_preset_model_workflow(&models, &duplicate)?;
+            validate_recipe_preset_lora_compatibility(&models, &loras, &duplicate)?;
             entries.push(duplicate.clone());
             Ok((entries, duplicate))
         })
@@ -3578,6 +3584,64 @@ fn validate_recipe_preset_model_workflow(models: &[Value], preset: &Value) -> Re
         Err(ApiError::bad_request(format!(
             "Model {model_id} does not support workflow {workflow}"
         )))
+    }
+}
+
+fn validate_recipe_preset_lora_compatibility(
+    models: &[Value],
+    loras: &[Value],
+    preset: &Value,
+) -> Result<(), ApiError> {
+    let Some(model_id) = preset.get("model").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let Some(model) = models
+        .iter()
+        .find(|model| model.get("id").and_then(Value::as_str) == Some(model_id))
+    else {
+        return Ok(());
+    };
+    let model_families = model_lora_families(model);
+    for preset_lora in recipe_preset_loras(preset) {
+        let Some(lora_id) = preset_lora_id(&preset_lora) else {
+            continue;
+        };
+        let lora = loras
+            .iter()
+            .find(|lora| lora.get("id").and_then(Value::as_str) == Some(lora_id))
+            .ok_or_else(|| {
+                ApiError::bad_request(format!("Recipe preset LoRA not found: {lora_id}"))
+            })?;
+        let families = lora_families(lora);
+        if model_families.is_empty() || families.is_empty() {
+            continue;
+        }
+        if !families.iter().any(|family| {
+            model_families
+                .iter()
+                .any(|model_family| model_family == family)
+        }) {
+            return Err(ApiError::bad_request(format!(
+                "LoRA {lora_id} is not compatible with model {model_id}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn model_lora_families(model: &Value) -> Vec<String> {
+    let compatibility = model.get("loraCompatibility").unwrap_or(&Value::Null);
+    let values = compatibility
+        .get("families")
+        .or_else(|| model.get("family"));
+    match values {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_owned)
+            .collect(),
+        Some(Value::String(value)) => vec![value.clone()],
+        _ => Vec::new(),
     }
 }
 
@@ -5579,6 +5643,38 @@ mod tests {
             r#"{ "schemaVersion": 1, "models": [] }"#,
         )
         .expect("user models writes");
+        std::fs::write(
+            config_dir.join("builtin.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("builtin loras writes");
+        std::fs::write(
+            config_dir.join("user.loras.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "loras": [
+                {
+                  "id": "style_lora",
+                  "name": "Style LoRA",
+                  "family": "z-image",
+                  "triggerWords": [],
+                  "compatibility": { "families": ["z-image"] },
+                  "source": { "provider": "local", "path": "loras/style.safetensors" }
+                },
+                {
+                  "id": "qwen_style",
+                  "name": "Qwen Style",
+                  "family": "qwen-image",
+                  "triggerWords": [],
+                  "compatibility": { "families": ["qwen-image"] },
+                  "source": { "provider": "local", "path": "loras/qwen.safetensors" }
+                }
+              ]
+            }
+            "#,
+        )
+        .expect("user loras writes");
 
         let app = create_app(test_settings(&temp_dir)).expect("app creates");
         let (status, created) = request(
@@ -5918,6 +6014,42 @@ mod tests {
         assert_eq!(
             bad_error["detail"],
             "Recipe preset LoRA weight must be between -2 and 2"
+        );
+
+        let (bad_status, bad_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/recipe-presets",
+            json!({
+                "name": "Missing LoRA",
+                "model": "z_image_turbo",
+                "workflow": "text_to_image",
+                "loras": [{ "id": "missing_lora" }]
+            }),
+        )
+        .await;
+        assert_eq!(bad_status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            bad_error["detail"],
+            "Recipe preset LoRA not found: missing_lora"
+        );
+
+        let (bad_status, bad_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/recipe-presets",
+            json!({
+                "name": "Wrong Family LoRA",
+                "model": "z_image_turbo",
+                "workflow": "text_to_image",
+                "loras": [{ "id": "qwen_style" }]
+            }),
+        )
+        .await;
+        assert_eq!(bad_status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            bad_error["detail"],
+            "LoRA qwen_style is not compatible with model z_image_turbo"
         );
 
         let create_one = request(

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -869,6 +869,8 @@ struct LoraImportRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     repo: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     source_path: Option<String>,
     #[serde(default)]
     files: Vec<String>,
@@ -2272,11 +2274,15 @@ async fn create_lora_import_job(
     ApiJson(payload): ApiJson<LoraImportRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
     if option_str_is_empty(payload.repo.as_deref())
+        && option_str_is_empty(payload.source_url.as_deref())
         && option_str_is_empty(payload.source_path.as_deref())
     {
         return Err(ApiError::bad_request(
-            "Provide a Hugging Face repo or source path",
+            "Provide a Hugging Face repo, source URL, or source path",
         ));
+    }
+    if let Some(source_url) = payload.source_url.as_deref() {
+        validate_source_url(source_url)?;
     }
     if !matches!(payload.scope.as_str(), "global" | "project") {
         return Err(ApiError::bad_request(
@@ -2287,6 +2293,7 @@ async fn create_lora_import_job(
         .name
         .clone()
         .or_else(|| payload.repo.clone())
+        .or_else(|| payload.source_url.as_deref().and_then(source_url_file_stem))
         .or_else(|| {
             payload.source_path.as_deref().and_then(|path| {
                 FsPath::new(path)
@@ -2338,8 +2345,9 @@ async fn create_lora_import_job(
         "name": name,
         "scope": payload.scope.clone(),
         "source": {
-            "provider": if payload.repo.is_some() { "huggingface" } else { "local" },
+            "provider": lora_source_provider(&payload),
             "repo": payload.repo.clone(),
+            "url": payload.source_url.clone(),
             "path": source_path,
         },
         "files": payload.files.clone(),
@@ -4000,6 +4008,50 @@ fn safe_download_dir(repo: &str) -> String {
     }
 }
 
+fn validate_source_url(source_url: &str) -> Result<(), ApiError> {
+    let url = reqwest::Url::parse(source_url)
+        .map_err(|_| ApiError::bad_request("LoRA sourceUrl must be a valid URL"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(ApiError::bad_request(
+            "LoRA sourceUrl must use http or https",
+        ));
+    }
+    if source_url_file_name(source_url).is_none() {
+        return Err(ApiError::bad_request(
+            "LoRA sourceUrl must include a filename",
+        ));
+    }
+    Ok(())
+}
+
+fn source_url_file_name(source_url: &str) -> Option<String> {
+    let url = reqwest::Url::parse(source_url).ok()?;
+    url.path_segments()?
+        .next_back()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn source_url_file_stem(source_url: &str) -> Option<String> {
+    source_url_file_name(source_url).and_then(|file_name| {
+        FsPath::new(&file_name)
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .map(str::to_owned)
+    })
+}
+
+fn lora_source_provider(payload: &LoraImportRequest) -> &'static str {
+    if payload.repo.is_some() {
+        "huggingface"
+    } else if payload.source_url.is_some() {
+        "url"
+    } else {
+        "local"
+    }
+}
+
 fn slugify_lora_id(value: &str) -> String {
     let mut output = String::new();
     let mut previous_separator = false;
@@ -5430,6 +5482,35 @@ mod tests {
                 || value.ends_with("data\\loras\\imported_lora")));
         assert_eq!(job["payload"]["manifestEntry"]["scope"], "global");
         assert!(job["payload"].get("sourcePath").is_none());
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, url_job) = request(
+            app,
+            "POST",
+            "/api/v1/loras/import",
+            json!({
+                "sourceUrl": "https://example.com/loras/detail.safetensors",
+                "name": "Detail LoRA",
+                "family": "z-image"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(url_job["type"], "lora_import");
+        assert_eq!(
+            url_job["payload"]["sourceUrl"],
+            "https://example.com/loras/detail.safetensors"
+        );
+        assert_eq!(url_job["payload"]["loraId"], "detail_lora");
+        assert_eq!(
+            url_job["payload"]["manifestEntry"]["source"]["provider"],
+            "url"
+        );
+        assert_eq!(
+            url_job["payload"]["manifestEntry"]["source"]["url"],
+            "https://example.com/loras/detail.safetensors"
+        );
+        assert_eq!(url_job["payload"]["manifestEntry"]["family"], "z-image");
     }
 
     #[tokio::test]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2363,13 +2363,20 @@ async fn create_lora_import_job(
         "source": {
             "provider": lora_source_provider(&payload),
             "repo": payload.repo.clone(),
-            "url": payload.source_url.clone(),
             "path": source_path,
         },
         "files": payload.files.clone(),
         "createdAt": timestamp,
         "updatedAt": timestamp,
     });
+    if let Some(source_url) = payload.source_url.clone() {
+        if let Some(source) = manifest_entry
+            .get_mut("source")
+            .and_then(Value::as_object_mut)
+        {
+            source.insert("url".to_owned(), Value::String(source_url));
+        }
+    }
     if let Some(family) = payload.family.clone() {
         if let Some(object) = manifest_entry.as_object_mut() {
             object.insert("family".to_owned(), Value::String(family));

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -10,6 +11,10 @@ use sceneworks_core::contracts::{
     ClaimRequest, ClaimResponse, ContractNumber, JobSnapshot, JobStatus, JobType, JsonObject,
     ProgressRequest, ProgressStage, WorkerCapability, WorkerHeartbeatRequest,
     WorkerRegisterRequest, WorkerSnapshot, WorkerStatus,
+};
+use sceneworks_core::lora_url::{
+    lora_source_url_file_name, lora_source_url_file_stem, parse_lora_source_url_with_private,
+    validate_public_ip,
 };
 use sceneworks_core::project_store::{ProjectStore, ProjectStoreError};
 use serde::Deserialize;
@@ -25,6 +30,7 @@ use uuid::Uuid;
 const INSTALL_MARKER: &str = ".sceneworks-download-complete.json";
 const DEFAULT_API_URL: &str = "http://localhost:8000";
 const DEFAULT_HUGGINGFACE_BASE_URL: &str = "https://huggingface.co";
+const DEFAULT_MAX_LORA_URL_BYTES: u64 = 8 * 1024 * 1024 * 1024;
 const DEFAULT_TRANSITION_DURATION_SECONDS: f64 = 0.5;
 const PERSON_TRACK_SAMPLE_RATE_FPS: f64 = 2.0;
 const PERSON_TRACK_MAX_SAMPLES: usize = 24;
@@ -44,6 +50,8 @@ pub struct Settings {
     pub shutdown_timeout_seconds: u64,
     pub huggingface_base_url: String,
     pub huggingface_token: Option<String>,
+    pub max_lora_url_bytes: u64,
+    pub allow_private_lora_urls: bool,
 }
 
 impl Settings {
@@ -83,6 +91,12 @@ impl Settings {
                 .ok()
                 .map(|value| value.trim().to_owned())
                 .filter(|value| !value.is_empty()),
+            max_lora_url_bytes: env_u64_any(
+                &["SCENEWORKS_MAX_LORA_URL_BYTES"],
+                DEFAULT_MAX_LORA_URL_BYTES,
+            ),
+            allow_private_lora_urls: std::env::var("SCENEWORKS_ALLOW_PRIVATE_LORA_URLS")
+                .is_ok_and(|value| value.trim() == "1"),
         }
     }
 
@@ -1005,7 +1019,7 @@ async fn run_lora_import_job(
         .or_else(|| optional_payload_string(&job.payload, "name"))
         .map(str::to_owned)
         .or_else(|| repo.map(str::to_owned))
-        .or_else(|| source_url.and_then(source_url_file_stem))
+        .or_else(|| source_url.and_then(|value| lora_source_url_file_stem(value).ok()))
         .map(|value| safe_download_dir(&value))
         .unwrap_or_else(|| {
             source_path
@@ -1095,6 +1109,7 @@ async fn run_lora_import_job(
         .await;
     }
 
+    write_lora_install_marker(&target_dir, &job.payload, &job.id).await?;
     if let Some(manifest_entry) = job
         .payload
         .get("manifestEntry")
@@ -1109,6 +1124,12 @@ async fn run_lora_import_job(
     result.insert(
         "repo".to_owned(),
         repo.map(|value| Value::String(value.to_owned()))
+            .unwrap_or(Value::Null),
+    );
+    result.insert(
+        "sourceUrl".to_owned(),
+        source_url
+            .map(|value| Value::String(value.to_owned()))
             .unwrap_or(Value::Null),
     );
     result.insert(
@@ -2264,25 +2285,83 @@ async fn download_lora_source_url(
     source_url: &str,
     target_dir: &Path,
 ) -> WorkerResult<()> {
-    let file_name = source_url_file_name(source_url).ok_or_else(|| {
-        WorkerError::InvalidPayload("LoRA sourceUrl must include a filename".to_owned())
-    })?;
+    let url =
+        parse_lora_source_url_with_private(source_url, context.settings.allow_private_lora_urls)
+            .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
+    validate_lora_url_dns(context.settings, &url).await?;
+    let file_name = lora_source_url_file_name(source_url)
+        .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
     tokio::fs::create_dir_all(target_dir).await?;
     let target_path = target_dir.join(file_name);
-    let mut response = context
-        .client
-        .get(source_url)
-        .send()
-        .await?
-        .error_for_status()?;
-    let total_bytes = response.content_length();
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+    let total_bytes = lora_source_content_length(&client, source_url).await?;
+    if total_bytes.is_some_and(|total| total > context.settings.max_lora_url_bytes) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "LoRA sourceUrl exceeds the {} limit",
+            format_bytes(context.settings.max_lora_url_bytes)
+        )));
+    }
+    let existing_bytes = existing_download_bytes(&target_path, total_bytes).await?;
+    if total_bytes.is_some_and(|total| total > 0 && existing_bytes == total) {
+        return Ok(());
+    }
+    let mut request = client.get(source_url);
+    if existing_bytes > 0 {
+        request = request.header(header::RANGE, format!("bytes={existing_bytes}-"));
+    }
+    let mut response = request.send().await?;
+    if response.status().is_redirection() {
+        return Err(WorkerError::InvalidPayload(
+            "LoRA sourceUrl redirects are not allowed".to_owned(),
+        ));
+    }
+    if response.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+        let range_total = response
+            .headers()
+            .get(header::CONTENT_RANGE)
+            .and_then(|value| value.to_str().ok())
+            .and_then(content_range_total);
+        if total_bytes
+            .or(range_total)
+            .is_some_and(|total| total > 0 && existing_bytes == total)
+        {
+            return Ok(());
+        }
+    }
+    response = response.error_for_status()?;
+    let appending = existing_bytes > 0 && response.status() == StatusCode::PARTIAL_CONTENT;
+    let expected_bytes = total_bytes.or_else(|| {
+        response.content_length().map(|remaining| {
+            if appending {
+                existing_bytes + remaining
+            } else {
+                remaining
+            }
+        })
+    });
+    if expected_bytes.is_some_and(|total| total > context.settings.max_lora_url_bytes) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "LoRA sourceUrl exceeds the {} limit",
+            format_bytes(context.settings.max_lora_url_bytes)
+        )));
+    }
     let mut progress = DownloadProgress::new(
         source_url,
-        0,
-        total_bytes,
+        if appending { existing_bytes } else { 0 },
+        expected_bytes,
         progress_report_interval(context.settings),
     );
-    let mut output = tokio::fs::File::create(&target_path).await?;
+    let mut output = if appending {
+        tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&target_path)
+            .await?
+    } else {
+        tokio::fs::File::create(&target_path).await?
+    };
     let mut interval = tokio::time::interval(progress.report_interval());
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     interval.tick().await;
@@ -2292,15 +2371,88 @@ async fn download_lora_source_url(
                 let Some(chunk) = chunk? else {
                     break;
                 };
+                check_cancel(context.api, context.job_id, context.cancel_message).await?;
                 output.write_all(&chunk).await?;
                 progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
+                if progress.downloaded_bytes() > context.settings.max_lora_url_bytes {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "LoRA sourceUrl exceeds the {} limit",
+                        format_bytes(context.settings.max_lora_url_bytes)
+                    )));
+                }
             }
             _ = interval.tick() => {
                 report_download_progress(context, &progress).await?;
             }
         }
     }
+    if expected_bytes.is_some_and(|expected| progress.downloaded_bytes() != expected) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "LoRA sourceUrl download ended at {} but expected {}",
+            format_bytes(progress.downloaded_bytes()),
+            format_bytes(expected_bytes.unwrap_or_default())
+        )));
+    }
     Ok(())
+}
+
+async fn lora_source_content_length(
+    client: &reqwest::Client,
+    source_url: &str,
+) -> WorkerResult<Option<u64>> {
+    let response = client.head(source_url).send().await?;
+    if response.status().is_success() {
+        return Ok(response.content_length().filter(|value| *value > 0));
+    }
+    if response.status().is_redirection() {
+        return Err(WorkerError::InvalidPayload(
+            "LoRA sourceUrl redirects are not allowed".to_owned(),
+        ));
+    }
+    if matches!(
+        response.status(),
+        StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED | StatusCode::FORBIDDEN
+    ) {
+        return Ok(None);
+    }
+    response.error_for_status()?;
+    Ok(None)
+}
+
+fn content_range_total(value: &str) -> Option<u64> {
+    value
+        .rsplit_once('/')
+        .and_then(|(_, total)| total.trim().parse::<u64>().ok())
+}
+
+async fn validate_lora_url_dns(settings: &Settings, url: &reqwest::Url) -> WorkerResult<()> {
+    if settings.allow_private_lora_urls {
+        return Ok(());
+    }
+    let Some(host) = url.host_str() else {
+        return Err(WorkerError::InvalidPayload(
+            "LoRA sourceUrl host is not allowed".to_owned(),
+        ));
+    };
+    if let Ok(address) = host.parse::<IpAddr>() {
+        validate_public_ip(address)
+            .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
+        return Ok(());
+    }
+    let port = url.port_or_known_default().unwrap_or(443);
+    let mut resolved_any = false;
+    for address in tokio::net::lookup_host((host, port)).await? {
+        resolved_any = true;
+        validate_public_ip(address.ip())
+            .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
+    }
+    if resolved_any {
+        Ok(())
+    } else {
+        Err(WorkerError::InvalidPayload(
+            "LoRA sourceUrl host did not resolve".to_owned(),
+        ))
+    }
 }
 
 async fn report_download_progress(
@@ -2485,6 +2637,26 @@ async fn write_model_install_marker(
     Ok(())
 }
 
+async fn write_lora_install_marker(
+    target_dir: &Path,
+    payload: &JsonObject,
+    job_id: &str,
+) -> WorkerResult<()> {
+    tokio::fs::create_dir_all(target_dir).await?;
+    let marker = json!({
+        "loraId": payload.get("loraId").cloned().unwrap_or(Value::Null),
+        "loraName": payload.get("name").cloned().unwrap_or(Value::Null),
+        "repo": payload.get("repo").cloned().unwrap_or(Value::Null),
+        "sourceUrl": payload.get("sourceUrl").cloned().unwrap_or(Value::Null),
+        "sourcePath": payload.get("sourcePath").cloned().unwrap_or(Value::Null),
+        "jobId": job_id,
+        "completedAt": now_rfc3339(),
+    });
+    let bytes = serde_json::to_vec_pretty(&marker)?;
+    tokio::fs::write(target_dir.join(INSTALL_MARKER), bytes).await?;
+    Ok(())
+}
+
 pub fn allow_pattern_matches(path: &str, patterns: &[String]) -> bool {
     if patterns.is_empty() {
         return true;
@@ -2521,24 +2693,6 @@ pub fn safe_download_dir(value: &str) -> String {
     } else {
         output
     }
-}
-
-fn source_url_file_name(source_url: &str) -> Option<String> {
-    let url = reqwest::Url::parse(source_url).ok()?;
-    url.path_segments()?
-        .next_back()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-fn source_url_file_stem(source_url: &str) -> Option<String> {
-    source_url_file_name(source_url).and_then(|file_name| {
-        Path::new(&file_name)
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .map(str::to_owned)
-    })
 }
 
 async fn directory_size(path: &Path) -> u64 {
@@ -3643,12 +3797,13 @@ mod tests {
     use std::process::Stdio as StdStdio;
     use std::time::Duration;
 
+    use axum::body::Body;
     use axum::extract::State;
     use axum::http::{HeaderMap, StatusCode as AxumStatusCode};
     use axum::response::{IntoResponse, Response};
-    use axum::routing::get;
+    use axum::routing::{get, post};
     use axum::{Json, Router};
-    use serde_json::json;
+    use serde_json::{json, Value};
     use tempfile::tempdir;
 
     use super::{
@@ -3659,7 +3814,8 @@ mod tests {
         restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
         value_f64, visible_gpu_ids, worker_capabilities_with_utility, write_model_install_marker,
         ApiClient, DownloadContext, HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError,
-        WorkerSpec, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+        WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
+        INSTALL_MARKER,
     };
 
     #[test]
@@ -3914,10 +4070,11 @@ mod tests {
     #[tokio::test]
     async fn lora_url_import_downloads_to_named_file() {
         let temp = tempdir().expect("tempdir creates");
-        let settings = test_settings("http://127.0.0.1".to_owned(), None);
+        let source_url = spawn_binary_stub(b"url-lora".to_vec()).await;
+        let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+        settings.api_url = source_url.clone();
         let api = ApiClient::new(&settings);
         let client = reqwest::Client::new();
-        let source_url = spawn_binary_stub(b"url-lora".to_vec()).await;
         let target_dir = temp.path().join("url-target");
 
         download_lora_source_url(
@@ -3940,6 +4097,115 @@ mod tests {
                 .unwrap(),
             b"url-lora"
         );
+    }
+
+    #[tokio::test]
+    async fn lora_url_import_skips_existing_matching_file() {
+        let temp = tempdir().expect("tempdir creates");
+        let source_url = spawn_binary_stub(b"new-lora".to_vec()).await;
+        let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+        settings.api_url = source_url.clone();
+        let api = ApiClient::new(&settings);
+        let client = reqwest::Client::new();
+        let target_dir = temp.path().join("url-target");
+        tokio::fs::create_dir_all(&target_dir).await.unwrap();
+        tokio::fs::write(target_dir.join("style.safetensors"), b"old-lora")
+            .await
+            .unwrap();
+
+        download_lora_source_url(
+            &DownloadContext {
+                api: &api,
+                client: &client,
+                settings: &settings,
+                job_id: "job-1",
+                cancel_message: "canceled",
+            },
+            &format!("{source_url}/loras/style.safetensors"),
+            &target_dir,
+        )
+        .await
+        .expect("existing LoRA is accepted");
+
+        assert_eq!(
+            tokio::fs::read(target_dir.join("style.safetensors"))
+                .await
+                .unwrap(),
+            b"old-lora"
+        );
+    }
+
+    #[tokio::test]
+    async fn lora_url_import_rejects_failed_and_oversized_downloads() {
+        let temp = tempdir().expect("tempdir creates");
+        let missing_url =
+            spawn_binary_stub_with_options(b"missing".to_vec(), AxumStatusCode::NOT_FOUND, false)
+                .await;
+        let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+        settings.api_url = missing_url.clone();
+        let api = ApiClient::new(&settings);
+        let client = reqwest::Client::new();
+
+        let error = download_lora_source_url(
+            &DownloadContext {
+                api: &api,
+                client: &client,
+                settings: &settings,
+                job_id: "job-1",
+                cancel_message: "canceled",
+            },
+            &format!("{missing_url}/loras/missing.safetensors"),
+            &temp.path().join("missing-target"),
+        )
+        .await
+        .expect_err("failed URL returns an error");
+        assert!(error.to_string().contains("404"));
+
+        let large_url = spawn_binary_stub(b"too-large".to_vec()).await;
+        settings.api_url = large_url.clone();
+        settings.max_lora_url_bytes = 4;
+        let api = ApiClient::new(&settings);
+        let error = download_lora_source_url(
+            &DownloadContext {
+                api: &api,
+                client: &client,
+                settings: &settings,
+                job_id: "job-1",
+                cancel_message: "canceled",
+            },
+            &format!("{large_url}/loras/large.safetensors"),
+            &temp.path().join("large-target"),
+        )
+        .await
+        .expect_err("oversized URL returns an error");
+        assert!(error.to_string().contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn lora_url_import_honors_midstream_cancel() {
+        let temp = tempdir().expect("tempdir creates");
+        let source_url =
+            spawn_binary_stub_with_options(b"url-lora".to_vec(), AxumStatusCode::OK, true).await;
+        let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+        settings.api_url = source_url.clone();
+        let api = ApiClient::new(&settings);
+        let client = reqwest::Client::new();
+
+        let error = download_lora_source_url(
+            &DownloadContext {
+                api: &api,
+                client: &client,
+                settings: &settings,
+                job_id: "job-1",
+                cancel_message: "LoRA import canceled by user.",
+            },
+            &format!("{source_url}/loras/style.safetensors"),
+            &temp.path().join("cancel-target"),
+        )
+        .await
+        .expect_err("cancel request interrupts the URL import");
+
+        assert!(matches!(error, WorkerError::Canceled(_)));
     }
 
     #[test]
@@ -4146,12 +4412,28 @@ mod tests {
     #[derive(Clone)]
     struct BinaryStubState {
         bytes: Vec<u8>,
+        status: AxumStatusCode,
+        cancel_requested: bool,
     }
 
     async fn spawn_binary_stub(bytes: Vec<u8>) -> String {
-        let state = BinaryStubState { bytes };
+        spawn_binary_stub_with_options(bytes, AxumStatusCode::OK, false).await
+    }
+
+    async fn spawn_binary_stub_with_options(
+        bytes: Vec<u8>,
+        status: AxumStatusCode,
+        cancel_requested: bool,
+    ) -> String {
+        let state = BinaryStubState {
+            bytes,
+            status,
+            cancel_requested,
+        };
         let app = Router::new()
-            .route("/*path", get(binary_stub))
+            .route("/api/v1/jobs/:job_id", get(job_stub))
+            .route("/api/v1/jobs/:job_id/progress", post(progress_stub))
+            .route("/*path", get(binary_stub).head(binary_head_stub))
             .with_state(state);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -4163,8 +4445,85 @@ mod tests {
         format!("http://{address}")
     }
 
-    async fn binary_stub(State(state): State<BinaryStubState>) -> Response {
-        state.bytes.into_response()
+    async fn binary_stub(State(state): State<BinaryStubState>, headers: HeaderMap) -> Response {
+        let length = state.bytes.len();
+        if headers
+            .get(axum::http::header::RANGE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value == format!("bytes={length}-"))
+        {
+            let mut response = Response::new(Body::empty());
+            *response.status_mut() = AxumStatusCode::RANGE_NOT_SATISFIABLE;
+            response.headers_mut().insert(
+                axum::http::header::CONTENT_RANGE,
+                axum::http::HeaderValue::from_str(&format!("bytes */{length}"))
+                    .expect("content range header"),
+            );
+            return response;
+        }
+        let mut response = state.bytes.into_response();
+        *response.status_mut() = state.status;
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from_str(&length.to_string()).expect("content length header"),
+        );
+        response
+    }
+
+    async fn binary_head_stub(State(state): State<BinaryStubState>) -> Response {
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = state.status;
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from_str(&state.bytes.len().to_string())
+                .expect("content length header"),
+        );
+        response
+    }
+
+    async fn job_stub(
+        State(state): State<BinaryStubState>,
+        axum::extract::Path(job_id): axum::extract::Path<String>,
+    ) -> Response {
+        Json(job_snapshot_json(&job_id, state.cancel_requested)).into_response()
+    }
+
+    async fn progress_stub(
+        State(state): State<BinaryStubState>,
+        axum::extract::Path(job_id): axum::extract::Path<String>,
+    ) -> Response {
+        Json(job_snapshot_json(&job_id, state.cancel_requested)).into_response()
+    }
+
+    fn job_snapshot_json(job_id: &str, cancel_requested: bool) -> Value {
+        json!({
+            "id": job_id,
+            "type": "lora_import",
+            "status": "running",
+            "projectId": null,
+            "projectName": null,
+            "payload": {},
+            "result": {},
+            "requestedGpu": "auto",
+            "assignedGpu": null,
+            "workerId": "test-worker",
+            "progress": 0.1,
+            "stage": "importing",
+            "message": "running",
+            "error": null,
+            "etaSeconds": null,
+            "elapsedSeconds": null,
+            "attempts": 1,
+            "sourceJobId": null,
+            "duplicateOfJobId": null,
+            "cancelRequested": cancel_requested,
+            "createdAt": "2026-05-18T00:00:00Z",
+            "updatedAt": "2026-05-18T00:00:00Z",
+            "startedAt": null,
+            "completedAt": null,
+            "canceledAt": null,
+            "lastHeartbeatAt": null
+        })
     }
 
     fn test_settings(huggingface_base_url: String, huggingface_token: Option<&str>) -> Settings {
@@ -4181,6 +4540,8 @@ mod tests {
             shutdown_timeout_seconds: 1,
             huggingface_base_url,
             huggingface_token: huggingface_token.map(str::to_owned),
+            max_lora_url_bytes: DEFAULT_MAX_LORA_URL_BYTES,
+            allow_private_lora_urls: true,
         }
     }
 

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -999,11 +999,14 @@ async fn run_lora_import_job(
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
     let repo = optional_payload_string(&job.payload, "repo");
+    let source_url = optional_payload_string(&job.payload, "sourceUrl");
     let source_path = optional_payload_string(&job.payload, "sourcePath");
     let target_name = optional_payload_string(&job.payload, "loraId")
         .or_else(|| optional_payload_string(&job.payload, "name"))
-        .or(repo)
-        .map(safe_download_dir)
+        .map(str::to_owned)
+        .or_else(|| repo.map(str::to_owned))
+        .or_else(|| source_url.and_then(source_url_file_stem))
+        .map(|value| safe_download_dir(&value))
         .unwrap_or_else(|| {
             source_path
                 .and_then(|path| {
@@ -1069,12 +1072,25 @@ async fn run_lora_import_job(
         .await?;
     } else if let Some(source_path) = source_path {
         copy_lora_source(Path::new(source_path), &target_dir).await?;
+    } else if let Some(source_url) = source_url {
+        download_lora_source_url(
+            &DownloadContext {
+                api,
+                client: http_client,
+                settings,
+                job_id: &job.id,
+                cancel_message: "LoRA import canceled by user.",
+            },
+            source_url,
+            &target_dir,
+        )
+        .await?;
     } else {
         return fail_job(
             api,
             &job.id,
             "LoRA import failed.",
-            Some("Provide repo or sourcePath for LoRA import".to_owned()),
+            Some("Provide repo, sourceUrl, or sourcePath for LoRA import".to_owned()),
         )
         .await;
     }
@@ -2243,6 +2259,50 @@ async fn download_snapshot(
     Ok(())
 }
 
+async fn download_lora_source_url(
+    context: &DownloadContext<'_>,
+    source_url: &str,
+    target_dir: &Path,
+) -> WorkerResult<()> {
+    let file_name = source_url_file_name(source_url).ok_or_else(|| {
+        WorkerError::InvalidPayload("LoRA sourceUrl must include a filename".to_owned())
+    })?;
+    tokio::fs::create_dir_all(target_dir).await?;
+    let target_path = target_dir.join(file_name);
+    let mut response = context
+        .client
+        .get(source_url)
+        .send()
+        .await?
+        .error_for_status()?;
+    let total_bytes = response.content_length();
+    let mut progress = DownloadProgress::new(
+        source_url,
+        0,
+        total_bytes,
+        progress_report_interval(context.settings),
+    );
+    let mut output = tokio::fs::File::create(&target_path).await?;
+    let mut interval = tokio::time::interval(progress.report_interval());
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            chunk = response.chunk() => {
+                let Some(chunk) = chunk? else {
+                    break;
+                };
+                output.write_all(&chunk).await?;
+                progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
+            }
+            _ = interval.tick() => {
+                report_download_progress(context, &progress).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn report_download_progress(
     context: &DownloadContext<'_>,
     progress: &DownloadProgress<'_>,
@@ -2461,6 +2521,24 @@ pub fn safe_download_dir(value: &str) -> String {
     } else {
         output
     }
+}
+
+fn source_url_file_name(source_url: &str) -> Option<String> {
+    let url = reqwest::Url::parse(source_url).ok()?;
+    url.path_segments()?
+        .next_back()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn source_url_file_stem(source_url: &str) -> Option<String> {
+    source_url_file_name(source_url).and_then(|file_name| {
+        Path::new(&file_name)
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .map(str::to_owned)
+    })
 }
 
 async fn directory_size(path: &Path) -> u64 {
@@ -3576,12 +3654,12 @@ mod tests {
     use super::{
         allow_pattern_matches, auto_worker_specs, bounded_tail, candidate_people,
         child_environment, concat_file_contents, copy_lora_source, cpu_gpu, cpu_worker_id,
-        crossfade_duration, download_progress_payload, fallback_gpu, fresh_asset_id, gpu_worker_id,
-        now_rfc3339, output_dimensions, parse_nvidia_smi_gpus,
+        crossfade_duration, download_lora_source_url, download_progress_payload, fallback_gpu,
+        fresh_asset_id, gpu_worker_id, now_rfc3339, output_dimensions, parse_nvidia_smi_gpus,
         restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
         value_f64, visible_gpu_ids, worker_capabilities_with_utility, write_model_install_marker,
-        HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError, WorkerSpec,
-        DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+        ApiClient, DownloadContext, HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError,
+        WorkerSpec, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
     };
 
     #[test]
@@ -3833,6 +3911,37 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn lora_url_import_downloads_to_named_file() {
+        let temp = tempdir().expect("tempdir creates");
+        let settings = test_settings("http://127.0.0.1".to_owned(), None);
+        let api = ApiClient::new(&settings);
+        let client = reqwest::Client::new();
+        let source_url = spawn_binary_stub(b"url-lora".to_vec()).await;
+        let target_dir = temp.path().join("url-target");
+
+        download_lora_source_url(
+            &DownloadContext {
+                api: &api,
+                client: &client,
+                settings: &settings,
+                job_id: "job-1",
+                cancel_message: "canceled",
+            },
+            &format!("{source_url}/loras/style.safetensors"),
+            &target_dir,
+        )
+        .await
+        .expect("url LoRA downloads");
+
+        assert_eq!(
+            tokio::fs::read(target_dir.join("style.safetensors"))
+                .await
+                .unwrap(),
+            b"url-lora"
+        );
+    }
+
     #[test]
     fn now_matches_python_second_precision() {
         let value = now_rfc3339();
@@ -4032,6 +4141,30 @@ mod tests {
             }
         }
         Json(state.payload).into_response()
+    }
+
+    #[derive(Clone)]
+    struct BinaryStubState {
+        bytes: Vec<u8>,
+    }
+
+    async fn spawn_binary_stub(bytes: Vec<u8>) -> String {
+        let state = BinaryStubState { bytes };
+        let app = Router::new()
+            .route("/*path", get(binary_stub))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener binds");
+        let address = listener.local_addr().expect("listener has address");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("stub serves");
+        });
+        format!("http://{address}")
+    }
+
+    async fn binary_stub(State(state): State<BinaryStubState>) -> Response {
+        state.bytes.into_response()
     }
 
     fn test_settings(huggingface_base_url: String, huggingface_token: Option<&str>) -> Settings {

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -11,6 +11,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 mime_guess = "2.0"
+url = "2.5"
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod character_store;
 pub mod contracts;
 pub mod jobs_store;
+pub mod lora_url;
 pub mod project_store;
 
 pub const API_PREFIX: &str = "/api/v1";

--- a/crates/sceneworks-core/src/lora_url.rs
+++ b/crates/sceneworks-core/src/lora_url.rs
@@ -1,0 +1,157 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::path::Path;
+
+use url::{Host, Url};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LoraUrlError {
+    Invalid,
+    UnsupportedScheme,
+    MissingFilename,
+    UnsafeFilename,
+    BlockedHost,
+}
+
+impl LoraUrlError {
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::Invalid => "LoRA sourceUrl must be a valid URL",
+            Self::UnsupportedScheme => "LoRA sourceUrl must use http or https",
+            Self::MissingFilename => "LoRA sourceUrl must include a filename",
+            Self::UnsafeFilename => {
+                "LoRA sourceUrl filename must use letters, numbers, dots, dashes, or underscores"
+            }
+            Self::BlockedHost => "LoRA sourceUrl host is not allowed",
+        }
+    }
+}
+
+pub fn parse_lora_source_url(source_url: &str) -> Result<Url, LoraUrlError> {
+    parse_lora_source_url_with_private(source_url, false)
+}
+
+pub fn parse_lora_source_url_with_private(
+    source_url: &str,
+    allow_private_hosts: bool,
+) -> Result<Url, LoraUrlError> {
+    let url = Url::parse(source_url).map_err(|_| LoraUrlError::Invalid)?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(LoraUrlError::UnsupportedScheme);
+    }
+    if !allow_private_hosts {
+        validate_lora_url_host(&url)?;
+    }
+    lora_source_url_file_name(source_url)?;
+    Ok(url)
+}
+
+pub fn lora_source_url_file_name(source_url: &str) -> Result<String, LoraUrlError> {
+    let url = Url::parse(source_url).map_err(|_| LoraUrlError::Invalid)?;
+    let file_name = url
+        .path_segments()
+        .and_then(Iterator::last)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or(LoraUrlError::MissingFilename)?;
+    if !safe_lora_filename(file_name) {
+        return Err(LoraUrlError::UnsafeFilename);
+    }
+    Ok(file_name.to_owned())
+}
+
+pub fn lora_source_url_file_stem(source_url: &str) -> Result<String, LoraUrlError> {
+    let file_name = lora_source_url_file_name(source_url)?;
+    Path::new(&file_name)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .map(str::to_owned)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or(LoraUrlError::MissingFilename)
+}
+
+pub fn safe_lora_filename(file_name: &str) -> bool {
+    let trimmed = file_name.trim();
+    !trimmed.is_empty()
+        && trimmed.len() <= 160
+        && trimmed.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_')
+        })
+}
+
+pub fn validate_lora_url_host(url: &Url) -> Result<(), LoraUrlError> {
+    let Some(host) = url.host() else {
+        return Err(LoraUrlError::BlockedHost);
+    };
+    match host {
+        Host::Ipv4(address) => validate_public_ip(IpAddr::V4(address)),
+        Host::Ipv6(address) => validate_public_ip(IpAddr::V6(address)),
+        Host::Domain(domain) => {
+            let domain = domain.trim_end_matches('.').to_ascii_lowercase();
+            if domain == "localhost" || domain.ends_with(".localhost") || domain.ends_with(".local")
+            {
+                return Err(LoraUrlError::BlockedHost);
+            }
+            Ok(())
+        }
+    }
+}
+
+pub fn validate_public_ip(address: IpAddr) -> Result<(), LoraUrlError> {
+    let blocked = match address {
+        IpAddr::V4(address) => blocked_ipv4(address),
+        IpAddr::V6(address) => blocked_ipv6(address),
+    };
+    if blocked {
+        Err(LoraUrlError::BlockedHost)
+    } else {
+        Ok(())
+    }
+}
+
+fn blocked_ipv4(address: Ipv4Addr) -> bool {
+    address.is_private()
+        || address.is_loopback()
+        || address.is_link_local()
+        || address.is_broadcast()
+        || address.is_documentation()
+        || address.octets()[0] == 0
+        || address.octets()[0] >= 224
+}
+
+fn blocked_ipv6(address: Ipv6Addr) -> bool {
+    address.is_loopback()
+        || address.is_unspecified()
+        || address.is_unique_local()
+        || address.is_unicast_link_local()
+        || (address.segments()[0] == 0x2001 && address.segments()[1] == 0x0db8)
+        || address.is_multicast()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{lora_source_url_file_name, parse_lora_source_url, LoraUrlError};
+
+    #[test]
+    fn lora_source_urls_validate_scheme_host_and_filename() {
+        assert_eq!(
+            lora_source_url_file_name("https://example.com/models/style.safetensors").unwrap(),
+            "style.safetensors"
+        );
+        assert_eq!(
+            parse_lora_source_url("file:///tmp/style.safetensors").unwrap_err(),
+            LoraUrlError::UnsupportedScheme
+        );
+        assert_eq!(
+            parse_lora_source_url("https://example.com/").unwrap_err(),
+            LoraUrlError::MissingFilename
+        );
+        assert_eq!(
+            parse_lora_source_url("http://127.0.0.1/style.safetensors").unwrap_err(),
+            LoraUrlError::BlockedHost
+        );
+        assert_eq!(
+            parse_lora_source_url("https://example.com/style.safetensors%00.txt").unwrap_err(),
+            LoraUrlError::UnsafeFilename
+        );
+    }
+}

--- a/crates/sceneworks-core/src/lora_url.rs
+++ b/crates/sceneworks-core/src/lora_url.rs
@@ -119,11 +119,12 @@ fn blocked_ipv4(address: Ipv4Addr) -> bool {
 }
 
 fn blocked_ipv6(address: Ipv6Addr) -> bool {
+    let first_segment = address.segments()[0];
     address.is_loopback()
         || address.is_unspecified()
-        || address.is_unique_local()
-        || address.is_unicast_link_local()
-        || (address.segments()[0] == 0x2001 && address.segments()[1] == 0x0db8)
+        || (first_segment & 0xfe00) == 0xfc00
+        || (first_segment & 0xffc0) == 0xfe80
+        || (first_segment == 0x2001 && address.segments()[1] == 0x0db8)
         || address.is_multicast()
 }
 


### PR DESCRIPTION
## Summary

- Add `sourceUrl` support to LoRA import jobs so presets can register direct URL-based LoRAs alongside Hugging Face repo and local path imports.
- Teach the Rust worker to download direct LoRA URLs into the managed import target and preserve manifest registration metadata.
- Validate recipe preset LoRA references before save, including missing LoRAs and model-family incompatibilities.

## Stories

- sc-1309 Download and register LoRA from URL for presets
- sc-1310 Validate LoRA compatibility before preset save

## Validation

- `cargo test`