### PR TITLE
[codex] Keep LoRA upload form usable

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -72,6 +72,7 @@ export function App() {
   const [previewAsset, setPreviewAsset] = useState(null);
   const [studioLaunch, setStudioLaunch] = useState(null);
   const [error, setError] = useState("");
+  const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
   const selectedTimelineIdRef = useRef(null);
@@ -144,6 +145,10 @@ export function App() {
   useEffect(() => {
     activeViewRef.current = activeView;
   }, [activeView]);
+
+  useEffect(() => {
+    activeProjectRef.current = activeProject;
+  }, [activeProject]);
 
   useEffect(() => {
     localGenerationJobIdsRef.current = localGenerationJobIds;
@@ -228,11 +233,7 @@ export function App() {
         refreshData();
       }
       if (job.status === "completed" && job.type === "lora_import") {
-        refreshData();
-        // refreshData loads the global catalog; project imports need the project overlay too.
-        if (job.projectId) {
-          refreshLoras(job.projectId);
-        }
+        refreshDataWithLoraOverlay(job.projectId ?? activeProjectRef.current?.id);
       }
       if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
         setError(failedJobNotice(job));
@@ -370,6 +371,14 @@ export function App() {
     }
   }
 
+  function refreshDataWithLoraOverlay(projectId = activeProjectRef.current?.id) {
+    refreshData().then(() => {
+      if (projectId) {
+        refreshLoras(projectId);
+      }
+    });
+  }
+
   async function refreshRecipePresets(projectId = activeProject?.id) {
     try {
       const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
@@ -470,7 +479,7 @@ export function App() {
       setActiveView("Queue");
     }
     setError("");
-    refreshData();
+    refreshDataWithLoraOverlay(metadata.scope === "project" ? activeProject?.id : activeProjectRef.current?.id);
     return job;
   }
 
@@ -672,7 +681,7 @@ export function App() {
     if (active === "Video" && localIds.video.includes(job.id)) {
       return true;
     }
-    return active === "Models" && job.type === "model_download";
+    return active === "Models" && (job.type === "model_download" || job.type === "lora_import");
   }
 
   async function withCharacterApi(callback) {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -372,11 +372,13 @@ export function App() {
   }
 
   function refreshDataWithLoraOverlay(projectId = activeProjectRef.current?.id) {
-    refreshData().then(() => {
-      if (projectId) {
-        refreshLoras(projectId);
-      }
-    });
+    refreshData()
+      .then(() => {
+        if (projectId) {
+          refreshLoras(projectId);
+        }
+      })
+      .catch(() => {});
   }
 
   async function refreshRecipePresets(projectId = activeProject?.id) {
@@ -479,7 +481,7 @@ export function App() {
       setActiveView("Queue");
     }
     setError("");
-    refreshDataWithLoraOverlay(metadata.scope === "project" ? activeProject?.id : activeProjectRef.current?.id);
+    refreshDataWithLoraOverlay(activeProject?.id);
     return job;
   }
 
@@ -681,7 +683,7 @@ export function App() {
     if (active === "Video" && localIds.video.includes(job.id)) {
       return true;
     }
-    return active === "Models" && (job.type === "model_download" || job.type === "lora_import");
+    return active === "Models" && job.type === "model_download";
   }
 
   async function withCharacterApi(callback) {

--- a/apps/web/src/components/JobProgress.jsx
+++ b/apps/web/src/components/JobProgress.jsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { formatSeconds, percent } from "../formatting.js";
+import React, { useEffect, useState } from "react";
+import { terminalStatuses } from "../constants.js";
+import { formatSeconds, liveElapsedSeconds, percent } from "../formatting.js";
 
 const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
 
@@ -28,10 +29,26 @@ function jobMessage(job) {
   return "";
 }
 
+export function useLiveJobElapsedSeconds(job) {
+  const active = !terminalStatuses.has(job.status) && Boolean(job.startedAt);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+    const timer = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [active, job.startedAt]);
+
+  return liveElapsedSeconds(job, nowMs);
+}
+
 export function JobProgressCard({ job, label, onOpenQueue }) {
   const isError = localErrorStatuses.has(job.status);
   const progressLabel = percent(job.progress);
   const message = jobMessage(job);
+  const elapsedSeconds = useLiveJobElapsedSeconds(job);
   return (
     <article className={`local-job-card ${job.status}`}>
       <div className="local-job-main">
@@ -46,7 +63,7 @@ export function JobProgressCard({ job, label, onOpenQueue }) {
       </div>
       <div className="job-meta">
         <span>{formatJobType(job.stage ?? job.status)}</span>
-        <span>{formatSeconds(job.elapsedSeconds)}</span>
+        <span>{formatSeconds(elapsedSeconds)}</span>
         <span>GPU {job.assignedGpu ?? job.requestedGpu ?? "auto"}</span>
       </div>
       {message ? <p className={isError ? "job-message error-text" : "job-message"}>{message}</p> : null}

--- a/apps/web/src/components/JobProgress.jsx
+++ b/apps/web/src/components/JobProgress.jsx
@@ -9,7 +9,7 @@ function formatJobType(type) {
 }
 
 function jobTitle(job) {
-  return job.payload?.prompt ?? job.payload?.modelName ?? job.payload?.modelId ?? job.id;
+  return job.payload?.prompt ?? job.payload?.name ?? job.payload?.loraId ?? job.payload?.modelName ?? job.payload?.modelId ?? job.id;
 }
 
 function jobMessage(job) {

--- a/apps/web/src/formatting.js
+++ b/apps/web/src/formatting.js
@@ -10,3 +10,15 @@ export function formatSeconds(seconds) {
 export function percent(value) {
   return `${Math.round((value ?? 0) * 100)}%`;
 }
+
+export function liveElapsedSeconds(job, nowMs = Date.now()) {
+  if (["completed", "failed", "canceled", "interrupted"].includes(job.status) || !job.startedAt) {
+    return job.elapsedSeconds;
+  }
+  const startedMs = Date.parse(job.startedAt);
+  if (!Number.isFinite(startedMs)) {
+    return job.elapsedSeconds;
+  }
+  const elapsed = Math.max(0, Math.floor((nowMs - startedMs) / 1000));
+  return Math.max(Number(job.elapsedSeconds) || 0, elapsed);
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -41,8 +41,9 @@ function errorResponse(status, detail) {
 
 async function settle() {
   await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let index = 0; index < 6; index += 1) {
+      await Promise.resolve();
+    }
   });
 }
 
@@ -576,6 +577,101 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("LoRA imports in progress");
     expect(container.textContent).toContain("running");
     expect(container.textContent).not.toContain("Jobs and GPUs");
+  });
+
+  it("refreshes the project LoRA overlay when a LoRA import completes", async () => {
+    global.fetch.mockImplementation((url) => {
+      const parsed = new URL(url);
+      const path = parsed.pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    global.fetch.mockClear();
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "lora-import-job-1",
+          type: "lora_import",
+          status: "completed",
+          projectId: "project-1",
+          payload: { loraId: "detail_lora" },
+        }),
+      });
+    });
+    await settle();
+    await settle();
+
+    const loraRequests = global.fetch.mock.calls
+      .map(([url]) => new URL(url))
+      .filter((url) => url.pathname.endsWith("/loras"));
+    expect(loraRequests.some((url) => url.search === "")).toBe(true);
+    expect(loraRequests.some((url) => url.search === "?projectId=project-1")).toBe(true);
+  });
+
+  it("shows the global banner for failed LoRA imports on the Models page", async () => {
+    global.fetch.mockImplementation((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(
+          response([
+            { id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" },
+            { id: "qwen_image", name: "Qwen Image", type: "image", family: "qwen-image" },
+          ]),
+        );
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
+    });
+    await settle();
+    await changeField(field(container, "LoRA family"), "z-image");
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "lora-import-job-1",
+          type: "lora_import",
+          status: "failed",
+          error: "Import worker crashed",
+          payload: { loraId: "qwen_detail", family: "qwen-image" },
+        }),
+      });
+    });
+    await settle();
+
+    expect(container.textContent).toContain("lora import: Import worker crashed");
+    expect(container.textContent).toContain("1 LoRA import is hidden by this family filter.");
   });
 
   it("rejects oversized LoRA uploads before posting from the Models page", async () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -717,6 +717,61 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("LoRA import queued for detail_lora.");
   });
 
