### PR TITLE
Lift studio + library headers into hero strips

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1541,6 +1541,7 @@ export function App() {
 
         {activeView === "Library" ? (
           <LibraryScreen
+            activeProject={activeProject}
             assets={assets}
             deleteAsset={deleteAsset}
             purgeAsset={purgeAsset}

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -387,10 +387,13 @@ export function EditorScreen({
 
   return (
     <section className="main-surface editor-surface">
-      <div className="surface-header editor-header">
+      <div className="surface-header editor-header hero">
         <div className="section-heading">
           <p className="eyebrow">Editor</p>
           <h2>{activeTimeline?.name ?? "Timelines"}</h2>
+          <p className="hero-blurb">
+            Sequence clips on the timeline, scrub through the preview, and export when the cut feels right.
+          </p>
         </div>
         <div className="editor-actions">
           <select onChange={(event) => setSelectedTimelineId(event.target.value)} value={selectedTimelineId ?? ""}>

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -394,10 +394,13 @@ export function ImageStudio({
 
   return (
     <section className="main-surface image-studio">
-      <div className="surface-header">
+      <div className="surface-header hero">
         <div className="section-heading">
           <p className="eyebrow">Image Studio</p>
           <h2>{activeProject ? activeProject.name : "Create a project"}</h2>
+          <p className="hero-blurb">
+            Describe what you want — we'll render variations side by side. Pick a mode, then fill in the prompt below.
+          </p>
         </div>
         <div className="segmented-control" role="tablist" aria-label="Image mode">
           {[

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { AssetDetail, AssetGrid } from "../components/assetPanels.jsx";
 
 export function LibraryScreen({
+  activeProject,
   assets,
   deleteAsset,
   purgeAsset,
@@ -42,12 +43,19 @@ export function LibraryScreen({
     event.target.value = "";
   }
 
+  const imageCount = assets.filter((asset) => asset.type === "image").length;
+  const videoCount = assets.filter((asset) => asset.type === "video").length;
+  const uploadCount = assets.filter((asset) => asset.type === "upload").length;
+
   return (
     <section className="main-surface library-surface">
-      <div className="surface-header">
+      <div className="surface-header hero">
         <div className="section-heading">
           <p className="eyebrow">Project assets</p>
           <h2>Library</h2>
+          <p className="hero-blurb">
+            Browse stills and clips across {activeProject?.name ?? "your project"} — pick a recent render to drop into the editor, or send one back to a studio for another pass.
+          </p>
         </div>
         <div className="toolbar">
           <label className="file-upload-button">
@@ -69,6 +77,24 @@ export function LibraryScreen({
             <input checked={showTrashed} onChange={(event) => setShowTrashed(event.target.checked)} type="checkbox" />
             Trash
           </label>
+        </div>
+        <div className="hero-stats">
+          <div className="hero-stat">
+            <span className="hero-stat-label">Project</span>
+            <span className="hero-stat-value">{activeProject?.name ?? "—"}</span>
+          </div>
+          <div className="hero-stat">
+            <span className="hero-stat-label">Assets</span>
+            <span className="hero-stat-value">{assets.length} total</span>
+          </div>
+          <div className="hero-stat">
+            <span className="hero-stat-label">Images</span>
+            <span className="hero-stat-value">{imageCount}</span>
+          </div>
+          <div className="hero-stat">
+            <span className="hero-stat-label">Clips</span>
+            <span className="hero-stat-value">{videoCount + uploadCount}</span>
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -363,10 +363,13 @@ export function VideoStudio({
 
   return (
     <section className="main-surface video-studio">
-      <div className="surface-header">
+      <div className="surface-header hero">
         <div className="section-heading">
           <p className="eyebrow">Video Studio</p>
           <h2>{activeProject ? activeProject.name : "Create a project"}</h2>
+          <p className="hero-blurb">
+            Bring a still to life, extend an existing clip, or render fresh motion from a prompt. Pick a mode to set the source and controls.
+          </p>
         </div>
         <div className="segmented-control mode-control" role="tablist" aria-label="Video mode">
           {modeOptions.map(([value, label]) => (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -941,6 +941,104 @@ label {
   align-items: flex-end;
 }
 
+/* Hero strip — gradient background + decorative orb. Used as a modifier on
+   surface-header for the welcome / studio screens. Switches to grid so an
+   optional `.hero-stats` row can wrap below the title + actions. */
+.surface-header.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px 24px;
+  align-items: end;
+  position: relative;
+  overflow: hidden;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, var(--accent-soft) 70%, var(--surface)),
+    var(--surface) 60%
+  );
+}
+
+[data-theme="dark"] .surface-header.hero {
+  background: linear-gradient(135deg, color-mix(in oklch, var(--accent) 12%, var(--surface)), var(--surface) 65%);
+}
+
+.surface-header.hero::after {
+  content: "";
+  position: absolute;
+  right: -80px;
+  top: -80px;
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in oklch, var(--warm) 35%, transparent), transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.surface-header.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.surface-header.hero .section-heading h2 {
+  font-size: 24px;
+  letter-spacing: -0.015em;
+}
+
+.hero-blurb {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 13.5px;
+  line-height: 1.5;
+  max-width: 60ch;
+}
+
+.hero-stats {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.hero-stat {
+  display: grid;
+  gap: 2px;
+  padding: 8px 14px;
+  min-width: 140px;
+  background: color-mix(in oklch, var(--surface) 88%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  backdrop-filter: blur(6px);
+}
+
+.hero-stat-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.hero-stat-value {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .surface-header.hero {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+}
+
 .checkline {
   display: inline-flex;
   gap: 6px;


### PR DESCRIPTION
Apply the design's prompt-hero treatment as a `.hero` modifier on `.surface-header`: gradient background, decorative warm orb, larger title, and a short blurb that explains the screen. The grid layout keeps the title block on the left and the existing action zone (segmented control, editor actions, library toolbar) on the right, with an optional `.hero-stats` row wrapping below.

Library hero now also shows four quick-stat cards (project, total assets, image count, clip count) backed by the assets prop — so the landing surface communicates project state at a glance the way the welcome strip in the design does. Threaded `activeProject` through LibraryScreen for the project label.

Image / Video / Editor headers each pick up the hero treatment and a single-line blurb tailored to the screen.