### PR TITLE
[codex] Fix LTX Gemma text encoder resource

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -204,7 +204,7 @@
           "file": "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
         },
         "gemma": {
-          "repo": "google/gemma-3-4b-it"
+          "repo": "google/gemma-3-12b-it-qat-q4_0-unquantized"
         }
       },
       "defaults": {

--- a/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
+++ b/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
@@ -88,7 +88,7 @@ SceneWorks must manage these as model resources, not hidden one-off paths:
 - Distilled LoRA for two-stage pipelines:
   - `ltx-2.3-22b-distilled-lora-384-1.1.safetensors`
 - Gemma text encoder assets:
-  - full local Gemma repo or local text encoder path required by `ltx-pipelines`.
+  - full local Gemma 3-12B repo or local text encoder path required by `ltx-pipelines`.
 
 The adapter should not hardcode absolute user paths. Add advanced settings and manifest fields for:
 
@@ -122,13 +122,13 @@ Recommended shape:
       "file": "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
     },
     "gemma": {
-      "repo": "google/gemma-3-4b-it"
+      "repo": "google/gemma-3-12b-it-qat-q4_0-unquantized"
     }
   }
 }
 ```
 
-Exact Gemma repo and file requirements must be validated against the installed `ltx-pipelines` version before implementation is marked complete.
+The official `ltx-pipelines` stack expects the Gemma 3-12B text encoder family; using Gemma 3-4B causes tensor shape mismatches during text encoder load.
 
 ## Worker Dependency Plan
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1151,7 +1151,7 @@ def write_native_ltx_manifest(config_dir, *, checkpoint=None, spatial=None, lora
         "checkpoint": {"repo": "Lightricks/LTX-2.3", "file": "checkpoint.safetensors"},
         "spatialUpscaler": {"repo": "Lightricks/LTX-2.3", "file": "spatial.safetensors"},
         "distilledLora": {"repo": "Lightricks/LTX-2.3", "file": "distilled-lora.safetensors"},
-        "gemma": {"repo": "google/gemma-3-4b-it"},
+        "gemma": {"repo": "google/gemma-3-12b-it-qat-q4_0-unquantized"},
     }
     if checkpoint is not None:
         resources["checkpoint"] = {"path": str(checkpoint)}
@@ -1278,7 +1278,7 @@ def test_native_ltx_missing_resources_reports_all_paths(monkeypatch, tmp_path):
     assert "distilledLoraPath" in message
     assert "gemmaRoot" in message
     assert str(data_dir / "models" / safe_download_dir("Lightricks/LTX-2.3") / "checkpoint.safetensors") in message
-    assert str(data_dir / "models" / safe_download_dir("google/gemma-3-4b-it")) in message
+    assert str(data_dir / "models" / safe_download_dir("google/gemma-3-12b-it-qat-q4_0-unquantized")) in message
 
 
 def test_native_ltx_resources_resolve_from_huggingface_cache(monkeypatch, tmp_path):
@@ -1291,7 +1291,7 @@ def test_native_ltx_resources_resolve_from_huggingface_cache(monkeypatch, tmp_pa
     write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "checkpoint.safetensors")
     write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "spatial.safetensors")
     write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "distilled-lora.safetensors")
-    gemma_snapshot = write_huggingface_cache_resource(cache_root, "google/gemma-3-4b-it", "config.json")
+    gemma_snapshot = write_huggingface_cache_resource(cache_root, "google/gemma-3-12b-it-qat-q4_0-unquantized", "config.json")
     adapter = LtxPipelinesVideoAdapter()
     request = adapter.prepare(
         settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
@@ -1329,7 +1329,7 @@ def test_native_ltx_resources_resolve_from_mounted_data_cache_without_hf_env(mon
     write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "checkpoint.safetensors")
     write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "spatial.safetensors")
     write_huggingface_cache_resource(cache_root, "Lightricks/LTX-2.3", "distilled-lora.safetensors")
-    gemma_snapshot = write_huggingface_cache_resource(cache_root, "google/gemma-3-4b-it", "config.json")
+    gemma_snapshot = write_huggingface_cache_resource(cache_root, "google/gemma-3-12b-it-qat-q4_0-unquantized", "config.json")
     adapter = LtxPipelinesVideoAdapter()
     request = adapter.prepare(
         settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),


### PR DESCRIPTION
## Summary

- Point the built-in LTX-2.3 Gemma resource at `google/gemma-3-12b-it-qat-q4_0-unquantized`.
- Update native LTX resource tests to expect the Gemma 3-12B repo.
- Document that using Gemma 3-4B causes text encoder tensor shape mismatches.

## Root Cause

The native LTX pipeline constructs a Gemma 3-12B text encoder with 3840-wide hidden states, but the manifest previously resolved Gemma 3-4B weights with 2560-wide tensors. That caused state dict size mismatches while loading `GemmaTextEncoder`.

## Validation

- `python -m pytest tests/test_worker_runtime.py`