### PR TITLE
[codex] Harden LoRA model compatibility validation

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1472,6 +1472,7 @@ async fn create_character_test_job(
         payload.look_id.map(Value::String).unwrap_or(Value::Null),
     );
     job_payload.insert("advanced".to_owned(), Value::Object(advanced));
+    validate_job_lora_compatibility(&state, Some(&project_id), &mut job_payload, true).await?;
     let job = create_generation_job(
         state,
         JobType::ImageGenerate,
@@ -1735,6 +1736,8 @@ async fn create_image_job(
         job_payload.remove("recipePresetId");
     }
     apply_recipe_preset_to_image_payload(&state, &payload, &mut job_payload).await?;
+    validate_job_lora_compatibility(&state, Some(&payload.project_id), &mut job_payload, false)
+        .await?;
     if payload.seed.is_none() {
         let count = job_payload
             .get("count")
@@ -1932,6 +1935,8 @@ async fn create_video_job(
     if payload.recipe_preset_id.is_none() {
         job_payload.remove("recipePresetId");
     }
+    validate_job_lora_compatibility(&state, Some(&payload.project_id), &mut job_payload, false)
+        .await?;
     let job = create_generation_job(
         state,
         job_type,
@@ -3907,11 +3912,67 @@ fn validate_recipe_preset_lora_compatibility(
     let Some(model_id) = preset.get("model").and_then(Value::as_str) else {
         return Ok(());
     };
+    validate_lora_specs_for_model(
+        models,
+        loras,
+        model_id,
+        &recipe_preset_loras(preset),
+        false,
+        "Recipe preset LoRA",
+    )?;
+    Ok(())
+}
+
+async fn validate_job_lora_compatibility(
+    state: &AppState,
+    project_id: Option<&str>,
+    job_payload: &mut JsonObject,
+    allow_inline_loras: bool,
+) -> Result<(), ApiError> {
+    let Some(loras) = job_payload
+        .get("loras")
+        .and_then(Value::as_array)
+        .filter(|loras| !loras.is_empty())
+        .cloned()
+    else {
+        return Ok(());
+    };
+    let model_id = job_payload
+        .get("model")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::bad_request("Model is required for LoRA compatibility"))?;
+    let models = model_catalog(state).await?;
+    let catalog_loras = lora_catalog(state, project_id).await?;
+    let normalized = validate_lora_specs_for_model(
+        &models,
+        &catalog_loras,
+        model_id,
+        &loras,
+        allow_inline_loras,
+        "LoRA",
+    )?;
+    job_payload.insert("loras".to_owned(), Value::Array(normalized));
+    Ok(())
+}
+
+fn validate_lora_specs_for_model(
+    models: &[Value],
+    catalog_loras: &[Value],
+    model_id: &str,
+    attached_loras: &[Value],
+    allow_inline_loras: bool,
+    lora_label: &str,
+) -> Result<Vec<Value>, ApiError> {
+    if attached_loras.is_empty() {
+        return Ok(Vec::new());
+    }
     let Some(model) = models
         .iter()
         .find(|model| model.get("id").and_then(Value::as_str) == Some(model_id))
     else {
-        return Ok(());
+        return Err(ApiError::bad_request(format!(
+            "Model {model_id} not found; cannot verify LoRA compatibility"
+        )));
     };
     let model_families = model_lora_families(model);
     if model_families.is_empty() {
@@ -3919,19 +3980,19 @@ fn validate_recipe_preset_lora_compatibility(
             "Model {model_id} has no declared LoRA families"
         )));
     }
-    for preset_lora in recipe_preset_loras(preset) {
-        let Some(lora_id) = preset_lora_id(&preset_lora) else {
+    let mut normalized_loras = Vec::new();
+    for attached_lora in attached_loras {
+        let Some((lora_id, lora, normalized_lora, catalog_backed)) =
+            hydrate_lora_spec(catalog_loras, attached_lora, allow_inline_loras, lora_label)?
+        else {
             continue;
         };
-        let lora = loras
-            .iter()
-            .find(|lora| lora.get("id").and_then(Value::as_str) == Some(lora_id))
-            .ok_or_else(|| {
-                ApiError::bad_request(format!("Recipe preset LoRA not found: {lora_id}"))
-            })?;
-        if lora.get("installState").and_then(Value::as_str) != Some("installed") {
+        let install_state = lora.get("installState").and_then(Value::as_str);
+        if install_state.is_some_and(|state| state != "installed")
+            || (catalog_backed && install_state.is_none())
+        {
             return Err(ApiError::bad_request(format!(
-                "Recipe preset LoRA is not installed: {lora_id}"
+                "{lora_label} is not installed: {lora_id}"
             )));
         }
         validate_lora_safetensors_header(lora_id, lora)?;
@@ -3950,8 +4011,43 @@ fn validate_recipe_preset_lora_compatibility(
                 "LoRA {lora_id} is not compatible with model {model_id}"
             )));
         }
+        normalized_loras.push(normalized_lora);
     }
-    Ok(())
+    Ok(normalized_loras)
+}
+
+fn hydrate_lora_spec<'a>(
+    catalog_loras: &'a [Value],
+    attached_lora: &'a Value,
+    allow_inline_loras: bool,
+    lora_label: &str,
+) -> Result<Option<(&'a str, &'a Value, Value, bool)>, ApiError> {
+    let Some(lora_id) = job_lora_id(attached_lora) else {
+        return Ok(None);
+    };
+    let catalog_lora = if allow_inline_loras {
+        None
+    } else {
+        catalog_loras
+            .iter()
+            .find(|lora| lora.get("id").and_then(Value::as_str) == Some(lora_id))
+    };
+    if catalog_lora.is_none() && !allow_inline_loras {
+        return Err(ApiError::bad_request(format!(
+            "{lora_label} not found: {lora_id}"
+        )));
+    }
+    let source_lora = catalog_lora.unwrap_or(attached_lora);
+    let normalized_lora = match catalog_lora {
+        Some(catalog_lora) => serialize_job_lora(catalog_lora, attached_lora, lora_id),
+        None => normalize_inline_job_lora(attached_lora, lora_id),
+    };
+    Ok(Some((
+        lora_id,
+        source_lora,
+        normalized_lora,
+        catalog_lora.is_some(),
+    )))
 }
 
 /// Returns the parsed safetensors header for `lora` when one is available