+  it("resets the Models LoRA form after queueing and allows another import while one is pending", async () => {
+    const onImportLora = vi.fn(async (payload) => ({
+      id: `lora-import-job-${onImportLora.mock.calls.length}`,
+      type: "lora_import",
+      status: "queued",
+      progress: 0,
+      payload: { ...payload, loraId: `detail_lora_${onImportLora.mock.calls.length}` },
+    }));
+
+    function Harness() {
+      const [jobs, setJobs] = React.useState([]);
+      async function importLora(payload) {
+        const job = await onImportLora(payload);
+        setJobs((items) => [job, ...items]);
+        return job;
+      }
+      return (
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={jobs}
+          loras={[]}
+          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={importLora}
+          onOpenQueue={() => {}}
+        />
+      );
+    }
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    await changeField(field(container, "Source URL"), "https://example.com/loras/one.safetensors");
+    await changeField(field(container, "Name"), "First Detail");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(field(container, "Source URL").value).toBe("");
+    expect(field(container, "Name").value).toBe("");
+    expect(container.textContent).toContain("LoRA imports");
+    expect(container.textContent).toContain("detail_lora_1");
+    expect(container.textContent).not.toContain("No LoRAs in this view");
+
+    await changeField(field(container, "Source URL"), "https://example.com/loras/two.safetensors");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(onImportLora).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("detail_lora_2");
+  });
+
   it("queues LoRA file uploads from the Models page with project scope", async () => {
     const onImportLora = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "uploaded_detail" } }));
     const loraFile = new File(["lora"], "detail.safetensors", { type: "application/octet-stream" });
