### PR TITLE
[codex] Use HF cache for model downloads and LTX resources

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2138,7 +2138,10 @@ async fn delete_model(
     let cleanup_source = removed_entry.as_ref().unwrap_or(&model);
     let mut removed_paths = Vec::new();
     let mut retained_paths = Vec::new();
-    let allowed_roots = vec![state.settings.data_dir.join("models")];
+    let allowed_roots = vec![
+        state.settings.data_dir.join("models"),
+        huggingface_hub_cache_dir(&state.settings.data_dir),
+    ];
     for path in model_artifact_paths(cleanup_source, &state.settings.data_dir) {
         remove_owned_artifact_path(
             path,
@@ -3643,13 +3646,27 @@ async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
             download_size_bytes.is_none() && fallback_size_bytes.is_some();
         let (downloadable, installed_path, installed) =
             if let Some(download_context) = download_context {
-                let installed_path = state
+                let managed_path = state
                     .settings
                     .data_dir
                     .join("models")
                     .join(safe_download_dir(&download_context.repo));
-                let installed = model_is_installed(&installed_path);
-                (true, Some(installed_path.display().to_string()), installed)
+                let cache_path =
+                    huggingface_repo_cache_path(&state.settings.data_dir, &download_context.repo);
+                let cache_installed = cache_path
+                    .as_ref()
+                    .is_some_and(|path| huggingface_repo_cache_exists(path));
+                let managed_installed = model_is_installed(&managed_path);
+                let installed_path = if cache_installed {
+                    cache_path
+                } else {
+                    Some(managed_path)
+                };
+                (
+                    true,
+                    installed_path.map(|path| path.display().to_string()),
+                    managed_installed || cache_installed,
+                )
             } else if let Some(installed_path) =
                 model_manifest_installed_path(model, &state.settings.data_dir)
             {
@@ -5624,6 +5641,47 @@ fn model_is_installed(path: &FsPath) -> bool {
     path.is_dir() && path.join(".sceneworks-download-complete.json").is_file()
 }
 
+fn huggingface_hub_cache_dir(data_dir: &FsPath) -> PathBuf {
+    if let Some(path) = std::env::var("HUGGINGFACE_HUB_CACHE")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path);
+    }
+    if let Some(path) = std::env::var("HF_HOME")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path).join("hub");
+    }
+    data_dir.join("cache").join("huggingface").join("hub")
+}
+
+fn huggingface_repo_cache_path(data_dir: &FsPath, repo: &str) -> Option<PathBuf> {
+    let safe_repo = repo
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+                character.to_string()
+            } else {
+                "--".to_owned()
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned();
+    if safe_repo.is_empty() {
+        return None;
+    }
+    Some(huggingface_hub_cache_dir(data_dir).join(format!("models--{safe_repo}")))
+}
+
+fn huggingface_repo_cache_exists(path: &FsPath) -> bool {
+    path.join("snapshots").is_dir() || path.join("blobs").is_dir()
+}
+
 fn lora_is_installed(path: &FsPath) -> bool {
     first_safetensors_path(path).is_some()
 }
@@ -5640,6 +5698,9 @@ fn model_artifact_paths(model: &Value, data_dir: &FsPath) -> Vec<PathBuf> {
             .map(str::to_owned)
     }) {
         paths.push(data_dir.join("models").join(safe_download_dir(&repo)));
+        if let Some(cache_path) = huggingface_repo_cache_path(data_dir, &repo) {
+            paths.push(cache_path);
+        }
     }
     if let Some(source_path) = model
         .get("source")
