### PR TITLE
[codex] Add preset management and studio picker integration

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -830,6 +830,8 @@ struct VideoJobRequest {
     #[serde(default)]
     seed: Option<i64>,
     #[serde(default)]
+    recipe_preset_id: Option<String>,
+    #[serde(default)]
     loras: Vec<Value>,
     #[serde(default)]
     character_id: Option<String>,
@@ -1913,6 +1915,9 @@ async fn create_video_job(
     let project_name = payload.project_name.clone();
     let mut job_payload = to_json_object(&payload)?;
     job_payload.remove("requestedGpu");
+    if payload.recipe_preset_id.is_none() {
+        job_payload.remove("recipePresetId");
+    }
     let job = create_generation_job(
         state,
         job_type,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -356,7 +356,7 @@ export function App() {
     if (scope) {
       params.set("scope", scope);
     }
-    if (activeProject?.id) {
+    if (scope === "project" && activeProject?.id) {
       params.set("projectId", activeProject.id);
     }
     const value = params.toString();
@@ -375,8 +375,8 @@ export function App() {
     return created;
   }
 
-  async function updateRecipePreset(presetId, payload) {
-    const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${recipePresetQuery()}`, token, {
+  async function updateRecipePreset(presetId, payload, scope = payload.scope) {
+    const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${recipePresetQuery(scope)}`, token, {
       method: "PATCH",
       body: JSON.stringify(payload),
     });
@@ -393,12 +393,30 @@ export function App() {
     return duplicated;
   }
 
-  async function deleteRecipePreset(presetId) {
-    const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${recipePresetQuery()}`, token, {
+  async function deleteRecipePreset(presetId, scope = null) {
+    const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${recipePresetQuery(scope)}`, token, {
       method: "DELETE",
     });
     await refreshRecipePresets(activeProject?.id);
     return archived;
+  }
+
+  async function createLoraImportJob(payload) {
+    if (payload.scope === "project" && !activeProject) {
+      throw new Error("Create or open a project first.");
+    }
+    const job = await apiFetch("/api/v1/loras/import", token, {
+      method: "POST",
+      body: JSON.stringify({
+        ...payload,
+        projectId: payload.scope === "project" ? activeProject.id : null,
+        projectName: payload.scope === "project" ? activeProject.name : null,
+      }),
+    });
+    setActiveView("Queue");
+    setError("");
+    refreshData();
+    return job;
   }
 
   async function refreshPersonTracks(projectId = activeProject?.id) {
@@ -1241,6 +1259,7 @@ export function App() {
         {activeView === "Presets" ? (
           <PresetManagerScreen
             activeProject={activeProject}
+            createLoraImportJob={createLoraImportJob}
             createRecipePreset={createRecipePreset}
             deleteRecipePreset={deleteRecipePreset}
             duplicateRecipePreset={duplicateRecipePreset}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -10,6 +10,7 @@ import { VideoStudio } from "./screens/VideoStudio.jsx";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { EditorScreen } from "./screens/EditorScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
+import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { sortNewest, sortWorkers } from "./sorters.js";
 import { ensureItemVersionFields } from "./timeline.js";
 
@@ -343,9 +344,61 @@ export function App() {
       const items = await apiFetch(`/api/v1/recipe-presets${query}`, token);
       setRecipePresets(items);
       setError("");
+      return items;
     } catch (err) {
       setError(err.message);
+      return [];
     }
+  }
+
+  function recipePresetQuery(scope = null) {
+    const params = new URLSearchParams();
+    if (scope) {
+      params.set("scope", scope);
+    }
+    if (activeProject?.id) {
+      params.set("projectId", activeProject.id);
+    }
+    const value = params.toString();
+    return value ? `?${value}` : "";
+  }
+
+  async function createRecipePreset(payload) {
+    if (payload.scope === "project" && !activeProject) {
+      throw new Error("Create or open a project first.");
+    }
+    const created = await apiFetch(`/api/v1/recipe-presets${recipePresetQuery(payload.scope)}`, token, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    await refreshRecipePresets(activeProject?.id);
+    return created;
+  }
+
+  async function updateRecipePreset(presetId, payload) {
+    const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${recipePresetQuery()}`, token, {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    });
+    await refreshRecipePresets(activeProject?.id);
+    return updated;
+  }
+
+  async function duplicateRecipePreset(presetId, scope = null) {
+    const duplicated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}/duplicate${recipePresetQuery(scope)}`, token, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    await refreshRecipePresets(activeProject?.id);
+    return duplicated;
+  }
+
+  async function deleteRecipePreset(presetId) {
+    const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${recipePresetQuery()}`, token, {
+      method: "DELETE",
+    });
+    await refreshRecipePresets(activeProject?.id);
+    return archived;
   }
 
   async function refreshPersonTracks(projectId = activeProject?.id) {
@@ -1179,6 +1232,20 @@ export function App() {
             selectedAsset={selectedAsset}
             setRequestedGpu={setRequestedGpu}
             updateAssetStatus={updateAssetStatus}
+            videoModels={videoModels}
+          />
+        ) : null}
+
+        {activeView === "Presets" ? (
+          <PresetManagerScreen
+            activeProject={activeProject}
+            createRecipePreset={createRecipePreset}
+            deleteRecipePreset={deleteRecipePreset}
+            duplicateRecipePreset={duplicateRecipePreset}
+            imageModels={imageModels}
+            loras={loras}
+            recipePresets={recipePresets}
+            updateRecipePreset={updateRecipePreset}
             videoModels={videoModels}
           />
         ) : null}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1225,9 +1225,11 @@ export function App() {
             gpuOptions={gpuOptions}
             latestAssets={latestVideoAssets}
             launchRequest={studioLaunch}
+            loras={loras}
             jobs={jobs}
             onPreview={setPreviewAsset}
             personTracks={personTracks}
+            recipePresets={recipePresets}
             requestedGpu={requestedGpu}
             selectedAsset={selectedAsset}
             setRequestedGpu={setRequestedGpu}

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -1,4 +1,4 @@
-export const navItems = ["Library", "Image", "Video", "Models", "Characters", "Editor", "Queue"];
+export const navItems = ["Library", "Image", "Video", "Presets", "Models", "Characters", "Editor", "Queue"];
 export const terminalStatuses = new Set(["completed", "failed", "canceled", "interrupted"]);
 export const actionStatuses = new Set(["failed", "canceled", "interrupted", "completed"]);
 export const fallbackModels = [

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -441,6 +441,7 @@ describe("SceneWorks app shell", () => {
               id: "cinematic",
               name: "Cinematic",
               model: "z_image_turbo",
+              workflow: "text_to_image",
               defaults: { count: 2, resolution: "1280x720", negativePrompt: "flat lighting" },
               prompt: { suffix: "cinematic lighting" },
               builtInLoras: [{ id: "builtin_cinematic_detail", weight: 0.4 }],
@@ -476,6 +477,49 @@ describe("SceneWorks app shell", () => {
         advanced: { resolution: "1280x720" },
       }),
     );
+  });
+
+  it("keeps Qwen selected when applying a Qwen image preset", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={createImageJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[
+            { id: "qwen_image", name: "Qwen Image", type: "image", family: "qwen-image" },
+            { id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" },
+          ]}
+          latestAssets={[]}
+          loras={[]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          recipePresets={[
+            { id: "qwen_detail", name: "Qwen Detail", model: "qwen_image", workflow: "text_to_image", defaults: { count: 1 } },
+            { id: "cinematic", name: "Cinematic", model: "z_image_turbo", workflow: "text_to_image", defaults: { count: 4 } },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Qwen Detail");
+    expect(container.textContent).not.toContain("Cinematic");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(expect.objectContaining({ model: "qwen_image", recipePresetId: "qwen_detail" }));
   });
 
   it("applies recipe preset defaults to video jobs", async () => {
@@ -546,6 +590,7 @@ describe("SceneWorks app shell", () => {
         quality: "best",
         negativePrompt: "jitter",
         recipePresetId: "dream_motion",
+        loras: [expect.objectContaining({ id: "video_motion", weight: 0.8, presetManaged: true })],
         advanced: expect.objectContaining({
           recipePresetName: "Dream Motion",
           recipePresetPrompt: { suffix: "smooth camera motion" },
@@ -555,21 +600,98 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("filters video presets by mode and selected model", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <VideoStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
+          characters={[]}
+          createPersonDetectionJob={() => {}}
+          createPersonTrackJob={() => {}}
+          createVideoJob={() => {}}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          latestAssets={[]}
+          loras={[]}
+          onPreview={() => {}}
+          personTracks={[]}
+          purgeAsset={() => {}}
+          recipePresets={[
+            { id: "ltx_motion", name: "LTX Motion", workflow: "image_to_video", model: "ltx_2_3" },
+            { id: "ltx_story", name: "LTX Story", workflow: "text_to_video", model: "ltx_2_3" },
+            { id: "wan_motion", name: "Wan Motion", workflow: "image_to_video", model: "wan_2_2" },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+          videoModels={[
+            {
+              id: "ltx_2_3",
+              name: "LTX",
+              type: "video",
+              capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip"],
+              defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+              limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
+            },
+            {
+              id: "wan_2_2",
+              name: "Wan2.2",
+              type: "video",
+              capabilities: ["image_to_video", "text_to_video"],
+              defaults: { duration: 5, fps: 24, resolution: "1280x720", quality: "balanced" },
+              limits: { durations: [4, 5], fps: [24], resolutions: ["1280x720"] },
+            },
+          ]}
+        />,
+      );
+    });
+    await settle();
+
+    expect(container.textContent).toContain("LTX Motion");
+    expect(container.textContent).not.toContain("Wan Motion");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Text to Video").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("LTX Story");
+    expect(container.textContent).not.toContain("LTX Motion");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+    await changeField(field(container, "Model"), "wan_2_2");
+    await settle();
+
+    expect(container.textContent).toContain("Presets unavailable");
+    expect(container.textContent).not.toContain("LTX Story");
+  });
+
   it("creates, edits, duplicates, and archives recipe presets from the manager", async () => {
     const createRecipePreset = vi.fn(async (payload) => payload);
     const updateRecipePreset = vi.fn(async (id, payload) => ({ ...payload, id }));
     const duplicateRecipePreset = vi.fn(async (id) => ({ id: `${id}_copy` }));
     const deleteRecipePreset = vi.fn(async (id) => ({ id, archived: true }));
+    const createLoraImportJob = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "imported_detail" } }));
     root = createRoot(container);
     await act(async () => {
       root.render(
         <PresetManagerScreen
           activeProject={{ id: "project-1", name: "Noir" }}
+          createLoraImportJob={createLoraImportJob}
           createRecipePreset={createRecipePreset}
           deleteRecipePreset={deleteRecipePreset}
           duplicateRecipePreset={duplicateRecipePreset}
-          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image" }]}
-          loras={[{ id: "builtin_cinematic_detail", name: "Cinematic Detail", family: "z-image", presetManaged: true }]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
+          loras={[
+            { id: "builtin_cinematic_detail", name: "Cinematic Detail", family: "z-image", scope: "builtin", defaultWeight: 0.55 },
+            { id: "global_detail", name: "Global Detail", family: "z-image", scope: "global", defaultWeight: 0.7 },
+            { id: "qwen_only", name: "Qwen Only", family: "qwen-image", scope: "global" },
+          ]}
           recipePresets={[
             {
               id: "cinematic",
@@ -577,6 +699,7 @@ describe("SceneWorks app shell", () => {
               scope: "builtin",
               workflow: "text_to_image",
               model: "z_image_turbo",
+              loras: [{ id: "builtin_cinematic_detail", weight: 0.5 }],
               ui: { description: "Built in cinematic finish." },
             },
             {
@@ -598,12 +721,40 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "New Preset").click();
     });
     await changeField(field(container, "Name"), "Soft Morning");
+    await act(async () => {
+      [...container.querySelectorAll('.lora-choice input[type="checkbox"]')].find((input) => input.closest(".lora-choice").textContent.includes("Global Detail")).click();
+    });
+    await changeField(field(container, "Weight"), "0.35");
     expect(field(container, "ID").value).toBe("soft_morning");
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Preset").click();
     });
-    expect(createRecipePreset).toHaveBeenCalledWith(expect.objectContaining({ id: "soft_morning", name: "Soft Morning", scope: "global" }));
+    expect(createRecipePreset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "soft_morning",
+        name: "Soft Morning",
+        scope: "global",
+        loras: [{ id: "global_detail", weight: 0.35 }],
+        modes: ["text_to_image", "character_image", "style_variations"],
+      }),
+    );
+    expect(container.textContent).toContain("Valid");
+    expect(container.textContent).not.toContain("Qwen Only");
 
+    await act(async () => {
+      [...container.querySelectorAll(".preset-row")].find((button) => button.textContent.includes("Moody")).click();
+    });
+    await changeField(field(container, "Description"), "Richer low key color.");
+    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+    expect(createLoraImportJob).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceUrl: "https://example.com/loras/detail.safetensors", scope: "global", family: "z-image" }),
+    );
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "New Preset").click();
+    });
     await act(async () => {
       [...container.querySelectorAll(".preset-row")].find((button) => button.textContent.includes("Moody")).click();
     });
@@ -611,7 +762,7 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Save Preset").click();
     });
-    expect(updateRecipePreset).toHaveBeenCalledWith("moody", expect.objectContaining({ ui: { description: "Richer low key color." } }));
+    expect(updateRecipePreset).toHaveBeenCalledWith("moody", expect.objectContaining({ ui: { description: "Richer low key color." } }), "global");
 
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Duplicate").click();
@@ -624,6 +775,6 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Archive").click();
     });
-    expect(deleteRecipePreset).toHaveBeenCalledWith("moody");
+    expect(deleteRecipePreset).toHaveBeenCalledWith("moody", "global");
   });
 });

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5,6 +5,7 @@ import { App, eventUrl } from "./main.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
+import { VideoStudio } from "./screens/VideoStudio.jsx";
 
 class FakeEventSource {
   constructor(url) {
@@ -473,6 +474,83 @@ describe("SceneWorks app shell", () => {
         recipePresetId: "cinematic",
         loras: [],
         advanced: { resolution: "1280x720" },
+      }),
+    );
+  });
+
+  it("applies recipe preset defaults to video jobs", async () => {
+    const createVideoJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <VideoStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
+          characters={[]}
+          createPersonDetectionJob={() => {}}
+          createPersonTrackJob={() => {}}
+          createVideoJob={createVideoJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          latestAssets={[]}
+          loras={[{ id: "video_motion", name: "Video Motion" }]}
+          onPreview={() => {}}
+          personTracks={[]}
+          purgeAsset={() => {}}
+          recipePresets={[
+            {
+              id: "dream_motion",
+              name: "Dream Motion",
+              workflow: "image_to_video",
+              model: "ltx_2_3",
+              defaults: { duration: 8, fps: 30, resolution: "1280x720", quality: "best", negativePrompt: "jitter" },
+              prompt: { suffix: "smooth camera motion" },
+              builtInLoras: [{ id: "video_motion" }],
+              ui: { description: "Soft camera motion." },
+            },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+          videoModels={[
+            {
+              id: "ltx_2_3",
+              name: "LTX",
+              type: "video",
+              capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip"],
+              defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+              limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
+            },
+          ]}
+        />,
+      );
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Dream Motion");
+    expect(container.textContent).toContain("Soft camera motion.");
+    expect(container.textContent).toContain("Adds: smooth camera motion");
+    expect(container.textContent).toContain("Uses LoRA: Video Motion");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate Clip").click();
+    });
+
+    expect(createVideoJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        duration: 8,
+        fps: 30,
+        width: 1280,
+        height: 720,
+        quality: "best",
+        negativePrompt: "jitter",
+        recipePresetId: "dream_motion",
+        advanced: expect.objectContaining({
+          recipePresetName: "Dream Motion",
+          recipePresetPrompt: { suffix: "smooth camera motion" },
+          resolution: "1280x720",
+        }),
       }),
     );
   });

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
+import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 
 class FakeEventSource {
@@ -37,6 +38,19 @@ async function settle() {
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
+  });
+}
+
+function field(container, labelText) {
+  const label = [...container.querySelectorAll("label")].find((item) => item.childNodes[0]?.textContent.trim() === labelText);
+  return label?.querySelector("input, select, textarea");
+}
+
+async function changeField(input, value) {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(input.constructor.prototype, "value")?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new window.Event(input.tagName === "SELECT" ? "change" : "input", { bubbles: true }));
   });
 }
 
@@ -461,5 +475,77 @@ describe("SceneWorks app shell", () => {
         advanced: { resolution: "1280x720" },
       }),
     );
+  });
+
+  it("creates, edits, duplicates, and archives recipe presets from the manager", async () => {
+    const createRecipePreset = vi.fn(async (payload) => payload);
+    const updateRecipePreset = vi.fn(async (id, payload) => ({ ...payload, id }));
+    const duplicateRecipePreset = vi.fn(async (id) => ({ id: `${id}_copy` }));
+    const deleteRecipePreset = vi.fn(async (id) => ({ id, archived: true }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <PresetManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          createRecipePreset={createRecipePreset}
+          deleteRecipePreset={deleteRecipePreset}
+          duplicateRecipePreset={duplicateRecipePreset}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image" }]}
+          loras={[{ id: "builtin_cinematic_detail", name: "Cinematic Detail", family: "z-image", presetManaged: true }]}
+          recipePresets={[
+            {
+              id: "cinematic",
+              name: "Cinematic",
+              scope: "builtin",
+              workflow: "text_to_image",
+              model: "z_image_turbo",
+              ui: { description: "Built in cinematic finish." },
+            },
+            {
+              id: "moody",
+              name: "Moody",
+              scope: "global",
+              workflow: "text_to_image",
+              model: "z_image_turbo",
+              ui: { description: "Low key color." },
+            },
+          ]}
+          updateRecipePreset={updateRecipePreset}
+          videoModels={[{ id: "ltx_2_3", name: "LTX", type: "video" }]}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "New Preset").click();
+    });
+    await changeField(field(container, "Name"), "Soft Morning");
+    expect(field(container, "ID").value).toBe("soft_morning");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Preset").click();
+    });
+    expect(createRecipePreset).toHaveBeenCalledWith(expect.objectContaining({ id: "soft_morning", name: "Soft Morning", scope: "global" }));
+
+    await act(async () => {
+      [...container.querySelectorAll(".preset-row")].find((button) => button.textContent.includes("Moody")).click();
+    });
+    await changeField(field(container, "Description"), "Richer low key color.");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Save Preset").click();
+    });
+    expect(updateRecipePreset).toHaveBeenCalledWith("moody", expect.objectContaining({ ui: { description: "Richer low key color." } }));
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Duplicate").click();
+    });
+    expect(duplicateRecipePreset).toHaveBeenCalledWith("moody", "global");
+
+    await act(async () => {
+      [...container.querySelectorAll(".preset-row")].find((button) => button.textContent.includes("Moody")).click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Archive").click();
+    });
+    expect(deleteRecipePreset).toHaveBeenCalledWith("moody");
   });
 });

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -1,0 +1,109 @@
+export const defaultModesByWorkflow = {
+  text_to_image: ["text_to_image", "character_image", "style_variations"],
+  edit_image: ["edit_image"],
+  image_to_video: ["image_to_video"],
+  text_to_video: ["text_to_video"],
+  first_last_frame: ["first_last_frame"],
+};
+
+export function workflowModelType(workflow) {
+  return workflow?.includes("video") || workflow === "first_last_frame" ? "video" : "image";
+}
+
+export function workflowModes(workflow) {
+  return defaultModesByWorkflow[workflow] ?? [workflow].filter(Boolean);
+}
+
+export function loraFamilies(lora) {
+  const compatibility = lora?.compatibility ?? {};
+  const values =
+    lora?.families ??
+    lora?.compatibleFamilies ??
+    lora?.modelFamilies ??
+    compatibility.families ??
+    (lora?.family ? [lora.family] : []);
+  return Array.isArray(values) ? values : [values].filter(Boolean);
+}
+
+export function modelLoraFamilies(model) {
+  const compatibility = model?.loraCompatibility ?? {};
+  const values = model?.loraFamilies ?? compatibility.families ?? (model?.family ? [model.family] : []);
+  return Array.isArray(values) ? values : [values].filter(Boolean);
+}
+
+export function loraMatchesModel(lora, model) {
+  const modelFamilies = modelLoraFamilies(model);
+  const families = loraFamilies(lora);
+  return !modelFamilies.length || !families.length || families.some((family) => modelFamilies.includes(family));
+}
+
+export function presetMatchesWorkflow(preset, mode) {
+  if (preset?.modes?.length) {
+    return preset.modes.includes(mode);
+  }
+  return preset?.workflow === mode;
+}
+
+export function presetMatchesModel(preset, model) {
+  return !preset?.model || !model?.id || preset.model === model.id;
+}
+
+export function presetLoras(preset) {
+  return preset?.loras ?? preset?.builtInLoras ?? [];
+}
+
+export function presetLoraId(presetLora) {
+  return typeof presetLora === "string" ? presetLora : presetLora?.id ?? presetLora?.loraId;
+}
+
+export function loraWeight(lora, presetLora = {}) {
+  const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? 0.8);
+  return Number.isFinite(value) ? value : 0.8;
+}
+
+export function serializePresetLora(lora, presetLora = {}) {
+  const id = presetLoraId(presetLora) ?? lora?.id;
+  return {
+    id,
+    name: lora?.name ?? presetLora?.name ?? presetLora?.displayName ?? id,
+    scope: lora?.scope ?? presetLora?.scope ?? "global",
+    weight: loraWeight(lora, presetLora),
+    triggerWords: lora?.triggerWords ?? [],
+    compatibility: lora?.compatibility ?? presetLora?.compatibility ?? {},
+    presetManaged: true,
+  };
+}
+
+export function presetLoraDetails(preset, loras) {
+  return presetLoras(preset)
+    .map((presetLora) => {
+      const id = presetLoraId(presetLora);
+      const lora = loras.find((item) => item.id === id);
+      return lora
+        ? { ...serializePresetLora(lora, presetLora), missing: false }
+        : { id, name: id, weight: loraWeight(null, presetLora), missing: true };
+    })
+    .filter((lora) => lora.id);
+}
+
+export function presetPromptParts(preset) {
+  return [preset?.prompt?.prefix, preset?.prompt?.suffix]
+    .map((part) => String(part ?? "").trim())
+    .filter(Boolean);
+}
+
+export function presetValidation(preset, loras, model) {
+  const details = presetLoraDetails(preset, loras);
+  const missing = details.filter((lora) => lora.missing).map((lora) => lora.id);
+  const incompatible = details
+    .filter((detail) => {
+      const lora = loras.find((item) => item.id === detail.id);
+      return lora && !loraMatchesModel(lora, model);
+    })
+    .map((lora) => lora.id);
+  return {
+    missing,
+    incompatible,
+    ok: missing.length === 0 && incompatible.length === 0,
+  };
+}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetCard } from "../components/assetPanels.jsx";
+import {
+  loraMatchesModel,
+  loraWeight,
+  presetLoraDetails as buildPresetLoraDetails,
+  presetMatchesModel,
+  presetMatchesWorkflow,
+  presetPromptParts as buildPresetPromptParts,
+} from "../presetUtils.js";
 
 export function ImageStudio({
   activeProject,
@@ -34,22 +42,6 @@ export function ImageStudio({
   const [characterLookId, setCharacterLookId] = useState("");
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
-
-  function loraFamilies(lora) {
-    const compatibility = lora.compatibility ?? {};
-    const values =
-      lora.families ??
-      lora.compatibleFamilies ??
-      lora.modelFamilies ??
-      compatibility.families ??
-      (lora.family ? [lora.family] : []);
-    return Array.isArray(values) ? values : [values].filter(Boolean);
-  }
-
-  function loraWeight(lora) {
-    const value = Number(lora.defaultWeight ?? lora.weight ?? 0.8);
-    return Number.isFinite(value) ? value : 0.8;
-  }
 
   function serializeLora(lora, override = {}) {
     return {
@@ -109,10 +101,9 @@ export function ImageStudio({
     return item.type === "image";
   });
   const selectedModel = imageModels.find((item) => item.id === model);
-  const selectedModelFamily = selectedModel?.family ?? null;
   const availableRecipePresets = useMemo(() => {
-    return recipePresets.filter((preset) => !preset.modes?.length || preset.modes.includes(mode));
-  }, [mode, recipePresets]);
+    return recipePresets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel));
+  }, [mode, recipePresets, selectedModel?.id]);
   const selectedRecipePreset = availableRecipePresets.find((preset) => preset.id === stylePreset) ?? availableRecipePresets[0] ?? null;
   const compatibleLoras = useMemo(() => loras.filter((lora) => {
     if (lora.presetManaged) {
@@ -124,21 +115,14 @@ export function ImageStudio({
     if (showIncompatibleLoras) {
       return true;
     }
-    const families = loraFamilies(lora);
-    return !selectedModelFamily || families.length === 0 || families.includes(selectedModelFamily);
-  }), [loras, selectedModelFamily, showIncompatibleLoras]);
+    return loraMatchesModel(lora, selectedModel);
+  }), [loras, selectedModel, showIncompatibleLoras]);
   const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
   const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
   const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
-  const presetLoraDetails = (selectedRecipePreset?.builtInLoras ?? [])
-    .map((presetLora) => {
-      const loraId = typeof presetLora === "string" ? presetLora : presetLora.id;
-      const lora = loras.find((item) => item.id === loraId);
-      return lora ? { ...serializeLora(lora, presetLora), missing: false } : { id: loraId, name: loraId, missing: true };
-    })
-    .filter((lora) => lora.id);
-  const presetPromptParts = [selectedRecipePreset?.prompt?.prefix, selectedRecipePreset?.prompt?.suffix]
-    .filter((part) => String(part ?? "").trim());
+  const presetLoraDetails = buildPresetLoraDetails(selectedRecipePreset, loras);
+  const presetPromptParts = buildPresetPromptParts(selectedRecipePreset);
+  const presetMissingLoras = presetLoraDetails.filter((lora) => lora.missing);
   const [width, height] = resolution.split("x").map((value) => Number(value));
 
   useEffect(() => {
@@ -150,9 +134,6 @@ export function ImageStudio({
   useEffect(() => {
     if (!selectedRecipePreset) {
       return;
-    }
-    if (selectedRecipePreset.model) {
-      setModel(selectedRecipePreset.model);
     }
     const defaults = selectedRecipePreset.defaults ?? {};
     if (defaults.count) {
@@ -411,7 +392,12 @@ export function ImageStudio({
             </div>
           ) : null}
 
-          <button className="primary-action" disabled={!activeProject || !prompt.trim() || (mode === "character_image" && !characterId)} type="submit">
+          {presetMissingLoras.length ? <p className="inline-warning">Preset is missing LoRA: {presetMissingLoras.map((lora) => lora.id).join(", ")}</p> : null}
+          <button
+            className="primary-action"
+            disabled={!activeProject || !prompt.trim() || (mode === "character_image" && !characterId) || Boolean(presetMissingLoras.length)}
+            type="submit"
+          >
             Generate
           </button>
         </section>

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -1,4 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
+import {
+  loraMatchesModel,
+  presetLoraId,
+  presetLoras,
+  presetValidation,
+  workflowModelType,
+  workflowModes,
+} from "../presetUtils.js";
 
 const workflowOptions = [
   ["text_to_image", "Text to Image"],
@@ -8,14 +16,6 @@ const workflowOptions = [
   ["first_last_frame", "First/Last Frame"],
 ];
 
-const defaultModesByWorkflow = {
-  text_to_image: "text_to_image, character_image, style_variations",
-  edit_image: "edit_image",
-  image_to_video: "image_to_video",
-  text_to_video: "text_to_video",
-  first_last_frame: "first_last_frame",
-};
-
 function slugify(value) {
   return String(value ?? "")
     .trim()
@@ -24,20 +24,18 @@ function slugify(value) {
     .replace(/^_+|_+$/g, "");
 }
 
-function loraId(lora) {
-  return typeof lora === "string" ? lora : lora?.id;
-}
-
-function parseList(value) {
-  return String(value ?? "")
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
 function modelOptions(models, workflow) {
-  const type = workflow.includes("video") || workflow === "first_last_frame" ? "video" : "image";
+  const type = workflowModelType(workflow);
   return models.filter((model) => model.type === type);
+}
+
+function formLorasFromPreset(preset) {
+  return presetLoras(preset)
+    .map((lora) => {
+      const id = presetLoraId(lora);
+      return id ? { id, weight: typeof lora === "object" && lora.weight != null ? String(lora.weight) : "" } : null;
+    })
+    .filter(Boolean);
 }
 
 function formFromPreset(preset, fallbackModel) {
@@ -46,21 +44,32 @@ function formFromPreset(preset, fallbackModel) {
     name: preset?.name ?? "",
     scope: preset?.scope === "project" ? "project" : "global",
     workflow: preset?.workflow ?? "text_to_image",
-    modes: (preset?.modes ?? []).join(", "),
     model: preset?.model ?? fallbackModel ?? "",
     order: preset?.order ?? "",
     count: preset?.defaults?.count ?? "",
+    duration: preset?.defaults?.duration ?? "",
+    fps: preset?.defaults?.fps ?? "",
+    quality: preset?.defaults?.quality ?? "",
     resolution: preset?.defaults?.resolution ?? "",
     negativePrompt: preset?.defaults?.negativePrompt ?? "",
     promptPrefix: preset?.prompt?.prefix ?? "",
     promptSuffix: preset?.prompt?.suffix ?? "",
     description: preset?.ui?.description ?? "",
-    loraIds: (preset?.builtInLoras ?? preset?.loras ?? []).map(loraId).filter(Boolean),
+    loras: formLorasFromPreset(preset),
   };
+}
+
+function selectedLoraIds(form) {
+  return form.loras.map((lora) => lora.id);
+}
+
+function loraLabel(lora) {
+  return [lora.scope, lora.family ?? "compatible"].filter(Boolean).join(" | ");
 }
 
 export function PresetManagerScreen({
   activeProject,
+  createLoraImportJob,
   createRecipePreset,
   deleteRecipePreset,
   duplicateRecipePreset,
@@ -75,10 +84,31 @@ export function PresetManagerScreen({
   const selectedPreset = recipePresets.find((preset) => preset.id === selectedPresetId) ?? null;
   const [form, setForm] = useState(() => formFromPreset(selectedPreset, models[0]?.id));
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState({ tone: "neutral", text: "" });
+  const [importForm, setImportForm] = useState({ sourceUrl: "", name: "" });
   const editable = !selectedPreset || selectedPreset.scope !== "builtin";
   const availableModels = modelOptions(models, form.workflow);
-  const compatibleLoras = loras.filter((lora) => lora.presetManaged || lora.scope === "builtin");
+  const selectedModel = models.find((model) => model.id === form.model) ?? availableModels[0] ?? null;
+  const availableLoras = loras.filter((lora) => lora.installState !== "missing" && loraMatchesModel(lora, selectedModel));
+  const validation = presetValidation({ ...selectedPreset, loras: form.loras }, loras, selectedModel);
+  const unknownSelectedLoras = form.loras.filter((selection) => !loras.some((lora) => lora.id === selection.id)).map((lora) => lora.id);
+  const incompatibleSelectedLoras = form.loras
+    .filter((selection) => {
+      const lora = loras.find((item) => item.id === selection.id);
+      return lora && !loraMatchesModel(lora, selectedModel);
+    })
+    .map((lora) => lora.id);
+  const saveDisabledReason = !editable
+    ? "Built-in presets are read-only."
+    : !form.name.trim()
+      ? "Name is required."
+      : !form.model
+        ? "Model is required."
+        : unknownSelectedLoras.length
+          ? `Wait for imported LoRA ${unknownSelectedLoras.join(", ")} to finish before saving.`
+          : incompatibleSelectedLoras.length
+            ? `Remove incompatible LoRA ${incompatibleSelectedLoras.join(", ")} before saving.`
+            : "";
 
   useEffect(() => {
     if (selectedPreset && !recipePresets.some((preset) => preset.id === selectedPreset.id)) {
@@ -88,29 +118,32 @@ export function PresetManagerScreen({
 
   useEffect(() => {
     setForm(formFromPreset(selectedPreset, modelOptions(models, selectedPreset?.workflow ?? "text_to_image")[0]?.id ?? models[0]?.id));
-    setMessage("");
-  }, [selectedPreset?.id, models.length]);
+    setMessage({ tone: "neutral", text: "" });
+  }, [selectedPreset?.id, models]);
 
   useEffect(() => {
     if (!availableModels.length) {
       return;
     }
     if (!availableModels.some((model) => model.id === form.model)) {
-      setForm((current) => ({ ...current, model: availableModels[0].id }));
+      setForm((current) => ({ ...current, model: availableModels[0].id, loras: [] }));
     }
   }, [availableModels, form.model]);
 
   function updateField(field, value) {
     setForm((current) => {
       if (field === "workflow") {
-        return {
-          ...current,
-          workflow: value,
-          modes: current.modes || defaultModesByWorkflow[value] || value,
-        };
+        return { ...current, workflow: value, loras: [] };
       }
       if (field === "name" && !selectedPreset) {
         return { ...current, name: value, id: slugify(value) };
+      }
+      if (field === "model") {
+        return { ...current, model: value, loras: current.loras.filter((selection) => {
+          const lora = loras.find((item) => item.id === selection.id);
+          const model = models.find((item) => item.id === value);
+          return !lora || loraMatchesModel(lora, model);
+        }) };
       }
       return { ...current, [field]: value };
     });
@@ -118,16 +151,39 @@ export function PresetManagerScreen({
 
   function toggleLora(id) {
     setForm((current) => {
-      const hasLora = current.loraIds.includes(id);
-      const loraIds = hasLora ? current.loraIds.filter((item) => item !== id) : [...current.loraIds, id].slice(0, 3);
-      return { ...current, loraIds };
+      const hasLora = current.loras.some((lora) => lora.id === id);
+      if (hasLora) {
+        return { ...current, loras: current.loras.filter((lora) => lora.id !== id) };
+      }
+      if (current.loras.length >= 3) {
+        return current;
+      }
+      const source = loras.find((lora) => lora.id === id);
+      const weight = source?.defaultWeight ?? source?.weight ?? 0.8;
+      return { ...current, loras: [...current.loras, { id, weight: String(weight) }] };
     });
+  }
+
+  function updateLoraWeight(id, weight) {
+    setForm((current) => ({
+      ...current,
+      loras: current.loras.map((lora) => (lora.id === id ? { ...lora, weight } : lora)),
+    }));
   }
 
   function buildPayload() {
     const defaults = {};
     if (form.count !== "") {
       defaults.count = Number(form.count);
+    }
+    if (form.duration !== "") {
+      defaults.duration = Number(form.duration);
+    }
+    if (form.fps !== "") {
+      defaults.fps = Number(form.fps);
+    }
+    if (form.quality.trim()) {
+      defaults.quality = form.quality.trim();
     }
     if (form.resolution.trim()) {
       defaults.resolution = form.resolution.trim();
@@ -147,9 +203,12 @@ export function PresetManagerScreen({
       name: form.name.trim(),
       scope: form.scope,
       workflow: form.workflow,
-      modes: parseList(form.modes),
+      modes: workflowModes(form.workflow),
       model: form.model,
-      builtInLoras: form.loraIds.map((id) => ({ id })),
+      loras: form.loras.map((lora) => ({
+        id: lora.id,
+        weight: Number.isFinite(Number(lora.weight)) ? Number(lora.weight) : 0.8,
+      })),
       ui: { description: form.description.trim() },
     };
     if (form.order !== "") {
@@ -166,20 +225,24 @@ export function PresetManagerScreen({
 
   async function savePreset(event) {
     event.preventDefault();
+    if (saveDisabledReason) {
+      setMessage({ tone: "error", text: saveDisabledReason });
+      return;
+    }
     setSaving(true);
-    setMessage("");
+    setMessage({ tone: "neutral", text: "" });
     try {
       const payload = buildPayload();
       if (selectedPreset) {
-        await updateRecipePreset(selectedPreset.id, payload);
-        setMessage("Preset saved.");
+        await updateRecipePreset(selectedPreset.id, payload, selectedPreset.scope);
+        setMessage({ tone: "success", text: "Preset saved." });
       } else {
         const created = await createRecipePreset(payload);
         setSelectedPresetId(created?.id ?? payload.id);
-        setMessage("Preset created.");
+        setMessage({ tone: "success", text: "Preset created." });
       }
     } catch (err) {
-      setMessage(err.message);
+      setMessage({ tone: "error", text: err.message });
     } finally {
       setSaving(false);
     }
@@ -190,7 +253,7 @@ export function PresetManagerScreen({
       return;
     }
     setSaving(true);
-    setMessage("");
+    setMessage({ tone: "neutral", text: "" });
     try {
       if (selectedPreset.scope === "builtin") {
         const payload = buildPayload();
@@ -198,14 +261,14 @@ export function PresetManagerScreen({
         payload.name = `${selectedPreset.name ?? selectedPreset.id} Copy`;
         const created = await createRecipePreset(payload);
         setSelectedPresetId(created.id);
-        setMessage("Preset duplicated.");
+        setMessage({ tone: "success", text: "Preset duplicated." });
         return;
       }
       const duplicated = await duplicateRecipePreset(selectedPreset.id, form.scope);
       setSelectedPresetId(duplicated.id);
-      setMessage("Preset duplicated.");
+      setMessage({ tone: "success", text: "Preset duplicated." });
     } catch (err) {
-      setMessage(err.message);
+      setMessage({ tone: "error", text: err.message });
     } finally {
       setSaving(false);
     }
@@ -216,13 +279,45 @@ export function PresetManagerScreen({
       return;
     }
     setSaving(true);
-    setMessage("");
+    setMessage({ tone: "neutral", text: "" });
     try {
-      await deleteRecipePreset(selectedPreset.id);
+      await deleteRecipePreset(selectedPreset.id, selectedPreset.scope);
       setSelectedPresetId("");
-      setMessage("Preset archived.");
+      setMessage({ tone: "success", text: "Preset archived." });
     } catch (err) {
-      setMessage(err.message);
+      setMessage({ tone: "error", text: err.message });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function importLora(event) {
+    event.preventDefault();
+    if (!importForm.sourceUrl.trim()) {
+      return;
+    }
+    setSaving(true);
+    setMessage({ tone: "neutral", text: "" });
+    try {
+      const job = await createLoraImportJob({
+        sourceUrl: importForm.sourceUrl.trim(),
+        name: importForm.name.trim() || undefined,
+        scope: form.scope,
+        family: selectedModel?.family ?? undefined,
+      });
+      const importedId = job?.payload?.loraId;
+      if (importedId) {
+        setForm((current) => ({
+          ...current,
+          loras: current.loras.some((lora) => lora.id === importedId)
+            ? current.loras
+            : [...current.loras, { id: importedId, weight: "0.8" }].slice(0, 3),
+        }));
+      }
+      setImportForm({ sourceUrl: "", name: "" });
+      setMessage({ tone: "success", text: "LoRA import queued. Save after the import finishes." });
+    } catch (err) {
+      setMessage({ tone: "error", text: err.message });
     } finally {
       setSaving(false);
     }
@@ -231,7 +326,7 @@ export function PresetManagerScreen({
   function startNewPreset() {
     setSelectedPresetId("");
     setForm(formFromPreset(null, modelOptions(models, "text_to_image")[0]?.id ?? models[0]?.id));
-    setMessage("");
+    setMessage({ tone: "neutral", text: "" });
   }
 
   return (
@@ -257,22 +352,27 @@ export function PresetManagerScreen({
       <div className="preset-layout">
         <section className="preset-list" aria-label="Recipe presets">
           {recipePresets.length ? (
-            recipePresets.map((preset) => (
-              <button
-                className={selectedPresetId === preset.id ? "preset-row active" : "preset-row"}
-                key={`${preset.scope}-${preset.id}`}
-                onClick={() => setSelectedPresetId(preset.id)}
-                type="button"
-              >
-                <span>
-                  <strong>{preset.name ?? preset.id}</strong>
-                  <small>
-                    {preset.scope ?? "global"} | {preset.workflow}
-                  </small>
-                </span>
-                <span>{preset.model}</span>
-              </button>
-            ))
+            recipePresets.map((preset) => {
+              const presetModel = models.find((model) => model.id === preset.model);
+              const status = presetValidation(preset, loras, presetModel);
+              const label = status.ok ? "Valid" : status.missing.length ? `Missing ${status.missing.join(", ")}` : `Incompatible ${status.incompatible.join(", ")}`;
+              return (
+                <button
+                  className={selectedPresetId === preset.id ? "preset-row active" : "preset-row"}
+                  key={`${preset.scope}-${preset.id}`}
+                  onClick={() => setSelectedPresetId(preset.id)}
+                  type="button"
+                >
+                  <span>
+                    <strong>{preset.name ?? preset.id}</strong>
+                    <small>
+                      {preset.scope ?? "global"} | {preset.workflow}
+                    </small>
+                  </span>
+                  <span className={status.ok ? "preset-status ok" : "preset-status error"}>{label}</span>
+                </button>
+              );
+            })
           ) : (
             <div className="empty-panel compact-panel">No presets</div>
           )}
@@ -328,8 +428,8 @@ export function PresetManagerScreen({
               </select>
             </label>
             <label>
-              Modes
-              <input disabled={!editable} onChange={(event) => updateField("modes", event.target.value)} value={form.modes} />
+              Derived modes
+              <input disabled readOnly value={workflowModes(form.workflow).join(", ")} />
             </label>
           </div>
 
@@ -339,14 +439,30 @@ export function PresetManagerScreen({
               <input disabled={!editable} min="1" max="8" onChange={(event) => updateField("count", event.target.value)} type="number" value={form.count} />
             </label>
             <label>
+              Duration
+              <input disabled={!editable} min="1" max="30" onChange={(event) => updateField("duration", event.target.value)} type="number" value={form.duration} />
+            </label>
+            <label>
               Resolution
               <input disabled={!editable} onChange={(event) => updateField("resolution", event.target.value)} placeholder="1024x1024" value={form.resolution} />
             </label>
+          </div>
+
+          <div className="control-grid compact-controls">
             <label>
-              Negative
-              <input disabled={!editable} onChange={(event) => updateField("negativePrompt", event.target.value)} value={form.negativePrompt} />
+              FPS
+              <input disabled={!editable} min="1" max="60" onChange={(event) => updateField("fps", event.target.value)} type="number" value={form.fps} />
+            </label>
+            <label>
+              Quality
+              <input disabled={!editable} onChange={(event) => updateField("quality", event.target.value)} value={form.quality} />
             </label>
           </div>
+
+          <label>
+            Negative
+            <input disabled={!editable} onChange={(event) => updateField("negativePrompt", event.target.value)} value={form.negativePrompt} />
+          </label>
 
           <label>
             Description
@@ -367,31 +483,83 @@ export function PresetManagerScreen({
           <section className="lora-picker" aria-label="Preset LoRAs">
             <div>
               <strong>Managed LoRAs</strong>
-              <span>{form.loraIds.length}/3 selected</span>
+              <span>{form.loras.length}/3 selected</span>
             </div>
-            {compatibleLoras.length ? (
+            {availableLoras.length ? (
               <div className="lora-choice-list">
-                {compatibleLoras.map((lora) => {
-                  const checked = form.loraIds.includes(lora.id);
+                {availableLoras.map((lora) => {
+                  const checked = selectedLoraIds(form).includes(lora.id);
+                  const selected = form.loras.find((item) => item.id === lora.id);
                   return (
-                    <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
-                      <input checked={checked} disabled={!editable || (!checked && form.loraIds.length >= 3)} onChange={() => toggleLora(lora.id)} type="checkbox" />
-                      <span>
-                        <strong>{lora.name ?? lora.id}</strong>
-                        <small>{lora.family ?? lora.scope ?? "global"}</small>
-                      </span>
-                    </label>
+                    <div className={checked ? "lora-choice active editable-lora-choice" : "lora-choice editable-lora-choice"} key={lora.id}>
+                      <label>
+                        <input checked={checked} disabled={!editable || (!checked && form.loras.length >= 3)} onChange={() => toggleLora(lora.id)} type="checkbox" />
+                        <span>
+                          <strong>{lora.name ?? lora.id}</strong>
+                          <small>{loraLabel(lora)}</small>
+                        </span>
+                      </label>
+                      {checked ? (
+                        <label>
+                          Weight
+                          <input
+                            disabled={!editable}
+                            max="2"
+                            min="-2"
+                            onChange={(event) => updateLoraWeight(lora.id, event.target.value)}
+                            step="0.05"
+                            type="number"
+                            value={selected?.weight ?? ""}
+                          />
+                        </label>
+                      ) : null}
+                    </div>
                   );
                 })}
               </div>
             ) : (
-              <div className="empty-panel compact-panel">No managed LoRAs</div>
+              <div className="empty-panel compact-panel">No compatible LoRAs</div>
             )}
           </section>
 
-          {selectedPreset?.scope === "builtin" ? <p className="inline-warning">Built-in presets are read-only.</p> : null}
-          {message ? <p className="inline-warning">{message}</p> : null}
-          <button className="primary-action" disabled={!editable || saving || !form.name.trim() || !form.model} type="submit">
+          <section className="lora-import-panel" aria-label="Import LoRA by URL">
+            <div>
+              <strong>Add by URL</strong>
+              <span>{selectedModel?.family ?? "selected model family"}</span>
+            </div>
+            <div className="inline-create">
+              <label>
+                Source URL
+                <input
+                  disabled={!editable}
+                  onChange={(event) => setImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
+                  placeholder="https://..."
+                  value={importForm.sourceUrl}
+                />
+              </label>
+              <label>
+                Name
+                <input
+                  disabled={!editable}
+                  onChange={(event) => setImportForm((current) => ({ ...current, name: event.target.value }))}
+                  placeholder="Optional"
+                  value={importForm.name}
+                />
+              </label>
+              <button disabled={!editable || saving || !importForm.sourceUrl.trim()} onClick={importLora} type="button">
+                Queue Import
+              </button>
+            </div>
+          </section>
+
+          {!validation.ok ? (
+            <p className="inline-warning">
+              {validation.missing.length ? `Missing LoRA: ${validation.missing.join(", ")}` : `Incompatible LoRA: ${validation.incompatible.join(", ")}`}
+            </p>
+          ) : null}
+          {saveDisabledReason ? <p className="inline-warning">{saveDisabledReason}</p> : null}
+          {message.text ? <p className={message.tone === "success" ? "inline-success" : "inline-warning"}>{message.text}</p> : null}
+          <button className="primary-action" disabled={Boolean(saveDisabledReason) || saving} type="submit">
             {selectedPreset ? "Save Preset" : "Create Preset"}
           </button>
         </form>

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -1,0 +1,401 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+const workflowOptions = [
+  ["text_to_image", "Text to Image"],
+  ["edit_image", "Image Edit"],
+  ["image_to_video", "Image to Video"],
+  ["text_to_video", "Text to Video"],
+  ["first_last_frame", "First/Last Frame"],
+];
+
+const defaultModesByWorkflow = {
+  text_to_image: "text_to_image, character_image, style_variations",
+  edit_image: "edit_image",
+  image_to_video: "image_to_video",
+  text_to_video: "text_to_video",
+  first_last_frame: "first_last_frame",
+};
+
+function slugify(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function loraId(lora) {
+  return typeof lora === "string" ? lora : lora?.id;
+}
+
+function parseList(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function modelOptions(models, workflow) {
+  const type = workflow.includes("video") || workflow === "first_last_frame" ? "video" : "image";
+  return models.filter((model) => model.type === type);
+}
+
+function formFromPreset(preset, fallbackModel) {
+  return {
+    id: preset?.id ?? "",
+    name: preset?.name ?? "",
+    scope: preset?.scope === "project" ? "project" : "global",
+    workflow: preset?.workflow ?? "text_to_image",
+    modes: (preset?.modes ?? []).join(", "),
+    model: preset?.model ?? fallbackModel ?? "",
+    order: preset?.order ?? "",
+    count: preset?.defaults?.count ?? "",
+    resolution: preset?.defaults?.resolution ?? "",
+    negativePrompt: preset?.defaults?.negativePrompt ?? "",
+    promptPrefix: preset?.prompt?.prefix ?? "",
+    promptSuffix: preset?.prompt?.suffix ?? "",
+    description: preset?.ui?.description ?? "",
+    loraIds: (preset?.builtInLoras ?? preset?.loras ?? []).map(loraId).filter(Boolean),
+  };
+}
+
+export function PresetManagerScreen({
+  activeProject,
+  createRecipePreset,
+  deleteRecipePreset,
+  duplicateRecipePreset,
+  imageModels,
+  loras = [],
+  recipePresets = [],
+  updateRecipePreset,
+  videoModels,
+}) {
+  const models = useMemo(() => [...imageModels, ...videoModels], [imageModels, videoModels]);
+  const [selectedPresetId, setSelectedPresetId] = useState(recipePresets.find((preset) => preset.scope !== "builtin")?.id ?? "");
+  const selectedPreset = recipePresets.find((preset) => preset.id === selectedPresetId) ?? null;
+  const [form, setForm] = useState(() => formFromPreset(selectedPreset, models[0]?.id));
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const editable = !selectedPreset || selectedPreset.scope !== "builtin";
+  const availableModels = modelOptions(models, form.workflow);
+  const compatibleLoras = loras.filter((lora) => lora.presetManaged || lora.scope === "builtin");
+
+  useEffect(() => {
+    if (selectedPreset && !recipePresets.some((preset) => preset.id === selectedPreset.id)) {
+      setSelectedPresetId(recipePresets.find((preset) => preset.scope !== "builtin")?.id ?? "");
+    }
+  }, [recipePresets, selectedPreset?.id]);
+
+  useEffect(() => {
+    setForm(formFromPreset(selectedPreset, modelOptions(models, selectedPreset?.workflow ?? "text_to_image")[0]?.id ?? models[0]?.id));
+    setMessage("");
+  }, [selectedPreset?.id, models.length]);
+
+  useEffect(() => {
+    if (!availableModels.length) {
+      return;
+    }
+    if (!availableModels.some((model) => model.id === form.model)) {
+      setForm((current) => ({ ...current, model: availableModels[0].id }));
+    }
+  }, [availableModels, form.model]);
+
+  function updateField(field, value) {
+    setForm((current) => {
+      if (field === "workflow") {
+        return {
+          ...current,
+          workflow: value,
+          modes: current.modes || defaultModesByWorkflow[value] || value,
+        };
+      }
+      if (field === "name" && !selectedPreset) {
+        return { ...current, name: value, id: slugify(value) };
+      }
+      return { ...current, [field]: value };
+    });
+  }
+
+  function toggleLora(id) {
+    setForm((current) => {
+      const hasLora = current.loraIds.includes(id);
+      const loraIds = hasLora ? current.loraIds.filter((item) => item !== id) : [...current.loraIds, id].slice(0, 3);
+      return { ...current, loraIds };
+    });
+  }
+
+  function buildPayload() {
+    const defaults = {};
+    if (form.count !== "") {
+      defaults.count = Number(form.count);
+    }
+    if (form.resolution.trim()) {
+      defaults.resolution = form.resolution.trim();
+    }
+    if (form.negativePrompt.trim()) {
+      defaults.negativePrompt = form.negativePrompt.trim();
+    }
+    const prompt = {};
+    if (form.promptPrefix.trim()) {
+      prompt.prefix = form.promptPrefix.trim();
+    }
+    if (form.promptSuffix.trim()) {
+      prompt.suffix = form.promptSuffix.trim();
+    }
+    const payload = {
+      id: slugify(form.id || form.name),
+      name: form.name.trim(),
+      scope: form.scope,
+      workflow: form.workflow,
+      modes: parseList(form.modes),
+      model: form.model,
+      builtInLoras: form.loraIds.map((id) => ({ id })),
+      ui: { description: form.description.trim() },
+    };
+    if (form.order !== "") {
+      payload.order = Number(form.order);
+    }
+    if (Object.keys(defaults).length) {
+      payload.defaults = defaults;
+    }
+    if (Object.keys(prompt).length) {
+      payload.prompt = prompt;
+    }
+    return payload;
+  }
+
+  async function savePreset(event) {
+    event.preventDefault();
+    setSaving(true);
+    setMessage("");
+    try {
+      const payload = buildPayload();
+      if (selectedPreset) {
+        await updateRecipePreset(selectedPreset.id, payload);
+        setMessage("Preset saved.");
+      } else {
+        const created = await createRecipePreset(payload);
+        setSelectedPresetId(created?.id ?? payload.id);
+        setMessage("Preset created.");
+      }
+    } catch (err) {
+      setMessage(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function duplicateSelected() {
+    if (!selectedPreset) {
+      return;
+    }
+    setSaving(true);
+    setMessage("");
+    try {
+      if (selectedPreset.scope === "builtin") {
+        const payload = buildPayload();
+        payload.id = slugify(`${selectedPreset.id}_copy`);
+        payload.name = `${selectedPreset.name ?? selectedPreset.id} Copy`;
+        const created = await createRecipePreset(payload);
+        setSelectedPresetId(created.id);
+        setMessage("Preset duplicated.");
+        return;
+      }
+      const duplicated = await duplicateRecipePreset(selectedPreset.id, form.scope);
+      setSelectedPresetId(duplicated.id);
+      setMessage("Preset duplicated.");
+    } catch (err) {
+      setMessage(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function archiveSelected() {
+    if (!selectedPreset || selectedPreset.scope === "builtin") {
+      return;
+    }
+    setSaving(true);
+    setMessage("");
+    try {
+      await deleteRecipePreset(selectedPreset.id);
+      setSelectedPresetId("");
+      setMessage("Preset archived.");
+    } catch (err) {
+      setMessage(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function startNewPreset() {
+    setSelectedPresetId("");
+    setForm(formFromPreset(null, modelOptions(models, "text_to_image")[0]?.id ?? models[0]?.id));
+    setMessage("");
+  }
+
+  return (
+    <section className="main-surface preset-manager">
+      <div className="surface-header">
+        <div className="section-heading">
+          <p className="eyebrow">Preset Manager</p>
+          <h2>{activeProject ? activeProject.name : "Global presets"}</h2>
+        </div>
+        <div className="toolbar">
+          <button onClick={startNewPreset} type="button">
+            New Preset
+          </button>
+          <button disabled={!selectedPreset || saving} onClick={duplicateSelected} type="button">
+            Duplicate
+          </button>
+          <button disabled={!selectedPreset || selectedPreset.scope === "builtin" || saving} onClick={archiveSelected} type="button">
+            Archive
+          </button>
+        </div>
+      </div>
+
+      <div className="preset-layout">
+        <section className="preset-list" aria-label="Recipe presets">
+          {recipePresets.length ? (
+            recipePresets.map((preset) => (
+              <button
+                className={selectedPresetId === preset.id ? "preset-row active" : "preset-row"}
+                key={`${preset.scope}-${preset.id}`}
+                onClick={() => setSelectedPresetId(preset.id)}
+                type="button"
+              >
+                <span>
+                  <strong>{preset.name ?? preset.id}</strong>
+                  <small>
+                    {preset.scope ?? "global"} | {preset.workflow}
+                  </small>
+                </span>
+                <span>{preset.model}</span>
+              </button>
+            ))
+          ) : (
+            <div className="empty-panel compact-panel">No presets</div>
+          )}
+        </section>
+
+        <form className="preset-editor" onSubmit={savePreset}>
+          <div className="control-grid compact-controls">
+            <label>
+              Name
+              <input disabled={!editable} onChange={(event) => updateField("name", event.target.value)} required value={form.name} />
+            </label>
+            <label>
+              ID
+              <input disabled={Boolean(selectedPreset) || !editable} onChange={(event) => updateField("id", event.target.value)} required value={form.id} />
+            </label>
+          </div>
+
+          <div className="control-grid">
+            <label>
+              Scope
+              <select disabled={!editable} onChange={(event) => updateField("scope", event.target.value)} value={form.scope}>
+                <option value="global">Global</option>
+                <option disabled={!activeProject} value="project">
+                  Project
+                </option>
+              </select>
+            </label>
+            <label>
+              Workflow
+              <select disabled={!editable} onChange={(event) => updateField("workflow", event.target.value)} value={form.workflow}>
+                {workflowOptions.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Order
+              <input disabled={!editable} onChange={(event) => updateField("order", event.target.value)} type="number" value={form.order} />
+            </label>
+          </div>
+
+          <div className="control-grid compact-controls">
+            <label>
+              Model
+              <select disabled={!editable} onChange={(event) => updateField("model", event.target.value)} value={form.model}>
+                {availableModels.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.name ?? model.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Modes
+              <input disabled={!editable} onChange={(event) => updateField("modes", event.target.value)} value={form.modes} />
+            </label>
+          </div>
+
+          <div className="control-grid">
+            <label>
+              Count
+              <input disabled={!editable} min="1" max="8" onChange={(event) => updateField("count", event.target.value)} type="number" value={form.count} />
+            </label>
+            <label>
+              Resolution
+              <input disabled={!editable} onChange={(event) => updateField("resolution", event.target.value)} placeholder="1024x1024" value={form.resolution} />
+            </label>
+            <label>
+              Negative
+              <input disabled={!editable} onChange={(event) => updateField("negativePrompt", event.target.value)} value={form.negativePrompt} />
+            </label>
+          </div>
+
+          <label>
+            Description
+            <input disabled={!editable} onChange={(event) => updateField("description", event.target.value)} value={form.description} />
+          </label>
+
+          <div className="control-grid compact-controls">
+            <label>
+              Prompt Prefix
+              <textarea disabled={!editable} onChange={(event) => updateField("promptPrefix", event.target.value)} value={form.promptPrefix} />
+            </label>
+            <label>
+              Prompt Suffix
+              <textarea disabled={!editable} onChange={(event) => updateField("promptSuffix", event.target.value)} value={form.promptSuffix} />
+            </label>
+          </div>
+
+          <section className="lora-picker" aria-label="Preset LoRAs">
+            <div>
+              <strong>Managed LoRAs</strong>
+              <span>{form.loraIds.length}/3 selected</span>
+            </div>
+            {compatibleLoras.length ? (
+              <div className="lora-choice-list">
+                {compatibleLoras.map((lora) => {
+                  const checked = form.loraIds.includes(lora.id);
+                  return (
+                    <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
+                      <input checked={checked} disabled={!editable || (!checked && form.loraIds.length >= 3)} onChange={() => toggleLora(lora.id)} type="checkbox" />
+                      <span>
+                        <strong>{lora.name ?? lora.id}</strong>
+                        <small>{lora.family ?? lora.scope ?? "global"}</small>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="empty-panel compact-panel">No managed LoRAs</div>
+            )}
+          </section>
+
+          {selectedPreset?.scope === "builtin" ? <p className="inline-warning">Built-in presets are read-only.</p> : null}
+          {message ? <p className="inline-warning">{message}</p> : null}
+          <button className="primary-action" disabled={!editable || saving || !form.name.trim() || !form.model} type="submit">
+            {selectedPreset ? "Save Preset" : "Create Preset"}
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
+import {
+  presetLoraDetails as buildPresetLoraDetails,
+  presetMatchesModel,
+  presetMatchesWorkflow,
+  presetPromptParts as buildPresetPromptParts,
+} from "../presetUtils.js";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 
 export function VideoStudio({
@@ -55,23 +61,12 @@ export function VideoStudio({
   const supportsMode = capabilities.includes(mode);
   const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
   const availableRecipePresets = useMemo(() => {
-    return recipePresets.filter((preset) => {
-      if (preset.modes?.length) {
-        return preset.modes.includes(mode);
-      }
-      return preset.workflow === mode;
-    });
-  }, [mode, recipePresets]);
+    return recipePresets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel));
+  }, [mode, recipePresets, selectedModel?.id]);
   const selectedRecipePreset = availableRecipePresets.find((preset) => preset.id === recipePresetId) ?? availableRecipePresets[0] ?? null;
-  const presetPromptParts = [selectedRecipePreset?.prompt?.prefix, selectedRecipePreset?.prompt?.suffix]
-    .filter((part) => String(part ?? "").trim());
-  const presetLoraDetails = (selectedRecipePreset?.builtInLoras ?? selectedRecipePreset?.loras ?? [])
-    .map((presetLora) => {
-      const loraId = typeof presetLora === "string" ? presetLora : presetLora.id;
-      const lora = loras.find((item) => item.id === loraId);
-      return lora ? { id: loraId, name: lora.name ?? loraId } : { id: loraId, name: loraId, missing: true };
-    })
-    .filter((lora) => lora.id);
+  const presetPromptParts = buildPresetPromptParts(selectedRecipePreset);
+  const presetLoraDetails = buildPresetLoraDetails(selectedRecipePreset, loras);
+  const presetMissingLoras = presetLoraDetails.filter((lora) => lora.missing);
 
   useEffect(() => {
     if (!videoModels.some((item) => item.id === model)) {
@@ -155,9 +150,6 @@ export function VideoStudio({
     if (!selectedRecipePreset) {
       return;
     }
-    if (selectedRecipePreset.model) {
-      setModel(selectedRecipePreset.model);
-    }
     const defaults = selectedRecipePreset.defaults ?? {};
     if (defaults.duration) {
       setDuration(Number(defaults.duration));
@@ -215,7 +207,7 @@ export function VideoStudio({
     (mode === "first_last_frame" && sourceAssetId && lastFrameAssetId) ||
     (mode === "extend_clip" && sourceClipAssetId) ||
     (mode === "replace_person" && sourceClipAssetId && personTrackId && characterId);
-  const canSubmit = Boolean(activeProject && prompt.trim() && supportsMode && implementedMode && hasInputs);
+  const canSubmit = Boolean(activeProject && prompt.trim() && supportsMode && implementedMode && hasInputs && !presetMissingLoras.length);
   const [width, height] = resolution.split("x").map((value) => Number(value));
   const durationOptions = selectedModel?.limits?.durations ?? [4, 6, 8, 10];
   const resolutionOptions = selectedModel?.limits?.resolutions ?? ["768x512", "640x640", "1280x720", "720x1280"];
@@ -257,7 +249,7 @@ export function VideoStudio({
       sourceClipAssetId: ["extend_clip", "replace_person"].includes(mode) ? sourceClipAssetId || null : null,
       personTrackId: mode === "replace_person" ? personTrackId || null : null,
       replacementMode: mode === "replace_person" ? replacementMode : "face_only",
-      loras: [],
+      loras: presetLoraDetails.filter((lora) => !lora.missing),
       advanced: {
         resolution,
         durationHint,
@@ -503,6 +495,7 @@ export function VideoStudio({
           ) : null}
 
           {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
+          {presetMissingLoras.length ? <p className="inline-warning">Preset is missing LoRA: {presetMissingLoras.map((lora) => lora.id).join(", ")}</p> : null}
           <button className="primary-action" disabled={!canSubmit} type="submit">
             {mode === "replace_person" ? "Replace Person" : "Generate Clip"}
           </button>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
@@ -15,9 +15,11 @@ export function VideoStudio({
   gpuOptions,
   latestAssets,
   launchRequest,
+  loras = [],
   jobs = [],
   onPreview,
   personTracks = [],
+  recipePresets = [],
   requestedGpu,
   selectedAsset,
   setRequestedGpu,
@@ -29,6 +31,7 @@ export function VideoStudio({
   const [mode, setMode] = useState("image_to_video");
   const [prompt, setPrompt] = useState("Camera slowly pushes in while the scene comes alive");
   const [quality, setQuality] = useState("balanced");
+  const [recipePresetId, setRecipePresetId] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(videoModels[0]?.id ?? "ltx_2_3");
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
@@ -51,6 +54,24 @@ export function VideoStudio({
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
+  const availableRecipePresets = useMemo(() => {
+    return recipePresets.filter((preset) => {
+      if (preset.modes?.length) {
+        return preset.modes.includes(mode);
+      }
+      return preset.workflow === mode;
+    });
+  }, [mode, recipePresets]);
+  const selectedRecipePreset = availableRecipePresets.find((preset) => preset.id === recipePresetId) ?? availableRecipePresets[0] ?? null;
+  const presetPromptParts = [selectedRecipePreset?.prompt?.prefix, selectedRecipePreset?.prompt?.suffix]
+    .filter((part) => String(part ?? "").trim());
+  const presetLoraDetails = (selectedRecipePreset?.builtInLoras ?? selectedRecipePreset?.loras ?? [])
+    .map((presetLora) => {
+      const loraId = typeof presetLora === "string" ? presetLora : presetLora.id;
+      const lora = loras.find((item) => item.id === loraId);
+      return lora ? { id: loraId, name: lora.name ?? loraId } : { id: loraId, name: loraId, missing: true };
+    })
+    .filter((lora) => lora.id);
 
   useEffect(() => {
     if (!videoModels.some((item) => item.id === model)) {
@@ -125,6 +146,37 @@ export function VideoStudio({
   }, [mode, supportsMode, videoModels]);
 
   useEffect(() => {
+    if (!availableRecipePresets.some((preset) => preset.id === recipePresetId)) {
+      setRecipePresetId(availableRecipePresets[0]?.id ?? "");
+    }
+  }, [availableRecipePresets, recipePresetId]);
+
+  useEffect(() => {
+    if (!selectedRecipePreset) {
+      return;
+    }
+    if (selectedRecipePreset.model) {
+      setModel(selectedRecipePreset.model);
+    }
+    const defaults = selectedRecipePreset.defaults ?? {};
+    if (defaults.duration) {
+      setDuration(Number(defaults.duration));
+    }
+    if (defaults.fps) {
+      setFps(Number(defaults.fps));
+    }
+    if (defaults.quality) {
+      setQuality(defaults.quality);
+    }
+    if (defaults.resolution) {
+      setResolution(defaults.resolution);
+    }
+    if (Object.prototype.hasOwnProperty.call(defaults, "negativePrompt")) {
+      setNegativePrompt(defaults.negativePrompt ?? "");
+    }
+  }, [selectedRecipePreset?.id]);
+
+  useEffect(() => {
     if (mode !== "replace_person") {
       return;
     }
@@ -197,6 +249,7 @@ export function VideoStudio({
       height,
       quality,
       seed: seed === "" ? null : Number(seed),
+      recipePresetId: selectedRecipePreset?.id ?? null,
       characterId: characterId || null,
       characterLookId: characterLookId || null,
       sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,
@@ -208,6 +261,8 @@ export function VideoStudio({
       advanced: {
         resolution,
         durationHint,
+        recipePresetName: selectedRecipePreset?.name ?? null,
+        recipePresetPrompt: selectedRecipePreset?.prompt ?? null,
         selectedPersonTrack: selectedTrack ?? null,
         replacementModeLabel: replacementModeLabels[replacementMode],
       },
@@ -332,7 +387,21 @@ export function VideoStudio({
             <textarea onChange={(event) => setPrompt(event.target.value)} value={prompt} />
           </label>
 
-          <div className="control-grid">
+          <div className="control-grid video-preset-grid">
+            <label>
+              Preset
+              <select disabled={!availableRecipePresets.length} onChange={(event) => setRecipePresetId(event.target.value)} value={recipePresetId}>
+                {availableRecipePresets.length ? (
+                  availableRecipePresets.map((preset) => (
+                    <option key={preset.id} value={preset.id}>
+                      {preset.name ?? preset.id}
+                    </option>
+                  ))
+                ) : (
+                  <option value="">No presets</option>
+                )}
+              </select>
+            </label>
             <label>
               Duration
               <select onChange={(event) => setDuration(Number(event.target.value))} value={duration}>
@@ -362,6 +431,24 @@ export function VideoStudio({
               </select>
             </label>
           </div>
+
+          {selectedRecipePreset ? (
+            <div className="guidance-strip">
+              <strong>{selectedRecipePreset.ui?.description ?? "Preset defaults active"}</strong>
+              <span>
+                {presetPromptParts.length ? `Adds: ${presetPromptParts.join(", ")}` : "No prompt fragments"}
+                {presetLoraDetails.length
+                  ? ` | Uses LoRA: ${presetLoraDetails.map((lora) => lora.name ?? lora.id).join(", ")}`
+                  : " | No preset LoRAs"}
+                {presetLoraDetails.some((lora) => lora.missing) ? " | Preset incomplete" : ""}
+              </span>
+            </div>
+          ) : (
+            <div className="guidance-strip">
+              <strong>Presets unavailable</strong>
+              <span>Generation can continue without preset defaults.</span>
+            </div>
+          )}
 
           <div className="guidance-strip">
             <strong>{selectedModel?.name ?? "Video model"}</strong>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -823,7 +823,9 @@ button:disabled {
 
 .guidance-strip,
 .lora-picker,
-.inline-warning {
+.lora-import-panel,
+.inline-warning,
+.inline-success {
   border: 1px solid #4b463d;
   background: #191815;
 }
@@ -840,7 +842,14 @@ button:disabled {
   padding: 12px;
 }
 
+.lora-import-panel {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
 .lora-picker > div:first-child,
+.lora-import-panel > div:first-child,
 .lora-choice {
   display: flex;
   justify-content: space-between;
@@ -848,6 +857,7 @@ button:disabled {
 }
 
 .lora-picker > div:first-child span,
+.lora-import-panel > div:first-child span,
 .lora-choice small {
   color: #aaa397;
 }
@@ -879,15 +889,42 @@ button:disabled {
   min-width: 0;
 }
 
+.editable-lora-choice {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(80px, 120px);
+  align-items: end;
+}
+
+.editable-lora-choice > label:first-child {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
 .guidance-strip span,
-.inline-warning {
+.inline-warning,
+.inline-success {
   color: #c7bfb2;
   line-height: 1.45;
 }
 
-.inline-warning {
+.inline-warning,
+.inline-success {
   margin: 0;
   padding: 10px;
+}
+
+.inline-success {
+  border-color: #6ec6b8;
+  background: #183f3a;
+}
+
+.preset-status.ok {
+  color: #6ec6b8;
+}
+
+.preset-status.error {
+  color: #e28e78;
 }
 
 .compact-panel {
@@ -1598,7 +1635,8 @@ button:disabled {
   .control-grid,
   .advanced-panel,
   .editor-layout,
-  .compact-controls {
+  .compact-controls,
+  .editable-lora-choice {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -817,6 +817,10 @@ button:disabled {
   grid-template-columns: minmax(320px, 460px) minmax(0, 1fr);
 }
 
+.video-preset-grid {
+  grid-template-columns: minmax(0, 1.2fr) repeat(3, minmax(0, 0.8fr));
+}
+
 .guidance-strip,
 .lora-picker,
 .inline-warning {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -472,6 +472,9 @@ button:disabled {
 .model-card,
 .lora-panel,
 .lora-row,
+.preset-list,
+.preset-editor,
+.preset-row,
 .character-list,
 .character-editor,
 .character-section,
@@ -488,6 +491,66 @@ button:disabled {
   gap: 12px;
   align-content: start;
   padding: 14px;
+}
+
+.preset-layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 340px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.preset-list,
+.preset-editor {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  padding: 12px;
+}
+
+.preset-list {
+  max-height: 680px;
+  overflow: auto;
+}
+
+.preset-editor label {
+  display: grid;
+  gap: 7px;
+}
+
+.preset-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  color: #f3f0e8;
+  padding: 10px;
+  text-align: left;
+}
+
+.preset-row.active {
+  border-color: #6ec6b8;
+  background: #183f3a;
+}
+
+.preset-row span:first-child {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.preset-row strong,
+.preset-row small,
+.preset-row > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preset-row small,
+.preset-row > span:last-child {
+  color: #aaa397;
+  font-size: 12px;
 }
 
 .model-card h3,
@@ -1508,6 +1571,7 @@ button:disabled {
   .media-grid,
   .library-layout,
   .studio-layout,
+  .preset-layout,
   .character-layout,
   .queue-header,
   .job-composer,


### PR DESCRIPTION
## Summary
- Add a Presets view for browsing, creating, editing, duplicating, and archiving recipe presets.
- Wire preset CRUD actions through the web app to the existing recipe preset API.
- Integrate recipe presets into Video Studio mode pickers, applying defaults and preserving `recipePresetId` in video job payloads.
- Add focused React coverage for preset management and video preset defaults.

## Validation
- `npm --prefix apps/web test`
- `npm --prefix apps/web run build`
- `cargo test -p sceneworks-rust-api --lib video`
- Browser verification attempted via the in-app browser, but new localhost dev ports were blocked with `ERR_BLOCKED_BY_CLIENT`; the existing 5173 server is Docker/WSL-owned and serving an older bundle.
