### PR TITLE
[codex] Make video adapter routing model-aware

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -17,10 +17,11 @@ Override `PYTORCH_INDEX_URL` / `PYTORCH_SPEC` for direct `docker build`, or
 GPU workers with CPU-only PyTorch intentionally register without generation
 capabilities so jobs stay queued instead of crawling on CPU with an idle GPU.
 
-Native LTX-2.3 work is staged behind `SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines`.
-The base worker does not install that stack by default; install
-`requirements-ltx.txt` into an LTX-specific worker environment when validating
-the native pipeline adapter.
+Video adapter selection follows the selected model by default: LTX-2.3 uses the
+native `ltx_pipelines` adapter, while Diffusers-compatible video models such as
+Wan2.2 use `diffusers_video`. Docker Compose builds the worker with
+`requirements-ltx.txt` by default. Set `SCENEWORKS_VIDEO_ADAPTER` only when you
+explicitly want to force one adapter for all video jobs.
 
 Native LTX-2.3 text-to-video and image-to-video require these local resources:
 

--- a/apps/worker/requirements-ltx.txt
+++ b/apps/worker/requirements-ltx.txt
@@ -1,4 +1,4 @@
-# Optional native LTX-2.3 dependencies for SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines.
+# Native LTX-2.3 dependencies for SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines.
 # Pinned to the official Lightricks/LTX-2 HEAD inspected on 2026-05-19.
 ltx-core @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-core
 ltx-pipelines @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-pipelines

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -374,7 +374,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
 
 def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     job_id = job["id"]
-    adapter = create_video_adapter()
+    adapter = create_video_adapter(job)
 
     def adapter_loaded_models() -> list[str]:
         return loaded_models_from_adapter(adapter, job_id=job_id)

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -320,7 +320,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         if not self._mock_inference_enabled(request) and not self._dependencies_available():
             raise RuntimeError(
                 "Native LTX-2.3 generation requires optional worker dependencies. "
-                "Install apps/worker/requirements-ltx.txt in this worker environment or use "
+                "Install apps/worker/requirements-ltx.txt in this worker environment, rebuild the worker image, or use "
                 "advanced.mockNativeInference for local adapter smoke tests."
             )
 
@@ -1156,14 +1156,20 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
                 raise RuntimeError("Replace Person requires at least one readable approved character reference image.")
 
 
-def create_video_adapter() -> VideoGenerationAdapter:
+def create_video_adapter(job: dict[str, Any] | None = None) -> VideoGenerationAdapter:
     requested = os.getenv("SCENEWORKS_VIDEO_ADAPTER", "").strip()
-    if not requested or requested == "diffusers_video":
+    if requested in {"ltx", "ltx_pipelines", "native_ltx"}:
+        return LtxPipelinesVideoAdapter()
+    if requested == "diffusers_video":
         return DiffusersVideoAdapter()
     if requested in {"procedural", "procedural_video"}:
         return ProceduralVideoAdapter()
-    if requested in {"ltx", "ltx_pipelines", "native_ltx"}:
-        return LtxPipelinesVideoAdapter()
+    if not requested:
+        model = str((job or {}).get("payload", {}).get("model", "ltx_2_3"))
+        target = model_target(model)
+        if target["adapter"] == "ltx_video":
+            return LtxPipelinesVideoAdapter()
+        return DiffusersVideoAdapter()
     raise RuntimeError(f"Unsupported SCENEWORKS_VIDEO_ADAPTER value: {requested}.")
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       args:
         PYTORCH_INDEX_URL: ${SCENEWORKS_PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu128}
         PYTORCH_SPEC: ${SCENEWORKS_PYTORCH_SPEC:-torch>=2.7,<2.8}
+        INCLUDE_LTX_PIPELINES: ${SCENEWORKS_INCLUDE_LTX_PIPELINES:-1}
     environment:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8000}
       SCENEWORKS_DATA_DIR: /sceneworks/data

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.12-slim AS builder
 
 ARG PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
 ARG PYTORCH_SPEC=torch>=2.7,<2.8
+ARG INCLUDE_LTX_PIPELINES=1
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -16,9 +17,11 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
 COPY apps/worker/requirements.txt ./requirements.txt
+COPY apps/worker/requirements-ltx.txt ./requirements-ltx.txt
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir --no-compile --index-url "${PYTORCH_INDEX_URL}" "${PYTORCH_SPEC}" \
     && pip install --no-cache-dir --no-compile -r requirements.txt \
+    && if [ "${INCLUDE_LTX_PIPELINES}" = "1" ]; then pip install --no-cache-dir --no-compile -r requirements-ltx.txt; fi \
     && find /opt/venv -type d -name "__pycache__" -prune -exec rm -rf {} + \
     && rm -rf /opt/venv/lib/python3.12/site-packages/torch/include \
         /opt/venv/lib/python3.12/site-packages/torch/test \

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -966,7 +966,7 @@ def test_video_job_reports_dynamic_loaded_models_on_progress_and_keepalive(monke
         blocking_models.append(loaded_models())
         return result
 
-    monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda: VideoAdapter())
+    monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda _job=None: VideoAdapter())
     monkeypatch.setattr("scene_worker.runtime.run_blocking_job_step", run_immediately)
 
     run_video_job(
@@ -1019,7 +1019,7 @@ def test_video_job_estimate_progress_accepts_non_preview_frame_requirements(monk
         def cleanup(self, _job_id):
             raise AssertionError("cleanup should not be called")
 
-    monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda: VideoAdapter())
+    monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda _job=None: VideoAdapter())
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
         lambda *_args, **_kwargs: _args[4](),
@@ -1043,11 +1043,19 @@ def test_explicit_seed_uses_reproducible_ladder():
 
 
 def test_video_adapter_override_aliases_and_unknown_values(monkeypatch):
+    monkeypatch.delenv("SCENEWORKS_VIDEO_ADAPTER", raising=False)
+    assert create_video_adapter({"payload": {"model": "ltx_2_3"}}).__class__.__name__ == "LtxPipelinesVideoAdapter"
+    assert create_video_adapter({"payload": {"model": "wan_2_2"}}).__class__.__name__ == "DiffusersVideoAdapter"
+    assert create_video_adapter().__class__.__name__ == "LtxPipelinesVideoAdapter"
+
     monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "procedural")
     assert create_video_adapter().__class__.__name__ == "ProceduralVideoAdapter"
 
     monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "ltx_pipelines")
     assert create_video_adapter().__class__.__name__ == "LtxPipelinesVideoAdapter"
+
+    monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "diffusers_video")
+    assert create_video_adapter().__class__.__name__ == "DiffusersVideoAdapter"
 
     monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "typo")
     try:


### PR DESCRIPTION
﻿## Summary
- Route video jobs by selected model when no explicit adapter override is set: LTX-2.3 uses the native LTX pipelines adapter, while Wan2.2 stays on the Diffusers adapter.
- Install native LTX worker dependencies by default in the Docker worker build.
- Update worker docs and tests for the model-aware routing behavior.

## Why
LTX-2.3 is the default/primary video model, but forcing the LTX adapter globally would break Wan2.2. Routing from the selected model preserves both paths without requiring users to manage adapter environment variables.

## Validation
- `python -m pytest tests/test_worker_runtime.py -q`
- `docker compose config --quiet`