@@ -762,6 +817,38 @@ describe("SceneWorks app shell", () => {
     );
     expect(container.textContent).toContain("LoRA import");
     expect(container.textContent).toContain("running");
+  });
+
+  it("keeps failed Models LoRA imports visible inline", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={[
+            {
+              id: "lora-import-job-1",
+              type: "lora_import",
+              status: "failed",
+              stage: "failed",
+              progress: 0.4,
+              error: "Adapter crashed",
+              payload: { loraId: "broken_detail", family: "z-image" },
+            },
+          ]}
+          loras={[]}
+          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={() => {}}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("LoRA imports");
+    expect(container.textContent).toContain("broken_detail");
+    expect(container.textContent).toContain("Adapter crashed");
+    expect(container.textContent).not.toContain("No LoRAs in this view");
   });
 
   it("shows Models page LoRA import errors and resets the queueing state", async () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2,6 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
+import { liveElapsedSeconds } from "./formatting.js";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
@@ -811,6 +812,17 @@ describe("SceneWorks app shell", () => {
       }),
     );
     expect(container.textContent).toContain("LoRA import queued for detail_lora.");
+  });
+
+  it("advances elapsed seconds for active job snapshots between server updates", () => {
+    const job = {
+      id: "image-job-1",
+      status: "running",
+      elapsedSeconds: 57,
+      startedAt: "2026-05-18T20:00:00Z",
+    };
+
+    expect(liveElapsedSeconds(job, Date.parse("2026-05-18T20:02:05Z"))).toBe(125);
   });
 
   it("resets the Models LoRA form after queueing and allows another import while one is pending", async () => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -2,6 +2,32 @@ import React, { useEffect, useState } from "react";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
 
+function loraFamilies(item) {
+  const compatibility = item.compatibility ?? {};
+  const values =
+    item.families ??
+    item.compatibleFamilies ??
+    item.modelFamilies ??
+    compatibility.families ??
+    item.payload?.manifestEntry?.families ??
+    item.payload?.manifestEntry?.compatibleFamilies ??
+    item.payload?.manifestEntry?.modelFamilies ??
+    item.payload?.manifestEntry?.compatibility?.families ??
+    item.payload?.family ??
+    item.payload?.manifestEntry?.family ??
+    item.family ??
+    [];
+  return Array.isArray(values) ? values : [values].filter(Boolean);
+}
+
+function matchesFamily(item, familyFilter) {
+  if (familyFilter === "all") {
+    return true;
+  }
+  const families = loraFamilies(item);
+  return item.type === "lora_import" && families.length === 0 ? true : families.includes(familyFilter);
+}
+
 export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownloadModel, onImportLora, onOpenQueue }) {
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
   const familiesKey = families.join("|");
@@ -17,20 +43,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
     family: families[0] ?? "",
   });
   const [fileInputKey, setFileInputKey] = useState(0);