@@ -3963,7 +4059,12 @@ fn validate_lora_safetensors_header(
     lora_id: &str,
     lora: &Value,
 ) -> Result<Option<Value>, ApiError> {
-    let Some(path) = lora.get("installedPath").and_then(Value::as_str) else {
+    let Some(path) = lora
+        .get("installedPath")
+        .or_else(|| lora.get("sourcePath"))
+        .or_else(|| lora.get("path"))
+        .and_then(Value::as_str)
+    else {
         return Ok(None);
     };
     let path = PathBuf::from(path);
@@ -4002,9 +4103,13 @@ fn families_from_value_chain(
         .unwrap_or(&Value::Null);
     let values = direct_fields
         .iter()
-        .find_map(|field| value.get(*field))
-        .or_else(|| compatibility.get("families"))
-        .or_else(|| value.get("family"));
+        .find_map(|field| value.get(*field).filter(|value| !value.is_null()))
+        .or_else(|| {
+            compatibility
+                .get("families")
+                .filter(|value| !value.is_null())
+        })
+        .or_else(|| value.get("family").filter(|value| !value.is_null()));
     let mut families = match values {
         Some(Value::Array(items)) => items
             .iter()
@@ -4102,6 +4207,12 @@ fn preset_lora_id(preset_lora: &Value) -> Option<&str> {
         .or_else(|| preset_lora.get("id").and_then(Value::as_str))
 }
 
+fn job_lora_id(lora: &Value) -> Option<&str> {
+    lora.as_str()
+        .or_else(|| lora.get("id").and_then(Value::as_str))
+        .or_else(|| lora.get("loraId").and_then(Value::as_str))
+}
+
 fn preset_lora_weight(lora: &Value, preset_lora: &Value) -> f64 {
     preset_lora
         .get("weight")
@@ -4117,12 +4228,85 @@ fn serialize_preset_lora(lora: &Value, preset_lora: &Value, lora_id: &str) -> Va
         "name": lora.get("name").and_then(Value::as_str).unwrap_or(lora_id),
         "scope": lora.get("scope").and_then(Value::as_str).unwrap_or("builtin"),
         "weight": preset_lora_weight(lora, preset_lora),
+        "family": lora.get("family").cloned().unwrap_or(Value::Null),
+        "families": lora.get("families").cloned().unwrap_or(Value::Null),
+        "compatibleFamilies": lora.get("compatibleFamilies").cloned().unwrap_or(Value::Null),
+        "modelFamilies": lora.get("modelFamilies").cloned().unwrap_or(Value::Null),
         "triggerWords": lora.get("triggerWords").cloned().unwrap_or_else(|| Value::Array(Vec::new())),
         "compatibility": lora.get("compatibility").cloned().unwrap_or_else(|| Value::Object(JsonObject::new())),
         "installedPath": lora.get("installedPath").cloned().unwrap_or(Value::Null),
         "source": lora.get("source").cloned().unwrap_or(Value::Null),
         "presetManaged": true
     })
+}
+
+fn serialize_job_lora(lora: &Value, selected_lora: &Value, lora_id: &str) -> Value {
+    json!({
+        "id": lora_id,
+        "name": preferred_lora_str(selected_lora, lora, "name", lora_id),
+        "scope": preferred_lora_str(selected_lora, lora, "scope", "global"),
+        "weight": preset_lora_weight(lora, selected_lora),
+        "family": preferred_lora_value(selected_lora, lora, "family"),
+        "families": preferred_lora_value(selected_lora, lora, "families"),
+        "compatibleFamilies": preferred_lora_value(selected_lora, lora, "compatibleFamilies"),
+        "modelFamilies": preferred_lora_value(selected_lora, lora, "modelFamilies"),
+        "triggerWords": preferred_lora_array(selected_lora, lora, "triggerWords"),
+        "compatibility": preferred_lora_object(selected_lora, lora, "compatibility"),
+        "installedPath": preferred_lora_value(selected_lora, lora, "installedPath"),
+        "sourcePath": preferred_lora_value(selected_lora, lora, "sourcePath"),
+        "source": preferred_lora_value(selected_lora, lora, "source"),
+        "presetManaged": selected_lora.get("presetManaged").and_then(Value::as_bool).unwrap_or(false)
+    })
+}
+
+fn preferred_lora_str<'a>(
+    selected_lora: &'a Value,
+    catalog_lora: &'a Value,
+    field: &str,
+    fallback: &'a str,
+) -> &'a str {
+    selected_lora
+        .get(field)
+        .or_else(|| catalog_lora.get(field))
+        .and_then(Value::as_str)
+        .unwrap_or(fallback)
+}
+
+fn preferred_lora_value(selected_lora: &Value, catalog_lora: &Value, field: &str) -> Value {
+    selected_lora
+        .get(field)
+        .or_else(|| catalog_lora.get(field))
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+fn preferred_lora_array(selected_lora: &Value, catalog_lora: &Value, field: &str) -> Value {
+    selected_lora
+        .get(field)
+        .or_else(|| catalog_lora.get(field))
+        .filter(|value| value.is_array())
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()))
+}
+
+fn preferred_lora_object(selected_lora: &Value, catalog_lora: &Value, field: &str) -> Value {
+    selected_lora
+        .get(field)
+        .or_else(|| catalog_lora.get(field))
+        .filter(|value| value.is_object())
+        .cloned()
+        .unwrap_or_else(|| Value::Object(JsonObject::new()))
+}
+
+fn normalize_inline_job_lora(lora: &Value, lora_id: &str) -> Value {
+    match lora {
+        Value::Object(object) => {
+            let mut object = object.clone();
+            object.insert("id".to_owned(), Value::String(lora_id.to_owned()));
+            Value::Object(object)
+        }
+        _ => json!({ "id": lora_id }),
+    }
 }
 
 async fn load_manifest_entries(
@@ -6057,6 +6241,244 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn generation_job_routes_reject_incompatible_loras() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let config_dir = temp_dir.path().join("config/manifests");
+        std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+        std::fs::write(
+            config_dir.join("builtin.models.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "models": [
+                {
+                  "id": "z_image_turbo",
+                  "name": "Z-Image",
+                  "family": "z-image",
+                  "type": "image",
+                  "adapter": "z_image_diffusers",
+                  "capabilities": ["text_to_image", "edit_image", "character_image"],
+                  "downloads": [],
+                  "paths": {},
+                  "defaults": {},
+                  "limits": {},
+                  "loraCompatibility": { "families": ["z-image"] },
+                  "ui": {}
+                },
+                {
+                  "id": "ltx_2_3",
+                  "name": "LTX",
+                  "family": "ltx-video",
+                  "type": "video",
+                  "adapter": "ltx_video",
+                  "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
+                  "downloads": [],
+                  "paths": {},
+                  "defaults": {},
+                  "limits": {},
+                  "loraCompatibility": { "families": ["ltx-video"] },
+                  "ui": {}
+                }
+              ]
+            }
+            "#,
+        )
+        .expect("builtin models writes");
+        std::fs::write(
+            config_dir.join("user.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("user models writes");
+        std::fs::write(
+            config_dir.join("builtin.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("builtin loras writes");
+        std::fs::write(
+            config_dir.join("user.loras.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "loras": [
+                {
+                  "id": "qwen_style",
+                  "name": "Qwen Style",
+                  "family": "qwen-image",
+                  "triggerWords": [],
+                  "compatibility": { "families": ["qwen-image"] },
+                  "source": { "provider": "local", "path": "loras/qwen.safetensors" }
+                }
+              ]
+            }
+            "#,
+        )
+        .expect("user loras writes");
+        std::fs::write(
+            config_dir.join("builtin.recipe-presets.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "presets": [
+                {
+                  "id": "bad_qwen",
+                  "name": "Bad Qwen",
+                  "workflow": "text_to_image",
+                  "model": "z_image_turbo",
+                  "loras": [{ "id": "qwen_style" }]
+                }
+              ]
+            }
+            "#,
+        )
+        .expect("builtin recipe presets writes");
+        std::fs::write(
+            config_dir.join("user.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("user recipe presets writes");
+        let lora_dir = temp_dir.path().join("data/loras");
+        std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+        write_test_safetensors(&lora_dir.join("qwen.safetensors"));
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (_, project) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/projects",
+            json!({ "name": "Compatibility" }),
+        )
+        .await;
+        let project_id = project["id"].as_str().expect("project id");
+        let (status, image_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/image/jobs",
+            json!({
+                "projectId": project_id,
+                "prompt": "mist",
+                "model": "z_image_turbo",
+                "loras": [{ "id": "qwen_style" }]
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            image_error["detail"],
+            "LoRA qwen_style is not compatible with model z_image_turbo"
+        );
+
+        let (status, unknown_model_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/image/jobs",
+            json!({
+                "projectId": project_id,
+                "prompt": "mist",
+                "model": "missing_model",
+                "loras": [{ "id": "qwen_style" }]
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            unknown_model_error["detail"],
+            "Model missing_model not found; cannot verify LoRA compatibility"
+        );
+
+        let (status, preset_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/image/jobs",
+            json!({
+                "projectId": project_id,
+                "prompt": "mist",
+                "model": "z_image_turbo",
+                "recipePresetId": "bad_qwen"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            preset_error["detail"],
+            "LoRA qwen_style is not compatible with model z_image_turbo"
+        );
+
+        for (mode, extra) in [
+            ("image_to_video", json!({ "sourceAssetId": "asset-image" })),
+            ("text_to_video", json!({})),
+            (
+                "first_last_frame",
+                json!({ "sourceAssetId": "asset-first", "lastFrameAssetId": "asset-last" }),
+            ),
+            ("extend_clip", json!({ "sourceClipAssetId": "asset-video" })),
+            (
+                "video_bridge",
+                json!({ "sourceClipAssetId": "asset-left", "bridgeRightClipAssetId": "asset-right" }),
+            ),
+            (
+                "replace_person",
+                json!({ "sourceClipAssetId": "asset-video", "personTrackId": "track-1", "characterId": "character-1" }),
+            ),
+        ] {
+            let mut payload = json!({
+                "projectId": project_id,
+                "mode": mode,
+                "prompt": "motion",
+                "model": "ltx_2_3",
+                "loras": [{ "id": "qwen_style" }]
+            });
+            payload
+                .as_object_mut()
+                .expect("video payload object")
+                .extend(extra.as_object().expect("extra payload object").clone());
+            let (status, video_error) =
+                request(app.clone(), "POST", "/api/v1/video/jobs", payload).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{mode}");
+            assert_eq!(
+                video_error["detail"],
+                "LoRA qwen_style is not compatible with model ltx_2_3"
+            );
+        }
+
+        let (_, character) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/characters"),
+            json!({ "name": "Mira", "type": "person" }),
+        )
+        .await;
+        let character_id = character["id"].as_str().expect("character id");
+        let character_lora = temp_dir
+            .path()
+            .join("data/loras/character-qwen.safetensors");
+        write_test_safetensors(&character_lora);
+        let (status, _) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/characters/{character_id}/loras"),
+            json!({
+                "name": "Character Qwen",
+                "sourcePath": character_lora.display().to_string(),
+                "compatibility": { "families": ["qwen-image"] }
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        let (status, character_error) = request(
+            app,
+            "POST",
+            &format!("/api/v1/projects/{project_id}/characters/{character_id}/test-jobs"),
+            json!({ "prompt": "portrait", "model": "z_image_turbo" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(character_error["detail"]
+            .as_str()
+            .unwrap()
+            .contains("is not compatible with model z_image_turbo"));
+    }
+
+    #[tokio::test]
     async fn model_and_lora_routes_match_manifest_behavior() {
         std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
         let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -6136,7 +6558,7 @@ mod tests {
                   "id": "cinematic",
                   "name": "Cinematic",
                   "workflow": "text_to_image",
-                  "model": "preset-model",
+                  "model": "base-model",
                   "defaults": { "count": 4, "resolution": "1280x720", "negativePrompt": "flat lighting" },
                   "prompt": { "suffix": "cinematic lighting" },
                   "loras": [{ "id": "style-lora", "weight": 0.5 }]
@@ -6163,6 +6585,9 @@ mod tests {
         std::fs::create_dir_all(&marker_dir).expect("model dir creates");
         std::fs::write(marker_dir.join(".sceneworks-download-complete.json"), "{}")
             .expect("marker writes");
+        let lora_dir = temp_dir.path().join("data/loras");
+        std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+        write_test_safetensors(&lora_dir.join("style.safetensors"));
 
         let app = create_app(test_settings(&temp_dir)).expect("app creates");
         let (status, models) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
@@ -6239,7 +6664,7 @@ mod tests {
             json!({
                 "projectId": project_id,
                 "prompt": "city at night",
-                "model": "client-model",
+                "model": "base-model",
                 "count": 1,
                 "width": 512,
                 "height": 512,
@@ -6264,7 +6689,12 @@ mod tests {
             image_job["payload"]["loras"][0]["source"]["path"],
             "loras/style.safetensors"
         );
-        assert_eq!(image_job["payload"]["model"], "client-model");
+        assert_eq!(image_job["payload"]["model"], "base-model");
+        assert_eq!(image_job["payload"]["loras"][0]["family"], "z-image");
+        assert_eq!(
+            image_job["payload"]["loras"][0]["compatibility"]["families"][0],
+            "z-image"
+        );
         assert_eq!(image_job["payload"]["count"], 2);
         assert_eq!(image_job["payload"]["seeds"].as_array().unwrap().len(), 2);
         assert_eq!(image_job["payload"]["width"], 1280);
@@ -6291,7 +6721,7 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::CREATED);
-        assert_eq!(preset_model_job["payload"]["model"], "preset-model");
+        assert_eq!(preset_model_job["payload"]["model"], "base-model");
 
         let (status, job) = request(
             app.clone(),
@@ -7688,6 +8118,38 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("temp dir creates");
         let settings = test_settings(&temp_dir);
         let data_dir = settings.data_dir.clone();
+        let config_dir = settings.config_dir.join("manifests");
+        std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+        std::fs::write(
+            config_dir.join("builtin.models.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "models": [
+                {
+                  "id": "z_image_turbo",
+                  "name": "Z-Image",
+                  "family": "z-image",
+                  "type": "image",
+                  "adapter": "z_image_diffusers",
+                  "capabilities": ["text_to_image", "character_image"],
+                  "downloads": [],
+                  "paths": {},
+                  "defaults": {},
+                  "limits": {},
+                  "loraCompatibility": { "families": ["z-image"] },
+                  "ui": {}
+                }
+              ]
+            }
+            "#,
+        )
+        .expect("builtin models writes");
+        std::fs::write(
+            config_dir.join("user.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("user models writes");
         let app = create_app(settings).expect("app creates");
         let (_, project) = request(
             app.clone(),
@@ -7782,7 +8244,7 @@ mod tests {
         let lora_dir = data_dir.join("loras");
         std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
         let lora_source = lora_dir.join("mira.safetensors");
-        std::fs::write(&lora_source, b"lora").expect("lora writes");
+        write_test_safetensors(&lora_source);
         let (status, with_lora) = request(
             app.clone(),
             "POST",
@@ -7790,7 +8252,7 @@ mod tests {
             json!({
                 "name": "Mira LoRA",
                 "sourcePath": lora_source.display().to_string(),
-                "compatibility": { "families": ["sdxl"] },
+                "compatibility": { "families": ["z-image"] },
                 "triggerWords": ["mira"]
             }),
         )
@@ -7805,7 +8267,7 @@ mod tests {
         );
         assert_eq!(
             std::fs::read(project_lora_path).expect("lora copied"),
-            b"lora"
+            test_safetensors_bytes()
         );
 
         let (status, test_job) = request(

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2314,6 +2314,53 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("blocks image submit when a visible incompatible LoRA is selected", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={createImageJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
+          latestAssets={[]}
+          loras={[{ id: "qwen_only", name: "Qwen Only", family: "qwen-image", scope: "builtin" }]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+    await act(async () => {
+      container.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
+    });
+    await act(async () => {
+      container.querySelector('.lora-choice input[type="checkbox"]').click();
+    });
+
+    const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate");
+    expect(container.textContent).toContain("Generate is blocked");
+    expect(container.textContent).toContain("Qwen Only");
+    expect(generate.disabled).toBe(true);
+
+    await act(async () => {
+      generate.click();
+    });
+
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+
   it("applies recipe preset defaults and hidden preset LoRAs to image jobs", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -36,13 +36,29 @@ export function loraFamilies(lora) {
     lora?.modelFamilies ??
     compatibility.families ??
     (lora?.family ? [lora.family] : []);
-  return Array.isArray(values) ? values : [values].filter(Boolean);
+  return normalizeFamilies(values);
 }
 
 export function modelLoraFamilies(model) {
   const compatibility = model?.loraCompatibility ?? {};
-  const values = model?.loraFamilies ?? compatibility.families ?? (model?.family ? [model.family] : []);
-  return Array.isArray(values) ? values : [values].filter(Boolean);
+  const values =
+    model?.families ??
+    model?.compatibleFamilies ??
+    model?.modelFamilies ??
+    model?.loraFamilies ??
+    compatibility.families ??
+    (model?.family ? [model.family] : []);
+  return normalizeFamilies(values);
+}
+
+export function normalizeLoraFamily(family) {
+  return String(family ?? "").trim().toLowerCase().replaceAll("_", "-");
+}
+
+export function normalizeFamilies(values) {
+  return (Array.isArray(values) ? values : [values])
+    .map(normalizeLoraFamily)
+    .filter(Boolean);
 }
 
 export function loraMatchesModel(lora, model) {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -127,6 +127,13 @@ export function ImageStudio({
       weight: Number.isFinite(Number(override.weight)) ? Number(override.weight) : loraWeight(lora),
       triggerWords: lora.triggerWords ?? [],
       compatibility: lora.compatibility ?? {},
+      family: lora.family ?? null,
+      families: lora.families ?? null,
+      compatibleFamilies: lora.compatibleFamilies ?? null,
+      modelFamilies: lora.modelFamilies ?? null,
+      installedPath: lora.installedPath ?? null,
+      sourcePath: lora.sourcePath ?? null,
+      source: lora.source ?? null,
       presetManaged: Boolean(lora.presetManaged),
     };
   }
@@ -196,6 +203,13 @@ export function ImageStudio({
   const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
   const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
   const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
+  const selectedLoraValidationResult = useMemo(() => {
+    const incompatible = selectedLoras.filter((lora) => !loraMatchesModel(lora, selectedModel)).map((lora) => lora.name ?? lora.id);
+    return {
+      incompatible,
+      ok: incompatible.length === 0,
+    };
+  }, [selectedLoras, selectedModel]);
   const presetLoraDetails = buildPresetLoraDetails(selectedRecipePreset, loras);
   const presetPromptParts = buildPresetPromptParts(selectedRecipePreset);
   const presetValidationResult = useMemo(
@@ -556,9 +570,14 @@ export function ImageStudio({
               Preset cannot run with {selectedModel?.name ?? "the selected model"} because these LoRAs are incompatible: {presetValidationResult.incompatible.join(", ")}. Choose another preset or model.
             </p>
           ) : null}
+          {selectedLoraValidationResult.incompatible.length ? (
+            <p className="inline-warning">
+              Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
+            </p>
+          ) : null}
           <button
             className="primary-action"
-            disabled={submitting || !activeProject || !prompt.trim() || (mode === "character_image" && !characterId) || !presetValidationResult.ok}
+            disabled={submitting || !activeProject || !prompt.trim() || (mode === "character_image" && !characterId) || !presetValidationResult.ok || !selectedLoraValidationResult.ok}
             type="submit"
           >
             {submitting ? "Queueing..." : "Generate"}

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -651,10 +651,12 @@ class ZImageDiffusersAdapter:
 
     def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
         key = "img2img" if request.mode == "edit_image" else "text"
+        model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
         self._loaded_lora_states[key] = apply_loras_to_pipeline(
             pipe,
             request.loras,
             adapter_id=self.id,
+            model_family=model_target.get("family"),
             previous_state=self._loaded_lora_states.get(key),
         )
 
@@ -902,10 +904,12 @@ class QwenImageAdapter:
 
     def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
         key = "edit" if request.mode == "edit_image" else "text"
+        model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["qwen_image"])
         self._loaded_lora_states[key] = apply_loras_to_pipeline(
             pipe,
             request.loras,
             adapter_id=self.id,
+            model_family=model_target.get("family"),
             previous_state=self._loaded_lora_states.get(key),
         )
 

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -46,6 +46,48 @@ def reject_loras_if_unsupported(loras: list[dict[str, Any]], adapter_id: str) ->
         raise RuntimeError(f"{adapter_id} does not support LoRA application for generation jobs.")
 
 
+def normalize_lora_family(family: Any) -> str:
+    return str(family or "").strip().lower().replace("_", "-")
+
+
+def lora_families(lora: dict[str, Any]) -> list[str]:
+    compatibility = lora.get("compatibility") if isinstance(lora.get("compatibility"), dict) else {}
+    values = next(
+        (
+            candidate
+            for candidate in (
+                lora.get("families"),
+                lora.get("compatibleFamilies"),
+                lora.get("modelFamilies"),
+                compatibility.get("families"),
+                [lora.get("family")] if lora.get("family") else None,
+            )
+            if candidate is not None
+        ),
+        [],
+    )
+    if not isinstance(values, list):
+        values = [values]
+    families = sorted({normalize_lora_family(value) for value in values if normalize_lora_family(value)})
+    return families
+
+
+def validate_lora_compatibility(loras: list[dict[str, Any]], *, model_family: str | None, adapter_id: str) -> None:
+    normalized_model_family = normalize_lora_family(model_family)
+    if not loras or not normalized_model_family:
+        return
+    for index, item in enumerate(loras):
+        lora = item if isinstance(item, dict) else {"id": str(item)}
+        lora_id = str(lora.get("id") or lora.get("loraId") or f"lora_{index + 1}").strip()
+        families = lora_families(lora)
+        if not families:
+            continue
+        if normalized_model_family not in families:
+            raise RuntimeError(
+                f"LoRA {lora_id} is not compatible with model family {normalized_model_family} for {adapter_id}."
+            )
+
+
 def normalize_lora_specs(loras: list[dict[str, Any]]) -> list[LoraSpec]:
     if len(loras) > MAX_JOB_LORAS:
         raise RuntimeError(f"Generation supports at most {MAX_JOB_LORAS} LoRAs per job.")
@@ -76,9 +118,11 @@ def apply_loras_to_pipeline(
     loras: list[dict[str, Any]],
     *,
     adapter_id: str,
+    model_family: str | None = None,
     previous_state: LoraPipelineState | None = None,
 ) -> LoraPipelineState:
     previous_state = previous_state or LoraPipelineState()
+    validate_lora_compatibility(loras, model_family=model_family, adapter_id=adapter_id)
     specs = normalize_lora_specs(loras)
     key = lora_cache_key_for_specs(specs)
     if key == previous_state.key:

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -475,6 +475,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             pipe,
             request.loras,
             adapter_id=target["adapter"],
+            model_family=target.get("family"),
             previous_state=self._loaded_lora_state,
         )
 

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1956,6 +1956,39 @@
       "ui": {
         "label": "User"
       }
+    },
+    {
+      "adapter": "z_image_diffusers",
+      "capabilities": [
+        "text_to_image",
+        "edit_image",
+        "character_image"
+      ],
+      "defaults": {
+        "height": 1024,
+        "width": 1024
+      },
+      "downloadSizeBytes": null,
+      "downloadSizeEstimated": false,
+      "downloadSizeLabel": null,
+      "downloadable": false,
+      "downloads": [],
+      "family": "z-image",
+      "id": "z_image_turbo",
+      "installState": "missing",
+      "installedPath": null,
+      "limits": {},
+      "loraCompatibility": {
+        "families": [
+          "z-image"
+        ]
+      },
+      "name": "Z-Image Turbo",
+      "paths": {},
+      "type": "image",
+      "ui": {
+        "label": "Z-Image"
+      }
     }
   ],
   "persisted character sidecar": {

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -36,6 +36,13 @@ PNG_1X1 = (
     b"\x00\x00\x00\x0cIDAT\x08\xd7c\xf8\xff\xff?\x00\x05\xfe"
     b"\x02\xfeA\xe2&\x9b\x00\x00\x00\x00IEND\xaeB`\x82"
 )
+
+
+def safetensors_bytes() -> bytes:
+    header = json.dumps({"__metadata__": {"format": "pt"}}, separators=(",", ":")).encode("utf-8")
+    return len(header).to_bytes(8, "little") + header + b"tensor-bytes"
+
+
 TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z")
 PREFIXED_ID_RE = re.compile(
     r"\b(project|asset|job|timeline|track|transition|genset|generation_set|"
@@ -101,6 +108,20 @@ def write_contract_manifests(config_dir: Path) -> None:
               "limits": {},
               "loraCompatibility": { "families": ["z-image"] },
               "ui": { "label": "Base" }
+            },
+            {
+              "id": "z_image_turbo",
+              "name": "Z-Image Turbo",
+              "family": "z-image",
+              "type": "image",
+              "adapter": "z_image_diffusers",
+              "capabilities": ["text_to_image", "edit_image", "character_image"],
+              "downloads": [],
+              "paths": {},
+              "defaults": { "width": 1024, "height": 1024 },
+              "limits": {},
+              "loraCompatibility": { "families": ["z-image"] },
+              "ui": { "label": "Z-Image" }
             }
           ]
         }
@@ -616,7 +637,7 @@ def write_lora_sources(runtimes: list[ContractRuntime]) -> list[Path]:
         lora_dir = runtime.roots[0] / "data" / "loras"
         lora_dir.mkdir(parents=True, exist_ok=True)
         lora_source = lora_dir / "mira.safetensors"
-        lora_source.write_bytes(b"lora")
+        lora_source.write_bytes(safetensors_bytes())
         lora_sources.append(lora_source)
     return lora_sources
 
@@ -655,7 +676,7 @@ def attach_character_lora_pair(
     for runtime, response in zip(runtimes, responses):
         copied_path = runtime.project_path / response.body["loras"][0]["projectPath"]
         assert copied_path.exists(), f"{runtime.name} did not copy character LoRA to {copied_path}"
-        assert copied_path.read_bytes() == b"lora"
+        assert copied_path.read_bytes() == safetensors_bytes()
     copied_rel_paths = [response.body["loras"][0]["projectPath"] for response in responses]
     assert_runtime_consistency("character lora copied project path", baseline_runtime, candidate_runtime, copied_rel_paths[0], copied_rel_paths[1])
     return lora_link_ids, normalized
@@ -691,6 +712,11 @@ def collect_sse_events_during(runtime: ContractRuntime, action: Any, expected_ev
             ready = read_sse_message(lines)
             assert ready == {"event": "ready", "data": {"status": "connected"}}
             action_result = action()
+            if action_result.status_code >= 400:
+                raise AssertionError(
+                    f"{runtime.name} action failed before expected SSE events {expected_events}: "
+                    f"{action_result.status_code} {json.dumps(action_result.body, sort_keys=True)}"
+                )
             events: list[dict[str, Any]] = []
             try:
                 while len(events) < len(expected_events):

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -32,6 +32,7 @@ from scene_worker.lora_adapters import (
     lora_weight,
     normalize_lora_specs,
     reject_loras_if_unsupported,
+    validate_lora_compatibility,
 )
 from scene_worker.runtime import (
     child_environment,
@@ -427,6 +428,45 @@ def test_unsupported_adapter_guard_rejects_loras(tmp_path):
 
     with pytest.raises(RuntimeError, match="does not support LoRA application"):
         reject_loras_if_unsupported([{"id": "style", "installedPath": str(first)}], "procedural_preview")
+
+
+def test_lora_compatibility_guard_rejects_mismatched_family_before_load(tmp_path):
+    first = tmp_path / "style.safetensors"
+    first.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+
+    with pytest.raises(RuntimeError, match="LoRA style is not compatible with model family z-image"):
+        apply_loras_to_pipeline(
+            pipe,
+            [{"id": "style", "installedPath": str(first), "family": "qwen_image"}],
+            adapter_id="diffusers_test",
+            model_family="z-image",
+        )
+
+    assert pipe.loaded == []
+
+
+def test_lora_compatibility_guard_soft_passes_legacy_jobs_without_family(tmp_path):
+    first = tmp_path / "style.safetensors"
+    first.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+
+    apply_loras_to_pipeline(
+        pipe,
+        [{"id": "style", "installedPath": str(first)}],
+        adapter_id="diffusers_test",
+        model_family="z-image",
+    )
+
+    assert pipe.loaded[0][0] == str(first)
+
+
+def test_lora_compatibility_guard_accepts_normalized_family_aliases():
+    validate_lora_compatibility(
+        [{"id": "style", "compatibility": {"families": ["z_image"]}}],
+        model_family="z-image",
+        adapter_id="diffusers_test",
+    )
 
 
 def test_lora_weight_defaults_on_unparseable_values():


### PR DESCRIPTION
## Summary
- enforce LoRA/model family compatibility on image, video, preset-merged, and character test job submission paths
- hydrate job LoRA payloads from the catalog so the worker receives family/source metadata for defensive checks
- add worker-side family validation before LoRA weights are loaded, plus UI blocking for manually selected incompatible image LoRAs

## Validation
- cargo test -p sceneworks-rust-api --lib
- python -m pytest tests/test_worker_runtime.py -k "lora"
- npm --prefix apps/web test -- src/main.test.jsx

## Notes
- `config/manifests/user.recipe-presets.jsonc` had pre-existing local changes and is intentionally not included in this commit.