### PR TITLE
Add SentencePiece to worker deps and surface tokenizer backend failures

### DIFF
--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -6,6 +6,7 @@ imageio>=2.37,<3
 imageio-ffmpeg>=0.6,<1
 torch>=2.7
 transformers>=4.57
+sentencepiece>=0.2,<1
 accelerate>=1.11
 peft>=0.17,<1
 safetensors>=0.6

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -214,6 +214,22 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
                 f"Technical detail: {detail}"
             ),
         )
+    tokenizer_backend_markers = (
+        "sentencepiece",
+        "tokenization_t5",
+        "t5.tokenization",
+        "does not seem to have any of the loading methods",
+    )
+    if any(marker in lowered for marker in tokenizer_backend_markers):
+        return (
+            f"{job_kind} failed because the worker is missing a tokenizer backend.",
+            (
+                "The selected video model needs the SentencePiece tokenizer runtime. "
+                "For bare-metal workers, run `pip install -r apps/worker/requirements.txt`; "
+                "for Docker Compose, run `docker compose build worker --no-cache`, then restart the worker and retry. "
+                f"Technical detail: {detail}"
+            ),
+        )
     missing_model_markers = (
         "repo id",
         "repository not found",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -700,6 +700,24 @@ def test_friendly_failure_identifies_missing_peft_backend():
     assert "Technical detail" in error
 
 
+def test_friendly_failure_identifies_missing_sentencepiece_backend():
+    message, error = friendly_failure(
+        "Video generation",
+        RuntimeError(
+            "The component <class 'transformers.models.t5.tokenization_t5."
+            "_LazyModule.__getattr__.<locals>.Placeholder'> of <class "
+            "'diffusers.pipelines.ltx.pipeline_ltx_image2video.LTXImageToVideoPipeline'> "
+            "cannot be loaded as it does not seem to have any of the loading methods defined."
+        ),
+    )
+
+    assert message == "Video generation failed because the worker is missing a tokenizer backend."
+    assert "SentencePiece" in error
+    assert "pip install -r apps/worker/requirements.txt" in error
+    assert "docker compose build worker --no-cache" in error
+    assert "Technical detail" in error
+
+
 def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
     events = []
     monkeypatch.setattr("scene_worker.runtime.emit", events.append)


### PR DESCRIPTION
## Summary
- Add `sentencepiece` to the worker runtime dependencies so LTX video pipelines can load the T5 tokenizer.
- Map the resulting lazy-import failure to a clearer worker error when the tokenizer backend is missing.
- Add a regression test covering the tokenizer-backend failure message.

## Testing
- `python -m pytest tests/test_worker_runtime.py`