### PR TITLE
Add native LTX-2.3 video adapter support

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -17,6 +17,23 @@ Override `PYTORCH_INDEX_URL` / `PYTORCH_SPEC` for direct `docker build`, or
 GPU workers with CPU-only PyTorch intentionally register without generation
 capabilities so jobs stay queued instead of crawling on CPU with an idle GPU.
 
+Native LTX-2.3 work is staged behind `SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines`.
+The base worker does not install that stack by default; install
+`requirements-ltx.txt` into an LTX-specific worker environment when validating
+the native pipeline adapter.
+
+Native LTX-2.3 text-to-video and image-to-video require these local resources:
+
+- `checkpointPath`
+- `spatialUpscalerPath`
+- `distilledLoraPath`
+- `gemmaRoot`
+
+By default the worker resolves those from the model manifest `resources` block
+under `data/models`. A job can override them through matching advanced settings.
+Use `advanced.mockNativeInference=true` only for adapter smoke tests; otherwise
+the native adapter loads `ltx-pipelines` and writes MP4 video assets.
+
 Use a local smoke check without contacting the API:
 
 ```powershell

--- a/apps/worker/requirements-ltx.txt
+++ b/apps/worker/requirements-ltx.txt
@@ -1,0 +1,4 @@
+# Optional native LTX-2.3 dependencies for SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines.
+# Pinned to the official Lightricks/LTX-2 HEAD inspected on 2026-05-19.
+ltx-core @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-core
+ltx-pipelines @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-pipelines

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -241,6 +241,7 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
         "error no file named",
         "cannot load model",
         "missing model file",
+        "missing resources",
     )
     if any(marker in lowered for marker in missing_model_markers):
         return (

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -233,8 +233,10 @@ def friendly_failure(job_kind: str, exc: Exception) -> tuple[str, str]:
     missing_model_markers = (
         "repo id",
         "repository not found",
+        "entry not found",
         "is not a local folder",
         "couldn't connect to 'https://huggingface.co'",
+        "model_index.json",
         "no file named model_index.json",
         "error no file named",
         "cannot load model",

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import hashlib
 import importlib
+import importlib.util
+import json
 import os
 import warnings
 from pathlib import Path
@@ -43,7 +45,6 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "family": "ltx-video",
         "adapter": "ltx_video",
         "repo": "Lightricks/LTX-2.3",
-        "textRepo": "Lightricks/LTX-2",
         "fallbackRepo": "Lightricks/LTX-Video",
         "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
         "recommendedMaxDuration": 10,
@@ -88,6 +89,15 @@ class VideoRequest:
     source_clip_asset_id: str | None
     bridge_right_clip_asset_id: str | None
     advanced: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class LtxPipelinesResources:
+    checkpoint_path: Path
+    spatial_upsampler_path: Path
+    distilled_lora_path: Path
+    gemma_root: Path
+    temporal_upsampler_path: Path | None = None
 
 
 class VideoGenerationAdapter(ABC):
@@ -266,6 +276,507 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         }
 
 
+class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
+    id = "ltx_pipelines"
+
+    _supported_modes = {"text_to_video", "image_to_video"}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._loaded_models: set[str] = set()
+        self._settings: WorkerSettings | None = None
+        self._resources_by_model: dict[str, LtxPipelinesResources] = {}
+        self._pipeline: Any | None = None
+        self._pipeline_key_value: str | None = None
+
+    def loaded_models(self) -> list[str]:
+        return sorted(self._loaded_models)
+
+    def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
+        self._settings = settings
+        return video_request_from_job(job)
+
+    def ensure_models(self, request: VideoRequest) -> None:
+        target = model_target(request.model)
+        if target["adapter"] != "ltx_video":
+            raise RuntimeError("The native LTX pipelines adapter only supports LTX-family video models.")
+        if request.mode not in self._supported_modes:
+            supported = ", ".join(sorted(mode.replace("_", " ") for mode in self._supported_modes))
+            raise RuntimeError(f"{target['label']} native pipelines currently support {supported}.")
+        if request.duration > target["hardMaxDuration"]:
+            raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
+        reject_loras_if_unsupported(request.loras, self.id)
+        resources = self.resolve_resources(request)
+        missing = self._missing_resources(resources)
+        if missing:
+            details = "\n".join(f"- {label}: {path}" for label, path in missing)
+            raise RuntimeError(
+                "Native LTX-2.3 requires local model resources before generation. "
+                "Install the LTX-2.3 model resources in Model Manager or set advanced overrides "
+                "for checkpointPath, spatialUpscalerPath, distilledLoraPath, and gemmaRoot.\n"
+                f"Missing resources:\n{details}"
+            )
+        self._resources_by_model[request.model] = resources
+        if not self._mock_inference_enabled(request) and not self._dependencies_available():
+            raise RuntimeError(
+                "Native LTX-2.3 generation requires optional worker dependencies. "
+                "Install apps/worker/requirements-ltx.txt in this worker environment or use "
+                "advanced.mockNativeInference for local adapter smoke tests."
+            )
+
+    def estimate_requirements(self, request: VideoRequest) -> dict[str, Any]:
+        target = model_target(request.model)
+        raw_frames = max(1, int(round(request.duration * request.fps)))
+        resources = self._resources_by_model.get(request.model) or self.resolve_resources(request)
+        mocked = self._mock_inference_enabled(request)
+        return {
+            "estimatedFrames": ltx_frame_count(raw_frames),
+            "requestedFrames": raw_frames,
+            "previewFrames": preview_frame_count(request),
+            "pixelCount": request.width * request.height,
+            "recommendedMaxDuration": target["recommendedMaxDuration"],
+            "gpuPreference": request.advanced.get("gpuPreference", "auto"),
+            "adapter": self.id,
+            "pipeline": self._pipeline_module(request),
+            "resources": self._resource_summary(resources),
+            "nativeDependenciesAvailable": self._dependencies_available(),
+            "mockedInference": mocked,
+        }
+
+    def run(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: VideoRequest,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        if not self._mock_inference_enabled(request):
+            return self._run_real_ltx_video(
+                settings=settings,
+                job=job,
+                request=request,
+                progress=progress,
+                cancel_requested=cancel_requested,
+            )
+
+        self._loaded_models.update({request.model, self._pipeline_module(request)})
+        progress("running", "mocking_native_ltx", 0.2, "Rendering mocked native LTX-2.3 preview clip.")
+        return super().run(
+            settings=settings,
+            job=job,
+            request=request,
+            progress=progress,
+            cancel_requested=cancel_requested,
+        )
+
+    def cleanup(self, job_id: str) -> None:
+        super().cleanup(job_id)
+        self._loaded_models.clear()
+        self._evict_pipeline()
+
+    def map_settings(self, request: VideoRequest, target: dict[str, Any]) -> dict[str, Any]:
+        steps = target["steps"].get(request.quality, target["steps"]["balanced"])
+        resources = self._resources_by_model.get(request.model) or self.resolve_resources(request)
+        mocked = self._mock_inference_enabled(request)
+        return {
+            **request.advanced,
+            "adapterFamily": target["family"],
+            "targetAdapter": self.id,
+            "pipeline": self._pipeline_module(request),
+            "resources": self._resource_summary(resources),
+            "steps": safe_int(request.advanced.get("steps"), steps, 1, 80),
+            "frameCount": ltx_frame_count(max(1, int(round(request.duration * request.fps)))),
+            "previewFrameCount": preview_frame_count(request),
+            "recommendedMaxDuration": target["recommendedMaxDuration"],
+            "previewRenderer": mocked,
+            "mockedNativeInference": mocked,
+            "realModelInference": not mocked,
+        }
+
+    def _run_real_ltx_video(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: VideoRequest,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
+        for folder in ("assets/videos", "generation-sets", "recipes"):
+            (project_path / folder).mkdir(parents=True, exist_ok=True)
+
+        target = model_target(request.model)
+        resources = self._resources_by_model.get(request.model) or self.resolve_resources(request)
+        seed = resolve_seed(request.seed, request.prompt)
+        num_frames = ltx_frame_count(max(1, int(round(request.duration * request.fps))))
+        generation_set_id = f"genset_{uuid4().hex}"
+        asset_id = f"asset_{uuid4().hex}"
+        created_at = utc_now()
+        filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
+        media_rel = f"assets/videos/{filename_base}.mp4"
+        media_path = project_path / media_rel
+        temp_path = media_path.with_suffix(".tmp.mp4")
+        self._temporary_outputs.setdefault(job["id"], []).append(temp_path)
+
+        progress("preparing", "validating_inputs", 0.2, "Validating native LTX-2.3 inputs.")
+        conditioning_images = self._ltx_conditioning_images(project_path, request)
+        if cancel_requested():
+            raise InterruptedError("Video generation canceled before native LTX pipeline load.")
+
+        progress("loading_model", "loading_model", 0.28, "Loading native LTX-2.3 pipeline.")
+        pipeline = self._load_ltx_pipeline(request, resources)
+        if cancel_requested():
+            raise InterruptedError("Video generation canceled before native LTX inference.")
+
+        progress("running", "generating", 0.4, "Running native LTX-2.3 inference.")
+        video, audio, video_chunks_number, encode_video = self._run_ltx_pipeline(
+            pipeline=pipeline,
+            request=request,
+            resources=resources,
+            seed=seed,
+            num_frames=num_frames,
+            conditioning_images=conditioning_images,
+        )
+        if cancel_requested():
+            raise InterruptedError("Video generation canceled before saving.")
+
+        progress("saving", "saving", 0.9, "Saving native LTX-2.3 MP4 asset and recipe.")
+        encode_video(
+            video=video,
+            fps=request.fps,
+            audio=audio,
+            output_path=str(temp_path),
+            video_chunks_number=video_chunks_number,
+        )
+        temp_path.replace(media_path)
+
+        generation_set = {
+            "schemaVersion": 1,
+            "id": generation_set_id,
+            "projectId": request.project_id,
+            "jobId": job["id"],
+            "mode": request.mode,
+            "model": request.model,
+            "prompt": request.prompt,
+            "negativePrompt": request.negative_prompt,
+            "count": 1,
+            "createdAt": created_at,
+        }
+        asset = build_video_asset_sidecar(
+            asset_id=asset_id,
+            project_id=request.project_id,
+            generation_set_id=generation_set_id,
+            request=request,
+            job_id=job["id"],
+            media_rel=media_rel,
+            created_at=created_at,
+            seed=seed,
+            target=target,
+            adapter_id=self.id,
+            mime_type="video/mp4",
+            raw_settings=self.map_settings(request, target),
+        )
+        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
+        write_json(media_path.with_suffix(".sceneworks.json"), asset)
+        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
+        index_asset(project_path, asset)
+        self._loaded_models.update({request.model, self._pipeline_module(request), str(resources.checkpoint_path)})
+        return {
+            "generationSetId": generation_set_id,
+            "assetIds": [asset_id],
+            "assets": [asset],
+            "adapter": self.id,
+            "model": request.model,
+            "requirements": self.estimate_requirements(request),
+        }
+
+    def _ltx_conditioning_images(self, project_path: Path, request: VideoRequest) -> list[Any]:
+        if request.mode == "text_to_video":
+            return []
+        if request.mode != "image_to_video":
+            raise RuntimeError(f"Native LTX-2.3 does not support {request.mode.replace('_', ' ')} yet.")
+
+        media_path = source_asset_media_path(project_path, request.source_asset_id)
+        if media_path is None:
+            raise RuntimeError("Image to Video requires a readable source image.")
+        try:
+            with Image.open(media_path) as image:
+                image.verify()
+        except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+            raise RuntimeError("Image to Video requires a readable source image.") from exc
+
+        args_module = importlib.import_module("ltx_pipelines.utils.args")
+        condition_class = getattr(args_module, "ImageConditioningInput")
+        return [
+            condition_class(
+                str(media_path),
+                safe_int(request.advanced.get("imageFrameIndex"), 0, 0, 1_000_000),
+                self._advanced_float(request, "imageConditioningStrength", 1.0),
+            )
+        ]
+
+    def _load_ltx_pipeline(self, request: VideoRequest, resources: LtxPipelinesResources) -> Any:
+        key = self._pipeline_key(request, resources)
+        if self._pipeline is not None and self._pipeline_key_value == key:
+            return self._pipeline
+
+        loader = importlib.import_module("ltx_core.loader")
+        offload_mode = self._offload_mode(request)
+        common_kwargs = {
+            "gemma_root": str(resources.gemma_root),
+            "spatial_upsampler_path": str(resources.spatial_upsampler_path),
+            "loras": (),
+            "torch_compile": bool(request.advanced.get("compile", False)),
+            "offload_mode": offload_mode,
+        }
+        if self._pipeline_module(request) == "ltx_pipelines.distilled":
+            pipeline_module = importlib.import_module("ltx_pipelines.distilled")
+            pipeline = pipeline_module.DistilledPipeline(
+                distilled_checkpoint_path=str(resources.checkpoint_path),
+                **common_kwargs,
+            )
+        else:
+            pipeline_module = importlib.import_module("ltx_pipelines.ti2vid_two_stages")
+            lora_spec = loader.LoraPathStrengthAndSDOps(
+                str(resources.distilled_lora_path),
+                float(request.advanced.get("distilledLoraStrength", 0.8)),
+                loader.LTXV_LORA_COMFY_RENAMING_MAP,
+            )
+            pipeline = pipeline_module.TI2VidTwoStagesPipeline(
+                checkpoint_path=str(resources.checkpoint_path),
+                distilled_lora=[lora_spec],
+                **common_kwargs,
+            )
+        self._pipeline = pipeline
+        self._pipeline_key_value = key
+        self._loaded_models.update({request.model, self._pipeline_module(request), str(resources.checkpoint_path)})
+        return pipeline
+
+    def _run_ltx_pipeline(
+        self,
+        *,
+        pipeline: Any,
+        request: VideoRequest,
+        resources: LtxPipelinesResources,
+        seed: int,
+        num_frames: int,
+        conditioning_images: list[Any],
+    ) -> tuple[Any, Any, int, Any]:
+        video_vae = importlib.import_module("ltx_core.model.video_vae")
+        media_io = importlib.import_module("ltx_pipelines.utils.media_io")
+        tiling_config = video_vae.TilingConfig.default()
+        video_chunks_number = video_vae.get_video_chunks_number(num_frames, tiling_config)
+        base_kwargs = {
+            "prompt": request.prompt,
+            "seed": seed,
+            "height": request.height,
+            "width": request.width,
+            "num_frames": num_frames,
+            "frame_rate": request.fps,
+            "images": conditioning_images,
+            "tiling_config": tiling_config,
+            "enhance_prompt": bool(request.advanced.get("enhancePrompt", False)),
+        }
+        if self._pipeline_module(request) == "ltx_pipelines.distilled":
+            video, audio = pipeline(**base_kwargs)
+        else:
+            guiders = importlib.import_module("ltx_core.components.guiders")
+            video, audio = pipeline(
+                **base_kwargs,
+                negative_prompt=request.negative_prompt or default_negative_prompt(model_target(request.model)),
+                num_inference_steps=self._num_inference_steps(request, model_target(request.model)),
+                video_guider_params=guiders.MultiModalGuiderParams(
+                    cfg_scale=self._advanced_float(request, "videoCfgGuidanceScale", 4.0),
+                    stg_scale=self._advanced_float(request, "videoStgGuidanceScale", 0.0),
+                    rescale_scale=self._advanced_float(request, "videoRescaleScale", 0.7),
+                    modality_scale=self._advanced_float(request, "a2vGuidanceScale", 1.0),
+                    skip_step=safe_int(request.advanced.get("videoSkipStep"), 0, 0, 80),
+                    stg_blocks=request.advanced.get("videoStgBlocks", []),
+                ),
+                audio_guider_params=guiders.MultiModalGuiderParams(
+                    cfg_scale=self._advanced_float(request, "audioCfgGuidanceScale", 1.0),
+                    stg_scale=self._advanced_float(request, "audioStgGuidanceScale", 0.0),
+                    rescale_scale=self._advanced_float(request, "audioRescaleScale", 0.0),
+                    modality_scale=self._advanced_float(request, "v2aGuidanceScale", 1.0),
+                    skip_step=safe_int(request.advanced.get("audioSkipStep"), 0, 0, 80),
+                    stg_blocks=request.advanced.get("audioStgBlocks", []),
+                ),
+                max_batch_size=safe_int(request.advanced.get("maxBatchSize"), 1, 1, 16),
+            )
+        return video, audio, video_chunks_number, media_io.encode_video
+
+    def _pipeline_module(self, request: VideoRequest) -> str:
+        if request.quality == "fast":
+            return "ltx_pipelines.distilled"
+        return "ltx_pipelines.ti2vid_two_stages"
+
+    def _num_inference_steps(self, request: VideoRequest, target: dict[str, Any]) -> int:
+        default_steps = target["steps"].get(request.quality, target["steps"]["balanced"])
+        return safe_int(request.advanced.get("steps"), default_steps, 1, 80)
+
+    def _mock_inference_enabled(self, request: VideoRequest) -> bool:
+        return bool(request.advanced.get("mockNativeInference", False))
+
+    def _pipeline_key(self, request: VideoRequest, resources: LtxPipelinesResources) -> str:
+        return ":".join(
+            [
+                self._pipeline_module(request),
+                str(resources.checkpoint_path),
+                str(resources.spatial_upsampler_path),
+                str(resources.distilled_lora_path),
+                str(resources.gemma_root),
+                str(request.advanced.get("offloadMode", "none")),
+            ]
+        )
+
+    def _offload_mode(self, request: VideoRequest) -> Any:
+        offload_value = str(request.advanced.get("offloadMode", "none")).strip().lower()
+        types_module = importlib.import_module("ltx_pipelines.utils.types")
+        offload_mode = getattr(types_module, "OffloadMode")
+        if offload_value == "cpu":
+            return offload_mode.CPU
+        if offload_value == "disk":
+            return offload_mode.DISK
+        return offload_mode.NONE
+
+    def _advanced_float(self, request: VideoRequest, key: str, fallback: float) -> float:
+        try:
+            return float(request.advanced.get(key, fallback))
+        except (TypeError, ValueError):
+            return fallback
+
+    def _evict_pipeline(self) -> None:
+        self._pipeline = None
+        self._pipeline_key_value = None
+        try:
+            torch = importlib.import_module("torch")
+            cuda = getattr(torch, "cuda", None)
+            if cuda is not None and cuda.is_available():
+                cuda.empty_cache()
+        except Exception:
+            return
+
+    def resolve_resources(self, request: VideoRequest) -> LtxPipelinesResources:
+        settings = self._settings or WorkerSettings()
+        entry = ltx_model_manifest_entry(settings, request.model)
+        resources = entry.get("resources", {}) if isinstance(entry.get("resources"), dict) else {}
+        return LtxPipelinesResources(
+            checkpoint_path=self._resource_path(
+                settings,
+                request,
+                resources,
+                "checkpoint",
+                "checkpointPath",
+            ),
+            spatial_upsampler_path=self._resource_path(
+                settings,
+                request,
+                resources,
+                "spatialUpscaler",
+                "spatialUpscalerPath",
+            ),
+            distilled_lora_path=self._resource_path(
+                settings,
+                request,
+                resources,
+                "distilledLora",
+                "distilledLoraPath",
+            ),
+            gemma_root=self._resource_path(
+                settings,
+                request,
+                resources,
+                "gemma",
+                "gemmaRoot",
+                expect_file=False,
+            ),
+            temporal_upsampler_path=self._optional_resource_path(
+                settings,
+                request,
+                resources,
+                "temporalUpscaler",
+                "temporalUpscalerPath",
+            ),
+        )
+
+    def _resource_path(
+        self,
+        settings: WorkerSettings,
+        request: VideoRequest,
+        resources: dict[str, Any],
+        resource_key: str,
+        advanced_key: str,
+        *,
+        expect_file: bool = True,
+    ) -> Path:
+        override = request.advanced.get(advanced_key)
+        if override:
+            return resolve_worker_path(settings, override)
+        resource = resources.get(resource_key) if isinstance(resources.get(resource_key), dict) else {}
+        configured_path = resource.get("path")
+        if configured_path:
+            return resolve_manifest_path(settings, configured_path)
+        repo = str(resource.get("repo") or VIDEO_MODEL_TARGETS["ltx_2_3"]["repo"])
+        root = settings.data_dir / "models" / safe_download_dir(repo)
+        file_name = resource.get("file")
+        if expect_file and file_name:
+            return root / str(file_name)
+        return root
+
+    def _optional_resource_path(
+        self,
+        settings: WorkerSettings,
+        request: VideoRequest,
+        resources: dict[str, Any],
+        resource_key: str,
+        advanced_key: str,
+    ) -> Path | None:
+        override = request.advanced.get(advanced_key)
+        if override:
+            return resolve_worker_path(settings, override)
+        resource = resources.get(resource_key) if isinstance(resources.get(resource_key), dict) else None
+        if not resource:
+            return None
+        return self._resource_path(settings, request, resources, resource_key, advanced_key)
+
+    def _missing_resources(self, resources: LtxPipelinesResources) -> list[tuple[str, Path]]:
+        required = [
+            ("checkpointPath", resources.checkpoint_path, "file"),
+            ("spatialUpscalerPath", resources.spatial_upsampler_path, "file"),
+            ("distilledLoraPath", resources.distilled_lora_path, "file"),
+            ("gemmaRoot", resources.gemma_root, "dir"),
+        ]
+        missing = [
+            (label, path)
+            for label, path, kind in required
+            if not (path.is_file() if kind == "file" else path.is_dir())
+        ]
+        if resources.temporal_upsampler_path is not None and not resources.temporal_upsampler_path.is_file():
+            missing.append(("temporalUpscalerPath", resources.temporal_upsampler_path))
+        return missing
+
+    def _resource_summary(self, resources: LtxPipelinesResources) -> dict[str, str | None]:
+        return {
+            "checkpointPath": str(resources.checkpoint_path),
+            "spatialUpscalerPath": str(resources.spatial_upsampler_path),
+            "distilledLoraPath": str(resources.distilled_lora_path),
+            "gemmaRoot": str(resources.gemma_root),
+            "temporalUpscalerPath": str(resources.temporal_upsampler_path) if resources.temporal_upsampler_path else None,
+        }
+
+    def _dependencies_available(self) -> bool:
+        try:
+            return (
+                importlib.util.find_spec("ltx_core") is not None
+                and importlib.util.find_spec("ltx_pipelines") is not None
+            )
+        except (ImportError, ValueError):
+            return False
+
+
 class DiffusersVideoAdapter(VideoGenerationAdapter):
     id = "diffusers_video"
 
@@ -287,6 +798,18 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             raise RuntimeError(f"{target['label']} does not support {request.mode.replace('_', ' ')}.")
         if request.duration > target["hardMaxDuration"]:
             raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
+        if (
+            target["adapter"] == "ltx_video"
+            and request.mode == "text_to_video"
+            and not request.advanced.get("modelRepo")
+            and not target.get("diffusersTextRepo")
+        ):
+            raise RuntimeError(
+                "LTX-2.3 text-to-video is supported by the model, but this worker's Diffusers adapter cannot "
+                "load the raw LTX-2.3 checkpoint repo because it does not publish a Diffusers model_index.json. "
+                "Use an advanced modelRepo override that points to a Diffusers-compatible LTX-2.3 conversion, "
+                "or use an adapter backed by the official Lightricks LTX pipeline stack."
+            )
 
     def estimate_requirements(self, request: VideoRequest) -> dict[str, Any]:
         target = model_target(request.model)
@@ -520,8 +1043,8 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
     def _repo_for_request(self, request: VideoRequest, target: dict[str, Any]) -> str:
         if request.advanced.get("modelRepo"):
             return str(request.advanced["modelRepo"])
-        if target["adapter"] == "ltx_video" and request.mode == "text_to_video":
-            return target.get("textRepo") or target["repo"]
+        if target["adapter"] == "ltx_video" and request.mode == "text_to_video" and target.get("diffusersTextRepo"):
+            return target["diffusersTextRepo"]
         if target["adapter"] == "ltx_video" and request.mode != "text_to_video":
             return target.get("fallbackRepo") or target["repo"]
         return target["repo"]
@@ -639,6 +1162,8 @@ def create_video_adapter() -> VideoGenerationAdapter:
         return DiffusersVideoAdapter()
     if requested in {"procedural", "procedural_video"}:
         return ProceduralVideoAdapter()
+    if requested in {"ltx", "ltx_pipelines", "native_ltx"}:
+        return LtxPipelinesVideoAdapter()
     raise RuntimeError(f"Unsupported SCENEWORKS_VIDEO_ADAPTER value: {requested}.")
 
 
@@ -707,14 +1232,121 @@ def ltx_frame_count(raw_frames: int) -> int:
     return lower if lower_delta <= upper_delta else upper
 
 
-def load_source_image(project_path: Path, asset_id: str | None, width: int, height: int) -> Image.Image | None:
+def ltx_model_manifest_entry(settings: WorkerSettings, model_id: str) -> dict[str, Any]:
+    config_dir = getattr(settings, "config_dir", Path("config").resolve())
+    builtin_entry: dict[str, Any] = {}
+    user_entry: dict[str, Any] = {}
+    for manifest_name in ("builtin.models.jsonc", "user.models.jsonc"):
+        manifest_path = config_dir / "manifests" / manifest_name
+        try:
+            payload = json.loads(strip_jsonc_comments(manifest_path.read_text(encoding="utf-8")))
+        except (OSError, ValueError):
+            continue
+        models = payload.get("models", [])
+        if not isinstance(models, list):
+            continue
+        for entry in models:
+            if isinstance(entry, dict) and entry.get("id") == model_id:
+                if manifest_name.startswith("builtin"):
+                    builtin_entry = entry
+                else:
+                    user_entry = entry
+    if not user_entry:
+        return builtin_entry
+    merged = {**builtin_entry, **user_entry}
+    for nested_key in ("paths", "resources", "defaults", "limits", "loraCompatibility", "ui"):
+        builtin_nested = builtin_entry.get(nested_key) if isinstance(builtin_entry.get(nested_key), dict) else {}
+        user_nested = user_entry.get(nested_key) if isinstance(user_entry.get(nested_key), dict) else {}
+        if builtin_nested or user_nested:
+            merged[nested_key] = {**builtin_nested, **user_nested}
+    return merged
+
+
+def strip_jsonc_comments(text: str) -> str:
+    output = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(text):
+        char = text[index]
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            index += 1
+            continue
+        if char == "/" and next_char == "/":
+            index += 2
+            while index < len(text) and text[index] not in "\r\n":
+                index += 1
+            continue
+        if char == "/" and next_char == "*":
+            index += 2
+            while index + 1 < len(text) and not (text[index] == "*" and text[index + 1] == "/"):
+                index += 1
+            index += 2
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def resolve_worker_path(settings: WorkerSettings, value: Any) -> Path:
+    raw_path = str(value).strip()
+    path = Path(raw_path)
+    return path if path.is_absolute() else settings.data_dir / path
+
+
+def resolve_manifest_path(settings: WorkerSettings, value: Any) -> Path:
+    raw_path = str(value).strip()
+    if "${DATA_DIR}" in raw_path:
+        raw_path = raw_path.replace("${DATA_DIR}", str(settings.data_dir))
+    path = Path(raw_path)
+    return path if path.is_absolute() else settings.data_dir / path
+
+
+def safe_download_dir(repo: str) -> str:
+    output = []
+    in_replacement = False
+    for character in repo:
+        if character.isalnum() or character in "_.-":
+            output.append(character)
+            in_replacement = False
+        elif not in_replacement:
+            output.append("__")
+            in_replacement = True
+    safe = "".join(output).strip("_")
+    return safe or "download"
+
+
+def source_asset_media_path(project_path: Path, asset_id: str | None) -> Path | None:
     if not asset_id:
         return None
     sidecar_path = find_asset_sidecar_path(project_path, asset_id)
     if sidecar_path is None:
         return None
     payload = read_json(sidecar_path)
-    media_path = project_path / payload.get("file", {}).get("path", "")
+    media_rel = payload.get("file", {}).get("path", "")
+    media_path = project_path / media_rel
+    return media_path if media_path.exists() else None
+
+
+def load_source_image(project_path: Path, asset_id: str | None, width: int, height: int) -> Image.Image | None:
+    if not asset_id:
+        return None
+    media_path = source_asset_media_path(project_path, asset_id)
+    if media_path is None:
+        return None
     try:
         image = Image.open(media_path).convert("RGB")
     except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning):

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -43,6 +43,7 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "family": "ltx-video",
         "adapter": "ltx_video",
         "repo": "Lightricks/LTX-2.3",
+        "textRepo": "Lightricks/LTX-2",
         "fallbackRepo": "Lightricks/LTX-Video",
         "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
         "recommendedMaxDuration": 10,
@@ -519,6 +520,8 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
     def _repo_for_request(self, request: VideoRequest, target: dict[str, Any]) -> str:
         if request.advanced.get("modelRepo"):
             return str(request.advanced["modelRepo"])
+        if target["adapter"] == "ltx_video" and request.mode == "text_to_video":
+            return target.get("textRepo") or target["repo"]
         if target["adapter"] == "ltx_video" and request.mode != "text_to_video":
             return target.get("fallbackRepo") or target["repo"]
         return target["repo"]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -181,6 +181,23 @@
         "model": "${HF_CACHE}/Lightricks/LTX-2.3",
         "imageToVideoModel": "${HF_CACHE}/Lightricks/LTX-Video"
       },
+      "resources": {
+        "checkpoint": {
+          "repo": "Lightricks/LTX-2.3",
+          "file": "ltx-2.3-22b-distilled-1.1.safetensors"
+        },
+        "spatialUpscaler": {
+          "repo": "Lightricks/LTX-2.3",
+          "file": "ltx-2.3-spatial-upscaler-x2-1.1.safetensors"
+        },
+        "distilledLora": {
+          "repo": "Lightricks/LTX-2.3",
+          "file": "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
+        },
+        "gemma": {
+          "repo": "google/gemma-3-4b-it"
+        }
+      },
       "defaults": {
         "duration": 6,
         "fps": 25,

--- a/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
+++ b/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
@@ -1,0 +1,316 @@
+# Epic: Native LTX-2.3 Video Adapter
+
+Shortcut epic: `sc-1394`
+
+## Goal
+
+Implement first-class local LTX-2.3 video generation in SceneWorks without depending on ComfyUI or hosted LTX APIs.
+
+This epic replaces the current Diffusers-only LTX path for LTX-2.3 with an adapter backed by the official Lightricks `ltx-pipelines` stack. The adapter must support text-to-video first, then image-to-video, and must save generated clips as normal SceneWorks video assets with recipe, lineage, preview, and Library integration.
+
+## Problem Statement
+
+SceneWorks currently routes `ltx_2_3` through `DiffusionPipeline.from_pretrained(...)`. That works only for Hugging Face repositories that publish a Diffusers component layout with `model_index.json`.
+
+`Lightricks/LTX-2.3` currently publishes raw LTX-2.3 checkpoint files, upscalers, and LoRAs, but not a root Diffusers `model_index.json`. As a result, SceneWorks text-to-video attempts fail with a Hugging Face 404 for:
+
+```text
+https://huggingface.co/Lightricks/LTX-2.3/resolve/main/model_index.json
+```
+
+LTX-2.3 itself does support text-to-video and image-to-video. The missing piece is a native SceneWorks adapter that loads the same model family through the official Lightricks pipeline stack instead of generic Diffusers loading.
+
+## Non-Goals
+
+- No ComfyUI dependency.
+- No hosted LTX API dependency.
+- No network rendering.
+- No silent fallback from LTX-2.3 to LTX-2.
+- No attempt to build a general ComfyUI workflow runner.
+- No broad redesign of SceneWorks jobs, assets, or Library contracts.
+
+## User Outcomes
+
+- A user can select LTX-2.3 and generate a short text-to-video clip locally.
+- A user can select an image asset and generate a short image-to-video clip locally.
+- A generated clip appears in the Library as a video asset.
+- The asset recipe records the LTX-2.3 checkpoint, upscaler, LoRA, prompt, seed, resolution, frame count, FPS, duration, and adapter settings.
+- Queue progress reports useful stages instead of generic Python loader errors.
+- If required model files are missing, the job fails before inference with a clear list of missing files and where SceneWorks expected to find them.
+
+## Architecture
+
+Add a new worker adapter, tentatively `LtxPipelinesVideoAdapter`, separate from `DiffusersVideoAdapter`.
+
+The adapter should satisfy the existing `VideoGenerationAdapter` interface in `apps/worker/scene_worker/video_adapters.py`:
+
+- `prepare`
+- `ensure_models`
+- `estimate_requirements`
+- `run`
+- `cancel`
+- `cleanup`
+
+Adapter selection should be explicit:
+
+- `SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines` uses the native LTX-2.3 stack.
+- `SCENEWORKS_VIDEO_ADAPTER=diffusers_video` remains available for Wan and any Diffusers-compatible video models.
+- `SCENEWORKS_VIDEO_ADAPTER=procedural_video` remains available for tests and lightweight development.
+
+Longer term, model-level adapter routing can replace the environment toggle, but the first implementation should keep the change small and predictable.
+
+## Runtime Strategy
+
+Use the official Lightricks `LTX-2` repository packages:
+
+- `ltx-core`
+- `ltx-pipelines`
+
+The recommended production-quality pipeline is `ltx_pipelines.ti2vid_two_stages`. The faster path is `ltx_pipelines.distilled`.
+
+The first SceneWorks implementation should support two quality modes:
+
+- `fast`: distilled pipeline, 8-step-style settings where supported.
+- `balanced`: two-stage pipeline with distilled LoRA and spatial upscaler.
+
+`best` can initially map to `balanced` with a higher step budget, then become a separate HQ pipeline once validated.
+
+## Model Files
+
+SceneWorks must manage these as model resources, not hidden one-off paths:
+
+- LTX-2.3 model checkpoint:
+  - `ltx-2.3-22b-dev.safetensors`
+  - or `ltx-2.3-22b-distilled-1.1.safetensors`
+- Spatial upscaler:
+  - `ltx-2.3-spatial-upscaler-x2-1.1.safetensors`
+  - or a validated lower-memory upscaler variant.
+- Distilled LoRA for two-stage pipelines:
+  - `ltx-2.3-22b-distilled-lora-384-1.1.safetensors`
+- Gemma text encoder assets:
+  - full local Gemma repo or local text encoder path required by `ltx-pipelines`.
+
+The adapter should not hardcode absolute user paths. Add advanced settings and manifest fields for:
+
+- `checkpointPath`
+- `spatialUpscalerPath`
+- `distilledLoraPath`
+- `gemmaRoot`
+- optional `temporalUpscalerPath`
+
+## Manifest Changes
+
+Extend `config/manifests/builtin.models.jsonc` for `ltx_2_3` with resource entries for the native pipeline files.
+
+Recommended shape:
+
+```jsonc
+{
+  "id": "ltx_2_3",
+  "adapter": "ltx_pipelines",
+  "resources": {
+    "checkpoint": {
+      "repo": "Lightricks/LTX-2.3",
+      "file": "ltx-2.3-22b-distilled-1.1.safetensors"
+    },
+    "spatialUpscaler": {
+      "repo": "Lightricks/LTX-2.3",
+      "file": "ltx-2.3-spatial-upscaler-x2-1.1.safetensors"
+    },
+    "distilledLora": {
+      "repo": "Lightricks/LTX-2.3",
+      "file": "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
+    },
+    "gemma": {
+      "repo": "google/gemma-3-4b-it"
+    }
+  }
+}
+```
+
+Exact Gemma repo and file requirements must be validated against the installed `ltx-pipelines` version before implementation is marked complete.
+
+## Worker Dependency Plan
+
+Avoid bloating the default worker until the adapter is enabled.
+
+Preferred first approach:
+
+- Add optional install target or Docker build arg for LTX native dependencies.
+- Keep base image compatible with existing Diffusers image/video jobs.
+- Document that native LTX-2.3 requires the LTX-enabled worker image.
+
+Possible implementation options:
+
+- Add `apps/worker/requirements-ltx.txt`.
+- Add `docker/worker-ltx.Dockerfile` or `ARG INCLUDE_LTX_PIPELINES=1`.
+- Install LTX packages from a pinned Git commit of `https://github.com/Lightricks/LTX-2`.
+- Record the pinned commit in this repository.
+
+Do not install from an unpinned branch for production use.
+
+## Adapter Implementation Tasks
+
+1. Add `LtxPipelinesVideoAdapter`.
+2. Add adapter selection for `SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines`.
+3. Resolve model resource paths from manifest/download markers or advanced overrides.
+4. Validate required files in `ensure_models`.
+5. Map SceneWorks request fields:
+   - `prompt`
+   - `negativePrompt`
+   - `seed`
+   - `duration`
+   - `fps`
+   - `width`
+   - `height`
+   - `quality`
+   - `sourceAssetId` for image-to-video
+6. Normalize dimensions to LTX-compatible values.
+7. Normalize frame counts to supported pipeline constraints.
+8. Execute the selected `ltx-pipelines` pipeline.
+9. Stream coarse progress:
+   - preparing
+   - validating model files
+   - loading checkpoint
+   - encoding prompt
+   - stage 1 generation
+   - stage 2 upscaling/refinement
+   - saving
+10. Save output to `assets/videos`.
+11. Write generation set, asset sidecar, recipe, and project DB index.
+12. Clean up temporary files on cancellation or failure.
+13. Keep loaded model reporting meaningful enough for worker heartbeat.
+
+## UI And Product Behavior
+
+The Video Studio can keep the current simple controls:
+
+- Mode: Text to Video / Image to Video.
+- Prompt.
+- Duration.
+- Aspect/resolution.
+- Quality.
+- Seed.
+- Advanced model settings.
+
+Add LTX-native advanced fields only if needed:
+
+- checkpoint variant.
+- text encoder mode/local path.
+- distilled LoRA weight.
+- upscaler variant.
+- prompt enhancement toggle.
+
+Default UI should remain small. The adapter should pick conservative defaults from manifest metadata.
+
+## Recommended Defaults
+
+Initial defaults should favor successful local runs over maximum quality:
+
+- Duration: 4 seconds.
+- FPS: 25.
+- Resolution: 768x512 landscape and 512x768 portrait.
+- Quality: balanced.
+- Seed: generated when absent.
+- Output: MP4.
+
+If memory pressure is high, first fallback should be shorter duration or lower resolution, not switching models.
+
+## Testing Plan
+
+Unit tests:
+
+- Adapter selection returns `LtxPipelinesVideoAdapter` for `SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines`.
+- Required model path validation reports all missing files.
+- Request mapping preserves prompt, seed, duration, FPS, dimensions, quality, and source image.
+- Frame count normalization is deterministic.
+- Output sidecar preserves native LTX lineage.
+- Cancellation deletes temp outputs.
+
+Integration tests with mocked `ltx_pipelines`:
+
+- Text-to-video job completes and writes a video asset.
+- Image-to-video job loads source asset and passes image conditioning.
+- Missing Gemma root fails with clear user-facing message.
+- Missing spatial upscaler fails before inference.
+
+Manual validation:
+
+- Run one 4-second T2V generation on the target NVIDIA machine.
+- Run one 4-second I2V generation from a Library image.
+- Confirm output previews in Library.
+- Confirm recipe can be reused.
+- Confirm GPU memory returns after job completion/cancel.
+
+## Acceptance Criteria
+
+- LTX-2.3 text-to-video works locally without ComfyUI and without hosted API calls.
+- LTX-2.3 image-to-video works locally without ComfyUI and without hosted API calls.
+- SceneWorks fails fast with actionable messages when any required native LTX model file is missing.
+- Generated outputs are normal SceneWorks video assets.
+- Recipes preserve enough settings to reproduce the generation.
+- Existing Diffusers video paths and procedural video tests still pass.
+- The worker test suite covers adapter selection, validation, request mapping, and asset writing.
+
+## Risks And Open Questions
+
+- `ltx-pipelines` dependency weight may make the worker image much larger.
+- The LTX package may require Python/CUDA/PyTorch versions that diverge from the current worker.
+- Gemma local text encoder requirements need exact validation.
+- Two-stage pipeline defaults may require more VRAM than expected.
+- Audio generation support should be deferred unless it comes for free without destabilizing video-only output.
+- The current Model Manager may not express multi-file model resources cleanly enough; this may require a small manifest/resource schema expansion.
+- License prompts and gated model access must be handled clearly if any dependency requires Hugging Face auth or license acceptance.
+
+## Implementation Slices
+
+### Slice 1: Native Adapter Skeleton
+
+Shortcut story: `sc-1395`
+
+- Add optional LTX dependencies.
+- Add `LtxPipelinesVideoAdapter`.
+- Implement validation and mocked run path.
+- No real inference yet.
+
+### Slice 2: Model Resource Resolution
+
+Shortcut story: `sc-1396`
+
+- Extend manifest resource metadata.
+- Resolve checkpoint/upscaler/LoRA/Gemma paths.
+- Add missing-file diagnostics.
+
+### Slice 3: Real Text-To-Video
+
+Shortcut story: `sc-1397`
+
+- Wire `ltx_pipelines` text-to-video.
+- Save MP4 asset.
+- Validate one short local generation.
+
+### Slice 4: Real Image-To-Video
+
+Shortcut story: `sc-1398`
+
+- Load source image from SceneWorks asset.
+- Pass image conditioning into the pipeline.
+- Validate one short local generation.
+
+### Slice 5: Polish And Hardening
+
+Shortcut story: `sc-1399`
+
+- Progress stages.
+- Cancellation.
+- GPU cleanup.
+- Better model install UX.
+- Documentation.
+
+## Sources
+
+- LTX-2.3 model page: https://huggingface.co/Lightricks/LTX-2.3
+- LTX-2 repository: https://github.com/Lightricks/LTX-2
+- `ltx-pipelines` README: https://github.com/Lightricks/LTX-2/blob/main/packages/ltx-pipelines/README.md
+- LTX open-source quick start: https://docs.ltx.video/open-source-model/getting-started/quick-start
+- LTX-2.3 product FAQ: https://ltx.io/model/ltx-2-3

