### PR TITLE
[codex] Pin worker torchaudio CUDA runtime

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -12,8 +12,9 @@ Runtime dependencies live in `requirements.txt`. Test-only dependencies live in
 `requirements-dev.txt` and are intentionally excluded from the Docker image.
 The Dockerfile defaults to CPU-only PyTorch for direct image builds, while
 `docker-compose.yml` passes CUDA PyTorch build args for the inference worker.
-Override `PYTORCH_INDEX_URL` / `PYTORCH_SPEC` for direct `docker build`, or
-`SCENEWORKS_PYTORCH_INDEX_URL` / `SCENEWORKS_PYTORCH_SPEC` for Compose builds.
+Override `PYTORCH_INDEX_URL` / `PYTORCH_SPEC` / `PYTORCH_AUDIO_SPEC` for direct
+`docker build`, or `SCENEWORKS_PYTORCH_INDEX_URL` / `SCENEWORKS_PYTORCH_SPEC` /
+`SCENEWORKS_PYTORCH_AUDIO_SPEC` for Compose builds.
 GPU workers with CPU-only PyTorch intentionally register without generation
 capabilities so jobs stay queued instead of crawling on CPU with an idle GPU.
 

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -7,10 +7,12 @@ import importlib
 import importlib.util
 import json
 import os
+import sys
+import types
 import warnings
 from pathlib import Path
 from textwrap import wrap
-from typing import Any, Callable
+from typing import Any, Callable, Generic, TypeVar
 from uuid import uuid4
 
 from PIL import Image, ImageDraw, ImageEnhance, ImageFont, UnidentifiedImageError
@@ -37,6 +39,7 @@ warnings.simplefilter("error", Image.DecompressionBombWarning)
 
 ProgressCallback = Callable[[str, str, float, str], None]
 CancelCallback = Callable[[], bool]
+_DelegatingBuilderT = TypeVar("_DelegatingBuilderT")
 
 
 VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
@@ -98,6 +101,25 @@ class LtxPipelinesResources:
     distilled_lora_path: Path
     gemma_root: Path
     temporal_upsampler_path: Path | None = None
+
+
+def install_ltx_pipelines_multigpu_compat() -> None:
+    if "ltx_pipelines.multigpu.delegating_builder" in sys.modules:
+        return
+
+    class DelegatingBuilder(Generic[_DelegatingBuilderT]):
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError(
+                "The installed ltx-pipelines package references an optional multigpu DelegatingBuilder "
+                "that is not shipped by the package."
+            )
+
+    multigpu_module = types.ModuleType("ltx_pipelines.multigpu")
+    multigpu_module.__path__ = []
+    delegating_builder_module = types.ModuleType("ltx_pipelines.multigpu.delegating_builder")
+    delegating_builder_module.DelegatingBuilder = DelegatingBuilder
+    sys.modules.setdefault("ltx_pipelines.multigpu", multigpu_module)
+    sys.modules.setdefault("ltx_pipelines.multigpu.delegating_builder", delegating_builder_module)
 
 
 class VideoGenerationAdapter(ABC):
@@ -514,6 +536,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
             raise RuntimeError("Image to Video requires a readable source image.") from exc
 
+        install_ltx_pipelines_multigpu_compat()
         args_module = importlib.import_module("ltx_pipelines.utils.args")
         condition_class = getattr(args_module, "ImageConditioningInput")
         return [
@@ -529,6 +552,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         if self._pipeline is not None and self._pipeline_key_value == key:
             return self._pipeline
 
+        install_ltx_pipelines_multigpu_compat()
         loader = importlib.import_module("ltx_core.loader")
         offload_mode = self._offload_mode(request)
         common_kwargs = {
@@ -571,6 +595,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         num_frames: int,
         conditioning_images: list[Any],
     ) -> tuple[Any, Any, int, Any]:
+        install_ltx_pipelines_multigpu_compat()
         video_vae = importlib.import_module("ltx_core.model.video_vae")
         media_io = importlib.import_module("ltx_pipelines.utils.media_io")
         tiling_config = video_vae.TilingConfig.default()
@@ -640,6 +665,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
 
     def _offload_mode(self, request: VideoRequest) -> Any:
         offload_value = str(request.advanced.get("offloadMode", "none")).strip().lower()
+        install_ltx_pipelines_multigpu_compat()
         types_module = importlib.import_module("ltx_pipelines.utils.types")
         offload_mode = getattr(types_module, "OffloadMode")
         if offload_value == "cpu":
@@ -831,10 +857,11 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
 
     def _dependencies_available(self) -> bool:
         try:
-            return (
-                importlib.util.find_spec("ltx_core") is not None
-                and importlib.util.find_spec("ltx_pipelines") is not None
-            )
+            if importlib.util.find_spec("ltx_core") is None or importlib.util.find_spec("ltx_pipelines") is None:
+                return False
+            install_ltx_pipelines_multigpu_compat()
+            importlib.import_module("ltx_pipelines.distilled")
+            return True
         except (ImportError, ValueError):
             return False
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       args:
         PYTORCH_INDEX_URL: ${SCENEWORKS_PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu128}
         PYTORCH_SPEC: ${SCENEWORKS_PYTORCH_SPEC:-torch>=2.7,<2.8}
+        PYTORCH_AUDIO_SPEC: ${SCENEWORKS_PYTORCH_AUDIO_SPEC:-torchaudio>=2.7,<2.8}
         INCLUDE_LTX_PIPELINES: ${SCENEWORKS_INCLUDE_LTX_PIPELINES:-1}
     environment:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8000}

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.12-slim AS builder
 
 ARG PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
 ARG PYTORCH_SPEC=torch>=2.7,<2.8
