### PR TITLE
[codex] Fix incremental image batch display

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -256,15 +256,18 @@ export function App() {
 
     function handleJobUpdated(event) {
       const job = JSON.parse(event.data);
+      const hasGeneratedAssets = Boolean(job.result?.generationSetId || job.result?.assetIds?.length);
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      if (job.status === "completed" && (job.result?.generationSetId || job.result?.assetIds?.length)) {
+      if (hasGeneratedAssets) {
         if (job.result?.generationSetId) {
           setLatestGenerationSetId(job.result.generationSetId);
         }
-        enqueueTimelineGenerationApply(job);
         if (job.projectId) {
           refreshAssets(job.projectId);
         }
+      }
+      if (job.status === "completed" && hasGeneratedAssets) {
+        enqueueTimelineGenerationApply(job);
       }
       if (job.status === "completed" && job.projectId && job.type === "person_track") {
         refreshPersonTracks(job.projectId);

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -68,6 +68,16 @@ function mergeFreshJobs(currentJobs, serverJobs) {
   return [...merged.values()].sort(sortNewest);
 }
 
+function generatedResultAssetCount(job) {
+  if (Array.isArray(job.result?.assetIds)) {
+    return job.result.assetIds.length;
+  }
+  if (Array.isArray(job.result?.assets)) {
+    return job.result.assets.length;
+  }
+  return 0;
+}
+
 const localJobStackLimit = 4;
 const maxLoraUploadBytes = 2 * 1024 * 1024 * 1024;
 
@@ -105,6 +115,7 @@ export function App() {
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
   const selectedTimelineIdRef = useRef(null);
   const timelineApplyQueueRef = useRef(Promise.resolve());
+  const generatedAssetRefreshesRef = useRef(new Map());
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
@@ -256,13 +267,26 @@ export function App() {
 
     function handleJobUpdated(event) {
       const job = JSON.parse(event.data);
-      const hasGeneratedAssets = Boolean(job.result?.generationSetId || job.result?.assetIds?.length);
+      const hasGeneratedAssets = Boolean(job.result?.generationSetId || job.result?.assetIds?.length || job.result?.assets?.length);
+      const resultAssetCount = generatedResultAssetCount(job);
+      const generationSetId = job.result?.generationSetId ?? "";
+      const refreshKey = job.id ?? generationSetId;
+      const previousRefresh = generatedAssetRefreshesRef.current.get(refreshKey) ?? { assetCount: 0, generationSetId: "" };
+      const shouldRefreshGeneratedAssets =
+        Boolean(job.projectId) &&
+        hasGeneratedAssets &&
+        (resultAssetCount > previousRefresh.assetCount ||
+          (resultAssetCount === 0 && generationSetId && generationSetId !== previousRefresh.generationSetId));
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       if (hasGeneratedAssets) {
         if (job.result?.generationSetId) {
           setLatestGenerationSetId(job.result.generationSetId);
         }
-        if (job.projectId) {
+        generatedAssetRefreshesRef.current.set(refreshKey, {
+          assetCount: Math.max(resultAssetCount, previousRefresh.assetCount),
+          generationSetId: generationSetId || previousRefresh.generationSetId,
+        });
+        if (shouldRefreshGeneratedAssets) {
           refreshAssets(job.projectId);
         }
       }

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2064,6 +2064,69 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("No fresh image batch");
   });
 
+  it("reconstructs running image batch slots from a generation set without asset ids", async () => {
+    const localJob = {
+      id: "image-job-1",
+      type: "image_generate",
+      status: "running",
+      stage: "generating",
+      progress: 0.82,
+      elapsedSeconds: 8,
+      requestedGpu: "auto",
+      payload: { prompt: "long alley", count: 3 },
+      result: { generationSetId: "gen-1", expectedCount: 3 },
+    };
+    const assets = [
+      {
+        id: "asset-2",
+        projectId: "project-1",
+        type: "image",
+        displayName: "Generated",
+        generationSetId: "gen-1",
+        file: { path: "runs/run_0007/assets/images/generated_0002.png", mimeType: "image/png" },
+        status: {},
+      },
+      {
+        id: "asset-1",
+        projectId: "project-1",
+        type: "image",
+        displayName: "Generated",
+        generationSetId: "gen-1",
+        file: { path: "assets/images/generated_0001.png", mimeType: "image/png" },
+        status: {},
+      },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={assets}
+          characters={[]}
+          createImageJob={() => {}}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
+          latestAssets={[]}
+          localJobs={[localJob]}
+          loras={[]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+
+    const images = [...container.querySelectorAll(".review-grid img")].map((image) => image.getAttribute("src"));
+    expect(images[0]).toContain("/api/v1/projects/project-1/files/assets/images/generated_0001.png");
+    expect(images[1]).toContain("/api/v1/projects/project-1/files/runs/run_0007/assets/images/generated_0002.png");
+    expect(container.textContent).toContain("Pending #3");
+  });
+
   it("hides completed image progress with stale missing result metadata", async () => {
     const staleCompletedJob = {
       id: "image-job-stale",

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -624,6 +624,101 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Pending #4");
   });
 
+  it("reconstructs running image batch slots from partial asset records", async () => {
+    const createdJobs = [];
+    let currentAssets = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/assets")) {
+        return Promise.resolve(response(currentAssets));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]));
+      }
+      if (path.endsWith("/image/jobs") && options.method === "POST") {
+        const job = {
+          id: "image-job-1",
+          type: "image_generate",
+          status: "running",
+          stage: "running",
+          progress: 0.35,
+          elapsedSeconds: 4,
+          projectId: "project-1",
+          projectName: "Noir",
+          requestedGpu: "auto",
+          payload: { prompt: "A cinematic frame of a neon street at midnight", count: 4 },
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Image").click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+
+    currentAssets = [
+      {
+        id: "asset-1",
+        projectId: "project-1",
+        generationSetId: "genset-1",
+        type: "image",
+        displayName: "Generated #1",
+        file: { path: "assets/images/generated_0001.png", mimeType: "image/png" },
+        status: { favorite: false, rejected: false, trashed: false },
+      },
+    ];
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          ...createdJobs[0],
+          status: "running",
+          stage: "generating",
+          progress: 0.48,
+          message: "Running Z-Image 2 of 4.",
+          result: {
+            generationSetId: "genset-1",
+            assetIds: ["asset-1"],
+            expectedCount: 4,
+          },
+        }),
+      });
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Running Z-Image 2 of 4.");
+    expect(container.querySelector(".review-grid img")?.getAttribute("src")).toContain(
+      "/api/v1/projects/project-1/files/assets/images/generated_0001.png",
+    );
+    expect(container.textContent).not.toContain("Pending #1");
+    expect(container.textContent).toContain("Pending #2");
+    expect(container.textContent).toContain("Pending #4");
+  });
+
   it("shows local generation failures without duplicating the global banner", async () => {
     const createdJobs = [];
     global.fetch.mockImplementation((url, options = {}) => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -22,14 +22,49 @@ const localErrorLabels = {
 
 function jobResultAssets(job, assets) {
   const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
-  return (job.result?.assets ?? [])
-    .map((asset) => catalogById.get(asset.id) ?? asset)
-    .filter((asset) => asset?.type === "image");
+  const resultAssets = (job.result?.assets ?? []).filter((asset) => asset?.type === "image");
+  const resultById = new Map(resultAssets.map((asset) => [asset.id, catalogById.get(asset.id) ?? asset]));
+  const assetIds = job.result?.assetIds ?? [];
+  if (assetIds.length) {
+    return assetIds
+      .map((id) => resultById.get(id) ?? catalogById.get(id))
+      .filter((asset) => asset?.type === "image");
+  }
+  if (resultAssets.length) {
+    return resultAssets.map((asset) => catalogById.get(asset.id) ?? asset);
+  }
+  if (job.result?.generationSetId) {
+    return assets
+      .filter((asset) => asset.type === "image" && asset.generationSetId === job.result.generationSetId)
+      .sort((left, right) => assetBatchIndex(left) - assetBatchIndex(right));
+  }
+  return [];
 }
 
 function jobExpectedCount(job, completedCount) {
   const expected = Number(job.result?.expectedCount ?? job.result?.count ?? job.payload?.count);
   return Number.isFinite(expected) && expected > 0 ? Math.max(expected, completedCount) : completedCount;
+}
+
+function assetBatchIndex(asset) {
+  const candidates = [
+    asset?.batchIndex,
+    asset?.recipe?.batchIndex,
+    asset?.recipe?.normalizedSettings?.batchIndex,
+    asset?.lineage?.batchIndex,
+  ];
+  for (const candidate of candidates) {
+    const value = Number(candidate);
+    if (Number.isFinite(value)) {
+      return value;
+    }
+  }
+  const fileMatch = String(asset?.file?.path ?? "").match(/_(\d{4})\.[^./\\]+$/);
+  if (fileMatch) {
+    return Number(fileMatch[1]) - 1;
+  }
+  const nameMatch = String(asset?.displayName ?? "").match(/#(\d+)\s*$/);
+  return nameMatch ? Number(nameMatch[1]) - 1 : Number.POSITIVE_INFINITY;
 }
 
 function jobPendingSlotLabel(job, index) {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -26,6 +26,7 @@ function jobResultAssets(job, assets) {
   const resultById = new Map(resultAssets.map((asset) => [asset.id, catalogById.get(asset.id) ?? asset]));
   const assetIds = job.result?.assetIds ?? [];
   if (assetIds.length) {
+    // The worker emits assetIds in batch-slot order, so preserve this array order when filling review slots.
     return assetIds
       .map((id) => resultById.get(id) ?? catalogById.get(id))
       .filter((asset) => asset?.type === "image");
@@ -59,7 +60,8 @@ function assetBatchIndex(asset) {
       return value;
     }
   }
-  const fileMatch = String(asset?.file?.path ?? "").match(/_(\d{4})\.[^./\\]+$/);
+  const basename = String(asset?.file?.path ?? "").split(/[\\/]/).pop() ?? "";
+  const fileMatch = basename.match(/_(\d{4})\.[^.]+$/);
   if (fileMatch) {
     return Number(fileMatch[1]) - 1;
   }

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -168,6 +168,29 @@ class ImageAssetWriter:
         cancel_requested: CancelCallback,
         raw_settings: dict[str, Any],
     ) -> dict[str, Any]:
+        return self.write_incremental_outputs(
+            settings=settings,
+            job=job,
+            image_count=len(images),
+            image_at_index=lambda index: images[index],
+            adapter_id=adapter_id,
+            progress=progress,
+            cancel_requested=cancel_requested,
+            raw_settings=raw_settings,
+        )
+
+    def write_incremental_outputs(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        image_count: int,
+        image_at_index: Callable[[int], Image.Image],
+        adapter_id: str,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+        raw_settings: dict[str, Any],
+    ) -> dict[str, Any]:
         request = image_request_from_job(job)
         project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
         for folder in ("assets/images", "generation-sets", "recipes"):
@@ -189,12 +212,16 @@ class ImageAssetWriter:
             "model": request.model,
             "prompt": request.prompt,
             "negativePrompt": request.negative_prompt,
-            "count": len(images),
+            "count": image_count,
             "createdAt": created_at,
         }
         write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
 
-        for index, image in enumerate(images):
+        for index in range(image_count):
+            if cancel_requested():
+                raise InterruptedError("Image generation canceled by user.")
+
+            image = image_at_index(index)
             if cancel_requested():
                 raise InterruptedError("Image generation canceled by user.")
 
@@ -227,13 +254,13 @@ class ImageAssetWriter:
             progress(
                 "saving",
                 "saving",
-                0.78 + ((index + 1) / len(images)) * 0.17,
-                f"Saved image asset {index + 1} of {len(images)}.",
+                0.78 + ((index + 1) / image_count) * 0.17,
+                f"Saved image asset {index + 1} of {image_count}.",
                 {
                     "generationSetId": generation_set_id,
                     "assetIds": [item["id"] for item in assets],
                     "assets": assets,
-                    "expectedCount": len(images),
+                    "expectedCount": image_count,
                     "adapter": adapter_id,
                     "model": request.model,
                 },
@@ -243,7 +270,7 @@ class ImageAssetWriter:
             "generationSetId": generation_set_id,
             "assetIds": [asset["id"] for asset in assets],
             "assets": assets,
-            "expectedCount": len(images),
+            "expectedCount": image_count,
             "adapter": adapter_id,
             "model": request.model,
         }
@@ -281,19 +308,20 @@ class ZImageDiffusersAdapter:
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
         pipe = self._load_pipeline(settings, request, model_target, progress=progress)
         self._apply_loras(pipe, request)
-        images = []
         total = request.count
-        for index in range(total):
+
+        def image_at_index(index: int) -> Image.Image:
             if cancel_requested():
                 raise InterruptedError("Image generation canceled by user.")
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
             progress("running", "generating", 0.24 + (index / total) * 0.48, f"Running Z-Image {index + 1} of {total}.")
-            images.append(self._run_pipeline(settings, pipe, request, seed))
+            return self._run_pipeline(settings, pipe, request, seed)
 
-        return ImageAssetWriter().write_outputs(
+        return ImageAssetWriter().write_incremental_outputs(
             settings=settings,
             job=job,
-            images=images,
+            image_count=total,
+            image_at_index=image_at_index,
             adapter_id=self.id,
             progress=progress,
             cancel_requested=cancel_requested,
@@ -452,18 +480,19 @@ class QwenImageAdapter:
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
         pipe = self._load_pipeline(settings, request, model_target, progress=progress)
         self._apply_loras(pipe, request)
-        images = []
-        for index in range(request.count):
+
+        def image_at_index(index: int) -> Image.Image:
             if cancel_requested():
                 raise InterruptedError("Image generation canceled by user.")
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
             progress("running", "generating", 0.24 + (index / request.count) * 0.48, f"Running Qwen Image {index + 1} of {request.count}.")
-            images.append(self._run_pipeline(settings, pipe, request, seed))
+            return self._run_pipeline(settings, pipe, request, seed)
 
-        return ImageAssetWriter().write_outputs(
+        return ImageAssetWriter().write_incremental_outputs(
             settings=settings,
             job=job,
-            images=images,
+            image_count=request.count,
+            image_at_index=image_at_index,
             adapter_id=self.id,
             progress=progress,
             cancel_requested=cancel_requested,
@@ -595,23 +624,23 @@ class ProceduralImageAdapter:
         if request.mode == "edit_image" and not model_supports_edit(request.model):
             raise RuntimeError(f"{request.model} does not support image editing.")
 
-        images = []
-        for index in range(request.count):
+        def image_at_index(index: int) -> Image.Image:
             if cancel_requested():
                 raise InterruptedError("Image generation canceled by user.")
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
-            images.append(render_preview_image(request, model_target, seed, index))
             progress(
                 "running",
                 "generating",
                 0.2 + ((index + 1) / request.count) * 0.55,
                 f"Generated preview image {index + 1} of {request.count}.",
             )
+            return render_preview_image(request, model_target, seed, index)
 
-        return ImageAssetWriter().write_outputs(
+        return ImageAssetWriter().write_incremental_outputs(
             settings=settings,
             job=job,
-            images=images,
+            image_count=request.count,
+            image_at_index=image_at_index,
             adapter_id=self.id,
             progress=progress,
             cancel_requested=cancel_requested,

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -254,7 +254,7 @@ class ImageAssetWriter:
             progress(
                 "saving",
                 "saving",
-                0.78 + ((index + 1) / image_count) * 0.17,
+                image_batch_progress(index + 1, image_count),
                 f"Saved image asset {index + 1} of {image_count}.",
                 {
                     "generationSetId": generation_set_id,
@@ -311,10 +311,8 @@ class ZImageDiffusersAdapter:
         total = request.count
 
         def image_at_index(index: int) -> Image.Image:
-            if cancel_requested():
-                raise InterruptedError("Image generation canceled by user.")
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
-            progress("running", "generating", 0.24 + (index / total) * 0.48, f"Running Z-Image {index + 1} of {total}.")
+            progress("running", "generating", image_batch_progress(index, total), f"Running Z-Image {index + 1} of {total}.")
             return self._run_pipeline(settings, pipe, request, seed)
 
         return ImageAssetWriter().write_incremental_outputs(
@@ -482,10 +480,8 @@ class QwenImageAdapter:
         self._apply_loras(pipe, request)
 
         def image_at_index(index: int) -> Image.Image:
-            if cancel_requested():
-                raise InterruptedError("Image generation canceled by user.")
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
-            progress("running", "generating", 0.24 + (index / request.count) * 0.48, f"Running Qwen Image {index + 1} of {request.count}.")
+            progress("running", "generating", image_batch_progress(index, request.count), f"Running Qwen Image {index + 1} of {request.count}.")
             return self._run_pipeline(settings, pipe, request, seed)
 
         return ImageAssetWriter().write_incremental_outputs(
@@ -625,13 +621,11 @@ class ProceduralImageAdapter:
             raise RuntimeError(f"{request.model} does not support image editing.")
 
         def image_at_index(index: int) -> Image.Image:
-            if cancel_requested():
-                raise InterruptedError("Image generation canceled by user.")
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
             progress(
                 "running",
                 "generating",
-                0.2 + ((index + 1) / request.count) * 0.55,
+                image_batch_progress(index, request.count),
                 f"Generated preview image {index + 1} of {request.count}.",
             )
             return render_preview_image(request, model_target, seed, index)
@@ -687,6 +681,12 @@ def resolve_seed(seed: int | None, prompt: str, index: int, seeds: list[int] | N
         return int(seeds[index])
     digest = hashlib.sha256(f"{prompt}:{index}".encode("utf-8")).hexdigest()
     return int(digest[:8], 16)
+
+
+def image_batch_progress(completed_count: int, total: int) -> float:
+    safe_total = max(1, total)
+    bounded_count = min(max(0, completed_count), safe_total)
+    return 0.78 + (bounded_count / safe_total) * 0.17
 
 
 def select_torch_device(torch: Any, gpu_id: str | None = None) -> str:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -15,6 +15,7 @@ from scene_worker.image_adapters import (
     build_asset_sidecar,
     create_image_adapter,
     huggingface_repo_cache_path,
+    image_batch_progress,
     image_request_from_job,
     require_inference_backend_for_gpu_worker,
     resolve_seed,
@@ -558,6 +559,50 @@ def test_image_asset_writer_persists_each_image_before_requesting_next(tmp_path)
 
     assert len(result["assetIds"]) == 2
     assert len(list((project_path / "assets" / "images").glob("*.png"))) == 2
+
+
+def test_image_asset_writer_batch_progress_is_monotonic(tmp_path):
+    data_dir = tmp_path / "data"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    job = {
+        "id": "job-1",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "Neon alley",
+            "model": "z_image_turbo",
+            "count": 4,
+            "width": 16,
+            "height": 16,
+        },
+    }
+    progress_values = []
+
+    def progress(_status, _stage, value, _message, result=None):
+        progress_values.append(value)
+
+    def image_at_index(index):
+        progress("running", "generating", image_batch_progress(index, 4), f"Running image {index + 1} of 4.")
+        return Image.new("RGB", (16, 16), (255, 0, 0))
+
+    ImageAssetWriter().write_incremental_outputs(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job=job,
+        image_count=4,
+        image_at_index=image_at_index,
+        adapter_id="z_image_diffusers",
+        progress=progress,
+        cancel_requested=lambda: False,
+        raw_settings={"realModelInference": True},
+    )
+
+    assert progress_values == sorted(progress_values)
 
 
 def test_friendly_failure_identifies_gpu_oom():

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -517,6 +517,49 @@ def test_image_asset_writer_reports_partial_result_assets(tmp_path):
     assert result["expectedCount"] == 2
 
 
+def test_image_asset_writer_persists_each_image_before_requesting_next(tmp_path):
+    data_dir = tmp_path / "data"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    job = {
+        "id": "job-1",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "Neon alley",
+            "model": "z_image_turbo",
+            "count": 2,
+            "width": 16,
+            "height": 16,
+        },
+    }
+
+    def image_at_index(index):
+        if index == 1:
+            assert len(list((project_path / "assets" / "images").glob("*.png"))) == 1
+            assert len(list((project_path / "assets" / "images").glob("*.sceneworks.json"))) == 1
+        return Image.new("RGB", (16, 16), (255, 0, 0) if index == 0 else (0, 255, 0))
+
+    result = ImageAssetWriter().write_incremental_outputs(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job=job,
+        image_count=2,
+        image_at_index=image_at_index,
+        adapter_id="z_image_diffusers",
+        progress=lambda *_args, **_kwargs: None,
+        cancel_requested=lambda: False,
+        raw_settings={"realModelInference": True},
+    )
+
+    assert len(result["assetIds"]) == 2
+    assert len(list((project_path / "assets" / "images").glob("*.png"))) == 2
+
+
 def test_friendly_failure_identifies_gpu_oom():
     message, error = friendly_failure("Image generation", RuntimeError("CUDA error: out of memory"))
 


### PR DESCRIPTION
﻿## Summary
- Persist each image output immediately after it is generated so completed batch slots exist before the full batch finishes.
- Refresh project assets on partial generation result updates, not only completed jobs.
- Reconcile Image Studio review slots from embedded result assets, result asset IDs, or generation-set asset records.

## Root Cause
The UI had support for mixed completed/pending slots, but real image adapters generated the full batch in memory before writing any assets. At a progress state like `Running Z-Image 2 of 4`, slot 1 could still be unsaved, so the Review panel had nothing concrete to render. The UI also ignored some partial payload shapes during refresh/reload.

## Validation
- `python -m pytest tests/test_worker_runtime.py -q`
- `npm --prefix apps/web test -- src/main.test.jsx`

Shortcut: sc-1375
