### PR TITLE
Make LoRA import independent of model family selection

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1296,6 +1296,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    expect(field(container, "LoRA family").value).toBe("all");
     await changeField(field(container, "LoRA family"), "qwen-image");
     await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
@@ -1315,6 +1316,39 @@ describe("SceneWorks app shell", () => {
         family: "z-image",
       }),
     );
+  });
+
+  it("clears an explicit Models LoRA import family when the model family disappears", async () => {
+    const onImportLora = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "detail_lora" } }));
+    const renderScreen = (models) =>
+      root.render(
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={[]}
+          loras={[]}
+          models={models}
+          onDownloadModel={() => {}}
+          onImportLora={onImportLora}
+          onOpenQueue={() => {}}
+        />,
+      );
+
+    root = createRoot(container);
+    await act(async () => {
+      renderScreen([
+        { id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" },
+        { id: "qwen_image", name: "Qwen Image", type: "image", family: "qwen-image" },
+      ]);
+    });
+
+    await changeField(field(container, "Family"), "qwen-image");
+    expect(field(container, "Family").value).toBe("qwen-image");
+
+    await act(async () => {
+      renderScreen([{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]);
+    });
+
+    expect(field(container, "Family").value).toBe("");
   });
 
   it("shows model download size estimates and unavailable states before download", async () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1270,10 +1270,51 @@ describe("SceneWorks app shell", () => {
         sourceUrl: "https://example.com/loras/detail.safetensors",
         name: "Detail LoRA",
         scope: "global",
+      }),
+    );
+    expect(onImportLora.mock.calls[0][0]).not.toHaveProperty("family");
+    expect(container.textContent).toContain("LoRA import queued for detail_lora.");
+  });
+
+  it("keeps Models LoRA import family independent from the list filter", async () => {
+    const onImportLora = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "detail_lora" } }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={{ id: "project-1", name: "Noir" }}
+          jobs={[]}
+          loras={[]}
+          models={[
+            { id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" },
+            { id: "qwen_image", name: "Qwen Image", type: "image", family: "qwen-image" },
+          ]}
+          onDownloadModel={() => {}}
+          onImportLora={onImportLora}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    await changeField(field(container, "LoRA family"), "qwen-image");
+    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(onImportLora.mock.calls[0][0]).not.toHaveProperty("family");
+
+    await changeField(field(container, "Family"), "z-image");
+    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+    });
+
+    expect(onImportLora.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
         family: "z-image",
       }),
     );
-    expect(container.textContent).toContain("LoRA import queued for detail_lora.");
   });
 
   it("shows model download size estimates and unavailable states before download", async () => {
@@ -1439,9 +1480,9 @@ describe("SceneWorks app shell", () => {
       expect.objectContaining({
         file: loraFile,
         scope: "project",
-        family: "z-image",
       }),
     );
+    expect(onImportLora.mock.calls[0][0]).not.toHaveProperty("family");
     expect(container.textContent).toContain("LoRA import");
     expect(container.textContent).toContain("running");
   });

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -76,7 +76,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
     file: null,
     name: "",
     scope: "global",
-    family: families[0] ?? "",
+    family: "",
   });
   const [fileInputKey, setFileInputKey] = useState(0);
   const visibleLoras = loras.filter((lora) => matchesFamily(lora, familyFilter));
@@ -88,14 +88,8 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
   }, [familiesKey, familyFilter]);
 
   useEffect(() => {
-    setImportForm((current) => {
-      if (current.family && families.includes(current.family)) {
-        return current;
-      }
-      const family = familyFilter !== "all" && families.includes(familyFilter) ? familyFilter : families[0] ?? "";
-      return { ...current, family };
-    });
-  }, [familiesKey, familyFilter]);
+    setImportForm((current) => (current.family && !families.includes(current.family) ? { ...current, family: "" } : current));
+  }, [familiesKey]);
 
   function downloadJobsFor(model) {
     return jobs.filter((job) => job.type === "model_download" && job.payload?.modelId === model.id);
@@ -113,11 +107,12 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
       text: isFileImport ? "Uploading LoRA file before queueing import." : "",
     });
     try {
+      const familyOverride = importForm.family ? { family: importForm.family } : {};
       const job = await onImportLora({
         ...(isFileImport ? { file: importForm.file } : { sourceUrl: importForm.sourceUrl.trim() }),
         name: importForm.name.trim() || undefined,
         scope: importForm.scope,
-        family: importForm.family || undefined,
+        ...familyOverride,
       });
       const loraId = job?.payload?.loraId;
       const resolvedFamily = job?.payload?.manifestEntry?.family;
@@ -230,7 +225,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
         <form className="lora-import-panel models-import-panel" aria-label="Import LoRA" onSubmit={importLora}>
           <div>
             <strong>Import LoRA</strong>
-            <span>{importForm.family || "choose a family"}</span>
+            <span>{importForm.family || "auto family"}</span>
           </div>
           <div className="segmented-control compact-segment" aria-label="LoRA import source">
             <button
@@ -273,7 +268,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
               >
                 {families.length ? (
                   <>
-                    <option value="">Auto-detect from file</option>
+                    <option value="">{isFileImport ? "Auto-detect from file" : "No family override"}</option>
                     {families.map((family) => (
                       <option key={family} value={family}>
                         {family}

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -67,7 +67,7 @@ function downloadSizeText(model) {
 export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownloadModel, onImportLora, onOpenQueue }) {
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
   const familiesKey = families.join("|");
-  const [familyFilter, setFamilyFilter] = useState(families[0] ?? "all");
+  const [familyFilter, setFamilyFilter] = useState("all");
   const [importingLora, setImportingLora] = useState(false);
   const [importMessage, setImportMessage] = useState({ tone: "neutral", text: "" });
   const [importForm, setImportForm] = useState({
@@ -83,7 +83,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
 
   useEffect(() => {
     if (familyFilter !== "all" && !families.includes(familyFilter)) {
-      setFamilyFilter(families[0] ?? "all");
+      setFamilyFilter("all");
     }
   }, [familiesKey, familyFilter]);
 
@@ -225,7 +225,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
         <form className="lora-import-panel models-import-panel" aria-label="Import LoRA" onSubmit={importLora}>
           <div>
             <strong>Import LoRA</strong>
-            <span>{importForm.family || "auto family"}</span>
+            <span>{importForm.family || "auto-detect"}</span>
           </div>
           <div className="segmented-control compact-segment" aria-label="LoRA import source">
             <button
@@ -268,7 +268,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
               >
                 {families.length ? (
                   <>
-                    <option value="">{isFileImport ? "Auto-detect from file" : "No family override"}</option>
+                    <option value="">Auto-detect</option>
                     {families.map((family) => (
                       <option key={family} value={family}>
                         {family}


### PR DESCRIPTION
﻿## Summary
- Decouple the Models page LoRA import form from the top-level LoRA family filter.
- Leave imports in automatic/no-family-override mode unless the user explicitly selects an import family.
- Add regression tests for URL and file imports, plus filter changes that should not leak into import payloads.

## Why
The family filter is for browsing installed and pending LoRAs. It should not silently declare an import family or override import-time detection just because the user is viewing a filtered list.

## Validation
- `npm test` in `apps/web`
- `npm run build` in `apps/web`
- Browser smoke check on the Models page
