### PR TITLE
Show image batch results incrementally

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -40,6 +40,14 @@ function failedJobNotice(job) {
   return `${label}: ${detail}`;
 }
 
+function isImageGenerationJob(job) {
+  return ["image_generate", "image_edit"].includes(job.type);
+}
+
+function hasImageReviewResult(job) {
+  return Boolean(job.result?.generationSetId || job.result?.assetIds?.length || job.result?.assets?.length);
+}
+
 function isLoraImportNotice(message) {
   return String(message ?? "").startsWith("lora import: ");
 }
@@ -101,10 +109,25 @@ export function App() {
   );
   const latestImageAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "image"), [latestAssets]);
   const latestVideoAssets = useMemo(() => latestAssets.filter((asset) => asset.type === "video"), [latestAssets]);
-  const imageLocalJobs = useMemo(
-    () => localGenerationJobIds.image.map((id) => jobs.find((job) => job.id === id)).filter(Boolean),
-    [jobs, localGenerationJobIds.image],
-  );
+  const imageLocalJobs = useMemo(() => {
+    const localJobs = localGenerationJobIds.image.map((id) => jobs.find((job) => job.id === id)).filter(Boolean);
+    const projectJobs = jobs
+      .filter(
+        (job) =>
+          activeProject?.id &&
+          job.projectId === activeProject.id &&
+          isImageGenerationJob(job) &&
+          (!terminalStatuses.has(job.status) || (job.status !== "completed" && hasImageReviewResult(job))),
+      )
+      .sort(sortNewest);
+    const byId = new Map();
+    [...localJobs, ...projectJobs].forEach((job) => {
+      if (job?.id && !byId.has(job.id)) {
+        byId.set(job.id, job);
+      }
+    });
+    return Array.from(byId.values()).slice(0, localJobStackLimit);
+  }, [activeProject?.id, jobs, localGenerationJobIds.image]);
   const videoLocalJobs = useMemo(
     () => localGenerationJobIds.video.map((id) => jobs.find((job) => job.id === id)).filter(Boolean),
     [jobs, localGenerationJobIds.video],

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -44,10 +44,6 @@ function isImageGenerationJob(job) {
   return ["image_generate", "image_edit"].includes(job.type);
 }
 
-function hasImageReviewResult(job) {
-  return Boolean(job.result?.generationSetId || job.result?.assetIds?.length || job.result?.assets?.length);
-}
-
 function isLoraImportNotice(message) {
   return String(message ?? "").startsWith("lora import: ");
 }
@@ -117,7 +113,7 @@ export function App() {
           activeProject?.id &&
           job.projectId === activeProject.id &&
           isImageGenerationJob(job) &&
-          (!terminalStatuses.has(job.status) || (job.status !== "completed" && hasImageReviewResult(job))),
+          !terminalStatuses.has(job.status),
       )
       .sort(sortNewest);
     const byId = new Map();

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -2,7 +2,14 @@ import React from "react";
 import { API_BASE_URL } from "../api.js";
 
 export function assetUrl(asset) {
-  return asset?.url ? API_BASE_URL + asset.url : "";
+  if (asset?.url) {
+    return API_BASE_URL + asset.url;
+  }
+  if (asset?.projectId && asset?.file?.path) {
+    const normalizedPath = String(asset.file.path).replaceAll("\\", "/");
+    return `${API_BASE_URL}/api/v1/projects/${asset.projectId}/files/${normalizedPath}`;
+  }
+  return "";
 }
 
 export function assetCanRenderAsImage(asset) {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -309,6 +309,93 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("running");
   });
 
