### PR TITLE
[codex] Show live GPU utilization in Queue

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2777,6 +2777,7 @@ async fn register_worker(
             gpu_name: payload.gpu_name,
             capabilities: payload.capabilities,
             loaded_models: payload.loaded_models,
+            utilization: payload.utilization,
         })
     })
     .await?;
@@ -2796,6 +2797,7 @@ async fn heartbeat_worker(
             status: payload.status,
             current_job_id: payload.current_job_id,
             loaded_models: payload.loaded_models,
+            utilization: payload.utilization,
         })
     })
     .await?;

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -724,6 +724,7 @@ async fn register_worker(
             gpu_name: Some(gpu.name.clone()),
             capabilities: worker_capabilities(gpu),
             loaded_models: Vec::new(),
+            utilization: None,
             extra: BTreeMap::new(),
         },
     )
@@ -742,6 +743,7 @@ async fn heartbeat(
             status,
             current_job_id: current_job_id.map(str::to_owned),
             loaded_models: Vec::new(),
+            utilization: None,
             extra: BTreeMap::new(),
         },
     )

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -10,7 +10,7 @@ use reqwest::StatusCode;
 use sceneworks_core::contracts::{
     ClaimRequest, ClaimResponse, ContractNumber, JobSnapshot, JobStatus, JobType, JsonObject,
     ProgressRequest, ProgressStage, WorkerCapability, WorkerHeartbeatRequest,
-    WorkerRegisterRequest, WorkerSnapshot, WorkerStatus,
+    WorkerRegisterRequest, WorkerSnapshot, WorkerStatus, WorkerUtilizationSnapshot,
 };
 use sceneworks_core::lora_url::{
     lora_source_url_file_name, lora_source_url_file_stem, parse_lora_source_url_with_private,
@@ -228,11 +228,12 @@ where
     Ok(response.json::<T>().await?)
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 struct DiscoveredGpu {
     id: String,
     name: String,
     capabilities: Vec<WorkerCapability>,
+    utilization: Option<WorkerUtilizationSnapshot>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -467,7 +468,7 @@ async fn query_nvidia_gpus() -> Vec<DiscoveredGpu> {
         Duration::from_secs(3),
         Command::new("nvidia-smi")
             .args([
-                "--query-gpu=index,name,memory.total",
+                "--query-gpu=index,name,memory.total,memory.used,memory.free,utilization.gpu",
                 "--format=csv,noheader,nounits",
             ])
             .output(),
@@ -486,21 +487,56 @@ fn parse_nvidia_smi_gpus(output: &str) -> Vec<DiscoveredGpu> {
         .trim()
         .lines()
         .filter_map(|line| {
-            let parts = line.splitn(3, ',').map(str::trim).collect::<Vec<_>>();
-            let [index, name, memory_mb] = parts.as_slice() else {
+            let parts = line.split(',').map(str::trim).collect::<Vec<_>>();
+            if parts.len() < 3 {
                 return None;
-            };
+            }
+            let index = parts[0];
+            let name = parts[1];
+            let memory_mb = parts[2];
             Some(DiscoveredGpu {
-                id: (*index).to_owned(),
+                id: index.to_owned(),
                 name: format!("{name} ({memory_mb} MB)"),
                 capabilities: vec![
                     WorkerCapability::Placeholder,
                     WorkerCapability::Gpu,
                     WorkerCapability::Unknown("nvidia".to_owned()),
                 ],
+                utilization: utilization_from_parts(&parts),
             })
         })
         .collect()
+}
+
+fn utilization_from_parts(parts: &[&str]) -> Option<WorkerUtilizationSnapshot> {
+    if parts.len() < 6 {
+        return None;
+    }
+    Some(WorkerUtilizationSnapshot {
+        memory_total_mb: parse_u64(parts[2]),
+        memory_used_mb: parse_u64(parts[3]),
+        memory_free_mb: parse_u64(parts[4]),
+        gpu_load_percent: parse_f64(parts[5]),
+    })
+}
+
+fn parse_u64(value: &str) -> Option<u64> {
+    value.parse().ok()
+}
+
+fn parse_f64(value: &str) -> Option<f64> {
+    value.parse().ok()
+}
+
+async fn gpu_utilization(gpu_id: &str) -> Option<WorkerUtilizationSnapshot> {
+    if gpu_id == "cpu" {
+        return None;
+    }
+    query_nvidia_gpus()
+        .await
+        .into_iter()
+        .find(|gpu| gpu.id == gpu_id)
+        .and_then(|gpu| gpu.utilization)
 }
 
 fn visible_gpu_ids_from_env() -> Option<Vec<String>> {
@@ -528,6 +564,7 @@ fn cpu_gpu() -> DiscoveredGpu {
         id: "cpu".to_owned(),
         name: "Rust CPU utility worker".to_owned(),
         capabilities: vec![WorkerCapability::Placeholder, WorkerCapability::Cpu],
+        utilization: None,
     }
 }
 
@@ -536,6 +573,7 @@ fn fallback_gpu(gpu_id: &str) -> DiscoveredGpu {
         id: gpu_id.to_owned(),
         name: format!("GPU {gpu_id}"),
         capabilities: vec![WorkerCapability::Placeholder, WorkerCapability::Gpu],
+        utilization: None,
     }
 }
 
@@ -724,7 +762,7 @@ async fn register_worker(
             gpu_name: Some(gpu.name.clone()),
             capabilities: worker_capabilities(gpu),
             loaded_models: Vec::new(),
-            utilization: None,
+            utilization: gpu.utilization.clone(),
             extra: BTreeMap::new(),
         },
     )
@@ -743,7 +781,7 @@ async fn heartbeat(
             status,
             current_job_id: current_job_id.map(str::to_owned),
             loaded_models: Vec::new(),
-            utilization: None,
+            utilization: gpu_utilization(&settings.gpu_id).await,
             extra: BTreeMap::new(),
         },
     )