@@ -8261,6 +8322,70 @@ mod tests {
         assert_eq!(models[0]["downloadable"], false);
         assert_eq!(models[0]["installState"], "installed");
         assert_eq!(models[0]["installedPath"], model_dir.display().to_string());
+    }
+
+    #[tokio::test]
+    async fn downloadable_model_catalog_uses_huggingface_cache_install_state() {
+        std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let config_dir = temp_dir.path().join("config/manifests");
+        std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+        std::fs::write(
+            config_dir.join("builtin.models.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "base_model",
+                "name": "Base Model",
+                "type": "image",
+                "family": "z-image",
+                "downloads": [{ "provider": "huggingface", "repo": "owner/model" }]
+              }]
+            }
+            "#,
+        )
+        .expect("builtin models writes");
+        std::fs::write(
+            config_dir.join("user.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("user models writes");
+        std::fs::write(
+            config_dir.join("builtin.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("builtin loras writes");
+        std::fs::write(
+            config_dir.join("user.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("user loras writes");
+        std::fs::write(
+            config_dir.join("builtin.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("builtin presets writes");
+        std::fs::write(
+            config_dir.join("user.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("user presets writes");
+        let cache_dir = temp_dir
+            .path()
+            .join("data/cache/huggingface/hub/models--owner--model/snapshots/abc123");
+        std::fs::create_dir_all(&cache_dir).expect("hf cache creates");
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(models[0]["id"], "base_model");
+        assert_eq!(models[0]["downloadable"], true);
+        assert_eq!(models[0]["installState"], "installed");
+        assert!(models[0]["installedPath"]
+            .as_str()
+            .is_some_and(|value| value.contains("models--owner--model")));
     }
 
     #[tokio::test]

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -995,6 +995,41 @@ async fn run_model_download_job(
     )
     .await?;
 
+    if let Some(cache_path) =
+        download_model_with_hf_cli(api, settings, job, repo, revision, &files, &target_dir).await?
+    {
+        let mut result = JsonObject::new();
+        result.insert(
+            "modelId".to_owned(),
+            job.payload.get("modelId").cloned().unwrap_or(Value::Null),
+        );
+        result.insert("repo".to_owned(), Value::String(repo.to_owned()));
+        result.insert(
+            "path".to_owned(),
+            Value::String(cache_path.display().to_string()),
+        );
+        result.insert(
+            "storage".to_owned(),
+            Value::String("huggingface_cache".to_owned()),
+        );
+        result.insert("completedAt".to_owned(), Value::String(now_rfc3339()));
+        update_job(
+            api,
+            &job.id,
+            progress_payload(
+                JobStatus::Completed,
+                ProgressStage::Completed,
+                1.0,
+                "Model download completed in the Hugging Face cache.",
+                None,
+                Some(result),
+                None,
+            ),
+        )
+        .await?;
+        return Ok(());
+    }
+
     let snapshot =
         HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
     if let Some(total_bytes) = snapshot.total_bytes() {
@@ -1061,6 +1096,120 @@ async fn run_model_download_job(
     )
     .await?;
     Ok(())
+}
+
+async fn download_model_with_hf_cli(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    repo: &str,
+    revision: &str,
+    files: &[String],
+    marker_dir: &Path,
+) -> WorkerResult<Option<PathBuf>> {
+    let Some(program) = hf_cli_program().await else {
+        return Ok(None);
+    };
+    if settings.huggingface_base_url.trim_end_matches('/') != DEFAULT_HUGGINGFACE_BASE_URL {
+        return Ok(None);
+    }
+    let cache_dir = huggingface_hub_cache_dir(&settings.data_dir);
+    tokio::fs::create_dir_all(&cache_dir).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Downloading,
+            ProgressStage::Downloading,
+            0.12,
+            &format!("Downloading {repo} into the Hugging Face cache."),
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+
+    let mut command = Command::new(program);
+    command
+        .arg("download")
+        .arg(repo)
+        .arg("--repo-type")
+        .arg("model")
+        .arg("--revision")
+        .arg(revision)
+        .arg("--cache-dir")
+        .arg(&cache_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    if let Some(token) = &settings.huggingface_token {
+        command.env("HF_TOKEN", token);
+    }
+    for pattern in files {
+        command.arg("--include").arg(pattern);
+    }
+
+    let mut child = command.spawn().map_err(|error| {
+        WorkerError::InvalidPayload(format!(
+            "Failed to start Hugging Face CLI. Falling back to direct downloads is only possible when the CLI is absent, not when it fails to launch: {error}"
+        ))
+    })?;
+    let mut stderr = child.stderr.take();
+    let stderr_task = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        if let Some(stderr) = stderr.as_mut() {
+            let _ = stderr.read_to_end(&mut bytes).await;
+        }
+        bytes
+    });
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let status = loop {
+        tokio::select! {
+            status = child.wait() => break status?,
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                if let Err(error) = check_cancel(api, &job.id, "Model download canceled by user.").await {
+                    let _ = child.kill().await;
+                    return Err(error);
+                }
+            }
+        }
+    };
+    let stderr = stderr_task.await.unwrap_or_default();
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr);
+        let detail = bounded_tail(&stderr, 10, 2000);
+        let message = if detail.trim().is_empty() {
+            "Hugging Face CLI download failed without stderr output.".to_owned()
+        } else {
+            format!("Hugging Face CLI download failed:\n{detail}")
+        };
+        return Err(WorkerError::InvalidPayload(message));
+    }
+
+    let cache_path = huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Unable to resolve Hugging Face cache path for {repo}."
+        ))
+    })?;
+    write_model_install_marker(marker_dir, &job.payload, repo, &job.id).await?;
+    Ok(Some(cache_path))
+}
+
+async fn hf_cli_program() -> Option<&'static str> {
+    for program in ["hf", "huggingface-cli"] {
+        let status = Command::new(program)
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+        if status.is_ok_and(|status| status.success()) {
+            return Some(program);
+        }
+    }
+    None
 }
 
 /// Locates the first `.safetensors` under `dir`, reads its header, and