+  it("shows completed image batch items before the whole job finishes", async () => {
+    const createdJobs = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/image/jobs") && options.method === "POST") {
+        const job = {
+          id: "image-job-1",
+          type: "image_generate",
+          status: "running",
+          stage: "running",
+          progress: 0.35,
+          elapsedSeconds: 4,
+          projectId: "project-1",
+          projectName: "Noir",
+          requestedGpu: "auto",
+          payload: { prompt: "A cinematic frame of a neon street at midnight", count: 4 },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image").click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+
+    const partialAsset = {
+      id: "asset-1",
+      projectId: "project-1",
+      generationSetId: "genset-1",
+      type: "image",
+      displayName: "Generated #1",
+      file: { path: "assets/images/generated-1.png", mimeType: "image/png" },
+      status: { favorite: false, rejected: false, trashed: false },
+    };
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          ...createdJobs[0],
+          status: "saving",
+          stage: "saving",
+          progress: 0.82,
+          result: {
+            generationSetId: "genset-1",
+            assetIds: ["asset-1"],
+            assets: [partialAsset],
+            expectedCount: 4,
+          },
+        }),
+      });
+    });
+    await settle();
+
+    expect(container.querySelector(".review-grid img")?.getAttribute("src")).toContain(
+      "/api/v1/projects/project-1/files/assets/images/generated-1.png",
+    );
+    expect(container.textContent).toContain("Pending #2");
+    expect(container.textContent).toContain("Pending #4");
+  });
+
   it("shows local generation failures without duplicating the global banner", async () => {
     const createdJobs = [];
     global.fetch.mockImplementation((url, options = {}) => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -12,6 +12,11 @@ import {
 
 const completedResultFallbackMs = 30000;
 const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
+const localErrorLabels = {
+  failed: "Failed",
+  canceled: "Canceled",
+  interrupted: "Interrupted",
+};
 
 function jobResultAssets(job, assets) {
   const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
@@ -27,7 +32,7 @@ function jobExpectedCount(job, completedCount) {
 
 function jobPendingSlotLabel(job, index) {
   if (localErrorStatuses.has(job.status)) {
-    return `${job.status} #${index + 1}`;
+    return `${localErrorLabels[job.status] ?? "Failed"} #${index + 1}`;
   }
   return `Pending #${index + 1}`;
 }
@@ -237,8 +242,9 @@ export function ImageStudio({
     return () => window.clearTimeout(timer);
   }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
 
-  const localJobs = trackedLocalJobs.filter(
-    (job) => job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job)),
+  const localJobs = useMemo(
+    () => trackedLocalJobs.filter((job) => job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job))),
+    [assets, latestAssets, trackedLocalJobs, resultFallbackTick],
   );
   const reviewSlots = useMemo(() => {
     if (!localJobs.length) {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -11,6 +11,26 @@ import {
 } from "../presetUtils.js";
 
 const completedResultFallbackMs = 30000;
+const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
+
+function jobResultAssets(job, assets) {
+  const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
+  return (job.result?.assets ?? [])
+    .map((asset) => catalogById.get(asset.id) ?? asset)
+    .filter((asset) => asset?.type === "image");
+}
+
+function jobExpectedCount(job, completedCount) {
+  const expected = Number(job.result?.expectedCount ?? job.result?.count ?? job.payload?.count);
+  return Number.isFinite(expected) && expected > 0 ? Math.max(expected, completedCount) : completedCount;
+}
+
+function jobPendingSlotLabel(job, index) {
+  if (localErrorStatuses.has(job.status)) {
+    return `${job.status} #${index + 1}`;
+  }
+  return `Pending #${index + 1}`;
+}
 
 export function ImageStudio({
   activeProject,
@@ -220,7 +240,28 @@ export function ImageStudio({
   const localJobs = trackedLocalJobs.filter(
     (job) => job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job)),
   );
-  const hasReviewContent = Boolean(localJobs.length || latestAssets.length);
+  const reviewSlots = useMemo(() => {
+    if (!localJobs.length) {
+      return latestAssets.map((asset) => ({ type: "asset", id: asset.id, asset }));
+    }
+    return localJobs.flatMap((job) => {
+      const completedAssets = jobResultAssets(job, assets);
+      const expectedCount = jobExpectedCount(job, completedAssets.length);
+      return Array.from({ length: expectedCount }, (_, index) => {
+        const asset = completedAssets[index];
+        if (asset) {
+          return { type: "asset", id: `${job.id}:${asset.id}`, asset };
+        }
+        return {
+          type: "placeholder",
+          id: `${job.id}:slot-${index}`,
+          label: jobPendingSlotLabel(job, index),
+          isError: localErrorStatuses.has(job.status),
+        };
+      });
+    });
+  }, [assets, latestAssets, localJobs]);
+  const hasReviewContent = Boolean(localJobs.length || reviewSlots.length);
 
   async function submit(event) {
     event.preventDefault();
@@ -484,17 +525,23 @@ export function ImageStudio({
               ))}
             </div>
           ) : null}
-          {latestAssets.length ? (
+          {reviewSlots.length ? (
             <div className="review-grid">
-              {latestAssets.map((asset) => (
-                <AssetCard
-                  asset={asset}
-                  deleteAsset={deleteAsset}
-                  key={asset.id}
-                  onPreview={onPreview}
-                  purgeAsset={purgeAsset}
-                  updateAssetStatus={updateAssetStatus}
-                />
+              {reviewSlots.map((slot) => (
+                slot.type === "asset" ? (
+                  <AssetCard
+                    asset={slot.asset}
+                    deleteAsset={deleteAsset}
+                    key={slot.id}
+                    onPreview={onPreview}
+                    purgeAsset={purgeAsset}
+                    updateAssetStatus={updateAssetStatus}
+                  />
+                ) : (
+                  <div className={slot.isError ? "review-placeholder failed" : "review-placeholder"} key={slot.id}>
+                    <span>{slot.label}</span>
+                  </div>
+                )
               ))}
             </div>
           ) : hasReviewContent ? null : (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -915,6 +915,22 @@ button:disabled {
   padding: 10px;
 }
 
+.review-placeholder {
+  display: grid;
+  place-items: center;
+  min-height: 164px;
+  border: 1px dashed #4b463d;
+  background: #191815;
+  color: #c7bfb2;
+  font-size: 13px;
+  text-align: center;
+}
+
+.review-placeholder.failed {
+  border-color: #7a4739;
+  color: #f0b9a5;
+}
+
 .review-card.rejected {
   opacity: 0.58;
 }

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from pathlib import Path
 from textwrap import wrap
-from typing import Any, Callable
+from typing import Any, Callable, Protocol
 from uuid import uuid4
 
 from PIL import Image, ImageDraw, ImageFont
@@ -32,8 +32,18 @@ from .settings import WorkerSettings
 Image.MAX_IMAGE_PIXELS = 64_000_000
 warnings.simplefilter("error", Image.DecompressionBombWarning)
 
-ProgressCallback = Callable[[str, str, float, str], None]
 CancelCallback = Callable[[], bool]
+
+
+class ProgressCallback(Protocol):
+    def __call__(
+        self,
+        status: str,
+        stage: str,
+        value: float,
+        message: str,
+        result: dict[str, Any] | None = None,
+    ) -> None: ...
 
 
 def huggingface_repo_cache_exists(repo: str) -> bool:
@@ -219,12 +229,21 @@ class ImageAssetWriter:
                 "saving",
                 0.78 + ((index + 1) / len(images)) * 0.17,
                 f"Saved image asset {index + 1} of {len(images)}.",
+                {
+                    "generationSetId": generation_set_id,
+                    "assetIds": [item["id"] for item in assets],
+                    "assets": assets,
+                    "expectedCount": len(images),
+                    "adapter": adapter_id,
+                    "model": request.model,
+                },
             )
 
         return {
             "generationSetId": generation_set_id,
             "assetIds": [asset["id"] for asset in assets],
             "assets": assets,
+            "expectedCount": len(images),
             "adapter": adapter_id,
             "model": request.model,
         }

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -239,18 +239,17 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
     def adapter_loaded_models() -> list[str]:
         return loaded_models_from_adapter(adapter, job_id=job_id)
 
-    def progress(status: str, stage: str, value: float, message: str) -> None:
+    def progress(status: str, stage: str, value: float, message: str, result: dict[str, Any] | None = None) -> None:
         heartbeat_with_loaded_models(api, settings, "busy", job_id, adapter_loaded_models)
-        update_job(
-            api,
-            job_id,
-            {
-                "status": status,
-                "stage": stage,
-                "progress": value,
-                "message": message,
-            },
-        )
+        payload = {
+            "status": status,
+            "stage": stage,
+            "progress": value,
+            "message": message,
+        }
+        if result is not None:
+            payload["result"] = result
+        update_job(api, job_id, payload)
 
     try:
         progress("preparing", "preparing", 0.08, "Preparing Image Studio request.")

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -8,6 +8,7 @@ import pytest
 
 from scene_worker.adapter_utils import filter_call_kwargs
 from scene_worker.image_adapters import (
+    ImageAssetWriter,
     MODEL_TARGETS,
     QwenImageAdapter,
     ZImageDiffusersAdapter,
@@ -350,6 +351,62 @@ def test_huggingface_repo_cache_path_stays_under_cache_root(monkeypatch, tmp_pat
     assert path is not None
     path.relative_to((tmp_path / "hub").resolve())
     assert path.name.startswith("models--")
+
+
+def test_image_asset_writer_reports_partial_result_assets(tmp_path):
+    data_dir = tmp_path / "data"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    job = {
+        "id": "job-1",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "Neon alley",
+            "model": "z_image_turbo",
+            "count": 2,
+            "width": 16,
+            "height": 16,
+        },
+    }
+    progress_calls = []
+
+    def progress(status, stage, value, message, result=None):
+        progress_calls.append(
+            {
+                "status": status,
+                "stage": stage,
+                "value": value,
+                "message": message,
+                "result": result,
+            }
+        )
+
+    result = ImageAssetWriter().write_outputs(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job=job,
+        images=[
+            Image.new("RGB", (16, 16), (255, 0, 0)),
+            Image.new("RGB", (16, 16), (0, 255, 0)),
+        ],
+        adapter_id="procedural_preview",
+        progress=progress,
+        cancel_requested=lambda: False,
+        raw_settings={"preview": True},
+    )
+
+    result_progress = [call["result"] for call in progress_calls if call["result"]]
+    assert [len(item["assetIds"]) for item in result_progress] == [1, 2]
+    assert result_progress[0]["expectedCount"] == 2
+    assert result_progress[0]["generationSetId"] == result["generationSetId"]
+    assert result_progress[0]["assets"][0]["file"]["path"].startswith("assets/images/")
+    assert result_progress[1]["assetIds"] == result["assetIds"]
+    assert result["expectedCount"] == 2
 
 
 def test_friendly_failure_identifies_gpu_oom():


### PR DESCRIPTION
## Summary
- persist partial image batch results on worker progress updates as each asset is saved
- render Image Studio review slots with completed images plus pending/failed placeholders while a batch is still running
- recover in-progress image jobs for the active project from refreshed job state and support result-sidecar asset URLs before asset listing refreshes

## Tests
- npm test
- npm run build
- python -m pytest tests/test_worker_runtime.py
- Browser smoke: opened Image Studio at http://127.0.0.1:5173 and confirmed an active 4-image job shows Pending #1-#4 slots in the review panel

## Note
- Broader `python -m pytest tests/test_worker_runtime.py tests/test_rust_api_worker_smoke.py` hit an unrelated existing 400 Bad Request in `test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary` while creating a LoRA import job.

Shortcut: sc-1366