### PR TITLE
Move project picker into a sidebar switcher

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -130,6 +130,146 @@ function readStoredTheme() {
   }
 }
 
+function ProjectSwitcher({ activeProject, projects, onSelect, onCreate, disabled }) {
+  const [open, setOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const containerRef = useRef(null);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    function onDocMouseDown(event) {
+      if (!containerRef.current?.contains(event.target)) {
+        setOpen(false);
+        setCreating(false);
+        setName("");
+      }
+    }
+    function onDocKey(event) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        setCreating(false);
+        setName("");
+      }
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onDocKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onDocKey);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (creating) {
+      inputRef.current?.focus();
+    }
+  }, [creating]);
+
+  async function submitNew(event) {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    const created = await onCreate(trimmed);
+    setSubmitting(false);
+    if (created) {
+      setName("");
+      setCreating(false);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div className="project-switcher" ref={containerRef}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className="project-pill"
+        disabled={disabled}
+        onClick={() => setOpen((value) => !value)}
+        title={activeProject?.name ?? "Pick a workspace"}
+        type="button"
+      >
+        <span className="project-pill-thumb" aria-hidden="true" />
+        <span className="project-pill-meta">
+          <strong>{activeProject?.name ?? "No workspace open"}</strong>
+          <span>
+            {projects.length} workspace{projects.length === 1 ? "" : "s"}
+          </span>
+        </span>
+        <Icon.ChevDown className="chev" />
+      </button>
+
+      {open ? (
+        <div className="project-menu" role="listbox">
+          {projects.length === 0 ? (
+            <p className="project-menu-empty">No workspaces yet — create the first one below.</p>
+          ) : (
+            projects.map((project) => (
+              <button
+                aria-selected={project.id === activeProject?.id}
+                className={project.id === activeProject?.id ? "project-menu-item active" : "project-menu-item"}
+                key={project.id}
+                onClick={() => {
+                  onSelect(project);
+                  setOpen(false);
+                  setCreating(false);
+                  setName("");
+                }}
+                role="option"
+                type="button"
+              >
+                <span className="project-menu-thumb" aria-hidden="true" />
+                <span className="project-menu-label">{project.name}</span>
+              </button>
+            ))
+          )}
+
+          {creating ? (
+            <form className="project-menu-create" onSubmit={submitNew}>
+              <input
+                aria-label="New workspace name"
+                disabled={submitting}
+                onChange={(event) => setName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    setCreating(false);
+                    setName("");
+                  }
+                }}
+                placeholder="Workspace name"
+                ref={inputRef}
+                value={name}
+              />
+              <button disabled={!name.trim() || submitting} type="submit">
+                {submitting ? "Creating…" : "Create"}
+              </button>
+            </form>
+          ) : (
+            <button
+              className="project-menu-item project-menu-item-new"
+              disabled={disabled}
+              onClick={() => setCreating(true)}
+              type="button"
+            >
+              <Icon.Plus />
+              <span className="project-menu-label">New workspace</span>
+            </button>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function uploadLimitLabel(bytes) {
   const gib = bytes / (1024 * 1024 * 1024);
   return Number.isInteger(gib) ? `${gib}GB` : `${gib.toFixed(1)}GB`;
@@ -142,7 +282,6 @@ export function App() {
   const [projects, setProjects] = useState([]);
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
-  const [projectName, setProjectName] = useState("");
   const [jobs, setJobs] = useState([]);
   const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [] });
   const [workers, setWorkers] = useState([]);
@@ -793,24 +932,24 @@ export function App() {
     refreshData();
   }
 
-  async function createProject(event) {
-    event.preventDefault();
-    if (!projectName.trim()) {
-      return;
+  async function createProject(name) {
+    const trimmed = String(name ?? "").trim();
+    if (!trimmed) {
+      return null;
     }
-
     try {
       const created = await apiFetch("/api/v1/projects", token, {
         method: "POST",
-        body: JSON.stringify({ name: projectName }),
+        body: JSON.stringify({ name: trimmed }),
       });
       setProjects((items) => [created, ...items.filter((item) => item.id !== created.id)]);
       setActiveProject(created);
-      setProjectName("");
       setActiveView("Image");
       setError("");
+      return created;
     } catch (err) {
       setError(err.message);
+      return null;
     }
   }
 
@@ -1398,6 +1537,14 @@ export function App() {
           </div>
         </div>
 
+        <ProjectSwitcher
+          activeProject={activeProject}
+          disabled={!authenticated}
+          onCreate={createProject}
+          onSelect={setActiveProject}
+          projects={projects}
+        />
+
         {navSections.map((section) => (
           <div className="sidebar-section" key={section.label}>
             <div className="sidebar-section-title">{section.label}</div>
@@ -1423,24 +1570,6 @@ export function App() {
           </div>
         ))}
 
-        <div className="sidebar-foot">
-          <button
-            className="project-pill"
-            onClick={() => setActiveView("Library")}
-            title={activeProject?.name ?? "No project open"}
-            type="button"
-          >
-            <span className="project-pill-thumb" aria-hidden="true" />
-            <span className="project-pill-meta">
-              <strong>{activeProject?.name ?? "No project open"}</strong>
-              <span>
-                {assets.length} asset{assets.length === 1 ? "" : "s"} ·{" "}
-                {visibleWorkers.length || "0"} worker{visibleWorkers.length === 1 ? "" : "s"}
-              </span>
-            </span>
-            <Icon.ChevDown className="chev" />
-          </button>
-        </div>
       </aside>
 
       <section className="workspace">
@@ -1498,46 +1627,6 @@ export function App() {
             </form>
           </section>
         ) : null}
-
-        <section className="project-band">
-          <div className="project-list">
-            <div className="section-heading">
-              <p className="eyebrow">Recent projects</p>
-              <h2>Open a workspace</h2>
-            </div>
-            <div className="project-buttons">
-              {projects.length === 0 ? (
-                <span className="empty-state">No projects yet</span>
-              ) : (
-                projects.map((project) => (
-                  <button
-                    className={activeProject?.id === project.id ? "project-pill active" : "project-pill"}
-                    key={project.id}
-                    onClick={() => setActiveProject(project)}
-                    type="button"
-                  >
-                    {project.name}
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
-
-          <form className="create-project" onSubmit={createProject}>
-            <label htmlFor="project-name">New project</label>
-            <div className="form-row">
-              <input
-                id="project-name"
-                onChange={(event) => setProjectName(event.target.value)}
-                placeholder="Noir Alley"
-                value={projectName}
-              />
-              <button disabled={!authenticated} type="submit">
-                Create
-              </button>
-            </div>
-          </form>
-        </section>
 
         {activeView === "Library" ? (
           <LibraryScreen

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -337,10 +337,9 @@ button:focus-visible {
   flex: 0 0 auto;
 }
 
-.sidebar-foot {
-  margin-top: auto;
-  display: grid;
-  gap: 8px;
+/* Project switcher pill at top of sidebar */
+.project-switcher {
+  position: relative;
 }
 
 .project-pill {
@@ -354,14 +353,14 @@ button:focus-visible {
   width: 100%;
   text-align: left;
   color: var(--text);
-  transition: border-color var(--t-fast);
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
 }
 
-.project-pill:hover {
+.project-pill:hover:not(:disabled) {
   border-color: var(--border-strong);
 }
 
-.project-pill.active {
+.project-switcher .project-pill[aria-expanded="true"] {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
 }
@@ -402,6 +401,126 @@ button:focus-visible {
   margin-left: auto;
   opacity: 0.5;
   flex: 0 0 auto;
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.project-switcher .project-pill[aria-expanded="true"] .chev {
+  transform: rotate(180deg);
+}
+
+.project-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-lg);
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.project-menu-empty {
+  margin: 0;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.project-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  width: 100%;
+  transition: background var(--t-fast);
+}
+
+.project-menu-item:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.project-menu-item.active {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .project-menu-item.active {
+  color: var(--accent);
+}
+
+.project-menu-thumb {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  border-radius: 5px;
+  background:
+    repeating-linear-gradient(45deg, color-mix(in oklch, var(--accent) 24%, transparent) 0 3px, transparent 3px 6px),
+    color-mix(in oklch, var(--warm) 18%, var(--surface));
+}
+
+.project-menu-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-menu-item-new {
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  color: var(--accent-strong);
+  font-weight: 600;
+  border-radius: 0 0 var(--r-sm) var(--r-sm);
+}
+
+[data-theme="dark"] .project-menu-item-new {
+  color: var(--accent);
+}
+
+.project-menu-create {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 8px 6px 6px;
+  border-top: 1px solid var(--border);
+}
+
+.project-menu-create input {
+  flex: 1;
+  height: 32px;
+  padding: 0 10px;
+  font-size: 13px;
+}
+
+.project-menu-create button {
+  height: 32px;
+  padding: 0 14px;
+  border-radius: var(--r-sm);
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: 0;
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.project-menu-create button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .project-list {
@@ -570,7 +689,6 @@ button:focus-visible {
 
 /* ---------- Main content surface ---------- */
 .workspace > .auth-band,
-.workspace > .project-band,
 .workspace > .notice,
 .workspace > section.main-surface,
 .workspace > section[class*="-surface"],
@@ -589,7 +707,6 @@ button:focus-visible {
 }
 
 .workspace > .auth-band,
-.workspace > .project-band,
 .workspace > .notice {
   margin-top: 18px;
 }
@@ -611,8 +728,7 @@ button:focus-visible {
 
 /* Cards / surfaces shared by screens */
 .main-surface,
-.auth-band,
-.project-band {
+.auth-band {
   display: grid;
   align-content: start;
   gap: var(--gap-4);
@@ -621,11 +737,6 @@ button:focus-visible {
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   min-height: 0;
-}
-
-.project-band {
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 380px);
-  gap: 24px;
 }
 
 .section-heading {
@@ -658,39 +769,6 @@ button:focus-visible {
 .view-copy {
   max-width: 760px;
   line-height: 1.6;
-}
-
-.project-list {
-  display: grid;
-  gap: 12px;
-}
-
-.project-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.project-buttons .project-pill {
-  width: auto;
-  padding: 8px 14px;
-  background: var(--surface-2);
-  border-radius: var(--r-pill);
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.project-buttons .project-pill.active {
-  background: var(--accent);
-  color: var(--accent-fg);
-  border-color: transparent;
-  box-shadow: 0 1px 2px color-mix(in oklch, var(--accent) 40%, transparent),
-    0 6px 18px color-mix(in oklch, var(--accent) 25%, transparent);
-}
-
-.create-project {
-  display: grid;
-  gap: 8px;
 }
 
 label {
@@ -2843,7 +2921,6 @@ label {
   }
 
   .nav-list,
-  .project-band,
   .media-grid,
   .library-layout,
   .studio-layout,


### PR DESCRIPTION
The "Recent projects" hero in the workspace was a large fixed band that duplicated information already visible elsewhere; pull it out entirely and replace it with an interactive ProjectSwitcher pill at the top of the sidebar.

The switcher renders as the existing project pill (gradient thumb, workspace name, chev). Clicking it opens a menu of every workspace; the active one is highlighted. The last item, "New workspace," swaps the menu's footer into an inline input + Create button — submit (or Enter) creates the project, switches to it, and closes the menu. Outside mousedown and Escape both close.

The old form-event signature of createProject was incompatible with an inline create flow, so refactor it to take a name string and return the created project (or null on failure). Drop the unused projectName state and the dead .project-band / .project-buttons / .create-project styles.