+ARG PYTORCH_AUDIO_SPEC=torchaudio>=2.7,<2.8
 ARG INCLUDE_LTX_PIPELINES=1
 
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -19,8 +20,8 @@ ENV PATH="/opt/venv/bin:${PATH}"
 COPY apps/worker/requirements.txt ./requirements.txt
 COPY apps/worker/requirements-ltx.txt ./requirements-ltx.txt
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --no-compile --index-url "${PYTORCH_INDEX_URL}" "${PYTORCH_SPEC}" \
-    && pip freeze | grep -E '^(torch|nvidia-|triton)==.*' > /tmp/torch-constraints.txt \
+    && pip install --no-cache-dir --no-compile --index-url "${PYTORCH_INDEX_URL}" "${PYTORCH_SPEC}" "${PYTORCH_AUDIO_SPEC}" \
+    && pip freeze | grep -E '^(torch|torchaudio|torchvision|nvidia-|triton)==.*' > /tmp/torch-constraints.txt \
     && pip install --no-cache-dir --no-compile -c /tmp/torch-constraints.txt -r requirements.txt \
     && if [ "${INCLUDE_LTX_PIPELINES}" = "1" ]; then pip install --no-cache-dir --no-compile -c /tmp/torch-constraints.txt -r requirements-ltx.txt; fi \
     && find /opt/venv -type d -name "__pycache__" -prune -exec rm -rf {} + \

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib
 import json
+import sys
 from pathlib import Path
 from typing import NamedTuple
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 from PIL import Image
 import pytest
@@ -57,6 +59,7 @@ from scene_worker.video_adapters import (
     create_video_adapter,
     evenly_spaced_indices,
     frames_from_output,
+    install_ltx_pipelines_multigpu_compat,
     ltx_model_manifest_entry,
     ltx_frame_count,
     load_seekable_image_frame,
@@ -1121,6 +1124,24 @@ def test_ltx_video_requirements_report_normalized_frame_count():
     assert requirements["requestedFrames"] == 150
     assert requirements["estimatedFrames"] == 153
     assert requirements["repo"] == "Lightricks/LTX-2.3"
+
+
+def test_ltx_pipelines_multigpu_compat_installs_missing_type_module(monkeypatch):
+    for module_name in (
+        "ltx_pipelines",
+        "ltx_pipelines.multigpu",
+        "ltx_pipelines.multigpu.delegating_builder",
+    ):
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+    parent = ModuleType("ltx_pipelines")
+    parent.__path__ = []
+    monkeypatch.setitem(sys.modules, "ltx_pipelines", parent)
+
+    install_ltx_pipelines_multigpu_compat()
+
+    module = importlib.import_module("ltx_pipelines.multigpu.delegating_builder")
+    with pytest.raises(RuntimeError, match="optional multigpu DelegatingBuilder"):
+        module.DelegatingBuilder()
 
 
 def write_native_ltx_manifest(config_dir, *, checkpoint=None, spatial=None, lora=None, gemma=None):


### PR DESCRIPTION
## Summary
- Install `torchaudio` from the same PyTorch CUDA index as `torch` during the worker image build.
- Include `torchaudio`/`torchvision` in the frozen Torch runtime constraints before installing worker and LTX dependencies.
- Document the new `PYTORCH_AUDIO_SPEC` / `SCENEWORKS_PYTORCH_AUDIO_SPEC` override.

## Root Cause
`ltx-core` depends on `torchaudio`, but the worker image only preselected `torch`. During the later LTX dependency install, pip pulled `torchaudio 2.11.0`, whose native libraries are linked against CUDA 13 (`libcudart.so.13`), while the worker's selected Torch runtime is CUDA 12.8 and provides `libcudart.so.12`.

## Validation
- `docker compose config --quiet`
- `python -m pytest tests/test_worker_runtime.py -q`
- `git diff --check`