### PR TITLE
[codex] Fix preset PEFT LoRA failures

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1913,6 +1913,136 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("blocks image presets whose managed LoRAs do not match the selected model", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={createImageJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[
+            { id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" },
+            { id: "qwen_image", name: "Qwen Image", type: "image", family: "qwen-image" },
+          ]}
+          latestAssets={[]}
+          loras={[
+            {
+              id: "qwen_detail",
+              name: "Qwen Detail",
+              family: "qwen-image",
+              scope: "builtin",
+              presetManaged: true,
+            },
+          ]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          recipePresets={[
+            {
+              id: "cinematic",
+              name: "Cinematic",
+              workflow: "text_to_image",
+              builtInLoras: [{ id: "qwen_detail", weight: 0.4 }],
+            },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+
+    const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate");
+    expect(container.textContent).toContain("Preset cannot run with Z-Image");
+    expect(container.textContent).toContain("qwen_detail");
+    expect(generate.disabled).toBe(true);
+
+    await act(async () => {
+      generate.click();
+    });
+
+    expect(createImageJob).not.toHaveBeenCalled();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+    await changeField(field(container, "Model"), "qwen_image");
+    await settle();
+
+    expect(container.textContent).not.toContain("Preset cannot run with Qwen Image");
+    expect(generate.disabled).toBe(false);
+
+    await act(async () => {
+      generate.click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(expect.objectContaining({ model: "qwen_image", recipePresetId: "cinematic" }));
+  });
+
+  it("blocks video presets whose managed LoRAs do not match the selected model", async () => {
+    const createVideoJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <VideoStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
+          characters={[]}
+          createPersonDetectionJob={() => {}}
+          createPersonTrackJob={() => {}}
+          createVideoJob={createVideoJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          latestAssets={[]}
+          loras={[{ id: "wan_motion", name: "Wan Motion", family: "wan-video", scope: "builtin", presetManaged: true }]}
+          onPreview={() => {}}
+          personTracks={[]}
+          purgeAsset={() => {}}
+          recipePresets={[
+            {
+              id: "dream_motion",
+              name: "Dream Motion",
+              workflow: "image_to_video",
+              model: "ltx_2_3",
+              builtInLoras: [{ id: "wan_motion" }],
+            },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+          videoModels={[
+            {
+              id: "ltx_2_3",
+              name: "LTX",
+              type: "video",
+              family: "ltx-video",
+              capabilities: ["image_to_video"],
+              defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+              loraCompatibility: { families: ["ltx-video"] },
+            },
+          ]}
+        />,
+      );
+    });
+
+    const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate Clip");
+    expect(container.textContent).toContain("Preset cannot run with LTX");
+    expect(container.textContent).toContain("wan_motion");
+    expect(generate.disabled).toBe(true);
+
+    await act(async () => {
+      generate.click();
+    });
+
+    expect(createVideoJob).not.toHaveBeenCalled();
+  });
+
   it("keeps Qwen selected when applying a Qwen image preset", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -8,6 +8,7 @@ import {
   presetMatchesModel,
   presetMatchesWorkflow,
   presetPromptParts as buildPresetPromptParts,
+  presetValidation,
 } from "../presetUtils.js";
 
 const completedResultFallbackMs = 30000;
@@ -155,7 +156,10 @@ export function ImageStudio({
   const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
   const presetLoraDetails = buildPresetLoraDetails(selectedRecipePreset, loras);
   const presetPromptParts = buildPresetPromptParts(selectedRecipePreset);
-  const presetMissingLoras = presetLoraDetails.filter((lora) => lora.missing);
+  const presetValidationResult = useMemo(
+    () => presetValidation(selectedRecipePreset, loras, selectedModel),
+    [selectedRecipePreset, loras, selectedModel],
+  );
   const hasPendingCompatibleLoras = Boolean(selectedModel) && loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
   const loraEmptyMessage = !selectedModel
     ? "No model selected"
@@ -505,14 +509,19 @@ export function ImageStudio({
             </div>
           ) : null}
 
-          {presetMissingLoras.length ? (
+          {presetValidationResult.missing.length ? (
             <p className="inline-warning">
-              Preset cannot run until LoRA import finishes: {presetMissingLoras.map((lora) => lora.id).join(", ")}. Wait for the Queue or choose another preset.
+              Preset cannot run until LoRA import finishes: {presetValidationResult.missing.join(", ")}. Wait for the Queue or choose another preset.
+            </p>
+          ) : null}
+          {presetValidationResult.incompatible.length ? (
+            <p className="inline-warning">
+              Preset cannot run with {selectedModel?.name ?? "the selected model"} because these LoRAs are incompatible: {presetValidationResult.incompatible.join(", ")}. Choose another preset or model.
             </p>
           ) : null}
           <button
             className="primary-action"
-            disabled={submitting || !activeProject || !prompt.trim() || (mode === "character_image" && !characterId) || Boolean(presetMissingLoras.length)}
+            disabled={submitting || !activeProject || !prompt.trim() || (mode === "character_image" && !characterId) || !presetValidationResult.ok}
             type="submit"
           >
             {submitting ? "Queueing..." : "Generate"}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -7,6 +7,7 @@ import {
   presetMatchesModel,
   presetMatchesWorkflow,
   presetPromptParts as buildPresetPromptParts,
+  presetValidation,
 } from "../presetUtils.js";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 
@@ -74,7 +75,10 @@ export function VideoStudio({
   const selectedRecipePreset = availableRecipePresets.find((preset) => preset.id === recipePresetId) ?? availableRecipePresets[0] ?? null;
   const presetPromptParts = buildPresetPromptParts(selectedRecipePreset);
   const presetLoraDetails = buildPresetLoraDetails(selectedRecipePreset, loras);
-  const presetMissingLoras = presetLoraDetails.filter((lora) => lora.missing);
+  const presetValidationResult = useMemo(
+    () => presetValidation(selectedRecipePreset, loras, selectedModel),
+    [selectedRecipePreset, loras, selectedModel],
+  );
 
   useEffect(() => {
     if (!videoModels.some((item) => item.id === model)) {
@@ -215,7 +219,7 @@ export function VideoStudio({
     (mode === "first_last_frame" && sourceAssetId && lastFrameAssetId) ||
     (mode === "extend_clip" && sourceClipAssetId) ||
     (mode === "replace_person" && sourceClipAssetId && personTrackId && characterId);
-  const canSubmit = Boolean(activeProject && prompt.trim() && supportsMode && implementedMode && hasInputs && !presetMissingLoras.length);
+  const canSubmit = Boolean(activeProject && prompt.trim() && supportsMode && implementedMode && hasInputs && presetValidationResult.ok);
   const [width, height] = resolution.split("x").map((value) => Number(value));
   const durationOptions = selectedModel?.limits?.durations ?? [4, 6, 8, 10];
   const resolutionOptions = selectedModel?.limits?.resolutions ?? ["768x512", "640x640", "1280x720", "720x1280"];
@@ -553,9 +557,14 @@ export function VideoStudio({
           ) : null}
 
           {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
-          {presetMissingLoras.length ? (
+          {presetValidationResult.missing.length ? (
             <p className="inline-warning">
-              Preset cannot run until LoRA import finishes: {presetMissingLoras.map((lora) => lora.id).join(", ")}. Wait for the Queue or choose another preset.
+              Preset cannot run until LoRA import finishes: {presetValidationResult.missing.join(", ")}. Wait for the Queue or choose another preset.
+            </p>
+          ) : null}
+          {presetValidationResult.incompatible.length ? (
+            <p className="inline-warning">
+              Preset cannot run with {selectedModel?.name ?? "the selected model"} because these LoRAs are incompatible: {presetValidationResult.incompatible.join(", ")}. Choose another preset or model.
             </p>
           ) : null}
           <button className="primary-action" disabled={submitting || !canSubmit} type="submit">

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -7,5 +7,6 @@ imageio-ffmpeg>=0.6,<1
 torch>=2.7
 transformers>=4.57
 accelerate>=1.11
+peft>=0.17,<1
 safetensors>=0.6
 diffusers @ git+https://github.com/huggingface/diffusers.git

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -105,16 +105,17 @@ def apply_loras_to_pipeline(
             raise RuntimeError(f"{adapter_id} cannot clear previously loaded LoRAs between jobs.")
 
     for spec in specs_to_load:
-        pipe.load_lora_weights(spec.path, adapter_name=spec.adapter_name)
+        try:
+            pipe.load_lora_weights(spec.path, adapter_name=spec.adapter_name)
+        except Exception as exc:
+            if is_peft_backend_error(exc):
+                raise RuntimeError(peft_backend_message(adapter_id, [spec])) from exc
+            raise
 
     names = tuple(spec.adapter_name for spec in specs)
     weights = [spec.weight for spec in specs]
     if hasattr(pipe, "set_adapters"):
-        try:
-            # Newer Diffusers releases use adapter_weights; older builds used weights.
-            pipe.set_adapters(list(names), adapter_weights=weights)
-        except TypeError:
-            pipe.set_adapters(list(names), weights=weights)
+        set_lora_adapters(pipe, names, weights, adapter_id=adapter_id, specs=specs)
     elif len(names) > 1 or any(weight != 1.0 for weight in weights):
         raise RuntimeError(f"{adapter_id} loaded LoRAs but cannot apply per-LoRA weights.")
     return LoraPipelineState(key=key, adapter_names=names, specs=tuple(specs))
@@ -149,6 +150,47 @@ def lora_weight(lora: dict[str, Any]) -> float:
         return float(lora.get("weight", lora.get("defaultWeight", 0.8)))
     except (TypeError, ValueError):
         return 0.8
+
+
+def set_lora_adapters(pipe: Any, names: tuple[str, ...], weights: list[float], *, adapter_id: str, specs: list[LoraSpec]) -> None:
+    try:
+        # Newer Diffusers releases use adapter_weights; older builds used weights.
+        pipe.set_adapters(list(names), adapter_weights=weights)
+        return
+    except TypeError as exc:
+        if is_peft_backend_error(exc):
+            raise RuntimeError(peft_backend_message(adapter_id, specs)) from exc
+
+    try:
+        pipe.set_adapters(list(names), weights=weights)
+    except Exception as exc:
+        if is_peft_backend_error(exc):
+            raise RuntimeError(peft_backend_message(adapter_id, specs)) from exc
+        raise
+
+
+def is_peft_backend_error(exc: Exception) -> bool:
+    lowered = str(exc).lower()
+    peft_markers = (
+        "peft backend",
+        "requires peft",
+        "peft is required",
+        "install peft",
+        "no module named 'peft'",
+        'no module named "peft"',
+    )
+    return (
+        isinstance(exc, (ImportError, ModuleNotFoundError)) and "peft" in lowered
+    ) or any(marker in lowered for marker in peft_markers)
+
+
+def peft_backend_message(adapter_id: str, specs: list[LoraSpec]) -> str:
+    lora_ids = ", ".join(spec.id for spec in specs) or "selected LoRA"
+    return (
+        f"LoRA {lora_ids} requires the PEFT backend for {adapter_id}. "
+        "For bare-metal workers, run `pip install -r apps/worker/requirements.txt`; "
+        "for Docker Compose, run `docker compose build worker --no-cache`, then restart the worker and retry the preset."
+    )
 
 
 def safe_adapter_name(lora_id: str, path: str) -> str:

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -167,6 +167,26 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
                 f"Technical detail: {detail}"
             ),
         )
+    peft_markers = (
+        "peft backend",
+        "requires peft",
+        "requires the peft backend",
+        "peft is required",
+        "install peft",
+        "no module named 'peft'",
+        'no module named "peft"',
+    )
+    if any(marker in lowered for marker in peft_markers):
+        return (
+            f"{job_kind} failed because the selected preset or LoRA needs PEFT support.",
+            (
+                "The worker needs the PEFT backend to apply the selected preset LoRAs. "
+                "For bare-metal workers, run `pip install -r apps/worker/requirements.txt`; "
+                "for Docker Compose, run `docker compose build worker --no-cache`, then restart the worker and retry. "
+                "You can also choose a preset without LoRAs. "
+                f"Technical detail: {detail}"
+            ),
+        )
     missing_model_markers = (
         "repo id",
         "repository not found",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -91,6 +91,11 @@ class FakeSingleLoraPipe:
         self.loaded.append((path, adapter_name))
 
 
+class FakePeftBackendErrorPipe:
+    def load_lora_weights(self, path, adapter_name=None):
+        raise ValueError("PEFT backend is required for this method.")
+
+
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
 
@@ -307,6 +312,37 @@ def test_lora_loader_fails_when_pipeline_cannot_load_loras(tmp_path):
         apply_loras_to_pipeline(object(), [{"id": "style", "installedPath": str(first)}], adapter_id="diffusers_test")
 
 
+def test_lora_loader_explains_missing_peft_backend(tmp_path):
+    first = tmp_path / "style.safetensors"
+    first.write_bytes(b"lora")
+
+    with pytest.raises(RuntimeError, match="LoRA style requires the PEFT backend") as info:
+        apply_loras_to_pipeline(
+            FakePeftBackendErrorPipe(),
+            [{"id": "style", "installedPath": str(first)}],
+            adapter_id="diffusers_test",
+        )
+
+    assert isinstance(info.value.__cause__, ValueError)
+    assert "docker compose build worker --no-cache" in str(info.value)
+
+
+def test_lora_loader_detects_reworded_peft_backend_errors(tmp_path):
+    first = tmp_path / "style.safetensors"
+    first.write_bytes(b"lora")
+
+    class MissingPeftPipe:
+        def load_lora_weights(self, path, adapter_name=None):
+            raise ModuleNotFoundError("No module named 'peft'")
+
+    with pytest.raises(RuntimeError, match="LoRA style requires the PEFT backend"):
+        apply_loras_to_pipeline(
+            MissingPeftPipe(),
+            [{"id": "style", "installedPath": str(first)}],
+            adapter_id="diffusers_test",
+        )
+
+
 def test_unsupported_adapter_guard_rejects_loras(tmp_path):
     first = tmp_path / "style.safetensors"
     first.write_bytes(b"lora")
@@ -431,6 +467,18 @@ def test_friendly_failure_identifies_ltx_frame_count_errors():
 
     assert message == "Video generation failed because LTX requires a compatible frame count."
     assert "(frames - 1)" in error
+    assert "Technical detail" in error
+
+
+def test_friendly_failure_identifies_missing_peft_backend():
+    message, error = friendly_failure(
+        "Image generation",
+        RuntimeError("LoRA style requires the PEFT backend for z_image_diffusers."),
+    )
+
+    assert message == "Image generation failed because the selected preset or LoRA needs PEFT support."
+    assert "pip install -r apps/worker/requirements.txt" in error
+    assert "docker compose build worker --no-cache" in error
     assert "Technical detail" in error
 
 


### PR DESCRIPTION
## Summary
- Add PEFT to the Python worker runtime dependencies so Diffusers LoRA methods used by image presets have the required backend.
- Wrap raw PEFT backend failures with SceneWorks-friendly worker messages that identify the preset LoRA path and recovery step.
- Block Image Studio preset submission when a managed preset LoRA is incompatible with the selected model.

## Root Cause
Preset image generation can apply hidden managed LoRAs. Diffusers LoRA loading and adapter selection can require PEFT, but the worker image did not install `peft`, so jobs could fail after queueing with the raw `PEFT backend is required for this method.` exception.

## Validation
- `python -m pytest tests\test_worker_runtime.py -q`
- `npm test -- src/main.test.jsx`
- `cargo test -p sceneworks-rust-api recipe_preset --lib`

Shortcut: https://app.shortcut.com/trefry/story/1373/fix-preset-image-generation-peft-backend-error