@@ -3084,6 +3233,44 @@ pub fn safe_download_dir(value: &str) -> String {
     }
 }
 
+fn huggingface_hub_cache_dir(data_dir: &Path) -> PathBuf {
+    if let Some(path) = std::env::var("HUGGINGFACE_HUB_CACHE")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path);
+    }
+    if let Some(path) = std::env::var("HF_HOME")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path).join("hub");
+    }
+    data_dir.join("cache").join("huggingface").join("hub")
+}
+
+fn huggingface_repo_cache_path(data_dir: &Path, repo: &str) -> Option<PathBuf> {
+    let cache_dir = huggingface_hub_cache_dir(data_dir);
+    let safe_repo = repo
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+                character.to_string()
+            } else {
+                "--".to_owned()
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned();
+    if safe_repo.is_empty() {
+        return None;
+    }
+    Some(cache_dir.join(format!("models--{safe_repo}")))
+}
+
 async fn directory_size(path: &Path) -> u64 {
     let mut total = 0_u64;
     let mut stack = vec![path.to_path_buf()];
@@ -4342,6 +4529,18 @@ mod tests {
         ));
         assert_eq!(safe_download_dir("owner/model name"), "owner__model__name");
         assert_eq!(safe_download_dir("///"), "download");
+    }
+
+    #[test]
+    fn huggingface_cache_paths_follow_hub_layout() {
+        let root = tempdir().expect("temp dir creates");
+        let path = super::huggingface_repo_cache_path(root.path(), "owner/model-name")
+            .expect("cache path resolves");
+
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("models--owner--model-name")
+        );
     }
 
     #[test]

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -30,8 +30,10 @@ Native LTX-2.3 text-to-video and image-to-video require these local resources:
 - `distilledLoraPath`
 - `gemmaRoot`
 
-By default the worker resolves those from the model manifest `resources` block
-under `data/models`. A job can override them through matching advanced settings.
+By default the worker resolves those from the model manifest `resources` block,
+preferring SceneWorks-managed imports under `data/models` and then the shared
+Hugging Face cache (`HUGGINGFACE_HUB_CACHE` or `HF_HOME/hub`). A job can
+override them through matching advanced settings.
 Use `advanced.mockNativeInference=true` only for adapter smoke tests; otherwise
 the native adapter loads `ltx-pipelines` and writes MP4 video assets.
 

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -27,7 +27,13 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import filter_call_kwargs
-from .image_adapters import require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
+from .image_adapters import (
+    huggingface_repo_cache_path,
+    require_inference_backend_for_gpu_worker,
+    select_torch_device,
+    select_torch_dtype,
+    write_json,
+)
 from .lora_adapters import LoraPipelineState, apply_loras_to_pipeline, reject_loras_if_unsupported
 from .settings import WorkerSettings
 
@@ -307,13 +313,16 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
         reject_loras_if_unsupported(request.loras, self.id)
         resources = self.resolve_resources(request)
-        missing = self._missing_resources(resources)
+        missing = self._missing_resources(request, resources)
         if missing:
             details = "\n".join(f"- {label}: {path}" for label, path in missing)
