### PR TITLE
[codex] Make model and preset selection first-class

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2530,6 +2530,14 @@ describe("SceneWorks app shell", () => {
     expect(generate.disabled).toBe(true);
 
     await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Hide advanced").click();
+    });
+    await settle();
+
+    expect([...container.querySelectorAll("button")].some((button) => button.textContent === "Hide advanced")).toBe(true);
+    expect(container.textContent).toContain("Qwen Only");
+
+    await act(async () => {
       generate.click();
     });
 

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2449,10 +2449,15 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    expect(container.textContent).toContain("Built In");
+    expect(container.textContent).not.toContain("Built In");
     expect(container.textContent).not.toContain("Qwen Only");
     expect(container.textContent).not.toContain("Missing LoRA");
 
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+
+    expect(container.textContent).toContain("Built In");
     const checkboxes = [...container.querySelectorAll('.lora-choice input[type="checkbox"]')];
     await act(async () => {
       checkboxes[0].click();
@@ -2462,9 +2467,6 @@ describe("SceneWorks app shell", () => {
 
     expect(checkboxes[3].disabled).toBe(true);
 
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
-    });
     await act(async () => {
       container.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
     });
@@ -2599,6 +2601,78 @@ describe("SceneWorks app shell", () => {
         recipePresetId: "cinematic",
         loras: [],
         advanced: { resolution: "1280x720" },
+      }),
+    );
+  });
+
+  it("surfaces model and preset first and lets image generation run with no preset", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={createImageJob}
+          deleteAsset={() => {}}
+          gpuOptions={["auto", "1"]}
+          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
+          latestAssets={[]}
+          loras={[{ id: "cinematic_detail", name: "Cinematic Detail", family: "z-image", scope: "builtin", presetManaged: true }]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          recipePresets={[
+            {
+              id: "cinematic",
+              name: "Cinematic",
+              model: "z_image_turbo",
+              workflow: "text_to_image",
+              defaults: { count: 2, negativePrompt: "flat lighting" },
+              builtInLoras: [{ id: "cinematic_detail" }],
+            },
+          ]}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    const primaryLabels = [
+      ...container.querySelectorAll(".studio-controls > .generation-primary-grid label, .studio-controls > .prompt-field, .studio-controls > .count-control-grid label"),
+    ].map((label) => label.childNodes[0]?.textContent.trim());
+    expect(primaryLabels).toEqual(["Model", "Preset", "Prompt", "Count"]);
+    expect(field(container, "Preset").textContent).toContain("None");
+    expect(field(container, "Count").value).toBe("2");
+    expect(field(container, "GPU")).toBeUndefined();
+    expect(container.textContent).not.toContain("LoRAs");
+
+    await changeField(field(container, "Preset"), field(container, "Preset").options[0].value);
+    await settle();
+
+    expect(container.textContent).toContain("No preset selected");
+    expect(field(container, "Count").value).toBe("4");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+
+    expect(field(container, "GPU")).not.toBeUndefined();
+    expect(container.textContent).toContain("LoRAs");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        count: 4,
+        negativePrompt: "",
+        recipePresetId: null,
+        loras: [],
       }),
     );
   });
@@ -2974,7 +3048,7 @@ describe("SceneWorks app shell", () => {
     await changeField(field(container, "Model"), "wan_2_2");
     await settle();
 
-    expect(container.textContent).toContain("Presets unavailable");
+    expect(container.textContent).toContain("No preset selected");
     expect(container.textContent).not.toContain("LTX Story");
   });
 

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2642,7 +2642,7 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     const primaryLabels = [
-      ...container.querySelectorAll(".studio-controls > .generation-primary-grid label, .studio-controls > .prompt-field, .studio-controls > .count-control-grid label"),
+      ...container.querySelectorAll(".studio-controls > .generation-primary-grid label, .studio-controls > label"),
     ].map((label) => label.childNodes[0]?.textContent.trim());
     expect(primaryLabels).toEqual(["Model", "Preset", "Prompt", "Count"]);
     expect(field(container, "Preset").textContent).toContain("None");
@@ -2675,6 +2675,7 @@ describe("SceneWorks app shell", () => {
         loras: [],
       }),
     );
