### PR TITLE
[codex] Add LoRA imports to Models page

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -41,6 +41,7 @@ function failedJobNotice(job) {
 }
 
 const localJobStackLimit = 4;
+const maxLoraUploadBytes = 2 * 1024 * 1024 * 1024;
 
 export function App() {
   const [health, setHealth] = useState(null);
@@ -228,6 +229,7 @@ export function App() {
       }
       if (job.status === "completed" && job.type === "lora_import") {
         refreshData();
+        // refreshData loads the global catalog; project imports need the project overlay too.
         if (job.projectId) {
           refreshLoras(job.projectId);
         }
@@ -436,6 +438,9 @@ export function App() {
       throw new Error("Create or open a project first.");
     }
     const { file, ...metadata } = payload;
+    if (file?.size > maxLoraUploadBytes) {
+      throw new Error("Uploaded LoRA file exceeds the 2GB limit");
+    }
     let body;
     if (file) {
       body = new FormData();
@@ -460,7 +465,8 @@ export function App() {
       method: "POST",
       body,
     });
-    if (options.navigateToQueue ?? true) {
+    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    if (options.navigateToQueue ?? false) {
       setActiveView("Queue");
     }
     setError("");
@@ -1380,7 +1386,7 @@ export function App() {
             loras={loras}
             models={models}
             onDownloadModel={createModelDownloadJob}
-            onImportLora={(payload) => createLoraImportJob(payload, { navigateToQueue: false })}
+            onImportLora={createLoraImportJob}
             onOpenQueue={() => setActiveView("Queue")}
           />
         ) : null}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -226,6 +226,12 @@ export function App() {
       if (job.status === "completed" && job.type === "model_download") {
         refreshData();
       }
+      if (job.status === "completed" && job.type === "lora_import") {
+        refreshData();
+        if (job.projectId) {
+          refreshLoras(job.projectId);
+        }
+      }
       if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
         setError(failedJobNotice(job));
       }
@@ -425,7 +431,7 @@ export function App() {
     return archived;
   }
 
-  async function createLoraImportJob(payload) {
+  async function createLoraImportJob(payload, options = {}) {
     if (payload.scope === "project" && !activeProject) {
       throw new Error("Create or open a project first.");
     }
@@ -454,7 +460,9 @@ export function App() {
       method: "POST",
       body,
     });
-    setActiveView("Queue");
+    if (options.navigateToQueue ?? true) {
+      setActiveView("Queue");
+    }
     setError("");
     refreshData();
     return job;
@@ -1367,10 +1375,12 @@ export function App() {
 
         {activeView === "Models" ? (
           <ModelManagerScreen
+            activeProject={activeProject}
             jobs={jobs}
             loras={loras}
             models={models}
             onDownloadModel={createModelDownloadJob}
+            onImportLora={(payload) => createLoraImportJob(payload, { navigateToQueue: false })}
             onOpenQueue={() => setActiveView("Queue")}
           />
         ) : null}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -523,6 +523,166 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Jobs and GPUs");
   });
 
+  it("keeps LoRA imports on the Models page and shows local progress", async () => {
+    const createdJobs = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      if (path.endsWith("/loras/import") && options.method === "POST") {
+        const job = {
+          id: "lora-import-job-1",
+          type: "lora_import",
+          status: "running",
+          stage: "downloading",
+          progress: 0.25,
+          payload: { loraId: "detail_lora" },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
+    });
+    await settle();
+    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("LoRA imports in progress");
+    expect(container.textContent).toContain("running");
+    expect(container.textContent).not.toContain("Jobs and GPUs");
+  });
+
+  it("rejects oversized LoRA uploads before posting from the Models page", async () => {
+    let importCalls = 0;
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/loras/import") && options.method === "POST") {
+        importCalls += 1;
+        return Promise.resolve(response({ id: "should-not-create" }));
+      }
+      return Promise.resolve(response([]));
+    });
+    const loraFile = new File(["lora"], "too-large.safetensors", { type: "application/octet-stream" });
+    Object.defineProperty(loraFile, "size", { configurable: true, value: 2 * 1024 * 1024 * 1024 + 1 });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Upload").click();
+    });
+    await changeFile(field(container, "LoRA File"), loraFile);
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(container.textContent).toContain("Uploaded LoRA file exceeds the 2GB limit");
+    expect(importCalls).toBe(0);
+  });
+
+  it("keeps Preset Manager LoRA imports in context", async () => {
+    const createdJobs = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/recipe-presets")) {
+        return Promise.resolve(
+          response([{ id: "moody", name: "Moody", scope: "global", workflow: "text_to_image", model: "z_image_turbo" }]),
+        );
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      if (path.endsWith("/loras/import") && options.method === "POST") {
+        const job = {
+          id: "lora-import-job-1",
+          type: "lora_import",
+          status: "running",
+          payload: { loraId: "preset_detail" },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Presets").click();
+    });
+    await settle();
+    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Preset Manager");
+    expect(createdJobs).toHaveLength(1);
+    expect(container.textContent).not.toContain("Jobs and GPUs");
+  });
+
   it("queues LoRA URL imports from the Models page", async () => {
     const onImportLora = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "detail_lora" } }));
     root = createRoot(container);
