### PR TITLE
[codex] Fix queued job cancellation display

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -5479,6 +5479,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn canceling_queued_job_finishes_without_worker_acknowledgement() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+        let (status, created) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": "image_generate",
+                "projectId": "project-1",
+                "projectName": "Project 1",
+                "payload": { "prompt": "mist over hills" },
+                "requestedGpu": "auto"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+
+        let job_id = created["id"].as_str().expect("job id is string");
+        let (status, canceled) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/jobs/{job_id}/cancel"),
+            Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(canceled["status"], "canceled");
+        assert_eq!(canceled["stage"], "canceled");
+        assert_eq!(canceled["progress"], 1.0);
+        assert_eq!(canceled["cancelRequested"], true);
+        assert_eq!(canceled["message"], "Canceled before a worker started.");
+        assert!(canceled["canceledAt"].is_string());
+        assert!(canceled["completedAt"].is_string());
+        assert_eq!(canceled["workerId"], Value::Null);
+
+        let (status, queue) = request(app.clone(), "GET", "/api/v1/queue", Value::Null).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(queue["counts"]["canceled"], 1);
+        assert_eq!(queue["counts"]["queued"], 0);
+
+        let (status, _) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/workers/register",
+            json!({
+                "workerId": "worker-1",
+                "gpuId": "gpu-0",
+                "gpuName": "GPU 0",
+                "capabilities": ["image_generate"],
+                "loadedModels": []
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, claimed) = request(
+            app,
+            "POST",
+            "/api/v1/jobs/claim",
+            json!({ "workerId": "worker-1" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(claimed["job"], Value::Null);
+    }
+
+    #[tokio::test]
     async fn project_and_asset_routes_persist_contract_state() {
         let temp_dir = tempfile::tempdir().expect("temp dir creates");
         let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -48,6 +48,26 @@ function isLoraImportNotice(message) {
   return String(message ?? "").startsWith("lora import: ");
 }
 
+function jobFreshnessMs(job) {
+  const timestamp = job?.updatedAt ?? job?.completedAt ?? job?.canceledAt ?? job?.startedAt ?? job?.createdAt;
+  const parsed = Date.parse(timestamp ?? "");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function mergeFreshJobs(currentJobs, serverJobs) {
+  const merged = new Map();
+  for (const job of serverJobs) {
+    merged.set(job.id, job);
+  }
+  for (const current of currentJobs) {
+    const server = merged.get(current.id);
+    if (!server || jobFreshnessMs(current) > jobFreshnessMs(server)) {
+      merged.set(current.id, current);
+    }
+  }
+  return [...merged.values()].sort(sortNewest);
+}
+
 const localJobStackLimit = 4;
 const maxLoraUploadBytes = 2 * 1024 * 1024 * 1024;
 
@@ -347,7 +367,7 @@ export function App() {
     const projectItems = projectsResult.value;
     setProjects(projectItems);
     setActiveProject((current) => current ?? projectItems[0] ?? null);
-    setJobs(jobsResult.value.sort(sortNewest));
+    setJobs((current) => mergeFreshJobs(current, jobsResult.value));
     setWorkers(workersResult.value.sort(sortWorkers));
     setQueueSummary(null);
     setModels(modelsResult.value);
@@ -1193,9 +1213,10 @@ export function App() {
     try {
       const path = action === "duplicate" ? `/api/v1/jobs/${job.id}/duplicate` : `/api/v1/jobs/${job.id}/${action}`;
       const body = action === "duplicate" ? { payloadChanges: { duplicatedAt: new Date().toISOString() } } : {};
-      await apiFetch(path, token, { method: "POST", body: JSON.stringify(body) });
+      const updatedJob = await apiFetch(path, token, { method: "POST", body: JSON.stringify(body) });
+      setJobs((items) => [updatedJob, ...items.filter((item) => item.id !== updatedJob.id)].sort(sortNewest));
       setError("");
-      refreshData();
+      await refreshData();
     } catch (err) {
       setError(err.message);
     }

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1299,6 +1299,163 @@ describe("SceneWorks app shell", () => {
     expect([...container.querySelector("#queue-gpu").options].map((option) => option.value)).toEqual(["auto", "0"]);
   });
 
+  it("shows queued job cancellation from the action response even when the list refresh is stale", async () => {
+    const queuedJob = {
+      id: "job-queued",
+      type: "image_generate",
+      status: "queued",
+      stage: "queued",
+      progress: 0,
+      projectId: "project-1",
+      projectName: "Project 1",
+      requestedGpu: "auto",
+      payload: { prompt: "mist" },
+      attempts: 1,
+      cancelRequested: false,
+      createdAt: "2026-05-19T09:00:00Z",
+      updatedAt: "2026-05-19T09:00:00Z",
+    };
+    const canceledJob = {
+      ...queuedJob,
+      status: "canceled",
+      stage: "canceled",
+      progress: 1,
+      cancelRequested: true,
+      message: "Canceled before a worker started.",
+      updatedAt: "2026-05-19T09:01:00Z",
+    };
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/job-queued/cancel") && options.method === "POST") {
+        return Promise.resolve(response(canceledJob));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Project 1" }]));
+      }
+      if (path.endsWith("/workers")) {
+        return Promise.resolve(response([]));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response([queuedJob]));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("queued");
+
+    await act(async () => {
+      [...container.querySelectorAll(".job-actions button")].find((button) => button.textContent === "Cancel").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("canceled");
+    expect(container.textContent).toContain("Canceled before a worker started.");
+    expect(container.textContent).not.toContain("queued");
+    expect(container.textContent).not.toContain("Waiting for an available GPU worker.");
+  });
+
+  it("keeps fresher SSE job state when a post-action refresh returns stale data", async () => {
+    const failedJob = {
+      id: "job-failed",
+      type: "image_generate",
+      status: "failed",
+      stage: "failed",
+      progress: 1,
+      projectId: "project-1",
+      projectName: "Project 1",
+      requestedGpu: "auto",
+      payload: { prompt: "mist" },
+      attempts: 1,
+      cancelRequested: false,
+      createdAt: "2026-05-19T09:00:00Z",
+      updatedAt: "2026-05-19T09:00:00Z",
+    };
+    const retryJob = {
+      ...failedJob,
+      id: "job-retry",
+      status: "running",
+      stage: "generating",
+      progress: 0.1,
+      attempts: 2,
+      updatedAt: "2026-05-19T09:01:00Z",
+    };
+    const fresherRetryJob = {
+      ...retryJob,
+      progress: 0.4,
+      message: "Worker advanced during refresh.",
+      updatedAt: "2026-05-19T09:02:00Z",
+    };
+    let jobsRequestCount = 0;
+    let resolvePostRetryJobs;
+    const postRetryJobs = new Promise((resolve) => {
+      resolvePostRetryJobs = resolve;
+    });
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/job-failed/retry") && options.method === "POST") {
+        return Promise.resolve(response(retryJob));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Project 1" }]));
+      }
+      if (path.endsWith("/workers")) {
+        return Promise.resolve(response([]));
+      }
+      if (path.endsWith("/jobs")) {
+        jobsRequestCount += 1;
+        return jobsRequestCount === 1 ? Promise.resolve(response([failedJob])) : postRetryJobs;
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue").click();
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll(".job-actions button")].find((button) => button.textContent === "Retry").click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({ data: JSON.stringify(fresherRetryJob) });
+    });
+    await act(async () => {
+      resolvePostRetryJobs(response([retryJob]));
+    });
+    await settle();
+
+    expect(container.querySelector(".progress-track")?.getAttribute("aria-label")).toBe("40% complete");
+    expect(container.textContent).toContain("Worker advanced during refresh.");
+  });
+
   it("explains queued GPU jobs that are waiting on capability or busy workers", async () => {
     root = createRoot(container);
     await act(async () => {


### PR DESCRIPTION
## Summary
- Upsert job action responses immediately so queued cancellations render as canceled even if a follow-up list refresh is stale.
- Add an API regression test proving queued job cancellation finishes without worker acknowledgement and cannot be claimed afterward.
- Add a frontend regression test for stale refresh behavior after canceling a queued job.

## Validation
- npm --prefix apps/web test -- main.test.jsx
- cargo test --workspace canceling_queued_job_finishes_without_worker_acknowledgement

## Notes
- `cargo fmt --all -- --check` currently fails before formatting because several Rust files in the checkout report incorrect newline style.
- Leaves the existing unstaged `config/manifests/user.recipe-presets.jsonc` change out of this PR.

Shortcut: SC-1370