### PR TITLE
[codex] Complete next preset management stories

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3874,6 +3874,8 @@ fn serialize_preset_lora(lora: &Value, preset_lora: &Value, lora_id: &str) -> Va
         "weight": preset_lora_weight(lora, preset_lora),
         "triggerWords": lora.get("triggerWords").cloned().unwrap_or_else(|| Value::Array(Vec::new())),
         "compatibility": lora.get("compatibility").cloned().unwrap_or_else(|| Value::Object(JsonObject::new())),
+        "installedPath": lora.get("installedPath").cloned().unwrap_or(Value::Null),
+        "source": lora.get("source").cloned().unwrap_or(Value::Null),
         "presetManaged": true
     })
 }
@@ -5619,6 +5621,12 @@ mod tests {
             "city at night, cinematic lighting"
         );
         assert_eq!(image_job["payload"]["loras"][0]["id"], "style-lora");
+        assert!(image_job["payload"]["loras"][0]["installedPath"]
+            .as_str()
+            .is_some_and(|value| value.ends_with("data/loras/style.safetensors")
+                || value.ends_with("data\\loras\\style.safetensors")
+                || value.ends_with("loras/style.safetensors")
+                || value.ends_with("loras\\style.safetensors")));
         assert_eq!(image_job["payload"]["model"], "client-model");
         assert_eq!(image_job["payload"]["count"], 2);
         assert_eq!(image_job["payload"]["seeds"].as_array().unwrap().len(), 2);

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -5627,6 +5627,10 @@ mod tests {
                 || value.ends_with("data\\loras\\style.safetensors")
                 || value.ends_with("loras/style.safetensors")
                 || value.ends_with("loras\\style.safetensors")));
+        assert_eq!(
+            image_job["payload"]["loras"][0]["source"]["path"],
+            "loras/style.safetensors"
+        );
         assert_eq!(image_job["payload"]["model"], "client-model");
         assert_eq!(image_job["payload"]["count"], 2);
         assert_eq!(image_job["payload"]["seeds"].as_array().unwrap().len(), 2);

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -724,6 +724,74 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("LTX Story");
   });
 
