### PR TITLE
Diagnose Z-Image Turbo idle-GPU hangs

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -168,13 +168,16 @@ def verify_pipeline_on_device(
     if not devices:
         return devices
     target_index = requested_device.split(":", 1)[1] if ":" in requested_device else None
+    unexpected_devices = []
     for device in devices:
-        if not device.startswith("cuda"):
-            continue
         if target_index is None:
-            return devices
-        if device == requested_device or device.startswith(f"cuda:{target_index}"):
-            return devices
+            if device == "cuda" or device.startswith("cuda:"):
+                continue
+        elif device == "cuda" or device == requested_device:
+            continue
+        unexpected_devices.append(device)
+    if not unexpected_devices:
+        return devices
     observed = ", ".join(devices) or "no detected device"
     raise RuntimeError(
         f"{model_label} did not move onto {requested_device}; pipeline components are on {observed}. "
@@ -581,7 +584,8 @@ class ZImageDiffusersAdapter:
             componentDevices=pipeline_component_devices(pipe),
         )
         progress("loading_model", "loading_model", 0.22, f"Moving {model_target['label']} to {device}.")
-        if cpu_offload and hasattr(pipe, "enable_model_cpu_offload"):
+        offload_enabled = cpu_offload and hasattr(pipe, "enable_model_cpu_offload")
+        if offload_enabled:
             pipe.enable_model_cpu_offload()
         else:
             pipe.to(device)
@@ -589,7 +593,7 @@ class ZImageDiffusersAdapter:
             pipe,
             requested_device=device,
             model_label=model_target["label"],
-            allow_offload=cpu_offload,
+            allow_offload=offload_enabled,
         )
         emit_worker_event(
             "image_pipeline_on_device",
@@ -597,7 +601,7 @@ class ZImageDiffusersAdapter:
             adapter=self.id,
             model=request.model,
             requestedDevice=device,
-            cpuOffload=cpu_offload,
+            cpuOffload=offload_enabled,
             componentDevices=component_devices,
             gpuMemory=gpu_memory_snapshot(torch, device),
         )
@@ -837,7 +841,8 @@ class QwenImageAdapter:
             repo=repo,
             componentDevices=pipeline_component_devices(pipe),
         )
-        if cpu_offload and hasattr(pipe, "enable_model_cpu_offload"):
+        offload_enabled = cpu_offload and hasattr(pipe, "enable_model_cpu_offload")
+        if offload_enabled:
             pipe.enable_model_cpu_offload()
         else:
             pipe.to(device)
@@ -847,7 +852,7 @@ class QwenImageAdapter:
             pipe,
             requested_device=device,
             model_label=model_target["label"],
-            allow_offload=cpu_offload,
+            allow_offload=offload_enabled,
         )
         emit_worker_event(
             "image_pipeline_on_device",
@@ -855,7 +860,7 @@ class QwenImageAdapter:
             adapter=self.id,
             model=request.model,
             requestedDevice=device,
-            cpuOffload=cpu_offload,
+            cpuOffload=offload_enabled,
             componentDevices=component_devices,
             gpuMemory=gpu_memory_snapshot(torch, device),
         )

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib
 import json
 import os
+import sys
 import warnings
 from pathlib import Path
 from textwrap import wrap
@@ -67,6 +68,127 @@ def huggingface_repo_cache_path(repo: str) -> Path | None:
     except (OSError, ValueError):
         return None
     return repo_cache
