### PR TITLE
[codex] Add local LoRA upload import

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -65,6 +65,7 @@ const HEARTBEAT_SSE_DATA: &str = "{}";
 #[cfg(test)]
 const HEARTBEAT_SSE_WIRE: &str = "event: heartbeat\ndata: {}\n\n";
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
+const MAX_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
 const MANIFEST_CACHE_LIMIT: usize = 16;
 const MODEL_SIZE_CACHE_LIMIT: usize = 64;
 const API_MANAGED_MANIFEST_HEADER: &str = "// This file is rewritten by the SceneWorks API. Inline JSONC comments are not preserved across writes.";
@@ -512,7 +513,7 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         )
         .fallback(route_not_found)
         .with_state(state.clone())
-        .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
+        .layer(DefaultBodyLimit::max(MAX_MULTIPART_BODY_BYTES))
         .layer(middleware::from_fn_with_state(state, access_control))
         .layer(cors))
 }
@@ -883,6 +884,8 @@ struct LoraImportRequest {
     scope: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     project_id: Option<String>,
+    #[serde(default, skip_deserializing, skip_serializing_if = "bool_is_false")]
+    uploaded_source_path: bool,
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
@@ -2283,7 +2286,42 @@ async fn duplicate_recipe_preset(
 
 async fn create_lora_import_job(
     State(state): State<AppState>,
-    ApiJson(mut payload): ApiJson<LoraImportRequest>,
+    request: AxumRequest,
+) -> Result<(StatusCode, Json<JobSnapshot>), Response> {
+    let is_multipart = request
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("multipart/form-data"));
+    if is_multipart {
+        let multipart = Multipart::from_request(request, &state)
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()).into_response())?;
+        let (payload, staged_path) = lora_import_request_from_multipart(&state, multipart)
+            .await
+            .map_err(IntoResponse::into_response)?;
+        let result = queue_lora_import_job(state, payload).await;
+        if result.is_err() {
+            let _ = tokio::fs::remove_file(&staged_path).await;
+            if let Some(parent) = staged_path.parent() {
+                let _ = tokio::fs::remove_dir(parent).await;
+            }
+        }
+        return result.map_err(IntoResponse::into_response);
+    }
+
+    let payload = Json::<LoraImportRequest>::from_request(request, &state)
+        .await
+        .map(|Json(payload)| payload)
+        .map_err(json_rejection_response)?;
+    queue_lora_import_job(state, payload)
+        .await
+        .map_err(IntoResponse::into_response)
+}
+
+async fn queue_lora_import_job(
+    state: AppState,
+    mut payload: LoraImportRequest,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
     if option_str_is_empty(payload.repo.as_deref())
         && option_str_is_empty(payload.source_url.as_deref())
@@ -2409,6 +2447,110 @@ async fn create_lora_import_job(
     )
     .await?;
     Ok((StatusCode::CREATED, Json(job)))
+}
+
+async fn lora_import_request_from_multipart(
+    state: &AppState,
+    mut multipart: Multipart,
+) -> Result<(LoraImportRequest, PathBuf), ApiError> {
+    let mut payload = LoraImportRequest {
+        lora_id: None,
+        name: None,
+        repo: None,
+        source_url: None,
+        source_path: None,
+        files: Vec::new(),
+        family: None,
+        scope: default_lora_scope(),
+        project_id: None,
+        uploaded_source_path: false,
+    };
+    let mut staged_path = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|error| ApiError::bad_request(error.to_string()))?
+    {
+        let field_name = field.name().unwrap_or("").to_owned();
+        if field_name == "file" {
+            if staged_path.is_some() {
+                return Err(ApiError::bad_request("Only one LoRA file can be uploaded"));
+            }
+            let upload_name =
+                sanitized_upload_filename(field.file_name().unwrap_or("lora.safetensors"));
+            let path = write_lora_upload_field_to_staged_file(state, field, &upload_name).await?;
+            payload.source_path = Some(path.display().to_string());
+            payload.files = vec![upload_name];
+            payload.uploaded_source_path = true;
+            staged_path = Some(path);
+            continue;
+        }
+
+        let value = field
+            .text()
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()))?;
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        match field_name.as_str() {
+            "loraId" => payload.lora_id = Some(value.to_owned()),
+            "name" => payload.name = Some(value.to_owned()),
+            "family" => payload.family = Some(value.to_owned()),
+            "scope" => payload.scope = value.to_owned(),
+            "projectId" => payload.project_id = Some(value.to_owned()),
+            _ => {}
+        }
+    }
+
+    let Some(staged_path) = staged_path else {
+        return Err(ApiError::bad_request("Upload file field is required"));
+    };
+    Ok((payload, staged_path))
+}
+
+async fn write_lora_upload_field_to_staged_file(
+    state: &AppState,
+    mut field: axum::extract::multipart::Field<'_>,
+    filename: &str,
+) -> Result<PathBuf, ApiError> {
+    let upload_dir = state
+        .settings
+        .data_dir
+        .join("cache")
+        .join("lora-uploads")
+        .join(format!("upload-{}", Uuid::new_v4().simple()));
+    tokio::fs::create_dir_all(&upload_dir)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let temp_path = upload_dir.join(filename);
+    let mut file = tokio::fs::File::create(&temp_path)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let mut uploaded_bytes = 0usize;
+    while let Some(chunk) = field
+        .chunk()
+        .await
+        .map_err(|error| ApiError::bad_request(error.to_string()))?
+    {
+        uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
+        if uploaded_bytes > MAX_UPLOAD_BYTES {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            let _ = tokio::fs::remove_dir(&upload_dir).await;
+            return Err(ApiError::payload_too_large(
+                "Uploaded LoRA file exceeds the 2GB limit",
+            ));
+        }
+        file.write_all(&chunk)
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))?;
+    }
+    file.flush()
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    Ok(temp_path)
 }
 
 async fn list_jobs(
@@ -4277,6 +4419,20 @@ fn safe_download_dir(repo: &str) -> String {
     }
 }
 