@@ -602,6 +762,34 @@ describe("SceneWorks app shell", () => {
     );
     expect(container.textContent).toContain("LoRA import");
     expect(container.textContent).toContain("running");
+  });
+
+  it("shows Models page LoRA import errors and resets the queueing state", async () => {
+    const onImportLora = vi.fn(async () => {
+      throw new Error("LoRA sourceUrl must use http or https");
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={[]}
+          loras={[]}
+          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={onImportLora}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    await changeField(field(container, "Source URL"), "file:///tmp/detail.safetensors");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(container.textContent).toContain("LoRA sourceUrl must use http or https");
+    expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").disabled).toBe(false);
   });
 
   it("adds the SSE ticket as a query parameter", () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
+import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
@@ -520,6 +521,87 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Model download");
     expect(container.textContent).toContain("downloading");
     expect(container.textContent).not.toContain("Jobs and GPUs");
+  });
+
+  it("queues LoRA URL imports from the Models page", async () => {
+    const onImportLora = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "detail_lora" } }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={[]}
+          loras={[]}
+          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={onImportLora}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await changeField(field(container, "Name"), "Detail LoRA");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(onImportLora).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceUrl: "https://example.com/loras/detail.safetensors",
+        name: "Detail LoRA",
+        scope: "global",
+        family: "z-image",
+      }),
+    );
+    expect(container.textContent).toContain("LoRA import queued for detail_lora.");
+  });
+
+  it("queues LoRA file uploads from the Models page with project scope", async () => {
+    const onImportLora = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "uploaded_detail" } }));
+    const loraFile = new File(["lora"], "detail.safetensors", { type: "application/octet-stream" });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={[
+            {
+              id: "lora-import-job-1",
+              type: "lora_import",
+              status: "running",
+              stage: "downloading",
+              progress: 0.3,
+              payload: { loraId: "existing_import" },
+            },
+          ]}
+          loras={[]}
+          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={onImportLora}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Upload").click();
+    });
+    await changeField(field(container, "Scope"), "project");
+    await changeFile(field(container, "LoRA File"), loraFile);
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(onImportLora).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file: loraFile,
+        scope: "project",
+        family: "z-image",
+      }),
+    );
+    expect(container.textContent).toContain("LoRA import");
+    expect(container.textContent).toContain("running");
   });
 
   it("adds the SSE ticket as a query parameter", () => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -4,6 +4,7 @@ import { terminalStatuses } from "../constants.js";
 
 export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownloadModel, onImportLora, onOpenQueue }) {
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
+  const familiesKey = families.join("|");
   const [familyFilter, setFamilyFilter] = useState(families[0] ?? "all");
   const [importingLora, setImportingLora] = useState(false);
   const [importMessage, setImportMessage] = useState({ tone: "neutral", text: "" });
@@ -35,7 +36,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
     if (familyFilter !== "all" && !families.includes(familyFilter)) {
       setFamilyFilter(families[0] ?? "all");
     }
-  }, [families.join("|"), familyFilter]);
+  }, [familiesKey, familyFilter]);
 
   useEffect(() => {
     setImportForm((current) => {
@@ -45,7 +46,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
       const family = familyFilter !== "all" && families.includes(familyFilter) ? familyFilter : families[0] ?? "";
       return { ...current, family };
     });
-  }, [families.join("|"), familyFilter]);
+  }, [familiesKey, familyFilter]);
 
   function downloadJobsFor(model) {
     return jobs.filter((job) => job.type === "model_download" && job.payload?.modelId === model.id);
@@ -71,6 +72,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
       });
       const loraId = job?.payload?.loraId;
       setImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
