### PR TITLE
Support model upload and URL import with automatic family detection (sc-1381)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -28,8 +28,8 @@ use sceneworks_core::jobs_store::{
     WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
-    detect_lora_family, detect_model_family, first_safetensors_path, read_safetensors_header,
-    SafetensorsHeaderError,
+    apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
+    read_safetensors_header, reconcile_detected_family, SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{lora_source_url_file_stem, parse_lora_source_url, LoraUrlError};
 use sceneworks_core::project_store::{
@@ -69,13 +69,18 @@ const HEARTBEAT_SSE_DATA: &str = "{}";
 #[cfg(test)]
 const HEARTBEAT_SSE_WIRE: &str = "event: heartbeat\ndata: {}\n\n";
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
-const MAX_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
+const MAX_MODEL_UPLOAD_BYTES: usize = 256 * 1024 * 1024 * 1024;
+const MAX_LORA_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
+const MAX_MODEL_MULTIPART_BODY_BYTES: usize = MAX_MODEL_UPLOAD_BYTES + 16 * 1024 * 1024;
 const STALE_LORA_UPLOAD_SECONDS: u64 = 24 * 60 * 60;
 const MANIFEST_CACHE_LIMIT: usize = 16;
 const MODEL_SIZE_CACHE_LIMIT: usize = 64;
 const API_MANAGED_MANIFEST_HEADER: &str = "// This file is rewritten by the SceneWorks API. Inline JSONC comments are not preserved across writes.";
 #[cfg(test)]
 static TEST_MAX_LORA_UPLOAD_BYTES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static TEST_MAX_MODEL_UPLOAD_BYTES: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 #[derive(Debug, Clone)]
@@ -490,12 +495,14 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         )
         .route(
             "/api/v1/models/import",
-            post(create_model_import_job).layer(DefaultBodyLimit::max(MAX_MULTIPART_BODY_BYTES)),
+            post(create_model_import_job)
+                .layer(DefaultBodyLimit::max(MAX_MODEL_MULTIPART_BODY_BYTES)),
         )
         .route("/api/v1/loras", get(list_loras))
         .route(
             "/api/v1/loras/import",
-            post(create_lora_import_job).layer(DefaultBodyLimit::max(MAX_MULTIPART_BODY_BYTES)),
+            post(create_lora_import_job)
+                .layer(DefaultBodyLimit::max(MAX_LORA_MULTIPART_BODY_BYTES)),
         )
         .route(
             "/api/v1/recipe-presets",
@@ -886,7 +893,7 @@ struct ModelImportRequest {
     model_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, alias = "type", skip_serializing_if = "Option::is_none")]
     model_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     repo: Option<String>,
@@ -2752,7 +2759,8 @@ async fn queue_model_import_job(
             allowed_source_roots
         };
         validate_lora_import_source_path(source_path, &allowed_source_roots)?;
-        let detected = detect_family_from_local_model_path(source_path)?;
+        let detected =
+            detect_model_family(FsPath::new(source_path)).map_err(model_family_inspection_error)?;
         payload.family = reconcile_model_family(
             payload.family.take(),
             detected,
@@ -2788,6 +2796,9 @@ async fn queue_model_import_job(
         if let Some(object) = manifest_entry.as_object_mut() {
             object.insert("family".to_owned(), Value::String(family));
         }
+    }
+    if let Some(object) = manifest_entry.as_object_mut() {
+        apply_model_manifest_defaults(object, &model_type, payload.family.as_deref());
     }
     let mut payload = to_json_object(&payload)?;
     payload.insert("modelId".to_owned(), manifest_entry["id"].clone());
@@ -2912,10 +2923,11 @@ async fn write_model_upload_field_to_staged_file(
             .map_err(|error| ApiError::bad_request(error.to_string()))?
         {
             uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
-            if uploaded_bytes > max_lora_upload_bytes() {
-                return Err(ApiError::payload_too_large(
-                    "Uploaded model file exceeds the size limit",
-                ));
+            if uploaded_bytes > max_model_upload_bytes() {
+                return Err(ApiError::payload_too_large(format!(
+                    "Uploaded model file exceeds the {} limit",
+                    format_bytes(max_model_upload_bytes() as u64)
+                )));
             }
             file.write_all(&chunk)
                 .await
@@ -2952,19 +2964,15 @@ fn model_import_source_provider(payload: &ModelImportRequest) -> &'static str {
     }
 }
 
-/// Inspects a local model source (file or directory) and returns the detected
-/// family. Returns `Ok(None)` when the directory has no diffusers
-/// `model_index.json` and no readable `.safetensors`, or when the signal is
-/// ambiguous — callers should treat that as "unassociated".
-fn detect_family_from_local_model_path(source_path: &str) -> Result<Option<String>, ApiError> {
-    detect_model_family(FsPath::new(source_path)).map_err(|error| match error {
+fn model_family_inspection_error(error: SafetensorsHeaderError) -> ApiError {
+    match error {
         SafetensorsHeaderError::Io(io_error) => {
             ApiError::bad_request(format!("Unable to inspect model file: {io_error}"))
         }
         SafetensorsHeaderError::InvalidHeader => {
             ApiError::bad_request("Model file has an invalid safetensors header".to_owned())
         }
-    })
+    }
 }
 
 /// Applies the import-time policy for base models: confident detection rejects
@@ -2974,27 +2982,14 @@ fn detect_family_from_local_model_path(source_path: &str) -> Result<Option<Strin
 fn reconcile_model_family(
     supplied: Option<String>,
     detected: Option<String>,
-    context: &str,
+    _context: &str,
 ) -> Result<Option<String>, ApiError> {
-    match (supplied, detected) {
-        (Some(supplied), Some(detected)) => {
-            if supplied == detected {
-                Ok(Some(supplied))
-            } else {
-                Err(ApiError::bad_request(format!(
-                    "Model files appear to be {detected}, but family was declared as {supplied}. Re-import with family {detected} or pick different files."
-                )))
-            }
-        }
-        (None, Some(detected)) => Ok(Some(detected)),
-        (Some(supplied), None) => {
-            println!(
-                "Model import {context}: architecture detection inconclusive; accepting supplied family {supplied}"
-            );
-            Ok(Some(supplied))
-        }
-        (None, None) => Ok(None),
-    }
+    reconcile_detected_family(supplied, detected).map_err(|mismatch| {
+        ApiError::bad_request(format!(
+            "Model files appear to be {}, but family was declared as {}. Re-import with family {} or pick different files.",
+            mismatch.detected, mismatch.supplied, mismatch.detected
+        ))
+    })
 }
 
 fn max_lora_upload_bytes() -> usize {
@@ -3006,6 +3001,17 @@ fn max_lora_upload_bytes() -> usize {
         }
     }
     MAX_UPLOAD_BYTES
+}
+
+fn max_model_upload_bytes() -> usize {
+    #[cfg(test)]
+    {
+        let limit = TEST_MAX_MODEL_UPLOAD_BYTES.load(std::sync::atomic::Ordering::SeqCst);
+        if limit > 0 {
+            return limit;
+        }
+    }
+    MAX_MODEL_UPLOAD_BYTES
 }
 
 async fn list_jobs(
@@ -3471,6 +3477,11 @@ async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
                     .join(safe_download_dir(&download_context.repo));
                 let installed = model_is_installed(&installed_path);
                 (true, Some(installed_path.display().to_string()), installed)
+            } else if let Some(installed_path) =
+                model_manifest_installed_path(model, &state.settings.data_dir)
+            {
+                let installed = model_is_installed(&installed_path);
+                (false, Some(installed_path.display().to_string()), installed)
             } else {
                 (false, None, false)
             };
@@ -5129,6 +5140,24 @@ fn now_rfc3339() -> String {
 
 fn model_is_installed(path: &FsPath) -> bool {
     path.is_dir() && path.join(".sceneworks-download-complete.json").is_file()
+}
+
+fn model_manifest_installed_path(model: &Value, data_dir: &FsPath) -> Option<PathBuf> {
+    let raw_path = model
+        .get("paths")
+        .and_then(|paths| paths.get("model"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    if raw_path.contains("${") {
+        return None;
+    }
+    let path = PathBuf::from(raw_path);
+    Some(if path.is_absolute() {
+        path
+    } else {
+        data_dir.join(path)
+    })
 }
 
 fn lora_families(lora: &Value) -> Vec<String> {
@@ -7217,6 +7246,18 @@ mod tests {
             upload_job["payload"]["manifestEntry"]["family"],
             "qwen-image"
         );
+        assert_eq!(
+            upload_job["payload"]["manifestEntry"]["adapter"],
+            "qwen_image"
+        );
+        assert_eq!(
+            upload_job["payload"]["manifestEntry"]["capabilities"],
+            json!(["text_to_image", "style_variations"])
+        );
+        assert_eq!(
+            upload_job["payload"]["manifestEntry"]["loraCompatibility"]["families"],
+            json!(["qwen-image"])
+        );
         let source_path = std::path::PathBuf::from(
             upload_job["payload"]["sourcePath"]
                 .as_str()
@@ -7261,6 +7302,69 @@ mod tests {
             .as_str()
             .unwrap_or("")
             .contains("Hugging Face repo"));
+    }
+
+    #[tokio::test]
+    async fn imported_model_catalog_uses_paths_model_install_marker() {
+        std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let config_dir = temp_dir.path().join("config/manifests");
+        std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+        let model_dir = temp_dir.path().join("data/models/imports/custom_model");
+        std::fs::create_dir_all(&model_dir).expect("model dir creates");
+        std::fs::write(model_dir.join(".sceneworks-download-complete.json"), "{}")
+            .expect("marker writes");
+        std::fs::write(
+            config_dir.join("builtin.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("builtin models writes");
+        std::fs::write(
+            config_dir.join("user.models.jsonc"),
+            format!(
+                r#"{{
+                  "schemaVersion": 1,
+                  "models": [{{
+                    "id": "custom_model",
+                    "name": "Custom Model",
+                    "type": "image",
+                    "family": "z-image",
+                    "paths": {{ "model": "{}" }}
+                  }}]
+                }}"#,
+                model_dir.display().to_string().replace('\\', "\\\\")
+            ),
+        )
+        .expect("user models writes");
+        std::fs::write(
+            config_dir.join("builtin.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("builtin loras writes");
+        std::fs::write(
+            config_dir.join("user.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("user loras writes");
+        std::fs::write(
+            config_dir.join("builtin.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("builtin presets writes");
+        std::fs::write(
+            config_dir.join("user.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("user presets writes");
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(models[0]["id"], "custom_model");
+        assert_eq!(models[0]["downloadable"], false);
+        assert_eq!(models[0]["installState"], "installed");
+        assert_eq!(models[0]["installedPath"], model_dir.display().to_string());
     }
 
     #[tokio::test]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -28,7 +28,8 @@ use sceneworks_core::jobs_store::{
     WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
-    detect_lora_family, first_safetensors_path, read_safetensors_header, SafetensorsHeaderError,
+    detect_lora_family, detect_model_family, first_safetensors_path, read_safetensors_header,
+    SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{lora_source_url_file_stem, parse_lora_source_url, LoraUrlError};
 use sceneworks_core::project_store::{
@@ -487,6 +488,10 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
             "/api/v1/models/:model_id/download",
             post(create_model_download_job),
         )
+        .route(
+            "/api/v1/models/import",
+            post(create_model_import_job).layer(DefaultBodyLimit::max(MAX_MULTIPART_BODY_BYTES)),
+        )
         .route("/api/v1/loras", get(list_loras))
         .route(
             "/api/v1/loras/import",
@@ -872,6 +877,29 @@ struct VideoJobRequest {
 struct ModelDownloadRequest {
     #[serde(default = "default_requested_gpu")]
     requested_gpu: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ModelImportRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_path: Option<String>,
+    #[serde(default)]
+    files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    family: Option<String>,
+    #[serde(default, skip_deserializing, skip_serializing_if = "bool_is_false")]
+    uploaded_source_path: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2600,6 +2628,372 @@ async fn cleanup_staged_lora_upload(path: &FsPath) {
     let _ = tokio::fs::remove_file(path).await;
     if let Some(parent) = path.parent() {
         let _ = tokio::fs::remove_dir(parent).await;
+    }
+}
+
+const ALLOWED_MODEL_TYPES: &[&str] = &["image", "video", "utility"];
+
+async fn create_model_import_job(
+    State(state): State<AppState>,
+    request: AxumRequest,
+) -> Result<(StatusCode, Json<JobSnapshot>), Response> {
+    let is_multipart = request
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("multipart/form-data"));
+    if is_multipart {
+        let multipart = Multipart::from_request(request, &state)
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()).into_response())?;
+        let (payload, staged_path) = model_import_request_from_multipart(&state, multipart)
+            .await
+            .map_err(IntoResponse::into_response)?;
+        let result = queue_model_import_job(state, payload).await;
+        if result.is_err() {
+            cleanup_staged_model_upload(&staged_path).await;
+        }
+        return result.map_err(IntoResponse::into_response);
+    }
+
+    let payload = Json::<ModelImportRequest>::from_request(request, &state)
+        .await
+        .map(|Json(payload)| payload)
+        .map_err(json_rejection_response)?;
+    queue_model_import_job(state, payload)
+        .await
+        .map_err(IntoResponse::into_response)
+}
+
+async fn queue_model_import_job(
+    state: AppState,
+    mut payload: ModelImportRequest,
+) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    if option_str_is_empty(payload.repo.as_deref())
+        && option_str_is_empty(payload.source_url.as_deref())
+        && option_str_is_empty(payload.source_path.as_deref())
+    {
+        return Err(ApiError::bad_request(
+            "Provide a Hugging Face repo, source URL, or source path",
+        ));
+    }
+    if let Some(source_url) = payload.source_url.as_deref() {
+        validate_source_url(source_url)?;
+    }
+    let model_type = match payload.model_type.as_deref().map(str::trim) {
+        Some(value) if !value.is_empty() => {
+            let normalized = value.to_ascii_lowercase();
+            if !ALLOWED_MODEL_TYPES.contains(&normalized.as_str()) {
+                return Err(ApiError::bad_request(format!(
+                    "Model type must be one of {}",
+                    ALLOWED_MODEL_TYPES.join(", ")
+                )));
+            }
+            normalized
+        }
+        _ => "image".to_owned(),
+    };
+    payload.model_type = Some(model_type.clone());
+    if let Some(family) = payload.family.take() {
+        let models = model_catalog(&state).await?;
+        payload.family = Some(validate_lora_family(&models, &family)?);
+    }
+    let name = payload
+        .name
+        .clone()
+        .or_else(|| payload.repo.clone())
+        .or_else(|| {
+            payload
+                .source_url
+                .as_deref()
+                .and_then(|value| lora_source_url_file_stem(value).ok())
+        })
+        .or_else(|| {
+            payload.source_path.as_deref().and_then(|path| {
+                FsPath::new(path)
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .map(str::to_owned)
+            })
+        })
+        .unwrap_or_else(|| "Imported Model".to_owned());
+    let model_id = payload
+        .model_id
+        .clone()
+        .unwrap_or_else(|| slugify_lora_id(&name));
+    let existing_ids = model_catalog(&state)
+        .await?
+        .into_iter()
+        .filter_map(|model| model.get("id").and_then(Value::as_str).map(str::to_owned))
+        .collect::<std::collections::HashSet<_>>();
+    if existing_ids.contains(&model_id) {
+        return Err(ApiError::bad_request(format!(
+            "Model id '{model_id}' already exists. Pick a different id or delete the existing model first."
+        )));
+    }
+    let target_name = safe_download_dir(&model_id);
+    let target_dir = state
+        .settings
+        .data_dir
+        .join("models")
+        .join("imports")
+        .join(&target_name);
+    let manifest_path = state
+        .settings
+        .config_dir
+        .join("manifests")
+        .join("user.models.jsonc");
+    let source_path_rel = format!("models/imports/{target_name}");
+    let allowed_source_roots = vec![state.settings.data_dir.join("models")];
+    if let Some(source_path) = payload.source_path.as_deref() {
+        let allowed_source_roots = if payload.uploaded_source_path {
+            vec![state.settings.data_dir.join("cache").join("model-uploads")]
+        } else {
+            allowed_source_roots
+        };
+        validate_lora_import_source_path(source_path, &allowed_source_roots)?;
+        let detected = detect_family_from_local_model_path(source_path)?;
+        payload.family = reconcile_model_family(
+            payload.family.take(),
+            detected,
+            &format!("source_path={source_path}"),
+        )?;
+    }
+    let timestamp = now_rfc3339();
+    let mut manifest_entry = json!({
+        "id": model_id,
+        "name": name,
+        "type": model_type,
+        "source": {
+            "provider": model_import_source_provider(&payload),
+            "repo": payload.repo.clone(),
+            "path": source_path_rel,
+        },
+        "files": payload.files.clone(),
+        "paths": {
+            "model": target_dir.display().to_string(),
+        },
+        "createdAt": timestamp,
+        "updatedAt": timestamp,
+    });
+    if let Some(source_url) = payload.source_url.clone() {
+        if let Some(source) = manifest_entry
+            .get_mut("source")
+            .and_then(Value::as_object_mut)
+        {
+            source.insert("url".to_owned(), Value::String(source_url));
+        }
+    }
+    if let Some(family) = payload.family.clone() {
+        if let Some(object) = manifest_entry.as_object_mut() {
+            object.insert("family".to_owned(), Value::String(family));
+        }
+    }
+    let mut payload = to_json_object(&payload)?;
+    payload.insert("modelId".to_owned(), manifest_entry["id"].clone());
+    payload.insert("modelName".to_owned(), manifest_entry["name"].clone());
+    payload.insert(
+        "targetDir".to_owned(),
+        Value::String(target_dir.display().to_string()),
+    );
+    payload.insert(
+        "manifestPath".to_owned(),
+        Value::String(manifest_path.display().to_string()),
+    );
+    payload.insert("manifestEntry".to_owned(), manifest_entry);
+    let job = create_generation_job(
+        state,
+        JobType::ModelImport,
+        None,
+        None,
+        payload,
+        "auto".to_owned(),
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(job)))
+}
+
+async fn model_import_request_from_multipart(
+    state: &AppState,
+    mut multipart: Multipart,
+) -> Result<(ModelImportRequest, PathBuf), ApiError> {
+    let mut payload = ModelImportRequest {
+        model_id: None,
+        name: None,
+        model_type: None,
+        repo: None,
+        source_url: None,
+        source_path: None,
+        files: Vec::new(),
+        family: None,
+        uploaded_source_path: false,
+    };
+    let mut staged_path = None;
+
+    let parse_result = async {
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            let field_name = field.name().unwrap_or("").to_owned();
+            if field_name == "file" {
+                if staged_path.is_some() {
+                    return Err(ApiError::bad_request("Only one model file can be uploaded"));
+                }
+                let upload_name =
+                    sanitized_upload_filename(field.file_name().unwrap_or("model.safetensors"));
+                let path =
+                    write_model_upload_field_to_staged_file(state, field, &upload_name).await?;
+                payload.source_path = Some(path.display().to_string());
+                payload.files = vec![upload_name];
+                payload.uploaded_source_path = true;
+                staged_path = Some(path);
+                continue;
+            }
+
+            let value = field
+                .text()
+                .await
+                .map_err(|error| ApiError::bad_request(error.to_string()))?;
+            let value = value.trim();
+            if value.is_empty() {
+                continue;
+            }
+            match field_name.as_str() {
+                "modelId" => payload.model_id = Some(value.to_owned()),
+                "name" => payload.name = Some(value.to_owned()),
+                "type" => payload.model_type = Some(value.to_owned()),
+                "family" => payload.family = Some(value.to_owned()),
+                "repo" => payload.repo = Some(value.to_owned()),
+                "sourceUrl" => payload.source_url = Some(value.to_owned()),
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+    .await;
+    if let Err(error) = parse_result {
+        if let Some(path) = staged_path.as_deref() {
+            cleanup_staged_model_upload(path).await;
+        }
+        return Err(error);
+    }
+
+    let Some(staged_path) = staged_path else {
+        return Err(ApiError::bad_request("Upload file field is required"));
+    };
+    Ok((payload, staged_path))
+}
+
+async fn write_model_upload_field_to_staged_file(
+    state: &AppState,
+    mut field: axum::extract::multipart::Field<'_>,
+    filename: &str,
+) -> Result<PathBuf, ApiError> {
+    let upload_dir = state
+        .settings
+        .data_dir
+        .join("cache")
+        .join("model-uploads")
+        .join(format!("upload-{}", Uuid::new_v4().simple()));
+    tokio::fs::create_dir_all(&upload_dir)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let temp_path = upload_dir.join(filename);
+    let mut file = tokio::fs::File::create(&temp_path)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let mut uploaded_bytes = 0usize;
+    let write_result = async {
+        while let Some(chunk) = field
+            .chunk()
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
+            if uploaded_bytes > max_lora_upload_bytes() {
+                return Err(ApiError::payload_too_large(
+                    "Uploaded model file exceeds the size limit",
+                ));
+            }
+            file.write_all(&chunk)
+                .await
+                .map_err(|error| ApiError::internal(error.to_string()))?;
+        }
+        file.flush()
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))?;
+        Ok(())
+    }
+    .await;
+    if let Err(error) = write_result {
+        drop(file);
+        cleanup_staged_model_upload(&temp_path).await;
+        return Err(error);
+    }
+    Ok(temp_path)
+}
+
+async fn cleanup_staged_model_upload(path: &FsPath) {
+    let _ = tokio::fs::remove_file(path).await;
+    if let Some(parent) = path.parent() {
+        let _ = tokio::fs::remove_dir(parent).await;
+    }
+}
+
+fn model_import_source_provider(payload: &ModelImportRequest) -> &'static str {
+    if payload.repo.is_some() {
+        "huggingface"
+    } else if payload.source_url.is_some() {
+        "url"
+    } else {
+        "local"
+    }
+}
+
+/// Inspects a local model source (file or directory) and returns the detected
+/// family. Returns `Ok(None)` when the directory has no diffusers
+/// `model_index.json` and no readable `.safetensors`, or when the signal is
+/// ambiguous — callers should treat that as "unassociated".
+fn detect_family_from_local_model_path(source_path: &str) -> Result<Option<String>, ApiError> {
+    detect_model_family(FsPath::new(source_path)).map_err(|error| match error {
+        SafetensorsHeaderError::Io(io_error) => {
+            ApiError::bad_request(format!("Unable to inspect model file: {io_error}"))
+        }
+        SafetensorsHeaderError::InvalidHeader => {
+            ApiError::bad_request("Model file has an invalid safetensors header".to_owned())
+        }
+    })
+}
+
+/// Applies the import-time policy for base models: confident detection rejects
+/// a mismatched user-supplied family; an unsupplied family is filled in from
+/// the detection; an inconclusive detection accepts the supplied family
+/// unchanged (and leaves things unset if none was supplied).
+fn reconcile_model_family(
+    supplied: Option<String>,
+    detected: Option<String>,
+    context: &str,
+) -> Result<Option<String>, ApiError> {
+    match (supplied, detected) {
+        (Some(supplied), Some(detected)) => {
+            if supplied == detected {
+                Ok(Some(supplied))
+            } else {
+                Err(ApiError::bad_request(format!(
+                    "Model files appear to be {detected}, but family was declared as {supplied}. Re-import with family {detected} or pick different files."
+                )))
+            }
+        }
+        (None, Some(detected)) => Ok(Some(detected)),
+        (Some(supplied), None) => {
+            println!(
+                "Model import {context}: architecture detection inconclusive; accepting supplied family {supplied}"
+            );
+            Ok(Some(supplied))
+        }
+        (None, None) => Ok(None),
     }
 }
 
@@ -6670,6 +7064,203 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::CREATED);
         assert_eq!(qwen_job["payload"]["manifestEntry"]["family"], "qwen-image");
+    }
+
+    async fn request_multipart_model_upload(
+        app: axum::Router,
+        fields: &[(&str, &str)],
+        filename: &str,
+        bytes: &[u8],
+    ) -> (StatusCode, Value) {
+        let boundary = "SCENEWORKS_MODEL_BOUNDARY";
+        let mut body = Vec::new();
+        for (name, value) in fields {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+            );
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        body.extend_from_slice(bytes);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        let (status, _, bytes) = request_raw(
+            app,
+            "POST",
+            "/api/v1/models/import",
+            body,
+            &[(
+                "content-type",
+                &format!("multipart/form-data; boundary={boundary}"),
+            )],
+        )
+        .await;
+        let value = serde_json::from_slice(&bytes).expect("json body parses");
+        (status, value)
+    }
+
+    #[tokio::test]
+    async fn model_import_routes_handle_url_upload_and_family_detection() {
+        std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let config_dir = temp_dir.path().join("config/manifests");
+        std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+        std::fs::write(
+            config_dir.join("builtin.models.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "models": [
+                { "id": "z_image_turbo", "name": "Z-Image Turbo", "family": "z-image", "type": "image", "loraCompatibility": { "families": ["z-image"] } }
+              ]
+            }
+            "#,
+        )
+        .expect("builtin models writes");
+        std::fs::write(
+            config_dir.join("user.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("user models writes");
+        std::fs::write(
+            config_dir.join("builtin.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("builtin loras writes");
+        std::fs::write(
+            config_dir.join("user.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("user loras writes");
+        std::fs::write(
+            config_dir.join("builtin.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("builtin presets writes");
+        std::fs::write(
+            config_dir.join("user.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("user presets writes");
+
+        // URL import without supplied family is accepted, payload echoes
+        // the request fields, and target dir lives under data/models/imports.
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, url_job) = request(
+            app,
+            "POST",
+            "/api/v1/models/import",
+            json!({
+                "sourceUrl": "https://example.com/models/custom.safetensors",
+                "name": "Custom Model",
+                "type": "image"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(url_job["type"], "model_import");
+        assert_eq!(url_job["requestedGpu"], "auto");
+        assert_eq!(url_job["payload"]["modelId"], "custom_model");
+        assert_eq!(url_job["payload"]["modelName"], "Custom Model");
+        assert_eq!(
+            url_job["payload"]["manifestEntry"]["source"]["provider"],
+            "url"
+        );
+        assert_eq!(url_job["payload"]["manifestEntry"]["type"], "image");
+        assert!(url_job["payload"]["targetDir"]
+            .as_str()
+            .is_some_and(|value| value.contains("models/imports/custom_model")
+                || value.contains("models\\imports\\custom_model")));
+        assert!(url_job["payload"]["manifestEntry"].get("family").is_none());
+
+        // Duplicate id is rejected with an actionable error.
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (dup_status, dup_error) = request(
+            app,
+            "POST",
+            "/api/v1/models/import",
+            json!({
+                "modelId": "z_image_turbo",
+                "sourceUrl": "https://example.com/models/clone.safetensors",
+                "name": "Clone"
+            }),
+        )
+        .await;
+        assert_eq!(dup_status, StatusCode::BAD_REQUEST);
+        assert!(dup_error["detail"]
+            .as_str()
+            .unwrap_or("")
+            .contains("already exists"));
+
+        // Local upload stages bytes, queues an import job, and family
+        // detection from a diffusers-style header auto-fills the manifest.
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let upload_bytes = test_safetensors_bytes_with_keys(&qwen_image_tensor_keys());
+        let (upload_status, upload_job) = request_multipart_model_upload(
+            app,
+            &[("name", "Auto Family"), ("type", "image")],
+            "auto-family.safetensors",
+            &upload_bytes,
+        )
+        .await;
+        assert_eq!(upload_status, StatusCode::CREATED);
+        assert_eq!(upload_job["type"], "model_import");
+        assert_eq!(upload_job["payload"]["modelId"], "auto_family");
+        assert_eq!(upload_job["payload"]["uploadedSourcePath"], true);
+        assert_eq!(
+            upload_job["payload"]["manifestEntry"]["family"],
+            "qwen-image"
+        );
+        let source_path = std::path::PathBuf::from(
+            upload_job["payload"]["sourcePath"]
+                .as_str()
+                .expect("source path"),
+        );
+        assert_eq!(
+            std::fs::read(&source_path).expect("staged upload reads"),
+            upload_bytes
+        );
+
+        // Declared family must match detected family when detection is
+        // confident — mismatch is rejected at the API boundary.
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (mismatch_status, mismatch_error) = request_multipart_model_upload(
+            app,
+            &[
+                ("name", "Mismatch"),
+                ("type", "image"),
+                ("family", "z-image"),
+            ],
+            "mismatch.safetensors",
+            &test_safetensors_bytes_with_keys(&qwen_image_tensor_keys()),
+        )
+        .await;
+        assert_eq!(mismatch_status, StatusCode::BAD_REQUEST);
+        assert!(mismatch_error["detail"]
+            .as_str()
+            .unwrap_or("")
+            .contains("qwen-image"));
+
+        // Missing source produces an actionable error.
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (empty_status, empty_error) = request(
+            app,
+            "POST",
+            "/api/v1/models/import",
+            json!({ "name": "Nothing" }),
+        )
+        .await;
+        assert_eq!(empty_status, StatusCode::BAD_REQUEST);
+        assert!(empty_error["detail"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Hugging Face repo"));
     }
 
     #[tokio::test]

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -13,8 +13,8 @@ use sceneworks_core::contracts::{
     WorkerRegisterRequest, WorkerSnapshot, WorkerStatus, WorkerUtilizationSnapshot,
 };
 use sceneworks_core::lora_family::{
-    detect_lora_family, detect_model_family, first_safetensors_path, read_safetensors_header,
-    SafetensorsHeaderError,
+    apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
+    read_safetensors_header, reconcile_detected_family, SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{
     lora_source_url_file_name, lora_source_url_file_stem, parse_lora_source_url_with_private,
@@ -35,6 +35,7 @@ const INSTALL_MARKER: &str = ".sceneworks-download-complete.json";
 const DEFAULT_API_URL: &str = "http://localhost:8000";
 const DEFAULT_HUGGINGFACE_BASE_URL: &str = "https://huggingface.co";
 const DEFAULT_MAX_LORA_URL_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+const DEFAULT_MAX_MODEL_URL_BYTES: u64 = 256 * 1024 * 1024 * 1024;
 const DEFAULT_TRANSITION_DURATION_SECONDS: f64 = 0.5;
 const PERSON_TRACK_SAMPLE_RATE_FPS: f64 = 2.0;
 const PERSON_TRACK_MAX_SAMPLES: usize = 24;
@@ -55,6 +56,7 @@ pub struct Settings {
     pub huggingface_base_url: String,
     pub huggingface_token: Option<String>,
     pub max_lora_url_bytes: u64,
+    pub max_model_url_bytes: u64,
     pub allow_private_lora_urls: bool,
 }
 
@@ -98,6 +100,10 @@ impl Settings {
             max_lora_url_bytes: env_u64_any(
                 &["SCENEWORKS_MAX_LORA_URL_BYTES"],
                 DEFAULT_MAX_LORA_URL_BYTES,
+            ),
+            max_model_url_bytes: env_u64_any(
+                &["SCENEWORKS_MAX_MODEL_URL_BYTES"],
+                DEFAULT_MAX_MODEL_URL_BYTES,
             ),
             allow_private_lora_urls: std::env::var("SCENEWORKS_ALLOW_PRIVATE_LORA_URLS")
                 .is_ok_and(|value| value.trim() == "1"),
@@ -839,7 +845,7 @@ async fn run_utility_job(
         }
     };
     if matches!(job.job_type, JobType::LoraImport | JobType::ModelImport) {
-        let _ = cleanup_uploaded_lora_source(&job.payload).await;
+        let _ = cleanup_uploaded_import_source(&job.payload).await;
     }
     if let Err((message, error)) = result {
         match error {
@@ -1209,7 +1215,7 @@ async fn run_lora_import_job(
         }
         (None, Some(detected)) => Some(detected),
         (Some(supplied), None) => {
-            println!(
+            eprintln!(
                 "LoRA import job {}: architecture detection inconclusive; accepting supplied family {supplied}",
                 job.id
             );
@@ -1269,20 +1275,15 @@ async fn run_lora_import_job(
     Ok(())
 }
 
-/// Runs the architecture detector against a downloaded/imported model
-/// directory or file. Reads diffusers `model_index.json` first and falls
-/// back to safetensors header detection. Returns `Ok(None)` when no
-/// confident signal is available — callers should leave the manifest
-/// entry unassociated rather than failing the import.
-fn detect_model_family_in_target(dir: &Path) -> Result<Option<String>, String> {
-    detect_model_family(dir).map_err(|error| match error {
+fn model_family_detection_error(error: SafetensorsHeaderError) -> String {
+    match error {
         SafetensorsHeaderError::Io(io_error) => {
             format!("Unable to inspect imported model file: {io_error}")
         }
         SafetensorsHeaderError::InvalidHeader => {
             "Imported model file has an invalid safetensors header.".to_owned()
         }
-    })
+    }
 }
 
 async fn run_model_import_job(
@@ -1295,21 +1296,8 @@ async fn run_model_import_job(
     let source_url = optional_payload_string(&job.payload, "sourceUrl");
     let source_path = optional_payload_string(&job.payload, "sourcePath");
     let target_name = optional_payload_string(&job.payload, "modelId")
-        .or_else(|| optional_payload_string(&job.payload, "name"))
-        .map(str::to_owned)
-        .or_else(|| repo.map(str::to_owned))
-        .or_else(|| source_url.and_then(|value| lora_source_url_file_stem(value).ok()))
-        .map(|value| safe_download_dir(&value))
-        .unwrap_or_else(|| {
-            source_path
-                .and_then(|path| {
-                    Path::new(path)
-                        .file_stem()
-                        .and_then(|value| value.to_str())
-                        .map(safe_download_dir)
-                })
-                .unwrap_or_else(|| "model".to_owned())
-        });
+        .map(safe_download_dir)
+        .unwrap_or_else(|| "model".to_owned());
     let target_dir = resolve_model_import_target(
         settings,
         &job.payload,
@@ -1374,7 +1362,7 @@ async fn run_model_import_job(
         )
         .await?;
     } else if let Some(source_url) = source_url {
-        download_lora_source_url(
+        download_model_source_url(
             &DownloadContext {
                 api,
                 client: http_client,
@@ -1396,37 +1384,33 @@ async fn run_model_import_job(
         .await;
     }
 
-    let detected_family = match detect_model_family_in_target(&target_dir) {
+    let detected_family = match detect_model_family(&target_dir) {
         Ok(detected) => detected,
-        Err(detail) => {
-            return fail_job(api, &job.id, "Model import failed.", Some(detail)).await;
+        Err(error) => {
+            return fail_job(
+                api,
+                &job.id,
+                "Model import failed.",
+                Some(model_family_detection_error(error)),
+            )
+            .await;
         }
     };
     let supplied_family = optional_payload_string(&job.payload, "family").map(str::to_owned);
-    let resolved_family = match (supplied_family, detected_family) {
-        (Some(supplied), Some(detected)) => {
-            if supplied != detected {
-                return fail_job(
-                    api,
-                    &job.id,
-                    "Model import failed.",
-                    Some(format!(
-                        "Model files appear to be {detected}, but family was declared as {supplied}. Re-import with family {detected} or pick different files."
-                    )),
-                )
-                .await;
-            }
-            Some(supplied)
+    let resolved_family = match reconcile_detected_family(supplied_family, detected_family) {
+        Ok(family) => family,
+        Err(mismatch) => {
+            return fail_job(
+                api,
+                &job.id,
+                "Model import failed.",
+                Some(format!(
+                    "Model files appear to be {}, but family was declared as {}. Re-import with family {} or pick different files.",
+                    mismatch.detected, mismatch.supplied, mismatch.detected
+                )),
+            )
+            .await;
         }
-        (None, Some(detected)) => Some(detected),
-        (Some(supplied), None) => {
-            println!(
-                "Model import job {}: architecture detection inconclusive; accepting supplied family {supplied}",
-                job.id
-            );
-            Some(supplied)
-        }
-        (None, None) => None,
     };
 
     write_model_install_marker(&target_dir, &job.payload, repo.unwrap_or(""), &job.id).await?;
@@ -1442,6 +1426,16 @@ async fn run_model_import_job(
                 .entry("family")
                 .or_insert(Value::String(family));
         }
+        let model_type = manifest_entry
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("image")
+            .to_owned();
+        let family = manifest_entry
+            .get("family")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        apply_model_manifest_defaults(&mut manifest_entry, &model_type, family.as_deref());
         if let Some(paths) = manifest_entry
             .entry("paths")
             .or_insert_with(|| json!({}))
@@ -2629,6 +2623,38 @@ async fn download_lora_source_url(
     source_url: &str,
     target_dir: &Path,
 ) -> WorkerResult<()> {
+    download_source_url(
+        context,
+        source_url,
+        target_dir,
+        "LoRA",
+        context.settings.max_lora_url_bytes,
+    )
+    .await
+}
+
+async fn download_model_source_url(
+    context: &DownloadContext<'_>,
+    source_url: &str,
+    target_dir: &Path,
+) -> WorkerResult<()> {
+    download_source_url(
+        context,
+        source_url,
+        target_dir,
+        "Model",
+        context.settings.max_model_url_bytes,
+    )
+    .await
+}
+
+async fn download_source_url(
+    context: &DownloadContext<'_>,
+    source_url: &str,
+    target_dir: &Path,
+    source_label: &str,
+    max_bytes: u64,
+) -> WorkerResult<()> {
     let url =
         parse_lora_source_url_with_private(source_url, context.settings.allow_private_lora_urls)
             .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
@@ -2641,10 +2667,10 @@ async fn download_lora_source_url(
         .redirect(reqwest::redirect::Policy::none())
         .build()?;
     let total_bytes = lora_source_content_length(&client, source_url).await?;
-    if total_bytes.is_some_and(|total| total > context.settings.max_lora_url_bytes) {
+    if total_bytes.is_some_and(|total| total > max_bytes) {
         return Err(WorkerError::InvalidPayload(format!(
-            "LoRA sourceUrl exceeds the {} limit",
-            format_bytes(context.settings.max_lora_url_bytes)
+            "{source_label} sourceUrl exceeds the {} limit",
+            format_bytes(max_bytes)
         )));
     }
     let existing_bytes = existing_download_bytes(&target_path, total_bytes).await?;
@@ -2685,10 +2711,10 @@ async fn download_lora_source_url(
             }
         })
     });
-    if expected_bytes.is_some_and(|total| total > context.settings.max_lora_url_bytes) {
+    if expected_bytes.is_some_and(|total| total > max_bytes) {
         return Err(WorkerError::InvalidPayload(format!(
-            "LoRA sourceUrl exceeds the {} limit",
-            format_bytes(context.settings.max_lora_url_bytes)
+            "{source_label} sourceUrl exceeds the {} limit",
+            format_bytes(max_bytes)
         )));
     }
     let mut progress = DownloadProgress::new(
@@ -2718,10 +2744,10 @@ async fn download_lora_source_url(
                 check_cancel(context.api, context.job_id, context.cancel_message).await?;
                 output.write_all(&chunk).await?;
                 progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
-                if progress.downloaded_bytes() > context.settings.max_lora_url_bytes {
+                if progress.downloaded_bytes() > max_bytes {
                     return Err(WorkerError::InvalidPayload(format!(
-                        "LoRA sourceUrl exceeds the {} limit",
-                        format_bytes(context.settings.max_lora_url_bytes)
+                        "{source_label} sourceUrl exceeds the {} limit",
+                        format_bytes(max_bytes)
                     )));
                 }
             }
@@ -3151,7 +3177,7 @@ fn payload_bool(payload: &JsonObject, field: &str) -> bool {
     payload.get(field).and_then(Value::as_bool).unwrap_or(false)
 }
 
-async fn cleanup_uploaded_lora_source(payload: &JsonObject) -> WorkerResult<()> {
+async fn cleanup_uploaded_import_source(payload: &JsonObject) -> WorkerResult<()> {
     if !payload_bool(payload, "uploadedSourcePath") {
         return Ok(());
     }
@@ -4276,15 +4302,15 @@ mod tests {
 
     use super::{
         allow_pattern_matches, auto_worker_specs, bounded_tail, candidate_people,
-        child_environment, cleanup_uploaded_lora_source, concat_file_contents, copy_lora_source,
+        child_environment, cleanup_uploaded_import_source, concat_file_contents, copy_lora_source,
         cpu_gpu, cpu_worker_id, crossfade_duration, download_lora_source_url,
         download_progress_payload, fallback_gpu, fresh_asset_id, gpu_worker_id,
         import_lora_source_path, now_rfc3339, output_dimensions, parse_nvidia_smi_gpus,
         restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
         value_f64, visible_gpu_ids, worker_capabilities_with_utility, write_model_install_marker,
         ApiClient, DownloadContext, HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError,
-        WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
-        INSTALL_MARKER,
+        WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
+        DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
     };
 
     #[test]
@@ -4559,7 +4585,7 @@ mod tests {
         );
         payload.insert("uploadedSourcePath".to_owned(), json!(true));
 
-        cleanup_uploaded_lora_source(&payload).await.unwrap();
+        cleanup_uploaded_import_source(&payload).await.unwrap();
 
         assert!(!source_file.exists());
         assert!(!upload_dir.exists());
@@ -5059,6 +5085,7 @@ mod tests {
             huggingface_base_url,
             huggingface_token: huggingface_token.map(str::to_owned),
             max_lora_url_bytes: DEFAULT_MAX_LORA_URL_BYTES,
+            max_model_url_bytes: DEFAULT_MAX_MODEL_URL_BYTES,
             allow_private_lora_urls: true,
         }
     }

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -13,7 +13,8 @@ use sceneworks_core::contracts::{
     WorkerRegisterRequest, WorkerSnapshot, WorkerStatus, WorkerUtilizationSnapshot,
 };
 use sceneworks_core::lora_family::{
-    detect_lora_family, first_safetensors_path, read_safetensors_header, SafetensorsHeaderError,
+    detect_lora_family, detect_model_family, first_safetensors_path, read_safetensors_header,
+    SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{
     lora_source_url_file_name, lora_source_url_file_stem, parse_lora_source_url_with_private,
@@ -597,6 +598,7 @@ fn worker_capabilities_with_utility(
             WorkerCapability::FrameExtract,
             WorkerCapability::TimelineExport,
             WorkerCapability::ModelDownload,
+            WorkerCapability::ModelImport,
             WorkerCapability::LoraImport,
             WorkerCapability::PersonDetect,
             WorkerCapability::PersonTrack,
@@ -807,6 +809,9 @@ async fn run_utility_job(
         JobType::LoraImport => run_lora_import_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("LoRA import failed.", error)),
+        JobType::ModelImport => run_model_import_job(api, settings, http_client, &job)
+            .await
+            .map_err(|error| ("Model import failed.", error)),
         JobType::FrameExtract => run_frame_extract_job(api, settings, &job)
             .await
             .map_err(|error| ("Frame extraction failed.", error)),
@@ -833,7 +838,7 @@ async fn run_utility_job(
             result.map_err(|error| ("Utility job failed.", error))
         }
     };
-    if job.job_type == JobType::LoraImport {
+    if matches!(job.job_type, JobType::LoraImport | JobType::ModelImport) {
         let _ = cleanup_uploaded_lora_source(&job.payload).await;
     }
     if let Err((message, error)) = result {
@@ -1255,6 +1260,235 @@ async fn run_lora_import_job(
             ProgressStage::Completed,
             1.0,
             "LoRA import completed.",
+            None,
+            Some(result),
+            None,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Runs the architecture detector against a downloaded/imported model
+/// directory or file. Reads diffusers `model_index.json` first and falls
+/// back to safetensors header detection. Returns `Ok(None)` when no
+/// confident signal is available — callers should leave the manifest
+/// entry unassociated rather than failing the import.
+fn detect_model_family_in_target(dir: &Path) -> Result<Option<String>, String> {
+    detect_model_family(dir).map_err(|error| match error {
+        SafetensorsHeaderError::Io(io_error) => {
+            format!("Unable to inspect imported model file: {io_error}")
+        }
+        SafetensorsHeaderError::InvalidHeader => {
+            "Imported model file has an invalid safetensors header.".to_owned()
+        }
+    })
+}
+
+async fn run_model_import_job(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let repo = optional_payload_string(&job.payload, "repo");
+    let source_url = optional_payload_string(&job.payload, "sourceUrl");
+    let source_path = optional_payload_string(&job.payload, "sourcePath");
+    let target_name = optional_payload_string(&job.payload, "modelId")
+        .or_else(|| optional_payload_string(&job.payload, "name"))
+        .map(str::to_owned)
+        .or_else(|| repo.map(str::to_owned))
+        .or_else(|| source_url.and_then(|value| lora_source_url_file_stem(value).ok()))
+        .map(|value| safe_download_dir(&value))
+        .unwrap_or_else(|| {
+            source_path
+                .and_then(|path| {
+                    Path::new(path)
+                        .file_stem()
+                        .and_then(|value| value.to_str())
+                        .map(safe_download_dir)
+                })
+                .unwrap_or_else(|| "model".to_owned())
+        });
+    let target_dir = resolve_model_import_target(
+        settings,
+        &job.payload,
+        settings
+            .data_dir
+            .join("models")
+            .join("imports")
+            .join(target_name),
+    )?;
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Downloading,
+            ProgressStage::Importing,
+            0.1,
+            "Importing model.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+    check_cancel(
+        api,
+        &job.id,
+        "Model import canceled before transfer started.",
+    )
+    .await?;
+
+    if let Some(repo) = repo {
+        let files = payload_string_array(&job.payload, "files");
+        let revision = optional_payload_string(&job.payload, "revision").unwrap_or("main");
+        let snapshot =
+            HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
+        let mut progress = DownloadProgress::new(
+            repo,
+            directory_size(&target_dir).await,
+            snapshot.total_bytes(),
+            progress_report_interval(settings),
+        );
+        download_snapshot(
+            &DownloadContext {
+                api,
+                client: http_client,
+                settings,
+                job_id: &job.id,
+                cancel_message: "Model import canceled by user.",
+            },
+            &target_dir,
+            &snapshot,
+            &mut progress,
+        )
+        .await?;
+    } else if let Some(source_path) = source_path {
+        import_lora_source_path(
+            Path::new(source_path),
+            &target_dir,
+            payload_bool(&job.payload, "uploadedSourcePath"),
+        )
+        .await?;
+    } else if let Some(source_url) = source_url {
+        download_lora_source_url(
+            &DownloadContext {
+                api,
+                client: http_client,
+                settings,
+                job_id: &job.id,
+                cancel_message: "Model import canceled by user.",
+            },
+            source_url,
+            &target_dir,
+        )
+        .await?;
+    } else {
+        return fail_job(
+            api,
+            &job.id,
+            "Model import failed.",
+            Some("Provide repo, sourceUrl, or sourcePath for model import".to_owned()),
+        )
+        .await;
+    }
+
+    let detected_family = match detect_model_family_in_target(&target_dir) {
+        Ok(detected) => detected,
+        Err(detail) => {
+            return fail_job(api, &job.id, "Model import failed.", Some(detail)).await;
+        }
+    };
+    let supplied_family = optional_payload_string(&job.payload, "family").map(str::to_owned);
+    let resolved_family = match (supplied_family, detected_family) {
+        (Some(supplied), Some(detected)) => {
+            if supplied != detected {
+                return fail_job(
+                    api,
+                    &job.id,
+                    "Model import failed.",
+                    Some(format!(
+                        "Model files appear to be {detected}, but family was declared as {supplied}. Re-import with family {detected} or pick different files."
+                    )),
+                )
+                .await;
+            }
+            Some(supplied)
+        }
+        (None, Some(detected)) => Some(detected),
+        (Some(supplied), None) => {
+            println!(
+                "Model import job {}: architecture detection inconclusive; accepting supplied family {supplied}",
+                job.id
+            );
+            Some(supplied)
+        }
+        (None, None) => None,
+    };
+
+    write_model_install_marker(&target_dir, &job.payload, repo.unwrap_or(""), &job.id).await?;
+    if let Some(manifest_entry) = job
+        .payload
+        .get("manifestEntry")
+        .and_then(Value::as_object)
+        .cloned()
+    {
+        let mut manifest_entry = manifest_entry;
+        if let Some(family) = resolved_family.clone() {
+            manifest_entry
+                .entry("family")
+                .or_insert(Value::String(family));
+        }
+        if let Some(paths) = manifest_entry
+            .entry("paths")
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+        {
+            paths.insert(
+                "model".to_owned(),
+                Value::String(target_dir.display().to_string()),
+            );
+        }
+        let manifest_path = model_manifest_target(settings, &job.payload)?;
+        upsert_model_manifest_entry(&manifest_path, manifest_entry).await?;
+    }
+
+    let mut result = JsonObject::new();
+    result.insert(
+        "modelId".to_owned(),
+        job.payload.get("modelId").cloned().unwrap_or(Value::Null),
+    );
+    result.insert(
+        "repo".to_owned(),
+        repo.map(|value| Value::String(value.to_owned()))
+            .unwrap_or(Value::Null),
+    );
+    result.insert(
+        "sourceUrl".to_owned(),
+        source_url
+            .map(|value| Value::String(value.to_owned()))
+            .unwrap_or(Value::Null),
+    );
+    result.insert(
+        "path".to_owned(),
+        Value::String(target_dir.display().to_string()),
+    );
+    result.insert(
+        "family".to_owned(),
+        resolved_family.map(Value::String).unwrap_or(Value::Null),
+    );
+    result.insert("completedAt".to_owned(), Value::String(now_rfc3339()));
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Model import completed.",
             None,
             Some(result),
             None,
@@ -2994,6 +3228,44 @@ fn resolve_lora_import_target(
     ))
 }
 
+fn resolve_model_import_target(
+    settings: &Settings,
+    payload: &JsonObject,
+    fallback_target: PathBuf,
+) -> WorkerResult<PathBuf> {
+    let target = normalize_absolute_path(
+        &optional_payload_string(payload, "targetDir")
+            .map(PathBuf::from)
+            .unwrap_or(fallback_target),
+    )?;
+    let allowed_roots = [normalize_absolute_path(&settings.data_dir.join("models"))?];
+    if allowed_roots.iter().any(|root| target.starts_with(root)) {
+        return Ok(target);
+    }
+    Err(WorkerError::InvalidPayload(
+        "Model import targetDir must be inside app-managed data/models".to_owned(),
+    ))
+}
+
+fn model_manifest_target(settings: &Settings, payload: &JsonObject) -> WorkerResult<PathBuf> {
+    let manifest_path = normalize_absolute_path(&PathBuf::from(required_payload_string(
+        payload,
+        "manifestPath",
+    )?))?;
+    let allowed = [normalize_absolute_path(
+        &settings
+            .config_dir
+            .join("manifests")
+            .join("user.models.jsonc"),
+    )?];
+    if allowed.iter().any(|path| path == &manifest_path) {
+        return Ok(manifest_path);
+    }
+    Err(WorkerError::InvalidPayload(
+        "Model manifestPath must target the global user model manifest".to_owned(),
+    ))
+}
+
 fn lora_manifest_target(settings: &Settings, payload: &JsonObject) -> WorkerResult<PathBuf> {
     let manifest_path = normalize_absolute_path(&PathBuf::from(required_payload_string(
         payload,
@@ -3773,6 +4045,53 @@ async fn upsert_lora_manifest_entry(
     }
     if !found {
         loras.push(Value::Object(entry));
+    }
+    write_json_value(path, &manifest).await
+}
+
+async fn upsert_model_manifest_entry(
+    path: &Path,
+    entry: serde_json::Map<String, Value>,
+) -> WorkerResult<()> {
+    let mut manifest = match tokio::fs::read_to_string(path).await {
+        Ok(payload) => serde_json::from_str(&strip_jsonc_comments(&payload))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            json!({ "schemaVersion": 1, "models": [] })
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let model_id = entry.get("id").and_then(Value::as_str).ok_or_else(|| {
+        WorkerError::InvalidPayload("Model manifest entry requires id".to_owned())
+    })?;
+    let models = manifest
+        .as_object_mut()
+        .ok_or_else(|| WorkerError::InvalidPayload("Model manifest must be an object".to_owned()))?
+        .entry("models")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let models = models.as_array_mut().ok_or_else(|| {
+        WorkerError::InvalidPayload("Model manifest models must be an array".to_owned())
+    })?;
+    let mut found = false;
+    for item in models.iter_mut() {
+        if item.get("id").and_then(Value::as_str) != Some(model_id) {
+            continue;
+        }
+        found = true;
+        let created_at = item.get("createdAt").cloned();
+        let Some(object) = item.as_object_mut() else {
+            return Err(WorkerError::InvalidPayload(
+                "Model manifest entry must be an object".to_owned(),
+            ));
+        };
+        for (key, value) in entry.clone() {
+            object.insert(key, value);
+        }
+        if let Some(created_at) = created_at {
+            object.insert("createdAt".to_owned(), created_at);
+        }
+    }
+    if !found {
+        models.push(Value::Object(entry));
     }
     write_json_value(path, &manifest).await
 }

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -80,6 +80,12 @@ function generatedResultAssetCount(job) {
 
 const localJobStackLimit = 4;
 const maxLoraUploadBytes = 2 * 1024 * 1024 * 1024;
+const maxModelUploadBytes = 256 * 1024 * 1024 * 1024;
+
+function uploadLimitLabel(bytes) {
+  const gib = bytes / (1024 * 1024 * 1024);
+  return Number.isInteger(gib) ? `${gib}GB` : `${gib.toFixed(1)}GB`;
+}
 
 export function App() {
   const [health, setHealth] = useState(null);
@@ -517,8 +523,8 @@ export function App() {
 
   async function createModelImportJob(payload, options = {}) {
     const { file, ...metadata } = payload;
-    if (file?.size > maxLoraUploadBytes) {
-      throw new Error("Uploaded model file exceeds the 2GB limit");
+    if (file?.size > maxModelUploadBytes) {
+      throw new Error(`Uploaded model file exceeds the ${uploadLimitLabel(maxModelUploadBytes)} limit`);
     }
     let body;
     if (file) {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -515,6 +515,36 @@ export function App() {
     return archived;
   }
 
+  async function createModelImportJob(payload, options = {}) {
+    const { file, ...metadata } = payload;
+    if (file?.size > maxLoraUploadBytes) {
+      throw new Error("Uploaded model file exceeds the 2GB limit");
+    }
+    let body;
+    if (file) {
+      body = new FormData();
+      Object.entries(metadata).forEach(([key, value]) => {
+        if (value != null && value !== "") {
+          body.append(key, value);
+        }
+      });
+      body.append("file", file);
+    } else {
+      body = JSON.stringify(metadata);
+    }
+    const job = await apiFetch("/api/v1/models/import", token, {
+      method: "POST",
+      body,
+    });
+    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    if (options.navigateToQueue ?? false) {
+      setActiveView("Queue");
+    }
+    setError("");
+    refreshData();
+    return job;
+  }
+
   async function createLoraImportJob(payload, options = {}) {
     if (payload.scope === "project" && !activeProject) {
       throw new Error("Create or open a project first.");
@@ -1470,6 +1500,7 @@ export function App() {
             models={models}
             onDownloadModel={createModelDownloadJob}
             onImportLora={createLoraImportJob}
+            onImportModel={createModelImportJob}
             onOpenQueue={() => setActiveView("Queue")}
           />
         ) : null}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1673,7 +1673,7 @@ describe("SceneWorks app shell", () => {
       expect.objectContaining({
         sourceUrl: "https://example.com/models/custom.safetensors",
         name: "Custom Model",
-        type: "image",
+        modelType: "image",
       }),
     );
     expect(onImportModel.mock.calls[0][0]).not.toHaveProperty("family");

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -55,6 +55,18 @@ function field(container, labelText) {
   return label?.querySelector("input, select, textarea");
 }
 
+function loraPanel(container) {
+  return container.querySelector("form[aria-label='Import LoRA']");
+}
+
+function modelImportPanel(container) {
+  return container.querySelector("form[aria-label='Import model']");
+}
+
+function buttonInside(scope, label) {
+  return [...scope.querySelectorAll("button")].find((button) => button.textContent === label);
+}
+
 async function changeField(input, value) {
   await act(async () => {
     const setter = Object.getOwnPropertyDescriptor(input.constructor.prototype, "value")?.set;
@@ -979,9 +991,10 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
     });
     await settle();
-    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    const panel = loraPanel(container);
+    await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(panel, "Queue Import").click();
     });
     await settle();
 
@@ -1173,11 +1186,12 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Upload").click();
+      buttonInside(loraPanel(container), "Upload").click();
     });
-    await changeFile(field(container, "LoRA File"), loraFile);
+    const panel = loraPanel(container);
+    await changeFile(field(panel, "LoRA File"), loraFile);
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(loraPanel(container), "Queue Import").click();
     });
 
     expect(container.textContent).toContain("Uploaded LoRA file exceeds the 2GB limit");
@@ -1259,10 +1273,11 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
-    await changeField(field(container, "Name"), "Detail LoRA");
+    const panel = loraPanel(container);
+    await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await changeField(field(panel, "Name"), "Detail LoRA");
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(panel, "Queue Import").click();
     });
 
     expect(onImportLora).toHaveBeenCalledWith(
@@ -1298,17 +1313,18 @@ describe("SceneWorks app shell", () => {
 
     expect(field(container, "LoRA family").value).toBe("all");
     await changeField(field(container, "LoRA family"), "qwen-image");
-    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    const panel = loraPanel(container);
+    await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(panel, "Queue Import").click();
     });
 
     expect(onImportLora.mock.calls[0][0]).not.toHaveProperty("family");
 
-    await changeField(field(container, "Family"), "z-image");
-    await changeField(field(container, "Source URL"), "https://example.com/loras/detail.safetensors");
+    await changeField(field(panel, "Family"), "z-image");
+    await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(panel, "Queue Import").click();
     });
 
     expect(onImportLora.mock.calls[1][0]).toEqual(
@@ -1341,14 +1357,15 @@ describe("SceneWorks app shell", () => {
       ]);
     });
 
-    await changeField(field(container, "Family"), "qwen-image");
-    expect(field(container, "Family").value).toBe("qwen-image");
+    const panel = loraPanel(container);
+    await changeField(field(panel, "Family"), "qwen-image");
+    expect(field(panel, "Family").value).toBe("qwen-image");
 
     await act(async () => {
       renderScreen([{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]);
     });
 
-    expect(field(container, "Family").value).toBe("");
+    expect(field(loraPanel(container), "Family").value).toBe("");
   });
 
   it("shows model download size estimates and unavailable states before download", async () => {
@@ -1453,21 +1470,22 @@ describe("SceneWorks app shell", () => {
       root.render(<Harness />);
     });
 
-    await changeField(field(container, "Source URL"), "https://example.com/loras/one.safetensors");
-    await changeField(field(container, "Name"), "First Detail");
+    const panel = () => loraPanel(container);
+    await changeField(field(panel(), "Source URL"), "https://example.com/loras/one.safetensors");
+    await changeField(field(panel(), "Name"), "First Detail");
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(panel(), "Queue Import").click();
     });
 
-    expect(field(container, "Source URL").value).toBe("");
-    expect(field(container, "Name").value).toBe("");
+    expect(field(panel(), "Source URL").value).toBe("");
+    expect(field(panel(), "Name").value).toBe("");
     expect(container.textContent).toContain("LoRA imports");
     expect(container.textContent).toContain("detail_lora_1");
     expect(container.textContent).not.toContain("No LoRAs in this view");
 
-    await changeField(field(container, "Source URL"), "https://example.com/loras/two.safetensors");
+    await changeField(field(panel(), "Source URL"), "https://example.com/loras/two.safetensors");
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(panel(), "Queue Import").click();
     });
 
     expect(onImportLora).toHaveBeenCalledTimes(2);
@@ -1502,12 +1520,13 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Upload").click();
+      buttonInside(loraPanel(container), "Upload").click();
     });
-    await changeField(field(container, "Scope"), "project");
-    await changeFile(field(container, "LoRA File"), loraFile);
+    const panel = loraPanel(container);
+    await changeField(field(panel, "Scope"), "project");
+    await changeFile(field(panel, "LoRA File"), loraFile);
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(loraPanel(container), "Queue Import").click();
     });
 
     expect(onImportLora).toHaveBeenCalledWith(
@@ -1613,13 +1632,137 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await changeField(field(container, "Source URL"), "file:///tmp/detail.safetensors");
+    const panel = loraPanel(container);
+    await changeField(field(panel, "Source URL"), "file:///tmp/detail.safetensors");
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").click();
+      buttonInside(panel, "Queue Import").click();
     });
 
     expect(container.textContent).toContain("LoRA sourceUrl must use http or https");
-    expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Queue Import").disabled).toBe(false);
+    expect(buttonInside(loraPanel(container), "Queue Import").disabled).toBe(false);
+  });
+
+  it("queues model URL imports from the Models page", async () => {
+    const onImportModel = vi.fn(async (payload) => ({
+      payload: { ...payload, modelId: "custom_model", manifestEntry: { family: "z-image" } },
+    }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={null}
+          jobs={[]}
+          loras={[]}
+          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={() => {}}
+          onImportModel={onImportModel}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    const panel = modelImportPanel(container);
+    await changeField(field(panel, "Source URL"), "https://example.com/models/custom.safetensors");
+    await changeField(field(panel, "Name"), "Custom Model");
+    await act(async () => {
+      buttonInside(panel, "Queue Import").click();
+    });
+
+    expect(onImportModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceUrl: "https://example.com/models/custom.safetensors",
+        name: "Custom Model",
+        type: "image",
+      }),
+    );
+    expect(onImportModel.mock.calls[0][0]).not.toHaveProperty("family");
+    expect(container.textContent).toContain("Model import queued for custom_model.");
+    expect(container.textContent).toContain("Detected family: z-image.");
+  });
+
+  it("sends an explicit family override on model imports when chosen", async () => {
+    const onImportModel = vi.fn(async (payload) => ({
+      payload: { ...payload, modelId: "custom_model", manifestEntry: { family: payload.family } },
+    }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={null}
+          jobs={[]}
+          loras={[]}
+          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={() => {}}
+          onImportModel={onImportModel}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    const panel = modelImportPanel(container);
+    await changeField(field(panel, "Family"), "z-image");
+    await changeField(field(panel, "Source URL"), "https://example.com/models/custom.safetensors");
+    await act(async () => {
+      buttonInside(panel, "Queue Import").click();
+    });
+
+    expect(onImportModel.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ family: "z-image" }),
+    );
+  });
+
+  it("renders unassociated models with a needs-family badge", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={null}
+          jobs={[]}
+          loras={[]}
+          models={[{ id: "imported_custom", name: "Imported Custom", type: "image" }]}
+          onDownloadModel={() => {}}
+          onImportLora={() => {}}
+          onImportModel={() => {}}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("needs family");
+    expect(container.textContent).toContain("unassociated");
+  });
+
+  it("shows in-progress model imports inline", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ModelManagerScreen
+          activeProject={null}
+          jobs={[
+            {
+              id: "model-import-job-1",
+              type: "model_import",
+              status: "downloading",
+              stage: "downloading",
+              progress: 0.42,
+              payload: { modelId: "custom_model", name: "Custom Model" },
+            },
+          ]}
+          loras={[]}
+          models={[]}
+          onDownloadModel={() => {}}
+          onImportLora={() => {}}
+          onImportModel={() => {}}
+          onOpenQueue={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Model imports in progress");
+    expect(container.textContent).toContain("Model import");
+    expect(container.textContent).toContain("downloading");
   });
 
   it("adds the SSE ticket as a query parameter", () => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -165,7 +165,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
       const job = await onImportModel({
         ...(isFileImport ? { file: modelImportForm.file } : { sourceUrl: modelImportForm.sourceUrl.trim() }),
         name: modelImportForm.name.trim() || undefined,
-        type: modelImportForm.type,
+        modelType: modelImportForm.type,
         ...familyOverride,
       });
       const modelId = job?.payload?.modelId;

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -64,7 +64,13 @@ function downloadSizeText(model) {
   return model.downloadSizeEstimated ? `~${model.downloadSizeLabel}` : model.downloadSizeLabel;
 }
 
-export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownloadModel, onImportLora, onOpenQueue }) {
+const MODEL_TYPE_OPTIONS = [
+  { value: "image", label: "Image" },
+  { value: "video", label: "Video" },
+  { value: "utility", label: "Utility" },
+];
+
+export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownloadModel, onImportLora, onImportModel, onOpenQueue }) {
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
   const familiesKey = families.join("|");
   const [familyFilter, setFamilyFilter] = useState("all");
@@ -79,6 +85,17 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
     family: "",
   });
   const [fileInputKey, setFileInputKey] = useState(0);
+  const [importingModel, setImportingModel] = useState(false);
+  const [modelImportMessage, setModelImportMessage] = useState({ tone: "neutral", text: "" });
+  const [modelImportForm, setModelImportForm] = useState({
+    mode: "url",
+    sourceUrl: "",
+    file: null,
+    name: "",
+    type: "image",
+    family: "",
+  });
+  const [modelFileInputKey, setModelFileInputKey] = useState(0);
   const visibleLoras = loras.filter((lora) => matchesFamily(lora, familyFilter));
 
   useEffect(() => {
@@ -132,9 +149,51 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
     }
   }
 
+  async function importModel(event) {
+    event.preventDefault();
+    const isFileImport = modelImportForm.mode === "file";
+    if ((!isFileImport && !modelImportForm.sourceUrl.trim()) || (isFileImport && !modelImportForm.file) || !onImportModel) {
+      return;
+    }
+    setImportingModel(true);
+    setModelImportMessage({
+      tone: "neutral",
+      text: isFileImport ? "Uploading model file before queueing import." : "",
+    });
+    try {
+      const familyOverride = modelImportForm.family ? { family: modelImportForm.family } : {};
+      const job = await onImportModel({
+        ...(isFileImport ? { file: modelImportForm.file } : { sourceUrl: modelImportForm.sourceUrl.trim() }),
+        name: modelImportForm.name.trim() || undefined,
+        type: modelImportForm.type,
+        ...familyOverride,
+      });
+      const modelId = job?.payload?.modelId;
+      const resolvedFamily = job?.payload?.manifestEntry?.family;
+      const detectionNote =
+        !modelImportForm.family && resolvedFamily ? ` Detected family: ${resolvedFamily}.` : "";
+      setModelImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
+      setModelFileInputKey((current) => current + 1);
+      setModelImportMessage({
+        tone: "success",
+        text: `${modelId ? `Model import queued for ${modelId}.` : "Model import queued."}${detectionNote}`,
+      });
+    } catch (err) {
+      setModelImportMessage({ tone: "error", text: err.message });
+    } finally {
+      setImportingModel(false);
+    }
+  }
+
   const completedImportTimes = completedLoraImportTimes(jobs);
   const pendingLoraImportJobs = jobs.filter((job) => job.type === "lora_import" && !isSupersededLoraImport(job, completedImportTimes));
   const localLoraImportJobs = pendingLoraImportJobs.filter((job) => job.status !== "completed" && matchesFamily(job, familyFilter));
+  const pendingModelImportJobs = jobs.filter((job) => job.type === "model_import" && job.status !== "completed");
+  const isModelFileImport = modelImportForm.mode === "file";
+  const modelImportDisabled =
+    importingModel ||
+    !onImportModel ||
+    (isModelFileImport ? !modelImportForm.file : !modelImportForm.sourceUrl.trim());
   const hiddenImportCount =
     familyFilter === "all" ? 0 : pendingLoraImportJobs.filter((job) => job.status !== "completed" && !matchesFamily(job, familyFilter)).length;
   const visibleLoraCount = visibleLoras.length + localLoraImportJobs.length;
@@ -173,6 +232,7 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
           const localDownloadJob = installed ? null : downloadJobs.find((job) => job.status !== "completed");
           const failedDownload = localDownloadJob && terminalStatuses.has(localDownloadJob.status);
           const downloadSize = downloadSizeText(model);
+          const unassociated = !model.family;
           return (
             <article className="model-card" key={model.id}>
               <div>
@@ -180,11 +240,16 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
                 <h3>{model.name}</h3>
               </div>
               <span className={installed ? "status-badge installed" : "status-badge"}>{installed ? "installed" : "missing"}</span>
+              {unassociated ? (
+                <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
+                  needs family
+                </span>
+              ) : null}
               <p>{model.ui?.description ?? model.family ?? model.id}</p>
               <dl>
                 <div>
                   <dt>Family</dt>
-                  <dd>{model.family ?? "unknown"}</dd>
+                  <dd>{model.family ?? "unassociated"}</dd>
                 </div>
                 <div>
                   <dt>Repo</dt>
@@ -213,6 +278,121 @@ export function ModelManagerScreen({ activeProject, jobs, loras, models, onDownl
           );
         })}
       </div>
+
+      <section className="model-import-panel-section">
+        <form className="lora-import-panel models-import-panel" aria-label="Import model" onSubmit={importModel}>
+          <div>
+            <strong>Import model</strong>
+            <span>{modelImportForm.family || "auto-detect family"}</span>
+          </div>
+          <div className="segmented-control compact-segment" aria-label="Model import source">
+            <button
+              className={modelImportForm.mode === "url" ? "active" : ""}
+              disabled={importingModel}
+              onClick={() => setModelImportForm((current) => ({ ...current, mode: "url" }))}
+              type="button"
+            >
+              URL
+            </button>
+            <button
+              className={modelImportForm.mode === "file" ? "active" : ""}
+              disabled={importingModel}
+              onClick={() => setModelImportForm((current) => ({ ...current, mode: "file" }))}
+              type="button"
+            >
+              Upload
+            </button>
+          </div>
+          <div className="models-import-grid">
+            <label>
+              Type
+              <select
+                disabled={importingModel}
+                onChange={(event) => setModelImportForm((current) => ({ ...current, type: event.target.value }))}
+                value={modelImportForm.type}
+              >
+                {MODEL_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Family
+              <select
+                disabled={importingModel || !families.length}
+                onChange={(event) => setModelImportForm((current) => ({ ...current, family: event.target.value }))}
+                value={modelImportForm.family}
+              >
+                {families.length ? (
+                  <>
+                    <option value="">Auto-detect</option>
+                    {families.map((family) => (
+                      <option key={family} value={family}>
+                        {family}
+                      </option>
+                    ))}
+                  </>
+                ) : (
+                  <option value="">No known families</option>
+                )}
+              </select>
+            </label>
+            {isModelFileImport ? (
+              <label>
+                Model File
+                <span className="file-picker-row">
+                  <span className="file-upload-button">
+                    Choose
+                    <input
+                      accept=".safetensors,.ckpt,.pt,.bin"
+                      disabled={importingModel}
+                      key={modelFileInputKey}
+                      onChange={(event) => setModelImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
+                      type="file"
+                    />
+                  </span>
+                  <span className="selected-file-name">{modelImportForm.file?.name ?? "No file selected"}</span>
+                </span>
+              </label>
+            ) : (
+              <label>
+                Source URL
+                <input
+                  disabled={importingModel}
+                  onChange={(event) => setModelImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
+                  placeholder="https://..."
+                  value={modelImportForm.sourceUrl}
+                />
+              </label>
+            )}
+            <label>
+              Name
+              <input
+                disabled={importingModel}
+                onChange={(event) => setModelImportForm((current) => ({ ...current, name: event.target.value }))}
+                placeholder="Optional"
+                value={modelImportForm.name}
+              />
+            </label>
+            <button disabled={modelImportDisabled} type="submit">
+              {importingModel ? (isModelFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
+            </button>
+          </div>
+          {modelImportMessage.text ? <p className={modelImportMessage.tone === "success" ? "inline-success" : "inline-warning"}>{modelImportMessage.text}</p> : null}
+        </form>
+        {pendingModelImportJobs.length ? (
+          <div className="lora-import-progress">
+            <strong>Model imports in progress</strong>
+            <div className="local-job-stack">
+              {pendingModelImportJobs.map((job) => (
+                <JobProgressCard job={job} key={job.id} label="Model import" onOpenQueue={onOpenQueue} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </section>
 
       <section className="lora-panel">
         <div className="lora-panel-header">

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -121,6 +121,7 @@ string_enum! {
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",
+        ModelImport => "model_import",
         LoraImport => "lora_import",
     }
 }
@@ -177,6 +178,7 @@ string_enum! {
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",
+        ModelImport => "model_import",
         LoraImport => "lora_import",
     }
 }
@@ -242,6 +244,7 @@ string_enum! {
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",
+        ModelImport => "model_import",
         LoraImport => "lora_import",
     }
 }

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -32,7 +32,7 @@ pub const JOB_STATUSES: &[&str] = &[
     "canceled",
     "interrupted",
 ];
-pub const NON_GPU_JOB_TYPES: &[&str] = &["model_download", "lora_import"];
+pub const NON_GPU_JOB_TYPES: &[&str] = &["model_download", "model_import", "lora_import"];
 pub const MAX_JOB_ATTEMPTS: u32 = 5;
 const DISPATCH_MEMORY_NOT_WORSE_TOLERANCE_MB: f64 = 512.0;
 const DISPATCH_MEMORY_RELIEF_THRESHOLD_MB: f64 = 1024.0;
@@ -601,7 +601,7 @@ impl JobsStore {
                 select id from jobs
                  where assigned_gpu = ?1
                    and status in ('preparing', 'downloading', 'loading_model', 'running', 'saving')
-                   and type not in ('model_download', 'lora_import')
+                   and type not in ('model_download', 'model_import', 'lora_import')
                  limit 1
                 ",
                 params![worker.gpu_id],
@@ -614,8 +614,8 @@ impl JobsStore {
             "
             select * from jobs
              where status = 'queued'
-               and (type in ('model_download', 'lora_import') or requested_gpu = 'auto' or requested_gpu = ?1)
-               and (?2 = 0 or type in ('model_download', 'lora_import'))
+               and (type in ('model_download', 'model_import', 'lora_import') or requested_gpu = 'auto' or requested_gpu = ?1)
+               and (?2 = 0 or type in ('model_download', 'model_import', 'lora_import'))
              order by created_at asc
              limit 50
             ",
@@ -1219,7 +1219,7 @@ fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResu
             select id from jobs
              where assigned_gpu = ?1
                and status in ('preparing', 'downloading', 'loading_model', 'running', 'saving')
-               and type not in ('model_download', 'lora_import')
+               and type not in ('model_download', 'model_import', 'lora_import')
              limit 1
             ",
             params![gpu_id],

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use serde_json::Value;
+use serde_json::{json, Map, Value};
 
 /// Maximum allowed safetensors header size, in bytes. Matches the
 /// pre-existing 16 MiB cap enforced by the rust-api.
@@ -128,6 +128,127 @@ pub fn detect_model_family(path: &Path) -> Result<Option<String>, SafetensorsHea
     };
     let header = read_safetensors_header(&safetensors_path)?;
     Ok(detect_lora_family(&header))
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FamilyMismatch {
+    pub supplied: String,
+    pub detected: String,
+}
+
+/// Applies the shared import policy for detected architecture families.
+///
+/// A confident detector result rejects a conflicting user-supplied family; a
+/// missing detector result keeps the supplied family, if any.
+pub fn reconcile_detected_family(
+    supplied: Option<String>,
+    detected: Option<String>,
+) -> Result<Option<String>, FamilyMismatch> {
+    match (supplied, detected) {
+        (Some(supplied), Some(detected)) if supplied != detected => {
+            Err(FamilyMismatch { supplied, detected })
+        }
+        (Some(supplied), Some(_)) => Ok(Some(supplied)),
+        (None, Some(detected)) => Ok(Some(detected)),
+        (Some(supplied), None) => Ok(Some(supplied)),
+        (None, None) => Ok(None),
+    }
+}
+
+/// Adds model-manifest defaults derived from the imported model type/family.
+/// Existing author-supplied fields are preserved.
+pub fn apply_model_manifest_defaults(
+    entry: &mut Map<String, Value>,
+    model_type: &str,
+    family: Option<&str>,
+) {
+    entry
+        .entry("downloads".to_owned())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    entry
+        .entry("defaults".to_owned())
+        .or_insert_with(|| json!({}));
+    entry
+        .entry("limits".to_owned())
+        .or_insert_with(|| json!({}));
+    entry.entry("ui".to_owned()).or_insert_with(|| json!({}));
+
+    let Some(family) = family
+        .map(normalize_model_family)
+        .filter(|value| !value.is_empty())
+    else {
+        entry
+            .entry("loraCompatibility".to_owned())
+            .or_insert_with(|| json!({}));
+        return;
+    };
+
+    if let Some(adapter) = model_adapter_for_family(&family) {
+        entry
+            .entry("adapter".to_owned())
+            .or_insert_with(|| Value::String(adapter.to_owned()));
+    }
+
+    let capabilities = model_capabilities_for_type_and_family(model_type, &family);
+    if !capabilities.is_empty() {
+        entry.entry("capabilities".to_owned()).or_insert_with(|| {
+            Value::Array(
+                capabilities
+                    .into_iter()
+                    .map(|capability| Value::String(capability.to_owned()))
+                    .collect(),
+            )
+        });
+    }
+
+    let compatibility = entry
+        .entry("loraCompatibility".to_owned())
+        .or_insert_with(|| json!({}));
+    if let Some(object) = compatibility.as_object_mut() {
+        object
+            .entry("families".to_owned())
+            .or_insert_with(|| json!([family]));
+    }
+}
+
+pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
+    match normalize_model_family(family).as_str() {
+        "z-image" => Some("z_image_diffusers"),
+        "qwen-image" => Some("qwen_image"),
+        "ltx-video" => Some("ltx_video"),
+        "wan-video" => Some("wan_video"),
+        _ => None,
+    }
+}
+
+pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) -> Vec<&'static str> {
+    match (
+        model_type.trim().to_ascii_lowercase().as_str(),
+        normalize_model_family(family).as_str(),
+    ) {
+        ("image", "z-image") => vec!["text_to_image", "character_image", "style_variations"],
+        ("image", "qwen-image") => vec!["text_to_image", "style_variations"],
+        ("video", "ltx-video") => vec![
+            "image_to_video",
+            "text_to_video",
+            "first_last_frame",
+            "extend_clip",
+            "video_bridge",
+        ],
+        ("video", "wan-video") => vec![
+            "image_to_video",
+            "text_to_video",
+            "first_last_frame",
+            "extend_clip",
+            "video_bridge",
+            "replace_person",
+        ],
+        _ => Vec::new(),
+    }
+}
+
+fn normalize_model_family(family: &str) -> String {
+    family.trim().to_ascii_lowercase().replace('_', "-")
 }
 
 fn read_diffusers_model_index_family(dir: &Path) -> Option<String> {
@@ -652,6 +773,57 @@ mod tests {
             Some("sdxl")
         );
         assert!(diffusers_class_name_to_family("UnknownCustomPipeline").is_none());
+    }
+
+    #[test]
+    fn reconcile_detected_family_rejects_mismatches_only() {
+        assert_eq!(
+            reconcile_detected_family(Some("z-image".to_owned()), Some("z-image".to_owned()))
+                .unwrap()
+                .as_deref(),
+            Some("z-image")
+        );
+        assert_eq!(
+            reconcile_detected_family(None, Some("qwen-image".to_owned()))
+                .unwrap()
+                .as_deref(),
+            Some("qwen-image")
+        );
+        assert_eq!(
+            reconcile_detected_family(Some("wan-video".to_owned()), None)
+                .unwrap()
+                .as_deref(),
+            Some("wan-video")
+        );
+        assert_eq!(
+            reconcile_detected_family(Some("z-image".to_owned()), Some("qwen-image".to_owned()))
+                .unwrap_err(),
+            FamilyMismatch {
+                supplied: "z-image".to_owned(),
+                detected: "qwen-image".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn model_manifest_defaults_follow_supported_families() {
+        let mut entry = serde_json::Map::new();
+        apply_model_manifest_defaults(&mut entry, "video", Some("wan_video"));
+
+        assert_eq!(entry["adapter"], "wan_video");
+        assert_eq!(
+            entry["capabilities"],
+            json!([
+                "image_to_video",
+                "text_to_video",
+                "first_last_frame",
+                "extend_clip",
+                "video_bridge",
+                "replace_person"
+            ])
+        );
+        assert_eq!(entry["loraCompatibility"]["families"], json!(["wan-video"]));
+        assert_eq!(entry["downloads"], json!([]));
     }
 
     #[test]

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -94,6 +94,75 @@ fn has_safetensors_extension(path: &Path) -> bool {
         .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
 }
 
+/// Returns the detected family for a base model directory or file.
+///
+/// Detection strategy, in priority order:
+/// 1. Diffusers `model_index.json` `_class_name` — canonical for diffusers
+///    snapshots and the most reliable signal.
+/// 2. Safetensors header architecture detection via [`detect_lora_family`] —
+///    the architecture-prefix substrings (e.g. `transformer.transformer_blocks.`)
+///    appear in base models as well as LoRAs, so the same detector usefully
+///    classifies single-file diffusers checkpoints.
+///
+/// Returns `Ok(None)` when no confident signal is available — callers should
+/// treat that as "unassociated" rather than as an error.
+pub fn detect_model_family(path: &Path) -> Result<Option<String>, SafetensorsHeaderError> {
+    if path.is_dir() {
+        if let Some(family) = read_diffusers_model_index_family(path) {
+            return Ok(Some(family));
+        }
+    } else if path.is_file()
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("model_index.json"))
+    {
+        if let Some(parent) = path.parent() {
+            if let Some(family) = read_diffusers_model_index_family(parent) {
+                return Ok(Some(family));
+            }
+        }
+    }
+    let Some(safetensors_path) = first_safetensors_path(path) else {
+        return Ok(None);
+    };
+    let header = read_safetensors_header(&safetensors_path)?;
+    Ok(detect_lora_family(&header))
+}
+
+fn read_diffusers_model_index_family(dir: &Path) -> Option<String> {
+    let index_path = dir.join("model_index.json");
+    let bytes = fs::read(&index_path).ok()?;
+    let index: Value = serde_json::from_slice(&bytes).ok()?;
+    let class_name = index.get("_class_name").and_then(Value::as_str)?;
+    diffusers_class_name_to_family(class_name)
+}
+
+/// Maps a diffusers pipeline `_class_name` to a SceneWorks family. The map is
+/// intentionally conservative — only return a family when the mapping is
+/// unambiguous, and otherwise let the caller treat the model as unassociated.
+pub fn diffusers_class_name_to_family(class_name: &str) -> Option<String> {
+    let normalized = class_name.trim();
+    let lower = normalized.to_ascii_lowercase();
+    match lower.as_str() {
+        "zimagepipeline"
+        | "zimageimg2imgpipeline"
+        | "zimageturbopipeline"
+        | "zimageturboimg2imgpipeline" => Some("z-image".to_owned()),
+        "qwenimagepipeline" | "qwenimageimg2imgpipeline" | "qwenimageeditpipeline" => {
+            Some("qwen-image".to_owned())
+        }
+        "fluxpipeline" | "fluximg2imgpipeline" | "fluxinpaintpipeline" => Some("flux".to_owned()),
+        "wanpipeline" | "wani2vpipeline" | "wantext2videopipeline" => Some("wan-video".to_owned()),
+        "ltxpipeline" | "ltxvideopipeline" | "ltximagetovideopipeline" => {
+            Some("ltx-video".to_owned())
+        }
+        "stablediffusionpipeline" | "stablediffusionimg2imgpipeline" => Some("sd1.5".to_owned()),
+        "stablediffusionxlpipeline" | "stablediffusionxlimg2imgpipeline" => Some("sdxl".to_owned()),
+        _ => None,
+    }
+}
+
 /// Returns the detected LoRA architecture family or `None` if the header
 /// is ambiguous, empty, or matches no known signature with confidence.
 pub fn detect_lora_family(header: &Value) -> Option<String> {
@@ -369,6 +438,25 @@ mod tests {
         Value::Object(object)
     }
 
+    fn write_safetensors(path: &Path, keys: &[String]) {
+        // Emit a minimal valid safetensors layout: 8-byte little-endian header
+        // length, then a JSON header whose entries each point at empty tensor
+        // slices in the (empty) tensor section. The detector only reads the
+        // header, so empty offsets are fine.
+        let mut header = serde_json::Map::new();
+        header.insert("__metadata__".to_owned(), json!({"format": "pt"}));
+        for key in keys {
+            header.insert(
+                key.clone(),
+                json!({"dtype": "F16", "shape": [1], "data_offsets": [0, 0]}),
+            );
+        }
+        let header_bytes = serde_json::to_vec(&Value::Object(header)).expect("serialize header");
+        let mut buffer = (header_bytes.len() as u64).to_le_bytes().to_vec();
+        buffer.extend_from_slice(&header_bytes);
+        std::fs::write(path, buffer).expect("write safetensors");
+    }
+
     fn diffusers_double_stream_keys(prefix: &str, block_count: usize) -> Vec<String> {
         let mut keys = Vec::new();
         for block in 0..block_count {
@@ -543,5 +631,66 @@ mod tests {
     fn non_object_header_returns_none() {
         let header = json!(["not", "an", "object"]);
         assert!(detect_lora_family(&header).is_none());
+    }
+
+    #[test]
+    fn diffusers_class_names_map_to_known_families() {
+        assert_eq!(
+            diffusers_class_name_to_family("ZImagePipeline").as_deref(),
+            Some("z-image")
+        );
+        assert_eq!(
+            diffusers_class_name_to_family("QwenImagePipeline").as_deref(),
+            Some("qwen-image")
+        );
+        assert_eq!(
+            diffusers_class_name_to_family("FluxPipeline").as_deref(),
+            Some("flux")
+        );
+        assert_eq!(
+            diffusers_class_name_to_family("StableDiffusionXLPipeline").as_deref(),
+            Some("sdxl")
+        );
+        assert!(diffusers_class_name_to_family("UnknownCustomPipeline").is_none());
+    }
+
+    #[test]
+    fn detect_model_family_reads_diffusers_index() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("model_index.json"),
+            br#"{"_class_name": "ZImagePipeline", "_diffusers_version": "0.27.0"}"#,
+        )
+        .expect("write index");
+        let family = detect_model_family(temp.path()).expect("detect");
+        assert_eq!(family.as_deref(), Some("z-image"));
+    }
+
+    #[test]
+    fn detect_model_family_falls_back_to_header() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let keys = diffusers_double_stream_keys("transformer", 40);
+        write_safetensors(&temp.path().join("checkpoint.safetensors"), &keys);
+        let family = detect_model_family(temp.path()).expect("detect");
+        assert_eq!(family.as_deref(), Some("qwen-image"));
+    }
+
+    #[test]
+    fn detect_model_family_returns_none_for_empty_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let family = detect_model_family(temp.path()).expect("detect");
+        assert!(family.is_none());
+    }
+
+    #[test]
+    fn detect_model_family_returns_none_for_unmapped_class_name() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("model_index.json"),
+            br#"{"_class_name": "ExperimentalPipeline"}"#,
+        )
+        .expect("write index");
+        let family = detect_model_family(temp.path()).expect("detect");
+        assert!(family.is_none());
     }
 }

--- a/tests/fixtures/rust_migration_contracts/job_protocol.json
+++ b/tests/fixtures/rust_migration_contracts/job_protocol.json
@@ -13,6 +13,7 @@
     "frame_extract",
     "timeline_export",
     "model_download",
+    "model_import",
     "lora_import"
   ],
   "statuses": [
@@ -29,7 +30,7 @@
   ],
   "activeStatuses": ["preparing", "downloading", "loading_model", "running", "saving"],
   "terminalStatuses": ["completed", "failed", "canceled", "interrupted"],
-  "nonGpuJobTypes": ["model_download", "lora_import"],
+  "nonGpuJobTypes": ["model_download", "model_import", "lora_import"],
   "workerStatuses": ["idle", "busy", "offline"],
   "progressStages": [
     "queued",


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/models/import` (JSON or multipart) that mirrors the LoRA import flow: HF repo, source URL, or local upload; stages uploads under `data/cache/model-uploads/<uuid>/`, dedupes by id, queues a `model_import` job.
- New `JobType::ModelImport` / `WorkerCapability::ModelImport`; worker `run_model_import_job` downloads/copies, runs family detection, writes the install marker, and upserts `config/manifests/user.models.jsonc`.
- Family detection in `sceneworks-core::lora_family::detect_model_family` reads diffusers `model_index.json` `_class_name` first and falls back to the existing safetensors-header detector. Inconclusive detection leaves the model **unassociated** rather than failing.
- Models page gets an inline "Import model" panel (URL/upload, type, optional family override, progress card) and surfaces a `needs family` badge on unassociated catalog entries.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (100 tests; new `detect_model_family` unit tests in core, new `model_import_routes_handle_url_upload_and_family_detection` API test)
- [x] `npx vitest run --environment jsdom` from `apps/web` (55 tests; added 4 new model-import UI tests; updated affected LoRA tests to scope via `loraPanel`/`modelImportPanel` helpers since the new form added duplicate field labels)
- [ ] Manual: `data/cache/model-uploads/<uuid>/` survives a worker crash mid-import (out of scope for this PR — see Followups)
- [ ] Manual: queue a model via URL, watch progress, verify it lands in `user.models.jsonc` with detected family

## Acceptance criteria
| AC | Status |
|---|---|
| URL + upload model import on Models page | ✅ |
| Inline progress consistent with queued-action UX | ✅ |
| Family detection runs after import | ✅ |
| Detected models become selectable in generation/preset flows | ✅ (manifest entry includes `family`) |
| Undetected models remain listed as unassociated, not ready for generation | ✅ (no `family` → `needs family` badge) |
| Duplicate imports handled gracefully | ✅ (id collision rejected with actionable error) |
| Import errors surface actionable messages, no stale partial entries | ✅ (staged uploads cleaned on failure; manifest written only after worker completes) |

## Followups worth flagging (not in this PR)
- Stale-sweep for `data/cache/model-uploads/` analogous to `lora-uploads`.
- In-UI family editor for unassociated models (current correction path is editing `user.models.jsonc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)