### PR TITLE
Route LTX text-to-video to a Diffusers-compatible repo

### DIFF
--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -233,8 +233,10 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
     missing_model_markers = (
         "repo id",
         "repository not found",
+        "entry not found",
         "is not a local folder",
         "couldn't connect to 'https://huggingface.co'",
+        "model_index.json",
         "no file named model_index.json",
         "error no file named",
         "cannot load model",

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -43,6 +43,7 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "family": "ltx-video",
         "adapter": "ltx_video",
         "repo": "Lightricks/LTX-2.3",
+        "textRepo": "Lightricks/LTX-2",
         "fallbackRepo": "Lightricks/LTX-Video",
         "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
         "recommendedMaxDuration": 10,
@@ -519,6 +520,8 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
     def _repo_for_request(self, request: VideoRequest, target: dict[str, Any]) -> str:
         if request.advanced.get("modelRepo"):
             return str(request.advanced["modelRepo"])
+        if target["adapter"] == "ltx_video" and request.mode == "text_to_video":
+            return target.get("textRepo") or target["repo"]
         if target["adapter"] == "ltx_video" and request.mode != "text_to_video":
             return target.get("fallbackRepo") or target["repo"]
         return target["repo"]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -680,6 +680,20 @@ def test_friendly_failure_identifies_missing_model_files():
     assert "HF_TOKEN" in error
 
 
+def test_friendly_failure_identifies_missing_diffusers_model_index():
+    message, error = friendly_failure(
+        "Video generation",
+        RuntimeError(
+            "404 Client Error. Entry Not Found for url: "
+            "https://huggingface.co/Lightricks/LTX-2.3/resolve/main/model_index.json."
+        ),
+    )
+
+    assert message == "Video generation failed because required model files were not available."
+    assert "model_index.json" in error
+    assert "Technical detail" in error
+
+
 def test_friendly_failure_identifies_ltx_frame_count_errors():
     message, error = friendly_failure("Video generation", RuntimeError("num_frames must be divisible by 8 + 1"))
 
@@ -1090,7 +1104,48 @@ def test_ltx_video_requirements_report_normalized_frame_count():
 
     assert requirements["requestedFrames"] == 150
     assert requirements["estimatedFrames"] == 153
-    assert requirements["repo"] == "Lightricks/LTX-2.3"
+    assert requirements["repo"] == "Lightricks/LTX-2"
+
+
+def test_ltx_video_image_modes_keep_image_to_video_diffusers_repo():
+    adapter = DiffusersVideoAdapter()
+    request = video_request_from_job(
+        {
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "image_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "sourceAssetId": "asset-image",
+                "advanced": {},
+            },
+        }
+    )
+
+    requirements = adapter.estimate_requirements(request)
+
+    assert requirements["repo"] == "Lightricks/LTX-Video"
+
+
+def test_ltx_video_model_repo_override_wins_over_mode_specific_repos():
+    adapter = DiffusersVideoAdapter()
+    request = video_request_from_job(
+        {
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "advanced": {"modelRepo": "owner/custom-ltx-diffusers"},
+            },
+        }
+    )
+
+    requirements = adapter.estimate_requirements(request)
+
+    assert requirements["repo"] == "owner/custom-ltx-diffusers"
 
 
 def test_evenly_spaced_indices_are_bounded():


### PR DESCRIPTION
## Summary
- Route LTX-2.3 text-to-video jobs to `Lightricks/LTX-2`, which exposes the Diffusers layout the worker expects.
- Keep image-to-video on the existing `Lightricks/LTX-Video` fallback path.
- Expand worker failure mapping so missing `model_index.json` and related Hugging Face errors surface as a clear missing-model message.
- Add regression coverage for the repo selection and the new failure shape.

## Testing
- `python -m pytest tests/test_worker_runtime.py`
- Result: worker runtime test suite passed