--- a/documents/IMPLEMENTATION_PLAN.md
+++ b/documents/IMPLEMENTATION_PLAN.md
@@ -330,6 +330,7 @@ Research first:
 - Validate FPS/resolution constraints.
 - Validate LoRA support.
 - Validate Wan2.2 path separately.
+- See `documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md` for the native-only LTX-2.3 implementation track.
 
 Implementation:
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from typing import NamedTuple
 from types import SimpleNamespace
 
 from PIL import Image
@@ -48,15 +50,18 @@ from scene_worker.runtime import (
 )
 from scene_worker.video_adapters import (
     DiffusersVideoAdapter,
+    LtxPipelinesVideoAdapter,
     VIDEO_MODEL_TARGETS,
     build_video_asset_sidecar,
     character_reference_images,
     create_video_adapter,
     evenly_spaced_indices,
     frames_from_output,
+    ltx_model_manifest_entry,
     ltx_frame_count,
     load_seekable_image_frame,
     person_track_masks,
+    safe_download_dir,
     video_request_from_job,
 )
 
@@ -1041,6 +1046,9 @@ def test_video_adapter_override_aliases_and_unknown_values(monkeypatch):
     monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "procedural")
     assert create_video_adapter().__class__.__name__ == "ProceduralVideoAdapter"
 