+
+
+def emit_worker_event(event: str, **payload: Any) -> None:
+    """Emit a structured JSON diagnostic event on the worker's stdout.
+
+    Mirrors `scene_worker.runtime.emit` so adapter-level phase markers
+    (pipeline load, device placement, per-image inference) land in the
+    same operator log stream as worker lifecycle events. Keeps phases
+    distinguishable when a generation job appears to hang.
+    """
+
+    payload["event"] = event
+    payload["reportedAt"] = utc_now()
+    sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+    sys.stdout.flush()
+
+
+def gpu_memory_snapshot(torch: Any, device: str) -> dict[str, Any] | None:
+    if not isinstance(device, str) or not device.startswith("cuda"):
+        return None
+    cuda = getattr(torch, "cuda", None)
+    if cuda is None:
+        return None
+    try:
+        if not bool(cuda.is_available()):
+            return None
+    except Exception:
+        return None
+    snapshot: dict[str, Any] = {"device": device}
+    index = None
+    if ":" in device:
+        try:
+            index = int(device.split(":", 1)[1])
+        except ValueError:
+            index = None
+    try:
+        allocated = int(cuda.memory_allocated(index) if index is not None else cuda.memory_allocated())
+        snapshot["allocatedMb"] = round(allocated / (1024 * 1024), 2)
+    except Exception:
+        pass
+    try:
+        reserved = int(cuda.memory_reserved(index) if index is not None else cuda.memory_reserved())
+        snapshot["reservedMb"] = round(reserved / (1024 * 1024), 2)
+    except Exception:
+        pass
+    return snapshot
+
+
+def pipeline_component_devices(pipe: Any) -> list[str]:
+    """Return the sorted, unique torch device strings of a pipeline's submodules."""
+
+    devices: set[str] = set()
+    components = getattr(pipe, "components", None)
+    if isinstance(components, dict):
+        candidates = list(components.values())
+    else:
+        candidate_names = ("transformer", "unet", "text_encoder", "text_encoder_2", "vae")
+        candidates = [getattr(pipe, name, None) for name in candidate_names]
+    for component in candidates:
+        if component is None:
+            continue
+        device = getattr(component, "device", None)
+        if device is None:
+            parameters = getattr(component, "parameters", None)
+            if callable(parameters):
+                try:
+                    first = next(parameters())
+                except StopIteration:
+                    first = None
+                except Exception:
+                    first = None
+                if first is not None:
+                    device = getattr(first, "device", None)
+        if device is None:
+            continue
+        devices.add(str(device))
+    return sorted(devices)
+
+
+def verify_pipeline_on_device(
+    pipe: Any,
+    *,
+    requested_device: str,
+    model_label: str,
+    allow_offload: bool,
+) -> list[str]:
+    """Confirm a GPU-bound pipeline actually landed on the requested CUDA device.
+
+    Returns the observed component device strings. Raises RuntimeError when
+    the worker asked for a CUDA device but no pipeline component is on a
+    matching CUDA device — that path is the most common source of jobs that
+    look "running" while the GPU stays idle.
+    """
+
+    devices = pipeline_component_devices(pipe)
+    if allow_offload or not requested_device.startswith("cuda"):
+        return devices
+    if not devices:
+        return devices
+    target_index = requested_device.split(":", 1)[1] if ":" in requested_device else None
+    for device in devices:
+        if not device.startswith("cuda"):
+            continue
+        if target_index is None:
+            return devices
+        if device == requested_device or device.startswith(f"cuda:{target_index}"):
+            return devices
+    observed = ", ".join(devices) or "no detected device"
+    raise RuntimeError(
+        f"{model_label} did not move onto {requested_device}; pipeline components are on {observed}. "
+        "Check CUDA driver compatibility and worker GPU assignment, then retry."
+    )
+
+
+def format_batch_running_message(label: str, index: int, total: int) -> str:
+    """Build a per-iteration "Running" progress message that names the actual
+    saved count alongside the in-flight index, so users do not see "Running 3
+    of 4" without prior images being durable."""
+
+    prefix = f"Generated {index} of {total}. " if index > 0 else ""
+    return f"{prefix}Running {label} {index + 1} of {total}."
 
 
 MODEL_TARGETS = {
@@ -306,14 +428,58 @@ class ZImageDiffusersAdapter:
             raise RuntimeError(f"{request.model} is not a Z-Image Diffusers target.")
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
-        pipe = self._load_pipeline(settings, request, model_target, progress=progress)
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress, job_id=job["id"])
+        emit_worker_event(
+            "image_lora_apply_start",
+            jobId=job["id"],
+            adapter=self.id,
+            loraCount=len(request.loras),
+        )
         self._apply_loras(pipe, request)