+            override_keys = ["checkpointPath", "spatialUpscalerPath", "gemmaRoot"]
+            if self._pipeline_module(request) != "ltx_pipelines.distilled":
+                override_keys.insert(2, "distilledLoraPath")
             raise RuntimeError(
                 "Native LTX-2.3 requires local model resources before generation. "
                 "Install the LTX-2.3 model resources in Model Manager or set advanced overrides "
-                "for checkpointPath, spatialUpscalerPath, distilledLoraPath, and gemmaRoot.\n"
+                f"for {', '.join(override_keys)}.\n"
                 f"Missing resources:\n{details}"
             )
         self._resources_by_model[request.model] = resources
@@ -663,12 +672,13 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         settings = self._settings or WorkerSettings()
         entry = ltx_model_manifest_entry(settings, request.model)
         resources = entry.get("resources", {}) if isinstance(entry.get("resources"), dict) else {}
+        checkpoint_resource_key = "distilledCheckpoint" if self._pipeline_module(request) == "ltx_pipelines.distilled" else "checkpoint"
         return LtxPipelinesResources(
             checkpoint_path=self._resource_path(
                 settings,
                 request,
                 resources,
-                "checkpoint",
+                checkpoint_resource_key,
                 "checkpointPath",
             ),
             spatial_upsampler_path=self._resource_path(
@@ -716,6 +726,8 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         if override:
             return resolve_worker_path(settings, override)
         resource = resources.get(resource_key) if isinstance(resources.get(resource_key), dict) else {}
+        if not resource and resource_key == "distilledCheckpoint":
+            resource = resources.get("checkpoint") if isinstance(resources.get("checkpoint"), dict) else {}
         configured_path = resource.get("path")
         if configured_path:
             return resolve_manifest_path(settings, configured_path)
@@ -723,7 +735,18 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         root = settings.data_dir / "models" / safe_download_dir(repo)
         file_name = resource.get("file")
         if expect_file and file_name:
-            return root / str(file_name)
+            local_path = root / str(file_name)
+            if local_path.is_file():
+                return local_path
+            cached_path = huggingface_cached_resource_file(repo, str(file_name))
+            if cached_path is not None:
+                return cached_path
+            return local_path
+        if not expect_file and root.is_dir():
+            return root
+        cached_root = huggingface_cached_snapshot_dir(repo)
+        if cached_root is not None:
+            return cached_root
         return root
 
     def _optional_resource_path(
@@ -742,13 +765,14 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             return None
         return self._resource_path(settings, request, resources, resource_key, advanced_key)
 
-    def _missing_resources(self, resources: LtxPipelinesResources) -> list[tuple[str, Path]]:
+    def _missing_resources(self, request: VideoRequest, resources: LtxPipelinesResources) -> list[tuple[str, Path]]:
         required = [
             ("checkpointPath", resources.checkpoint_path, "file"),
             ("spatialUpscalerPath", resources.spatial_upsampler_path, "file"),
-            ("distilledLoraPath", resources.distilled_lora_path, "file"),
             ("gemmaRoot", resources.gemma_root, "dir"),
         ]
+        if self._pipeline_module(request) != "ltx_pipelines.distilled":
+            required.insert(2, ("distilledLoraPath", resources.distilled_lora_path, "file"))
         missing = [
             (label, path)
             for label, path, kind in required
@@ -1317,8 +1341,51 @@ def resolve_manifest_path(settings: WorkerSettings, value: Any) -> Path:
     raw_path = str(value).strip()
     if "${DATA_DIR}" in raw_path:
         raw_path = raw_path.replace("${DATA_DIR}", str(settings.data_dir))
+    if "${HF_CACHE}" in raw_path:
+        raw_path = raw_path.replace("${HF_CACHE}", str(huggingface_cache_root()))
     path = Path(raw_path)
     return path if path.is_absolute() else settings.data_dir / path
+
+
+def huggingface_cache_root() -> Path:
+    default_home = Path.home() / ".cache" / "huggingface"
+    hf_home = Path(os.getenv("HF_HOME") or default_home)
+    return Path(os.getenv("HUGGINGFACE_HUB_CACHE") or hf_home / "hub")
+
+
+def huggingface_cached_snapshot_dir(repo: str) -> Path | None:
+    repo_cache = huggingface_repo_cache_path(repo)
+    if repo_cache is None:
+        return None
+    snapshots_dir = repo_cache / "snapshots"
+    if not snapshots_dir.is_dir():
+        return None
+    try:
+        snapshots = [path for path in snapshots_dir.iterdir() if path.is_dir()]
+    except OSError:
+        return None
+    snapshots.sort(key=lambda path: path.stat().st_mtime if path.exists() else 0, reverse=True)
+    return snapshots[0] if snapshots else None
+
+
+def huggingface_cached_resource_file(repo: str, file_name: str) -> Path | None:
+    relative = Path(file_name)
+    if relative.is_absolute() or any(part in ("", ".", "..") for part in relative.parts):
+        return None
+    repo_cache = huggingface_repo_cache_path(repo)
+    snapshots_dir = repo_cache / "snapshots" if repo_cache is not None else None
+    if snapshots_dir is None or not snapshots_dir.is_dir():
+        return None
+    try:
+        snapshots = [path for path in snapshots_dir.iterdir() if path.is_dir()]
+    except OSError:
+        return None
+    snapshots.sort(key=lambda path: path.stat().st_mtime if path.exists() else 0, reverse=True)
+    for snapshot in snapshots:
+        candidate = snapshot / relative
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def safe_download_dir(repo: str) -> str:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -166,7 +166,12 @@
         {
           "provider": "huggingface",
           "repo": "Lightricks/LTX-2.3",
-          "files": [],
+          "files": [
+            "ltx-2.3-22b-dev.safetensors",
+            "ltx-2.3-22b-distilled-1.1.safetensors",
+            "ltx-2.3-spatial-upscaler-x2-1.1.safetensors",
+            "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
+          ],
           "default": true,
           "estimatedSizeBytes": 157004895813
         },
@@ -183,6 +188,10 @@
       },
       "resources": {
         "checkpoint": {
+          "repo": "Lightricks/LTX-2.3",
+          "file": "ltx-2.3-22b-dev.safetensors"
+        },
+        "distilledCheckpoint": {
           "repo": "Lightricks/LTX-2.3",
           "file": "ltx-2.3-22b-distilled-1.1.safetensors"
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       SCENEWORKS_CORS_ORIGINS: ${SCENEWORKS_CORS_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174,http://localhost:5175,http://127.0.0.1:5175,http://localhost:5176,http://127.0.0.1:5176}
       SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE: ${SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE:-1}
+      HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
+      HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
     ports:
       - "${SCENEWORKS_API_PORT:-8000}:${SCENEWORKS_API_PORT:-8000}"
     volumes:
@@ -70,6 +72,8 @@ services:
       SCENEWORKS_GPU_ID: ${SCENEWORKS_RUST_WORKER_GPU_ID:-cpu}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       HF_TOKEN: ${HF_TOKEN:-}
+      HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
+      HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data

--- a/docker/rust-worker.Dockerfile
+++ b/docker/rust-worker.Dockerfile
@@ -12,8 +12,14 @@ RUN cargo build -p sceneworks-rust-worker --release
 FROM debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
+    && apt-get install -y --no-install-recommends ca-certificates ffmpeg python3 python3-venv \
     && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/hf-cli \
+    && /opt/hf-cli/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/hf-cli/bin/pip install --no-cache-dir "huggingface_hub[cli]>=0.36,<1"
+
+ENV PATH="/opt/hf-cli/bin:${PATH}"
 
 COPY --from=builder /app/target/release/sceneworks-rust-worker /usr/local/bin/sceneworks-rust-worker
 

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1832,6 +1832,7 @@
       "installedPath": "<runtime-root>/data/loras/style.safetensors",
       "manifestPath": "<runtime-root>/config/manifests/builtin.loras.jsonc",
       "name": "Style LoRA",
+      "removable": false,
       "scope": "builtin",
       "source": {
         "path": "loras/style.safetensors",
@@ -1913,6 +1914,7 @@
       "capabilities": [
         "text_to_image"
       ],
+      "catalogScope": "user",
       "defaults": {
         "height": 1024,
         "width": 1024
@@ -1952,6 +1954,7 @@
       },
       "name": "User Model",
       "paths": {},
+      "removable": true,
       "type": "image",
       "ui": {
         "label": "User"
@@ -1964,6 +1967,7 @@
         "edit_image",
         "character_image"
       ],
+      "catalogScope": "builtin",
       "defaults": {
         "height": 1024,
         "width": 1024
@@ -1985,6 +1989,7 @@
       },
       "name": "Z-Image Turbo",
       "paths": {},
+      "removable": false,
       "type": "image",
       "ui": {
         "label": "Z-Image"

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1179,6 +1179,17 @@ def write_native_ltx_resource_files(tmp_path):
     return checkpoint, spatial, lora, gemma
 
 
+def write_huggingface_cache_resource(cache_root, repo, file_name=None):
+    safe_repo = "".join(char if char.isalnum() or char in "._-" else "--" for char in repo).strip("-")
+    snapshot = cache_root / f"models--{safe_repo}" / "snapshots" / "abc123"
+    snapshot.mkdir(parents=True, exist_ok=True)
+    if file_name is not None:
+        path = snapshot / file_name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(file_name.encode("utf-8"))
+    return snapshot
+
+
 def test_native_ltx_adapter_reports_mocked_pipeline_requirements(tmp_path):
     data_dir = tmp_path / "data"
     config_dir = tmp_path / "config"
@@ -1244,6 +1255,70 @@ def test_native_ltx_missing_resources_reports_all_paths(tmp_path):
     assert "gemmaRoot" in message
     assert str(data_dir / "models" / safe_download_dir("Lightricks/LTX-2.3") / "checkpoint.safetensors") in message
     assert str(data_dir / "models" / safe_download_dir("google/gemma-3-4b-it")) in message
+
+
+def test_native_ltx_resources_resolve_from_huggingface_cache(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    cache_root = tmp_path / "hf" / "hub"
+    data_dir.mkdir()
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(cache_root))
+    write_native_ltx_manifest(config_dir)
+    write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "checkpoint.safetensors")
+    write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "spatial.safetensors")
+    write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "distilled-lora.safetensors")
+    gemma_snapshot = write_huggingface_cache_resource(cache_root, "google/gemma-3-4b-it", "config.json")
+    adapter = LtxPipelinesVideoAdapter()
+    request = adapter.prepare(
+        settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
+        job={
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "advanced": {"mockNativeInference": True},
+            },
+        },
+    )
+
+    adapter.ensure_models(request)
+    resources = adapter.estimate_requirements(request)["resources"]
+
+    assert resources["checkpointPath"].endswith("checkpoint.safetensors")
+    assert str(cache_root) in resources["checkpointPath"]
+    assert resources["spatialUpscalerPath"].endswith("spatial.safetensors")
+    assert resources["distilledLoraPath"].endswith("distilled-lora.safetensors")
+    assert resources["gemmaRoot"] == str(gemma_snapshot)
+
+
+def test_native_ltx_fast_pipeline_does_not_require_distilled_lora(tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    data_dir.mkdir()
+    checkpoint, spatial, _lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, gemma=gemma)
+    adapter = LtxPipelinesVideoAdapter()
+    request = adapter.prepare(
+        settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
+        job={
+            "id": "job-1",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "city",
+                "model": "ltx_2_3",
+                "quality": "fast",
+                "advanced": {"mockNativeInference": True},
+            },
+        },
+    )
+
+    adapter.ensure_models(request)
+    requirements = adapter.estimate_requirements(request)
+
+    assert requirements["pipeline"] == "ltx_pipelines.distilled"
 
 
 def test_native_ltx_advanced_resource_overrides_win(tmp_path):


### PR DESCRIPTION
## Summary
- Make the shared Hugging Face cache the canonical storage path for Hugging Face-backed catalog models.
- Teach Model Manager downloads to use `hf download` into `HUGGINGFACE_HUB_CACHE` when the CLI is available, with the old direct downloader kept as a fallback for bare environments.
- Share `HF_HOME` / `HUGGINGFACE_HUB_CACHE` across API, Rust utility worker, and Python inference worker in Docker Compose.
- Resolve native LTX-2.3 resources from managed imports first, then the HF cache, and split dev vs distilled checkpoint resources by pipeline.
- Keep `data/models` for manual imports and small SceneWorks install metadata instead of duplicating multi-GB HF repos.

## Root Cause
SceneWorks had two model stores pretending to be one: Model Manager downloaded Hugging Face repos into `/data/models`, while Diffusers loaded repo IDs through the Hugging Face hub cache. That could duplicate huge downloads and also left native LTX looking in the wrong place when the real files were already cached.

## Validation
- `python -m pytest tests/test_worker_runtime.py -q`
- `cargo test -p sceneworks-rust-worker --lib`
- `cargo test -p sceneworks-rust-api --lib`
- `python -m compileall apps/worker/scene_worker/video_adapters.py`
- `docker compose config --quiet`
- `git diff --check`