### PR TITLE
[codex] Replace asset dropdowns with thumbnail picker

### DIFF
--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -65,6 +65,11 @@ function statusLabel(asset) {
   return asset?.status?.state ?? asset?.status?.label ?? "";
 }
 
+function assetIdentity(asset) {
+  const id = String(asset?.id ?? "");
+  return id.length <= 8 ? id : `...${id.slice(-6)}`;
+}
+
 function categoryMatches(asset, category) {
   if (category === "all") {
     return true;
@@ -100,6 +105,10 @@ function searchableText(asset) {
     .toLowerCase();
 }
 
+function assetSearchIndex(assets) {
+  return new Map(assets.map((asset) => [asset.id, searchableText(asset)]));
+}
+
 function normalizeSelection(ids, assets, multiple) {
   const available = new Set(assets.map((asset) => asset.id));
   const kept = ids.filter((id) => available.has(id));
@@ -118,8 +127,8 @@ export function AssetPreviewChips({ assets, emptyLabel = "No asset selected" }) 
           <AssetThumbnail asset={asset} />
           <span>
             <strong>{titleFor(asset)}</strong>
-            <small>
-              {typeLabel(asset)} | {compactDate(asset.createdAt ?? asset.updatedAt)} | {String(asset.id).slice(-6)}
+            <small title={asset.id}>
+              {typeLabel(asset)} | {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
             </small>
           </span>
         </div>
@@ -133,6 +142,7 @@ export function AssetPickerField({
   buttonLabel = "Select",
   emptyLabel,
   label,
+  changeLabel = "Change",
   multiple = false,
   onChange,
   value = "",
@@ -152,7 +162,7 @@ export function AssetPickerField({
       <div className="asset-picker-head">
         <span className="asset-picker-label">{label}</span>
         <button aria-haspopup="dialog" onClick={() => setOpen(true)} type="button">
-          {selectedAssets.length ? "Change" : buttonLabel}
+          {selectedAssets.length ? changeLabel : buttonLabel}
         </button>
       </div>
       <AssetPreviewChips assets={selectedAssets} emptyLabel={emptyLabel ?? (multiple ? "No assets selected" : "No asset selected")} />
@@ -177,32 +187,23 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
   const dialogRef = useRef(null);
 
   useEffect(() => {
-    setSelectedIds(normalizeSelection(initialSelectedIds, assets, multiple));
-  }, [assets, initialSelectedIds, multiple]);
+    setSelectedIds((ids) => normalizeSelection(ids, assets, multiple));
+  }, [assets, multiple]);
 
   useEffect(() => {
     dialogRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    function onKeyDown(event) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onCancel();
-      }
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onCancel]);
-
   const categoryCounts = useMemo(() => {
     return Object.fromEntries(categoryOptions.map(([key]) => [key, assets.filter((asset) => categoryMatches(asset, key)).length]));
   }, [assets]);
 
+  const searchIndex = useMemo(() => assetSearchIndex(assets), [assets]);
+
   const visibleAssets = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    return assets.filter((asset) => categoryMatches(asset, category) && (!needle || searchableText(asset).includes(needle)));
-  }, [assets, category, query]);
+    return assets.filter((asset) => categoryMatches(asset, category) && (!needle || searchIndex.get(asset.id)?.includes(needle)));
+  }, [assets, category, query, searchIndex]);
 
   function toggleAsset(asset) {
     setSelectedIds((ids) => {
@@ -216,9 +217,15 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
   return (
     <div className="modal-backdrop" onMouseDown={(event) => event.target === event.currentTarget && onCancel()}>
       <section
-        aria-label={title}
+        aria-labelledby="asset-picker-title"
         aria-modal="true"
         className="asset-picker-modal"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+          }
+        }}
         onMouseDown={(event) => event.stopPropagation()}
         ref={dialogRef}
         role="dialog"
@@ -226,8 +233,8 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
       >
         <header className="asset-picker-modal-head">
           <div>
-            <p className="eyebrow">{multiple ? "Choose assets" : "Choose asset"}</p>
-            <h2>{title}</h2>
+            <p className="eyebrow">Library</p>
+            <h2 id="asset-picker-title">{title}</h2>
           </div>
           <button className="modal-close" onClick={onCancel} type="button">
             Close
@@ -270,8 +277,8 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
                   <small>
                     {typeLabel(asset)} | {sourceLabel(asset)}
                   </small>
-                  <small>
-                    {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {String(asset.id).slice(-6)}
+                  <small title={asset.id}>
+                    {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
                     {status ? ` | ${status}` : ""}
                   </small>
                 </span>

--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -1,0 +1,298 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { AssetThumbnail, assetCanRenderAsImage, assetCanRenderAsVideo } from "./assetMedia.jsx";
+
+const categoryOptions = [
+  ["all", "All"],
+  ["image", "Images"],
+  ["video", "Video"],
+  ["upload", "Uploads"],
+  ["render", "Renders"],
+];
+
+function compactDate(value) {
+  if (!value) {
+    return "No date";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "No date";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function titleFor(asset) {
+  return asset?.displayName ?? asset?.title ?? asset?.name ?? asset?.id ?? "Untitled asset";
+}
+
+function typeLabel(asset) {
+  if (assetCanRenderAsImage(asset)) {
+    return asset.type === "frame" ? "Frame" : "Image";
+  }
+  if (assetCanRenderAsVideo(asset)) {
+    return "Video";
+  }
+  return asset?.type ? asset.type[0].toUpperCase() + asset.type.slice(1) : "Asset";
+}
+
+function sourceLabel(asset) {
+  if (asset?.type === "upload") {
+    return "Upload";
+  }
+  if (asset?.recipe?.mode) {
+    return asset.recipe.mode.replaceAll("_", " ");
+  }
+  if (asset?.generationSetId) {
+    return "Render";
+  }
+  return asset?.recipe?.model ?? asset?.file?.mimeType ?? "Library";
+}
+
+function statusLabel(asset) {
+  if (asset?.status?.trashed) {
+    return "Trashed";
+  }
+  if (asset?.status?.rejected) {
+    return "Rejected";
+  }
+  if (asset?.status?.favorite) {
+    return "Favorite";
+  }
+  return asset?.status?.state ?? asset?.status?.label ?? "";
+}
+
+function categoryMatches(asset, category) {
+  if (category === "all") {
+    return true;
+  }
+  if (category === "image") {
+    return assetCanRenderAsImage(asset);
+  }
+  if (category === "video") {
+    return assetCanRenderAsVideo(asset);
+  }
+  if (category === "upload") {
+    return asset?.type === "upload" || asset?.source === "upload" || asset?.file?.source === "upload";
+  }
+  if (category === "render") {
+    return Boolean(asset?.generationSetId || asset?.recipe || asset?.type === "render");
+  }
+  return true;
+}
+
+function searchableText(asset) {
+  return [
+    titleFor(asset),
+    asset?.id,
+    asset?.type,
+    asset?.file?.mimeType,
+    asset?.recipe?.mode,
+    asset?.recipe?.model,
+    asset?.recipe?.prompt,
+    statusLabel(asset),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function normalizeSelection(ids, assets, multiple) {
+  const available = new Set(assets.map((asset) => asset.id));
+  const kept = ids.filter((id) => available.has(id));
+  return multiple ? kept : kept.slice(0, 1);
+}
+
+export function AssetPreviewChips({ assets, emptyLabel = "No asset selected" }) {
+  if (!assets.length) {
+    return <div className="asset-picker-empty">{emptyLabel}</div>;
+  }
+
+  return (
+    <div className="asset-preview-chips">
+      {assets.map((asset) => (
+        <div className="asset-preview-chip" key={asset.id}>
+          <AssetThumbnail asset={asset} />
+          <span>
+            <strong>{titleFor(asset)}</strong>
+            <small>
+              {typeLabel(asset)} | {compactDate(asset.createdAt ?? asset.updatedAt)} | {String(asset.id).slice(-6)}
+            </small>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function AssetPickerField({
+  assets,
+  buttonLabel = "Select",
+  emptyLabel,
+  label,
+  multiple = false,
+  onChange,
+  value = "",
+  values = [],
+}) {
+  const [open, setOpen] = useState(false);
+  const selectedIds = multiple ? values : value ? [value] : [];
+  const selectedAssets = selectedIds.map((id) => assets.find((asset) => asset.id === id)).filter(Boolean);
+
+  function confirm(ids) {
+    onChange(multiple ? ids : ids[0] ?? "");
+    setOpen(false);
+  }
+
+  return (
+    <div className="asset-picker-field">
+      <div className="asset-picker-head">
+        <span className="asset-picker-label">{label}</span>
+        <button aria-haspopup="dialog" onClick={() => setOpen(true)} type="button">
+          {selectedAssets.length ? "Change" : buttonLabel}
+        </button>
+      </div>
+      <AssetPreviewChips assets={selectedAssets} emptyLabel={emptyLabel ?? (multiple ? "No assets selected" : "No asset selected")} />
+      {open ? (
+        <AssetPickerModal
+          assets={assets}
+          initialSelectedIds={selectedIds}
+          multiple={multiple}
+          onCancel={() => setOpen(false)}
+          onConfirm={confirm}
+          title={label}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function AssetPickerModal({ assets, initialSelectedIds, multiple = false, onCancel, onConfirm, title = "Select assets" }) {
+  const [category, setCategory] = useState("all");
+  const [query, setQuery] = useState("");
+  const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
+  const dialogRef = useRef(null);
+
+  useEffect(() => {
+    setSelectedIds(normalizeSelection(initialSelectedIds, assets, multiple));
+  }, [assets, initialSelectedIds, multiple]);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancel();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onCancel]);
+
+  const categoryCounts = useMemo(() => {
+    return Object.fromEntries(categoryOptions.map(([key]) => [key, assets.filter((asset) => categoryMatches(asset, key)).length]));
+  }, [assets]);
+
+  const visibleAssets = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return assets.filter((asset) => categoryMatches(asset, category) && (!needle || searchableText(asset).includes(needle)));
+  }, [assets, category, query]);
+
+  function toggleAsset(asset) {
+    setSelectedIds((ids) => {
+      if (multiple) {
+        return ids.includes(asset.id) ? ids.filter((id) => id !== asset.id) : [...ids, asset.id];
+      }
+      return [asset.id];
+    });
+  }
+
+  return (
+    <div className="modal-backdrop" onMouseDown={(event) => event.target === event.currentTarget && onCancel()}>
+      <section
+        aria-label={title}
+        aria-modal="true"
+        className="asset-picker-modal"
+        onMouseDown={(event) => event.stopPropagation()}
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <header className="asset-picker-modal-head">
+          <div>
+            <p className="eyebrow">{multiple ? "Choose assets" : "Choose asset"}</p>
+            <h2>{title}</h2>
+          </div>
+          <button className="modal-close" onClick={onCancel} type="button">
+            Close
+          </button>
+        </header>
+
+        <div className="asset-picker-toolbar">
+          <div className="segmented-control compact-segment" role="tablist" aria-label="Asset category">
+            {categoryOptions.map(([key, label]) => (
+              <button className={category === key ? "active" : ""} key={key} onClick={() => setCategory(key)} type="button">
+                {label} <span>{categoryCounts[key]}</span>
+              </button>
+            ))}
+          </div>
+          <input
+            aria-label="Search assets"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search title, type, prompt"
+            value={query}
+          />
+        </div>
+
+        <div aria-multiselectable={multiple || undefined} className="asset-picker-grid" role="listbox">
+          {visibleAssets.map((asset) => {
+            const selected = selectedIds.includes(asset.id);
+            const status = statusLabel(asset);
+            return (
+              <button
+                aria-selected={selected}
+                className={selected ? "asset-picker-card selected" : "asset-picker-card"}
+                key={asset.id}
+                onClick={() => toggleAsset(asset)}
+                onDoubleClick={() => !multiple && onConfirm([asset.id])}
+                role="option"
+                type="button"
+              >
+                <AssetThumbnail asset={asset} />
+                <span className="asset-picker-card-copy">
+                  <strong>{titleFor(asset)}</strong>
+                  <small>
+                    {typeLabel(asset)} | {sourceLabel(asset)}
+                  </small>
+                  <small>
+                    {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {String(asset.id).slice(-6)}
+                    {status ? ` | ${status}` : ""}
+                  </small>
+                </span>
+              </button>
+            );
+          })}
+          {visibleAssets.length ? null : <div className="empty-panel compact-panel">No assets match this view</div>}
+        </div>
+
+        <footer className="asset-picker-footer">
+          <span>{selectedIds.length ? `${selectedIds.length} selected` : "No selection"}</span>
+          <div className="detail-actions">
+            <button onClick={onCancel} type="button">
+              Cancel
+            </button>
+            <button disabled={!selectedIds.length} onClick={() => onConfirm(selectedIds)} type="button">
+              Use Selection
+            </button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -16,13 +16,37 @@ export function assetCanRenderAsImage(asset) {
   return asset?.type === "image" || asset?.file?.mimeType?.startsWith("image/");
 }
 
-export function AssetMedia({ asset, className = "" }) {
+export function assetCanRenderAsVideo(asset) {
+  return asset?.type === "video" || asset?.file?.mimeType?.startsWith("video/");
+}
+
+export function AssetThumbnail({ asset, className = "" }) {
   if (!asset) {
     return null;
   }
   const src = assetUrl(asset);
-  if (asset.file?.mimeType?.startsWith("video/")) {
-    return <video className={className} controls muted playsInline src={src} />;
+  if (!src) {
+    return <span className={className}>{asset.type ?? "asset"}</span>;
+  }
+  if (assetCanRenderAsVideo(asset)) {
+    return <video className={className} muted playsInline preload="metadata" src={src} />;
+  }
+  if (assetCanRenderAsImage(asset)) {
+    return <img alt="" className={className} src={src} />;
+  }
+  return <span className={className}>{asset.type ?? "asset"}</span>;
+}
+
+export function AssetMedia({ asset, className = "", controls = true }) {
+  if (!asset) {
+    return null;
+  }
+  const src = assetUrl(asset);
+  if (!src) {
+    return <span className={className}>{asset.type ?? "asset"}</span>;
+  }
+  if (assetCanRenderAsVideo(asset)) {
+    return <video className={className} controls={controls} muted playsInline src={src} />;
   }
   if (assetCanRenderAsImage(asset)) {
     return <img alt="" className={className} src={src} />;

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2,6 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
+import { AssetPickerField } from "./components/AssetPicker.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
@@ -111,6 +112,74 @@ describe("SceneWorks app shell", () => {
 
     expect(container.textContent).toContain("Library");
     expect(container.textContent).toContain("Queue");
+  });
+
+  it("selects duplicate-titled assets through the thumbnail asset picker", async () => {
+    const onChange = vi.fn();
+    const assets = [
+      { id: "image-alpha", type: "image", displayName: "Shot", createdAt: "2026-05-19T09:00:00Z", recipe: { mode: "text_to_image" } },
+      { id: "image-beta", type: "image", displayName: "Shot", createdAt: "2026-05-19T09:05:00Z", recipe: { mode: "edit_image" } },
+      { id: "clip-gamma", type: "video", displayName: "Shot", createdAt: "2026-05-19T09:10:00Z", file: { mimeType: "video/mp4" } },
+      { id: "upload-delta", type: "upload", displayName: "Plate", createdAt: "2026-05-19T09:15:00Z" },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <AssetPickerField
+          assets={assets}
+          buttonLabel="Select image"
+          emptyLabel="No source image selected"
+          label="Source"
+          onChange={onChange}
+          value=""
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Select image").click();
+    });
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(container.textContent).toContain("Images 2");
+    expect(container.textContent).toContain("Video 1");
+    expect(container.textContent).toContain("Uploads 1");
+    expect(container.textContent).toContain("Renders 2");
+
+    const cards = [...container.querySelectorAll(".asset-picker-card")];
+    await act(async () => {
+      cards[1].click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Use Selection").click();
+    });
+
+    expect(onChange).toHaveBeenCalledWith("image-beta");
+
+    await act(async () => {
+      root.render(
+        <AssetPickerField
+          assets={assets}
+          buttonLabel="Select image"
+          emptyLabel="No source image selected"
+          label="Source"
+          onChange={onChange}
+          value="image-beta"
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("image-beta".slice(-6));
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Change").click();
+    });
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
   });
 
   it("keeps the shell usable when recipe presets are unavailable", async () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
+import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
@@ -147,6 +148,31 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Uploads 1");
     expect(container.textContent).toContain("Renders 2");
 
+    await act(async () => {
+      [...container.querySelectorAll(".asset-picker-toolbar button")].find((button) => button.textContent.includes("Video")).click();
+    });
+
+    expect(container.querySelectorAll(".asset-picker-card")).toHaveLength(1);
+    expect(container.querySelector('[title="clip-gamma"]')).not.toBeNull();
+
+    await act(async () => {
+      [...container.querySelectorAll(".asset-picker-toolbar button")].find((button) => button.textContent.includes("All")).click();
+    });
+    await changeField(container.querySelector('[aria-label="Search assets"]'), "plate");
+
+    expect(container.querySelectorAll(".asset-picker-card")).toHaveLength(1);
+    expect(container.textContent).toContain("Plate");
+
+    await act(async () => {
+      container.querySelector(".modal-backdrop").dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Select image").click();
+    });
+
     const cards = [...container.querySelectorAll(".asset-picker-card")];
     await act(async () => {
       cards[1].click();
@@ -176,10 +202,143 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Change").click();
     });
     await act(async () => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      container.querySelector('[role="dialog"]').dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
 
     expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("keeps in-progress picker selection across parent rerenders", async () => {
+    const onChange = vi.fn();
+    const assets = [
+      { id: "image-alpha", type: "image", displayName: "Alpha" },
+      { id: "image-beta", type: "image", displayName: "Beta" },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AssetPickerField assets={assets} label="Source" onChange={onChange} value="image-alpha" />);
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Change").click();
+    });
+    await act(async () => {
+      container.querySelectorAll(".asset-picker-card")[1].click();
+    });
+    await act(async () => {
+      root.render(<AssetPickerField assets={[...assets]} label="Source" onChange={onChange} value="image-alpha" />);
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Use Selection").click();
+    });
+
+    expect(onChange).toHaveBeenCalledWith("image-beta");
+  });
+
+  it("toggles and confirms multiple assets through the thumbnail picker", async () => {
+    const onChange = vi.fn();
+    const assets = [
+      { id: "image-alpha", type: "image", displayName: "Alpha" },
+      { id: "image-beta", type: "image", displayName: "Beta" },
+      { id: "image-gamma", type: "image", displayName: "Gamma" },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AssetPickerField assets={assets} label="Reference assets" multiple onChange={onChange} values={[]} />);
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Select").click();
+    });
+
+    const cards = [...container.querySelectorAll(".asset-picker-card")];
+    await act(async () => {
+      cards[0].click();
+      cards[1].click();
+      cards[0].click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Use Selection").click();
+    });
+
+    expect(onChange).toHaveBeenCalledWith(["image-beta"]);
+
+    await act(async () => {
+      root.render(<AssetPickerField assets={assets} label="Reference assets" multiple onChange={onChange} values={["image-beta"]} />);
+    });
+
+    expect(container.querySelectorAll(".asset-preview-chip")).toHaveLength(1);
+    expect(container.textContent).toContain("Beta");
+  });
+
+  it("keeps unsaved character reference selections when a multi-add partially fails", async () => {
+    const addCharacterReference = vi.fn(async (_characterId, reference) => {
+      if (reference.assetId === "image-beta") {
+        throw new Error("network hiccup");
+      }
+      return {};
+    });
+    const assets = [
+      { id: "image-alpha", type: "image", displayName: "Alpha" },
+      { id: "image-beta", type: "image", displayName: "Beta" },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <CharacterStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          addCharacterReference={addCharacterReference}
+          archiveCharacter={() => {}}
+          assets={assets}
+          attachCharacterLora={() => {}}
+          characters={[{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }]}
+          createCharacter={() => {}}
+          createCharacterLook={() => {}}
+          createCharacterTestJob={() => {}}
+          deleteAsset={() => {}}
+          deleteCharacterLook={() => {}}
+          detachCharacterLora={() => {}}
+          imageModels={[]}
+          latestAssets={[]}
+          loras={[]}
+          onPreview={() => {}}
+          onSendImage={() => {}}
+          onSendVideo={() => {}}
+          purgeAsset={() => {}}
+          removeCharacterReference={() => {}}
+          updateAssetStatus={() => {}}
+          updateCharacter={() => {}}
+          updateCharacterLook={() => {}}
+          updateCharacterLora={() => {}}
+          updateCharacterReference={() => {}}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add image or frame").click();
+    });
+
+    const cards = [...container.querySelectorAll(".asset-picker-card")];
+    await act(async () => {
+      cards[0].click();
+      cards[1].click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Use Selection").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add").click();
+    });
+
+    expect(addCharacterReference).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Added 1 reference");
+    expect(container.textContent).toContain("network hiccup");
+    expect(container.querySelectorAll(".asset-preview-chip")).toHaveLength(1);
+    expect(container.textContent).toContain("Beta");
   });
 
   it("keeps the shell usable when recipe presets are unavailable", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -51,6 +51,7 @@ export function CharacterStudio({
   const [referenceAssetIds, setReferenceAssetIds] = useState([]);
   const [lookDraft, setLookDraft] = useState({ name: "", description: "" });
   const [selectedReferenceIds, setSelectedReferenceIds] = useState([]);
+  const [referenceMessage, setReferenceMessage] = useState("");
   const [loraId, setLoraId] = useState("");
   const [loraEdits, setLoraEdits] = useState({});
   const [testPrompt, setTestPrompt] = useState("A clean character reference portrait, consistent identity, studio lighting");
@@ -118,10 +119,23 @@ export function CharacterStudio({
   async function submitReference(event) {
     event.preventDefault();
     if (selectedCharacter && referenceAssetIds.length) {
-      for (const assetId of referenceAssetIds) {
-        await addCharacterReference(selectedCharacter.id, { assetId, approved: false });
+      const savedAssetIds = [];
+      try {
+        for (const assetId of referenceAssetIds) {
+          await addCharacterReference(selectedCharacter.id, { assetId, approved: false });
+          savedAssetIds.push(assetId);
+        }
+        setReferenceAssetIds([]);
+        setReferenceMessage("");
+      } catch (err) {
+        const message = err?.message ?? "Unknown error";
+        setReferenceAssetIds((ids) => ids.filter((id) => !savedAssetIds.includes(id)));
+        setReferenceMessage(
+          savedAssetIds.length
+            ? `Added ${savedAssetIds.length} reference${savedAssetIds.length === 1 ? "" : "s"}. Could not add the remaining selection: ${message}`
+            : `Could not add references: ${message}`,
+        );
       }
-      setReferenceAssetIds([]);
     }
   }
 
@@ -304,6 +318,7 @@ export function CharacterStudio({
             <CharacterReferences
               imageAssets={imageAssets}
               onPreview={onPreview}
+              referenceMessage={referenceMessage}
               referenceAssetIds={referenceAssetIds}
               removeCharacterReference={removeCharacterReference}
               selectedCharacter={selectedCharacter}

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -48,7 +48,7 @@ export function CharacterStudio({
   const [selectedCharacterId, setSelectedCharacterId] = useState(characters[0]?.id ?? "");
   const [draft, setDraft] = useState({ name: "", type: "person", description: "" });
   const [newCharacter, setNewCharacter] = useState({ name: "", type: "person", description: "" });
-  const [referenceAssetId, setReferenceAssetId] = useState("");
+  const [referenceAssetIds, setReferenceAssetIds] = useState([]);
   const [lookDraft, setLookDraft] = useState({ name: "", description: "" });
   const [selectedReferenceIds, setSelectedReferenceIds] = useState([]);
   const [loraId, setLoraId] = useState("");
@@ -117,9 +117,11 @@ export function CharacterStudio({
 
   async function submitReference(event) {
     event.preventDefault();
-    if (selectedCharacter && referenceAssetId) {
-      await addCharacterReference(selectedCharacter.id, { assetId: referenceAssetId, approved: false });
-      setReferenceAssetId("");
+    if (selectedCharacter && referenceAssetIds.length) {
+      for (const assetId of referenceAssetIds) {
+        await addCharacterReference(selectedCharacter.id, { assetId, approved: false });
+      }
+      setReferenceAssetIds([]);
     }
   }
 
@@ -302,10 +304,10 @@ export function CharacterStudio({
             <CharacterReferences
               imageAssets={imageAssets}
               onPreview={onPreview}
-              referenceAssetId={referenceAssetId}
+              referenceAssetIds={referenceAssetIds}
               removeCharacterReference={removeCharacterReference}
               selectedCharacter={selectedCharacter}
-              setReferenceAssetId={setReferenceAssetId}
+              setReferenceAssetIds={setReferenceAssetIds}
               submitReference={submitReference}
               updateCharacterReference={updateCharacterReference}
             />

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import {
@@ -76,6 +77,10 @@ export function ImageStudio({
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [resultFallbackTick, setResultFallbackTick] = useState(0);
+  const editImageAssets = useMemo(
+    () => assets.filter((asset) => asset.type === "image" || asset.type === "frame"),
+    [assets],
+  );
 
   function serializeLora(lora, override = {}) {
     return {
@@ -329,19 +334,14 @@ export function ImageStudio({
       <form className="studio-layout" onSubmit={submit}>
         <section className="studio-controls">
           {mode === "edit_image" ? (
-            <label>
-              Source
-              <select onChange={(event) => setSourceAssetId(event.target.value)} value={sourceAssetId}>
-                <option value="">Select image</option>
-                {assets
-                  .filter((asset) => asset.type === "image" || asset.type === "frame")
-                  .map((asset) => (
-                    <option key={asset.id} value={asset.id}>
-                      {asset.displayName}
-                    </option>
-                  ))}
-              </select>
-            </label>
+            <AssetPickerField
+              assets={editImageAssets}
+              buttonLabel="Select image"
+              emptyLabel="No source image selected"
+              label="Source"
+              onChange={setSourceAssetId}
+              value={sourceAssetId}
+            />
           ) : null}
 
           {mode === "character_image" ? (

--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 
 export function findReplacementModel(videoModels) {
@@ -48,17 +49,14 @@ export function ReplacePersonPanel({
 
   return (
     <div className="replace-person-panel">
-      <label>
-        Source clip
-        <select onChange={(event) => setSourceClipAssetId(event.target.value)} value={sourceClipAssetId}>
-          <option value="">Select clip</option>
-          {videoAssets.map((asset) => (
-            <option key={asset.id} value={asset.id}>
-              {asset.displayName}
-            </option>
-          ))}
-        </select>
-      </label>
+      <AssetPickerField
+        assets={videoAssets}
+        buttonLabel="Select clip"
+        emptyLabel="No source clip selected"
+        label="Source clip"
+        onChange={setSourceClipAssetId}
+        value={sourceClipAssetId}
+      />
 
       <div className="guidance-strip">
         <strong>V1 placeholder tracking</strong>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
@@ -342,45 +343,36 @@ export function VideoStudio({
       <form className="studio-layout video-layout" onSubmit={submit}>
         <section className="studio-controls">
           {mode === "image_to_video" || mode === "first_last_frame" ? (
-            <label>
-              First frame
-              <select onChange={(event) => setSourceAssetId(event.target.value)} value={sourceAssetId}>
-                <option value="">Select image</option>
-                {imageAssets.map((asset) => (
-                  <option key={asset.id} value={asset.id}>
-                    {asset.displayName}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <AssetPickerField
+              assets={imageAssets}
+              buttonLabel="Select image"
+              emptyLabel="No first frame selected"
+              label="First frame"
+              onChange={setSourceAssetId}
+              value={sourceAssetId}
+            />
           ) : null}
 
           {mode === "first_last_frame" ? (
-            <label>
-              Last frame
-              <select onChange={(event) => setLastFrameAssetId(event.target.value)} value={lastFrameAssetId}>
-                <option value="">Select image</option>
-                {imageAssets.map((asset) => (
-                  <option key={asset.id} value={asset.id}>
-                    {asset.displayName}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <AssetPickerField
+              assets={imageAssets}
+              buttonLabel="Select image"
+              emptyLabel="No last frame selected"
+              label="Last frame"
+              onChange={setLastFrameAssetId}
+              value={lastFrameAssetId}
+            />
           ) : null}
 
           {mode === "extend_clip" ? (
-            <label>
-              Source clip
-              <select onChange={(event) => setSourceClipAssetId(event.target.value)} value={sourceClipAssetId}>
-                <option value="">Select clip</option>
-                {videoAssets.map((asset) => (
-                  <option key={asset.id} value={asset.id}>
-                    {asset.displayName}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <AssetPickerField
+              assets={videoAssets}
+              buttonLabel="Select clip"
+              emptyLabel="No source clip selected"
+              label="Source clip"
+              onChange={setSourceClipAssetId}
+              value={sourceClipAssetId}
+            />
           ) : null}
 
           {mode === "replace_person" ? (

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -32,6 +32,7 @@ function summarizeCompatibility(item) {
 export function CharacterReferences({
   imageAssets,
   onPreview,
+  referenceMessage,
   referenceAssetIds,
   removeCharacterReference,
   selectedCharacter,
@@ -59,6 +60,7 @@ export function CharacterReferences({
           Add
         </button>
       </form>
+      {referenceMessage ? <p className="inline-warning">{referenceMessage}</p> : null}
       <div className="character-reference-grid">
         {(selectedCharacter.references ?? []).map((reference) => (
           <article className={reference.approved ? "reference-card approved" : "reference-card"} key={reference.assetId}>

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 
@@ -31,10 +32,10 @@ function summarizeCompatibility(item) {
 export function CharacterReferences({
   imageAssets,
   onPreview,
-  referenceAssetId,
+  referenceAssetIds,
   removeCharacterReference,
   selectedCharacter,
-  setReferenceAssetId,
+  setReferenceAssetIds,
   submitReference,
   updateCharacterReference,
 }) {
@@ -44,16 +45,17 @@ export function CharacterReferences({
         <p className="eyebrow">References</p>
         <h2>Approved set</h2>
       </div>
-      <form className="inline-create" onSubmit={submitReference}>
-        <select onChange={(event) => setReferenceAssetId(event.target.value)} value={referenceAssetId}>
-          <option value="">Add image or frame</option>
-          {imageAssets.map((asset) => (
-            <option key={asset.id} value={asset.id}>
-              {asset.displayName}
-            </option>
-          ))}
-        </select>
-        <button disabled={!referenceAssetId} type="submit">
+      <form className="inline-create asset-reference-create" onSubmit={submitReference}>
+        <AssetPickerField
+          assets={imageAssets}
+          buttonLabel="Add image or frame"
+          emptyLabel="No references selected"
+          label="Reference assets"
+          multiple
+          onChange={setReferenceAssetIds}
+          values={referenceAssetIds}
+        />
+        <button disabled={!referenceAssetIds.length} type="submit">
           Add
         </button>
       </form>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -217,7 +217,12 @@ button {
   align-items: end;
 }
 
-.inline-create button,
+.asset-reference-create {
+  grid-template-columns: minmax(220px, 1fr) auto;
+  align-items: start;
+}
+
+.inline-create > button,
 .look-composer button,
 .test-result > button {
   min-height: 38px;
@@ -267,6 +272,94 @@ select {
   background: #191815;
   color: #f3f0e8;
   padding: 9px 10px;
+}
+
+.asset-picker-field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.asset-picker-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+
+.asset-picker-label {
+  color: #d8d2c7;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.asset-picker-head button,
+.asset-picker-footer .detail-actions button {
+  min-height: 34px;
+  border: 1px solid #4b463d;
+  background: #292722;
+  color: #f3f0e8;
+  padding: 7px 10px;
+}
+
+.asset-preview-chips {
+  display: grid;
+  gap: 8px;
+}
+
+.asset-preview-chip,
+.asset-picker-empty {
+  border: 1px solid #4b463d;
+  background: #191815;
+}
+
+.asset-preview-chip {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  min-height: 78px;
+  padding: 8px;
+}
+
+.asset-preview-chip img,
+.asset-preview-chip video,
+.asset-preview-chip > span:first-child {
+  width: 62px;
+  height: 62px;
+  object-fit: cover;
+  background: #0f0f0e;
+}
+
+.asset-preview-chip > span:first-child {
+  display: grid;
+  place-items: center;
+  color: #aaa397;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.asset-preview-chip > span:last-child {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.asset-preview-chip strong,
+.asset-preview-chip small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-preview-chip small,
+.asset-picker-empty {
+  color: #aaa397;
+  font-size: 12px;
+}
+
+.asset-picker-empty {
+  padding: 10px;
 }
 
 input:focus,
@@ -1547,6 +1640,115 @@ button:disabled {
 
 .modal-close {
   justify-self: end;
+}
+
+.asset-picker-modal {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 12px;
+  width: min(1180px, 96vw);
+  max-height: 92vh;
+  padding: 16px;
+  border: 1px solid #4b463d;
+  background: #191815;
+}
+
+.asset-picker-modal-head,
+.asset-picker-toolbar,
+.asset-picker-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.asset-picker-modal-head h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.asset-picker-toolbar input {
+  width: min(320px, 100%);
+}
+
+.asset-picker-toolbar .segmented-control button {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.asset-picker-toolbar .segmented-control span {
+  color: #aaa397;
+  font-size: 12px;
+}
+
+.asset-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(172px, 1fr));
+  gap: 10px;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.asset-picker-card {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  min-height: 236px;
+  border: 1px solid #3c3a34;
+  background: #23221f;
+  color: #f3f0e8;
+  padding: 8px;
+  text-align: left;
+}
+
+.asset-picker-card.selected {
+  border-color: #6ec6b8;
+  background: #183f3a;
+}
+
+.asset-picker-card img,
+.asset-picker-card video,
+.asset-picker-card > span:first-child {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  background: #0f0f0e;
+}
+
+.asset-picker-card > span:first-child {
+  display: grid;
+  place-items: center;
+  color: #aaa397;
+  text-transform: uppercase;
+}
+
+.asset-picker-card-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.asset-picker-card-copy strong {
+  display: -webkit-box;
+  overflow: hidden;
+  min-height: 34px;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 14px;
+}
+
+.asset-picker-card-copy small,
+.asset-picker-footer {
+  color: #aaa397;
+  font-size: 12px;
+}
+
+.asset-picker-card-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .queue-chip {


### PR DESCRIPTION
## Summary
- Add a reusable thumbnail asset picker modal with category filters, search, metadata, and Escape/cancel behavior.
- Replace title-only library asset dropdowns in Image Studio, Video Studio, Replace Person, and Character References.
- Show compact selected-asset preview chips and support multi-select for character references.

## Story
Shortcut: https://app.shortcut.com/trefry/story/1374/replace-title-only-asset-dropdowns-with-thumbnail-asset-picker-modal

## Validation
- npm test
- npm run build
- Browser smoke check at http://127.0.0.1:5173 for modal open, metadata/category rendering, Escape close, and console errors.