+        emit_worker_event("image_lora_apply_complete", jobId=job["id"], adapter=self.id)
         total = request.count
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        label = "Z-Image"
 
         def image_at_index(index: int) -> Image.Image:
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
-            progress("running", "generating", image_batch_progress(index, total), f"Running Z-Image {index + 1} of {total}.")
-            return self._run_pipeline(settings, pipe, request, seed)
+            progress(
+                "running",
+                "generating",
+                image_batch_progress(index, total),
+                format_batch_running_message(label, index, total),
+            )
+            emit_worker_event(
+                "image_inference_start",
+                jobId=job["id"],
+                adapter=self.id,
+                model=request.model,
+                imageIndex=index,
+                imageCount=total,
+                device=device,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            try:
+                image = self._run_pipeline(settings, pipe, request, seed)
+            except Exception as exc:
+                emit_worker_event(
+                    "image_inference_failed",
+                    jobId=job["id"],
+                    adapter=self.id,
+                    imageIndex=index,
+                    error=str(exc),
+                    errorType=exc.__class__.__name__,
+                )
+                raise
+            emit_worker_event(
+                "image_inference_complete",
+                jobId=job["id"],
+                adapter=self.id,
+                imageIndex=index,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return image
 
         return ImageAssetWriter().write_incremental_outputs(
             settings=settings,
@@ -332,7 +498,15 @@ class ZImageDiffusersAdapter:
             },
         )
 
-    def _load_pipeline(self, settings: WorkerSettings, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
+    def _load_pipeline(
+        self,
+        settings: WorkerSettings,
+        request: ImageRequest,
+        model_target: dict[str, Any],
+        progress: ProgressCallback,
+        *,
+        job_id: str,
+    ) -> Any:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = request.advanced.get("modelRepo") or model_target["repo"]
@@ -341,10 +515,21 @@ class ZImageDiffusersAdapter:
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         use_img2img = request.mode == "edit_image"
+        cpu_offload = bool(request.advanced.get("cpuOffload", False))
         cached_pipe = self._img2img_pipe if use_img2img else self._text_pipe
         if cached_pipe is not None and self._loaded_repo == repo:
             self._loaded_model = request.model
             progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
+            emit_worker_event(
+                "image_pipeline_cache_hit",
+                jobId=job_id,
+                adapter=self.id,
+                model=request.model,
+                repo=repo,
+                device=device,
+                componentDevices=pipeline_component_devices(cached_pipe),
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
             return cached_pipe
 
         if self._loaded_repo and self._loaded_repo != repo:
@@ -370,16 +555,52 @@ class ZImageDiffusersAdapter:
 
         cache_action = "Loading cached" if huggingface_repo_cache_exists(repo) else "Downloading"
         progress("loading_model", "loading_model", 0.2, f"{cache_action} {model_target['label']} model files.")
+        emit_worker_event(
+            "image_pipeline_load_start",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            device=device,
+            dtype=str(dtype),
+            useImg2img=use_img2img,
+            cpuOffload=cpu_offload,
+            cached=cache_action == "Loading cached",
+        )
         pipe = pipeline_class.from_pretrained(
             repo,
             torch_dtype=dtype,
             low_cpu_mem_usage=bool(request.advanced.get("lowCpuMemUsage", False)),
         )
+        emit_worker_event(
+            "image_pipeline_load_complete",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            componentDevices=pipeline_component_devices(pipe),
+        )
         progress("loading_model", "loading_model", 0.22, f"Moving {model_target['label']} to {device}.")
-        if bool(request.advanced.get("cpuOffload", False)) and hasattr(pipe, "enable_model_cpu_offload"):
+        if cpu_offload and hasattr(pipe, "enable_model_cpu_offload"):
             pipe.enable_model_cpu_offload()
         else:
             pipe.to(device)
+        component_devices = verify_pipeline_on_device(
+            pipe,
+            requested_device=device,
+            model_label=model_target["label"],
+            allow_offload=cpu_offload,
+        )
+        emit_worker_event(
+            "image_pipeline_on_device",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            requestedDevice=device,
+            cpuOffload=cpu_offload,
+            componentDevices=component_devices,
+            gpuMemory=gpu_memory_snapshot(torch, device),
+        )
 
         if use_img2img:
             self._img2img_pipe = pipe
@@ -476,13 +697,57 @@ class QwenImageAdapter:
             raise RuntimeError(f"{request.model} does not support image editing.")
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
-        pipe = self._load_pipeline(settings, request, model_target, progress=progress)
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress, job_id=job["id"])
+        emit_worker_event(
+            "image_lora_apply_start",
+            jobId=job["id"],
+            adapter=self.id,
+            loraCount=len(request.loras),
+        )
         self._apply_loras(pipe, request)
+        emit_worker_event("image_lora_apply_complete", jobId=job["id"], adapter=self.id)
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        label = "Qwen Image"
 
         def image_at_index(index: int) -> Image.Image:
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
-            progress("running", "generating", image_batch_progress(index, request.count), f"Running Qwen Image {index + 1} of {request.count}.")
-            return self._run_pipeline(settings, pipe, request, seed)
+            progress(
+                "running",
+                "generating",
+                image_batch_progress(index, request.count),
+                format_batch_running_message(label, index, request.count),
+            )
+            emit_worker_event(
+                "image_inference_start",
+                jobId=job["id"],
+                adapter=self.id,
+                model=request.model,
+                imageIndex=index,
+                imageCount=request.count,
+                device=device,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            try:
+                image = self._run_pipeline(settings, pipe, request, seed)
+            except Exception as exc:
+                emit_worker_event(
+                    "image_inference_failed",
+                    jobId=job["id"],
+                    adapter=self.id,
+                    imageIndex=index,
+                    error=str(exc),
+                    errorType=exc.__class__.__name__,
+                )
+                raise
+            emit_worker_event(
+                "image_inference_complete",
+                jobId=job["id"],
+                adapter=self.id,
+                imageIndex=index,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return image
 
         return ImageAssetWriter().write_incremental_outputs(
             settings=settings,
@@ -501,7 +766,15 @@ class QwenImageAdapter:
             },
         )
 
-    def _load_pipeline(self, settings: WorkerSettings, request: ImageRequest, model_target: dict[str, Any], progress: ProgressCallback) -> Any:
+    def _load_pipeline(
+        self,
+        settings: WorkerSettings,
+        request: ImageRequest,
+        model_target: dict[str, Any],
+        progress: ProgressCallback,
+        *,
+        job_id: str,
+    ) -> Any:
         torch = importlib.import_module("torch")
         diffusers = importlib.import_module("diffusers")
         repo = self._repo_for_request(request, model_target)
@@ -510,11 +783,22 @@ class QwenImageAdapter:
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         use_edit = request.mode == "edit_image"
+        cpu_offload = bool(request.advanced.get("cpuOffload", False))
         cached_pipe = self._edit_pipe if use_edit else self._text_pipe
         cached_repo = self._edit_repo if use_edit else self._text_repo
         if cached_pipe is not None and cached_repo == repo:
             self._loaded_model = request.model
             progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
+            emit_worker_event(
+                "image_pipeline_cache_hit",
+                jobId=job_id,
+                adapter=self.id,
+                model=request.model,
+                repo=repo,
+                device=device,
+                componentDevices=pipeline_component_devices(cached_pipe),
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
             return cached_pipe
         if cached_pipe is not None:
             if use_edit:
@@ -532,13 +816,49 @@ class QwenImageAdapter:
             raise RuntimeError(f"The installed diffusers package does not expose {pipeline_name}. Install the latest diffusers build.")
 
         progress("loading_model", "loading_model", 0.2, f"Loading {model_target['label']} model files.")
+        emit_worker_event(
+            "image_pipeline_load_start",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            device=device,
+            dtype=str(dtype),
+            useImg2img=use_edit,
+            cpuOffload=cpu_offload,
+            cached=huggingface_repo_cache_exists(repo),
+        )
         pipe = pipeline_class.from_pretrained(repo, torch_dtype=dtype)
-        if bool(request.advanced.get("cpuOffload", False)) and hasattr(pipe, "enable_model_cpu_offload"):
+        emit_worker_event(
+            "image_pipeline_load_complete",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            componentDevices=pipeline_component_devices(pipe),
+        )
+        if cpu_offload and hasattr(pipe, "enable_model_cpu_offload"):
             pipe.enable_model_cpu_offload()
         else:
             pipe.to(device)
         if hasattr(pipe, "enable_vae_tiling"):
             pipe.enable_vae_tiling()
+        component_devices = verify_pipeline_on_device(
+            pipe,
+            requested_device=device,
+            model_label=model_target["label"],
+            allow_offload=cpu_offload,
+        )
+        emit_worker_event(
+            "image_pipeline_on_device",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            requestedDevice=device,
+            cpuOffload=cpu_offload,
+            componentDevices=component_devices,
+            gpuMemory=gpu_memory_snapshot(torch, device),
+        )
 
         if use_edit:
             self._edit_pipe = pipe

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -14,12 +14,17 @@ from scene_worker.image_adapters import (
     ZImageDiffusersAdapter,
     build_asset_sidecar,
     create_image_adapter,
+    emit_worker_event,
+    format_batch_running_message,
+    gpu_memory_snapshot,
     huggingface_repo_cache_path,
     image_batch_progress,
     image_request_from_job,
+    pipeline_component_devices,
     require_inference_backend_for_gpu_worker,
     resolve_seed,
     select_torch_device,
+    verify_pipeline_on_device,
 )
 from scene_worker.lora_adapters import (
     apply_loras_to_pipeline,
@@ -1121,3 +1126,357 @@ def test_replace_person_video_sidecar_preserves_lineage():
     assert asset["recipe"]["normalizedSettings"]["replacementActive"] is False
     assert asset["lineage"]["sourceClipAssetId"] == "asset-video"
     assert asset["lineage"]["characterId"] == "character-1"
+
+
+def test_format_batch_running_message_names_completed_count_after_first_image():
+    assert format_batch_running_message("Z-Image", 0, 4) == "Running Z-Image 1 of 4."
+    assert format_batch_running_message("Z-Image", 2, 4) == "Generated 2 of 4. Running Z-Image 3 of 4."
+
+
+def test_gpu_memory_snapshot_returns_none_when_cuda_unavailable():
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+    assert gpu_memory_snapshot(Torch, "cuda:0") is None
+    assert gpu_memory_snapshot(Torch, "cpu") is None
+
+
+def test_gpu_memory_snapshot_reports_allocated_and_reserved_bytes():
+    class Torch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def memory_allocated(index=None):
+                return 50 * 1024 * 1024
+
+            @staticmethod
+            def memory_reserved(index=None):
+                return 60 * 1024 * 1024
+
+    snapshot = gpu_memory_snapshot(Torch, "cuda:0")
+
+    assert snapshot == {"device": "cuda:0", "allocatedMb": 50.0, "reservedMb": 60.0}
+
+
+def test_pipeline_component_devices_inspects_known_submodules():
+    class Module:
+        def __init__(self, device):
+            self.device = device
+
+    class Pipe:
+        components = {"unet": Module("cuda:0"), "text_encoder": Module("cuda:0"), "vae": Module("cpu")}
+
+    assert pipeline_component_devices(Pipe()) == ["cpu", "cuda:0"]
+
+
+def test_pipeline_component_devices_falls_back_to_named_attributes():
+    class Module:
+        def __init__(self, device):
+            self.device = device
+
+    class Pipe:
+        transformer = Module("cuda:1")
+        vae = Module("cuda:1")
+
+    assert pipeline_component_devices(Pipe()) == ["cuda:1"]
+
+
+def test_verify_pipeline_on_device_raises_when_components_stayed_on_cpu():
+    class Module:
+        device = "cpu"
+
+    class Pipe:
+        components = {"unet": Module(), "vae": Module()}
+
+    with pytest.raises(RuntimeError, match="did not move onto cuda:0"):
+        verify_pipeline_on_device(
+            Pipe(),
+            requested_device="cuda:0",
+            model_label="Z-Image-Turbo",
+            allow_offload=False,
+        )
+
+
+def test_verify_pipeline_on_device_allows_cpu_offload_layouts():
+    class Module:
+        device = "cpu"
+
+    class Pipe:
+        components = {"unet": Module(), "vae": Module()}
+
+    devices = verify_pipeline_on_device(
+        Pipe(),
+        requested_device="cuda:0",
+        model_label="Z-Image-Turbo",
+        allow_offload=True,
+    )
+
+    assert devices == ["cpu"]
+
+
+def test_verify_pipeline_on_device_accepts_matching_cuda_index():
+    class Module:
+        def __init__(self, device):
+            self.device = device
+
+    class Pipe:
+        components = {"unet": Module("cuda:0"), "vae": Module("cuda:0")}
+
+    devices = verify_pipeline_on_device(
+        Pipe(),
+        requested_device="cuda:0",
+        model_label="Z-Image-Turbo",
+        allow_offload=False,
+    )
+
+    assert devices == ["cuda:0"]
+
+
+def test_emit_worker_event_writes_json_to_stdout(capsys):
+    emit_worker_event("image_inference_start", jobId="job-1", imageIndex=2)
+
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["event"] == "image_inference_start"
+    assert payload["jobId"] == "job-1"
+    assert payload["imageIndex"] == 2
+    assert "reportedAt" in payload
+
+
+def test_z_image_adapter_emits_phase_diagnostics_and_running_message(tmp_path, monkeypatch, capsys):
+    data_dir = tmp_path / "data"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+
+    class FakeTransformer:
+        device = "cuda:0"
+
+        def parameters(self):
+            return iter([])
+
+    class FakePipe:
+        components = {"transformer": FakeTransformer(), "vae": FakeTransformer()}
+
+        def __init__(self):
+            self.calls = 0
+
+        def to(self, device):
+            self._device = device
+            return self
+
+        def __call__(self, **_kwargs):
+            self.calls += 1
+            return SimpleNamespace(images=[Image.new("RGB", (8, 8), (10, 20, 30))])
+
+    class FakePipelineClass:
+        @staticmethod
+        def from_pretrained(repo, **_kwargs):
+            return FakePipe()
+
+    class FakeDiffusers:
+        ZImagePipeline = FakePipelineClass
+
+        @staticmethod
+        def __getattr__(name):
+            raise AttributeError(name)
+
+    class FakeTorch:
+        bfloat16 = "bfloat16"
+        float16 = "float16"
+        float32 = "float32"
+
+        class cuda:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def device_count():
+                return 1
+
+            @staticmethod
+            def memory_allocated(index=None):
+                return 10 * 1024 * 1024
+
+            @staticmethod
+            def memory_reserved(index=None):
+                return 12 * 1024 * 1024
+
+            @staticmethod
+            def set_device(_device):
+                return None
+
+            @staticmethod
+            def empty_cache():
+                return None
+
+        class backends:
+            mps = None
+
+        @staticmethod
+        def Generator(_device):
+            class Gen:
+                def manual_seed(self, _seed):
+                    return self
+
+            return Gen()
+
+    real_import = __import__
+
+    def fake_import_module(name):
+        if name == "torch":
+            return FakeTorch
+        if name == "diffusers":
+            return FakeDiffusers
+        return real_import(name)
+
+    monkeypatch.setattr("scene_worker.image_adapters.importlib.import_module", fake_import_module)
+
+    job = {
+        "id": "job-z",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "Stormy bridge",
+            "model": "z_image_turbo",
+            "count": 2,
+            "width": 16,
+            "height": 16,
+        },
+    }
+
+    progress_calls: list[dict] = []
+
+    def progress(status, stage, value, message, result=None):
+        progress_calls.append(
+            {"status": status, "stage": stage, "value": value, "message": message, "result": result}
+        )
+
+    adapter = ZImageDiffusersAdapter()
+    adapter.generate(
+        settings=SimpleNamespace(data_dir=data_dir, gpu_id="0"),
+        job=job,
+        progress=progress,
+        cancel_requested=lambda: False,
+    )
+
+    events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines() if line.strip()]
+    event_names = [event["event"] for event in events]
+    assert "image_pipeline_load_start" in event_names
+    assert "image_pipeline_load_complete" in event_names
+    assert "image_pipeline_on_device" in event_names
+    assert event_names.count("image_inference_start") == 2
+    assert event_names.count("image_inference_complete") == 2
+    on_device = next(event for event in events if event["event"] == "image_pipeline_on_device")
+    assert on_device["componentDevices"] == ["cuda:0"]
+    assert on_device["gpuMemory"]["allocatedMb"] == 10.0
+
+    running_messages = [call["message"] for call in progress_calls if call["status"] == "running"]
+    assert running_messages == [
+        "Running Z-Image 1 of 2.",
+        "Generated 1 of 2. Running Z-Image 2 of 2.",
+    ]
+
+
+def test_z_image_adapter_fails_fast_when_pipeline_stays_on_cpu(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+
+    class StuckOnCpu:
+        device = "cpu"
+
+    class FakePipe:
+        components = {"transformer": StuckOnCpu(), "vae": StuckOnCpu()}
+
+        def to(self, device):
+            return self
+
+    class FakePipelineClass:
+        @staticmethod
+        def from_pretrained(repo, **_kwargs):
+            return FakePipe()
+
+    class FakeDiffusers:
+        ZImagePipeline = FakePipelineClass
+
+    class FakeTorch:
+        bfloat16 = "bfloat16"
+        float16 = "float16"
+        float32 = "float32"
+
+        class cuda:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def device_count():
+                return 1
+
+            @staticmethod
+            def memory_allocated(index=None):
+                return 0
+
+            @staticmethod
+            def memory_reserved(index=None):
+                return 0
+
+            @staticmethod
+            def set_device(_device):
+                return None
+
+            @staticmethod
+            def empty_cache():
+                return None
+
+        class backends:
+            mps = None
+
+    def fake_import_module(name):
+        if name == "torch":
+            return FakeTorch
+        if name == "diffusers":
+            return FakeDiffusers
+        raise ImportError(name)
+
+    monkeypatch.setattr("scene_worker.image_adapters.importlib.import_module", fake_import_module)
+
+    job = {
+        "id": "job-cpu-stuck",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "Misty harbor",
+            "model": "z_image_turbo",
+            "count": 1,
+            "width": 16,
+            "height": 16,
+        },
+    }
+
+    adapter = ZImageDiffusersAdapter()
+
+    with pytest.raises(RuntimeError, match="did not move onto"):
+        adapter.generate(
+            settings=SimpleNamespace(data_dir=data_dir, gpu_id="0"),
+            job=job,
+            progress=lambda *_args, **_kwargs: None,
+            cancel_requested=lambda: False,
+        )

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1203,6 +1203,39 @@ def test_verify_pipeline_on_device_raises_when_components_stayed_on_cpu():
         )
 
 
+def test_verify_pipeline_on_device_raises_when_any_component_stayed_on_cpu():
+    class Module:
+        def __init__(self, device):
+            self.device = device
+
+    class Pipe:
+        components = {"transformer": Module("cuda:0"), "vae": Module("cpu")}
+
+    with pytest.raises(RuntimeError, match="pipeline components are on cpu, cuda:0"):
+        verify_pipeline_on_device(
+            Pipe(),
+            requested_device="cuda:0",
+            model_label="Z-Image-Turbo",
+            allow_offload=False,
+        )
+
+
+def test_verify_pipeline_on_device_rejects_wrong_cuda_index():
+    class Module:
+        device = "cuda:10"
+
+    class Pipe:
+        components = {"transformer": Module()}
+
+    with pytest.raises(RuntimeError, match="did not move onto cuda:1"):
+        verify_pipeline_on_device(
+            Pipe(),
+            requested_device="cuda:1",
+            model_label="Z-Image-Turbo",
+            allow_offload=False,
+        )
+
+
 def test_verify_pipeline_on_device_allows_cpu_offload_layouts():
     class Module:
         device = "cpu"
@@ -1389,7 +1422,7 @@ def test_z_image_adapter_emits_phase_diagnostics_and_running_message(tmp_path, m
     ]
 
 
-def test_z_image_adapter_fails_fast_when_pipeline_stays_on_cpu(tmp_path, monkeypatch):
+def test_z_image_adapter_fails_fast_when_pipeline_stays_on_cpu_with_offload_fallback(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     project_path = tmp_path / "project"
     data_dir.mkdir()
@@ -1468,6 +1501,7 @@ def test_z_image_adapter_fails_fast_when_pipeline_stays_on_cpu(tmp_path, monkeyp
             "count": 1,
             "width": 16,
             "height": 16,
+            "advanced": {"cpuOffload": True},
         },
     }
 


### PR DESCRIPTION
## Summary

Closes [sc-1376](https://app.shortcut.com/trefry/story/1376/fix-z-image-turbo-jobs-stuck-running-with-idle-gpu).

- Emit structured worker diagnostics — `image_pipeline_load_start/_complete/_on_device/_cache_hit`, `image_lora_apply_start/_complete`, and per-image `image_inference_start/_complete/_failed` — so an operator can pinpoint which phase is stalled when a Z-Image Turbo (or Qwen) job appears to be running with 0% GPU load and 0 MB GPU memory. Each event carries a `gpuMemory` snapshot (allocated + reserved) for the assigned CUDA device.
- After `pipe.to(device)`, verify at least one pipeline component is on the requested CUDA device (skipped only when `cpuOffload` was explicitly requested). The worker now raises an actionable RuntimeError instead of running inference silently on CPU — `friendly_failure` already maps that into the existing "missing CUDA-enabled PyTorch" guidance.
- Updated the per-image "Running" progress label so it carries the durable saved count — e.g., `Generated 2 of 4. Running Z-Image 3 of 4.` — instead of `Running Z-Image 3 of 4.`. The label is built from `format_batch_running_message(label, completed, total)`, and the writer is still the only thing that advances the loop, so the count cannot drift ahead of the on-disk images.
- Added unit tests for `emit_worker_event`, `gpu_memory_snapshot`, `pipeline_component_devices`, `verify_pipeline_on_device`, `format_batch_running_message`, and two `ZImageDiffusersAdapter` integration tests that exercise the new phase events and the fast-fail path.

## Test plan

- [x] `python -m pytest tests/test_worker_runtime.py -q` (70 passed)
- [x] `python -m pytest tests/ --deselect tests/test_rust_api_worker_smoke.py::test_python_worker_protocol_round_trips_against_rust_api_binary` (other failure in that smoke file is pre-existing; reproduced on `main`).
- [ ] Smoke test on the workstation: kick off a Z-Image Turbo 4-image batch, confirm `image_pipeline_on_device` shows `componentDevices=["cuda:0"]` and `gpuMemory.allocatedMb > 0`, and that the queue panel reads `Generated K of N. Running Z-Image N+1 of N.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)