@@ -3851,6 +3889,7 @@ mod tests {
     use axum::response::{IntoResponse, Response};
     use axum::routing::{get, post};
     use axum::{Json, Router};
+    use sceneworks_core::contracts::WorkerUtilizationSnapshot;
     use serde_json::{json, Value};
     use tempfile::tempdir;
 
@@ -3901,8 +3940,8 @@ mod tests {
     #[test]
     fn nvidia_smi_parsing_and_visible_device_filtering_match_python_worker() {
         let gpus = parse_nvidia_smi_gpus(
-            "0, NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, 97887\n\
-             1, NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, 97887\n",
+            "0, NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, 97887, 4096, 93791, 12\n\
+             1, NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, 97887, 8192, 89695, 25\n",
         );
 
         assert_eq!(
@@ -3921,6 +3960,15 @@ mod tests {
             .capabilities
             .iter()
             .any(|capability| capability.as_str() == "placeholder"));
+        assert_eq!(
+            gpus[0].utilization,
+            Some(WorkerUtilizationSnapshot {
+                memory_total_mb: Some(97887),
+                memory_used_mb: Some(4096),
+                memory_free_mb: Some(93791),
+                gpu_load_percent: Some(12.0),
+            })
+        );
 
         assert_eq!(visible_gpu_ids(None), None);
         assert_eq!(visible_gpu_ids(Some("all")), None);

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -817,6 +817,7 @@ describe("SceneWorks app shell", () => {
               gpuName: "Fixture GPU 0",
               status: "idle",
               capabilities: ["placeholder", "gpu", "image_generate"],
+              utilization: { memoryTotalMb: 24576, memoryUsedMb: 4096, memoryFreeMb: 20480, gpuLoadPercent: 12 },
             },
             {
               id: "rust-gpu-1",
@@ -857,7 +858,10 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     expect(container.textContent).toContain("Fixture GPU 0");
-    expect(container.textContent).toContain("Rust CPU utility worker");
+    expect(container.textContent).toContain("20.0 GB");
+    expect(container.textContent).toContain("4.0 GB / 24.0 GB");
+    expect(container.textContent).toContain("12%");
+    expect(container.textContent).not.toContain("Rust CPU utility worker");
     expect(container.textContent).not.toContain("Rust placeholder GPU");
     expect(container.textContent).not.toContain("Stale GPU");
     expect([...container.querySelector("#queue-gpu").options].map((option) => option.value)).toEqual(["auto", "0"]);

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -985,6 +985,58 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Warm: z_image_turbo");
   });
 
+  it("updates Queue GPU utilization when worker props change", async () => {
+    const queueProps = {
+      activeProject: { id: "project-1", name: "Project 1" },
+      createJob: (event) => event.preventDefault(),
+      filteredJobs: [],
+      gpuOptions: ["auto", "0"],
+      jobAction: () => {},
+      jobPrompt: "Placeholder generation",
+      projectFilter: "all",
+      projects: [{ id: "project-1", name: "Project 1" }],
+      requestedGpu: "auto",
+      setJobPrompt: () => {},
+      setProjectFilter: () => {},
+      setRequestedGpu: () => {},
+    };
+    const worker = {
+      id: "python-gpu-0",
+      gpuId: "0",
+      gpuName: "Fixture GPU 0",
+      status: "idle",
+      capabilities: ["placeholder", "gpu", "image_generate"],
+      loadedModels: [],
+      utilization: { memoryTotalMb: 24576, memoryUsedMb: 4096, memoryFreeMb: 20480, gpuLoadPercent: 12 },
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<QueueScreen {...queueProps} workers={[worker]} />);
+    });
+
+    expect(container.textContent).toContain("20.0 GB");
+    expect(container.textContent).toContain("12%");
+
+    await act(async () => {
+      root.render(
+        <QueueScreen
+          {...queueProps}
+          workers={[
+            {
+              ...worker,
+              utilization: { memoryTotalMb: 24576, memoryUsedMb: 12288, memoryFreeMb: 12288, gpuLoadPercent: 67 },
+            },
+          ]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("12.0 GB / 24.0 GB");
+    expect(container.textContent).toContain("67%");
+    expect(container.textContent).not.toContain("20.0 GB");
+  });
+
   it("ignores duplicate image submits while job creation is in flight", async () => {
     let resolveJob;
     const createImageJob = vi.fn(

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -103,6 +103,7 @@ function workerStatusLine(worker) {
 }
 
 function isGpuWorker(worker) {
+  // Queue resource cards are for live GPU capacity; CPU utility workers stay out of this panel.
   return worker.gpuId && worker.gpuId !== "cpu" && Array.isArray(worker.capabilities) && worker.capabilities.includes("gpu");
 }
 
@@ -163,12 +164,16 @@ function WorkerCard({ worker }) {
           <strong>{utilizationLabel(loadPercent)}</strong>
         </span>
       </div>
-      <div className="worker-meter" aria-label={`GPU memory usage ${utilizationLabel(memoryPercent)}`}>
-        <span style={{ width: `${memoryPercent ?? 0}%` }} />
-      </div>
-      <div className="worker-meter gpu-load" aria-label={`GPU load ${utilizationLabel(loadPercent)}`}>
-        <span style={{ width: `${loadPercent ?? 0}%` }} />
-      </div>
+      {memoryPercent === null ? null : (
+        <div className="worker-meter" aria-label={`GPU memory usage ${utilizationLabel(memoryPercent)}`}>
+          <span style={{ width: `${memoryPercent}%` }} />
+        </div>
+      )}
+      {loadPercent === null ? null : (
+        <div className="worker-meter gpu-load" aria-label={`GPU load ${utilizationLabel(loadPercent)}`}>
+          <span style={{ width: `${loadPercent}%` }} />
+        </div>
+      )}
       <small>{worker.loadedModels?.length ? `Warm: ${worker.loadedModels.join(", ")}` : "No warm model"}</small>
     </div>
   );

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -102,6 +102,78 @@ function workerStatusLine(worker) {
   return worker.status === "idle" ? "Ready" : worker.status;
 }
 
+function isGpuWorker(worker) {
+  return worker.gpuId && worker.gpuId !== "cpu" && Array.isArray(worker.capabilities) && worker.capabilities.includes("gpu");
+}
+
+function formatMemory(mb) {
+  if (!Number.isFinite(mb)) {
+    return "Unknown";
+  }
+  if (mb >= 1024) {
+    return `${(mb / 1024).toFixed(1)} GB`;
+  }
+  return `${Math.round(mb)} MB`;
+}
+
+function boundedPercent(value) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return Math.min(100, Math.max(0, value));
+}
+
+function memoryUsagePercent(utilization) {
+  const total = Number(utilization?.memoryTotalMb);
+  const used = Number(utilization?.memoryUsedMb);
+  if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(used)) {
+    return null;
+  }
+  return boundedPercent((used / total) * 100);
+}
+
+function utilizationLabel(value) {
+  return Number.isFinite(value) ? `${Math.round(value)}%` : "Unknown";
+}
+
+function WorkerCard({ worker }) {
+  const utilization = worker.utilization ?? {};
+  const memoryPercent = memoryUsagePercent(utilization);
+  const loadPercent = boundedPercent(Number(utilization.gpuLoadPercent));
+  const freeMb = Number(utilization.memoryFreeMb);
+  const usedMb = Number(utilization.memoryUsedMb);
+  const totalMb = Number(utilization.memoryTotalMb);
+  return (
+    <div className="worker-card">
+      <div className="worker-card-header">
+        <strong>{worker.gpuName ?? `GPU ${worker.gpuId}`}</strong>
+        <span>{workerStatusLine(worker)}</span>
+      </div>
+      <div className="worker-stat-grid">
+        <span>
+          <small>Available</small>
+          <strong>{formatMemory(freeMb)}</strong>
+        </span>
+        <span>
+          <small>Memory</small>
+          <strong>{Number.isFinite(usedMb) && Number.isFinite(totalMb) ? `${formatMemory(usedMb)} / ${formatMemory(totalMb)}` : "Unknown"}</strong>
+        </span>
+        <span>
+          <small>Load</small>
+          <strong>{utilizationLabel(loadPercent)}</strong>
+        </span>
+      </div>
+      <div className="worker-meter" aria-label={`GPU memory usage ${utilizationLabel(memoryPercent)}`}>
+        <span style={{ width: `${memoryPercent ?? 0}%` }} />
+      </div>
+      <div className="worker-meter gpu-load" aria-label={`GPU load ${utilizationLabel(loadPercent)}`}>
+        <span style={{ width: `${loadPercent ?? 0}%` }} />
+      </div>
+      <small>{worker.loadedModels?.length ? `Warm: ${worker.loadedModels.join(", ")}` : "No warm model"}</small>
+    </div>
+  );
+}
+
 export function QueueScreen({
   activeProject,
   createJob,
@@ -119,6 +191,7 @@ export function QueueScreen({
   workers,
 }) {
   const workersById = useMemo(() => new Map(workers.map((worker) => [worker.id, worker])), [workers]);
+  const gpuWorkers = useMemo(() => workers.filter(isGpuWorker), [workers]);
   return (
     <section className="main-surface queue-surface">
       <div className="queue-header">
@@ -156,19 +229,13 @@ export function QueueScreen({
       </div>
 
       <div className="worker-grid">
-        {workers.length === 0 ? (
+        {gpuWorkers.length === 0 ? (
           <div className="worker-card">
-            <strong>No workers registered</strong>
-            <span>Start the worker service to claim queued jobs.</span>
+            <strong>No GPU workers registered</strong>
+            <span>Start a GPU worker to claim generation jobs.</span>
           </div>
         ) : (
-          workers.map((worker) => (
-            <div className="worker-card" key={worker.id}>
-              <strong>{worker.gpuName ?? worker.gpuId}</strong>
-              <span>{workerStatusLine(worker)}</span>
-              <small>{worker.loadedModels?.length ? `Warm: ${worker.loadedModels.join(", ")}` : "No warm model"}</small>
-            </div>
-          ))
+          gpuWorkers.map((worker) => <WorkerCard key={worker.id} worker={worker} />)
         )}
       </div>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1575,15 +1575,65 @@ button:disabled {
 
 .worker-card {
   display: grid;
-  gap: 6px;
+  gap: 10px;
   padding: 12px;
   min-width: 0;
+}
+
+.worker-card-header,
+.worker-stat-grid {
+  display: grid;
+  gap: 4px;
+}
+
+.worker-card-header {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+}
+
+.worker-card-header span {
+  color: #6ec6b8;
+  font-size: 12px;
+  text-align: right;
+}
+
+.worker-stat-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.worker-stat-grid span {
+  min-width: 0;
+}
+
+.worker-stat-grid strong {
+  display: block;
+  margin-top: 2px;
+  font-size: 13px;
+  overflow-wrap: anywhere;
 }
 
 .worker-card span,
 .worker-card small {
   color: #aaa397;
   overflow-wrap: anywhere;
+}
+
+.worker-meter {
+  height: 7px;
+  overflow: hidden;
+  background: #191815;
+  border: 1px solid #3c3a34;
+}
+
+.worker-meter span {
+  display: block;
+  height: 100%;
+  background: #6ec6b8;
+  transition: width 180ms ease;
+}
+
+.worker-meter.gpu-load span {
+  background: #d7b46a;
 }
 
 .job-list {

--- a/apps/worker/scene_worker/gpu.py
+++ b/apps/worker/scene_worker/gpu.py
@@ -22,18 +22,39 @@ def cpu_worker_id(base_worker_id: str) -> str:
 def parse_nvidia_smi_gpus(output: str) -> list[dict]:
     gpus = []
     for line in output.strip().splitlines():
-        parts = [part.strip() for part in line.split(",", maxsplit=2)]
-        if len(parts) != 3:
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) < 3:
             continue
-        index, name, memory_mb = parts
-        gpus.append(
-            {
-                "id": index,
-                "name": f"{name} ({memory_mb} MB)",
-                "capabilities": ["gpu", "nvidia"],
+        index, name, memory_mb = parts[:3]
+        gpu = {
+            "id": index,
+            "name": f"{name} ({memory_mb} MB)",
+            "capabilities": ["gpu", "nvidia"],
+        }
+        if len(parts) >= 6:
+            used_mb, free_mb, load_percent = parts[3:6]
+            gpu["utilization"] = {
+                "memoryTotalMb": parse_int(memory_mb),
+                "memoryUsedMb": parse_int(used_mb),
+                "memoryFreeMb": parse_int(free_mb),
+                "gpuLoadPercent": parse_float(load_percent),
             }
-        )
+        gpus.append(gpu)
     return gpus
+
+
+def parse_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_float(value: str) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def query_nvidia_gpus() -> list[dict]:
@@ -41,7 +62,7 @@ def query_nvidia_gpus() -> list[dict]:
         result = subprocess.run(
             [
                 "nvidia-smi",
-                "--query-gpu=index,name,memory.total",
+                "--query-gpu=index,name,memory.total,memory.used,memory.free,utilization.gpu",
                 "--format=csv,noheader,nounits",
             ],
             check=True,
@@ -52,6 +73,15 @@ def query_nvidia_gpus() -> list[dict]:
         return parse_nvidia_smi_gpus(result.stdout)
     except (OSError, subprocess.SubprocessError):
         return []
+
+
+def gpu_utilization(gpu_id: str) -> dict | None:
+    if gpu_id == "cpu":
+        return None
+    for gpu in query_nvidia_gpus():
+        if gpu["id"] == gpu_id:
+            return gpu.get("utilization")
+    return None
 
 
 def visible_gpu_ids() -> list[str] | None:

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 import httpx
 
-from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_worker_id
+from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_utilization, gpu_worker_id
 from .image_adapters import ProceduralImageAdapter, QwenImageAdapter, ZImageDiffusersAdapter, create_image_adapter
 from .settings import WorkerSettings
 from .video_adapters import create_video_adapter
@@ -80,6 +80,8 @@ def register_worker(api: ApiClient, settings: WorkerSettings, gpu: dict, loaded_
         "capabilities": worker_capabilities(gpu),
         "loadedModels": loaded_models or [],
     }
+    if gpu.get("utilization"):
+        payload["utilization"] = gpu["utilization"]
     worker = api.post("/api/v1/workers/register", payload)
     emit({"event": "registered", "worker": worker, "reportedAt": now()})
 
@@ -91,9 +93,13 @@ def heartbeat(
     current_job_id: str | None = None,
     loaded_models: list[str] | None = None,
 ) -> None:
+    payload = {"status": status, "currentJobId": current_job_id, "loadedModels": loaded_models or []}
+    utilization = gpu_utilization(getattr(settings, "gpu_id", "cpu"))
+    if utilization:
+        payload["utilization"] = utilization
     api.post(
         f"/api/v1/workers/{settings.worker_id}/heartbeat",
-        {"status": status, "currentJobId": current_job_id, "loadedModels": loaded_models or []},
+        payload,
     )
 
 

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -432,6 +432,8 @@ pub struct WorkerRegisterRequest {
     pub gpu_name: Option<String>,
     pub capabilities: Vec<WorkerCapability>,
     pub loaded_models: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub utilization: Option<WorkerUtilizationSnapshot>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }
@@ -443,6 +445,8 @@ pub struct WorkerHeartbeatRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_job_id: Option<String>,
     pub loaded_models: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub utilization: Option<WorkerUtilizationSnapshot>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }
@@ -530,10 +534,25 @@ pub struct WorkerSnapshot {
     pub current_job_id: Option<String>,
     pub capabilities: Vec<WorkerCapability>,
     pub loaded_models: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub utilization: Option<WorkerUtilizationSnapshot>,
     pub registered_at: String,
     pub last_seen_at: String,
     #[serde(flatten)]
     pub extra: ExtraFields,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerUtilizationSnapshot {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_total_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_used_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_free_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu_load_percent: Option<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -9,7 +9,7 @@ use serde_json::{Map, Number, Value};
 
 use crate::contracts::{
     ContractNumber, JobSnapshot, JobStatus, JobType, ProgressStage, QueueSummary, WorkerCapability,
-    WorkerSnapshot, WorkerStatus,
+    WorkerSnapshot, WorkerStatus, WorkerUtilizationSnapshot,
 };
 
 pub const ACTIVE_STATUSES: &[&str] = &[
@@ -118,6 +118,7 @@ pub struct RegisterWorker {
     pub gpu_name: Option<String>,
     pub capabilities: Vec<WorkerCapability>,
     pub loaded_models: Vec<String>,
+    pub utilization: Option<WorkerUtilizationSnapshot>,
 }
 
 #[derive(Debug, Clone)]
@@ -126,6 +127,7 @@ pub struct WorkerHeartbeat {
     pub status: WorkerStatus,
     pub current_job_id: Option<String>,
     pub loaded_models: Vec<String>,
+    pub utilization: Option<WorkerUtilizationSnapshot>,
 }
 
 #[derive(Debug, Clone)]
@@ -206,11 +208,13 @@ impl JobsStore {
               current_job_id text,
               capabilities_json text not null,
               loaded_models_json text not null,
+              utilization_json text,
               registered_at text not null,
               last_seen_at text not null
             );
             ",
         )?;
+        ensure_column(&transaction, "workers", "utilization_json", "text")?;
         transaction.commit()?;
         Ok(())
     }
@@ -409,14 +413,15 @@ impl JobsStore {
             "
             insert into workers (
               id, gpu_id, gpu_name, status, current_job_id, capabilities_json,
-              loaded_models_json, registered_at, last_seen_at
-            ) values (?1, ?2, ?3, 'idle', null, ?4, ?5, ?6, ?6)
+              loaded_models_json, utilization_json, registered_at, last_seen_at
+            ) values (?1, ?2, ?3, 'idle', null, ?4, ?5, ?6, ?7, ?7)
             on conflict(id) do update set
               gpu_id = excluded.gpu_id,
               gpu_name = excluded.gpu_name,
               status = case when workers.current_job_id is null then 'idle' else workers.status end,
               capabilities_json = excluded.capabilities_json,
               loaded_models_json = excluded.loaded_models_json,
+              utilization_json = excluded.utilization_json,
               last_seen_at = excluded.last_seen_at
             ",
             params![
@@ -425,6 +430,7 @@ impl JobsStore {
                 request.gpu_name,
                 dumps(&request.capabilities)?,
                 dumps(&request.loaded_models)?,
+                optional_dumps(request.utilization.as_ref())?,
                 now,
             ],
         )?;
@@ -466,13 +472,15 @@ impl JobsStore {
                set status = ?1,
                    current_job_id = ?2,
                    loaded_models_json = ?3,
-                   last_seen_at = ?4
-             where id = ?5
+                   utilization_json = ?4,
+                   last_seen_at = ?5
+             where id = ?6
             ",
             params![
                 request.status.as_str(),
                 request.current_job_id,
                 dumps(&request.loaded_models)?,
+                optional_dumps(request.utilization.as_ref())?,
                 now,
                 request.worker_id,
             ],
@@ -609,6 +617,9 @@ impl JobsStore {
             return Ok(None);
         };
         drop(statement);
+        if should_defer_auto_gpu_claim(&transaction, &queued, &worker)? {
+            return Ok(None);
+        }
 
         let assigned_gpu = if is_non_gpu_job_type(queued.job_type.as_str()) {
             "cpu".to_owned()
@@ -939,6 +950,7 @@ fn row_to_worker(row: &Row<'_>) -> rusqlite::Result<WorkerSnapshot> {
             row.get::<_, Option<String>>("loaded_models_json")?
                 .as_deref(),
         ),
+        utilization: loads_optional(row.get::<_, Option<String>>("utilization_json")?.as_deref()),
         registered_at: row.get("registered_at")?,
         last_seen_at: row.get("last_seen_at")?,
         extra: Default::default(),
@@ -982,6 +994,13 @@ where
     value
         .and_then(|text| serde_json::from_str::<Vec<T>>(text).ok())
         .unwrap_or_default()
+}
+
+fn loads_optional<T>(value: Option<&str>) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    value.and_then(|text| serde_json::from_str::<T>(text).ok())
 }
 
 fn parse_string_enum<T>(value: &str) -> T
@@ -1104,6 +1123,25 @@ fn remove_sqlite_sidecars(db_path: &Path) {
     }
 }
 
+fn ensure_column(
+    connection: &Connection,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> JobsStoreResult<()> {
+    let mut statement = connection.prepare(&format!("pragma table_info({table})"))?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>("name"))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|existing| existing == column) {
+        connection.execute(
+            &format!("alter table {table} add column {column} {definition}"),
+            [],
+        )?;
+    }
+    Ok(())
+}
+
 fn is_active_status(status: &str) -> bool {
     ACTIVE_STATUSES.contains(&status)
 }
@@ -1116,15 +1154,136 @@ fn is_non_gpu_job_type(job_type: &str) -> bool {
     NON_GPU_JOB_TYPES.contains(&job_type)
 }
 
+fn should_defer_auto_gpu_claim(
+    connection: &Connection,
+    job: &JobSnapshot,
+    worker: &WorkerSnapshot,
+) -> JobsStoreResult<bool> {
+    if job.requested_gpu != "auto"
+        || is_non_gpu_job_type(job.job_type.as_str())
+        || worker.gpu_id == "cpu"
+    {
+        return Ok(false);
+    }
+    let current_score = dispatch_score(job, worker);
+    if !current_score.has_utilization {
+        return Ok(false);
+    }
+
+    let mut statement = connection.prepare(
+        "
+        select * from workers
+         where id != ?1
+           and gpu_id != 'cpu'
+           and status = 'idle'
+         order by gpu_id, id
+        ",
+    )?;
+    let candidates = collect_workers(statement.query_map(params![worker.id], row_to_worker)?)?;
+    for candidate in candidates {
+        if !worker_supports_job(&candidate, job)
+            || active_gpu_job_exists(connection, &candidate.gpu_id)?
+        {
+            continue;
+        }
+        let candidate_score = dispatch_score(job, &candidate);
+        if dispatch_score_is_better(candidate_score, current_score) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResult<bool> {
+    Ok(connection
+        .query_row(
+            "
+            select id from jobs
+             where assigned_gpu = ?1
+               and status in ('preparing', 'downloading', 'loading_model', 'running', 'saving')
+               and type not in ('model_download', 'lora_import')
+             limit 1
+            ",
+            params![gpu_id],
+            |_row| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
+    worker
+        .capabilities
+        .iter()
+        .any(|capability| capability.as_str() == job.job_type.as_str())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DispatchScore {
+    has_utilization: bool,
+    free_memory_mb: f64,
+    memory_usage_percent: f64,
+    gpu_load_percent: f64,
+    warm_model: bool,
+}
+
+fn dispatch_score(job: &JobSnapshot, worker: &WorkerSnapshot) -> DispatchScore {
+    let utilization = worker.utilization.as_ref();
+    let total = utilization
+        .and_then(|item| item.memory_total_mb)
+        .unwrap_or(0);
+    let used = utilization
+        .and_then(|item| item.memory_used_mb)
+        .unwrap_or(0);
+    let free = utilization
+        .and_then(|item| item.memory_free_mb)
+        .or_else(|| total.checked_sub(used));
+    let memory_usage_percent = if total > 0 {
+        used as f64 / total as f64 * 100.0
+    } else {
+        0.0
+    };
+    DispatchScore {
+        has_utilization: free.is_some()
+            || utilization.and_then(|item| item.gpu_load_percent).is_some()
+            || total > 0,
+        free_memory_mb: free.unwrap_or(0) as f64,
+        memory_usage_percent,
+        gpu_load_percent: utilization
+            .and_then(|item| item.gpu_load_percent)
+            .unwrap_or(0.0),
+        warm_model: job_matches_loaded_model(job, worker),
+    }
+}
+
+fn dispatch_score_is_better(candidate: DispatchScore, current: DispatchScore) -> bool {
+    if !candidate.has_utilization || !current.has_utilization {
+        return false;
+    }
+
+    let free_delta = candidate.free_memory_mb - current.free_memory_mb;
+    let load_delta = current.gpu_load_percent - candidate.gpu_load_percent;
+    let usage_delta = current.memory_usage_percent - candidate.memory_usage_percent;
+    let candidate_is_not_worse = candidate.free_memory_mb + 512.0 >= current.free_memory_mb
+        && candidate.gpu_load_percent <= current.gpu_load_percent + 10.0
+        && candidate.memory_usage_percent <= current.memory_usage_percent + 10.0;
+    let candidate_relief = free_delta >= 1024.0 || load_delta >= 15.0 || usage_delta >= 10.0;
+
+    if candidate_is_not_worse && candidate_relief {
+        return true;
+    }
+    if candidate_is_not_worse && candidate.warm_model && !current.warm_model {
+        return true;
+    }
+    (current.free_memory_mb < 2048.0 && candidate.free_memory_mb >= 4096.0)
+        || (current.gpu_load_percent >= 85.0 && candidate.gpu_load_percent <= 75.0)
+        || (current.memory_usage_percent >= 90.0 && candidate.memory_usage_percent <= 80.0)
+}
+
 fn choose_claimable_job(rows: Vec<JobSnapshot>, worker: &WorkerSnapshot) -> Option<JobSnapshot> {
     let compatible = rows
         .into_iter()
-        .filter(|job| {
-            worker
-                .capabilities
-                .iter()
-                .any(|capability| capability.as_str() == job.job_type.as_str())
-        })
+        .filter(|job| worker_supports_job(worker, job))
         .collect::<Vec<_>>();
     let first = compatible.first()?;
     if is_non_gpu_job_type(first.job_type.as_str()) || first.requested_gpu != "auto" {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -34,6 +34,18 @@ pub const JOB_STATUSES: &[&str] = &[
 ];
 pub const NON_GPU_JOB_TYPES: &[&str] = &["model_download", "lora_import"];
 pub const MAX_JOB_ATTEMPTS: u32 = 5;
+const DISPATCH_MEMORY_NOT_WORSE_TOLERANCE_MB: f64 = 512.0;
+const DISPATCH_MEMORY_RELIEF_THRESHOLD_MB: f64 = 1024.0;
+const DISPATCH_LOW_MEMORY_THRESHOLD_MB: f64 = 2048.0;
+const DISPATCH_HEALTHY_MEMORY_THRESHOLD_MB: f64 = 4096.0;
+const DISPATCH_LOAD_NOT_WORSE_TOLERANCE_PERCENT: f64 = 10.0;
+const DISPATCH_LOAD_RELIEF_THRESHOLD_PERCENT: f64 = 15.0;
+const DISPATCH_HIGH_LOAD_THRESHOLD_PERCENT: f64 = 85.0;
+const DISPATCH_RECOVERED_LOAD_THRESHOLD_PERCENT: f64 = 75.0;
+const DISPATCH_MEMORY_USAGE_NOT_WORSE_TOLERANCE_PERCENT: f64 = 10.0;
+const DISPATCH_MEMORY_USAGE_RELIEF_THRESHOLD_PERCENT: f64 = 10.0;
+const DISPATCH_HIGH_MEMORY_USAGE_THRESHOLD_PERCENT: f64 = 90.0;
+const DISPATCH_RECOVERED_MEMORY_USAGE_THRESHOLD_PERCENT: f64 = 80.0;
 
 pub type JobsStoreResult<T> = Result<T, JobsStoreError>;
 
@@ -1000,6 +1012,7 @@ fn loads_optional<T>(value: Option<&str>) -> Option<T>
 where
     T: DeserializeOwned,
 {
+    // Best-effort worker telemetry should disappear rather than poison the queue.
     value.and_then(|text| serde_json::from_str::<T>(text).ok())
 }
 
@@ -1264,10 +1277,17 @@ fn dispatch_score_is_better(candidate: DispatchScore, current: DispatchScore) ->
     let free_delta = candidate.free_memory_mb - current.free_memory_mb;
     let load_delta = current.gpu_load_percent - candidate.gpu_load_percent;
     let usage_delta = current.memory_usage_percent - candidate.memory_usage_percent;
-    let candidate_is_not_worse = candidate.free_memory_mb + 512.0 >= current.free_memory_mb
-        && candidate.gpu_load_percent <= current.gpu_load_percent + 10.0
-        && candidate.memory_usage_percent <= current.memory_usage_percent + 10.0;
-    let candidate_relief = free_delta >= 1024.0 || load_delta >= 15.0 || usage_delta >= 10.0;
+    // Prefer a meaningfully freer/lower-load GPU, with tolerance bands so two
+    // similarly healthy GPUs do not trade claims back and forth on tiny deltas.
+    let candidate_is_not_worse = candidate.free_memory_mb + DISPATCH_MEMORY_NOT_WORSE_TOLERANCE_MB
+        >= current.free_memory_mb
+        && candidate.gpu_load_percent
+            <= current.gpu_load_percent + DISPATCH_LOAD_NOT_WORSE_TOLERANCE_PERCENT
+        && candidate.memory_usage_percent
+            <= current.memory_usage_percent + DISPATCH_MEMORY_USAGE_NOT_WORSE_TOLERANCE_PERCENT;
+    let candidate_relief = free_delta >= DISPATCH_MEMORY_RELIEF_THRESHOLD_MB
+        || load_delta >= DISPATCH_LOAD_RELIEF_THRESHOLD_PERCENT
+        || usage_delta >= DISPATCH_MEMORY_USAGE_RELIEF_THRESHOLD_PERCENT;
 
     if candidate_is_not_worse && candidate_relief {
         return true;
@@ -1275,9 +1295,12 @@ fn dispatch_score_is_better(candidate: DispatchScore, current: DispatchScore) ->
     if candidate_is_not_worse && candidate.warm_model && !current.warm_model {
         return true;
     }
-    (current.free_memory_mb < 2048.0 && candidate.free_memory_mb >= 4096.0)
-        || (current.gpu_load_percent >= 85.0 && candidate.gpu_load_percent <= 75.0)
-        || (current.memory_usage_percent >= 90.0 && candidate.memory_usage_percent <= 80.0)
+    (current.free_memory_mb < DISPATCH_LOW_MEMORY_THRESHOLD_MB
+        && candidate.free_memory_mb >= DISPATCH_HEALTHY_MEMORY_THRESHOLD_MB)
+        || (current.gpu_load_percent >= DISPATCH_HIGH_LOAD_THRESHOLD_PERCENT
+            && candidate.gpu_load_percent <= DISPATCH_RECOVERED_LOAD_THRESHOLD_PERCENT)
+        || (current.memory_usage_percent >= DISPATCH_HIGH_MEMORY_USAGE_THRESHOLD_PERCENT
+            && candidate.memory_usage_percent <= DISPATCH_RECOVERED_MEMORY_USAGE_THRESHOLD_PERCENT)
 }
 
 fn choose_claimable_job(rows: Vec<JobSnapshot>, worker: &WorkerSnapshot) -> Option<JobSnapshot> {

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use rusqlite::{params, Connection};
 use sceneworks_core::contracts::{
-    JobStatus, JobType, ProgressStage, WorkerCapability, WorkerStatus,
+    JobStatus, JobType, ProgressStage, WorkerCapability, WorkerStatus, WorkerUtilizationSnapshot,
 };
 use sceneworks_core::jobs_store::{
     CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker,
@@ -49,6 +49,7 @@ fn register_image_worker(store: &JobsStore) {
             gpu_name: Some("GPU 0".to_owned()),
             capabilities: vec![WorkerCapability::ImageGenerate],
             loaded_models: Vec::new(),
+            utilization: None,
         })
         .expect("worker registers");
 }
@@ -105,6 +106,7 @@ fn non_gpu_jobs_can_claim_while_gpu_is_busy() {
                 WorkerCapability::ModelDownload,
             ],
             loaded_models: Vec::new(),
+            utilization: None,
         })
         .expect("worker registers");
 
@@ -150,6 +152,7 @@ fn claim_skips_jobs_not_supported_by_worker_capabilities() {
             gpu_name: None,
             capabilities: vec![WorkerCapability::ModelDownload],
             loaded_models: Vec::new(),
+            utilization: None,
         })
         .expect("worker registers");
     store
@@ -191,6 +194,7 @@ fn auto_claim_prefers_job_matching_loaded_model() {
                 "z_image_turbo".to_owned(),
                 "Tongyi-MAI/Z-Image-Turbo".to_owned(),
             ],
+            utilization: None,
         })
         .expect("worker registers");
     let other_model_job = store
@@ -225,6 +229,7 @@ fn loaded_model_preference_does_not_skip_explicit_gpu_job() {
             gpu_name: None,
             capabilities: vec![WorkerCapability::ImageGenerate],
             loaded_models: vec!["z_image_turbo".to_owned()],
+            utilization: None,
         })
         .expect("worker registers");
     let explicit_job = store
@@ -257,6 +262,7 @@ fn explicit_gpu_job_beats_younger_warm_auto_match() {
             gpu_name: None,
             capabilities: vec![WorkerCapability::ImageGenerate],
             loaded_models: vec!["model-x".to_owned()],
+            utilization: None,
         })
         .expect("worker registers");
     let auto_other = store
@@ -295,6 +301,56 @@ fn explicit_gpu_job_beats_younger_warm_auto_match() {
 }
 
 #[test]
+fn auto_gpu_claim_defers_to_less_loaded_compatible_worker() {
+    let store = store("auto-gpu-utilization-preference");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-loaded".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: Some("Loaded GPU".to_owned()),
+            capabilities: vec![WorkerCapability::ImageGenerate],
+            loaded_models: Vec::new(),
+            utilization: Some(WorkerUtilizationSnapshot {
+                memory_total_mb: Some(24_000),
+                memory_used_mb: Some(22_000),
+                memory_free_mb: Some(2_000),
+                gpu_load_percent: Some(92.0),
+            }),
+        })
+        .expect("loaded worker registers");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-idle".to_owned(),
+            gpu_id: "gpu-1".to_owned(),
+            gpu_name: Some("Idle GPU".to_owned()),
+            capabilities: vec![WorkerCapability::ImageGenerate],
+            loaded_models: Vec::new(),
+            utilization: Some(WorkerUtilizationSnapshot {
+                memory_total_mb: Some(24_000),
+                memory_used_mb: Some(4_000),
+                memory_free_mb: Some(20_000),
+                gpu_load_percent: Some(8.0),
+            }),
+        })
+        .expect("idle worker registers");
+    let job = store
+        .create_job(image_job(object(json!({ "prompt": "mist" }))))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-loaded")
+        .expect("loaded claim succeeds")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-idle")
+        .expect("idle claim succeeds")
+        .expect("idle worker claims");
+
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("gpu-1"));
+}
+
+#[test]
 fn cpu_utility_worker_does_not_claim_gpu_generation_job() {
     let store = store("cpu-utility-no-gpu-jobs");
     store
@@ -310,6 +366,7 @@ fn cpu_utility_worker_does_not_claim_gpu_generation_job() {
                 WorkerCapability::TimelineExport,
             ],
             loaded_models: Vec::new(),
+            utilization: None,
         })
         .expect("worker registers");
     store
@@ -342,6 +399,7 @@ fn idle_heartbeat_interrupts_previous_active_job() {
             status: WorkerStatus::Idle,
             current_job_id: None,
             loaded_models: Vec::new(),
+            utilization: None,
         })
         .expect("heartbeat succeeds");
     let job = store.get_job(&created.id).expect("job loads");

--- a/tests/test_worker_gpu.py
+++ b/tests/test_worker_gpu.py
@@ -15,6 +15,17 @@ def test_parse_nvidia_smi_gpus_returns_all_devices():
     assert "placeholder" not in gpus[1]["capabilities"]
 
 
+def test_parse_nvidia_smi_gpus_includes_live_utilization_when_available():
+    gpus = parse_nvidia_smi_gpus("0, NVIDIA RTX, 24576, 4096, 20480, 12\n")
+
+    assert gpus[0]["utilization"] == {
+        "memoryTotalMb": 24576,
+        "memoryUsedMb": 4096,
+        "memoryFreeMb": 20480,
+        "gpuLoadPercent": 12.0,
+    }
+
+
 def test_gpu_worker_id_preserves_existing_first_worker_id():
     assert gpu_worker_id("worker-gpu-auto-0", "0") == "worker-gpu-auto-0"
     assert gpu_worker_id("worker-gpu-auto-0", "1") == "worker-gpu-auto-1"

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -373,7 +373,7 @@ def test_main_check_exits_without_api_loop(monkeypatch):
     assert calls == ["worker-local-0"]
 
 
-def test_heartbeat_loaded_models_are_not_sent_as_current_job():
+def test_heartbeat_loaded_models_are_not_sent_as_current_job(monkeypatch):
     class Api:
         def __init__(self):
             self.path = None
@@ -386,12 +386,43 @@ def test_heartbeat_loaded_models_are_not_sent_as_current_job():
 
     class Settings:
         worker_id = "worker-1"
+        gpu_id = "0"
 
+    monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
     api = Api()
     heartbeat(api, Settings(), "idle", loaded_models=["model-a"])
 
     assert api.path == "/api/v1/workers/worker-1/heartbeat"
     assert api.payload == {"status": "idle", "currentJobId": None, "loadedModels": ["model-a"]}
+
+
+def test_heartbeat_reports_gpu_utilization_when_available(monkeypatch):
+    class Api:
+        def __init__(self):
+            self.payload = None
+
+        def post(self, _path, payload):
+            self.payload = payload
+            return {}
+
+    class Settings:
+        worker_id = "worker-1"
+        gpu_id = "0"
+
+    monkeypatch.setattr(
+        "scene_worker.runtime.gpu_utilization",
+        lambda _gpu_id: {"memoryTotalMb": 24576, "memoryUsedMb": 4096, "memoryFreeMb": 20480, "gpuLoadPercent": 12},
+    )
+
+    api = Api()
+    heartbeat(api, Settings(), "idle")
+
+    assert api.payload["utilization"] == {
+        "memoryTotalMb": 24576,
+        "memoryUsedMb": 4096,
+        "memoryFreeMb": 20480,
+        "gpuLoadPercent": 12,
+    }
 
 
 def test_keepalive_heartbeat_reports_current_loaded_models_each_tick(monkeypatch):


### PR DESCRIPTION
﻿## Summary

Implements Shortcut story sc-1328 by wiring live GPU utilization through the worker heartbeat contract, Queue UI, and dispatch ranking.

## What changed

- Added optional worker utilization snapshots with GPU memory total/used/free and GPU load.
- Updated Python GPU workers to report `nvidia-smi` utilization on registration and heartbeat.
- Updated Queue GPU cards to hide CPU utility workers and show available memory, used/total memory, memory percentage, GPU load, warm models, and assigned GPU details for active jobs.
- Updated GPU job claiming so auto GPU work defers from a heavily loaded or memory-constrained worker when a compatible idle GPU has better live headroom.
- Kept Rust utility worker and Rust API contract builders compatible with the new optional field.

## Validation

- `cargo test`
- `npm test`
- `npm run build`
- `python -m pytest tests/test_worker_gpu.py tests/test_worker_runtime.py`
- Browser smoke check against a mocked Queue response confirmed GPU stats render and CPU utility workers are hidden from the Queue resource cards.