+      // Force a re-mount so choosing the same file again still emits a change event.
       setFileInputKey((current) => current + 1);
       setImportMessage({
         tone: "success",
@@ -260,16 +262,19 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
               />
             </label>
             <button disabled={importDisabled} type="submit">
-              {importingLora && isFileImport ? "Uploading" : "Queue Import"}
+              {importingLora ? (isFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
             </button>
           </div>
           {importForm.scope === "project" && !activeProject ? <p className="helper-copy">Open a project before importing a project LoRA.</p> : null}
           {importMessage.text ? <p className={importMessage.tone === "success" ? "inline-success" : "inline-warning"}>{importMessage.text}</p> : null}
           {activeLoraImportJobs.length ? (
-            <div className="local-job-stack">
-              {activeLoraImportJobs.map((job) => (
-                <JobProgressCard job={job} key={job.id} label="LoRA import" onOpenQueue={onOpenQueue} />
-              ))}
+            <div className="lora-import-progress">
+              <strong>LoRA imports in progress</strong>
+              <div className="local-job-stack">
+                {activeLoraImportJobs.map((job) => (
+                  <JobProgressCard job={job} key={job.id} label="LoRA import" onOpenQueue={onOpenQueue} />
+                ))}
+              </div>
             </div>
           ) : null}
         </form>

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -2,9 +2,20 @@ import React, { useEffect, useState } from "react";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
 
-export function ModelManagerScreen({ jobs, loras, models, onDownloadModel, onOpenQueue }) {
+export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownloadModel, onImportLora, onOpenQueue }) {
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
   const [familyFilter, setFamilyFilter] = useState(families[0] ?? "all");
+  const [importingLora, setImportingLora] = useState(false);
+  const [importMessage, setImportMessage] = useState({ tone: "neutral", text: "" });
+  const [importForm, setImportForm] = useState({
+    mode: "url",
+    sourceUrl: "",
+    file: null,
+    name: "",
+    scope: "global",
+    family: families[0] ?? "",
+  });
+  const [fileInputKey, setFileInputKey] = useState(0);
   const visibleLoras =
     familyFilter === "all"
       ? loras
@@ -26,9 +37,59 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel, onOpe
     }
   }, [families.join("|"), familyFilter]);
 
+  useEffect(() => {
+    setImportForm((current) => {
+      if (current.family && families.includes(current.family)) {
+        return current;
+      }
+      const family = familyFilter !== "all" && families.includes(familyFilter) ? familyFilter : families[0] ?? "";
+      return { ...current, family };
+    });
+  }, [families.join("|"), familyFilter]);
+
   function downloadJobsFor(model) {
     return jobs.filter((job) => job.type === "model_download" && job.payload?.modelId === model.id);
   }
+
+  async function importLora(event) {
+    event.preventDefault();
+    const isFileImport = importForm.mode === "file";
+    if ((!isFileImport && !importForm.sourceUrl.trim()) || (isFileImport && !importForm.file) || !onImportLora) {
+      return;
+    }
+    setImportingLora(true);
+    setImportMessage({
+      tone: "neutral",
+      text: isFileImport ? "Uploading LoRA file before queueing import." : "",
+    });
+    try {
+      const job = await onImportLora({
+        ...(isFileImport ? { file: importForm.file } : { sourceUrl: importForm.sourceUrl.trim() }),
+        name: importForm.name.trim() || undefined,
+        scope: importForm.scope,
+        family: importForm.family || undefined,
+      });
+      const loraId = job?.payload?.loraId;
+      setImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
+      setFileInputKey((current) => current + 1);
+      setImportMessage({
+        tone: "success",
+        text: loraId ? `LoRA import queued for ${loraId}.` : "LoRA import queued.",
+      });
+    } catch (err) {
+      setImportMessage({ tone: "error", text: err.message });
+    } finally {
+      setImportingLora(false);
+    }
+  }
+
+  const activeLoraImportJobs = jobs.filter((job) => job.type === "lora_import" && !terminalStatuses.has(job.status));
+  const isFileImport = importForm.mode === "file";
+  const importDisabled =
+    importingLora ||
+    !onImportLora ||
+    (importForm.scope === "project" && !activeProject) ||
+    (isFileImport ? !importForm.file : !importForm.sourceUrl.trim());
 
   return (
     <section className="main-surface models-surface">
@@ -99,10 +160,119 @@ export function ModelManagerScreen({ jobs, loras, models, onDownloadModel, onOpe
       </div>
 
       <section className="lora-panel">
-        <div className="section-heading">
-          <p className="eyebrow">LoRAs</p>
-          <h2>{familyFilter === "all" ? "All compatible" : familyFilter}</h2>
+        <div className="lora-panel-header">
+          <div className="section-heading">
+            <p className="eyebrow">LoRAs</p>
+            <h2>{familyFilter === "all" ? "All compatible" : familyFilter}</h2>
+          </div>
+          <span>{visibleLoras.length} installed or pending</span>
         </div>
+        <form className="lora-import-panel models-import-panel" aria-label="Import LoRA" onSubmit={importLora}>
+          <div>
+            <strong>Import LoRA</strong>
+            <span>{importForm.family || "choose a family"}</span>
+          </div>
+          <div className="segmented-control compact-segment" aria-label="LoRA import source">
+            <button
+              className={importForm.mode === "url" ? "active" : ""}
+              disabled={importingLora}
+              onClick={() => setImportForm((current) => ({ ...current, mode: "url" }))}
+              type="button"
+            >
+              URL
+            </button>
+            <button
+              className={importForm.mode === "file" ? "active" : ""}
+              disabled={importingLora}
+              onClick={() => setImportForm((current) => ({ ...current, mode: "file" }))}
+              type="button"
+            >
+              Upload
+            </button>
+          </div>
+          <div className="models-import-grid">
+            <label>
+              Scope
+              <select
+                disabled={importingLora}
+                onChange={(event) => setImportForm((current) => ({ ...current, scope: event.target.value }))}
+                value={importForm.scope}
+              >
+                <option value="global">Global</option>
+                <option disabled={!activeProject} value="project">
+                  Project
+                </option>
+              </select>
+            </label>
+            <label>
+              Family
+              <select
+                disabled={importingLora || !families.length}
+                onChange={(event) => setImportForm((current) => ({ ...current, family: event.target.value }))}
+                value={importForm.family}
+              >
+                {families.length ? (
+                  families.map((family) => (
+                    <option key={family} value={family}>
+                      {family}
+                    </option>
+                  ))
+                ) : (
+                  <option value="">No model families</option>
+                )}
+              </select>
+            </label>
+            {isFileImport ? (
+              <label>
+                LoRA File
+                <span className="file-picker-row">
+                  <span className="file-upload-button">
+                    Choose
+                    <input
+                      accept=".safetensors,.ckpt,.pt,.bin"
+                      disabled={importingLora}
+                      key={fileInputKey}
+                      onChange={(event) => setImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
+                      type="file"
+                    />
+                  </span>
+                  <span className="selected-file-name">{importForm.file?.name ?? "No file selected"}</span>
+                </span>
+              </label>
+            ) : (
+              <label>
+                Source URL
+                <input
+                  disabled={importingLora}
+                  onChange={(event) => setImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
+                  placeholder="https://..."
+                  value={importForm.sourceUrl}
+                />
+              </label>
+            )}
+            <label>
+              Name
+              <input
+                disabled={importingLora}
+                onChange={(event) => setImportForm((current) => ({ ...current, name: event.target.value }))}
+                placeholder="Optional"
+                value={importForm.name}
+              />
+            </label>
+            <button disabled={importDisabled} type="submit">
+              {importingLora && isFileImport ? "Uploading" : "Queue Import"}
+            </button>
+          </div>
+          {importForm.scope === "project" && !activeProject ? <p className="helper-copy">Open a project before importing a project LoRA.</p> : null}
+          {importMessage.text ? <p className={importMessage.tone === "success" ? "inline-success" : "inline-warning"}>{importMessage.text}</p> : null}
+          {activeLoraImportJobs.length ? (
+            <div className="local-job-stack">
+              {activeLoraImportJobs.map((job) => (
+                <JobProgressCard job={job} key={job.id} label="LoRA import" onOpenQueue={onOpenQueue} />
+              ))}
+            </div>
+          ) : null}
+        </form>
         {visibleLoras.length ? (
           <div className="lora-list">
             {visibleLoras.map((lora) => (

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -608,7 +608,7 @@ export function PresetManagerScreen({
                 onClick={importLora}
                 type="button"
               >
-                {importingLora && importForm.mode === "file" ? "Uploading" : "Queue Import"}
+                {importingLora ? (importForm.mode === "file" ? "Uploading" : "Queueing...") : "Queue Import"}
               </button>
             </div>
             {!selectedModel ? <p className="helper-copy">Choose a model before importing so compatibility can be recorded.</p> : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -700,6 +700,11 @@ button:disabled {
   padding: 8px 12px;
 }
 
+.lora-import-progress {
+  display: grid;
+  gap: 8px;
+}
+
 .lora-list {
   display: grid;
   gap: 8px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -668,6 +668,38 @@ button:disabled {
   padding: 14px;
 }
 
+.lora-panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: end;
+}
+
+.lora-panel-header > span {
+  color: #aaa397;
+  font-size: 13px;
+}
+
+.models-import-panel label {
+  display: grid;
+  gap: 7px;
+}
+
+.models-import-grid {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.6fr) minmax(130px, 0.8fr) minmax(220px, 1.7fr) minmax(140px, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.models-import-grid button {
+  min-height: 38px;
+  border: 1px solid #6ec6b8;
+  background: #183f3a;
+  color: #f3f0e8;
+  padding: 8px 12px;
+}
+
 .lora-list {
   display: grid;
   gap: 8px;
@@ -1696,6 +1728,7 @@ button:disabled {
   .job-composer,
   .job-composer.compact,
   .inline-create,
+  .models-import-grid,
   .look-composer {
     grid-template-columns: 1fr;
   }
@@ -1706,6 +1739,11 @@ button:disabled {
   }
 
   .surface-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .lora-panel-header {
     align-items: flex-start;
     flex-direction: column;
   }


### PR DESCRIPTION
﻿## Summary

Adds LoRA import controls directly to the Models page so users can queue LoRA imports from either a source URL or a local upload while choosing global/project scope and model-family compatibility.

## What changed

- Added a Models-page LoRA import panel with URL and upload modes.
- Kept imports initiated from Models on the Models page while showing active LoRA import progress there.
- Refreshed LoRA catalog data when `lora_import` jobs complete.
- Added focused UI coverage for URL imports and local file uploads from the Models page.

## Validation

- `npm test`
- `npm run build`
- `cargo test -p sceneworks-core lora_source_urls_validate_scheme_host_and_filename`
- Browser smoke check on `http://localhost:5175` for the Models LoRA import panel and source toggle behavior.
