### PR TITLE
[codex] Fix stale timeline workspace banner

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -293,6 +293,7 @@ export function App() {
   const [characters, setCharacters] = useState([]);
   const [personTracks, setPersonTracks] = useState([]);
   const [timelines, setTimelines] = useState([]);
+  const [timelinesProjectId, setTimelinesProjectId] = useState(null);
   const [selectedTimelineId, setSelectedTimelineId] = useState(null);
   const [activeTimeline, setActiveTimeline] = useState(null);
   const [selectedAssetId, setSelectedAssetId] = useState(null);
@@ -441,6 +442,7 @@ export function App() {
       setCharacters([]);
       setPersonTracks([]);
       setTimelines([]);
+      setTimelinesProjectId(null);
       setRecipePresets([]);
       setSelectedTimelineId(null);
       setActiveTimeline(null);
@@ -455,11 +457,11 @@ export function App() {
   }, [activeProject?.id, authenticated, token]);
 
   useEffect(() => {
-    if (!activeProject || !selectedTimelineId) {
+    if (!activeProject || !selectedTimelineId || timelinesProjectId !== activeProject.id) {
       return;
     }
     loadTimeline(activeProject.id, selectedTimelineId);
-  }, [activeProject?.id, selectedTimelineId]);
+  }, [activeProject?.id, selectedTimelineId, timelinesProjectId]);
 
   useEffect(() => {
     if (!authenticated) {
@@ -843,8 +845,12 @@ export function App() {
     }
     try {
       const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token);
+      if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
+        return;
+      }
       setTimelines(items);
-      setSelectedTimelineId((current) => current ?? items[0]?.id ?? null);
+      setTimelinesProjectId(projectId);
+      setSelectedTimelineId((current) => (items.some((item) => item.id === current) ? current : items[0]?.id ?? null));
       if (!items.length) {
         setActiveTimeline(null);
       }
@@ -857,6 +863,9 @@ export function App() {
   async function loadTimeline(projectId, timelineId) {
     try {
       const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
+      if (activeProjectRef.current?.id !== projectId || selectedTimelineIdRef.current !== timelineId) {
+        return;
+      }
       setActiveTimeline(timeline);
       setError("");
     } catch (err) {
@@ -875,6 +884,7 @@ export function App() {
         body: JSON.stringify(payload),
       });
       setTimelines((items) => [created, ...items.filter((item) => item.id !== created.id)]);
+      setTimelinesProjectId(activeProject.id);
       setSelectedTimelineId(created.id);
       setActiveTimeline(created);
       setError("");

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -385,6 +385,89 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Not Found");
   });
 
+  it("does not show a stale timeline lookup error after creating a workspace", async () => {
+    const requests = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      requests.push({ method: options.method ?? "GET", path });
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects") && options.method === "POST") {
+        return Promise.resolve(response({ id: "project-2", name: "Fresh Workspace" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Project One" }]));
+      }
+      if (path.endsWith("/projects/project-1/timelines/timeline-1")) {
+        return Promise.resolve(
+          response({
+            id: "timeline-1",
+            projectId: "project-1",
+            name: "Main timeline",
+            aspectRatio: "16:9",
+            width: 1280,
+            height: 720,
+            fps: 30,
+            duration: 0,
+            tracks: [],
+            transitions: [],
+          }),
+        );
+      }
+      if (path.endsWith("/projects/project-1/timelines")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "timeline-1",
+              name: "Main timeline",
+              filePath: "timelines/main.sceneworks.timeline.json",
+              aspectRatio: "16:9",
+              width: 1280,
+              height: 720,
+              fps: 30,
+              duration: 0,
+              createdAt: "2026-05-19T12:00:00Z",
+              updatedAt: "2026-05-19T12:00:00Z",
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/projects/project-2/timelines/timeline-1")) {
+        return Promise.resolve(errorResponse(404, "Timeline not found"));
+      }
+      if (path.endsWith("/projects/project-2/timelines")) {
+        return Promise.resolve(response([]));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector(".project-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "New workspace").click();
+    });
+    await changeField(container.querySelector('[aria-label="New workspace name"]'), "Fresh Workspace");
+    await act(async () => {
+      [...container.querySelectorAll(".project-menu-create button")].find((button) => button.textContent === "Create").click();
+    });
+    await settle();
+
+    expect(requests.some((request) => request.path.endsWith("/projects/project-2/timelines/timeline-1"))).toBe(false);
+    expect(container.textContent).toContain("Fresh Workspace");
+    expect(container.textContent).not.toContain("Timeline not found");
+  });
+
   it("switches Replace Person to the replacement-capable video model", async () => {
     root = createRoot(container);
     await act(async () => {


### PR DESCRIPTION
## Summary
- Track which workspace owns the current timeline list before loading a selected timeline
- Ignore late timeline list/load responses after switching workspaces
- Add a regression test for creating a new workspace while an old timeline is selected

## Root Cause
The app kept the previously selected timeline id while a newly-created workspace was becoming active. That could trigger a timeline fetch for the old timeline id under the new workspace, causing the backend's expected 404 detail, `Timeline not found`, to show as a global error banner.

## Validation
- `npm test -- src/main.test.jsx`
