### PR TITLE
[codex] Replace preset LoRA import with selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# SceneWorks Agent Notes
+
+## Pull Requests
+
+- For this repository, create pull requests with authenticated `gh pr create` directly.
+- Do not try the GitHub connector PR creation first; it repeatedly fails with `Resource not accessible by integration` and then requires falling back to `gh` anyway.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1359,12 +1359,12 @@ export function App() {
         {activeView === "Presets" ? (
           <PresetManagerScreen
             activeProject={activeProject}
-            createLoraImportJob={createLoraImportJob}
             createRecipePreset={createRecipePreset}
             deleteRecipePreset={deleteRecipePreset}
             duplicateRecipePreset={duplicateRecipePreset}
             imageModels={imageModels}
             loras={loras}
+            onOpenModels={() => setActiveView("Models")}
             recipePresets={recipePresets}
             updateRecipePreset={updateRecipePreset}
             videoModels={videoModels}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -722,8 +722,8 @@ describe("SceneWorks app shell", () => {
     expect(importCalls).toBe(0);
   });
 
-  it("keeps Preset Manager LoRA imports in context", async () => {
-    const createdJobs = [];
+  it("keeps Preset Manager LoRA acquisition on the Models page", async () => {
+    let importCalls = 0;
     global.fetch.mockImplementation((url, options = {}) => {
       const path = new URL(url).pathname;
       if (path.endsWith("/health")) {
@@ -744,17 +744,11 @@ describe("SceneWorks app shell", () => {
         );
       }
       if (path.endsWith("/jobs")) {
-        return Promise.resolve(response(createdJobs));
+        return Promise.resolve(response([]));
       }
       if (path.endsWith("/loras/import") && options.method === "POST") {
-        const job = {
-          id: "lora-import-job-1",
-          type: "lora_import",
-          status: "running",
-          payload: { loraId: "preset_detail" },
-        };
-        createdJobs.unshift(job);
-        return Promise.resolve(response(job));
+        importCalls += 1;
+        return Promise.resolve(response({ id: "lora-import-job-1", type: "lora_import", status: "running" }));
       }
       return Promise.resolve(response([]));
     });
@@ -769,15 +763,21 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Presets").click();
     });
     await settle();
-    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+
+    expect(container.textContent).toContain("Preset Manager");
+    expect(container.textContent).toContain("No uploaded LoRAs yet. Manage LoRAs on the Models page.");
+    expect(container.textContent).not.toContain("Import LoRA");
+    expect(container.textContent).not.toContain("Queue Import");
+    expect(field(container, "Source URL")).toBeUndefined();
+
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Open Models").click();
     });
     await settle();
 
-    expect(container.textContent).toContain("Preset Manager");
-    expect(createdJobs).toHaveLength(1);
-    expect(container.textContent).not.toContain("Jobs and GPUs");
+    expect(container.textContent).toContain("Models");
+    expect(container.textContent).toContain("Import LoRA");
+    expect(importCalls).toBe(0);
   });
 
   it("queues LoRA URL imports from the Models page", async () => {
@@ -1837,13 +1837,11 @@ describe("SceneWorks app shell", () => {
     const updateRecipePreset = vi.fn(async (id, payload) => ({ ...payload, id }));
     const duplicateRecipePreset = vi.fn(async (id) => ({ id: `${id}_copy` }));
     const deleteRecipePreset = vi.fn(async (id) => ({ id, archived: true }));
-    const createLoraImportJob = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "imported_detail" } }));
     root = createRoot(container);
     await act(async () => {
       root.render(
         <PresetManagerScreen
           activeProject={{ id: "project-1", name: "Noir" }}
-          createLoraImportJob={createLoraImportJob}
           createRecipePreset={createRecipePreset}
           deleteRecipePreset={deleteRecipePreset}
           duplicateRecipePreset={duplicateRecipePreset}
@@ -1882,8 +1880,9 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "New Preset").click();
     });
     await changeField(field(container, "Name"), "Soft Morning");
+    await changeField(field(container, "Add LoRA"), "global_detail");
     await act(async () => {
-      [...container.querySelectorAll('.lora-choice input[type="checkbox"]')].find((input) => input.closest(".lora-choice").textContent.includes("Global Detail")).click();
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
     });
     await changeField(field(container, "Weight"), "0.35");
     expect(field(container, "ID").value).toBe("soft_morning");
@@ -1906,26 +1905,8 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll(".preset-row")].find((button) => button.textContent.includes("Moody")).click();
     });
     await changeField(field(container, "Description"), "Richer low key color.");