+    monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "ltx_pipelines")
+    assert create_video_adapter().__class__.__name__ == "LtxPipelinesVideoAdapter"
+
     monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "typo")
     try:
         create_video_adapter()
@@ -1104,7 +1112,640 @@ def test_ltx_video_requirements_report_normalized_frame_count():
 
     assert requirements["requestedFrames"] == 150
     assert requirements["estimatedFrames"] == 153
-    assert requirements["repo"] == "Lightricks/LTX-2"
+    assert requirements["repo"] == "Lightricks/LTX-2.3"
+
+
+def write_native_ltx_manifest(config_dir, *, checkpoint=None, spatial=None, lora=None, gemma=None):
+    manifest_dir = config_dir / "manifests"
+    manifest_dir.mkdir(parents=True)
+    resources = {
+        "checkpoint": {"repo": "Lightricks/LTX-2.3", "file": "checkpoint.safetensors"},
+        "spatialUpscaler": {"repo": "Lightricks/LTX-2.3", "file": "spatial.safetensors"},
+        "distilledLora": {"repo": "Lightricks/LTX-2.3", "file": "distilled-lora.safetensors"},
+        "gemma": {"repo": "google/gemma-3-4b-it"},
+    }
+    if checkpoint is not None:
+        resources["checkpoint"] = {"path": str(checkpoint)}
+    if spatial is not None:
+        resources["spatialUpscaler"] = {"path": str(spatial)}
+    if lora is not None:
+        resources["distilledLora"] = {"path": str(lora)}
+    if gemma is not None:
+        resources["gemma"] = {"path": str(gemma)}
+    (manifest_dir / "builtin.models.jsonc").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "models": [
+                    {
+                        "id": "ltx_2_3",
+                        "name": "LTX-2.3",
+                        "family": "ltx-video",
+                        "type": "video",
+                        "adapter": "ltx_video",
+                        "capabilities": ["text_to_video", "image_to_video"],
+                        "downloads": [],
+                        "paths": {},
+                        "resources": resources,
+                        "defaults": {},
+                        "limits": {},
+                        "loraCompatibility": {},
+                        "ui": {},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_native_ltx_resource_files(tmp_path):
+    checkpoint = tmp_path / "checkpoint.safetensors"
+    spatial = tmp_path / "spatial.safetensors"
+    lora = tmp_path / "distilled-lora.safetensors"
+    gemma = tmp_path / "gemma"
+    checkpoint.write_bytes(b"checkpoint")
+    spatial.write_bytes(b"spatial")
+    lora.write_bytes(b"lora")
+    gemma.mkdir()
+    return checkpoint, spatial, lora, gemma
+
+
+def test_native_ltx_adapter_reports_mocked_pipeline_requirements(tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    data_dir.mkdir()
+    checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+    adapter = LtxPipelinesVideoAdapter()
+    request = adapter.prepare(
+        settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
+        job={
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "duration": 6,
+                "fps": 25,
+                "quality": "fast",
+                "advanced": {"mockNativeInference": True},
+            },
+        },
+    )
+
+    adapter.ensure_models(request)
+    requirements = adapter.estimate_requirements(request)
+
+    assert requirements["adapter"] == "ltx_pipelines"
+    assert requirements["pipeline"] == "ltx_pipelines.distilled"
+    assert requirements["requestedFrames"] == 150
+    assert requirements["estimatedFrames"] == 153
+    assert requirements["mockedInference"] is True
+    assert requirements["resources"]["checkpointPath"] == str(checkpoint)
+
+
+def test_native_ltx_missing_resources_reports_all_paths(tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    data_dir.mkdir()
+    write_native_ltx_manifest(config_dir)
+    adapter = LtxPipelinesVideoAdapter()
+    request = adapter.prepare(
+        settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
+        job={
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "advanced": {},
+            },
+        },
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        adapter.ensure_models(request)
+
+    message = str(exc.value)
+    assert "checkpointPath" in message
+    assert "spatialUpscalerPath" in message
+    assert "distilledLoraPath" in message
+    assert "gemmaRoot" in message
+    assert str(data_dir / "models" / safe_download_dir("Lightricks/LTX-2.3") / "checkpoint.safetensors") in message
+    assert str(data_dir / "models" / safe_download_dir("google/gemma-3-4b-it")) in message
+
+
+def test_native_ltx_advanced_resource_overrides_win(tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    data_dir.mkdir()
+    checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir)
+    adapter = LtxPipelinesVideoAdapter()
+    request = adapter.prepare(
+        settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
+        job={
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "advanced": {
+                    "mockNativeInference": True,
+                    "checkpointPath": str(checkpoint),
+                    "spatialUpscalerPath": str(spatial),
+                    "distilledLoraPath": str(lora),
+                    "gemmaRoot": str(gemma),
+                },
+            },
+        },
+    )
+
+    adapter.ensure_models(request)
+    resources = adapter.estimate_requirements(request)["resources"]
+
+    assert resources["checkpointPath"] == str(checkpoint)
+    assert resources["spatialUpscalerPath"] == str(spatial)
+    assert resources["distilledLoraPath"] == str(lora)
+    assert resources["gemmaRoot"] == str(gemma)
+
+
+def test_ltx_model_manifest_entry_reads_jsonc_comments(tmp_path):
+    config_dir = tmp_path / "config"
+    manifest_dir = config_dir / "manifests"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "builtin.models.jsonc").write_text(
+        """
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              // Keep comment stripping out of quoted strings like "https://example.test".
+              "id": "ltx_2_3",
+              "resources": { "checkpoint": { "path": "models/checkpoint.safetensors" } }
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    entry = ltx_model_manifest_entry(SimpleNamespace(config_dir=config_dir), "ltx_2_3")
+
+    assert entry["resources"]["checkpoint"]["path"] == "models/checkpoint.safetensors"
+
+
+def test_ltx_model_manifest_entry_preserves_builtin_resources_for_user_entry(tmp_path):
+    config_dir = tmp_path / "config"
+    manifest_dir = config_dir / "manifests"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "builtin.models.jsonc").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "models": [
+                    {
+                        "id": "ltx_2_3",
+                        "paths": {"model": "data/models/builtin"},
+                        "resources": {"checkpoint": {"path": "models/checkpoint.safetensors"}},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (manifest_dir / "user.models.jsonc").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "models": [
+                    {
+                        "id": "ltx_2_3",
+                        "paths": {"model": "data/models/user"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    entry = ltx_model_manifest_entry(SimpleNamespace(config_dir=config_dir), "ltx_2_3")
+
+    assert entry["paths"]["model"] == "data/models/user"
+    assert entry["resources"]["checkpoint"]["path"] == "models/checkpoint.safetensors"
+
+
+def test_native_ltx_adapter_rejects_unsupported_modes():
+    adapter = LtxPipelinesVideoAdapter()
+    request = video_request_from_job(
+        {
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "video_bridge",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "advanced": {},
+            },
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="native pipelines currently support"):
+        adapter.ensure_models(request)
+
+
+def test_native_ltx_mocked_run_writes_scene_video_asset(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    job = {
+        "id": "job-ltx",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_video",
+            "prompt": "Neon harbor",
+            "model": "ltx_2_3",
+            "duration": 1,
+            "fps": 12,
+            "width": 320,
+            "height": 256,
+            "quality": "balanced",
+            "advanced": {"mockNativeInference": True},
+        },
+    }
+    monkeypatch.setattr(
+        "scene_worker.video_adapters.gradient_frame",
+        lambda width, height, _digest: Image.new("RGB", (width, height), "navy"),
+    )
+    adapter = LtxPipelinesVideoAdapter()
+    request = adapter.prepare(settings=SimpleNamespace(data_dir=data_dir), job=job)
+
+    result = adapter.run(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job=job,
+        request=request,
+        progress=lambda *_args: None,
+        cancel_requested=lambda: False,
+    )
+
+    asset = result["assets"][0]
+    media_path = project_path / asset["file"]["path"]
+    assert media_path.exists()
+    assert result["adapter"] == "ltx_pipelines"
+    assert asset["recipe"]["adapter"] == "ltx_pipelines"
+    assert asset["recipe"]["rawAdapterSettings"]["pipeline"] == "ltx_pipelines.ti2vid_two_stages"
+    assert asset["recipe"]["rawAdapterSettings"]["mockedNativeInference"] is True
+    assert adapter.loaded_models() == ["ltx_2_3", "ltx_pipelines.ti2vid_two_stages"]
+
+
+def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+    calls = {"init": None, "run": None, "encode": None}
+
+    class FakePipeline:
+        def __init__(self, **kwargs):
+            calls["init"] = kwargs
+
+        def __call__(self, **kwargs):
+            calls["run"] = kwargs
+            return ["video-chunk"], "audio-track"
+
+    class FakeTilingConfig:
+        @staticmethod
+        def default():
+            return "tiling-config"
+
+    class FakeOffloadMode:
+        NONE = "none"
+        CPU = "cpu"
+        DISK = "disk"
+
+    class FakeGuiderParams:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def fake_encode_video(**kwargs):
+        calls["encode"] = kwargs
+        Path(kwargs["output_path"]).write_bytes(b"mp4")
+
+    def fake_import_module(name):
+        if name == "ltx_core.loader":
+            return SimpleNamespace(
+                LoraPathStrengthAndSDOps=lambda path, strength, sd_ops: (path, strength, sd_ops),
+                LTXV_LORA_COMFY_RENAMING_MAP={"rename": "map"},
+            )
+        if name == "ltx_pipelines.utils.types":
+            return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_pipelines.ti2vid_two_stages":
+            return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
+        if name == "ltx_core.model.video_vae":
+            return SimpleNamespace(
+                TilingConfig=FakeTilingConfig,
+                get_video_chunks_number=lambda _frames, _tiling: 2,
+            )
+        if name == "ltx_pipelines.utils.media_io":
+            return SimpleNamespace(encode_video=fake_encode_video)
+        if name == "ltx_core.components.guiders":
+            return SimpleNamespace(MultiModalGuiderParams=FakeGuiderParams)
+        raise ImportError(name)
+
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
+    adapter = LtxPipelinesVideoAdapter()
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    job = {
+        "id": "job-real-ltx",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_video",
+            "prompt": "Neon harbor",
+            "negativePrompt": "rain",
+            "model": "ltx_2_3",
+            "duration": 1,
+            "fps": 12,
+            "width": 320,
+            "height": 256,
+            "quality": "balanced",
+            "advanced": {"steps": 7, "distilledLoraStrength": 0.6},
+        },
+    }
+    request = adapter.prepare(settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir), job=job)
+
+    adapter.ensure_models(request)
+    result = adapter.run(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job=job,
+        request=request,
+        progress=lambda *_args: None,
+        cancel_requested=lambda: False,
+    )
+
+    asset = result["assets"][0]
+    media_path = project_path / asset["file"]["path"]
+    assert media_path.read_bytes() == b"mp4"
+    assert calls["init"]["checkpoint_path"] == str(checkpoint)
+    assert calls["init"]["distilled_lora"] == [(str(lora), 0.6, {"rename": "map"})]
+    assert calls["run"]["prompt"] == "Neon harbor"
+    assert calls["run"]["negative_prompt"] == "rain"
+    assert calls["run"]["num_inference_steps"] == 7
+    assert calls["run"]["images"] == []
+    assert calls["encode"]["video"] == ["video-chunk"]
+    assert calls["encode"]["audio"] == "audio-track"
+    assert calls["encode"]["video_chunks_number"] == 2
+    assert asset["file"]["mimeType"] == "video/mp4"
+    assert asset["recipe"]["rawAdapterSettings"]["realModelInference"] is True
+    assert asset["recipe"]["rawAdapterSettings"]["mockedNativeInference"] is False
+    assert result["requirements"]["mockedInference"] is False
+
+
+def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    image_rel = "assets/images/source.png"
+    (project_path / "assets" / "images").mkdir(parents=True)
+    Image.new("RGB", (16, 16), "teal").save(project_path / image_rel)
+    (project_path / "assets" / "images" / "source.sceneworks.json").write_text(
+        json.dumps({"id": "asset-source", "file": {"path": image_rel}}),
+        encoding="utf-8",
+    )
+    checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+    calls = {"run": None, "encode": None}
+
+    class FakePipeline:
+        def __init__(self, **_kwargs):
+            return None
+
+        def __call__(self, **kwargs):
+            calls["run"] = kwargs
+            return ["video-chunk"], None
+
+    class FakeConditioningInput(NamedTuple):
+        path: str
+        frame_idx: int
+        strength: float
+
+    class FakeTilingConfig:
+        @staticmethod
+        def default():
+            return "tiling-config"
+
+    class FakeOffloadMode:
+        NONE = "none"
+        CPU = "cpu"
+        DISK = "disk"
+
+    class FakeGuiderParams:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def fake_encode_video(**kwargs):
+        calls["encode"] = kwargs
+        Path(kwargs["output_path"]).write_bytes(b"mp4")
+
+    def fake_import_module(name):
+        if name == "ltx_core.loader":
+            return SimpleNamespace(
+                LoraPathStrengthAndSDOps=lambda path, strength, sd_ops: (path, strength, sd_ops),
+                LTXV_LORA_COMFY_RENAMING_MAP={},
+            )
+        if name == "ltx_pipelines.utils.types":
+            return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_pipelines.ti2vid_two_stages":
+            return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
+        if name == "ltx_core.model.video_vae":
+            return SimpleNamespace(
+                TilingConfig=FakeTilingConfig,
+                get_video_chunks_number=lambda _frames, _tiling: 1,
+            )
+        if name == "ltx_pipelines.utils.media_io":
+            return SimpleNamespace(encode_video=fake_encode_video)
+        if name == "ltx_core.components.guiders":
+            return SimpleNamespace(MultiModalGuiderParams=FakeGuiderParams)
+        if name == "ltx_pipelines.utils.args":
+            return SimpleNamespace(ImageConditioningInput=FakeConditioningInput)
+        raise ImportError(name)
+
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
+    adapter = LtxPipelinesVideoAdapter()
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    job = {
+        "id": "job-i2v",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "image_to_video",
+            "prompt": "Make the harbor move",
+            "model": "ltx_2_3",
+            "sourceAssetId": "asset-source",
+            "duration": 1,
+            "fps": 12,
+            "width": 320,
+            "height": 256,
+            "quality": "balanced",
+            "advanced": {"imageConditioningStrength": 0.7},
+        },
+    }
+    request = adapter.prepare(settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir), job=job)
+
+    adapter.ensure_models(request)
+    result = adapter.run(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job=job,
+        request=request,
+        progress=lambda *_args: None,
+        cancel_requested=lambda: False,
+    )
+
+    image_condition = calls["run"]["images"][0]
+    assert image_condition.path == str(project_path / image_rel)
+    assert image_condition.frame_idx == 0
+    assert image_condition.strength == 0.7
+    assert result["assets"][0]["lineage"]["sourceAssetId"] == "asset-source"
+    assert result["assets"][0]["recipe"]["rawAdapterSettings"]["realModelInference"] is True
+
+
+def test_native_ltx_cleanup_deletes_temp_output_and_evicts_pipeline(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+
+    class FakePipeline:
+        def __init__(self, **_kwargs):
+            return None
+
+        def __call__(self, **_kwargs):
+            return ["video-chunk"], None
+
+    class FakeTilingConfig:
+        @staticmethod
+        def default():
+            return "tiling-config"
+
+    class FakeOffloadMode:
+        NONE = "none"
+        CPU = "cpu"
+        DISK = "disk"
+
+    class FakeGuiderParams:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def fake_encode_video(**kwargs):
+        Path(kwargs["output_path"]).write_bytes(b"partial")
+        raise RuntimeError("encoder failed")
+
+    def fake_import_module(name):
+        if name == "ltx_core.loader":
+            return SimpleNamespace(
+                LoraPathStrengthAndSDOps=lambda path, strength, sd_ops: (path, strength, sd_ops),
+                LTXV_LORA_COMFY_RENAMING_MAP={},
+            )
+        if name == "ltx_pipelines.utils.types":
+            return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_pipelines.ti2vid_two_stages":
+            return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
+        if name == "ltx_core.model.video_vae":
+            return SimpleNamespace(
+                TilingConfig=FakeTilingConfig,
+                get_video_chunks_number=lambda _frames, _tiling: 1,
+            )
+        if name == "ltx_pipelines.utils.media_io":
+            return SimpleNamespace(encode_video=fake_encode_video)
+        if name == "ltx_core.components.guiders":
+            return SimpleNamespace(MultiModalGuiderParams=FakeGuiderParams)
+        raise ImportError(name)
+
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
+    adapter = LtxPipelinesVideoAdapter()
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    job = {
+        "id": "job-cleanup",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "text_to_video",
+            "prompt": "Neon harbor",
+            "model": "ltx_2_3",
+            "duration": 1,
+            "fps": 12,
+            "width": 320,
+            "height": 256,
+            "quality": "balanced",
+            "advanced": {},
+        },
+    }
+    request = adapter.prepare(settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir), job=job)
+
+    adapter.ensure_models(request)
+    with pytest.raises(RuntimeError, match="encoder failed"):
+        adapter.run(
+            settings=SimpleNamespace(data_dir=data_dir),
+            job=job,
+            request=request,
+            progress=lambda *_args: None,
+            cancel_requested=lambda: False,
+        )
+    assert list((project_path / "assets" / "videos").glob("*.tmp.mp4"))
+
+    adapter.cleanup(job["id"])
+
+    assert list((project_path / "assets" / "videos").glob("*.tmp.mp4")) == []
+    assert adapter.loaded_models() == []
+    assert adapter._pipeline is None
+
+
+def test_ltx_video_text_to_video_default_repo_fails_before_diffusers_404():
+    adapter = DiffusersVideoAdapter()
+    request = video_request_from_job(
+        {
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "advanced": {},
+            },
+        }
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        adapter.ensure_models(request)
+
+    assert "LTX-2.3 text-to-video is supported by the model" in str(exc.value)
+    assert "model_index.json" in str(exc.value)
 
 
 def test_ltx_video_image_modes_keep_image_to_video_diffusers_repo():
@@ -1146,6 +1787,7 @@ def test_ltx_video_model_repo_override_wins_over_mode_specific_repos():
     requirements = adapter.estimate_requirements(request)
 
     assert requirements["repo"] == "owner/custom-ltx-diffusers"
+    adapter.ensure_models(request)
 
 
 def test_evenly_spaced_indices_are_bounded():

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -680,6 +680,20 @@ def test_friendly_failure_identifies_missing_model_files():
     assert "HF_TOKEN" in error
 
 
+def test_friendly_failure_identifies_missing_diffusers_model_index():
+    message, error = friendly_failure(
+        "Video generation",
+        RuntimeError(
+            "404 Client Error. Entry Not Found for url: "
+            "https://huggingface.co/Lightricks/LTX-2.3/resolve/main/model_index.json."
+        ),
+    )
+
+    assert message == "Video generation failed because required model files were not available."
+    assert "model_index.json" in error
+    assert "Technical detail" in error
+
+
 def test_friendly_failure_identifies_ltx_frame_count_errors():
     message, error = friendly_failure("Video generation", RuntimeError("num_frames must be divisible by 8 + 1"))
 
@@ -1090,7 +1104,48 @@ def test_ltx_video_requirements_report_normalized_frame_count():
 
     assert requirements["requestedFrames"] == 150
     assert requirements["estimatedFrames"] == 153
-    assert requirements["repo"] == "Lightricks/LTX-2.3"
+    assert requirements["repo"] == "Lightricks/LTX-2"
+
+
+def test_ltx_video_image_modes_keep_image_to_video_diffusers_repo():
+    adapter = DiffusersVideoAdapter()
+    request = video_request_from_job(
+        {
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "image_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "sourceAssetId": "asset-image",
+                "advanced": {},
+            },
+        }
+    )
+
+    requirements = adapter.estimate_requirements(request)
+
+    assert requirements["repo"] == "Lightricks/LTX-Video"
+
+
+def test_ltx_video_model_repo_override_wins_over_mode_specific_repos():
+    adapter = DiffusersVideoAdapter()
+    request = video_request_from_job(
+        {
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "advanced": {"modelRepo": "owner/custom-ltx-diffusers"},
+            },
+        }
+    )
+
+    requirements = adapter.estimate_requirements(request)
+
+    assert requirements["repo"] == "owner/custom-ltx-diffusers"
 
 
 def test_evenly_spaced_indices_are_bounded():


### PR DESCRIPTION
## Summary
- Add a first-class `ltx_pipelines` video adapter for LTX-2.3 with explicit selection and worker-side resource resolution.
- Wire native text-to-video and image-to-video execution paths through the LTX pipeline stack, with mocked smoke-test mode still available.
- Add manifest resource metadata, optional LTX worker requirements, clearer missing-resource failures, and cleanup/cancellation hardening.
- Expand worker tests to cover adapter selection, resource validation, text/image conditioning, and temp file cleanup.

## Testing
- `python -m pytest tests/test_worker_runtime.py -q` passed.
- Added unit coverage for native adapter selection, manifest parsing, resource overrides, real text-to-video call flow, real image-to-video conditioning, and cleanup behavior.