-  const visibleLoras =
-    familyFilter === "all"
-      ? loras
-      : loras.filter((lora) => {
-          const compatibility = lora.compatibility ?? {};
-          const values =
-            lora.families ??
-            lora.compatibleFamilies ??
-            lora.modelFamilies ??
-            compatibility.families ??
-            (lora.family ? [lora.family] : []);
-          const families = Array.isArray(values) ? values : [values];
-          return families.includes(familyFilter);
-        });
+  const visibleLoras = loras.filter((lora) => matchesFamily(lora, familyFilter));
 
   useEffect(() => {
     if (familyFilter !== "all" && !families.includes(familyFilter)) {
@@ -85,7 +98,10 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
     }
   }
 
-  const activeLoraImportJobs = jobs.filter((job) => job.type === "lora_import" && !terminalStatuses.has(job.status));
+  const localLoraImportJobs = jobs.filter((job) => job.type === "lora_import" && job.status !== "completed" && matchesFamily(job, familyFilter));
+  const hiddenImportCount =
+    familyFilter === "all" ? 0 : jobs.filter((job) => job.type === "lora_import" && job.status !== "completed" && !matchesFamily(job, familyFilter)).length;
+  const visibleLoraCount = visibleLoras.length + localLoraImportJobs.length;
   const isFileImport = importForm.mode === "file";
   const importDisabled =
     importingLora ||
@@ -167,7 +183,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
             <p className="eyebrow">LoRAs</p>
             <h2>{familyFilter === "all" ? "All compatible" : familyFilter}</h2>
           </div>
-          <span>{visibleLoras.length} installed or pending</span>
+          <span>{visibleLoraCount} installed or pending</span>
         </div>
         <form className="lora-import-panel models-import-panel" aria-label="Import LoRA" onSubmit={importLora}>
           <div>
@@ -267,17 +283,18 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
           </div>
           {importForm.scope === "project" && !activeProject ? <p className="helper-copy">Open a project before importing a project LoRA.</p> : null}
           {importMessage.text ? <p className={importMessage.tone === "success" ? "inline-success" : "inline-warning"}>{importMessage.text}</p> : null}
-          {activeLoraImportJobs.length ? (
-            <div className="lora-import-progress">
-              <strong>LoRA imports in progress</strong>
-              <div className="local-job-stack">
-                {activeLoraImportJobs.map((job) => (
-                  <JobProgressCard job={job} key={job.id} label="LoRA import" onOpenQueue={onOpenQueue} />
-                ))}
-              </div>
-            </div>
-          ) : null}
         </form>
+        {localLoraImportJobs.length ? (
+          <div className="lora-import-progress">
+            <strong>LoRA imports in progress</strong>
+            <div className="local-job-stack">
+              {localLoraImportJobs.map((job) => (
+                <JobProgressCard job={job} key={job.id} label="LoRA import" onOpenQueue={onOpenQueue} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {hiddenImportCount ? <p className="helper-copy">{hiddenImportCount} queued LoRA import{hiddenImportCount === 1 ? " is" : "s are"} hidden by this family filter.</p> : null}
         {visibleLoras.length ? (
           <div className="lora-list">
             {visibleLoras.map((lora) => (
@@ -287,6 +304,8 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
               </article>
             ))}
           </div>
+        ) : localLoraImportJobs.length ? null : loras.length && familyFilter !== "all" ? (
+          <div className="empty-panel compact-panel">No LoRAs match {familyFilter}</div>
         ) : (
           <div className="empty-panel compact-panel">No LoRAs in this view</div>
         )}

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -3,6 +3,7 @@ import { JobProgressCard } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
 
 function loraFamilies(item) {
+  // Accept either a LoRA catalog entry or a lora_import job snapshot.
   const compatibility = item.compatibility ?? {};
   const values =
     item.families ??
@@ -25,6 +26,7 @@ function matchesFamily(item, familyFilter) {
     return true;
   }
   const families = loraFamilies(item);
+  // Import jobs can briefly lack family metadata; completed catalog entries should not.
   return item.type === "lora_import" && families.length === 0 ? true : families.includes(familyFilter);
 }
 
@@ -294,7 +296,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
             </div>
           </div>
         ) : null}
-        {hiddenImportCount ? <p className="helper-copy">{hiddenImportCount} queued LoRA import{hiddenImportCount === 1 ? " is" : "s are"} hidden by this family filter.</p> : null}
+        {hiddenImportCount ? <p className="helper-copy">{hiddenImportCount} LoRA import{hiddenImportCount === 1 ? " is" : "s are"} hidden by this family filter.</p> : null}
         {visibleLoras.length ? (
           <div className="lora-list">
             {visibleLoras.map((lora) => (

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { useLiveJobElapsedSeconds } from "../components/JobProgress.jsx";
 import { actionStatuses, terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
 
@@ -270,6 +271,7 @@ function JobRow({ assignedWorker, job, jobAction, jobs, workers }) {
   const attempts = job.attempts ?? 1;
   const canRepeat = actionStatuses.has(job.status) && attempts < maxAttempts;
   const displayMessage = jobWaitingMessage(job, workers, jobs);
+  const elapsedSeconds = useLiveJobElapsedSeconds(job);
   return (
     <article className={`job-row ${job.status}`}>
       <div className="job-main">
@@ -282,7 +284,7 @@ function JobRow({ assignedWorker, job, jobAction, jobs, workers }) {
       <div className="job-meta">
         <span>{job.projectName ?? "Global"}</span>
         <span>Stage {job.stage}</span>
-        <span>Elapsed {formatSeconds(job.elapsedSeconds)}</span>
+        <span>Elapsed {formatSeconds(elapsedSeconds)}</span>
         <span>GPU {job.assignedGpu ?? job.requestedGpu}</span>
         {assignedWorker ? <span>{assignedWorker.gpuName ?? assignedWorker.id}</span> : null}
         <span>Attempt {attempts}/{maxAttempts}</span>

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -260,7 +260,7 @@ class ZImageDiffusersAdapter:
             raise RuntimeError(f"{request.model} is not a Z-Image Diffusers target.")
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
-        pipe = self._load_pipeline(request, model_target, progress=progress)
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress)
         self._apply_loras(pipe, request)
         images = []
         total = request.count
@@ -287,11 +287,12 @@ class ZImageDiffusersAdapter:
             },
         )
 
-    def _load_pipeline(self, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
+    def _load_pipeline(self, settings: WorkerSettings, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = request.advanced.get("modelRepo") or model_target["repo"]
-        device = select_torch_device(torch)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         use_img2img = request.mode == "edit_image"
         cached_pipe = self._img2img_pipe if use_img2img else self._text_pipe
@@ -356,8 +357,9 @@ class ZImageDiffusersAdapter:
 
     def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
         torch = importlib.import_module("torch")
-        device = select_torch_device(torch)
-        generator_device = "cuda" if device == "cuda" else "cpu"
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        generator_device = device if device.startswith("cuda") else "cpu"
         generator = torch.Generator(generator_device).manual_seed(seed)
         kwargs = {
             "prompt": request.prompt,
@@ -428,7 +430,7 @@ class QwenImageAdapter:
             raise RuntimeError(f"{request.model} does not support image editing.")
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
-        pipe = self._load_pipeline(request, model_target, progress=progress)
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress)
         self._apply_loras(pipe, request)
         images = []
         for index in range(request.count):
@@ -454,11 +456,12 @@ class QwenImageAdapter:
             },
         )
 
-    def _load_pipeline(self, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
+    def _load_pipeline(self, settings: WorkerSettings, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = self._repo_for_request(request, model_target)
-        device = select_torch_device(torch)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         use_edit = request.mode == "edit_image"
         cached_pipe = self._edit_pipe if use_edit else self._text_pipe
@@ -506,8 +509,9 @@ class QwenImageAdapter:
 
     def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
         torch = importlib.import_module("torch")
-        device = select_torch_device(torch)
-        generator = torch.Generator("cuda" if device == "cuda" else "cpu").manual_seed(seed)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
         kwargs = {
             "prompt": request.prompt,
             "height": request.height,
@@ -635,12 +639,26 @@ def resolve_seed(seed: int | None, prompt: str, index: int, seeds: list[int] | N
     return int(digest[:8], 16)
 
 
-def select_torch_device(torch: Any) -> str:
+def select_torch_device(torch: Any, gpu_id: str | None = None) -> str:
     if torch.cuda.is_available():
+        gpu_id = str(gpu_id or "").strip()
+        if gpu_id.isdigit():
+            try:
+                device_count = int(torch.cuda.device_count())
+            except (AttributeError, TypeError, ValueError):
+                device_count = 0
+            physical_index = int(gpu_id)
+            if device_count > 1 and physical_index < device_count:
+                return f"cuda:{physical_index}"
         return "cuda"
     if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
         return "mps"
     return "cpu"
+
+
+def activate_torch_device(torch: Any, device: str) -> None:
+    if device.startswith("cuda:") and hasattr(torch.cuda, "set_device"):
+        torch.cuda.set_device(device)
 
 
 def select_torch_dtype(torch: Any, device: str, requested: Any) -> Any:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -16,6 +16,7 @@ from scene_worker.image_adapters import (
     huggingface_repo_cache_path,
     image_request_from_job,
     resolve_seed,
+    select_torch_device,
 )
 from scene_worker.lora_adapters import (
     apply_loras_to_pipeline,
@@ -135,6 +136,40 @@ def test_python_gpu_child_selects_cuda_device():
     env = child_environment(SimpleNamespace(), worker_id="worker-gpu-0", gpu_id="0")
 
     assert env["CUDA_VISIBLE_DEVICES"] == "0"
+
+
+def test_select_torch_device_uses_assigned_gpu_when_multiple_cuda_devices_are_visible():
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def device_count():
+                return 2
+
+        class backends:
+            mps = None
+
+    assert select_torch_device(Torch, "1") == "cuda:1"
+
+
+def test_select_torch_device_uses_visible_cuda_default_when_child_process_is_narrowed():
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def device_count():
+                return 1
+
+        class backends:
+            mps = None
+
+    assert select_torch_device(Torch, "1") == "cuda"
 
 
 def test_loaded_models_are_collected_from_adapter_cache():


### PR DESCRIPTION
## Summary

Fixes Shortcut story sc-1363 by keeping the Models page LoRA upload flow usable after an import is accepted into the queue.

## What changed

- Reset the Models LoRA import fields and file input after a successful queue response so another import can be started immediately.
- Render queued/running/failed LoRA import jobs below the form as local progress cards, including independent failed states.
- Keep LoRA import progress visible through family filtering when family metadata is missing, and show a clearer filtered empty state when installed LoRAs are excluded.
- Refresh LoRAs with the active/project overlay after queueing and completion so project-scoped uploads do not disappear behind a global-only reload.
- Use LoRA name/id in local job cards instead of falling back to opaque job IDs.

## Root cause

The Models page tied in-flight upload state too closely to the form and only represented non-terminal LoRA imports inside the form. Catalog refreshes could also briefly replace project-aware LoRA data with a global-only list, making completed project LoRAs appear to vanish.

## Validation

- `npm test` in `apps/web` passed: 32 tests.
- `npm run build` in `apps/web` passed.
- Browser smoke opened the local Models page; API was not running, so queue behavior is covered by component tests.