### PR TITLE
[codex] Prevent CPU generation jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ HF_TOKEN=
 SCENEWORKS_HF_HOME=/sceneworks/data/cache/huggingface
 SCENEWORKS_HUGGINGFACE_HUB_CACHE=/sceneworks/data/cache/huggingface/hub
 
+# Compose worker PyTorch build. The default CUDA wheel lets the Python
+# inference worker actually use NVIDIA GPUs; set the index URL to
+# https://download.pytorch.org/whl/cpu only for an intentional CPU-only build.
+SCENEWORKS_PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
+SCENEWORKS_PYTORCH_SPEC=torch>=2.7,<2.8
+
 # Worker image adapter override: auto, procedural/procedural_preview, z_image_diffusers, or qwen_image.
 SCENEWORKS_IMAGE_ADAPTER=auto
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ container and is exposed on the same host port.
 `SCENEWORKS_WEB_PORT` controls the host port for the Vite web service. The web
 service receives `VITE_API_BASE_URL=http://localhost:${SCENEWORKS_API_PORT}`,
 and workers call `http://api:${SCENEWORKS_API_PORT}` on the compose network.
+Compose builds the Python inference worker with CUDA PyTorch wheels by default
+using `SCENEWORKS_PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu128`.
+Set `SCENEWORKS_PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu` before
+building only when you intentionally want a CPU-only worker; CPU-only PyTorch
+workers do not advertise image or video inference capabilities.
 
 API volume contracts:
 

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -5178,6 +5178,7 @@ impl From<JobsStoreError> for ApiError {
             JobsStoreError::InvalidNumber(field) => {
                 Self::bad_request(format!("Invalid numeric value for {field}"))
             }
+            JobsStoreError::InvalidRequestedGpu(detail) => Self::bad_request(detail),
             JobsStoreError::RetryLimit { max_attempts } => Self {
                 status: StatusCode::BAD_REQUEST,
                 detail: format!("Job retry limit reached after {max_attempts} attempts."),

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1554,6 +1554,15 @@ describe("SceneWorks app shell", () => {
           setRequestedGpu={() => {}}
           workers={[
             {
+              id: "misregistered-cpu",
+              gpuId: "cpu",
+              gpuName: "CPU worker",
+              status: "idle",
+              currentJobId: null,
+              capabilities: ["placeholder", "cpu", "video_generate"],
+              loadedModels: [],
+            },
+            {
               id: "python-gpu-0",
               gpuId: "0",
               gpuName: "Fixture GPU 0",

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -4,6 +4,7 @@ import { actionStatuses, terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
 
 const nonGpuJobTypes = new Set(["model_download", "lora_import"]);
+const gpuRequiredJobTypes = new Set(["image_generate", "image_edit", "video_generate", "video_extend", "video_bridge", "person_replace"]);
 const terminalStatusesForBlocking = new Set(["completed", "failed", "canceled", "interrupted"]);
 
 function formatJobType(type) {
@@ -20,6 +21,9 @@ function workerCanClaim(job, worker) {
   }
   if (nonGpuJobTypes.has(job.type)) {
     return true;
+  }
+  if (gpuRequiredJobTypes.has(job.type) && worker.gpuId === "cpu") {
+    return false;
   }
   return job.requestedGpu === "auto" || job.requestedGpu === worker.gpuId;
 }

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -4,6 +4,9 @@ import { actionStatuses, terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
 
 const nonGpuJobTypes = new Set(["model_download", "lora_import"]);
+// Keep GPU-required generation types in sync with
+// crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
+// apps/worker/scene_worker/runtime.py::SUPPORTED_JOB_TYPES.
 const gpuRequiredJobTypes = new Set(["image_generate", "image_edit", "video_generate", "video_extend", "video_bridge", "person_replace"]);
 const terminalStatusesForBlocking = new Set(["completed", "failed", "canceled", "interrupted"]);
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -10,9 +10,12 @@ alongside the API.
 
 Runtime dependencies live in `requirements.txt`. Test-only dependencies live in
 `requirements-dev.txt` and are intentionally excluded from the Docker image.
-The Dockerfile preinstalls CPU-only PyTorch by default to avoid accidentally
-vendoring the full CUDA wheel stack; override `PYTORCH_INDEX_URL` and
-`PYTORCH_SPEC` at build time when a CUDA-enabled image is required.
+The Dockerfile defaults to CPU-only PyTorch for direct image builds, while
+`docker-compose.yml` passes CUDA PyTorch build args for the inference worker.
+Override `PYTORCH_INDEX_URL` / `PYTORCH_SPEC` for direct `docker build`, or
+`SCENEWORKS_PYTORCH_INDEX_URL` / `SCENEWORKS_PYTORCH_SPEC` for Compose builds.
+GPU workers with CPU-only PyTorch intentionally register without generation
+capabilities so jobs stay queued instead of crawling on CPU with an idle GPU.
 
 Use a local smoke check without contacting the API:
 

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -310,6 +310,7 @@ class ZImageDiffusersAdapter:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = request.advanced.get("modelRepo") or model_target["repo"]
+        require_cuda_for_gpu_worker(torch, settings.gpu_id)
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
@@ -479,6 +480,7 @@ class QwenImageAdapter:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = self._repo_for_request(request, model_target)
+        require_cuda_for_gpu_worker(torch, settings.gpu_id)
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
@@ -673,6 +675,16 @@ def select_torch_device(torch: Any, gpu_id: str | None = None) -> str:
     if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
         return "mps"
     return "cpu"
+
+
+def require_cuda_for_gpu_worker(torch: Any, gpu_id: str | None) -> None:
+    requested = str(gpu_id or "").strip()
+    if requested and requested not in {"auto", "cpu"} and not torch.cuda.is_available():
+        raise RuntimeError(
+            "CUDA-enabled PyTorch is not available in this GPU worker. "
+            "Rebuild the worker with a CUDA PyTorch wheel, for example "
+            "`docker compose build --no-cache worker`, then restart the worker."
+        )
 
 
 def activate_torch_device(torch: Any, device: str) -> None:

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -310,7 +310,7 @@ class ZImageDiffusersAdapter:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = request.advanced.get("modelRepo") or model_target["repo"]
-        require_cuda_for_gpu_worker(torch, settings.gpu_id)
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
@@ -480,7 +480,7 @@ class QwenImageAdapter:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = self._repo_for_request(request, model_target)
-        require_cuda_for_gpu_worker(torch, settings.gpu_id)
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
@@ -677,13 +677,20 @@ def select_torch_device(torch: Any, gpu_id: str | None = None) -> str:
     return "cpu"
 
 
-def require_cuda_for_gpu_worker(torch: Any, gpu_id: str | None) -> None:
-    requested = str(gpu_id or "").strip()
-    if requested and requested not in {"auto", "cpu"} and not torch.cuda.is_available():
+def torch_inference_backend_available(torch: Any) -> bool:
+    if torch.cuda.is_available():
+        return True
+    mps = getattr(getattr(torch, "backends", None), "mps", None)
+    return bool(mps and mps.is_available())
+
+
+def require_inference_backend_for_gpu_worker(torch: Any, gpu_id: str | None) -> None:
+    requested = str(gpu_id or "").strip().lower()
+    if requested != "cpu" and not torch_inference_backend_available(torch):
         raise RuntimeError(
             "CUDA-enabled PyTorch is not available in this GPU worker. "
             "Rebuild the worker with a CUDA PyTorch wheel, for example "
-            "`docker compose build --no-cache worker`, then restart the worker."
+            "`docker compose build worker --no-cache`, then restart the worker."
         )
 
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import importlib
 import json
 import os
 import signal
@@ -53,9 +54,20 @@ class ApiClient:
 def worker_capabilities(gpu: dict) -> list[str]:
     gpu_capabilities = set(gpu["capabilities"])
     capabilities = set(gpu["capabilities"]) - {"placeholder"}
-    if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities:
+    if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities and torch_cuda_available():
         capabilities |= set(SUPPORTED_JOB_TYPES)
     return sorted(capabilities)
+
+
+def torch_cuda_available() -> bool:
+    try:
+        torch = importlib.import_module("torch")
+    except Exception:
+        return False
+    try:
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
 
 
 def loaded_models_from_adapter(adapter: object, *, job_id: str | None = None) -> list[str]:
@@ -148,6 +160,15 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
             (
                 "GPU memory was exhausted. Try a lower resolution, shorter clip, smaller batch count, "
                 f"or a different GPU. Technical detail: {detail}"
+            ),
+        )
+    if "cuda-enabled pytorch" in lowered or "torch.cuda.is_available" in lowered:
+        return (
+            f"{job_kind} failed because the worker is missing CUDA-enabled PyTorch.",
+            (
+                "The worker claimed a GPU inference job, but PyTorch cannot use CUDA in that environment. "
+                "Rebuild the worker image with CUDA PyTorch support, then restart the worker and retry. "
+                f"Technical detail: {detail}"
             ),
         )
     ltx_frame_markers = (

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -22,6 +22,9 @@ from .video_adapters import create_video_adapter
 LoadedModelsSource = Callable[[], list[str]] | None
 IMAGE_JOB_TYPES = ("image_generate", "image_edit")
 VIDEO_JOB_TYPES = ("video_generate", "video_extend", "video_bridge", "person_replace")
+# Keep GPU-required generation types in sync with
+# crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
+# apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
 SUPPORTED_JOB_TYPES = IMAGE_JOB_TYPES + VIDEO_JOB_TYPES
 
 
@@ -54,18 +57,21 @@ class ApiClient:
 def worker_capabilities(gpu: dict) -> list[str]:
     gpu_capabilities = set(gpu["capabilities"])
     capabilities = set(gpu["capabilities"]) - {"placeholder"}
-    if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities and torch_cuda_available():
+    if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities and torch_inference_backend_available():
         capabilities |= set(SUPPORTED_JOB_TYPES)
     return sorted(capabilities)
 
 
-def torch_cuda_available() -> bool:
+def torch_inference_backend_available() -> bool:
     try:
         torch = importlib.import_module("torch")
     except Exception:
         return False
     try:
-        return bool(torch.cuda.is_available())
+        if bool(torch.cuda.is_available()):
+            return True
+        mps = getattr(getattr(torch, "backends", None), "mps", None)
+        return bool(mps and mps.is_available())
     except Exception:
         return False
 

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -25,7 +25,7 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import filter_call_kwargs
-from .image_adapters import select_torch_device, select_torch_dtype, write_json
+from .image_adapters import require_cuda_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
 from .lora_adapters import LoraPipelineState, apply_loras_to_pipeline, reject_loras_if_unsupported
 from .settings import WorkerSettings
 
@@ -316,7 +316,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
         target = model_target(request.model)
         progress("loading_model", "loading_model", 0.2, f"Loading {target['label']} Diffusers pipeline.")
-        pipe = self._load_pipeline(request, target)
+        pipe = self._load_pipeline(settings, request, target)
         self._apply_loras(pipe, request, target)
 
         first_image = self._first_condition_image(project_path, request)
@@ -421,7 +421,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             "realModelInference": True,
         }
 
-    def _load_pipeline(self, request: VideoRequest, target: dict[str, Any]) -> Any:
+    def _load_pipeline(self, settings: WorkerSettings, request: VideoRequest, target: dict[str, Any]) -> Any:
         key = self._pipeline_key(request, target)
         repo = self._repo_for_request(request, target)
         if self._pipeline is not None and self._pipeline_key_value == key:
@@ -430,7 +430,8 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
-        device = select_torch_device(torch)
+        require_cuda_for_gpu_worker(torch, settings.gpu_id)
+        device = select_torch_device(torch, settings.gpu_id)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         self._evict_pipeline(torch)
         pipeline_class = self._pipeline_class(diffusers, request, target)

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -25,7 +25,7 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import filter_call_kwargs
-from .image_adapters import require_cuda_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
+from .image_adapters import require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
 from .lora_adapters import LoraPipelineState, apply_loras_to_pipeline, reject_loras_if_unsupported
 from .settings import WorkerSettings
 
@@ -430,7 +430,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
-        require_cuda_for_gpu_worker(torch, settings.gpu_id)
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
         device = select_torch_device(torch, settings.gpu_id)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         self._evict_pipeline(torch)

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -57,6 +57,7 @@ pub enum JobsStoreError {
     NotFound(String),
     InvalidStatus(String),
     InvalidNumber(String),
+    InvalidRequestedGpu(String),
     RetryLimit { max_attempts: u32 },
 }
 
@@ -69,6 +70,7 @@ impl std::fmt::Display for JobsStoreError {
             Self::NotFound(id) => write!(formatter, "Record not found: {id}"),
             Self::InvalidStatus(status) => write!(formatter, "Unsupported job status: {status}"),
             Self::InvalidNumber(field) => write!(formatter, "Invalid numeric value for {field}"),
+            Self::InvalidRequestedGpu(detail) => write!(formatter, "{detail}"),
             Self::RetryLimit { max_attempts } => {
                 write!(
                     formatter,
@@ -786,6 +788,13 @@ impl JobsStore {
         connection: &Connection,
         request: CreateJob,
     ) -> JobsStoreResult<JobSnapshot> {
+        let requested_gpu = normalize_requested_gpu(&request.requested_gpu);
+        if job_requires_gpu(&request.job_type) && requested_gpu == "cpu" {
+            return Err(JobsStoreError::InvalidRequestedGpu(format!(
+                "{} jobs cannot target CPU workers. Choose auto or a GPU id.",
+                request.job_type.as_str()
+            )));
+        }
         let now = utc_now();
         let job_hex: String =
             connection.query_row("select lower(hex(randomblob(16)))", [], |row| row.get(0))?;
@@ -804,11 +813,7 @@ impl JobsStore {
                 request.project_id,
                 request.project_name,
                 dumps(&request.payload)?,
-                if request.requested_gpu.is_empty() {
-                    "auto".to_owned()
-                } else {
-                    request.requested_gpu
-                },
+                requested_gpu,
                 "Waiting for an available worker.",
                 request.attempts,
                 request.source_job_id,
@@ -1225,6 +1230,9 @@ fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResu
 }
 
 fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
+    if job_requires_gpu(&job.job_type) && worker.gpu_id == "cpu" {
+        return false;
+    }
     worker
         .capabilities
         .iter()
@@ -1360,6 +1368,27 @@ fn push_string_value(output: &mut Vec<String>, value: Option<&Value>) {
     {
         output.push(value.to_owned());
     }
+}
+
+fn normalize_requested_gpu(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        "auto".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+fn job_requires_gpu(job_type: &JobType) -> bool {
+    matches!(
+        job_type,
+        JobType::ImageGenerate
+            | JobType::ImageEdit
+            | JobType::VideoGenerate
+            | JobType::VideoExtend
+            | JobType::VideoBridge
+            | JobType::PersonReplace
+    )
 }
 
 fn placeholders_from(start: usize, count: usize) -> String {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1230,7 +1230,7 @@ fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResu
 }
 
 fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
-    if job_requires_gpu(&job.job_type) && worker.gpu_id == "cpu" {
+    if job_requires_gpu(&job.job_type) && worker.gpu_id.eq_ignore_ascii_case("cpu") {
         return false;
     }
     worker
@@ -1374,11 +1374,16 @@ fn normalize_requested_gpu(value: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         "auto".to_owned()
+    } else if trimmed.eq_ignore_ascii_case("auto") || trimmed.eq_ignore_ascii_case("cpu") {
+        trimmed.to_ascii_lowercase()
     } else {
         trimmed.to_owned()
     }
 }
 
+// Keep GPU-required generation types in sync with
+// apps/worker/scene_worker/runtime.py::SUPPORTED_JOB_TYPES and
+// apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
 fn job_requires_gpu(job_type: &JobType) -> bool {
     matches!(
         job_type,

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -182,6 +182,44 @@ fn claim_skips_jobs_not_supported_by_worker_capabilities() {
 }
 
 #[test]
+fn gpu_generation_jobs_reject_cpu_requested_gpu() {
+    let store = store("gpu-jobs-reject-cpu");
+
+    let error = store
+        .create_job(CreateJob {
+            requested_gpu: " cpu ".to_owned(),
+            ..image_job(Map::new())
+        })
+        .expect_err("cpu requestedGpu should be rejected");
+
+    assert!(matches!(error, JobsStoreError::InvalidRequestedGpu(_)));
+    assert!(error.to_string().contains("cannot target CPU workers"));
+}
+
+#[test]
+fn cpu_worker_cannot_claim_auto_gpu_generation_job_even_with_capability() {
+    let store = store("cpu-cannot-claim-auto-gpu-job");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-cpu".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            gpu_name: Some("CPU inference worker".to_owned()),
+            capabilities: vec![WorkerCapability::Cpu, WorkerCapability::ImageGenerate],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+    store
+        .create_job(image_job(Map::new()))
+        .expect("gpu job creates");
+
+    assert!(store
+        .claim_next_job("worker-cpu")
+        .expect("claim succeeds")
+        .is_none());
+}
+
+#[test]
 fn auto_claim_prefers_job_matching_loaded_model() {
     let store = store("loaded-model-preference");
     store

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -187,7 +187,7 @@ fn gpu_generation_jobs_reject_cpu_requested_gpu() {
 
     let error = store
         .create_job(CreateJob {
-            requested_gpu: " cpu ".to_owned(),
+            requested_gpu: " CPU ".to_owned(),
             ..image_job(Map::new())
         })
         .expect_err("cpu requestedGpu should be rejected");
@@ -202,7 +202,7 @@ fn cpu_worker_cannot_claim_auto_gpu_generation_job_even_with_capability() {
     store
         .register_worker(RegisterWorker {
             worker_id: "worker-cpu".to_owned(),
-            gpu_id: "cpu".to_owned(),
+            gpu_id: "CPU".to_owned(),
             gpu_name: Some("CPU inference worker".to_owned()),
             capabilities: vec![WorkerCapability::Cpu, WorkerCapability::ImageGenerate],
             loaded_models: Vec::new(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
     build:
       context: .
       dockerfile: docker/worker.Dockerfile
+      args:
+        PYTORCH_INDEX_URL: ${SCENEWORKS_PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu128}
+        PYTORCH_SPEC: ${SCENEWORKS_PYTORCH_SPEC:-torch>=2.7,<2.8}
     environment:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8000}
       SCENEWORKS_DATA_DIR: /sceneworks/data

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -16,6 +16,7 @@ from scene_worker.image_adapters import (
     create_image_adapter,
     huggingface_repo_cache_path,
     image_request_from_job,
+    require_cuda_for_gpu_worker,
     resolve_seed,
     select_torch_device,
 )
@@ -103,7 +104,8 @@ def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
     assert "placeholder" not in capabilities
 
 
-def test_gpu_worker_advertises_generation_capabilities():
+def test_gpu_worker_advertises_generation_capabilities(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: True)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
 
     assert "image_generate" in capabilities
@@ -112,7 +114,15 @@ def test_gpu_worker_advertises_generation_capabilities():
     assert "placeholder" not in capabilities
 
 
-def test_python_worker_only_advertises_inference_job_capabilities():
+def test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: False)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu", "nvidia"]})
+
+    assert capabilities == ["gpu", "nvidia"]
+
+
+def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: True)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
     job_capabilities = [capability for capability in capabilities if capability != "gpu"]
 
@@ -176,6 +186,17 @@ def test_select_torch_device_uses_visible_cuda_default_when_child_process_is_nar
             mps = None
 
     assert select_torch_device(Torch, "1") == "cuda"
+
+
+def test_gpu_worker_fails_fast_when_torch_cuda_is_unavailable():
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+    with pytest.raises(RuntimeError, match="CUDA-enabled PyTorch"):
+        require_cuda_for_gpu_worker(Torch, "0")
 
 
 def test_loaded_models_are_collected_from_adapter_cache():
@@ -453,6 +474,14 @@ def test_friendly_failure_identifies_gpu_oom():
     assert "Technical detail" in error
 
 
+def test_friendly_failure_identifies_cpu_only_torch_worker():
+    message, error = friendly_failure("Image generation", RuntimeError("CUDA-enabled PyTorch is not available."))
+
+    assert message == "Image generation failed because the worker is missing CUDA-enabled PyTorch."
+    assert "Rebuild the worker image" in error
+    assert "Technical detail" in error
+
+
 def test_friendly_failure_identifies_missing_model_files():
     message, error = friendly_failure("Image generation", RuntimeError("Repository not found: owner/model"))
 
@@ -485,6 +514,7 @@ def test_friendly_failure_identifies_missing_peft_backend():
 def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
     events = []
     monkeypatch.setattr("scene_worker.runtime.emit", events.append)
+    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: True)
     monkeypatch.setattr(
         "scene_worker.runtime.discover_gpu",
         lambda _gpu_id: {"id": "0", "name": "GPU 0", "capabilities": ["gpu"]},

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -16,7 +16,7 @@ from scene_worker.image_adapters import (
     create_image_adapter,
     huggingface_repo_cache_path,
     image_request_from_job,
-    require_cuda_for_gpu_worker,
+    require_inference_backend_for_gpu_worker,
     resolve_seed,
     select_torch_device,
 )
@@ -105,7 +105,7 @@ def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
 
 
 def test_gpu_worker_advertises_generation_capabilities(monkeypatch):
-    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
 
     assert "image_generate" in capabilities
@@ -115,14 +115,14 @@ def test_gpu_worker_advertises_generation_capabilities(monkeypatch):
 
 
 def test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs(monkeypatch):
-    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: False)
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: False)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu", "nvidia"]})
 
     assert capabilities == ["gpu", "nvidia"]
 
 
 def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
-    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
     job_capabilities = [capability for capability in capabilities if capability != "gpu"]
 
@@ -196,7 +196,58 @@ def test_gpu_worker_fails_fast_when_torch_cuda_is_unavailable():
                 return False
 
     with pytest.raises(RuntimeError, match="CUDA-enabled PyTorch"):
-        require_cuda_for_gpu_worker(Torch, "0")
+        require_inference_backend_for_gpu_worker(Torch, "0")
+
+
+def test_auto_gpu_worker_fails_fast_when_inference_backend_is_unavailable():
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+        class backends:
+            mps = None
+
+    with pytest.raises(RuntimeError, match="CUDA-enabled PyTorch"):
+        require_inference_backend_for_gpu_worker(Torch, "auto")
+
+
+def test_mps_worker_can_advertise_generation_capabilities(monkeypatch):
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+        class backends:
+            class mps:
+                @staticmethod
+                def is_available():
+                    return True
+
+    monkeypatch.setattr("scene_worker.runtime.importlib.import_module", lambda name: Torch if name == "torch" else None)
+
+    capabilities = worker_capabilities({"id": "mps", "name": "Apple GPU", "capabilities": ["placeholder", "gpu"]})
+
+    assert "image_generate" in capabilities
+    assert "video_generate" in capabilities
+
+
+def test_gpu_worker_accepts_mps_inference_backend():
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+        class backends:
+            class mps:
+                @staticmethod
+                def is_available():
+                    return True
+
+    require_inference_backend_for_gpu_worker(Torch, "mps")
 
 
 def test_loaded_models_are_collected_from_adapter_cache():
@@ -514,7 +565,7 @@ def test_friendly_failure_identifies_missing_peft_backend():
 def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
     events = []
     monkeypatch.setattr("scene_worker.runtime.emit", events.append)
-    monkeypatch.setattr("scene_worker.runtime.torch_cuda_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
     monkeypatch.setattr(
         "scene_worker.runtime.discover_gpu",
         lambda _gpu_id: {"id": "0", "name": "GPU 0", "capabilities": ["gpu"]},


### PR DESCRIPTION
## Summary
- prevent image/video generation jobs from targeting `requestedGpu: cpu`
- ensure auto-dispatch never assigns GPU-required jobs to CPU workers, even if a worker is misregistered
- require a real torch inference backend before Diffusers image/video adapters load, and build the Compose worker with CUDA PyTorch by default
- update Queue eligibility messaging and docs/env examples for the CUDA worker build knobs

## Root Cause
The Python worker image could be built with CPU-only PyTorch while still appearing eligible for GPU generation work. That allowed Z-Image jobs to be claimed and kept alive with progress/heartbeats while no CUDA inference was happening.

## User Impact
After this change, GPU-required jobs stay on real GPU-capable workers. Direct API requests with `requestedGpu: cpu` for image/video generation return a 400 instead of entering the queue.

## Build Note
Compose now defaults the Python inference worker to CUDA PyTorch wheels (`cu128`) so local GPU inference actually uses NVIDIA GPUs. This materially increases worker build/download size compared with the old CPU-only default. Users on slow connections or intentional CPU-only setups can set `SCENEWORKS_PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu`, but those workers will not advertise image/video generation capability.

## Validation
- `python -m pytest -q tests\\test_worker_runtime.py tests\\test_worker_gpu.py`
- `cargo test -p sceneworks-core --test jobs_store`
- `cargo test -p sceneworks-rust-api create_job`
- `npm --prefix apps/web test`
- `npm run check`
- `npm run check:compose`

## Notes
`cargo fmt --all -- --check` is currently blocked by existing Rust newline-style issues across multiple files, including files outside this change. I left line endings alone to avoid unrelated churn.