-    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
-    });
-    expect(createLoraImportJob).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceUrl: "https://example.com/loras/detail.safetensors", scope: "global", family: "z-image" }),
-    );
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Local File").click();
-    });
-    const loraFile = new File(["lora"], "detail.safetensors", { type: "application/octet-stream" });
-    const importPanel = container.querySelector(".lora-import-panel");
-    await changeFile(field(importPanel, "Local File"), loraFile);
-    await changeField(field(importPanel, "Name"), "Uploaded Detail");
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
-    });
-    expect(createLoraImportJob).toHaveBeenLastCalledWith(
-      expect.objectContaining({ file: loraFile, name: "Uploaded Detail", scope: "global", family: "z-image" }),
-    );
+    expect(container.textContent).not.toContain("Queue Import");
+    expect(field(container, "Source URL")).toBeUndefined();
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "New Preset").click();
     });
@@ -1959,7 +1940,6 @@ describe("SceneWorks app shell", () => {
       root.render(
         <PresetManagerScreen
           activeProject={{ id: "project-1", name: "Noir" }}
-          createLoraImportJob={() => {}}
           createRecipePreset={() => {}}
           deleteRecipePreset={() => {}}
           duplicateRecipePreset={() => {}}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1902,6 +1902,20 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Qwen Only");
 
     await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "New Preset").click();
+    });
+    await changeField(field(container, "Name"), "Plain Morning");
+    await changeField(field(container, "Add LoRA"), "global_detail");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
+    });
+    expect(container.querySelector(".lora-choice-list").textContent).toContain("Global Detail");
+    await act(async () => {
+      [...container.querySelectorAll(".lora-choice button")].find((button) => button.textContent === "Remove").click();
+    });
+    expect(container.querySelector(".lora-choice-list")).toBeNull();
+
+    await act(async () => {
       [...container.querySelectorAll(".preset-row")].find((button) => button.textContent.includes("Moody")).click();
     });
     await changeField(field(container, "Description"), "Richer low key color.");
@@ -1933,7 +1947,7 @@ describe("SceneWorks app shell", () => {
     expect(deleteRecipePreset).toHaveBeenCalledWith("moody", "global");
   });
 