+    expect(createImageJob.mock.calls[0][0]).not.toHaveProperty("stylePreset");
   });
 
   it("blocks image presets whose managed LoRAs do not match the selected model", async () => {

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -1,5 +1,24 @@
-export const autoRecipePresetId = "__auto_recipe_preset__";
 export const noRecipePresetId = "__no_recipe_preset__";
+
+export function rememberPresetDefault(snapshots, key, currentValue, appliedValue) {
+  const previousSnapshot = snapshots.current[key];
+  snapshots.current[key] = {
+    appliedValue,
+    previousValue:
+      previousSnapshot && Object.is(currentValue, previousSnapshot.appliedValue)
+        ? previousSnapshot.previousValue
+        : currentValue,
+  };
+}
+
+export function clearPresetDefault(setter, snapshots, key) {
+  const snapshot = snapshots.current[key];
+  if (!snapshot) {
+    return;
+  }
+  setter((current) => (Object.is(current, snapshot.appliedValue) ? snapshot.previousValue : current));
+  delete snapshots.current[key];
+}
 
 export const defaultModesByWorkflow = {
   text_to_image: ["text_to_image", "character_image", "style_variations"],

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -1,3 +1,6 @@
+export const autoRecipePresetId = "__auto_recipe_preset__";
+export const noRecipePresetId = "__no_recipe_preset__";
+
 export const defaultModesByWorkflow = {
   text_to_image: ["text_to_image", "character_image", "style_variations"],
   edit_image: ["edit_image"],

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -225,6 +225,11 @@ export function ImageStudio({
     () => presetValidation(selectedRecipePreset, loras, selectedModel),
     [selectedRecipePreset, loras, selectedModel],
   );
+  useEffect(() => {
+    if (selectedLoraValidationResult.incompatible.length && !advancedOpen) {
+      setAdvancedOpen(true);
+    }
+  }, [advancedOpen, selectedLoraValidationResult.incompatible.length]);
   const hasPendingCompatibleLoras = Boolean(selectedModel) && loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
   const loraEmptyMessage = !selectedModel
     ? "No model selected"

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -5,13 +5,14 @@ import { JobProgressCard } from "../components/JobProgress.jsx";
 import {
   loraMatchesModel,
   loraWeight,
-  autoRecipePresetId,
+  clearPresetDefault,
   noRecipePresetId,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
   presetMatchesWorkflow,
   presetPromptParts as buildPresetPromptParts,
   presetValidation,
+  rememberPresetDefault,
 } from "../presetUtils.js";
 
 const completedResultFallbackMs = 30000;
@@ -21,26 +22,6 @@ const localErrorLabels = {
   canceled: "Canceled",
   interrupted: "Interrupted",
 };
-
-function rememberPresetDefault(snapshots, key, currentValue, appliedValue) {
-  const previousSnapshot = snapshots.current[key];
-  snapshots.current[key] = {
-    appliedValue,
-    previousValue:
-      previousSnapshot && Object.is(currentValue, previousSnapshot.appliedValue)
-        ? previousSnapshot.previousValue
-        : currentValue,
-  };
-}
-
-function clearPresetDefault(setter, snapshots, key) {
-  const snapshot = snapshots.current[key];
-  if (!snapshot) {
-    return;
-  }
-  setter((current) => (Object.is(current, snapshot.appliedValue) ? snapshot.previousValue : current));
-  delete snapshots.current[key];
-}
 
 function jobResultAssets(job, assets) {
   const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
@@ -122,10 +103,10 @@ export function ImageStudio({
 }) {
   const [mode, setMode] = useState("text_to_image");
   const [prompt, setPrompt] = useState("A cinematic frame of a neon street at midnight");
-  const [stylePreset, setStylePreset] = useState(autoRecipePresetId);
   const [count, setCount] = useState(4);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(imageModels[0]?.id ?? "z_image_turbo");
+  const [stylePreset, setStylePreset] = useState(null);
   const [seed, setSeed] = useState("");
   const [negativePrompt, setNegativePrompt] = useState("");
   const [resolution, setResolution] = useState("1024x1024");
@@ -213,7 +194,9 @@ export function ImageStudio({
   const selectedRecipePreset =
     stylePreset === noRecipePresetId
       ? null
-      : availableRecipePresets.find((preset) => preset.id === stylePreset) ?? availableRecipePresets[0] ?? null;
+      : stylePreset
+        ? availableRecipePresets.find((preset) => preset.id === stylePreset) ?? null
+        : availableRecipePresets[0] ?? null;
   const compatibleLoras = useMemo(() => loras.filter((lora) => {
     if (lora.presetManaged) {
       return false;
@@ -253,13 +236,13 @@ export function ImageStudio({
   const [width, height] = resolution.split("x").map((value) => Number(value));
 
   useEffect(() => {
-    if (stylePreset === noRecipePresetId) {
+    if (!stylePreset || stylePreset === noRecipePresetId) {
       return;
     }
-    if (selectedRecipePreset?.id && selectedRecipePreset.id !== stylePreset) {
-      setStylePreset(selectedRecipePreset.id);
+    if (!selectedRecipePreset) {
+      setStylePreset(availableRecipePresets[0]?.id ?? noRecipePresetId);
     }
-  }, [selectedRecipePreset?.id, stylePreset]);
+  }, [availableRecipePresets, selectedRecipePreset, stylePreset]);
 
   useEffect(() => {
     if (!selectedRecipePreset) {
@@ -389,7 +372,6 @@ export function ImageStudio({
         seed: seed === "" ? null : Number(seed),
         width,
         height,
-        stylePreset,
         recipePresetId: selectedRecipePreset?.id ?? null,
         characterId: mode === "character_image" ? characterId || null : null,
         characterLookId: mode === "character_image" ? characterLookId || null : null,
@@ -501,12 +483,10 @@ export function ImageStudio({
             <textarea onChange={(event) => setPrompt(event.target.value)} value={prompt} />
           </label>
 
-          <div className="control-grid count-control-grid">
-            <label>
-              Count
-              <input min="1" max="8" onChange={(event) => setCount(Number(event.target.value))} type="number" value={count} />
-            </label>
-          </div>
+          <label>
+            Count
+            <input min="1" max="8" onChange={(event) => setCount(Number(event.target.value))} type="number" value={count} />
+          </label>
           {selectedRecipePreset ? (
             <div className="guidance-strip">
               <strong>{selectedRecipePreset.ui?.description ?? "Preset defaults active"}</strong>

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import {
   loraMatchesModel,
   loraWeight,
+  autoRecipePresetId,
+  noRecipePresetId,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
   presetMatchesWorkflow,
@@ -19,6 +21,26 @@ const localErrorLabels = {
   canceled: "Canceled",
   interrupted: "Interrupted",
 };
+
+function rememberPresetDefault(snapshots, key, currentValue, appliedValue) {
+  const previousSnapshot = snapshots.current[key];
+  snapshots.current[key] = {
+    appliedValue,
+    previousValue:
+      previousSnapshot && Object.is(currentValue, previousSnapshot.appliedValue)
+        ? previousSnapshot.previousValue
+        : currentValue,
+  };
+}
+
+function clearPresetDefault(setter, snapshots, key) {
+  const snapshot = snapshots.current[key];
+  if (!snapshot) {
+    return;
+  }
+  setter((current) => (Object.is(current, snapshot.appliedValue) ? snapshot.previousValue : current));
+  delete snapshots.current[key];
+}
 
 function jobResultAssets(job, assets) {
   const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
@@ -100,7 +122,7 @@ export function ImageStudio({
 }) {
   const [mode, setMode] = useState("text_to_image");
   const [prompt, setPrompt] = useState("A cinematic frame of a neon street at midnight");
-  const [stylePreset, setStylePreset] = useState("cinematic");
+  const [stylePreset, setStylePreset] = useState(autoRecipePresetId);
   const [count, setCount] = useState(4);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(imageModels[0]?.id ?? "z_image_turbo");
@@ -114,6 +136,7 @@ export function ImageStudio({
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [resultFallbackTick, setResultFallbackTick] = useState(0);
+  const presetDefaultSnapshots = useRef({});
   const editImageAssets = useMemo(
     () => assets.filter((asset) => asset.type === "image" || asset.type === "frame"),
     [assets],
@@ -187,7 +210,10 @@ export function ImageStudio({
   const availableRecipePresets = useMemo(() => {
     return recipePresets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel));
   }, [mode, recipePresets, selectedModel?.id]);
-  const selectedRecipePreset = availableRecipePresets.find((preset) => preset.id === stylePreset) ?? availableRecipePresets[0] ?? null;
+  const selectedRecipePreset =
+    stylePreset === noRecipePresetId
+      ? null
+      : availableRecipePresets.find((preset) => preset.id === stylePreset) ?? availableRecipePresets[0] ?? null;
   const compatibleLoras = useMemo(() => loras.filter((lora) => {
     if (lora.presetManaged) {
       return false;
@@ -227,24 +253,42 @@ export function ImageStudio({
   const [width, height] = resolution.split("x").map((value) => Number(value));
 
   useEffect(() => {
-    if (!availableRecipePresets.some((preset) => preset.id === stylePreset)) {
-      setStylePreset(availableRecipePresets[0]?.id ?? "");
+    if (stylePreset === noRecipePresetId) {
+      return;
     }
-  }, [availableRecipePresets, stylePreset]);
+    if (selectedRecipePreset?.id && selectedRecipePreset.id !== stylePreset) {
+      setStylePreset(selectedRecipePreset.id);
+    }
+  }, [selectedRecipePreset?.id, stylePreset]);
 
   useEffect(() => {
     if (!selectedRecipePreset) {
+      clearPresetDefault(setCount, presetDefaultSnapshots, "count");
+      clearPresetDefault(setResolution, presetDefaultSnapshots, "resolution");
+      clearPresetDefault(setNegativePrompt, presetDefaultSnapshots, "negativePrompt");
       return;
     }
     const defaults = selectedRecipePreset.defaults ?? {};
     if (defaults.count) {
-      setCount(Number(defaults.count));
+      const appliedValue = Number(defaults.count);
+      setCount((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "count", current, appliedValue);
+        return appliedValue;
+      });
     }
     if (defaults.resolution) {
-      setResolution(defaults.resolution);
+      const appliedValue = defaults.resolution;
+      setResolution((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "resolution", current, appliedValue);
+        return appliedValue;
+      });
     }
     if (Object.prototype.hasOwnProperty.call(defaults, "negativePrompt")) {
-      setNegativePrompt(defaults.negativePrompt ?? "");
+      const appliedValue = defaults.negativePrompt ?? "";
+      setNegativePrompt((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "negativePrompt", current, appliedValue);
+        return appliedValue;
+      });
     }
   }, [selectedRecipePreset?.id]);
 
@@ -384,6 +428,30 @@ export function ImageStudio({
 
       <form className="studio-layout" onSubmit={submit}>
         <section className="studio-controls">
+          <div className="control-grid generation-primary-grid">
+            <label>
+              Model
+              <select onChange={(event) => setModel(event.target.value)} value={model}>
+                {(availableModels.length ? availableModels : imageModels).map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Preset
+              <select onChange={(event) => setStylePreset(event.target.value)} value={selectedRecipePreset?.id ?? noRecipePresetId}>
+                <option value={noRecipePresetId}>None</option>
+                {availableRecipePresets.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name ?? preset.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
           {mode === "edit_image" ? (
             <AssetPickerField
               assets={editImageAssets}
@@ -433,34 +501,10 @@ export function ImageStudio({
             <textarea onChange={(event) => setPrompt(event.target.value)} value={prompt} />
           </label>
 
-          <div className="control-grid">
-            <label>
-              Style
-              <select disabled={!availableRecipePresets.length} onChange={(event) => setStylePreset(event.target.value)} value={stylePreset}>
-                {availableRecipePresets.length ? (
-                  availableRecipePresets.map((preset) => (
-                    <option key={preset.id} value={preset.id}>
-                      {preset.name ?? preset.id}
-                    </option>
-                  ))
-                ) : (
-                  <option value="">Presets unavailable</option>
-                )}
-              </select>
-            </label>
+          <div className="control-grid count-control-grid">
             <label>
               Count
               <input min="1" max="8" onChange={(event) => setCount(Number(event.target.value))} type="number" value={count} />
-            </label>
-            <label>
-              GPU
-              <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
-                {gpuOptions.map((gpu) => (
-                  <option key={gpu} value={gpu}>
-                    {gpu === "auto" ? "Auto" : gpu}
-                  </option>
-                ))}
-              </select>
             </label>
           </div>
           {selectedRecipePreset ? (
@@ -476,53 +520,10 @@ export function ImageStudio({
             </div>
           ) : (
             <div className="guidance-strip">
-              <strong>Presets unavailable</strong>
-              <span>Generation can continue, but no preset defaults or managed LoRAs will be applied.</span>
+              <strong>No preset selected</strong>
+              <span>Generation will use only the visible prompt, count, model, and advanced settings.</span>
             </div>
           )}
-
-          <section className="lora-picker" aria-label="LoRA selection">
-            <div>
-              <strong>LoRAs</strong>
-              <span>{selectedLoras.length ? `${selectedLoras.length} selected` : selectedModel ? "Installed and compatible" : "Choose a model"}</span>
-            </div>
-            {advancedOpen ? (
-              <label className="checkline">
-                <input
-                  checked={showIncompatibleLoras}
-                  onChange={(event) => setShowIncompatibleLoras(event.target.checked)}
-                  type="checkbox"
-                />
-                Show incompatible
-              </label>
-            ) : null}
-            {compatibleLoras.length ? (
-              <div className="lora-choice-list">
-                {compatibleLoras.map((lora) => {
-                  const checked = selectedLoraIds.includes(lora.id);
-                  const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
-                  return (
-                    <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
-                      <input
-                        checked={checked}
-                        disabled={userLimitReached}
-                        onChange={() => toggleLora(lora)}
-                        type="checkbox"
-                      />
-                      <span>
-                        <strong>{lora.name ?? lora.id}</strong>
-                        <small>
-                          {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
-                        </small>
-                      </span>
-                    </label>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
-            )}
-          </section>
 
           <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
             {advancedOpen ? "Hide advanced" : "Advanced"}
@@ -531,11 +532,11 @@ export function ImageStudio({
           {advancedOpen ? (
             <div className="advanced-panel">
               <label>
-                Model
-                <select onChange={(event) => setModel(event.target.value)} value={model}>
-                  {(availableModels.length ? availableModels : imageModels).map((item) => (
-                    <option key={item.id} value={item.id}>
-                      {item.name}
+                GPU
+                <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
+                  {gpuOptions.map((gpu) => (
+                    <option key={gpu} value={gpu}>
+                      {gpu === "auto" ? "Auto" : gpu}
                     </option>
                   ))}
                 </select>
@@ -557,6 +558,46 @@ export function ImageStudio({
                 Negative prompt
                 <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
               </label>
+              <section className="lora-picker" aria-label="LoRA selection">
+                <div>
+                  <strong>LoRAs</strong>
+                  <span>{selectedLoras.length ? `${selectedLoras.length} selected` : selectedModel ? "Installed and compatible" : "Choose a model"}</span>
+                </div>
+                <label className="checkline">
+                  <input
+                    checked={showIncompatibleLoras}
+                    onChange={(event) => setShowIncompatibleLoras(event.target.checked)}
+                    type="checkbox"
+                  />
+                  Show incompatible
+                </label>
+                {compatibleLoras.length ? (
+                  <div className="lora-choice-list">
+                    {compatibleLoras.map((lora) => {
+                      const checked = selectedLoraIds.includes(lora.id);
+                      const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
+                      return (
+                        <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
+                          <input
+                            checked={checked}
+                            disabled={userLimitReached}
+                            onChange={() => toggleLora(lora)}
+                            type="checkbox"
+                          />
+                          <span>
+                            <strong>{lora.name ?? lora.id}</strong>
+                            <small>
+                              {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
+                            </small>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
+                )}
+              </section>
             </div>
           ) : null}
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import {
+  autoRecipePresetId,
+  noRecipePresetId,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
   presetMatchesWorkflow,
@@ -13,6 +15,26 @@ import {
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 
 const completedResultFallbackMs = 30000;
+
+function rememberPresetDefault(snapshots, key, currentValue, appliedValue) {
+  const previousSnapshot = snapshots.current[key];
+  snapshots.current[key] = {
+    appliedValue,
+    previousValue:
+      previousSnapshot && Object.is(currentValue, previousSnapshot.appliedValue)
+        ? previousSnapshot.previousValue
+        : currentValue,
+  };
+}
+
+function clearPresetDefault(setter, snapshots, key) {
+  const snapshot = snapshots.current[key];
+  if (!snapshot) {
+    return;
+  }
+  setter((current) => (Object.is(current, snapshot.appliedValue) ? snapshot.previousValue : current));
+  delete snapshots.current[key];
+}
 
 export function VideoStudio({
   activeProject,
@@ -45,7 +67,7 @@ export function VideoStudio({
   const [mode, setMode] = useState("image_to_video");
   const [prompt, setPrompt] = useState("Camera slowly pushes in while the scene comes alive");
   const [quality, setQuality] = useState("balanced");
-  const [recipePresetId, setRecipePresetId] = useState("");
+  const [recipePresetId, setRecipePresetId] = useState(autoRecipePresetId);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(videoModels[0]?.id ?? "ltx_2_3");
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
@@ -67,13 +89,17 @@ export function VideoStudio({
   const [abSide, setAbSide] = useState("replacement");
   const [submitting, setSubmitting] = useState(false);
   const [resultFallbackTick, setResultFallbackTick] = useState(0);
+  const presetDefaultSnapshots = useRef({});
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
   const availableRecipePresets = useMemo(() => {
     return recipePresets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel));
   }, [mode, recipePresets, selectedModel?.id]);
-  const selectedRecipePreset = availableRecipePresets.find((preset) => preset.id === recipePresetId) ?? availableRecipePresets[0] ?? null;
+  const selectedRecipePreset =
+    recipePresetId === noRecipePresetId
+      ? null
+      : availableRecipePresets.find((preset) => preset.id === recipePresetId) ?? availableRecipePresets[0] ?? null;
   const presetPromptParts = buildPresetPromptParts(selectedRecipePreset);
   const presetLoraDetails = buildPresetLoraDetails(selectedRecipePreset, loras);
   const presetValidationResult = useMemo(
@@ -154,30 +180,58 @@ export function VideoStudio({
   }, [mode, supportsMode, videoModels]);
 
   useEffect(() => {
-    if (!availableRecipePresets.some((preset) => preset.id === recipePresetId)) {
-      setRecipePresetId(availableRecipePresets[0]?.id ?? "");
+    if (recipePresetId === noRecipePresetId) {
+      return;
     }
-  }, [availableRecipePresets, recipePresetId]);
+    if (selectedRecipePreset?.id && selectedRecipePreset.id !== recipePresetId) {
+      setRecipePresetId(selectedRecipePreset.id);
+    }
+  }, [recipePresetId, selectedRecipePreset?.id]);
 
   useEffect(() => {
     if (!selectedRecipePreset) {
+      clearPresetDefault(setDuration, presetDefaultSnapshots, "duration");
+      clearPresetDefault(setFps, presetDefaultSnapshots, "fps");
+      clearPresetDefault(setQuality, presetDefaultSnapshots, "quality");
+      clearPresetDefault(setResolution, presetDefaultSnapshots, "resolution");
+      clearPresetDefault(setNegativePrompt, presetDefaultSnapshots, "negativePrompt");
       return;
     }
     const defaults = selectedRecipePreset.defaults ?? {};
     if (defaults.duration) {
-      setDuration(Number(defaults.duration));
+      const appliedValue = Number(defaults.duration);
+      setDuration((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "duration", current, appliedValue);
+        return appliedValue;
+      });
     }
     if (defaults.fps) {
-      setFps(Number(defaults.fps));
+      const appliedValue = Number(defaults.fps);
+      setFps((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "fps", current, appliedValue);
+        return appliedValue;
+      });
     }
     if (defaults.quality) {
-      setQuality(defaults.quality);
+      const appliedValue = defaults.quality;
+      setQuality((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "quality", current, appliedValue);
+        return appliedValue;
+      });
     }
     if (defaults.resolution) {
-      setResolution(defaults.resolution);
+      const appliedValue = defaults.resolution;
+      setResolution((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "resolution", current, appliedValue);
+        return appliedValue;
+      });
     }
     if (Object.prototype.hasOwnProperty.call(defaults, "negativePrompt")) {
-      setNegativePrompt(defaults.negativePrompt ?? "");
+      const appliedValue = defaults.negativePrompt ?? "";
+      setNegativePrompt((current) => {
+        rememberPresetDefault(presetDefaultSnapshots, "negativePrompt", current, appliedValue);
+        return appliedValue;
+      });
     }
   }, [selectedRecipePreset?.id]);
 
@@ -342,6 +396,30 @@ export function VideoStudio({
 
       <form className="studio-layout video-layout" onSubmit={submit}>
         <section className="studio-controls">
+          <div className="control-grid generation-primary-grid">
+            <label>
+              Model
+              <select onChange={(event) => setModel(event.target.value)} value={model}>
+                {videoModels.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Preset
+              <select onChange={(event) => setRecipePresetId(event.target.value)} value={selectedRecipePreset?.id ?? noRecipePresetId}>
+                <option value={noRecipePresetId}>None</option>
+                {availableRecipePresets.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name ?? preset.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
           {mode === "image_to_video" || mode === "first_last_frame" ? (
             <AssetPickerField
               assets={imageAssets}
@@ -435,20 +513,6 @@ export function VideoStudio({
 
           <div className="control-grid video-preset-grid">
             <label>
-              Preset
-              <select disabled={!availableRecipePresets.length} onChange={(event) => setRecipePresetId(event.target.value)} value={recipePresetId}>
-                {availableRecipePresets.length ? (
-                  availableRecipePresets.map((preset) => (
-                    <option key={preset.id} value={preset.id}>
-                      {preset.name ?? preset.id}
-                    </option>
-                  ))
-                ) : (
-                  <option value="">No presets</option>
-                )}
-              </select>
-            </label>
-            <label>
               Duration
               <select onChange={(event) => setDuration(Number(event.target.value))} value={duration}>
                 {durationOptions.map((value) => (
@@ -466,16 +530,6 @@ export function VideoStudio({
                 <option value="best">Best</option>
               </select>
             </label>
-            <label>
-              GPU
-              <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
-                {gpuOptions.map((gpu) => (
-                  <option key={gpu} value={gpu}>
-                    {gpu === "auto" ? "Auto" : gpu}
-                  </option>
-                ))}
-              </select>
-            </label>
           </div>
 
           {selectedRecipePreset ? (
@@ -491,8 +545,8 @@ export function VideoStudio({
             </div>
           ) : (
             <div className="guidance-strip">
-              <strong>Presets unavailable</strong>
-              <span>Generation can continue without preset defaults.</span>
+              <strong>No preset selected</strong>
+              <span>Generation will use only the visible prompt, model, and advanced settings.</span>
             </div>
           )}
 
@@ -508,11 +562,11 @@ export function VideoStudio({
           {advancedOpen ? (
             <div className="advanced-panel">
               <label>
-                Model
-                <select onChange={(event) => setModel(event.target.value)} value={model}>
-                  {videoModels.map((item) => (
-                    <option key={item.id} value={item.id}>
-                      {item.name}
+                GPU
+                <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
+                  {gpuOptions.map((gpu) => (
+                    <option key={gpu} value={gpu}>
+                      {gpu === "auto" ? "Auto" : gpu}
                     </option>
                   ))}
                 </select>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -4,37 +4,18 @@ import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import {
-  autoRecipePresetId,
+  clearPresetDefault,
   noRecipePresetId,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
   presetMatchesWorkflow,
   presetPromptParts as buildPresetPromptParts,
   presetValidation,
+  rememberPresetDefault,
 } from "../presetUtils.js";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 
 const completedResultFallbackMs = 30000;
-
-function rememberPresetDefault(snapshots, key, currentValue, appliedValue) {
-  const previousSnapshot = snapshots.current[key];
-  snapshots.current[key] = {
-    appliedValue,
-    previousValue:
-      previousSnapshot && Object.is(currentValue, previousSnapshot.appliedValue)
-        ? previousSnapshot.previousValue
-        : currentValue,
-  };
-}
-
-function clearPresetDefault(setter, snapshots, key) {
-  const snapshot = snapshots.current[key];
-  if (!snapshot) {
-    return;
-  }
-  setter((current) => (Object.is(current, snapshot.appliedValue) ? snapshot.previousValue : current));
-  delete snapshots.current[key];
-}
 
 export function VideoStudio({
   activeProject,
@@ -67,9 +48,9 @@ export function VideoStudio({
   const [mode, setMode] = useState("image_to_video");
   const [prompt, setPrompt] = useState("Camera slowly pushes in while the scene comes alive");
   const [quality, setQuality] = useState("balanced");
-  const [recipePresetId, setRecipePresetId] = useState(autoRecipePresetId);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(videoModels[0]?.id ?? "ltx_2_3");
+  const [recipePresetId, setRecipePresetId] = useState(null);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
   const [duration, setDuration] = useState(selectedModel?.defaults?.duration ?? 6);
   const [resolution, setResolution] = useState(selectedModel?.defaults?.resolution ?? "768x512");
@@ -99,7 +80,9 @@ export function VideoStudio({
   const selectedRecipePreset =
     recipePresetId === noRecipePresetId
       ? null
-      : availableRecipePresets.find((preset) => preset.id === recipePresetId) ?? availableRecipePresets[0] ?? null;
+      : recipePresetId
+        ? availableRecipePresets.find((preset) => preset.id === recipePresetId) ?? null
+        : availableRecipePresets[0] ?? null;
   const presetPromptParts = buildPresetPromptParts(selectedRecipePreset);
   const presetLoraDetails = buildPresetLoraDetails(selectedRecipePreset, loras);
   const presetValidationResult = useMemo(
@@ -180,13 +163,13 @@ export function VideoStudio({
   }, [mode, supportsMode, videoModels]);
 
   useEffect(() => {
-    if (recipePresetId === noRecipePresetId) {
+    if (!recipePresetId || recipePresetId === noRecipePresetId) {
       return;
     }
-    if (selectedRecipePreset?.id && selectedRecipePreset.id !== recipePresetId) {
-      setRecipePresetId(selectedRecipePreset.id);
+    if (!selectedRecipePreset) {
+      setRecipePresetId(availableRecipePresets[0]?.id ?? noRecipePresetId);
     }
-  }, [recipePresetId, selectedRecipePreset?.id]);
+  }, [availableRecipePresets, recipePresetId, selectedRecipePreset]);
 
   useEffect(() => {
     if (!selectedRecipePreset) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -994,10 +994,6 @@ button:disabled {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.count-control-grid {
-  grid-template-columns: minmax(0, 1fr);
-}
-
 .advanced-panel {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   padding: 12px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -990,12 +990,21 @@ button:disabled {
   gap: 10px;
 }
 
+.generation-primary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.count-control-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .advanced-panel {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   padding: 12px;
 }
 
-.advanced-panel .prompt-field {
+.advanced-panel .prompt-field,
+.advanced-panel .lora-picker {
   grid-column: 1 / -1;
 }
 
@@ -1042,7 +1051,7 @@ button:disabled {
 }
 
 .video-preset-grid {
-  grid-template-columns: minmax(0, 1.2fr) repeat(3, minmax(0, 0.8fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .guidance-strip,


### PR DESCRIPTION
## Summary
- Move model and preset selection to the top of Image and Video generation forms.
- Add an explicit `None` preset option for no-preset generation.
- Move GPU and Image Studio LoRA selection into Advanced while preserving existing generation behavior.

## Behavior
Selecting `None` submits with `recipePresetId: null`, skips preset-managed LoRAs and prompt/default effects, and restores preset-applied defaults when they have not been manually changed.

Shortcut: https://app.shortcut.com/trefry/story/1383/make-model-and-preset-selection-first-class-on-generation-pages

## Validation
- `npm test`
- `npm run build`
- Browser sanity check on Image and Video Studio at `http://127.0.0.1:5173`