+fn sanitized_upload_filename(filename: &str) -> String {
+    let filename = filename
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(filename)
+        .trim();
+    let sanitized = safe_download_dir(filename);
+    if sanitized.is_empty() || sanitized == "download" {
+        "lora.safetensors".to_owned()
+    } else {
+        sanitized
+    }
+}
+
 fn validate_source_url(source_url: &str) -> Result<(), ApiError> {
     parse_lora_source_url(source_url)
         .map(|_| ())
@@ -4732,6 +4888,10 @@ fn default_lora_scope() -> String {
     "global".to_owned()
 }
 
+fn bool_is_false(value: &bool) -> bool {
+    !*value
+}
+
 fn default_project_lora_scope() -> String {
     "project".to_owned()
 }
@@ -5019,6 +5179,45 @@ mod tests {
             app,
             "POST",
             uri,
+            body,
+            &[(
+                "content-type",
+                &format!("multipart/form-data; boundary={boundary}"),
+            )],
+        )
+        .await;
+        let value = serde_json::from_slice(&bytes).expect("json body parses");
+        (status, value)
+    }
+
+    async fn request_multipart_lora_upload(
+        app: axum::Router,
+        fields: &[(&str, &str)],
+        filename: &str,
+        bytes: &[u8],
+    ) -> (StatusCode, Value) {
+        let boundary = "SCENEWORKS_LORA_BOUNDARY";
+        let mut body = Vec::new();
+        for (name, value) in fields {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+            );
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        body.extend_from_slice(bytes);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        let (status, _, bytes) = request_raw(
+            app,
+            "POST",
+            "/api/v1/loras/import",
             body,
             &[(
                 "content-type",
@@ -5818,6 +6017,44 @@ mod tests {
             "https://example.com/loras/detail.safetensors"
         );
         assert_eq!(url_job["payload"]["manifestEntry"]["family"], "z-image");
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, upload_job) = request_multipart_lora_upload(
+            app,
+            &[
+                ("name", "Uploaded Detail"),
+                ("scope", "global"),
+                ("family", "z-image"),
+            ],
+            "detail.safetensors",
+            b"local-lora",
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(upload_job["type"], "lora_import");
+        assert_eq!(upload_job["payload"]["loraId"], "uploaded_detail");
+        assert_eq!(upload_job["payload"]["uploadedSourcePath"], true);
+        assert_eq!(
+            upload_job["payload"]["manifestEntry"]["source"]["provider"],
+            "local"
+        );
+        assert_eq!(
+            upload_job["payload"]["manifestEntry"]["files"][0],
+            "detail.safetensors"
+        );
+        let source_path = std::path::PathBuf::from(
+            upload_job["payload"]["sourcePath"]
+                .as_str()
+                .expect("source path"),
+        );
+        assert_eq!(
+            std::fs::read(&source_path).expect("staged upload reads"),
+            b"local-lora"
+        );
+        assert_eq!(
+            source_path.file_name().and_then(|value| value.to_str()),
+            Some("detail.safetensors")
+        );
 
         let app = create_app(test_settings(&temp_dir)).expect("app creates");
         let (bad_status, bad_error) = request(

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3,7 +3,7 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use axum::body::Body;
 use axum::extract::rejection::JsonRejection;
@@ -66,9 +66,13 @@ const HEARTBEAT_SSE_DATA: &str = "{}";
 const HEARTBEAT_SSE_WIRE: &str = "event: heartbeat\ndata: {}\n\n";
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MAX_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
+const STALE_LORA_UPLOAD_SECONDS: u64 = 24 * 60 * 60;
 const MANIFEST_CACHE_LIMIT: usize = 16;
 const MODEL_SIZE_CACHE_LIMIT: usize = 64;
 const API_MANAGED_MANIFEST_HEADER: &str = "// This file is rewritten by the SceneWorks API. Inline JSONC comments are not preserved across writes.";
+#[cfg(test)]
+static TEST_MAX_LORA_UPLOAD_BYTES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 #[derive(Debug, Clone)]
 pub struct Settings {
@@ -343,6 +347,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
+    let _ = sweep_stale_lora_uploads(&settings.data_dir);
     let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
     jobs_store.initialize()?;
     let interrupted_jobs_on_startup = jobs_store.mark_interrupted_on_startup()?.len();
@@ -480,7 +485,10 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
             post(create_model_download_job),
         )
         .route("/api/v1/loras", get(list_loras))
-        .route("/api/v1/loras/import", post(create_lora_import_job))
+        .route(
+            "/api/v1/loras/import",
+            post(create_lora_import_job).layer(DefaultBodyLimit::max(MAX_MULTIPART_BODY_BYTES)),
+        )
         .route(
             "/api/v1/recipe-presets",
             get(list_recipe_presets).post(create_recipe_preset),
@@ -513,7 +521,7 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         )
         .fallback(route_not_found)
         .with_state(state.clone())
-        .layer(DefaultBodyLimit::max(MAX_MULTIPART_BODY_BYTES))
+        .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
         .layer(middleware::from_fn_with_state(state, access_control))
         .layer(cors))
 }
@@ -2302,10 +2310,7 @@ async fn create_lora_import_job(
             .map_err(IntoResponse::into_response)?;
         let result = queue_lora_import_job(state, payload).await;
         if result.is_err() {
-            let _ = tokio::fs::remove_file(&staged_path).await;
-            if let Some(parent) = staged_path.parent() {
-                let _ = tokio::fs::remove_dir(parent).await;
-            }
+            cleanup_staged_lora_upload(&staged_path).await;
         }
         return result.map_err(IntoResponse::into_response);
     }
@@ -2367,7 +2372,7 @@ async fn queue_lora_import_job(
         .clone()
         .unwrap_or_else(|| slugify_lora_id(&name));
     let target_name = safe_download_dir(&lora_id);
-    let (target_dir, manifest_path, source_path, project_id, project_name) =
+    let (target_dir, manifest_path, source_path, project_id, project_name, allowed_source_roots) =
         if payload.scope == "project" {
             let Some(project_id) = payload.project_id.clone() else {
                 return Err(ApiError::bad_request(
@@ -2384,6 +2389,10 @@ async fn queue_lora_import_job(
                 format!("loras/imports/{target_name}"),
                 Some(project_id),
                 None,
+                vec![
+                    state.settings.data_dir.join("loras"),
+                    project_path.join("loras"),
+                ],
             )
         } else {
             (
@@ -2396,8 +2405,17 @@ async fn queue_lora_import_job(
                 format!("loras/{target_name}"),
                 None,
                 None,
+                vec![state.settings.data_dir.join("loras")],
             )
         };
+    if let Some(source_path) = payload.source_path.as_deref() {
+        let allowed_source_roots = if payload.uploaded_source_path {
+            vec![state.settings.data_dir.join("cache").join("lora-uploads")]
+        } else {
+            allowed_source_roots
+        };
+        validate_lora_import_source_path(source_path, &allowed_source_roots)?;
+    }
     let timestamp = now_rfc3339();
     let mut manifest_entry = json!({
         "id": lora_id,
@@ -2467,42 +2485,53 @@ async fn lora_import_request_from_multipart(
     };
     let mut staged_path = None;
 
-    while let Some(field) = multipart
-        .next_field()
-        .await
-        .map_err(|error| ApiError::bad_request(error.to_string()))?
-    {
-        let field_name = field.name().unwrap_or("").to_owned();
-        if field_name == "file" {
-            if staged_path.is_some() {
-                return Err(ApiError::bad_request("Only one LoRA file can be uploaded"));
-            }
-            let upload_name =
-                sanitized_upload_filename(field.file_name().unwrap_or("lora.safetensors"));
-            let path = write_lora_upload_field_to_staged_file(state, field, &upload_name).await?;
-            payload.source_path = Some(path.display().to_string());
-            payload.files = vec![upload_name];
-            payload.uploaded_source_path = true;
-            staged_path = Some(path);
-            continue;
-        }
-
-        let value = field
-            .text()
+    let parse_result = async {
+        while let Some(field) = multipart
+            .next_field()
             .await
-            .map_err(|error| ApiError::bad_request(error.to_string()))?;
-        let value = value.trim();
-        if value.is_empty() {
-            continue;
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            let field_name = field.name().unwrap_or("").to_owned();
+            if field_name == "file" {
+                if staged_path.is_some() {
+                    return Err(ApiError::bad_request("Only one LoRA file can be uploaded"));
+                }
+                let upload_name =
+                    sanitized_upload_filename(field.file_name().unwrap_or("lora.safetensors"));
+                let path =
+                    write_lora_upload_field_to_staged_file(state, field, &upload_name).await?;
+                payload.source_path = Some(path.display().to_string());
+                payload.files = vec![upload_name];
+                payload.uploaded_source_path = true;
+                staged_path = Some(path);
+                continue;
+            }
+
+            let value = field
+                .text()
+                .await
+                .map_err(|error| ApiError::bad_request(error.to_string()))?;
+            let value = value.trim();
+            if value.is_empty() {
+                continue;
+            }
+            match field_name.as_str() {
+                "loraId" => payload.lora_id = Some(value.to_owned()),
+                "name" => payload.name = Some(value.to_owned()),
+                "family" => payload.family = Some(value.to_owned()),
+                "scope" => payload.scope = value.to_owned(),
+                "projectId" => payload.project_id = Some(value.to_owned()),
+                _ => {}
+            }
         }
-        match field_name.as_str() {
-            "loraId" => payload.lora_id = Some(value.to_owned()),
-            "name" => payload.name = Some(value.to_owned()),
-            "family" => payload.family = Some(value.to_owned()),
-            "scope" => payload.scope = value.to_owned(),
-            "projectId" => payload.project_id = Some(value.to_owned()),
-            _ => {}
+        Ok(())
+    }
+    .await;
+    if let Err(error) = parse_result {
+        if let Some(path) = staged_path.as_deref() {
+            cleanup_staged_lora_upload(path).await;
         }
+        return Err(error);
     }
 
     let Some(staged_path) = staged_path else {
@@ -2530,27 +2559,50 @@ async fn write_lora_upload_field_to_staged_file(
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
     let mut uploaded_bytes = 0usize;
-    while let Some(chunk) = field
-        .chunk()
-        .await
-        .map_err(|error| ApiError::bad_request(error.to_string()))?
-    {
-        uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
-        if uploaded_bytes > MAX_UPLOAD_BYTES {
-            let _ = tokio::fs::remove_file(&temp_path).await;
-            let _ = tokio::fs::remove_dir(&upload_dir).await;
-            return Err(ApiError::payload_too_large(
-                "Uploaded LoRA file exceeds the 2GB limit",
-            ));
-        }
-        file.write_all(&chunk)
+    let write_result = async {
+        while let Some(chunk) = field
+            .chunk()
             .await
-            .map_err(|error| ApiError::internal(error.to_string()))?;
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
+            if uploaded_bytes > max_lora_upload_bytes() {
+                return Err(ApiError::payload_too_large(
+                    "Uploaded LoRA file exceeds the 2GB limit",
+                ));
+            }
+            file.write_all(&chunk)
+                .await
+                .map_err(|error| ApiError::internal(error.to_string()))?;
+        }
+        file.flush()
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))
     }
-    file.flush()
-        .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
+    .await;
+    if let Err(error) = write_result {
+        cleanup_staged_lora_upload(&temp_path).await;
+        return Err(error);
+    }
     Ok(temp_path)
+}
+
+async fn cleanup_staged_lora_upload(path: &FsPath) {
+    let _ = tokio::fs::remove_file(path).await;
+    if let Some(parent) = path.parent() {
+        let _ = tokio::fs::remove_dir(parent).await;
+    }
+}
+
+fn max_lora_upload_bytes() -> usize {
+    #[cfg(test)]
+    {
+        let limit = TEST_MAX_LORA_UPLOAD_BYTES.load(std::sync::atomic::Ordering::SeqCst);
+        if limit > 0 {
+            return limit;
+        }
+    }
+    MAX_UPLOAD_BYTES
 }
 
 async fn list_jobs(
@@ -4433,6 +4485,73 @@ fn sanitized_upload_filename(filename: &str) -> String {
     }
 }
 
+fn validate_lora_import_source_path(
+    source_path: &str,
+    allowed_roots: &[PathBuf],
+) -> Result<(), ApiError> {
+    let source = FsPath::new(source_path);
+    if !source.is_absolute() {
+        return Err(ApiError::bad_request("LoRA sourcePath must be absolute"));
+    }
+    let source = std::fs::canonicalize(source)
+        .map_err(|_| ApiError::bad_request(format!("LoRA sourcePath not found: {source_path}")))?;
+    let metadata = std::fs::metadata(&source)
+        .map_err(|error| ApiError::bad_request(format!("Invalid LoRA sourcePath: {error}")))?;
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err(ApiError::bad_request(
+            "LoRA sourcePath must point to a file or directory",
+        ));
+    }
+    for root in allowed_roots {
+        if let Ok(root) = std::fs::canonicalize(root) {
+            if source.starts_with(root) {
+                return Ok(());
+            }
+        }
+    }
+    Err(ApiError::bad_request(
+        "LoRA sourcePath must be inside app-managed data/loras, project/loras, or staged upload folders",
+    ))
+}
+
+fn sweep_stale_lora_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
+    sweep_stale_lora_uploads_before(
+        data_dir,
+        SystemTime::now() - Duration::from_secs(STALE_LORA_UPLOAD_SECONDS),
+    )
+}
+
+fn sweep_stale_lora_uploads_before(
+    data_dir: &FsPath,
+    cutoff: SystemTime,
+) -> std::io::Result<usize> {
+    let upload_root = data_dir.join("cache").join("lora-uploads");
+    let entries = match std::fs::read_dir(upload_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    let mut removed = 0usize;
+    for entry in entries {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let filename = entry.file_name();
+        let filename = filename.to_string_lossy();
+        if !filename.starts_with("upload-") {
+            continue;
+        }
+        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
+        if modified <= cutoff {
+            std::fs::remove_dir_all(entry.path())?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
 fn validate_source_url(source_url: &str) -> Result<(), ApiError> {
     parse_lora_source_url(source_url)
         .map(|_| ())
@@ -5060,12 +5179,15 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_app, strip_jsonc_comments, EventHub, EventMessage, Settings,
-        API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE,
+        create_app, strip_jsonc_comments, sweep_stale_lora_uploads_before, EventHub, EventMessage,
+        Settings, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
+        HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
     };
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
     use serde_json::{json, Value};
+    use std::sync::atomic::Ordering;
+    use std::time::{Duration, SystemTime};
     use tokio_stream::StreamExt;
     use tower::ServiceExt;
 
@@ -5227,6 +5349,29 @@ mod tests {
         .await;
         let value = serde_json::from_slice(&bytes).expect("json body parses");
         (status, value)
+    }
+
+    #[test]
+    fn stale_lora_upload_sweep_removes_only_upload_dirs_before_cutoff() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let upload_root = temp_dir.path().join("data/cache/lora-uploads");
+        let expired = upload_root.join("upload-expired");
+        let fresh = upload_root.join("upload-fresh");
+        let unrelated = upload_root.join("keep-me");
+        std::fs::create_dir_all(&expired).expect("expired dir creates");
+        std::fs::create_dir_all(&fresh).expect("fresh dir creates");
+        std::fs::create_dir_all(&unrelated).expect("unrelated dir creates");
+
+        let removed = sweep_stale_lora_uploads_before(
+            &temp_dir.path().join("data"),
+            SystemTime::now() + Duration::from_secs(1),
+        )
+        .expect("stale uploads sweep");
+
+        assert_eq!(removed, 2);
+        assert!(!expired.exists());
+        assert!(!fresh.exists());
+        assert!(unrelated.exists());
     }
 
     #[tokio::test]
@@ -6054,6 +6199,62 @@ mod tests {
         assert_eq!(
             source_path.file_name().and_then(|value| value.to_str()),
             Some("detail.safetensors")
+        );
+
+        TEST_MAX_LORA_UPLOAD_BYTES.store(4, Ordering::SeqCst);
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (bad_status, bad_error) = request_multipart_lora_upload(
+            app,
+            &[("name", "Too Large"), ("scope", "global")],
+            "too-large.safetensors",
+            b"12345",
+        )
+        .await;
+        TEST_MAX_LORA_UPLOAD_BYTES.store(0, Ordering::SeqCst);
+        assert_eq!(bad_status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(
+            bad_error["detail"],
+            "Uploaded LoRA file exceeds the 2GB limit"
+        );
+
+        let lora_source_dir = temp_dir.path().join("data").join("loras");
+        std::fs::create_dir_all(&lora_source_dir).expect("lora source dir creates");
+        let lora_source = lora_source_dir.join("safe-local.safetensors");
+        std::fs::write(&lora_source, b"local-source").expect("local source writes");
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, source_path_job) = request(
+            app,
+            "POST",
+            "/api/v1/loras/import",
+            json!({
+                "sourcePath": lora_source.display().to_string(),
+                "name": "Safe Local Source"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            source_path_job["payload"]["manifestEntry"]["source"]["provider"],
+            "local"
+        );
+
+        let outside_source = temp_dir.path().join("outside.safetensors");
+        std::fs::write(&outside_source, b"private").expect("outside source writes");
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (bad_status, bad_error) = request(
+            app,
+            "POST",
+            "/api/v1/loras/import",
+            json!({
+                "sourcePath": outside_source.display().to_string(),
+                "name": "Unsafe Local Source"
+            }),
+        )
+        .await;
+        assert_eq!(bad_status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            bad_error["detail"],
+            "LoRA sourcePath must be inside app-managed data/loras, project/loras, or staged upload folders"
         );
 
         let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -790,6 +790,9 @@ async fn run_utility_job(
             result.map_err(|error| ("Utility job failed.", error))
         }
     };
+    if job.job_type == JobType::LoraImport {
+        let _ = cleanup_uploaded_lora_source(&job.payload).await;
+    }
     if let Err((message, error)) = result {
         match error {
             WorkerError::Canceled(_) => {}
@@ -2784,6 +2787,25 @@ fn optional_payload_string<'a>(payload: &'a JsonObject, field: &str) -> Option<&
         .filter(|value| !value.trim().is_empty())
 }
 
+fn payload_bool(payload: &JsonObject, field: &str) -> bool {
+    payload.get(field).and_then(Value::as_bool).unwrap_or(false)
+}
+
+async fn cleanup_uploaded_lora_source(payload: &JsonObject) -> WorkerResult<()> {
+    if !payload_bool(payload, "uploadedSourcePath") {
+        return Ok(());
+    }
+    let Some(source_path) = optional_payload_string(payload, "sourcePath") else {
+        return Ok(());
+    };
+    let source_path = PathBuf::from(source_path);
+    let _ = tokio::fs::remove_file(&source_path).await;
+    if let Some(parent) = source_path.parent() {
+        let _ = tokio::fs::remove_dir(parent).await;
+    }
+    Ok(())
+}
+
 fn normalize_absolute_path(path: &Path) -> WorkerResult<PathBuf> {
     let mut output = if path.is_absolute() {
         PathBuf::new()
@@ -3808,14 +3830,14 @@ mod tests {
 
     use super::{
         allow_pattern_matches, auto_worker_specs, bounded_tail, candidate_people,
-        child_environment, concat_file_contents, copy_lora_source, cpu_gpu, cpu_worker_id,
-        crossfade_duration, download_lora_source_url, download_progress_payload, fallback_gpu,
-        fresh_asset_id, gpu_worker_id, now_rfc3339, output_dimensions, parse_nvidia_smi_gpus,
-        restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
-        value_f64, visible_gpu_ids, worker_capabilities_with_utility, write_model_install_marker,
-        ApiClient, DownloadContext, HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError,
-        WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
-        INSTALL_MARKER,
+        child_environment, cleanup_uploaded_lora_source, concat_file_contents, copy_lora_source,
+        cpu_gpu, cpu_worker_id, crossfade_duration, download_lora_source_url,
+        download_progress_payload, fallback_gpu, fresh_asset_id, gpu_worker_id, now_rfc3339,
+        output_dimensions, parse_nvidia_smi_gpus, restart_exited_children_with_spawner, run_ffmpeg,
+        safe_download_dir, safe_project_path, value_f64, visible_gpu_ids,
+        worker_capabilities_with_utility, write_model_install_marker, ApiClient, DownloadContext,
+        HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError, WorkerSpec,
+        DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
     };
 
     #[test]
@@ -4065,6 +4087,26 @@ mod tests {
                 .unwrap(),
             b"adapter"
         );
+    }
+
+    #[tokio::test]
+    async fn uploaded_lora_source_cleanup_removes_staged_file_and_parent() {
+        let temp = tempdir().expect("tempdir creates");
+        let upload_dir = temp.path().join("upload-1");
+        tokio::fs::create_dir_all(&upload_dir).await.unwrap();
+        let source_file = upload_dir.join("detail.safetensors");
+        tokio::fs::write(&source_file, b"lora").await.unwrap();
+        let mut payload = serde_json::Map::new();
+        payload.insert(
+            "sourcePath".to_owned(),
+            json!(source_file.display().to_string()),
+        );
+        payload.insert("uploadedSourcePath".to_owned(), json!(true));
+
+        cleanup_uploaded_lora_source(&payload).await.unwrap();
+
+        assert!(!source_file.exists());
+        assert!(!upload_dir.exists());
     }
 
     #[tokio::test]

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -1088,7 +1088,12 @@ async fn run_lora_import_job(
         )
         .await?;
     } else if let Some(source_path) = source_path {
-        copy_lora_source(Path::new(source_path), &target_dir).await?;
+        import_lora_source_path(
+            Path::new(source_path),
+            &target_dir,
+            payload_bool(&job.payload, "uploadedSourcePath"),
+        )
+        .await?;
     } else if let Some(source_url) = source_url {
         download_lora_source_url(
             &DownloadContext {
@@ -2584,6 +2589,14 @@ pub fn download_progress_payload(
 }
 
 pub async fn copy_lora_source(source: &Path, target_dir: &Path) -> WorkerResult<()> {
+    import_lora_source_path(source, target_dir, false).await
+}
+
+async fn import_lora_source_path(
+    source: &Path,
+    target_dir: &Path,
+    prefer_move: bool,
+) -> WorkerResult<()> {
     let source = source.canonicalize()?;
     if !source.exists() {
         return Err(WorkerError::Io(std::io::Error::new(
@@ -2598,9 +2611,20 @@ pub async fn copy_lora_source(source: &Path, target_dir: &Path) -> WorkerResult<
         let target = target_dir.join(source.file_name().ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA source has no filename".to_owned())
         })?);
+        if prefer_move {
+            match tokio::fs::rename(&source, &target).await {
+                Ok(()) => return Ok(()),
+                Err(error) if is_cross_device_rename_error(&error) => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
         tokio::fs::copy(source, target).await?;
     }
     Ok(())
+}
+
+fn is_cross_device_rename_error(error: &std::io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(17 | 18))
 }
 
 async fn copy_dir_recursive(source: &Path, target: &Path) -> WorkerResult<()> {
@@ -3832,12 +3856,13 @@ mod tests {
         allow_pattern_matches, auto_worker_specs, bounded_tail, candidate_people,
         child_environment, cleanup_uploaded_lora_source, concat_file_contents, copy_lora_source,
         cpu_gpu, cpu_worker_id, crossfade_duration, download_lora_source_url,
-        download_progress_payload, fallback_gpu, fresh_asset_id, gpu_worker_id, now_rfc3339,
-        output_dimensions, parse_nvidia_smi_gpus, restart_exited_children_with_spawner, run_ffmpeg,
-        safe_download_dir, safe_project_path, value_f64, visible_gpu_ids,
-        worker_capabilities_with_utility, write_model_install_marker, ApiClient, DownloadContext,
-        HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError, WorkerSpec,
-        DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+        download_progress_payload, fallback_gpu, fresh_asset_id, gpu_worker_id,
+        import_lora_source_path, now_rfc3339, output_dimensions, parse_nvidia_smi_gpus,
+        restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
+        value_f64, visible_gpu_ids, worker_capabilities_with_utility, write_model_install_marker,
+        ApiClient, DownloadContext, HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError,
+        WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
+        INSTALL_MARKER,
     };
 
     #[test]
@@ -4107,6 +4132,26 @@ mod tests {
 
         assert!(!source_file.exists());
         assert!(!upload_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn uploaded_lora_file_import_prefers_move_over_copy() {
+        let temp = tempdir().expect("tempdir creates");
+        let source_file = temp.path().join("uploaded.safetensors");
+        tokio::fs::write(&source_file, b"lora").await.unwrap();
+        let target_dir = temp.path().join("target");
+
+        import_lora_source_path(&source_file, &target_dir, true)
+            .await
+            .unwrap();
+
+        assert!(!source_file.exists());
+        assert_eq!(
+            tokio::fs::read(target_dir.join("uploaded.safetensors"))
+                .await
+                .unwrap(),
+            b"lora"
+        );
     }
 
     #[tokio::test]

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -405,13 +405,30 @@ export function App() {
     if (payload.scope === "project" && !activeProject) {
       throw new Error("Create or open a project first.");
     }
+    const { file, ...metadata } = payload;
+    let body;
+    if (file) {
+      body = new FormData();
+      Object.entries({
+        ...metadata,
+        projectId: metadata.scope === "project" ? activeProject.id : null,
+        projectName: metadata.scope === "project" ? activeProject.name : null,
+      }).forEach(([key, value]) => {
+        if (value != null && value !== "") {
+          body.append(key, value);
+        }
+      });
+      body.append("file", file);
+    } else {
+      body = JSON.stringify({
+        ...metadata,
+        projectId: metadata.scope === "project" ? activeProject.id : null,
+        projectName: metadata.scope === "project" ? activeProject.name : null,
+      });
+    }
     const job = await apiFetch("/api/v1/loras/import", token, {
       method: "POST",
-      body: JSON.stringify({
-        ...payload,
-        projectId: payload.scope === "project" ? activeProject.id : null,
-        projectName: payload.scope === "project" ? activeProject.name : null,
-      }),
+      body,
     });
     setActiveView("Queue");
     setError("");

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -55,6 +55,13 @@ async function changeField(input, value) {
   });
 }
 
+async function changeFile(input, file) {
+  await act(async () => {
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    input.dispatchEvent(new window.Event("change", { bubbles: true }));
+  });
+}
+
 describe("SceneWorks app shell", () => {
   let container;
   let root;
@@ -872,6 +879,19 @@ describe("SceneWorks app shell", () => {
     });
     expect(createLoraImportJob).toHaveBeenCalledWith(
       expect.objectContaining({ sourceUrl: "https://example.com/loras/detail.safetensors", scope: "global", family: "z-image" }),
+    );
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Local File").click();
+    });
+    const loraFile = new File(["lora"], "detail.safetensors", { type: "application/octet-stream" });
+    const importPanel = container.querySelector(".lora-import-panel");
+    await changeFile(field(importPanel, "Local File"), loraFile);
+    await changeField(field(importPanel, "Name"), "Uploaded Detail");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+    expect(createLoraImportJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({ file: loraFile, name: "Uploaded Detail", scope: "global", family: "z-image" }),
     );
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "New Preset").click();

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -96,9 +96,12 @@ export function PresetManagerScreen({
   const selectedPreset = recipePresets.find((preset) => preset.id === selectedPresetId) ?? null;
   const [form, setForm] = useState(() => formFromPreset(selectedPreset, models[0]?.id));
   const [saving, setSaving] = useState(false);
+  const [importingLora, setImportingLora] = useState(false);
   const [message, setMessage] = useState({ tone: "neutral", text: "" });
-  const [importForm, setImportForm] = useState({ sourceUrl: "", name: "" });
+  const [importForm, setImportForm] = useState({ mode: "url", sourceUrl: "", file: null, name: "" });
+  const [fileInputKey, setFileInputKey] = useState(0);
   const editable = !selectedPreset || selectedPreset.scope !== "builtin";
+  const busy = saving || importingLora;
   const availableModels = modelOptions(models, form.workflow);
   const selectedModel = models.find((model) => model.id === form.model) ?? availableModels[0] ?? null;
   const availableLoras = selectedModel ? loras.filter((lora) => lora.installState !== "missing" && loraMatchesModel(lora, selectedModel)) : [];
@@ -301,14 +304,18 @@ export function PresetManagerScreen({
 
   async function importLora(event) {
     event.preventDefault();
-    if (!importForm.sourceUrl.trim()) {
+    const isFileImport = importForm.mode === "file";
+    if ((!isFileImport && !importForm.sourceUrl.trim()) || (isFileImport && !importForm.file)) {
       return;
     }
-    setSaving(true);
-    setMessage({ tone: "neutral", text: "" });
+    setImportingLora(true);
+    setMessage({
+      tone: "neutral",
+      text: isFileImport ? "Uploading LoRA file before queueing import." : "",
+    });
     try {
       const job = await createLoraImportJob({
-        sourceUrl: importForm.sourceUrl.trim(),
+        ...(isFileImport ? { file: importForm.file } : { sourceUrl: importForm.sourceUrl.trim() }),
         name: importForm.name.trim() || undefined,
         scope: form.scope,
         family: selectedModel?.family ?? undefined,
@@ -322,12 +329,13 @@ export function PresetManagerScreen({
             : [...current.loras, { id: importedId, weight: "0.8" }].slice(0, 3),
         }));
       }
-      setImportForm({ sourceUrl: "", name: "" });
+      setImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
+      setFileInputKey((current) => current + 1);
       setMessage({ tone: "success", text: "LoRA import queued. Save after the import finishes." });
     } catch (err) {
       setMessage({ tone: "error", text: err.message });
     } finally {
-      setSaving(false);
+      setImportingLora(false);
     }
   }
 
@@ -348,10 +356,10 @@ export function PresetManagerScreen({
           <button onClick={startNewPreset} type="button">
             New Preset
           </button>
-          <button disabled={!selectedPreset || saving} onClick={duplicateSelected} type="button">
+          <button disabled={!selectedPreset || busy} onClick={duplicateSelected} type="button">
             Duplicate
           </button>
-          <button disabled={!selectedPreset || selectedPreset.scope === "builtin" || saving} onClick={archiveSelected} type="button">
+          <button disabled={!selectedPreset || selectedPreset.scope === "builtin" || busy} onClick={archiveSelected} type="button">
             Archive
           </button>
         </div>
@@ -533,32 +541,73 @@ export function PresetManagerScreen({
             )}
           </section>
 
-          <section className="lora-import-panel" aria-label="Import LoRA by URL">
+          <section className="lora-import-panel" aria-label="Import LoRA">
             <div>
-              <strong>Import LoRA by URL</strong>
-              <span>{selectedModel?.family ?? "choose a model first"}</span>
+              <strong>Import LoRA</strong>
+              <span>{selectedModel?.family ?? selectedModel?.name ?? "choose a model first"}</span>
+            </div>
+            <div className="segmented-control compact-segment" aria-label="LoRA import source">
+              <button
+                className={importForm.mode === "url" ? "active" : ""}
+                disabled={!editable || importingLora}
+                onClick={() => setImportForm((current) => ({ ...current, mode: "url" }))}
+                type="button"
+              >
+                URL
+              </button>
+              <button
+                className={importForm.mode === "file" ? "active" : ""}
+                disabled={!editable || importingLora}
+                onClick={() => setImportForm((current) => ({ ...current, mode: "file" }))}
+                type="button"
+              >
+                Local File
+              </button>
             </div>
             <div className="inline-create">
-              <label>
-                Source URL
-                <input
-                  disabled={!editable || !selectedModel}
-                  onChange={(event) => setImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
-                  placeholder="https://..."
-                  value={importForm.sourceUrl}
-                />
-              </label>
+              {importForm.mode === "url" ? (
+                <label>
+                  Source URL
+                  <input
+                    disabled={!editable || !selectedModel || importingLora}
+                    onChange={(event) => setImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
+                    placeholder="https://..."
+                    value={importForm.sourceUrl}
+                  />
+                </label>
+              ) : (
+                <label>
+                  Local File
+                  <span className="file-picker-row">
+                    <span className="file-upload-button">
+                      Choose
+                      <input
+                        accept=".safetensors,.ckpt,.pt,.bin"
+                        disabled={!editable || !selectedModel || importingLora}
+                        key={fileInputKey}
+                        onChange={(event) => setImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
+                        type="file"
+                      />
+                    </span>
+                    <span className="selected-file-name">{importForm.file?.name ?? "No file selected"}</span>
+                  </span>
+                </label>
+              )}
               <label>
                 Name
                 <input
-                  disabled={!editable || !selectedModel}
+                  disabled={!editable || !selectedModel || importingLora}
                   onChange={(event) => setImportForm((current) => ({ ...current, name: event.target.value }))}
                   placeholder="Optional"
                   value={importForm.name}
                 />
               </label>
-              <button disabled={!editable || saving || !selectedModel || !importForm.sourceUrl.trim()} onClick={importLora} type="button">
-                Queue Import
+              <button
+                disabled={!editable || busy || !selectedModel || (importForm.mode === "url" ? !importForm.sourceUrl.trim() : !importForm.file)}
+                onClick={importLora}
+                type="button"
+              >
+                {importingLora && importForm.mode === "file" ? "Uploading" : "Queue Import"}
               </button>
             </div>
             {!selectedModel ? <p className="helper-copy">Choose a model before importing so compatibility can be recorded.</p> : null}
@@ -566,7 +615,7 @@ export function PresetManagerScreen({
 
           {saveDisabledReason ? <p className="inline-warning">{saveDisabledReason}</p> : null}
           {message.text ? <p className={message.tone === "success" ? "inline-success" : "inline-warning"}>{message.text}</p> : null}
-          <button className="primary-action" disabled={Boolean(saveDisabledReason) || saving} type="submit">
+          <button className="primary-action" disabled={Boolean(saveDisabledReason) || busy} type="submit">
             {selectedPreset ? "Save Preset" : "Create Preset"}
           </button>
         </form>

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -330,6 +330,7 @@ export function PresetManagerScreen({
         }));
       }
       setImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
+      // Force a re-mount so choosing the same file again still emits a change event.
       setFileInputKey((current) => current + 1);
       setMessage({ tone: "success", text: "LoRA import queued. Save after the import finishes." });
     } catch (err) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -343,6 +343,22 @@ button:disabled {
   pointer-events: none;
 }
 
+.file-picker-row {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+}
+
+.selected-file-name {
+  min-width: 0;
+  color: #aaa397;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .segmented-control button.active,
 .rating-row button.active {
   border-color: #6ec6b8;


### PR DESCRIPTION
## Summary
- Adds multipart LoRA uploads to `/api/v1/loras/import`, streaming the uploaded file into a staged server path and queueing the normal `lora_import` job with `sourcePath`.
- Keeps URL imports on the existing JSON path and preserves URL validation, family validation, scope handling, manifest payloads, and project/global targets.
- Updates the Preset Manager import panel with URL vs Local File modes, upload progress/disabled duplicate submit state, and file-selection UI.
- Cleans staged local upload files after the Rust worker finishes, fails, or cancels the LoRA import job.

## Validation
- `cargo test -p sceneworks-rust-api --lib`
- `cargo test -p sceneworks-rust-worker --lib`
- `npm test` in `apps/web`
- `npm run build` in `apps/web`
- Browser sanity check of the Preset Manager Local File import mode at `http://localhost:5177`