### PR TITLE
[codex] Keep queued actions in context

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -202,6 +202,9 @@ export function App() {
       if (job.status === "completed" && job.projectId && job.type === "person_detect") {
         refreshAssets(job.projectId);
       }
+      if (job.status === "completed" && job.type === "model_download") {
+        refreshData();
+      }
       if (job.status === "failed") {
         setError(failedJobNotice(job));
       }
@@ -592,10 +595,10 @@ export function App() {
   async function createImageJob(payload) {
     if (!activeProject) {
       setError("Create or open a project first.");
-      return;
+      return null;
     }
     try {
-      await apiFetch("/api/v1/image/jobs", token, {
+      const job = await apiFetch("/api/v1/image/jobs", token, {
         method: "POST",
         body: JSON.stringify({
           ...payload,
@@ -604,11 +607,13 @@ export function App() {
           requestedGpu,
         }),
       });
-      setActiveView("Queue");
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
       refreshData();
+      return job;
     } catch (err) {
       setError(err.message);
+      return null;
     }
   }
 
@@ -766,7 +771,7 @@ export function App() {
   }
 
   async function createVideoJob(payload, options = {}) {
-    const { navigateToQueue = true } = options;
+    const { navigateToQueue = false } = options;
     if (!activeProject) {
       setError("Create or open a project first.");
       return null;
@@ -784,6 +789,7 @@ export function App() {
       if (navigateToQueue) {
         setActiveView("Queue");
       }
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
       refreshData();
       return job;
@@ -1076,15 +1082,17 @@ export function App() {
 
   async function createModelDownloadJob(model) {
     try {
-      await apiFetch(`/api/v1/models/${model.id}/download`, token, {
+      const job = await apiFetch(`/api/v1/models/${model.id}/download`, token, {
         method: "POST",
         body: JSON.stringify({ requestedGpu: "auto" }),
       });
-      setActiveView("Queue");
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
       refreshData();
+      return job;
     } catch (err) {
       setError(err.message);
+      return null;
     }
   }
 
@@ -1233,9 +1241,11 @@ export function App() {
             createImageJob={createImageJob}
             gpuOptions={gpuOptions}
             imageModels={imageModels}
+            jobs={jobs}
             latestAssets={latestImageAssets}
             launchRequest={studioLaunch}
             loras={loras}
+            onOpenQueue={() => setActiveView("Queue")}
             onPreview={setPreviewAsset}
             recipePresets={recipePresets}
             requestedGpu={requestedGpu}
@@ -1262,6 +1272,7 @@ export function App() {
             launchRequest={studioLaunch}
             loras={loras}
             jobs={jobs}
+            onOpenQueue={() => setActiveView("Queue")}
             onPreview={setPreviewAsset}
             personTracks={personTracks}
             recipePresets={recipePresets}
@@ -1308,7 +1319,13 @@ export function App() {
         ) : null}
 
         {activeView === "Models" ? (
-          <ModelManagerScreen jobs={jobs} loras={loras} models={models} onDownloadModel={createModelDownloadJob} />
+          <ModelManagerScreen
+            jobs={jobs}
+            loras={loras}
+            models={models}
+            onDownloadModel={createModelDownloadJob}
+            onOpenQueue={() => setActiveView("Queue")}
+          />
         ) : null}
 
         {activeView === "Editor" ? (

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1316,6 +1316,7 @@ export function App() {
             latestAssets={latestVideoAssets}
             launchRequest={studioLaunch}
             loras={loras}
+            jobs={jobs}
             localJobs={videoLocalJobs}
             onLocalJobCreated={(job) => rememberLocalGenerationJob("video", job)}
             onOpenQueue={() => setActiveView("Queue")}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -40,6 +40,8 @@ function failedJobNotice(job) {
   return `${label}: ${detail}`;
 }
 
+const localJobStackLimit = 4;
+
 export function App() {
   const [health, setHealth] = useState(null);
   const [access, setAccess] = useState({ authRequired: false });
@@ -49,6 +51,7 @@ export function App() {
   const [activeView, setActiveView] = useState("Library");
   const [projectName, setProjectName] = useState("");
   const [jobs, setJobs] = useState([]);
+  const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [] });
   const [workers, setWorkers] = useState([]);
   const [queueSummary, setQueueSummary] = useState(null);
   const [models, setModels] = useState([]);
@@ -68,6 +71,8 @@ export function App() {
   const [previewAsset, setPreviewAsset] = useState(null);
   const [studioLaunch, setStudioLaunch] = useState(null);
   const [error, setError] = useState("");
+  const activeViewRef = useRef(activeView);
+  const localGenerationJobIdsRef = useRef(localGenerationJobIds);
   const selectedTimelineIdRef = useRef(null);
   const timelineApplyQueueRef = useRef(Promise.resolve());
 
@@ -90,6 +95,14 @@ export function App() {
   );
   const latestImageAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "image"), [latestAssets]);
   const latestVideoAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "video"), [latestAssets]);
+  const imageLocalJobs = useMemo(
+    () => localGenerationJobIds.image.map((id) => jobs.find((job) => job.id === id)).filter(Boolean),
+    [jobs, localGenerationJobIds.image],
+  );
+  const videoLocalJobs = useMemo(
+    () => localGenerationJobIds.video.map((id) => jobs.find((job) => job.id === id)).filter(Boolean),
+    [jobs, localGenerationJobIds.video],
+  );
   const queueCounts = useMemo(() => {
     if (queueSummary?.counts) {
       return {
@@ -126,6 +139,14 @@ export function App() {
     () => assets.filter((asset) => ["image", "video", "upload", "frame", "render"].includes(asset.type)),
     [assets],
   );
+
+  useEffect(() => {
+    activeViewRef.current = activeView;
+  }, [activeView]);
+
+  useEffect(() => {
+    localGenerationJobIdsRef.current = localGenerationJobIds;
+  }, [localGenerationJobIds]);
 
   useEffect(() => {
     selectedTimelineIdRef.current = selectedTimelineId;
@@ -205,7 +226,7 @@ export function App() {
       if (job.status === "completed" && job.type === "model_download") {
         refreshData();
       }
-      if (job.status === "failed") {
+      if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
         setError(failedJobNotice(job));
       }
     }
@@ -615,6 +636,29 @@ export function App() {
       setError(err.message);
       return null;
     }
+  }
+
+  function rememberLocalGenerationJob(kind, job) {
+    if (!job?.id) {
+      return;
+    }
+    setLocalGenerationJobIds((current) => ({
+      ...current,
+      // Keep the local review stack compact for burst submissions.
+      [kind]: [job.id, ...current[kind].filter((id) => id !== job.id)].slice(0, localJobStackLimit),
+    }));
+  }
+
+  function hasVisibleLocalFailure(job) {
+    const active = activeViewRef.current;
+    const localIds = localGenerationJobIdsRef.current;
+    if (active === "Image" && localIds.image.includes(job.id)) {
+      return true;
+    }
+    if (active === "Video" && localIds.video.includes(job.id)) {
+      return true;
+    }
+    return active === "Models" && job.type === "model_download";
   }
 
   async function withCharacterApi(callback) {
@@ -1241,10 +1285,11 @@ export function App() {
             createImageJob={createImageJob}
             gpuOptions={gpuOptions}
             imageModels={imageModels}
-            jobs={jobs}
             latestAssets={latestImageAssets}
             launchRequest={studioLaunch}
             loras={loras}
+            localJobs={imageLocalJobs}
+            onLocalJobCreated={(job) => rememberLocalGenerationJob("image", job)}
             onOpenQueue={() => setActiveView("Queue")}
             onPreview={setPreviewAsset}
             recipePresets={recipePresets}
@@ -1271,7 +1316,8 @@ export function App() {
             latestAssets={latestVideoAssets}
             launchRequest={studioLaunch}
             loras={loras}
-            jobs={jobs}
+            localJobs={videoLocalJobs}
+            onLocalJobCreated={(job) => rememberLocalGenerationJob("video", job)}
             onOpenQueue={() => setActiveView("Queue")}
             onPreview={setPreviewAsset}
             personTracks={personTracks}

--- a/apps/web/src/components/JobProgress.jsx
+++ b/apps/web/src/components/JobProgress.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { formatSeconds, percent } from "../formatting.js";
+
+const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
+
+function formatJobType(type) {
+  return String(type ?? "job").replaceAll("_", " ");
+}
+
+function jobTitle(job) {
+  return job.payload?.prompt ?? job.payload?.modelName ?? job.payload?.modelId ?? job.id;
+}
+
+function jobMessage(job) {
+  if (job.error || job.message) {
+    return job.error ?? job.message;
+  }
+  if (job.status === "queued") {
+    return "Queued and waiting for an eligible worker.";
+  }
+  if (job.stage && job.stage !== job.status) {
+    return `Stage: ${formatJobType(job.stage)}.`;
+  }
+  return "";
+}
+
+export function JobProgressCard({ job, label, onOpenQueue }) {
+  const isError = localErrorStatuses.has(job.status);
+  const progressLabel = percent(job.progress);
+  const message = jobMessage(job);
+  return (
+    <article className={`local-job-card ${job.status}`}>
+      <div className="local-job-main">
+        <div>
+          <p className="eyebrow">{label ?? formatJobType(job.type)}</p>
+          <h3>{jobTitle(job)}</h3>
+        </div>
+        <span className="status-badge">{job.status}</span>
+      </div>
+      <div className="progress-track" aria-label={`${progressLabel} complete`}>
+        <span style={{ width: progressLabel }} />
+      </div>
+      <div className="job-meta">
+        <span>{formatJobType(job.stage ?? job.status)}</span>
+        <span>{formatSeconds(job.elapsedSeconds)}</span>
+        <span>GPU {job.assignedGpu ?? job.requestedGpu ?? "auto"}</span>
+      </div>
+      {message ? <p className={isError ? "job-message error-text" : "job-message"}>{message}</p> : null}
+      {isError && onOpenQueue ? (
+        <button className="secondary-action" onClick={onOpenQueue} type="button">
+          Open Queue
+        </button>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/src/components/JobProgress.jsx
+++ b/apps/web/src/components/JobProgress.jsx
@@ -4,7 +4,8 @@ import { formatSeconds, percent } from "../formatting.js";
 const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
 
 function formatJobType(type) {
-  return String(type ?? "job").replaceAll("_", " ");
+  const label = String(type ?? "job").replaceAll("_", " ");
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
 function jobTitle(job) {
@@ -17,6 +18,9 @@ function jobMessage(job) {
   }
   if (job.status === "queued") {
     return "Queued and waiting for an eligible worker.";
+  }
+  if (job.status === "completed") {
+    return "Finished. Fetching result...";
   }
   if (job.stage && job.stage !== job.status) {
     return `Stage: ${formatJobType(job.stage)}.`;
@@ -35,7 +39,7 @@ export function JobProgressCard({ job, label, onOpenQueue }) {
           <p className="eyebrow">{label ?? formatJobType(job.type)}</p>
           <h3>{jobTitle(job)}</h3>
         </div>
-        <span className="status-badge">{job.status}</span>
+        <span className={`status-badge ${job.status}`}>{job.status}</span>
       </div>
       <div className="progress-track" aria-label={`${progressLabel} complete`}>
         <span style={{ width: progressLabel }} />
@@ -46,9 +50,9 @@ export function JobProgressCard({ job, label, onOpenQueue }) {
         <span>GPU {job.assignedGpu ?? job.requestedGpu ?? "auto"}</span>
       </div>
       {message ? <p className={isError ? "job-message error-text" : "job-message"}>{message}</p> : null}
-      {isError && onOpenQueue ? (
+      {onOpenQueue ? (
         <button className="secondary-action" onClick={onOpenQueue} type="button">
-          Open Queue
+          {isError ? "Open Queue" : "View in Queue"}
         </button>
       ) : null}
     </article>

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -158,6 +158,204 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("V1 placeholder tracking");
   });
 
+  it("keeps image generation in the studio and shows local progress", async () => {
+    const createdJobs = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/image/jobs") && options.method === "POST") {
+        const job = {
+          id: "image-job-1",
+          type: "image_generate",
+          status: "running",
+          stage: "running",
+          progress: 0.35,
+          elapsedSeconds: 4,
+          projectId: "project-1",
+          projectName: "Noir",
+          requestedGpu: "auto",
+          payload: { prompt: "A cinematic frame of a neon street at midnight" },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image").click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Image generation");
+    expect(container.textContent).toContain("running");
+    expect(container.textContent).not.toContain("Jobs and GPUs");
+  });
+
+  it("keeps video generation in the studio and shows local progress", async () => {
+    const createdJobs = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "ltx_2_3",
+              name: "LTX",
+              type: "video",
+              capabilities: ["image_to_video", "text_to_video"],
+              defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+              limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/video/jobs") && options.method === "POST") {
+        const job = {
+          id: "video-job-1",
+          type: "video_generate",
+          status: "queued",
+          stage: "queued",
+          progress: 0,
+          elapsedSeconds: 0,
+          projectId: "project-1",
+          projectName: "Noir",
+          requestedGpu: "auto",
+          payload: { prompt: "Camera slowly pushes in while the scene comes alive" },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Video").click();
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Text to Video").click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".video-studio form").requestSubmit();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Video generation");
+    expect(container.textContent).toContain("queued");
+    expect(container.textContent).not.toContain("Jobs and GPUs");
+  });
+
+  it("keeps model downloads on the Models page and shows local progress", async () => {
+    const createdJobs = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "z_image_turbo",
+              name: "Z-Image Turbo",
+              type: "image",
+              family: "z-image",
+              downloadable: true,
+              installState: "missing",
+              downloadSizeLabel: "12 GB",
+              downloads: [{ provider: "huggingface", repo: "Tongyi-MAI/Z-Image-Turbo" }],
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      if (path.endsWith("/models/z_image_turbo/download") && options.method === "POST") {
+        const job = {
+          id: "download-job-1",
+          type: "model_download",
+          status: "downloading",
+          stage: "downloading",
+          progress: 0.5,
+          elapsedSeconds: 12,
+          requestedGpu: "auto",
+          assignedGpu: "cpu",
+          payload: { modelId: "z_image_turbo", modelName: "Z-Image Turbo" },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Download 12 GB").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Model download");
+    expect(container.textContent).toContain("downloading");
+    expect(container.textContent).not.toContain("Jobs and GPUs");
+  });
+
   it("adds the SSE ticket as a query parameter", () => {
     expect(eventUrl("/api/v1/jobs/events", "stream-ticket")).toContain("ticket=stream-ticket");
   });

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -162,6 +162,80 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("V1 placeholder tracking");
   });
 
+  it("keeps completed Replace Person detections visible in Video Studio", async () => {
+    global.fetch.mockImplementation((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Project One" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "wan_replace",
+              name: "Wan Replace",
+              type: "video",
+              capabilities: ["replace_person", "image_to_video", "text_to_video"],
+              defaults: { duration: 4, fps: 24, resolution: "1280x720", quality: "balanced" },
+              limits: { durations: [4], fps: [24], resolutions: ["1280x720"] },
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "detect-job-1",
+              type: "person_detect",
+              status: "completed",
+              projectId: "project-1",
+              payload: { sourceAssetId: "clip-1" },
+              result: {
+                frameAssetId: "frame-1",
+                detections: [{ id: "person-1", label: "person", confidence: 0.82, box: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 } }],
+              },
+              createdAt: "2026-05-18T22:00:00Z",
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/assets")) {
+        return Promise.resolve(
+          response([
+            { id: "clip-1", type: "video", displayName: "Source Clip", file: { mimeType: "video/mp4" }, status: {} },
+            { id: "frame-1", type: "image", displayName: "Detection Frame", file: { mimeType: "image/png" }, status: {} },
+          ]),
+        );
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Video").click();
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Replace Person").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("1 candidates");
+    expect(container.textContent).not.toContain("No analysis yet");
+  });
+
   it("keeps image generation in the studio and shows local progress", async () => {
     const createdJobs = [];
     global.fetch.mockImplementation((url, options = {}) => {
@@ -741,6 +815,48 @@ describe("SceneWorks app shell", () => {
 
     expect(container.textContent).not.toContain("Finished. Fetching result...");
     expect(container.textContent).not.toContain("No fresh image batch");
+  });
+
+  it("hides completed image progress with stale missing result metadata", async () => {
+    const staleCompletedJob = {
+      id: "image-job-stale",
+      type: "image_generate",
+      status: "completed",
+      stage: "completed",
+      progress: 1,
+      elapsedSeconds: 8,
+      requestedGpu: "auto",
+      updatedAt: "2026-05-18T00:00:00Z",
+      payload: { prompt: "missing result metadata" },
+      result: {},
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={() => {}}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
+          latestAssets={[]}
+          localJobs={[staleCompletedJob]}
+          loras={[]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).not.toContain("Finished. Fetching result...");
+    expect(container.textContent).toContain("No fresh image batch");
   });
 
   it("submits compatible image LoRAs while capping simple user selections at two", async () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -8,9 +8,12 @@ import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
 
 class FakeEventSource {
+  static instances = [];
+
   constructor(url) {
     this.url = url;
     this.listeners = {};
+    FakeEventSource.instances.push(this);
   }
 
   addEventListener(event, handler) {
@@ -70,6 +73,7 @@ describe("SceneWorks app shell", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     container = document.createElement("div");
     document.body.appendChild(container);
+    FakeEventSource.instances = [];
     window.EventSource = FakeEventSource;
     window.localStorage.clear();
     global.fetch = vi.fn((url) => {
@@ -214,6 +218,82 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Image generation");
     expect(container.textContent).toContain("running");
     expect(container.textContent).not.toContain("Jobs and GPUs");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Library").click();
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Image generation");
+    expect(container.textContent).toContain("running");
+  });
+
+  it("shows local generation failures without duplicating the global banner", async () => {
+    const createdJobs = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/image/jobs") && options.method === "POST") {
+        const job = {
+          id: "image-job-1",
+          type: "image_generate",
+          status: "running",
+          stage: "running",
+          progress: 0.25,
+          elapsedSeconds: 3,
+          projectId: "project-1",
+          projectName: "Noir",
+          requestedGpu: "auto",
+          payload: { prompt: "A cinematic frame of a neon street at midnight" },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image").click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({ ...createdJobs[0], status: "failed", stage: "failed", progress: 0.25, error: "Adapter crashed" }),
+      });
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Adapter crashed");
+    expect(container.textContent).not.toContain("image generate: Adapter crashed");
   });
 
   it("keeps video generation in the studio and shows local progress", async () => {
@@ -287,6 +367,18 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Video generation");
     expect(container.textContent).toContain("queued");
     expect(container.textContent).not.toContain("Jobs and GPUs");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Library").click();
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Video").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Video generation");
+    expect(container.textContent).toContain("queued");
   });
 
   it("keeps model downloads on the Models page and shows local progress", async () => {
@@ -543,6 +635,112 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Waiting for model download Qwen Image Edit to finish.");
     expect(container.textContent).toContain("Waiting for dependency job-dependency to finish.");
     expect(container.textContent).toContain("Warm: z_image_turbo");
+  });
+
+  it("ignores duplicate image submits while job creation is in flight", async () => {
+    let resolveJob;
+    const createImageJob = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveJob = resolve;
+        }),
+    );
+    const onLocalJobCreated = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={createImageJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
+          latestAssets={[]}
+          localJobs={[]}
+          loras={[]}
+          onLocalJobCreated={onLocalJobCreated}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+
+    expect(createImageJob).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveJob({ id: "image-job-1" });
+    });
+    await settle();
+
+    expect(onLocalJobCreated).toHaveBeenCalledWith({ id: "image-job-1" });
+  });
+
+  it("keeps completed image progress visible until the generated asset renders", async () => {
+    const completedJob = {
+      id: "image-job-1",
+      type: "image_generate",
+      status: "completed",
+      stage: "completed",
+      progress: 1,
+      elapsedSeconds: 8,
+      requestedGpu: "auto",
+      payload: { prompt: "long alley" },
+      result: { generationSetId: "gen-1", assetIds: ["asset-1"] },
+    };
+    const imageProps = {
+      activeProject: { id: "project-1", name: "Noir" },
+      assets: [],
+      characters: [],
+      createImageJob: () => {},
+      deleteAsset: () => {},
+      gpuOptions: ["auto"],
+      imageModels: [{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }],
+      latestAssets: [],
+      localJobs: [completedJob],
+      loras: [],
+      onPreview: () => {},
+      purgeAsset: () => {},
+      requestedGpu: "auto",
+      selectedAsset: null,
+      setRequestedGpu: () => {},
+      updateAssetStatus: () => {},
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<ImageStudio {...imageProps} />);
+    });
+
+    expect(container.textContent).toContain("Finished. Fetching result...");
+    expect(container.textContent).not.toContain("No fresh image batch");
+
+    const generatedAsset = {
+      id: "asset-1",
+      type: "image",
+      displayName: "Generated Image",
+      generationSetId: "gen-1",
+      status: {},
+    };
+    await act(async () => {
+      root.render(<ImageStudio {...imageProps} assets={[generatedAsset]} latestAssets={[generatedAsset]} />);
+    });
+
+    expect(container.textContent).not.toContain("Finished. Fetching result...");
+    expect(container.textContent).not.toContain("No fresh image batch");
   });
 
   it("submits compatible image LoRAs while capping simple user selections at two", async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetCard } from "../components/assetPanels.jsx";
+import { JobProgressCard } from "../components/JobProgress.jsx";
 import {
   loraMatchesModel,
   loraWeight,
@@ -18,9 +19,11 @@ export function ImageStudio({
   purgeAsset,
   gpuOptions,
   imageModels,
+  jobs = [],
   latestAssets,
   launchRequest,
   loras = [],
+  onOpenQueue,
   onPreview,
   recipePresets = [],
   requestedGpu,
@@ -42,6 +45,7 @@ export function ImageStudio({
   const [characterLookId, setCharacterLookId] = useState("");
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
+  const [localJobIds, setLocalJobIds] = useState([]);
 
   function serializeLora(lora, override = {}) {
     return {
@@ -173,9 +177,13 @@ export function ImageStudio({
     });
   }
 
-  function submit(event) {
+  const localJobs = localJobIds
+    .map((id) => jobs.find((job) => job.id === id))
+    .filter((job) => job && job.status !== "completed");
+
+  async function submit(event) {
     event.preventDefault();
-    createImageJob({
+    const job = await createImageJob({
       mode,
       prompt,
       negativePrompt,
@@ -194,6 +202,9 @@ export function ImageStudio({
         resolution,
       },
     });
+    if (job?.id) {
+      setLocalJobIds((ids) => [job.id, ...ids.filter((id) => id !== job.id)].slice(0, 4));
+    }
   }
 
   return (
@@ -419,6 +430,13 @@ export function ImageStudio({
             <p className="eyebrow">Fresh batch</p>
             <h2>Review</h2>
           </div>
+          {localJobs.length ? (
+            <div className="local-job-stack">
+              {localJobs.map((job) => (
+                <JobProgressCard job={job} key={job.id} label="Image generation" onOpenQueue={onOpenQueue} />
+              ))}
+            </div>
+          ) : null}
           {latestAssets.length ? (
             <div className="review-grid">
               {latestAssets.map((asset) => (
@@ -432,7 +450,7 @@ export function ImageStudio({
                 />
               ))}
             </div>
-          ) : (
+          ) : localJobs.length ? null : (
             <div className="empty-panel">No fresh image batch</div>
           )}
         </section>

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -10,6 +10,8 @@ import {
   presetPromptParts as buildPresetPromptParts,
 } from "../presetUtils.js";
 
+const completedResultFallbackMs = 30000;
+
 export function ImageStudio({
   activeProject,
   assets,
@@ -47,6 +49,7 @@ export function ImageStudio({
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [resultFallbackTick, setResultFallbackTick] = useState(0);
 
   function serializeLora(lora, override = {}) {
     return {
@@ -186,7 +189,37 @@ export function ImageStudio({
     return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
   }
 
-  const localJobs = trackedLocalJobs.filter((job) => job.status !== "completed" || !resultVisible(job));
+  function completedAnchorMs(job) {
+    return Date.parse(job.completedAt ?? job.updatedAt ?? "");
+  }
+
+  function completedWaitExpired(job, nowMs = Date.now()) {
+    const anchorMs = completedAnchorMs(job);
+    return Number.isFinite(anchorMs) && nowMs - anchorMs > completedResultFallbackMs;
+  }
+
+  useEffect(() => {
+    const nowMs = Date.now();
+    const pendingCompletedJobs = trackedLocalJobs.filter(
+      (job) =>
+        job.status === "completed" &&
+        Number.isFinite(completedAnchorMs(job)) &&
+        !resultVisible(job) &&
+        !completedWaitExpired(job, nowMs),
+    );
+    if (!pendingCompletedJobs.length) {
+      return undefined;
+    }
+    const nextDelay = Math.min(
+      ...pendingCompletedJobs.map((job) => Math.max(0, completedResultFallbackMs - (nowMs - completedAnchorMs(job)))),
+    );
+    const timer = window.setTimeout(() => setResultFallbackTick((value) => value + 1), nextDelay + 50);
+    return () => window.clearTimeout(timer);
+  }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
+
+  const localJobs = trackedLocalJobs.filter(
+    (job) => job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job)),
+  );
   const hasReviewContent = Boolean(localJobs.length || latestAssets.length);
 
   async function submit(event) {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -19,10 +19,11 @@ export function ImageStudio({
   purgeAsset,
   gpuOptions,
   imageModels,
-  jobs = [],
   latestAssets,
   launchRequest,
+  localJobs: trackedLocalJobs = [],
   loras = [],
+  onLocalJobCreated,
   onOpenQueue,
   onPreview,
   recipePresets = [],
@@ -45,7 +46,7 @@ export function ImageStudio({
   const [characterLookId, setCharacterLookId] = useState("");
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
-  const [localJobIds, setLocalJobIds] = useState([]);
+  const [submitting, setSubmitting] = useState(false);
 
   function serializeLora(lora, override = {}) {
     return {
@@ -177,33 +178,46 @@ export function ImageStudio({
     });
   }
 
-  const localJobs = localJobIds
-    .map((id) => jobs.find((job) => job.id === id))
-    .filter((job) => job && job.status !== "completed");
+  function resultVisible(job) {
+    if (job.result?.generationSetId) {
+      return latestAssets.some((asset) => asset.generationSetId === job.result.generationSetId);
+    }
+    const assetIds = job.result?.assetIds ?? [];
+    return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
+  }
+
+  const localJobs = trackedLocalJobs.filter((job) => job.status !== "completed" || !resultVisible(job));
+  const hasReviewContent = Boolean(localJobs.length || latestAssets.length);
 
   async function submit(event) {
     event.preventDefault();
-    const job = await createImageJob({
-      mode,
-      prompt,
-      negativePrompt,
-      model,
-      count,
-      seed: seed === "" ? null : Number(seed),
-      width,
-      height,
-      stylePreset,
-      recipePresetId: selectedRecipePreset?.id ?? null,
-      characterId: mode === "character_image" ? characterId || null : null,
-      characterLookId: mode === "character_image" ? characterLookId || null : null,
-      sourceAssetId: mode === "edit_image" ? sourceAssetId || null : null,
-      loras: selectedLoras.map((lora) => serializeLora(lora)),
-      advanced: {
-        resolution,
-      },
-    });
-    if (job?.id) {
-      setLocalJobIds((ids) => [job.id, ...ids.filter((id) => id !== job.id)].slice(0, 4));
+    if (submitting) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const job = await createImageJob({
+        mode,
+        prompt,
+        negativePrompt,
+        model,
+        count,
+        seed: seed === "" ? null : Number(seed),
+        width,
+        height,
+        stylePreset,
+        recipePresetId: selectedRecipePreset?.id ?? null,
+        characterId: mode === "character_image" ? characterId || null : null,
+        characterLookId: mode === "character_image" ? characterLookId || null : null,
+        sourceAssetId: mode === "edit_image" ? sourceAssetId || null : null,
+        loras: selectedLoras.map((lora) => serializeLora(lora)),
+        advanced: {
+          resolution,
+        },
+      });
+      onLocalJobCreated?.(job);
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -418,10 +432,10 @@ export function ImageStudio({
           ) : null}
           <button
             className="primary-action"
-            disabled={!activeProject || !prompt.trim() || (mode === "character_image" && !characterId) || Boolean(presetMissingLoras.length)}
+            disabled={submitting || !activeProject || !prompt.trim() || (mode === "character_image" && !characterId) || Boolean(presetMissingLoras.length)}
             type="submit"
           >
-            Generate
+            {submitting ? "Queueing..." : "Generate"}
           </button>
         </section>
 
@@ -450,7 +464,7 @@ export function ImageStudio({
                 />
               ))}
             </div>
-          ) : localJobs.length ? null : (
+          ) : hasReviewContent ? null : (
             <div className="empty-panel">No fresh image batch</div>
           )}
         </section>

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
+import { JobProgressCard } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
 
-export function ModelManagerScreen({ jobs, loras, models, onDownloadModel }) {
+export function ModelManagerScreen({ jobs, loras, models, onDownloadModel, onOpenQueue }) {
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
   const [familyFilter, setFamilyFilter] = useState(families[0] ?? "all");
   const visibleLoras =
@@ -34,6 +35,15 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel }) {
     );
   }
 
+  function localDownloadFor(model) {
+    return jobs.find(
+      (job) =>
+        job.type === "model_download" &&
+        job.payload?.modelId === model.id &&
+        job.status !== "completed",
+    );
+  }
+
   return (
     <section className="main-surface models-surface">
       <div className="surface-header">
@@ -58,6 +68,8 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel }) {
         {models.map((model) => {
           const downloadJob = activeDownloadFor(model);
           const installed = model.installState === "installed";
+          const localDownloadJob = installed ? null : localDownloadFor(model);
+          const failedDownload = localDownloadJob && terminalStatuses.has(localDownloadJob.status);
           return (
             <article className="model-card" key={model.id}>
               <div>
@@ -80,8 +92,19 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel }) {
                   <dd>{model.downloadSizeLabel ?? "unknown"}</dd>
                 </div>
               </dl>
+              {localDownloadJob ? (
+                <JobProgressCard job={localDownloadJob} label="Model download" onOpenQueue={onOpenQueue} />
+              ) : null}
               <button disabled={installed || !model.downloadable || Boolean(downloadJob)} onClick={() => onDownloadModel(model)} type="button">
-                {downloadJob ? downloadJob.status : installed ? "Ready" : model.downloadSizeLabel ? `Download ${model.downloadSizeLabel}` : "Download"}
+                {downloadJob
+                  ? downloadJob.status
+                  : installed
+                    ? "Ready"
+                    : failedDownload
+                      ? "Retry Download"
+                      : model.downloadSizeLabel
+                        ? `Download ${model.downloadSizeLabel}`
+                        : "Download"}
               </button>
             </article>
           );

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -26,22 +26,8 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel, onOpe
     }
   }, [families.join("|"), familyFilter]);
 
-  function activeDownloadFor(model) {
-    return jobs.find(
-      (job) =>
-        job.type === "model_download" &&
-        job.payload?.modelId === model.id &&
-        !terminalStatuses.has(job.status),
-    );
-  }
-
-  function localDownloadFor(model) {
-    return jobs.find(
-      (job) =>
-        job.type === "model_download" &&
-        job.payload?.modelId === model.id &&
-        job.status !== "completed",
-    );
+  function downloadJobsFor(model) {
+    return jobs.filter((job) => job.type === "model_download" && job.payload?.modelId === model.id);
   }
 
   return (
@@ -66,9 +52,10 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel, onOpe
 
       <div className="model-grid">
         {models.map((model) => {
-          const downloadJob = activeDownloadFor(model);
+          const downloadJobs = downloadJobsFor(model);
+          const downloadJob = downloadJobs.find((job) => !terminalStatuses.has(job.status));
           const installed = model.installState === "installed";
-          const localDownloadJob = installed ? null : localDownloadFor(model);
+          const localDownloadJob = installed ? null : downloadJobs.find((job) => job.status !== "completed");
           const failedDownload = localDownloadJob && terminalStatuses.has(localDownloadJob.status);
           return (
             <article className="model-card" key={model.id}>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
+import { JobProgressCard } from "../components/JobProgress.jsx";
 import {
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
@@ -23,6 +24,7 @@ export function VideoStudio({
   launchRequest,
   loras = [],
   jobs = [],
+  onOpenQueue,
   onPreview,
   personTracks = [],
   recipePresets = [],
@@ -57,6 +59,7 @@ export function VideoStudio({
   const [trackName, setTrackName] = useState("Selected person");
   const [comparisonMode, setComparisonMode] = useState("side_by_side");
   const [abSide, setAbSide] = useState("replacement");
+  const [localJobIds, setLocalJobIds] = useState([]);
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
@@ -228,9 +231,13 @@ export function VideoStudio({
     full_person_replace_outfit: "Full Person, Replace Outfit",
   };
 
-  function submit(event) {
+  const localJobs = localJobIds
+    .map((id) => jobs.find((job) => job.id === id))
+    .filter((job) => job && job.status !== "completed");
+
+  async function submit(event) {
     event.preventDefault();
-    createVideoJob({
+    const job = await createVideoJob({
       mode,
       prompt,
       negativePrompt,
@@ -259,6 +266,9 @@ export function VideoStudio({
         replacementModeLabel: replacementModeLabels[replacementMode],
       },
     });
+    if (job?.id) {
+      setLocalJobIds((ids) => [job.id, ...ids.filter((id) => id !== job.id)].slice(0, 4));
+    }
   }
 
   return (
@@ -510,6 +520,13 @@ export function VideoStudio({
             <p className="eyebrow">Fresh clip</p>
             <h2>Review</h2>
           </div>
+          {localJobs.length ? (
+            <div className="local-job-stack">
+              {localJobs.map((job) => (
+                <JobProgressCard job={job} key={job.id} label="Video generation" onOpenQueue={onOpenQueue} />
+              ))}
+            </div>
+          ) : null}
           {latestAssets.length ? (
             <div className="review-grid video-review-grid">
               {latestAssets.map((asset) => (
@@ -523,7 +540,7 @@ export function VideoStudio({
                 />
               ))}
             </div>
-          ) : (
+          ) : localJobs.length ? null : (
             <div className="empty-panel">No fresh video clip</div>
           )}
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -10,6 +10,8 @@ import {
 } from "../presetUtils.js";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 
+const completedResultFallbackMs = 30000;
+
 export function VideoStudio({
   activeProject,
   assets,
@@ -62,6 +64,7 @@ export function VideoStudio({
   const [comparisonMode, setComparisonMode] = useState("side_by_side");
   const [abSide, setAbSide] = useState("replacement");
   const [submitting, setSubmitting] = useState(false);
+  const [resultFallbackTick, setResultFallbackTick] = useState(0);
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
@@ -241,7 +244,37 @@ export function VideoStudio({
     return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
   }
 
-  const localJobs = trackedLocalJobs.filter((job) => job.status !== "completed" || !resultVisible(job));
+  function completedAnchorMs(job) {
+    return Date.parse(job.completedAt ?? job.updatedAt ?? "");
+  }
+
+  function completedWaitExpired(job, nowMs = Date.now()) {
+    const anchorMs = completedAnchorMs(job);
+    return Number.isFinite(anchorMs) && nowMs - anchorMs > completedResultFallbackMs;
+  }
+
+  useEffect(() => {
+    const nowMs = Date.now();
+    const pendingCompletedJobs = trackedLocalJobs.filter(
+      (job) =>
+        job.status === "completed" &&
+        Number.isFinite(completedAnchorMs(job)) &&
+        !resultVisible(job) &&
+        !completedWaitExpired(job, nowMs),
+    );
+    if (!pendingCompletedJobs.length) {
+      return undefined;
+    }
+    const nextDelay = Math.min(
+      ...pendingCompletedJobs.map((job) => Math.max(0, completedResultFallbackMs - (nowMs - completedAnchorMs(job)))),
+    );
+    const timer = window.setTimeout(() => setResultFallbackTick((value) => value + 1), nextDelay + 50);
+    return () => window.clearTimeout(timer);
+  }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
+
+  const localJobs = trackedLocalJobs.filter(
+    (job) => job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job)),
+  );
   const hasReviewContent = Boolean(localJobs.length || latestAssets.length);
 
   async function submit(event) {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -24,6 +24,8 @@ export function VideoStudio({
   launchRequest,
   loras = [],
   jobs = [],
+  localJobs: trackedLocalJobs = [],
+  onLocalJobCreated,
   onOpenQueue,
   onPreview,
   personTracks = [],
@@ -59,7 +61,7 @@ export function VideoStudio({
   const [trackName, setTrackName] = useState("Selected person");
   const [comparisonMode, setComparisonMode] = useState("side_by_side");
   const [abSide, setAbSide] = useState("replacement");
-  const [localJobIds, setLocalJobIds] = useState([]);
+  const [submitting, setSubmitting] = useState(false);
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
@@ -231,43 +233,56 @@ export function VideoStudio({
     full_person_replace_outfit: "Full Person, Replace Outfit",
   };
 
-  const localJobs = localJobIds
-    .map((id) => jobs.find((job) => job.id === id))
-    .filter((job) => job && job.status !== "completed");
+  function resultVisible(job) {
+    if (job.result?.generationSetId) {
+      return latestAssets.some((asset) => asset.generationSetId === job.result.generationSetId);
+    }
+    const assetIds = job.result?.assetIds ?? [];
+    return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
+  }
+
+  const localJobs = trackedLocalJobs.filter((job) => job.status !== "completed" || !resultVisible(job));
+  const hasReviewContent = Boolean(localJobs.length || latestAssets.length);
 
   async function submit(event) {
     event.preventDefault();
-    const job = await createVideoJob({
-      mode,
-      prompt,
-      negativePrompt,
-      model,
-      duration: Number(duration),
-      fps: Number(fps),
-      width,
-      height,
-      quality,
-      seed: seed === "" ? null : Number(seed),
-      recipePresetId: selectedRecipePreset?.id ?? null,
-      characterId: characterId || null,
-      characterLookId: characterLookId || null,
-      sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,
-      lastFrameAssetId: mode === "first_last_frame" ? lastFrameAssetId || null : null,
-      sourceClipAssetId: ["extend_clip", "replace_person"].includes(mode) ? sourceClipAssetId || null : null,
-      personTrackId: mode === "replace_person" ? personTrackId || null : null,
-      replacementMode: mode === "replace_person" ? replacementMode : "face_only",
-      loras: presetLoraDetails.filter((lora) => !lora.missing),
-      advanced: {
-        resolution,
-        durationHint,
-        recipePresetName: selectedRecipePreset?.name ?? null,
-        recipePresetPrompt: selectedRecipePreset?.prompt ?? null,
-        selectedPersonTrack: selectedTrack ?? null,
-        replacementModeLabel: replacementModeLabels[replacementMode],
-      },
-    });
-    if (job?.id) {
-      setLocalJobIds((ids) => [job.id, ...ids.filter((id) => id !== job.id)].slice(0, 4));
+    if (submitting) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const job = await createVideoJob({
+        mode,
+        prompt,
+        negativePrompt,
+        model,
+        duration: Number(duration),
+        fps: Number(fps),
+        width,
+        height,
+        quality,
+        seed: seed === "" ? null : Number(seed),
+        recipePresetId: selectedRecipePreset?.id ?? null,
+        characterId: characterId || null,
+        characterLookId: characterLookId || null,
+        sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,
+        lastFrameAssetId: mode === "first_last_frame" ? lastFrameAssetId || null : null,
+        sourceClipAssetId: ["extend_clip", "replace_person"].includes(mode) ? sourceClipAssetId || null : null,
+        personTrackId: mode === "replace_person" ? personTrackId || null : null,
+        replacementMode: mode === "replace_person" ? replacementMode : "face_only",
+        loras: presetLoraDetails.filter((lora) => !lora.missing),
+        advanced: {
+          resolution,
+          durationHint,
+          recipePresetName: selectedRecipePreset?.name ?? null,
+          recipePresetPrompt: selectedRecipePreset?.prompt ?? null,
+          selectedPersonTrack: selectedTrack ?? null,
+          replacementModeLabel: replacementModeLabels[replacementMode],
+        },
+      });
+      onLocalJobCreated?.(job);
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -510,8 +525,8 @@ export function VideoStudio({
               Preset cannot run until LoRA import finishes: {presetMissingLoras.map((lora) => lora.id).join(", ")}. Wait for the Queue or choose another preset.
             </p>
           ) : null}
-          <button className="primary-action" disabled={!canSubmit} type="submit">
-            {mode === "replace_person" ? "Replace Person" : "Generate Clip"}
+          <button className="primary-action" disabled={submitting || !canSubmit} type="submit">
+            {submitting ? "Queueing..." : mode === "replace_person" ? "Replace Person" : "Generate Clip"}
           </button>
         </section>
 
@@ -540,7 +555,7 @@ export function VideoStudio({
                 />
               ))}
             </div>
-          ) : localJobs.length ? null : (
+          ) : hasReviewContent ? null : (
             <div className="empty-panel">No fresh video clip</div>
           )}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -600,6 +600,49 @@ button:disabled {
   min-height: 36px;
 }
 
+.local-job-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.local-job-card {
+  display: grid;
+  gap: 9px;
+  border: 1px solid #3c3a34;
+  background: #191815;
+  padding: 12px;
+}
+
+.local-job-card.failed,
+.local-job-card.canceled,
+.local-job-card.interrupted {
+  border-color: #7a4739;
+}
+
+.local-job-main {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: start;
+}
+
+.local-job-main h3 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.secondary-action {
+  justify-self: start;
+  min-height: 34px;
+  border: 1px solid #4b463d;
+  background: #292722;
+  color: #f3f0e8;
+  padding: 7px 10px;
+}
+
 .status-badge.installed {
   border-color: #6ec6b8;
   background: #183f3a;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -628,6 +628,10 @@ button:disabled {
 }
 
 .local-job-main h3 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
   margin: 0;
   font-size: 15px;
   line-height: 1.35;
@@ -646,6 +650,16 @@ button:disabled {
 .status-badge.installed {
   border-color: #6ec6b8;
   background: #183f3a;
+}
+
+.status-badge.completed {
+  color: #6ec6b8;
+}
+
+.status-badge.failed,
+.status-badge.canceled,
+.status-badge.interrupted {
+  color: #e28e78;
 }
 
 .lora-panel {


### PR DESCRIPTION
﻿## Summary
- Stop image generation, video generation, and model downloads from forcing users into the global Queue view.
- Add a shared local job progress card and render it in the Image Review, Video Review, and Models surfaces.
- Refresh model state when model-download jobs complete while keeping Queue available for explicit inspection.

## Shortcut
- https://app.shortcut.com/trefry/story/1324/keep-users-in-context-for-queued-actions

## Validation
- `npm test -- --run`
- `npm run build`
- Local browser smoke check at `http://127.0.0.1:5173` with no console errors.
