### PR TITLE
[codex] Restore model download size estimates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ apps/web/node_modules/
 apps/web/dist/
 
 # SceneWorks local runtime data
+config/manifests/user.loras.jsonc
 data/projects/*
 !data/projects/.gitkeep
 data/recent-projects.json

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -4331,6 +4331,7 @@ fn model_download_context(model: &Value) -> Result<Option<DownloadContext>, ApiE
 }
 
 fn manifest_download_size_bytes(model: &Value, download: &Value) -> Option<u64> {
+    // Prefer the selected download entry, then fall back to legacy model-level metadata.
     ["estimatedSizeBytes", "downloadSizeBytes", "sizeBytes"]
         .iter()
         .find_map(|field| download.get(*field).and_then(json_size_to_u64))

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3025,6 +3025,7 @@ fn publish<T: Serialize>(state: &AppState, event: &str, data: &T) {
 struct DownloadContext {
     repo: String,
     files: Vec<String>,
+    fallback_size_bytes: Option<u64>,
 }
 
 async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
@@ -3052,6 +3053,12 @@ async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
         .iter_mut()
         .zip(download_contexts.into_iter().zip(download_size_bytes))
     {
+        let fallback_size_bytes = download_context
+            .as_ref()
+            .and_then(|context| context.fallback_size_bytes);
+        let effective_download_size_bytes = download_size_bytes.or(fallback_size_bytes);
+        let download_size_estimated =
+            download_size_bytes.is_none() && fallback_size_bytes.is_some();
         let (downloadable, installed_path, installed) =
             if let Some(download_context) = download_context {
                 let installed_path = state
@@ -3070,16 +3077,20 @@ async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
         object.insert("downloadable".to_owned(), Value::Bool(downloadable));
         object.insert(
             "downloadSizeBytes".to_owned(),
-            download_size_bytes
+            effective_download_size_bytes
                 .map(|value| json!(value))
                 .unwrap_or(Value::Null),
         );
         object.insert(
             "downloadSizeLabel".to_owned(),
-            download_size_bytes
+            effective_download_size_bytes
                 .map(format_bytes)
                 .map(Value::String)
                 .unwrap_or(Value::Null),
+        );
+        object.insert(
+            "downloadSizeEstimated".to_owned(),
+            Value::Bool(download_size_estimated),
         );
         object.insert(
             "installState".to_owned(),
@@ -4315,7 +4326,19 @@ fn model_download_context(model: &Value) -> Result<Option<DownloadContext>, ApiE
     Ok(Some(DownloadContext {
         repo: required_string_field(&download, "repo")?.to_owned(),
         files: string_array_field(&download, "files"),
+        fallback_size_bytes: manifest_download_size_bytes(model, &download),
     }))
+}
+
+fn manifest_download_size_bytes(model: &Value, download: &Value) -> Option<u64> {
+    ["estimatedSizeBytes", "downloadSizeBytes", "sizeBytes"]
+        .iter()
+        .find_map(|field| download.get(*field).and_then(json_size_to_u64))
+        .or_else(|| {
+            ["estimatedSizeBytes", "downloadSizeBytes", "sizeBytes"]
+                .iter()
+                .find_map(|field| model.get(*field).and_then(json_size_to_u64))
+        })
 }
 
 async fn estimate_huggingface_download_size(
@@ -5892,7 +5915,7 @@ mod tests {
                   "type": "image",
                   "adapter": "z_image_diffusers",
                   "capabilities": ["text_to_image", "edit_image"],
-                  "downloads": [{ "provider": "huggingface", "repo": "owner/model", "files": ["*.safetensors"] }],
+                  "downloads": [{ "provider": "huggingface", "repo": "owner/model", "files": ["*.safetensors"], "estimatedSizeBytes": 12884901888 }],
                   "paths": {},
                   "defaults": {},
                   "limits": {},
@@ -5984,6 +6007,9 @@ mod tests {
         assert_eq!(models[0]["name"], "User Model");
         assert_eq!(models[0]["adapter"], "z_image_diffusers");
         assert_eq!(models[0]["downloadable"], true);
+        assert_eq!(models[0]["downloadSizeBytes"], 12884901888_u64);
+        assert_eq!(models[0]["downloadSizeLabel"], "12.0 GB");
+        assert_eq!(models[0]["downloadSizeEstimated"], true);
         assert_eq!(models[0]["installState"], "installed");
         assert!(models[0]["installedPath"]
             .as_str()
@@ -7064,6 +7090,17 @@ mod tests {
         assert_eq!(super::json_size_to_u64(&json!("200.5")), None);
         assert_eq!(super::format_bytes(0), "0 B");
         assert_eq!(super::format_bytes(1024 * 1024 * 1024), "1.0 GB");
+        assert_eq!(
+            super::manifest_download_size_bytes(
+                &json!({ "downloads": [] }),
+                &json!({ "estimatedSizeBytes": "4096" })
+            ),
+            Some(4096)
+        );
+        assert_eq!(
+            super::manifest_download_size_bytes(&json!({ "sizeBytes": 2048 }), &json!({})),
+            Some(2048)
+        );
         assert_eq!(
             super::quote_huggingface_repo("owner/model name"),
             "owner/model%20name"

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -814,6 +814,49 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("LoRA import queued for detail_lora.");
   });
 
+  it("shows model download size estimates and unavailable states before download", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={[]}
+          loras={[]}
+          models={[
+            {
+              id: "z_image_turbo",
+              name: "Z-Image Turbo",
+              type: "image",
+              family: "z-image",
+              downloadable: true,
+              installState: "missing",
+              downloadSizeLabel: "30.6 GB",
+              downloadSizeEstimated: true,
+              downloads: [{ provider: "huggingface", repo: "Tongyi-MAI/Z-Image-Turbo" }],
+            },
+            {
+              id: "local_unknown",
+              name: "Unknown Size",
+              type: "image",
+              family: "z-image",
+              downloadable: true,
+              installState: "missing",
+              downloads: [{ provider: "huggingface", repo: "owner/unknown" }],
+            },
+          ]}
+          onDownloadModel={() => {}}
+          onImportLora={() => {}}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Download size");
+    expect(container.textContent).toContain("~30.6 GB");
+    expect(container.textContent).toContain("Unavailable");
+    expect([...container.querySelectorAll("button")].some((button) => button.textContent === "Download ~30.6 GB")).toBe(true);
+  });
+
   it("advances elapsed seconds for active job snapshots between server updates", () => {
     const job = {
       id: "image-job-1",

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -843,6 +843,17 @@ describe("SceneWorks app shell", () => {
               installState: "missing",
               downloads: [{ provider: "huggingface", repo: "owner/unknown" }],
             },
+            {
+              id: "exact_size",
+              name: "Exact Size",
+              type: "image",
+              family: "z-image",
+              downloadable: true,
+              installState: "missing",
+              downloadSizeLabel: "8.0 GB",
+              downloadSizeEstimated: false,
+              downloads: [{ provider: "huggingface", repo: "owner/exact" }],
+            },
           ]}
           onDownloadModel={() => {}}
           onImportLora={() => {}}
@@ -853,8 +864,11 @@ describe("SceneWorks app shell", () => {
 
     expect(container.textContent).toContain("Download size");
     expect(container.textContent).toContain("~30.6 GB");
+    expect(container.textContent).toContain("8.0 GB");
     expect(container.textContent).toContain("Unavailable");
     expect([...container.querySelectorAll("button")].some((button) => button.textContent === "Download ~30.6 GB")).toBe(true);
+    expect([...container.querySelectorAll("button")].some((button) => button.textContent === "Download 8.0 GB")).toBe(true);
+    expect(container.textContent).not.toContain("~8.0 GB");
   });
 
   it("advances elapsed seconds for active job snapshots between server updates", () => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -30,6 +30,13 @@ function matchesFamily(item, familyFilter) {
   return item.type === "lora_import" && families.length === 0 ? true : families.includes(familyFilter);
 }
 
+function downloadSizeText(model) {
+  if (!model.downloadSizeLabel) {
+    return "Unavailable";
+  }
+  return model.downloadSizeEstimated ? `~${model.downloadSizeLabel}` : model.downloadSizeLabel;
+}
+
 export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownloadModel, onImportLora, onOpenQueue }) {
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
   const familiesKey = families.join("|");
@@ -138,6 +145,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
           const installed = model.installState === "installed";
           const localDownloadJob = installed ? null : downloadJobs.find((job) => job.status !== "completed");
           const failedDownload = localDownloadJob && terminalStatuses.has(localDownloadJob.status);
+          const downloadSize = downloadSizeText(model);
           return (
             <article className="model-card" key={model.id}>
               <div>
@@ -156,8 +164,8 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
                   <dd>{model.downloads?.[0]?.repo ?? "none"}</dd>
                 </div>
                 <div>
-                  <dt>Download</dt>
-                  <dd>{model.downloadSizeLabel ?? "unknown"}</dd>
+                  <dt>Download size</dt>
+                  <dd>{downloadSize}</dd>
                 </div>
               </dl>
               {localDownloadJob ? (
@@ -171,7 +179,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
                     : failedDownload
                       ? "Retry Download"
                       : model.downloadSizeLabel
-                        ? `Download ${model.downloadSizeLabel}`
+                        ? `Download ${downloadSize}`
                         : "Download"}
               </button>
             </article>

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -10,6 +10,9 @@
       "adapter": "z_image_diffusers",
       "capabilities": ["text_to_image", "character_image", "style_variations"],
       "downloads": [
+        // Refresh estimatedSizeBytes from the Hugging Face recursive tree API:
+        // https://huggingface.co/api/models/<repo>/tree/main?recursive=true
+        // The value should match the bytes downloaded after any files filter, not necessarily the full repo.
         {
           "provider": "huggingface",
           "repo": "Tongyi-MAI/Z-Image-Turbo",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -13,7 +13,8 @@
         {
           "provider": "huggingface",
           "repo": "Tongyi-MAI/Z-Image-Turbo",
-          "files": []
+          "files": [],
+          "estimatedSizeBytes": 32899667397
         }
       ],
       "paths": {
@@ -50,7 +51,8 @@
         {
           "provider": "huggingface",
           "repo": "Tongyi-MAI/Z-Image-Turbo",
-          "files": []
+          "files": [],
+          "estimatedSizeBytes": 32899667397
         }
       ],
       "paths": {
@@ -87,7 +89,8 @@
         {
           "provider": "huggingface",
           "repo": "Qwen/Qwen-Image",
-          "files": []
+          "files": [],
+          "estimatedSizeBytes": 57704594653
         }
       ],
       "paths": {
@@ -123,7 +126,8 @@
         {
           "provider": "huggingface",
           "repo": "Qwen/Qwen-Image-Edit",
-          "files": []
+          "files": [],
+          "estimatedSizeBytes": 57720467613
         }
       ],
       "paths": {
@@ -159,12 +163,14 @@
         {
           "provider": "huggingface",
           "repo": "Lightricks/LTX-2.3",
-          "files": []
+          "files": [],
+          "estimatedSizeBytes": 157004895813
         },
         {
           "provider": "huggingface",
           "repo": "Lightricks/LTX-Video",
-          "files": []
+          "files": [],
+          "estimatedSizeBytes": 254107005436
         }
       ],
       "paths": {
@@ -208,7 +214,8 @@
         {
           "provider": "huggingface",
           "repo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
-          "files": []
+          "files": [],
+          "estimatedSizeBytes": 34203021834
         }
       ],
       "paths": {

--- a/config/manifests/user.loras.jsonc
+++ b/config/manifests/user.loras.jsonc
@@ -1,5 +1,0 @@
-{
-  "$schema": "../../packages/schemas/lora-manifest.schema.json",
-  "schemaVersion": 1,
-  "loras": []
-}

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -8,7 +8,29 @@
     "schemaVersion": { "type": "integer", "minimum": 1 },
     "models": {
       "type": "array",
-      "items": { "type": "object" }
+      "items": {
+        "type": "object",
+        "properties": {
+          "downloads": {
+            "type": "array",
+            "description": "Download options are ordered by preference; the API uses the first supported entry as the canonical model download.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "estimatedSizeBytes": {
+                  "type": ["integer", "string"],
+                  "description": "Estimated bytes for the actual files downloaded after applying the files filter. Refresh from the provider when upstream files change."
+                },
+                "files": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Optional allow-list of provider file patterns included in the download."
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1917,11 +1917,13 @@
         "height": 1024,
         "width": 1024
       },
-      "downloadSizeBytes": null,
-      "downloadSizeLabel": null,
+      "downloadSizeBytes": 12884901888,
+      "downloadSizeEstimated": true,
+      "downloadSizeLabel": "12.0 GB",
       "downloadable": true,
       "downloads": [
         {
+          "estimatedSizeBytes": 12884901888,
           "files": [
             "*.safetensors"
           ],

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -85,7 +85,8 @@ def write_contract_manifests(config_dir: Path) -> None:
                 {
                   "provider": "huggingface",
                   "repo": "owner/base-model",
-                  "files": ["*.safetensors"]
+                  "files": ["*.safetensors"],
+                  "estimatedSizeBytes": 12884901888
                 }
               ],
               "paths": {},


### PR DESCRIPTION
## Summary
- Add manifest-backed fallback download size estimates for model downloads when live Hugging Face lookup is disabled or unavailable.
- Populate built-in model download entries with current Hugging Face tree-size estimates.
- Show estimated sizes on the Models page with a `~` marker and show `Unavailable` when no size is known.

## Validation
- `cargo test -p sceneworks-rust-api model_`
- `cargo build -p sceneworks-rust-api`
- `python -m pytest tests/test_rust_api_contract_snapshots.py::test_system_manifest_and_http_contracts`
- `npm --prefix apps/web test -- src/main.test.jsx`