+  it("uses preset modes as the Video Studio picker surface", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <VideoStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[
+            { id: "image-1", type: "image", displayName: "Frame One" },
+            { id: "image-2", type: "image", displayName: "Frame Two" },
+          ]}
+          characters={[]}
+          createPersonDetectionJob={() => {}}
+          createPersonTrackJob={() => {}}
+          createVideoJob={() => {}}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          latestAssets={[]}
+          loras={[]}
+          onPreview={() => {}}
+          personTracks={[]}
+          purgeAsset={() => {}}
+          recipePresets={[
+            {
+              id: "camera_bridge",
+              name: "Camera Bridge",
+              workflow: "image_to_video",
+              modes: ["image_to_video", "first_last_frame"],
+              model: "ltx_2_3",
+            },
+            {
+              id: "start_frame",
+              name: "Start Frame",
+              workflow: "image_to_video",
+              modes: ["image_to_video"],
+              model: "ltx_2_3",
+            },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+          videoModels={[
+            {
+              id: "ltx_2_3",
+              name: "LTX",
+              type: "video",
+              capabilities: ["image_to_video", "text_to_video", "first_last_frame"],
+              defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+              limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
+            },
+          ]}
+        />,
+      );
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Camera Bridge");
+    expect(container.textContent).toContain("Start Frame");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "First/Last Frame").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Camera Bridge");
+    expect(container.textContent).not.toContain("Start Frame");
+  });
+
   it("creates, edits, duplicates, and archives recipe presets from the manager", async () => {
     const createRecipePreset = vi.fn(async (payload) => payload);
     const updateRecipePreset = vi.fn(async (id, payload) => ({ ...payload, id }));

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -522,6 +522,59 @@ describe("SceneWorks app shell", () => {
     expect(createImageJob).toHaveBeenCalledWith(expect.objectContaining({ model: "qwen_image", recipePresetId: "qwen_detail" }));
   });
 
+  it("uses preset modes as the Image Studio picker surface", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
+          characters={[]}
+          createImageJob={() => {}}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image", capabilities: ["edit_image"] }]}
+          latestAssets={[]}
+          loras={[]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          recipePresets={[
+            {
+              id: "cinematic",
+              name: "Cinematic",
+              model: "z_image_turbo",
+              workflow: "text_to_image",
+              modes: ["text_to_image", "edit_image", "character_image"],
+            },
+            {
+              id: "portrait_only",
+              name: "Portrait Only",
+              model: "z_image_turbo",
+              workflow: "text_to_image",
+              modes: ["character_image"],
+            },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Cinematic");
+    expect(container.textContent).not.toContain("Portrait Only");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Edit").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Cinematic");
+    expect(container.textContent).not.toContain("Portrait Only");
+  });
+
   it("applies recipe preset defaults to video jobs", async () => {
     const createVideoJob = vi.fn();
     root = createRoot(container);

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -72,6 +72,8 @@ export function serializePresetLora(lora, presetLora = {}) {
     weight: loraWeight(lora, presetLora),
     triggerWords: lora?.triggerWords ?? [],
     compatibility: lora?.compatibility ?? presetLora?.compatibility ?? {},
+    installedPath: lora?.installedPath ?? presetLora?.installedPath ?? null,
+    source: lora?.source ?? presetLora?.source ?? null,
     presetManaged: true,
   };
 }

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -38,6 +38,8 @@ export function loraMatchesModel(lora, model) {
 }
 
 export function presetMatchesWorkflow(preset, mode) {
+  // A preset has one primary workflow for persistence, but modes describe every
+  // Studio entry point where the picker should surface it.
   if (preset?.modes?.length) {
     return preset.modes.includes(mode);
   }

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -25,7 +25,7 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import filter_call_kwargs
-from .lora_adapters import apply_loras_to_pipeline, assert_loras_supported
+from .lora_adapters import LoraPipelineState, apply_loras_to_pipeline, reject_loras_if_unsupported
 from .settings import WorkerSettings
 
 
@@ -238,8 +238,7 @@ class ZImageDiffusersAdapter:
         self._img2img_pipe: Any | None = None
         self._loaded_repo: str | None = None
         self._loaded_model: str | None = None
-        self._loaded_lora_keys: dict[str, str] = {}
-        self._loaded_lora_names: dict[str, list[str]] = {}
+        self._loaded_lora_states: dict[str, LoraPipelineState] = {}
 
     def loaded_models(self) -> list[str]:
         return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
@@ -305,13 +304,11 @@ class ZImageDiffusersAdapter:
             self._evict_pipelines(torch)
         elif use_img2img and self._text_pipe is not None:
             self._text_pipe = None
-            self._loaded_lora_keys.pop("text", None)
-            self._loaded_lora_names.pop("text", None)
+            self._forget_loaded_loras("text")
             self._empty_cuda_cache(torch)
         elif not use_img2img and self._img2img_pipe is not None:
             self._img2img_pipe = None
-            self._loaded_lora_keys.pop("img2img", None)
-            self._loaded_lora_names.pop("img2img", None)
+            self._forget_loaded_loras("img2img")
             self._empty_cuda_cache(torch)
 
         pipeline_name = "ZImageImg2ImgPipeline" if use_img2img else "ZImagePipeline"
@@ -350,8 +347,7 @@ class ZImageDiffusersAdapter:
         self._img2img_pipe = None
         self._loaded_repo = None
         self._loaded_model = None
-        self._loaded_lora_keys.clear()
-        self._loaded_lora_names.clear()
+        self._loaded_lora_states.clear()
         self._empty_cuda_cache(torch)
 
     def _empty_cuda_cache(self, torch: Any) -> None:
@@ -382,15 +378,15 @@ class ZImageDiffusersAdapter:
 
     def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
         key = "img2img" if request.mode == "edit_image" else "text"
-        loaded_key, loaded_names = apply_loras_to_pipeline(
+        self._loaded_lora_states[key] = apply_loras_to_pipeline(
             pipe,
             request.loras,
             adapter_id=self.id,
-            previous_key=self._loaded_lora_keys.get(key, ""),
-            previous_adapter_names=self._loaded_lora_names.get(key, []),
+            previous_state=self._loaded_lora_states.get(key),
         )
-        self._loaded_lora_keys[key] = loaded_key
-        self._loaded_lora_names[key] = loaded_names
+
+    def _forget_loaded_loras(self, key: str) -> None:
+        self._loaded_lora_states.pop(key, None)
 
     def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
         return safe_int(request.advanced.get("steps"), model_target["steps"] + 1, 1, 80)
@@ -411,8 +407,7 @@ class QwenImageAdapter:
         self._text_repo: str | None = None
         self._edit_repo: str | None = None
         self._loaded_model: str | None = None
-        self._loaded_lora_keys: dict[str, str] = {}
-        self._loaded_lora_names: dict[str, list[str]] = {}
+        self._loaded_lora_states: dict[str, LoraPipelineState] = {}
 
     def loaded_models(self) -> list[str]:
         return sorted({value for value in (self._text_repo, self._edit_repo, self._loaded_model) if value})
@@ -480,8 +475,7 @@ class QwenImageAdapter:
                 self._text_pipe = None
                 self._text_repo = None
             self._empty_cuda_cache(torch)
-            self._loaded_lora_keys.pop("edit" if use_edit else "text", None)
-            self._loaded_lora_names.pop("edit" if use_edit else "text", None)
+            self._forget_loaded_loras("edit" if use_edit else "text")
 
         pipeline_name = "QwenImageEditPipeline" if use_edit else "QwenImagePipeline"
         pipeline_class = getattr(diffusers, pipeline_name, None)
@@ -533,15 +527,15 @@ class QwenImageAdapter:
 
     def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
         key = "edit" if request.mode == "edit_image" else "text"
-        loaded_key, loaded_names = apply_loras_to_pipeline(
+        self._loaded_lora_states[key] = apply_loras_to_pipeline(
             pipe,
             request.loras,
             adapter_id=self.id,
-            previous_key=self._loaded_lora_keys.get(key, ""),
-            previous_adapter_names=self._loaded_lora_names.get(key, []),
+            previous_state=self._loaded_lora_states.get(key),
         )
-        self._loaded_lora_keys[key] = loaded_key
-        self._loaded_lora_names[key] = loaded_names
+
+    def _forget_loaded_loras(self, key: str) -> None:
+        self._loaded_lora_states.pop(key, None)
 
     def _repo_for_request(self, request: ImageRequest, model_target: dict[str, Any]) -> str:
         return request.advanced.get("modelRepo") or model_target["repo"]
@@ -571,7 +565,7 @@ class ProceduralImageAdapter:
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
         request = image_request_from_job(job)
-        assert_loras_supported(request.loras, self.id)
+        reject_loras_if_unsupported(request.loras, self.id)
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
         if request.mode == "edit_image" and not model_supports_edit(request.model):
             raise RuntimeError(f"{request.model} does not support image editing.")

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -25,6 +25,7 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import filter_call_kwargs
+from .lora_adapters import apply_loras_to_pipeline, assert_loras_supported
 from .settings import WorkerSettings
 
 
@@ -237,6 +238,8 @@ class ZImageDiffusersAdapter:
         self._img2img_pipe: Any | None = None
         self._loaded_repo: str | None = None
         self._loaded_model: str | None = None
+        self._loaded_lora_keys: dict[str, str] = {}
+        self._loaded_lora_names: dict[str, list[str]] = {}
 
     def loaded_models(self) -> list[str]:
         return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
@@ -259,6 +262,7 @@ class ZImageDiffusersAdapter:
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
         pipe = self._load_pipeline(request, model_target, progress=progress)
+        self._apply_loras(pipe, request)
         images = []
         total = request.count
         for index in range(total):
@@ -301,9 +305,13 @@ class ZImageDiffusersAdapter:
             self._evict_pipelines(torch)
         elif use_img2img and self._text_pipe is not None:
             self._text_pipe = None
+            self._loaded_lora_keys.pop("text", None)
+            self._loaded_lora_names.pop("text", None)
             self._empty_cuda_cache(torch)
         elif not use_img2img and self._img2img_pipe is not None:
             self._img2img_pipe = None
+            self._loaded_lora_keys.pop("img2img", None)
+            self._loaded_lora_names.pop("img2img", None)
             self._empty_cuda_cache(torch)
 
         pipeline_name = "ZImageImg2ImgPipeline" if use_img2img else "ZImagePipeline"
@@ -342,6 +350,8 @@ class ZImageDiffusersAdapter:
         self._img2img_pipe = None
         self._loaded_repo = None
         self._loaded_model = None
+        self._loaded_lora_keys.clear()
+        self._loaded_lora_names.clear()
         self._empty_cuda_cache(torch)
 
     def _empty_cuda_cache(self, torch: Any) -> None:
@@ -370,6 +380,18 @@ class ZImageDiffusersAdapter:
         image = output.images[0]
         return image.convert("RGB")
 
+    def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
+        key = "img2img" if request.mode == "edit_image" else "text"
+        loaded_key, loaded_names = apply_loras_to_pipeline(
+            pipe,
+            request.loras,
+            adapter_id=self.id,
+            previous_key=self._loaded_lora_keys.get(key, ""),
+            previous_adapter_names=self._loaded_lora_names.get(key, []),
+        )
+        self._loaded_lora_keys[key] = loaded_key
+        self._loaded_lora_names[key] = loaded_names
+
     def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
         return safe_int(request.advanced.get("steps"), model_target["steps"] + 1, 1, 80)
 
@@ -389,6 +411,8 @@ class QwenImageAdapter:
         self._text_repo: str | None = None
         self._edit_repo: str | None = None
         self._loaded_model: str | None = None
+        self._loaded_lora_keys: dict[str, str] = {}
+        self._loaded_lora_names: dict[str, list[str]] = {}
 
     def loaded_models(self) -> list[str]:
         return sorted({value for value in (self._text_repo, self._edit_repo, self._loaded_model) if value})
@@ -410,6 +434,7 @@ class QwenImageAdapter:
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
         pipe = self._load_pipeline(request, model_target, progress=progress)
+        self._apply_loras(pipe, request)
         images = []
         for index in range(request.count):
             if cancel_requested():
@@ -455,6 +480,8 @@ class QwenImageAdapter:
                 self._text_pipe = None
                 self._text_repo = None
             self._empty_cuda_cache(torch)
+            self._loaded_lora_keys.pop("edit" if use_edit else "text", None)
+            self._loaded_lora_names.pop("edit" if use_edit else "text", None)
 
         pipeline_name = "QwenImageEditPipeline" if use_edit else "QwenImagePipeline"
         pipeline_class = getattr(diffusers, pipeline_name, None)
@@ -504,6 +531,18 @@ class QwenImageAdapter:
         output = pipe(**filter_call_kwargs(pipe, kwargs))
         return output.images[0].convert("RGB")
 
+    def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
+        key = "edit" if request.mode == "edit_image" else "text"
+        loaded_key, loaded_names = apply_loras_to_pipeline(
+            pipe,
+            request.loras,
+            adapter_id=self.id,
+            previous_key=self._loaded_lora_keys.get(key, ""),
+            previous_adapter_names=self._loaded_lora_names.get(key, []),
+        )
+        self._loaded_lora_keys[key] = loaded_key
+        self._loaded_lora_names[key] = loaded_names
+
     def _repo_for_request(self, request: ImageRequest, model_target: dict[str, Any]) -> str:
         return request.advanced.get("modelRepo") or model_target["repo"]
 
@@ -532,6 +571,7 @@ class ProceduralImageAdapter:
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
         request = image_request_from_job(job)
+        assert_loras_supported(request.loras, self.id)
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
         if request.mode == "edit_image" and not model_supports_edit(request.model):
             raise RuntimeError(f"{request.model} does not support image editing.")

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -1,43 +1,72 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+import hashlib
+import json
 import re
 from pathlib import Path
 from typing import Any
 
 
+# Keep in sync with packages/schemas/recipe-preset.schema.json and the Rust
+# normalize_recipe_preset_loras API guard.
 MAX_JOB_LORAS = 3
 
 
+@dataclass(frozen=True)
+class LoraSpec:
+    id: str
+    path: str
+    weight: float
+    adapter_name: str
+
+
+@dataclass(frozen=True)
+class LoraPipelineState:
+    key: str = ""
+    adapter_names: tuple[str, ...] = ()
+    specs: tuple[LoraSpec, ...] = ()
+
+
 def lora_cache_key(loras: list[dict[str, Any]]) -> str:
-    specs = normalize_lora_specs(loras)
-    return "|".join(f"{spec['id']}@{spec['path']}#{spec['weight']:g}" for spec in specs)
+    return lora_cache_key_for_specs(normalize_lora_specs(loras))
 
 
-def assert_loras_supported(loras: list[dict[str, Any]], adapter_id: str) -> None:
+def lora_cache_key_for_specs(specs: list[LoraSpec]) -> str:
+    canonical = [
+        {"id": spec.id, "path": spec.path, "weight": spec.weight}
+        for spec in sorted(specs, key=lambda item: (item.id, item.path, item.weight))
+    ]
+    payload = json.dumps(canonical, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def reject_loras_if_unsupported(loras: list[dict[str, Any]], adapter_id: str) -> None:
     if loras:
         raise RuntimeError(f"{adapter_id} does not support LoRA application for generation jobs.")
 
 
-def normalize_lora_specs(loras: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def normalize_lora_specs(loras: list[dict[str, Any]]) -> list[LoraSpec]:
     if len(loras) > MAX_JOB_LORAS:
         raise RuntimeError(f"Generation supports at most {MAX_JOB_LORAS} LoRAs per job.")
 
     specs = []
     for index, item in enumerate(loras):
         lora = item if isinstance(item, dict) else {"id": str(item)}
-        lora_id = str(lora.get("id") or lora.get("loraId") or f"lora_{index + 1}").strip()
         path = lora_path(lora)
+        lora_id = str(lora.get("id") or lora.get("loraId") or path_stem(path) or f"lora_{index + 1}").strip()
         if path is None:
             raise RuntimeError(f"LoRA {lora_id} is not installed. Import or download it before generation.")
         if not path.exists():
             raise RuntimeError(f"LoRA {lora_id} file is missing: {path}")
+        path_text = str(path)
         specs.append(
-            {
-                "id": lora_id,
-                "path": str(path),
-                "weight": lora_weight(lora),
-                "adapterName": safe_adapter_name(lora_id, index),
-            }
+            LoraSpec(
+                id=lora_id,
+                path=path_text,
+                weight=lora_weight(lora),
+                adapter_name=safe_adapter_name(lora_id, path_text),
+            )
         )
     return specs
 
@@ -47,59 +76,72 @@ def apply_loras_to_pipeline(
     loras: list[dict[str, Any]],
     *,
     adapter_id: str,
-    previous_key: str = "",
-    previous_adapter_names: list[str] | None = None,
-) -> tuple[str, list[str]]:
+    previous_state: LoraPipelineState | None = None,
+) -> LoraPipelineState:
+    previous_state = previous_state or LoraPipelineState()
     specs = normalize_lora_specs(loras)
-    key = lora_cache_key(loras)
-    if key == previous_key:
-        return previous_key, previous_adapter_names or []
+    key = lora_cache_key_for_specs(specs)
+    if key == previous_state.key:
+        return previous_state
 
-    clear_loras(pipe, previous_adapter_names or [], adapter_id=adapter_id)
     if not specs:
-        return "", []
+        clear_loras(pipe, previous_state.adapter_names, adapter_id=adapter_id)
+        return LoraPipelineState()
     if not hasattr(pipe, "load_lora_weights"):
         raise RuntimeError(f"{adapter_id} does not support loading LoRA weights.")
 
-    names = []
-    for spec in specs:
-        pipe.load_lora_weights(spec["path"], adapter_name=spec["adapterName"])
-        names.append(spec["adapterName"])
+    previous_by_name = {spec.adapter_name: spec for spec in previous_state.specs}
+    desired_by_name = {spec.adapter_name: spec for spec in specs}
+    removed_names = tuple(name for name in previous_state.adapter_names if name not in desired_by_name)
+    specs_to_load = [spec for spec in specs if spec.adapter_name not in previous_by_name]
 
-    weights = [spec["weight"] for spec in specs]
+    if removed_names:
+        if hasattr(pipe, "delete_adapters"):
+            pipe.delete_adapters(list(removed_names))
+        elif hasattr(pipe, "unload_lora_weights"):
+            pipe.unload_lora_weights()
+            specs_to_load = specs
+        else:
+            raise RuntimeError(f"{adapter_id} cannot clear previously loaded LoRAs between jobs.")
+
+    for spec in specs_to_load:
+        pipe.load_lora_weights(spec.path, adapter_name=spec.adapter_name)
+
+    names = tuple(spec.adapter_name for spec in specs)
+    weights = [spec.weight for spec in specs]
     if hasattr(pipe, "set_adapters"):
         try:
-            pipe.set_adapters(names, adapter_weights=weights)
+            # Newer Diffusers releases use adapter_weights; older builds used weights.
+            pipe.set_adapters(list(names), adapter_weights=weights)
         except TypeError:
-            pipe.set_adapters(names, weights=weights)
+            pipe.set_adapters(list(names), weights=weights)
     elif len(names) > 1 or any(weight != 1.0 for weight in weights):
         raise RuntimeError(f"{adapter_id} loaded LoRAs but cannot apply per-LoRA weights.")
-    return key, names
+    return LoraPipelineState(key=key, adapter_names=names, specs=tuple(specs))
 
 
-def clear_loras(pipe: Any, adapter_names: list[str], *, adapter_id: str) -> None:
+def clear_loras(pipe: Any, adapter_names: tuple[str, ...], *, adapter_id: str) -> None:
     if not adapter_names:
         return
     if hasattr(pipe, "unload_lora_weights"):
         pipe.unload_lora_weights()
         return
     if hasattr(pipe, "delete_adapters"):
-        pipe.delete_adapters(adapter_names)
+        pipe.delete_adapters(list(adapter_names))
         return
     raise RuntimeError(f"{adapter_id} cannot clear previously loaded LoRAs between jobs.")
 
 
 def lora_path(lora: dict[str, Any]) -> Path | None:
-    value = (
-        lora.get("installedPath")
-        or lora.get("sourcePath")
-        or lora.get("path")
-        or (lora.get("source") if isinstance(lora.get("source"), str) else None)
-        or (lora.get("source") or {}).get("path")
-    )
+    source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
+    value = lora.get("installedPath") or lora.get("sourcePath") or lora.get("path") or source.get("path")
     if not value:
         return None
     return Path(str(value)).expanduser()
+
+
+def path_stem(path: Path | None) -> str | None:
+    return path.stem if path else None
 
 
 def lora_weight(lora: dict[str, Any]) -> float:
@@ -109,6 +151,7 @@ def lora_weight(lora: dict[str, Any]) -> float:
         return 0.8
 
 
-def safe_adapter_name(lora_id: str, index: int) -> str:
+def safe_adapter_name(lora_id: str, path: str) -> str:
     safe_id = re.sub(r"[^a-zA-Z0-9_]+", "_", lora_id).strip("_") or "lora"
-    return f"sw_{index + 1}_{safe_id[:48]}"
+    digest = hashlib.sha256(f"{lora_id}:{path}".encode("utf-8")).hexdigest()[:10]
+    return f"sw_{safe_id[:40]}_{digest}"

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+MAX_JOB_LORAS = 3
+
+
+def lora_cache_key(loras: list[dict[str, Any]]) -> str:
+    specs = normalize_lora_specs(loras)
+    return "|".join(f"{spec['id']}@{spec['path']}#{spec['weight']:g}" for spec in specs)
+
+
+def assert_loras_supported(loras: list[dict[str, Any]], adapter_id: str) -> None:
+    if loras:
+        raise RuntimeError(f"{adapter_id} does not support LoRA application for generation jobs.")
+
+
+def normalize_lora_specs(loras: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if len(loras) > MAX_JOB_LORAS:
+        raise RuntimeError(f"Generation supports at most {MAX_JOB_LORAS} LoRAs per job.")
+
+    specs = []
+    for index, item in enumerate(loras):
+        lora = item if isinstance(item, dict) else {"id": str(item)}
+        lora_id = str(lora.get("id") or lora.get("loraId") or f"lora_{index + 1}").strip()
+        path = lora_path(lora)
+        if path is None:
+            raise RuntimeError(f"LoRA {lora_id} is not installed. Import or download it before generation.")
+        if not path.exists():
+            raise RuntimeError(f"LoRA {lora_id} file is missing: {path}")
+        specs.append(
+            {
+                "id": lora_id,
+                "path": str(path),
+                "weight": lora_weight(lora),
+                "adapterName": safe_adapter_name(lora_id, index),
+            }
+        )
+    return specs
+
+
+def apply_loras_to_pipeline(
+    pipe: Any,
+    loras: list[dict[str, Any]],
+    *,
+    adapter_id: str,
+    previous_key: str = "",
+    previous_adapter_names: list[str] | None = None,
+) -> tuple[str, list[str]]:
+    specs = normalize_lora_specs(loras)
+    key = lora_cache_key(loras)
+    if key == previous_key:
+        return previous_key, previous_adapter_names or []
+
+    clear_loras(pipe, previous_adapter_names or [], adapter_id=adapter_id)
+    if not specs:
+        return "", []
+    if not hasattr(pipe, "load_lora_weights"):
+        raise RuntimeError(f"{adapter_id} does not support loading LoRA weights.")
+
+    names = []
+    for spec in specs:
+        pipe.load_lora_weights(spec["path"], adapter_name=spec["adapterName"])
+        names.append(spec["adapterName"])
+
+    weights = [spec["weight"] for spec in specs]
+    if hasattr(pipe, "set_adapters"):
+        try:
+            pipe.set_adapters(names, adapter_weights=weights)
+        except TypeError:
+            pipe.set_adapters(names, weights=weights)
+    elif len(names) > 1 or any(weight != 1.0 for weight in weights):
+        raise RuntimeError(f"{adapter_id} loaded LoRAs but cannot apply per-LoRA weights.")
+    return key, names
+
+
+def clear_loras(pipe: Any, adapter_names: list[str], *, adapter_id: str) -> None:
+    if not adapter_names:
+        return
+    if hasattr(pipe, "unload_lora_weights"):
+        pipe.unload_lora_weights()
+        return
+    if hasattr(pipe, "delete_adapters"):
+        pipe.delete_adapters(adapter_names)
+        return
+    raise RuntimeError(f"{adapter_id} cannot clear previously loaded LoRAs between jobs.")
+
+
+def lora_path(lora: dict[str, Any]) -> Path | None:
+    value = (
+        lora.get("installedPath")
+        or lora.get("sourcePath")
+        or lora.get("path")
+        or (lora.get("source") if isinstance(lora.get("source"), str) else None)
+        or (lora.get("source") or {}).get("path")
+    )
+    if not value:
+        return None
+    return Path(str(value)).expanduser()
+
+
+def lora_weight(lora: dict[str, Any]) -> float:
+    try:
+        return float(lora.get("weight", lora.get("defaultWeight", 0.8)))
+    except (TypeError, ValueError):
+        return 0.8
+
+
+def safe_adapter_name(lora_id: str, index: int) -> str:
+    safe_id = re.sub(r"[^a-zA-Z0-9_]+", "_", lora_id).strip("_") or "lora"
+    return f"sw_{index + 1}_{safe_id[:48]}"

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -26,7 +26,7 @@ from sceneworks_shared import (
 
 from .adapter_utils import filter_call_kwargs
 from .image_adapters import select_torch_device, select_torch_dtype, write_json
-from .lora_adapters import apply_loras_to_pipeline, assert_loras_supported
+from .lora_adapters import LoraPipelineState, apply_loras_to_pipeline, reject_loras_if_unsupported
 from .settings import WorkerSettings
 
 
@@ -135,7 +135,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         return video_request_from_job(job)
 
     def ensure_models(self, request: VideoRequest) -> None:
-        assert_loras_supported(request.loras, self.id)
+        reject_loras_if_unsupported(request.loras, self.id)
         target = model_target(request.model)
         if request.mode not in target["capabilities"]:
             raise RuntimeError(f"{target['label']} does not support {request.mode.replace('_', ' ')}.")
@@ -272,8 +272,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         self._pipeline: Any | None = None
         self._pipeline_key_value: str | None = None
         self._loaded_models: set[str] = set()
-        self._loaded_lora_key = ""
-        self._loaded_lora_names: list[str] = []
+        self._loaded_lora_state = LoraPipelineState()
 
     def loaded_models(self) -> list[str]:
         return sorted(self._loaded_models)
@@ -466,21 +465,17 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         self._pipeline = None
         self._pipeline_key_value = None
         self._loaded_models.clear()
-        self._loaded_lora_key = ""
-        self._loaded_lora_names = []
+        self._loaded_lora_state = LoraPipelineState()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
     def _apply_loras(self, pipe: Any, request: VideoRequest, target: dict[str, Any]) -> None:
-        loaded_key, loaded_names = apply_loras_to_pipeline(
+        self._loaded_lora_state = apply_loras_to_pipeline(
             pipe,
             request.loras,
             adapter_id=target["adapter"],
-            previous_key=self._loaded_lora_key,
-            previous_adapter_names=self._loaded_lora_names,
+            previous_state=self._loaded_lora_state,
         )
-        self._loaded_lora_key = loaded_key
-        self._loaded_lora_names = loaded_names
 
     def _pipeline_class(self, diffusers: Any, request: VideoRequest, target: dict[str, Any]) -> Any:
         if target["adapter"] == "wan_video":

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -26,6 +26,7 @@ from sceneworks_shared import (
 
 from .adapter_utils import filter_call_kwargs
 from .image_adapters import select_torch_device, select_torch_dtype, write_json
+from .lora_adapters import apply_loras_to_pipeline, assert_loras_supported
 from .settings import WorkerSettings
 
 
@@ -134,6 +135,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         return video_request_from_job(job)
 
     def ensure_models(self, request: VideoRequest) -> None:
+        assert_loras_supported(request.loras, self.id)
         target = model_target(request.model)
         if request.mode not in target["capabilities"]:
             raise RuntimeError(f"{target['label']} does not support {request.mode.replace('_', ' ')}.")
@@ -270,6 +272,8 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         self._pipeline: Any | None = None
         self._pipeline_key_value: str | None = None
         self._loaded_models: set[str] = set()
+        self._loaded_lora_key = ""
+        self._loaded_lora_names: list[str] = []
 
     def loaded_models(self) -> list[str]:
         return sorted(self._loaded_models)
@@ -314,6 +318,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         target = model_target(request.model)
         progress("loading_model", "loading_model", 0.2, f"Loading {target['label']} Diffusers pipeline.")
         pipe = self._load_pipeline(request, target)
+        self._apply_loras(pipe, request, target)
 
         first_image = self._first_condition_image(project_path, request)
         last_image = self._last_condition_image(project_path, request)
@@ -461,8 +466,21 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         self._pipeline = None
         self._pipeline_key_value = None
         self._loaded_models.clear()
+        self._loaded_lora_key = ""
+        self._loaded_lora_names = []
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+
+    def _apply_loras(self, pipe: Any, request: VideoRequest, target: dict[str, Any]) -> None:
+        loaded_key, loaded_names = apply_loras_to_pipeline(
+            pipe,
+            request.loras,
+            adapter_id=target["adapter"],
+            previous_key=self._loaded_lora_key,
+            previous_adapter_names=self._loaded_lora_names,
+        )
+        self._loaded_lora_key = loaded_key
+        self._loaded_lora_names = loaded_names
 
     def _pipeline_class(self, diffusers: Any, request: VideoRequest, target: dict[str, Any]) -> Any:
         if target["adapter"] == "wan_video":

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -4,6 +4,7 @@ import json
 from types import SimpleNamespace
 
 from PIL import Image
+import pytest
 
 from scene_worker.adapter_utils import filter_call_kwargs
 from scene_worker.image_adapters import (
@@ -16,7 +17,13 @@ from scene_worker.image_adapters import (
     image_request_from_job,
     resolve_seed,
 )
-from scene_worker.lora_adapters import apply_loras_to_pipeline, normalize_lora_specs
+from scene_worker.lora_adapters import (
+    apply_loras_to_pipeline,
+    lora_cache_key,
+    lora_weight,
+    normalize_lora_specs,
+    reject_loras_if_unsupported,
+)
 from scene_worker.runtime import (
     child_environment,
     friendly_failure,
@@ -63,6 +70,23 @@ class FakeLoraPipe:
 
     def unload_lora_weights(self):
         self.unloaded += 1
+
+
+class FakeTargetedLoraPipe(FakeLoraPipe):
+    def __init__(self):
+        super().__init__()
+        self.deleted = []
+
+    def delete_adapters(self, names):
+        self.deleted.append(names)
+
+
+class FakeSingleLoraPipe:
+    def __init__(self):
+        self.loaded = []
+
+    def load_lora_weights(self, path, adapter_name=None):
+        self.loaded.append((path, adapter_name))
 
 
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
@@ -156,19 +180,17 @@ def test_lora_loader_applies_weights_and_reuses_cached_state(tmp_path):
         {"id": "detail", "installedPath": str(second), "weight": 0.8},
     ]
 
-    key, names = apply_loras_to_pipeline(pipe, loras, adapter_id="diffusers_test")
-    same_key, same_names = apply_loras_to_pipeline(
+    state = apply_loras_to_pipeline(pipe, loras, adapter_id="diffusers_test")
+    same_state = apply_loras_to_pipeline(
         pipe,
         loras,
         adapter_id="diffusers_test",
-        previous_key=key,
-        previous_adapter_names=names,
+        previous_state=state,
     )
 
-    assert same_key == key
-    assert same_names == names
+    assert same_state == state
     assert [path for path, _name in pipe.loaded] == [str(first), str(second)]
-    assert pipe.set_calls == [(names, [0.5, 0.8])]
+    assert pipe.set_calls == [(list(state.adapter_names), [0.5, 0.8])]
     assert pipe.unloaded == 0
 
 
@@ -179,36 +201,97 @@ def test_lora_loader_clears_previous_adapters_between_jobs(tmp_path):
     second.write_bytes(b"lora")
     pipe = FakeLoraPipe()
 
-    key, names = apply_loras_to_pipeline(pipe, [{"id": "style", "installedPath": str(first)}], adapter_id="diffusers_test")
+    state = apply_loras_to_pipeline(pipe, [{"id": "style", "installedPath": str(first)}], adapter_id="diffusers_test")
     apply_loras_to_pipeline(
         pipe,
         [{"id": "detail", "installedPath": str(second)}],
         adapter_id="diffusers_test",
-        previous_key=key,
-        previous_adapter_names=names,
+        previous_state=state,
     )
 
     assert pipe.unloaded == 1
     assert pipe.loaded[-1][0] == str(second)
 
 
+def test_lora_loader_reuses_overlap_when_adapter_can_delete_targeted_loras(tmp_path):
+    first = tmp_path / "style.safetensors"
+    second = tmp_path / "detail.safetensors"
+    third = tmp_path / "motion.safetensors"
+    first.write_bytes(b"lora")
+    second.write_bytes(b"lora")
+    third.write_bytes(b"lora")
+    pipe = FakeTargetedLoraPipe()
+    state = apply_loras_to_pipeline(
+        pipe,
+        [{"id": "style", "installedPath": str(first)}, {"id": "detail", "installedPath": str(second)}],
+        adapter_id="diffusers_test",
+    )
+
+    apply_loras_to_pipeline(
+        pipe,
+        [{"id": "style", "installedPath": str(first)}, {"id": "motion", "installedPath": str(third)}],
+        adapter_id="diffusers_test",
+        previous_state=state,
+    )
+
+    assert pipe.unloaded == 0
+    assert pipe.deleted == [[state.specs[1].adapter_name]]
+    assert [path for path, _name in pipe.loaded] == [str(first), str(second), str(third)]
+
+
+def test_lora_cache_key_is_stable_for_reordered_loras(tmp_path):
+    first = tmp_path / "style.safetensors"
+    second = tmp_path / "detail.safetensors"
+    first.write_bytes(b"lora")
+    second.write_bytes(b"lora")
+    left = [{"id": "style", "installedPath": str(first), "weight": 0.5}, {"id": "detail", "installedPath": str(second)}]
+    right = list(reversed(left))
+
+    key = lora_cache_key(left)
+    assert key == lora_cache_key(right)
+    assert len(key) == 64
+
+
+def test_lora_loader_allows_single_implicit_weight_without_set_adapters(tmp_path):
+    first = tmp_path / "style.safetensors"
+    first.write_bytes(b"lora")
+    pipe = FakeSingleLoraPipe()
+
+    state = apply_loras_to_pipeline(pipe, [{"id": "style", "installedPath": str(first), "weight": 1.0}], adapter_id="diffusers_test")
+
+    assert state.adapter_names
+    assert pipe.loaded[0][0] == str(first)
+
+
+def test_lora_loader_fails_when_pipeline_cannot_load_loras(tmp_path):
+    first = tmp_path / "style.safetensors"
+    first.write_bytes(b"lora")
+
+    with pytest.raises(RuntimeError, match="does not support loading LoRA weights"):
+        apply_loras_to_pipeline(object(), [{"id": "style", "installedPath": str(first)}], adapter_id="diffusers_test")
+
+
+def test_unsupported_adapter_guard_rejects_loras(tmp_path):
+    first = tmp_path / "style.safetensors"
+    first.write_bytes(b"lora")
+
+    with pytest.raises(RuntimeError, match="does not support LoRA application"):
+        reject_loras_if_unsupported([{"id": "style", "installedPath": str(first)}], "procedural_preview")
+
+
+def test_lora_weight_defaults_on_unparseable_values():
+    assert lora_weight({"weight": "not-a-number"}) == 0.8
+
+
 def test_lora_specs_fail_before_inference_for_missing_or_excess_loras(tmp_path):
     missing = tmp_path / "missing.safetensors"
 
-    try:
+    with pytest.raises(RuntimeError, match="file is missing"):
         normalize_lora_specs([{"id": "missing", "installedPath": str(missing)}])
-    except RuntimeError as exc:
-        assert "file is missing" in str(exc)
-    else:
-        raise AssertionError("Missing LoRA files should fail before inference.")
 
     many = [{"id": f"lora_{index}", "installedPath": str(missing)} for index in range(4)]
-    try:
+    with pytest.raises(RuntimeError, match="at most 3 LoRAs"):
         normalize_lora_specs(many)
-    except RuntimeError as exc:
-        assert "at most 3 LoRAs" in str(exc)
-    else:
-        raise AssertionError("More than three LoRAs should fail before inference.")
 
 
 def test_image_adapter_env_aliases_and_unknown_values(monkeypatch):

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -16,6 +16,7 @@ from scene_worker.image_adapters import (
     image_request_from_job,
     resolve_seed,
 )
+from scene_worker.lora_adapters import apply_loras_to_pipeline, normalize_lora_specs
 from scene_worker.runtime import (
     child_environment,
     friendly_failure,
@@ -46,6 +47,22 @@ from scene_worker.video_adapters import (
 class AcceptsNone:
     def __call__(self, *, prompt, image=None):
         return prompt, image
+
+
+class FakeLoraPipe:
+    def __init__(self):
+        self.loaded = []
+        self.set_calls = []
+        self.unloaded = 0
+
+    def load_lora_weights(self, path, adapter_name=None):
+        self.loaded.append((path, adapter_name))
+
+    def set_adapters(self, names, adapter_weights=None):
+        self.set_calls.append((names, adapter_weights))
+
+    def unload_lora_weights(self):
+        self.unloaded += 1
 
 
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
@@ -126,6 +143,72 @@ def test_filter_call_kwargs_preserves_none_for_accepted_parameters():
         "prompt": "city",
         "image": None,
     }
+
+
+def test_lora_loader_applies_weights_and_reuses_cached_state(tmp_path):
+    first = tmp_path / "style.safetensors"
+    second = tmp_path / "detail.safetensors"
+    first.write_bytes(b"lora")
+    second.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    loras = [
+        {"id": "style", "installedPath": str(first), "weight": 0.5},
+        {"id": "detail", "installedPath": str(second), "weight": 0.8},
+    ]
+
+    key, names = apply_loras_to_pipeline(pipe, loras, adapter_id="diffusers_test")
+    same_key, same_names = apply_loras_to_pipeline(
+        pipe,
+        loras,
+        adapter_id="diffusers_test",
+        previous_key=key,
+        previous_adapter_names=names,
+    )
+
+    assert same_key == key
+    assert same_names == names
+    assert [path for path, _name in pipe.loaded] == [str(first), str(second)]
+    assert pipe.set_calls == [(names, [0.5, 0.8])]
+    assert pipe.unloaded == 0
+
+
+def test_lora_loader_clears_previous_adapters_between_jobs(tmp_path):
+    first = tmp_path / "style.safetensors"
+    second = tmp_path / "detail.safetensors"
+    first.write_bytes(b"lora")
+    second.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+
+    key, names = apply_loras_to_pipeline(pipe, [{"id": "style", "installedPath": str(first)}], adapter_id="diffusers_test")
+    apply_loras_to_pipeline(
+        pipe,
+        [{"id": "detail", "installedPath": str(second)}],
+        adapter_id="diffusers_test",
+        previous_key=key,
+        previous_adapter_names=names,
+    )
+
+    assert pipe.unloaded == 1
+    assert pipe.loaded[-1][0] == str(second)
+
+
+def test_lora_specs_fail_before_inference_for_missing_or_excess_loras(tmp_path):
+    missing = tmp_path / "missing.safetensors"
+
+    try:
+        normalize_lora_specs([{"id": "missing", "installedPath": str(missing)}])
+    except RuntimeError as exc:
+        assert "file is missing" in str(exc)
+    else:
+        raise AssertionError("Missing LoRA files should fail before inference.")
+
+    many = [{"id": f"lora_{index}", "installedPath": str(missing)} for index in range(4)]
+    try:
+        normalize_lora_specs(many)
+    except RuntimeError as exc:
+        assert "at most 3 LoRAs" in str(exc)
+    else:
+        raise AssertionError("More than three LoRAs should fail before inference.")
 
 
 def test_image_adapter_env_aliases_and_unknown_values(monkeypatch):


### PR DESCRIPTION
## Summary

- Complete sc-1317 by documenting `modes` as the preset picker discoverability surface and adding Image Studio coverage for text/edit filtering semantics.
- Complete sc-1313 by adding worker-side LoRA loading for Diffusers image/video adapters, cache-safe LoRA clearing between jobs, pre-inference validation for missing/excess LoRAs, and installed path propagation from preset payloads.

## Validation

- `npm test` in `apps/web`
- `python -m pytest tests\test_worker_runtime.py`
- `cargo test -p sceneworks-rust-api`

## Notes

- `cargo fmt --all -- --check` is currently blocked by existing newline-style issues in Rust files, including files outside this PR scope.