-  it("explains preset save blockers and no-model empty states", async () => {
+  it("explains preset save blockers and selected LoRA warning states", async () => {
     const updateRecipePreset = vi.fn();
     root = createRoot(container);
     await act(async () => {
@@ -1962,8 +1976,11 @@ describe("SceneWorks app shell", () => {
     });
 
     expect(container.textContent).toContain("No models");
-    expect(container.textContent).toContain("No model selected");
+    expect(container.textContent).not.toContain("No model selected");
+    expect(container.textContent).toContain("Pending Style");
+    expect(container.textContent).toContain("Missing or still importing");
     expect(container.textContent).toContain("Save blocked: pending_style has not finished importing.");
+    expect(field(container, "Weight").disabled).toBe(true);
     expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Save Preset").disabled).toBe(true);
     expect(updateRecipePreset).not.toHaveBeenCalled();
   });

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -81,12 +81,12 @@ function presetStatusLabel(status) {
 
 export function PresetManagerScreen({
   activeProject,
-  createLoraImportJob,
   createRecipePreset,
   deleteRecipePreset,
   duplicateRecipePreset,
   imageModels,
   loras = [],
+  onOpenModels,
   recipePresets = [],
   updateRecipePreset,
   videoModels,
@@ -96,15 +96,16 @@ export function PresetManagerScreen({
   const selectedPreset = recipePresets.find((preset) => preset.id === selectedPresetId) ?? null;
   const [form, setForm] = useState(() => formFromPreset(selectedPreset, models[0]?.id));
   const [saving, setSaving] = useState(false);
-  const [importingLora, setImportingLora] = useState(false);
   const [message, setMessage] = useState({ tone: "neutral", text: "" });
-  const [importForm, setImportForm] = useState({ mode: "url", sourceUrl: "", file: null, name: "" });
-  const [fileInputKey, setFileInputKey] = useState(0);
+  const [selectedLoraToAdd, setSelectedLoraToAdd] = useState("");
   const editable = !selectedPreset || selectedPreset.scope !== "builtin";
-  const busy = saving || importingLora;
+  const busy = saving;
   const availableModels = modelOptions(models, form.workflow);
   const selectedModel = models.find((model) => model.id === form.model) ?? availableModels[0] ?? null;
-  const availableLoras = selectedModel ? loras.filter((lora) => lora.installState !== "missing" && loraMatchesModel(lora, selectedModel)) : [];
+  const installedLoras = loras.filter((lora) => lora.installState !== "missing");
+  const availableLoras = selectedModel ? installedLoras.filter((lora) => loraMatchesModel(lora, selectedModel)) : [];
+  const selectedIds = selectedLoraIds(form);
+  const addableLoras = availableLoras.filter((lora) => !selectedIds.includes(lora.id));
   const validation = presetValidation({ ...selectedPreset, loras: form.loras }, loras, selectedModel);
   const validationMessage = editable ? presetValidationMessage(validation) : "";
   const saveDisabledReason = !editable
@@ -117,9 +118,11 @@ export function PresetManagerScreen({
   const hasPendingCompatibleLoras = Boolean(selectedModel) && loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
   const loraEmptyMessage = !selectedModel
     ? "No model selected"
-    : hasPendingCompatibleLoras
-      ? "No installed compatible LoRAs. Imports appear here after the Queue completes."
-      : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
+    : !installedLoras.length
+      ? "No uploaded LoRAs yet. Manage LoRAs on the Models page."
+      : hasPendingCompatibleLoras
+        ? "No installed compatible LoRAs. Imports appear here after the Queue completes."
+        : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
 
   useEffect(() => {
     if (selectedPreset && !recipePresets.some((preset) => preset.id === selectedPreset.id)) {
@@ -141,6 +144,12 @@ export function PresetManagerScreen({
     }
   }, [availableModels, form.model]);
 
+  useEffect(() => {
+    if (!addableLoras.some((lora) => lora.id === selectedLoraToAdd)) {
+      setSelectedLoraToAdd(addableLoras[0]?.id ?? "");
+    }
+  }, [addableLoras, selectedLoraToAdd]);
+
   function updateField(field, value) {
     setForm((current) => {
       if (field === "workflow") {
@@ -160,19 +169,24 @@ export function PresetManagerScreen({
     });
   }
 
-  function toggleLora(id) {
+  function addSelectedLora() {
+    const id = selectedLoraToAdd;
+    if (!id) {
+      return;
+    }
     setForm((current) => {
       const hasLora = current.loras.some((lora) => lora.id === id);
-      if (hasLora) {
-        return { ...current, loras: current.loras.filter((lora) => lora.id !== id) };
-      }
-      if (current.loras.length >= 3) {
+      if (hasLora || current.loras.length >= 3) {
         return current;
       }
       const source = loras.find((lora) => lora.id === id);
       const weight = source?.defaultWeight ?? source?.weight ?? 0.8;
       return { ...current, loras: [...current.loras, { id, weight: String(weight) }] };
     });
+  }
+
+  function removeLora(id) {
+    setForm((current) => ({ ...current, loras: current.loras.filter((lora) => lora.id !== id) }));
   }
 
   function updateLoraWeight(id, weight) {
@@ -299,44 +313,6 @@ export function PresetManagerScreen({
       setMessage({ tone: "error", text: err.message });
     } finally {
       setSaving(false);
-    }
-  }
-
-  async function importLora(event) {
-    event.preventDefault();
-    const isFileImport = importForm.mode === "file";
-    if ((!isFileImport && !importForm.sourceUrl.trim()) || (isFileImport && !importForm.file)) {
-      return;
-    }
-    setImportingLora(true);
-    setMessage({
-      tone: "neutral",
-      text: isFileImport ? "Uploading LoRA file before queueing import." : "",
-    });
-    try {
-      const job = await createLoraImportJob({
-        ...(isFileImport ? { file: importForm.file } : { sourceUrl: importForm.sourceUrl.trim() }),
-        name: importForm.name.trim() || undefined,
-        scope: form.scope,
-        family: selectedModel?.family ?? undefined,
-      });
-      const importedId = job?.payload?.loraId;
-      if (importedId) {
-        setForm((current) => ({
-          ...current,
-          loras: current.loras.some((lora) => lora.id === importedId)
-            ? current.loras
-            : [...current.loras, { id: importedId, weight: "0.8" }].slice(0, 3),
-        }));
-      }
-      setImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
-      // Force a re-mount so choosing the same file again still emits a change event.
-      setFileInputKey((current) => current + 1);
-      setMessage({ tone: "success", text: "LoRA import queued. Save after the import finishes." });
-    } catch (err) {
-      setMessage({ tone: "error", text: err.message });
-    } finally {
-      setImportingLora(false);
     }
   }
 
@@ -503,23 +479,60 @@ export function PresetManagerScreen({
           <section className="lora-picker" aria-label="Preset LoRAs">
             <div>
               <strong>Applied LoRAs</strong>
-              <span>{form.loras.length}/3 installed and compatible</span>
+              <span>{form.loras.length}/3 selected</span>
             </div>
-            {availableLoras.length ? (
+            <div className="inline-create lora-add-row">
+              <label>
+                Add LoRA
+                <select
+                  disabled={!editable || !addableLoras.length || form.loras.length >= 3}
+                  onChange={(event) => setSelectedLoraToAdd(event.target.value)}
+                  value={selectedLoraToAdd}
+                >
+                  {addableLoras.length ? (
+                    addableLoras.map((lora) => (
+                      <option key={lora.id} value={lora.id}>
+                        {lora.name ?? lora.id}
+                      </option>
+                    ))
+                  ) : (
+                    <option value="">No LoRAs available</option>
+                  )}
+                </select>
+              </label>
+              <button disabled={!editable || !selectedLoraToAdd || form.loras.length >= 3} onClick={addSelectedLora} type="button">
+                Add LoRA
+              </button>
+            </div>
+            {!availableLoras.length ? (
+              <div className="empty-panel compact-panel">
+                <span>{loraEmptyMessage}</span>
+                {onOpenModels ? (
+                  <button onClick={onOpenModels} type="button">
+                    Open Models
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+            {form.loras.length ? (
               <div className="lora-choice-list">
-                {availableLoras.map((lora) => {
-                  const checked = selectedLoraIds(form).includes(lora.id);
-                  const selected = form.loras.find((item) => item.id === lora.id);
+                {form.loras.map((selected) => {
+                  const lora = loras.find((item) => item.id === selected.id);
+                  const missing = !lora || lora.installState === "missing";
+                  const incompatible = lora && selectedModel && !loraMatchesModel(lora, selectedModel);
                   return (
-                    <div className={checked ? "lora-choice active editable-lora-choice" : "lora-choice editable-lora-choice"} key={lora.id}>
-                      <label>
-                        <input checked={checked} disabled={!editable || (!checked && form.loras.length >= 3)} onChange={() => toggleLora(lora.id)} type="checkbox" />
-                        <span>
-                          <strong>{lora.name ?? lora.id}</strong>
-                          <small>{loraLabel(lora)}</small>
-                        </span>
-                      </label>
-                      {checked ? (
+                    <div className={incompatible || missing ? "lora-choice editable-lora-choice warning" : "lora-choice active editable-lora-choice"} key={selected.id}>
+                      <span>
+                        <strong>{lora?.name ?? selected.id}</strong>
+                        <small>
+                          {missing
+                            ? "Missing or still importing"
+                            : incompatible
+                              ? `${loraLabel(lora)} | incompatible with ${selectedModel?.name ?? selectedModel?.id}`
+                              : loraLabel(lora)}
+                        </small>
+                      </span>
+                      <div className="lora-selection-actions">
                         <label>
                           Weight
                           <input
@@ -532,86 +545,15 @@ export function PresetManagerScreen({
                             value={selected?.weight ?? ""}
                           />
                         </label>
-                      ) : null}
+                        <button disabled={!editable} onClick={() => removeLora(selected.id)} type="button">
+                          Remove
+                        </button>
+                      </div>
                     </div>
                   );
                 })}
               </div>
-            ) : (
-              <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
-            )}
-          </section>
-
-          <section className="lora-import-panel" aria-label="Import LoRA">
-            <div>
-              <strong>Import LoRA</strong>
-              <span>{selectedModel?.family ?? selectedModel?.name ?? "choose a model first"}</span>
-            </div>
-            <div className="segmented-control compact-segment" aria-label="LoRA import source">
-              <button
-                className={importForm.mode === "url" ? "active" : ""}
-                disabled={!editable || importingLora}
-                onClick={() => setImportForm((current) => ({ ...current, mode: "url" }))}
-                type="button"
-              >
-                URL
-              </button>
-              <button
-                className={importForm.mode === "file" ? "active" : ""}
-                disabled={!editable || importingLora}
-                onClick={() => setImportForm((current) => ({ ...current, mode: "file" }))}
-                type="button"
-              >
-                Local File
-              </button>
-            </div>
-            <div className="inline-create">
-              {importForm.mode === "url" ? (
-                <label>
-                  Source URL
-                  <input
-                    disabled={!editable || !selectedModel || importingLora}
-                    onChange={(event) => setImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
-                    placeholder="https://..."
-                    value={importForm.sourceUrl}
-                  />
-                </label>
-              ) : (
-                <label>
-                  Local File
-                  <span className="file-picker-row">
-                    <span className="file-upload-button">
-                      Choose
-                      <input
-                        accept=".safetensors,.ckpt,.pt,.bin"
-                        disabled={!editable || !selectedModel || importingLora}
-                        key={fileInputKey}
-                        onChange={(event) => setImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
-                        type="file"
-                      />
-                    </span>
-                    <span className="selected-file-name">{importForm.file?.name ?? "No file selected"}</span>
-                  </span>
-                </label>
-              )}
-              <label>
-                Name
-                <input
-                  disabled={!editable || !selectedModel || importingLora}
-                  onChange={(event) => setImportForm((current) => ({ ...current, name: event.target.value }))}
-                  placeholder="Optional"
-                  value={importForm.name}
-                />
-              </label>
-              <button
-                disabled={!editable || busy || !selectedModel || (importForm.mode === "url" ? !importForm.sourceUrl.trim() : !importForm.file)}
-                onClick={importLora}
-                type="button"
-              >
-                {importingLora ? (importForm.mode === "file" ? "Uploading" : "Queueing...") : "Queue Import"}
-              </button>
-            </div>
-            {!selectedModel ? <p className="helper-copy">Choose a model before importing so compatibility can be recorded.</p> : null}
+            ) : null}
           </section>
 
           {saveDisabledReason ? <p className="inline-warning">{saveDisabledReason}</p> : null}

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -106,6 +106,7 @@ export function PresetManagerScreen({
   const availableLoras = selectedModel ? installedLoras.filter((lora) => loraMatchesModel(lora, selectedModel)) : [];
   const selectedIds = selectedLoraIds(form);
   const addableLoras = availableLoras.filter((lora) => !selectedIds.includes(lora.id));
+  const showLoraEmptyState = !availableLoras.length && !form.loras.length;
   const validation = presetValidation({ ...selectedPreset, loras: form.loras }, loras, selectedModel);
   const validationMessage = editable ? presetValidationMessage(validation) : "";
   const saveDisabledReason = !editable
@@ -145,6 +146,7 @@ export function PresetManagerScreen({
   }, [availableModels, form.model]);
 
   useEffect(() => {
+    // After adding a LoRA, select the next addable item so repeat adds stay one-click.
     if (!addableLoras.some((lora) => lora.id === selectedLoraToAdd)) {
       setSelectedLoraToAdd(addableLoras[0]?.id ?? "");
     }
@@ -495,16 +497,14 @@ export function PresetManagerScreen({
                         {lora.name ?? lora.id}
                       </option>
                     ))
-                  ) : (
-                    <option value="">No LoRAs available</option>
-                  )}
+                  ) : null}
                 </select>
               </label>
               <button disabled={!editable || !selectedLoraToAdd || form.loras.length >= 3} onClick={addSelectedLora} type="button">
                 Add LoRA
               </button>
             </div>
-            {!availableLoras.length ? (
+            {showLoraEmptyState ? (
               <div className="empty-panel compact-panel">
                 <span>{loraEmptyMessage}</span>
                 {onOpenModels ? (
@@ -536,10 +536,10 @@ export function PresetManagerScreen({
                         <label>
                           Weight
                           <input
-                            disabled={!editable}
+                            disabled={!editable || missing || incompatible}
                             max="2"
                             min="-2"
-                            onChange={(event) => updateLoraWeight(lora.id, event.target.value)}
+                            onChange={(event) => updateLoraWeight(selected.id, event.target.value)}
                             step="0.05"
                             type="number"
                             value={selected?.weight ?? ""}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -989,6 +989,11 @@ button:disabled {
   background: #183f3a;
 }
 
+.lora-choice.warning {
+  border-color: #8f7552;
+  background: #2a251c;
+}
+
 .lora-choice input {
   width: auto;
 }
@@ -1002,6 +1007,16 @@ button:disabled {
 .editable-lora-choice {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(80px, 120px);
+  align-items: end;
+}
+
+.lora-add-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.lora-selection-actions {
+  display: flex;
+  gap: 8px;
   align-items: end;
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     environment:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8000}
       SCENEWORKS_DATA_DIR: /sceneworks/data
+      SCENEWORKS_CONFIG_DIR: /sceneworks/config
       SCENEWORKS_WORKER_ID: rust-utility-worker-0
       SCENEWORKS_GPU_ID: ${SCENEWORKS_RUST_WORKER_GPU_ID:-cpu}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
@@ -68,6 +69,7 @@ services:
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
+      - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
     depends_on:
       api:
         condition: service_healthy

--- a/scripts/check-compose-config.mjs
+++ b/scripts/check-compose-config.mjs
@@ -21,6 +21,13 @@ function assertEqual(actual, expected, label) {
   }
 }
 
+function assertServiceMountsTarget(service, target, label) {
+  const volumes = service?.volumes ?? [];
+  if (!volumes.some((volume) => volume?.target === target)) {
+    throw new Error(`${label}: expected a volume mounted at ${target}`);
+  }
+}
+
 function assertMissing(object, key, label) {
   if (Object.prototype.hasOwnProperty.call(object ?? {}, key)) {
     throw new Error(`${label}: expected ${key} to be absent`);
@@ -44,6 +51,8 @@ function assertRuntimeDefaults(config, label) {
     `${label} python HF hub cache`,
   );
   assertEqual(rustWorker?.environment?.SCENEWORKS_GPU_ID, "cpu", `${label} rust worker gpu mode`);
+  assertEqual(rustWorker?.environment?.SCENEWORKS_CONFIG_DIR, "/sceneworks/config", `${label} rust worker config dir`);
+  assertServiceMountsTarget(rustWorker, "/sceneworks/config", `${label} rust worker config mount`);
 }
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "sceneworks-compose-config-"));

--- a/scripts/check-compose-config.mjs
+++ b/scripts/check-compose-config.mjs
@@ -23,7 +23,7 @@ function assertEqual(actual, expected, label) {
 
 function assertServiceMountsTarget(service, target, label) {
   const volumes = service?.volumes ?? [];
-  if (!volumes.some((volume) => volume?.target === target)) {
+  if (!volumes.some((volume) => volume?.target === target || (typeof volume === "string" && volume.split(":").includes(target)))) {
     throw new Error(`${label}: expected a volume mounted at ${target}`);
   }
 }


### PR DESCRIPTION
﻿## Summary
- Replace Preset Manager LoRA URL/file import controls with an Add LoRA selector backed by registered installed LoRAs.
- Keep selected preset LoRAs editable/removable with weight controls, plus missing/incompatible warnings.
- Point empty Preset Manager LoRA states to the Models page instead of offering uploads inline.
- Fix Docker rust-worker config path/mount so global LoRA upload jobs validate against the same manifest path queued by the API.

## Why
LoRA acquisition and management now belong on the Models page. Preset Manager should only reference LoRAs that are already uploaded or registered, avoiding duplicate import flows and confusing ownership.

## Root Cause For Upload Fix
The API queued global LoRA upload jobs with `/sceneworks/config/manifests/user.loras.jsonc`, but the Docker rust-worker service did not receive `SCENEWORKS_CONFIG_DIR` or the shared config mount. The worker fell back to `config/...` during manifestPath validation and rejected the otherwise-global upload.

## Validation
- `npm test -- --run src/main.test.jsx` from `apps/web`
- `npm run build` from `apps/web`
- `npm run check:compose`
