### PR TITLE
[codex] Route LTX conditioning through IC-LoRA

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3922,12 +3922,12 @@ fn normalize_lora_entry(
         }
     });
     let lora_snapshot = Value::Object(object.clone());
-    let huggingface_path = lora_huggingface_cached_file(&lora_snapshot, data_dir);
-    let installed_path = match (local_path.as_ref(), huggingface_path.as_ref()) {
-        (Some(path), _) if lora_is_installed(path) => Some(path.clone()),
-        (_, Some(path)) if lora_is_installed(path) => Some(path.clone()),
-        (Some(path), _) => Some(path.clone()),
-        _ => None,
+    let installed_path = match local_path.as_ref() {
+        Some(path) if lora_is_installed(path) => Some(path.clone()),
+        _ => match lora_huggingface_cached_file(&lora_snapshot, data_dir) {
+            Some(path) if lora_is_installed(&path) => Some(path),
+            _ => local_path.clone(),
+        },
     };
     let install_state = match installed_path.as_ref() {
         Some(path) if lora_is_installed(path) => "installed",
@@ -4972,6 +4972,8 @@ fn serialize_preset_lora(lora: &Value, preset_lora: &Value, lora_id: &str) -> Va
         "modelFamilies": lora.get("modelFamilies").cloned().unwrap_or(Value::Null),
         "triggerWords": lora.get("triggerWords").cloned().unwrap_or_else(|| Value::Array(Vec::new())),
         "compatibility": lora.get("compatibility").cloned().unwrap_or_else(|| Value::Object(JsonObject::new())),
+        "icLora": lora.get("icLora").cloned().unwrap_or(Value::Bool(false)),
+        "conditioningRole": lora.get("conditioningRole").cloned().unwrap_or(Value::Null),
         "installedPath": lora.get("installedPath").cloned().unwrap_or(Value::Null),
         "source": lora.get("source").cloned().unwrap_or(Value::Null),
         "presetManaged": true
@@ -4990,6 +4992,8 @@ fn serialize_job_lora(lora: &Value, selected_lora: &Value, lora_id: &str) -> Val
         "modelFamilies": preferred_lora_value(selected_lora, lora, "modelFamilies"),
         "triggerWords": preferred_lora_array(selected_lora, lora, "triggerWords"),
         "compatibility": preferred_lora_object(selected_lora, lora, "compatibility"),
+        "icLora": preferred_lora_value(selected_lora, lora, "icLora"),
+        "conditioningRole": preferred_lora_value(selected_lora, lora, "conditioningRole"),
         "installedPath": preferred_lora_value(selected_lora, lora, "installedPath"),
         "sourcePath": preferred_lora_value(selected_lora, lora, "sourcePath"),
         "source": preferred_lora_value(selected_lora, lora, "source"),
@@ -5748,13 +5752,22 @@ fn model_artifact_paths(model: &Value, data_dir: &FsPath) -> Vec<PathBuf> {
 
 fn lora_artifact_paths(lora: &Value, default_root: &FsPath) -> Vec<PathBuf> {
     let mut paths = Vec::new();
-    if let Some(installed_path) = lora
-        .get("installedPath")
+    let is_huggingface_source = lora
+        .get("source")
+        .and_then(Value::as_object)
+        .and_then(|source| source.get("provider"))
+        .or_else(|| lora.get("provider"))
         .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && !value.contains("${"))
-    {
-        paths.push(PathBuf::from(installed_path));
+        == Some("huggingface");
+    if !is_huggingface_source {
+        if let Some(installed_path) = lora
+            .get("installedPath")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty() && !value.contains("${"))
+        {
+            paths.push(PathBuf::from(installed_path));
+        }
     }
     if let Some(source_path) = lora
         .get("source")
@@ -5771,9 +5784,6 @@ fn lora_artifact_paths(lora: &Value, default_root: &FsPath) -> Vec<PathBuf> {
         } else {
             default_root.join(path)
         });
-    }
-    if let Some(path) = lora_huggingface_cached_file(lora, default_root) {
-        paths.push(path);
     }
     unique_paths(paths)
 }
@@ -5810,23 +5820,50 @@ fn lora_huggingface_cached_file(lora: &Value, data_dir: &FsPath) -> Option<PathB
                 .and_then(Value::as_str)
         });
     if let Some(file_name) = file_name {
-        let snapshots = repo_root.join("snapshots");
-        if let Ok(entries) = std::fs::read_dir(&snapshots) {
-            let mut snapshots = entries
-                .flatten()
-                .map(|entry| entry.path())
-                .filter(|path| path.is_dir())
-                .collect::<Vec<_>>();
-            snapshots.sort();
-            for snapshot in snapshots {
-                let candidate = snapshot.join(file_name);
-                if candidate.is_file() {
-                    return Some(candidate);
-                }
+        for snapshot in huggingface_snapshot_dirs(&repo_root) {
+            let candidate = snapshot.join(file_name);
+            if candidate.is_file() {
+                return Some(candidate);
             }
         }
     }
-    first_safetensors_path(&repo_root)
+    huggingface_main_snapshot_dir(&repo_root)
+        .and_then(|snapshot| first_safetensors_path(&snapshot))
+        .or_else(|| first_safetensors_path(&repo_root))
+}
+
+fn huggingface_snapshot_dirs(repo_root: &FsPath) -> Vec<PathBuf> {
+    let snapshots = repo_root.join("snapshots");
+    let mut snapshot_dirs = std::fs::read_dir(&snapshots)
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| path.is_dir())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    snapshot_dirs.sort();
+    if let Some(main_snapshot) = huggingface_main_snapshot_dir(repo_root) {
+        let mut ordered = vec![main_snapshot.clone()];
+        ordered.extend(
+            snapshot_dirs
+                .into_iter()
+                .filter(|path| path != &main_snapshot),
+        );
+        return ordered;
+    }
+    snapshot_dirs
+}
+
+fn huggingface_main_snapshot_dir(repo_root: &FsPath) -> Option<PathBuf> {
+    let revision = std::fs::read_to_string(repo_root.join("refs").join("main")).ok()?;
+    let revision = revision.trim();
+    if revision.is_empty() {
+        return None;
+    }
+    let snapshot = repo_root.join("snapshots").join(revision);
+    snapshot.is_dir().then_some(snapshot)
 }
 
 fn unique_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
@@ -6405,9 +6442,9 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_app, strip_jsonc_comments, sweep_stale_lora_uploads_before, EventHub, EventMessage,
-        Settings, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
-        HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+        create_app, lora_artifact_paths, strip_jsonc_comments, sweep_stale_lora_uploads_before,
+        EventHub, EventMessage, Settings, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
+        HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
     };
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
@@ -8493,6 +8530,8 @@ mod tests {
                 "id": "ltx_ic_union",
                 "name": "LTX IC Union",
                 "family": "ltx-video",
+                "icLora": true,
+                "conditioningRole": "ic_lora",
                 "compatibility": { "families": ["ltx-video"] },
                 "source": {
                   "provider": "huggingface",
@@ -8519,23 +8558,60 @@ mod tests {
             r#"{ "schemaVersion": 1, "presets": [] }"#,
         )
         .expect("user presets writes");
+        let stale_cache_file = temp_dir
+            .path()
+            .join("data/cache/huggingface/hub/models--Lightricks--LTX-2.3-22b-IC-LoRA-Union-Control/snapshots/aaa111/ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors");
+        std::fs::create_dir_all(
+            stale_cache_file
+                .parent()
+                .expect("stale cache file has parent"),
+        )
+        .expect("stale hf cache creates");
+        std::fs::write(&stale_cache_file, b"stale-lora").expect("stale lora cache writes");
         let cache_file = temp_dir
             .path()
-            .join("data/cache/huggingface/hub/models--Lightricks--LTX-2.3-22b-IC-LoRA-Union-Control/snapshots/abc123/ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors");
+            .join("data/cache/huggingface/hub/models--Lightricks--LTX-2.3-22b-IC-LoRA-Union-Control/snapshots/zzz999/ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors");
         std::fs::create_dir_all(cache_file.parent().expect("cache file has parent"))
             .expect("hf cache creates");
         std::fs::write(&cache_file, b"lora").expect("lora cache writes");
+        let refs_main = temp_dir
+            .path()
+            .join("data/cache/huggingface/hub/models--Lightricks--LTX-2.3-22b-IC-LoRA-Union-Control/refs/main");
+        std::fs::create_dir_all(refs_main.parent().expect("refs main has parent"))
+            .expect("refs dir creates");
+        std::fs::write(&refs_main, b"zzz999").expect("refs main writes");
 
         let app = create_app(test_settings(&temp_dir)).expect("app creates");
         let (status, loras) = request(app, "GET", "/api/v1/loras", Value::Null).await;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(loras[0]["id"], "ltx_ic_union");
+        assert_eq!(loras[0]["icLora"], true);
+        assert_eq!(loras[0]["conditioningRole"], "ic_lora");
         assert_eq!(loras[0]["installState"], "installed");
         assert_eq!(
             std::path::PathBuf::from(loras[0]["installedPath"].as_str().expect("installed path")),
             cache_file
         );
+    }
+
+    #[test]
+    fn lora_artifact_paths_exclude_shared_huggingface_cache_files() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let cache_file = temp_dir.path().join(
+            "data/cache/huggingface/hub/models--owner--repo/snapshots/abc123/lora.safetensors",
+        );
+        let lora = json!({
+            "id": "hf_lora",
+            "installedPath": cache_file.display().to_string(),
+            "source": {
+                "provider": "huggingface",
+                "repo": "owner/repo",
+                "file": "lora.safetensors"
+            }
+        });
+
+        assert!(lora_artifact_paths(&lora, temp_dir.path()).is_empty());
     }
 
     #[tokio::test]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3748,6 +3748,7 @@ async fn lora_catalog(state: &AppState, project_id: Option<&str>) -> Result<Vec<
             "builtin",
             &manifest_dir.join("builtin.loras.jsonc"),
             &state.settings.data_dir,
+            &state.settings.data_dir,
         )?);
     }
     let user = user
@@ -3757,6 +3758,7 @@ async fn lora_catalog(state: &AppState, project_id: Option<&str>) -> Result<Vec<
                 lora,
                 "global",
                 &manifest_dir.join("user.loras.jsonc"),
+                &state.settings.data_dir,
                 &state.settings.data_dir,
             )
         })
@@ -3768,7 +3770,15 @@ async fn lora_catalog(state: &AppState, project_id: Option<&str>) -> Result<Vec<
         let project_loras = load_manifest_entries(state, &project_manifest, "loras")
             .await?
             .into_iter()
-            .map(|lora| normalize_lora_entry(lora, "project", &project_manifest, &project_path))
+            .map(|lora| {
+                normalize_lora_entry(
+                    lora,
+                    "project",
+                    &project_manifest,
+                    &project_path,
+                    &state.settings.data_dir,
+                )
+            })
             .collect::<Result<Vec<_>, _>>()?;
         loras = merge_entries_by_id(loras, project_loras);
     }
@@ -3889,6 +3899,7 @@ fn normalize_lora_entry(
     scope: &str,
     manifest_path: &FsPath,
     default_root: &FsPath,
+    data_dir: &FsPath,
 ) -> Result<Value, ApiError> {
     let object = lora
         .as_object_mut()
@@ -3902,7 +3913,7 @@ fn normalize_lora_entry(
         .and_then(|source| source.get("path"))
         .and_then(Value::as_str)
         .or_else(|| object.get("path").and_then(Value::as_str));
-    let installed_path = source_path.map(|source_path| {
+    let local_path = source_path.map(|source_path| {
         let path = PathBuf::from(source_path);
         if path.is_absolute() {
             path
@@ -3910,6 +3921,14 @@ fn normalize_lora_entry(
             default_root.join(path)
         }
     });
+    let lora_snapshot = Value::Object(object.clone());
+    let huggingface_path = lora_huggingface_cached_file(&lora_snapshot, data_dir);
+    let installed_path = match (local_path.as_ref(), huggingface_path.as_ref()) {
+        (Some(path), _) if lora_is_installed(path) => Some(path.clone()),
+        (_, Some(path)) if lora_is_installed(path) => Some(path.clone()),
+        (Some(path), _) => Some(path.clone()),
+        _ => None,
+    };
     let install_state = match installed_path.as_ref() {
         Some(path) if lora_is_installed(path) => "installed",
         _ => "missing",
@@ -5753,7 +5772,61 @@ fn lora_artifact_paths(lora: &Value, default_root: &FsPath) -> Vec<PathBuf> {
             default_root.join(path)
         });
     }
+    if let Some(path) = lora_huggingface_cached_file(lora, default_root) {
+        paths.push(path);
+    }
     unique_paths(paths)
+}
+
+fn lora_huggingface_cached_file(lora: &Value, data_dir: &FsPath) -> Option<PathBuf> {
+    let source = lora.get("source").and_then(Value::as_object);
+    let provider = source
+        .and_then(|source| source.get("provider"))
+        .or_else(|| lora.get("provider"))
+        .and_then(Value::as_str)?;
+    if provider != "huggingface" {
+        return None;
+    }
+    let repo = source
+        .and_then(|source| source.get("repo"))
+        .or_else(|| lora.get("repo"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let repo_root = huggingface_repo_cache_path(data_dir, repo)?;
+    if !repo_root.exists() {
+        return None;
+    }
+    let file_name = source
+        .and_then(|source| source.get("file"))
+        .or_else(|| lora.get("file"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            source
+                .and_then(|source| source.get("files"))
+                .or_else(|| lora.get("files"))
+                .and_then(Value::as_array)
+                .and_then(|files| files.first())
+                .and_then(Value::as_str)
+        });
+    if let Some(file_name) = file_name {
+        let snapshots = repo_root.join("snapshots");
+        if let Ok(entries) = std::fs::read_dir(&snapshots) {
+            let mut snapshots = entries
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| path.is_dir())
+                .collect::<Vec<_>>();
+            snapshots.sort();
+            for snapshot in snapshots {
+                let candidate = snapshot.join(file_name);
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    first_safetensors_path(&repo_root)
 }
 
 fn unique_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
@@ -8393,6 +8466,76 @@ mod tests {
         assert!(models[0]["installedPath"]
             .as_str()
             .is_some_and(|value| value.contains("models--owner--model")));
+    }
+
+    #[tokio::test]
+    async fn lora_catalog_uses_huggingface_cache_install_state() {
+        std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let config_dir = temp_dir.path().join("config/manifests");
+        std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+        std::fs::write(
+            config_dir.join("builtin.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("builtin models writes");
+        std::fs::write(
+            config_dir.join("user.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("user models writes");
+        std::fs::write(
+            config_dir.join("builtin.loras.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "loras": [{
+                "id": "ltx_ic_union",
+                "name": "LTX IC Union",
+                "family": "ltx-video",
+                "compatibility": { "families": ["ltx-video"] },
+                "source": {
+                  "provider": "huggingface",
+                  "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
+                  "file": "ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors"
+                }
+              }]
+            }
+            "#,
+        )
+        .expect("builtin loras writes");
+        std::fs::write(
+            config_dir.join("user.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("user loras writes");
+        std::fs::write(
+            config_dir.join("builtin.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("builtin presets writes");
+        std::fs::write(
+            config_dir.join("user.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("user presets writes");
+        let cache_file = temp_dir
+            .path()
+            .join("data/cache/huggingface/hub/models--Lightricks--LTX-2.3-22b-IC-LoRA-Union-Control/snapshots/abc123/ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors");
+        std::fs::create_dir_all(cache_file.parent().expect("cache file has parent"))
+            .expect("hf cache creates");
+        std::fs::write(&cache_file, b"lora").expect("lora cache writes");
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, loras) = request(app, "GET", "/api/v1/loras", Value::Null).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(loras[0]["id"], "ltx_ic_union");
+        assert_eq!(loras[0]["installState"], "installed");
+        assert_eq!(
+            std::path::PathBuf::from(loras[0]["installedPath"].as_str().expect("installed path")),
+            cache_file
+        );
     }
 
     #[tokio::test]

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -90,6 +90,12 @@ export function loraMatchesModel(lora, model) {
 }
 
 export function loraLooksLikeIcLora(lora) {
+  if (lora?.icLora === true || lora?.isIcLora === true) {
+    return true;
+  }
+  if (String(lora?.conditioningRole ?? "").trim().toLowerCase().replaceAll("-", "_") === "ic_lora") {
+    return true;
+  }
   const source = lora?.source ?? {};
   const files = Array.isArray(source.files) ? source.files : Array.isArray(lora?.files) ? lora.files : [];
   const text = [
@@ -147,6 +153,8 @@ export function serializePresetLora(lora, presetLora = {}) {
     weight: loraWeight(lora, presetLora),
     triggerWords: lora?.triggerWords ?? [],
     compatibility: lora?.compatibility ?? presetLora?.compatibility ?? {},
+    icLora: lora?.icLora ?? presetLora?.icLora ?? false,
+    conditioningRole: lora?.conditioningRole ?? presetLora?.conditioningRole ?? null,
     installedPath: lora?.installedPath ?? presetLora?.installedPath ?? null,
     source: lora?.source ?? presetLora?.source ?? null,
     presetManaged: true,

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -89,6 +89,29 @@ export function loraMatchesModel(lora, model) {
   return !modelFamilies.length || !families.length || families.some((family) => modelFamilies.includes(family));
 }
 
+export function loraLooksLikeIcLora(lora) {
+  const source = lora?.source ?? {};
+  const files = Array.isArray(source.files) ? source.files : Array.isArray(lora?.files) ? lora.files : [];
+  const text = [
+    lora?.id,
+    lora?.loraId,
+    lora?.name,
+    lora?.displayName,
+    lora?.installedPath,
+    lora?.sourcePath,
+    lora?.path,
+    source.repo,
+    source.file,
+    source.path,
+    ...files,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+    .replaceAll("_", "-");
+  return text.includes("ic-lora") || text.includes("ltx-2-3-ic-");
+}
+
 export function presetMatchesWorkflow(preset, mode) {
   // A preset has one primary workflow for persistence, but modes describe every
   // Studio entry point where the picker should surface it.

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -44,6 +44,8 @@ import {
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 
 const completedResultFallbackMs = 30000;
+const ltxVideoModelId = "ltx_2_3";
+const ltxIcLoraRequiredModes = new Set(["extend_clip", "video_bridge"]);
 
 export function VideoStudio({
   activeProject,
@@ -80,7 +82,7 @@ export function VideoStudio({
   const [prompt, setPrompt] = useState("Camera slowly pushes in while the scene comes alive");
   const [quality, setQuality] = useState("balanced");
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [model, setModel] = useState(videoModels[0]?.id ?? "ltx_2_3");
+  const [model, setModel] = useState(videoModels[0]?.id ?? ltxVideoModelId);
   const [selectedPresetId, setSelectedPresetId] = useState(null);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
   const [duration, setDuration] = useState(selectedModel?.defaults?.duration ?? 6);
@@ -120,12 +122,12 @@ export function VideoStudio({
     () => presetValidation(selectedPreset, loras, selectedModel),
     [selectedPreset, loras, selectedModel],
   );
-  const requiresLtxIcLora = selectedModel?.id === "ltx_2_3" && ["extend_clip"].includes(mode);
+  const requiresLtxIcLora = selectedModel?.id === ltxVideoModelId && ltxIcLoraRequiredModes.has(mode);
   const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing && loraLooksLikeIcLora(lora));
 
   useEffect(() => {
     if (!videoModels.some((item) => item.id === model)) {
-      setModel(videoModels[0]?.id ?? "ltx_2_3");
+      setModel(videoModels[0]?.id ?? ltxVideoModelId);
     }
   }, [videoModels, model]);
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -32,6 +32,7 @@ function estimateRenderSeconds(durationSeconds, quality) {
 }
 import {
   clearPresetDefault,
+  loraLooksLikeIcLora,
   noPresetId,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
@@ -119,8 +120,8 @@ export function VideoStudio({
     () => presetValidation(selectedPreset, loras, selectedModel),
     [selectedPreset, loras, selectedModel],
   );
-  const requiresLtxIcLora = selectedModel?.id === "ltx_2_3" && ["image_to_video", "first_last_frame", "extend_clip"].includes(mode);
-  const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing);
+  const requiresLtxIcLora = selectedModel?.id === "ltx_2_3" && ["extend_clip"].includes(mode);
+  const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing && loraLooksLikeIcLora(lora));
 
   useEffect(() => {
     if (!videoModels.some((item) => item.id === model)) {
@@ -312,7 +313,7 @@ export function VideoStudio({
       : !hasInputs
         ? "Required inputs are missing."
         : requiresLtxIcLora && !hasLtxIcLora
-          ? "LTX source-conditioned generation needs an installed IC-LoRA preset."
+          ? "LTX video-conditioned generation needs an installed IC-LoRA preset."
           : "";
   const replacementModeLabels = {
     face_only: "Face Only",
@@ -826,7 +827,9 @@ export function VideoStudio({
                   {characterId ? (
                     <div className="guidance-strip">
                       <strong>Character reference</strong>
-                      <span>Character and look are saved with the recipe; LTX source-conditioned generation uses the selected preset LoRA.</span>
+                      <span>
+                        Character and look are saved with the recipe; LTX image conditioning uses IC-LoRA when the selected preset includes one.
+                      </span>
                     </div>
                   ) : null}
                 </div>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -119,6 +119,8 @@ export function VideoStudio({
     () => presetValidation(selectedPreset, loras, selectedModel),
     [selectedPreset, loras, selectedModel],
   );
+  const requiresLtxIcLora = selectedModel?.id === "ltx_2_3" && ["image_to_video", "first_last_frame", "extend_clip"].includes(mode);
+  const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing);
 
   useEffect(() => {
     if (!videoModels.some((item) => item.id === model)) {
@@ -287,7 +289,15 @@ export function VideoStudio({
     (mode === "first_last_frame" && sourceAssetId && lastFrameAssetId) ||
     (mode === "extend_clip" && sourceClipAssetId) ||
     (mode === "replace_person" && sourceClipAssetId && personTrackId && characterId);
-  const canSubmit = Boolean(activeProject && prompt.trim() && supportsMode && implementedMode && hasInputs && presetValidationResult.ok);
+  const canSubmit = Boolean(
+    activeProject &&
+      prompt.trim() &&
+      supportsMode &&
+      implementedMode &&
+      hasInputs &&
+      presetValidationResult.ok &&
+      (!requiresLtxIcLora || hasLtxIcLora),
+  );
   const [width, height] = resolution.split("x").map((value) => Number(value));
   const durationOptions = selectedModel?.limits?.durations ?? [4, 6, 8, 10];
   const resolutionOptions = selectedModel?.limits?.resolutions ?? ["768x512", "640x640", "1280x720", "720x1280"];
@@ -301,7 +311,9 @@ export function VideoStudio({
       ? "This entry point is reserved for the next runtime slice."
       : !hasInputs
         ? "Required inputs are missing."
-        : "";
+        : requiresLtxIcLora && !hasLtxIcLora
+          ? "LTX source-conditioned generation needs an installed IC-LoRA preset."
+          : "";
   const replacementModeLabels = {
     face_only: "Face Only",
     full_person_keep_outfit: "Full Person, Keep Outfit",
@@ -813,8 +825,8 @@ export function VideoStudio({
                   </label>
                   {characterId ? (
                     <div className="guidance-strip">
-                      <strong>Preset-only character</strong>
-                      <span>Character and look are saved with the preset; adapter-level reference and LoRA conditioning are not active yet.</span>
+                      <strong>Character reference</strong>
+                      <span>Character and look are saved with the recipe; LTX source-conditioned generation uses the selected preset LoRA.</span>
                     </div>
                   ) : null}
                 </div>

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -31,9 +31,11 @@ Native LTX-2.3 text-to-video and image-to-video require these local resources:
 - `distilledLoraPath`
 - `gemmaRoot`
 
-Source-conditioned native LTX-2.3 modes such as image-to-video, first/last
-frame, and extend route through `ltx_pipelines.ic_lora` and require an
-installed LTX-compatible IC-LoRA in the selected preset.
+Image-conditioned native LTX-2.3 modes such as image-to-video and first/last
+frame route through `ltx_pipelines.ic_lora` when the selected preset includes
+an installed LTX-compatible IC-LoRA. Without an IC-LoRA they fall back to the
+standard distilled/two-stage LTX pipeline. Video-conditioned modes such as
+extend require an installed IC-LoRA preset.
 
 By default the worker resolves those from the model manifest `resources` block,
 preferring SceneWorks-managed imports under `data/models` and then the shared

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -31,6 +31,10 @@ Native LTX-2.3 text-to-video and image-to-video require these local resources:
 - `distilledLoraPath`
 - `gemmaRoot`
 
+Source-conditioned native LTX-2.3 modes such as image-to-video, first/last
+frame, and extend route through `ltx_pipelines.ic_lora` and require an
+installed LTX-compatible IC-LoRA in the selected preset.
+
 By default the worker resolves those from the model manifest `resources` block,
 preferring SceneWorks-managed imports under `data/models` and then the shared
 Hugging Face cache (`HUGGINGFACE_HUB_CACHE` or `HF_HOME/hub`). A job can

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -73,6 +73,28 @@ def lora_families(lora: dict[str, Any]) -> list[str]:
     return families
 
 
+def lora_looks_like_ic_lora(lora: dict[str, Any]) -> bool:
+    source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
+    files = source.get("files") or lora.get("files") or []
+    if not isinstance(files, list):
+        files = [files]
+    values = [
+        lora.get("id"),
+        lora.get("loraId"),
+        lora.get("name"),
+        lora.get("displayName"),
+        lora.get("installedPath"),
+        lora.get("sourcePath"),
+        lora.get("path"),
+        source.get("repo"),
+        source.get("file"),
+        source.get("path"),
+        *files,
+    ]
+    text = " ".join(str(value) for value in values if value).lower().replace("_", "-")
+    return "ic-lora" in text or "ltx-2-3-ic-" in text
+
+
 def validate_lora_compatibility(loras: list[dict[str, Any]], *, model_family: str | None, adapter_id: str) -> None:
     normalized_model_family = normalize_lora_family(model_family)
     if not loras or not normalized_model_family:

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -74,6 +74,10 @@ def lora_families(lora: dict[str, Any]) -> list[str]:
 
 
 def lora_looks_like_ic_lora(lora: dict[str, Any]) -> bool:
+    if lora.get("icLora") is True or lora.get("isIcLora") is True:
+        return True
+    if str(lora.get("conditioningRole") or "").strip().lower().replace("-", "_") == "ic_lora":
+        return True
     source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
     files = source.get("files") or lora.get("files") or []
     if not isinstance(files, list):
@@ -205,13 +209,12 @@ def clear_loras(pipe: Any, adapter_names: tuple[str, ...], *, adapter_id: str) -
 def lora_path(lora: dict[str, Any]) -> Path | None:
     source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
     value = lora.get("installedPath") or lora.get("sourcePath") or lora.get("path") or source.get("path")
-    fallback = huggingface_cached_lora_path(lora)
     if not value:
-        return fallback
+        return huggingface_cached_lora_path(lora)
     path = Path(str(value)).expanduser()
-    if path.exists() or fallback is None:
+    if path.exists():
         return path
-    return fallback
+    return huggingface_cached_lora_path(lora) or path
 
 
 def huggingface_cached_lora_path(lora: dict[str, Any]) -> Path | None:
@@ -235,6 +238,11 @@ def huggingface_cached_lora_path(lora: dict[str, Any]) -> Path | None:
             candidate = snapshot / str(file_name)
             if candidate.is_file():
                 return candidate
+    main_snapshot = huggingface_main_snapshot_dir(root)
+    if main_snapshot is not None:
+        safetensors_path = first_safetensors_path(main_snapshot)
+        if safetensors_path is not None:
+            return safetensors_path
     return first_safetensors_path(root)
 
 
@@ -261,7 +269,23 @@ def huggingface_snapshot_dirs(repo_root: Path) -> list[Path]:
     snapshots = repo_root / "snapshots"
     if not snapshots.is_dir():
         return []
-    return sorted(candidate for candidate in snapshots.iterdir() if candidate.is_dir())
+    candidates = sorted(candidate for candidate in snapshots.iterdir() if candidate.is_dir())
+    main_snapshot = huggingface_main_snapshot_dir(repo_root)
+    if main_snapshot is None:
+        return candidates
+    return [main_snapshot, *[candidate for candidate in candidates if candidate != main_snapshot]]
+
+
+def huggingface_main_snapshot_dir(repo_root: Path) -> Path | None:
+    ref_path = repo_root / "refs" / "main"
+    try:
+        revision = ref_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not revision:
+        return None
+    snapshot = repo_root / "snapshots" / revision
+    return snapshot if snapshot.is_dir() else None
 
 
 def path_stem(path: Path | None) -> str | None:

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -182,9 +183,63 @@ def clear_loras(pipe: Any, adapter_names: tuple[str, ...], *, adapter_id: str) -
 def lora_path(lora: dict[str, Any]) -> Path | None:
     source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
     value = lora.get("installedPath") or lora.get("sourcePath") or lora.get("path") or source.get("path")
+    fallback = huggingface_cached_lora_path(lora)
     if not value:
+        return fallback
+    path = Path(str(value)).expanduser()
+    if path.exists() or fallback is None:
+        return path
+    return fallback
+
+
+def huggingface_cached_lora_path(lora: dict[str, Any]) -> Path | None:
+    source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
+    provider = str(source.get("provider") or lora.get("provider") or "").strip().lower()
+    if provider != "huggingface":
         return None
-    return Path(str(value)).expanduser()
+    repo = str(source.get("repo") or lora.get("repo") or "").strip()
+    if not repo:
+        return None
+    root = huggingface_repo_cache_path(repo)
+    if root is None or not root.exists():
+        return None
+    file_name = source.get("file") or lora.get("file")
+    if not file_name:
+        files = source.get("files") or lora.get("files")
+        if isinstance(files, list) and files:
+            file_name = files[0]
+    if file_name:
+        for snapshot in huggingface_snapshot_dirs(root):
+            candidate = snapshot / str(file_name)
+            if candidate.is_file():
+                return candidate
+    return first_safetensors_path(root)
+
+
+def huggingface_repo_cache_path(repo: str) -> Path | None:
+    safe_repo = "".join(character if character.isalnum() or character in "._-" else "--" for character in repo).strip("-")
+    if not safe_repo:
+        return None
+    return huggingface_hub_cache_dir() / f"models--{safe_repo}"
+
+
+def huggingface_hub_cache_dir() -> Path:
+    for key in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"):
+        value = os.getenv(key, "").strip()
+        if value:
+            return Path(value).expanduser()
+    hf_home = os.getenv("HF_HOME", "").strip()
+    if hf_home:
+        return Path(hf_home).expanduser() / "hub"
+    data_dir = Path(os.getenv("SCENEWORKS_DATA_DIR", "data")).expanduser()
+    return data_dir / "cache" / "huggingface" / "hub"
+
+
+def huggingface_snapshot_dirs(repo_root: Path) -> list[Path]:
+    snapshots = repo_root / "snapshots"
+    if not snapshots.is_dir():
+        return []
+    return sorted(candidate for candidate in snapshots.iterdir() if candidate.is_dir())
 
 
 def path_stem(path: Path | None) -> str | None:

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -32,8 +32,9 @@ from .adapter_utils import filter_call_kwargs
 from .image_adapters import require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
 from .lora_adapters import (
     LoraPipelineState,
+    LoraSpec,
     apply_loras_to_pipeline,
-    lora_cache_key,
+    lora_cache_key_for_specs,
     lora_looks_like_ic_lora,
     normalize_lora_specs,
     reject_loras_if_unsupported,
@@ -316,6 +317,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         self._loaded_models: set[str] = set()
         self._settings: WorkerSettings | None = None
         self._resources_by_model: dict[str, LtxPipelinesResources] = {}
+        self._lora_specs_by_request_id: dict[int, list[LoraSpec]] = {}
         self._pipeline: Any | None = None
         self._pipeline_key_value: str | None = None
 
@@ -324,6 +326,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
 
     def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
         self._settings = settings
+        self._lora_specs_by_request_id.clear()
         return video_request_from_job(job)
 
     def ensure_models(self, request: VideoRequest) -> None:
@@ -336,7 +339,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         if request.duration > target["hardMaxDuration"]:
             raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
         validate_lora_compatibility(request.loras, model_family=target["family"], adapter_id=self.id)
-        normalize_lora_specs(request.loras)
+        self._ltx_lora_specs(request)
         if self._uses_ic_lora_pipeline(request) and not self._has_ic_lora(request) and not self._mock_inference_enabled(request):
             raise RuntimeError(
                 "Native LTX IC-LoRA video conditioning requires at least one installed LTX-compatible LoRA. "
@@ -359,7 +362,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 f"Missing resources:\n{details}"
             )
         self._resources_by_model[request.model] = resources
-        if not self._mock_inference_enabled(request) and not self._dependencies_available():
+        if not self._mock_inference_enabled(request) and not self._dependencies_available(request):
             raise RuntimeError(
                 "Native LTX-2.3 generation requires optional worker dependencies. "
                 "Install apps/worker/requirements-ltx.txt in this worker environment, rebuild the worker image, or use "
@@ -381,7 +384,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             "adapter": self.id,
             "pipeline": self._pipeline_module(request),
             "resources": self._resource_summary(resources),
-            "nativeDependenciesAvailable": self._dependencies_available(),
+            "nativeDependenciesAvailable": self._dependencies_available(request),
             "mockedInference": mocked,
         }
 
@@ -605,6 +608,8 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         loader = importlib.import_module("ltx_core.loader")
         offload_mode = self._offload_mode(request)
         loras = self._ltx_loras(loader, request)
+        # The native Lightricks constructors expose `loras` across distilled,
+        # two-stage, and IC-LoRA pipelines; `distilled_lora` remains separate.
         common_kwargs = {
             "gemma_root": str(resources.gemma_root),
             "spatial_upsampler_path": str(resources.spatial_upsampler_path),
@@ -737,12 +742,20 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 str(resources.distilled_lora_path),
                 str(resources.gemma_root),
                 str(request.advanced.get("offloadMode", "none")),
-                lora_cache_key(request.loras) if request.loras else "",
+                lora_cache_key_for_specs(self._ltx_lora_specs(request)) if request.loras else "",
             ]
         )
 
+    def _ltx_lora_specs(self, request: VideoRequest) -> list[LoraSpec]:
+        cache_key = id(request)
+        specs = self._lora_specs_by_request_id.get(cache_key)
+        if specs is None:
+            specs = normalize_lora_specs(request.loras)
+            self._lora_specs_by_request_id[cache_key] = specs
+        return specs
+
     def _ltx_loras(self, loader: Any, request: VideoRequest) -> tuple[Any, ...]:
-        specs = normalize_lora_specs(request.loras)
+        specs = self._ltx_lora_specs(request)
         return tuple(
             loader.LoraPathStrengthAndSDOps(
                 spec.path,
@@ -944,14 +957,12 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             "temporalUpscalerPath": str(resources.temporal_upsampler_path) if resources.temporal_upsampler_path else None,
         }
 
-    def _dependencies_available(self) -> bool:
+    def _dependencies_available(self, request: VideoRequest | None = None) -> bool:
         try:
             if importlib.util.find_spec("ltx_core") is None or importlib.util.find_spec("ltx_pipelines") is None:
                 return False
             install_ltx_pipelines_multigpu_compat()
-            importlib.import_module("ltx_pipelines.distilled")
-            importlib.import_module("ltx_pipelines.ti2vid_two_stages")
-            importlib.import_module("ltx_pipelines.ic_lora")
+            importlib.import_module(self._pipeline_module(request) if request is not None else "ltx_pipelines.distilled")
             return True
         except (ImportError, ValueError):
             return False

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -34,6 +34,7 @@ from .lora_adapters import (
     LoraPipelineState,
     apply_loras_to_pipeline,
     lora_cache_key,
+    lora_looks_like_ic_lora,
     normalize_lora_specs,
     reject_loras_if_unsupported,
     validate_lora_compatibility,
@@ -336,7 +337,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
         validate_lora_compatibility(request.loras, model_family=target["family"], adapter_id=self.id)
         normalize_lora_specs(request.loras)
-        if self._uses_ic_lora_pipeline(request) and not request.loras and not self._mock_inference_enabled(request):
+        if self._uses_ic_lora_pipeline(request) and not self._has_ic_lora(request) and not self._mock_inference_enabled(request):
             raise RuntimeError(
                 "Native LTX IC-LoRA video conditioning requires at least one installed LTX-compatible LoRA. "
                 "Add an IC-LoRA to the selected preset before running source-video conditioning."
@@ -711,9 +712,14 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         return "ltx_pipelines.ti2vid_two_stages"
 
     def _uses_ic_lora_pipeline(self, request: VideoRequest) -> bool:
-        return request.mode in {"image_to_video", "first_last_frame", "extend_clip", "video_bridge"} or bool(
-            request.advanced.get("useIcLoraPipeline", False)
-        )
+        if bool(request.advanced.get("useIcLoraPipeline", False)):
+            return True
+        if request.mode in {"extend_clip", "video_bridge"}:
+            return True
+        return request.mode in {"image_to_video", "first_last_frame"} and self._has_ic_lora(request)
+
+    def _has_ic_lora(self, request: VideoRequest) -> bool:
+        return any(lora_looks_like_ic_lora(lora if isinstance(lora, dict) else {"id": str(lora)}) for lora in request.loras)
 
     def _num_inference_steps(self, request: VideoRequest, target: dict[str, Any]) -> int:
         default_steps = target["steps"].get(request.quality, target["steps"]["balanced"])
@@ -944,6 +950,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 return False
             install_ltx_pipelines_multigpu_compat()
             importlib.import_module("ltx_pipelines.distilled")
+            importlib.import_module("ltx_pipelines.ti2vid_two_stages")
             importlib.import_module("ltx_pipelines.ic_lora")
             return True
         except (ImportError, ValueError):

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -30,7 +30,14 @@ from sceneworks_shared import (
 
 from .adapter_utils import filter_call_kwargs
 from .image_adapters import require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
-from .lora_adapters import LoraPipelineState, apply_loras_to_pipeline, reject_loras_if_unsupported
+from .lora_adapters import (
+    LoraPipelineState,
+    apply_loras_to_pipeline,
+    lora_cache_key,
+    normalize_lora_specs,
+    reject_loras_if_unsupported,
+    validate_lora_compatibility,
+)
 from .settings import WorkerSettings
 
 
@@ -301,7 +308,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
 class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
     id = "ltx_pipelines"
 
-    _supported_modes = {"text_to_video", "image_to_video"}
+    _supported_modes = {"text_to_video", "image_to_video", "first_last_frame", "extend_clip", "video_bridge"}
 
     def __init__(self) -> None:
         super().__init__()
@@ -327,7 +334,13 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             raise RuntimeError(f"{target['label']} native pipelines currently support {supported}.")
         if request.duration > target["hardMaxDuration"]:
             raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
-        reject_loras_if_unsupported(request.loras, self.id)
+        validate_lora_compatibility(request.loras, model_family=target["family"], adapter_id=self.id)
+        normalize_lora_specs(request.loras)
+        if self._uses_ic_lora_pipeline(request) and not request.loras and not self._mock_inference_enabled(request):
+            raise RuntimeError(
+                "Native LTX IC-LoRA video conditioning requires at least one installed LTX-compatible LoRA. "
+                "Add an IC-LoRA to the selected preset before running source-video conditioning."
+            )
         resources = self.resolve_resources(request)
         missing = self._missing_resources(request, resources)
         if missing:
@@ -336,7 +349,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             if search_details:
                 details = f"{details}\nSearched Hugging Face cache paths:\n{search_details}"
             override_keys = ["checkpointPath", "spatialUpscalerPath", "gemmaRoot"]
-            if self._pipeline_module(request) != "ltx_pipelines.distilled":
+            if self._pipeline_module(request) == "ltx_pipelines.ti2vid_two_stages":
                 override_keys.insert(2, "distilledLoraPath")
             raise RuntimeError(
                 "Native LTX-2.3 requires local model resources before generation. "
@@ -414,6 +427,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             "targetAdapter": self.id,
             "pipeline": self._pipeline_module(request),
             "resources": self._resource_summary(resources),
+            "icLoraConditioning": self._uses_ic_lora_pipeline(request),
             "steps": safe_int(request.advanced.get("steps"), steps, 1, 80),
             "frameCount": ltx_frame_count(max(1, int(round(request.duration * request.fps)))),
             "previewFrameCount": preview_frame_count(request),
@@ -450,7 +464,8 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         self._temporary_outputs.setdefault(job["id"], []).append(temp_path)
 
         progress("preparing", "validating_inputs", 0.2, "Validating native LTX-2.3 inputs.")
-        conditioning_images = self._ltx_conditioning_images(project_path, request)
+        conditioning_images = self._ltx_conditioning_images(project_path, request, num_frames)
+        video_conditioning = self._ltx_video_conditioning(project_path, request)
         if cancel_requested():
             raise InterruptedError("Video generation canceled before native LTX pipeline load.")
 
@@ -467,6 +482,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             seed=seed,
             num_frames=num_frames,
             conditioning_images=conditioning_images,
+            video_conditioning=video_conditioning,
         )
         if cancel_requested():
             raise InterruptedError("Video generation canceled before saving.")
@@ -521,15 +537,15 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             "requirements": self.estimate_requirements(request),
         }
 
-    def _ltx_conditioning_images(self, project_path: Path, request: VideoRequest) -> list[Any]:
-        if request.mode == "text_to_video":
+    def _ltx_conditioning_images(self, project_path: Path, request: VideoRequest, num_frames: int) -> list[Any]:
+        if request.mode in {"text_to_video", "extend_clip", "video_bridge"}:
             return []
-        if request.mode != "image_to_video":
+        if request.mode not in {"image_to_video", "first_last_frame"}:
             raise RuntimeError(f"Native LTX-2.3 does not support {request.mode.replace('_', ' ')} yet.")
 
         media_path = source_asset_media_path(project_path, request.source_asset_id)
         if media_path is None:
-            raise RuntimeError("Image to Video requires a readable source image.")
+            raise RuntimeError(f"{request.mode.replace('_', ' ').title()} requires a readable source image.")
         try:
             with Image.open(media_path) as image:
                 image.verify()
@@ -539,13 +555,45 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         install_ltx_pipelines_multigpu_compat()
         args_module = importlib.import_module("ltx_pipelines.utils.args")
         condition_class = getattr(args_module, "ImageConditioningInput")
-        return [
+        images = [
             condition_class(
                 str(media_path),
                 safe_int(request.advanced.get("imageFrameIndex"), 0, 0, 1_000_000),
                 self._advanced_float(request, "imageConditioningStrength", 1.0),
             )
         ]
+        if request.mode == "first_last_frame":
+            last_media_path = source_asset_media_path(project_path, request.last_frame_asset_id)
+            if last_media_path is None:
+                raise RuntimeError("First/Last Frame requires a readable last frame image.")
+            try:
+                with Image.open(last_media_path) as image:
+                    image.verify()
+            except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+                raise RuntimeError("First/Last Frame requires a readable last frame image.") from exc
+            images.append(
+                condition_class(
+                    str(last_media_path),
+                    max(0, num_frames - 1),
+                    self._advanced_float(request, "lastFrameConditioningStrength", 1.0),
+                )
+            )
+        return images
+
+    def _ltx_video_conditioning(self, project_path: Path, request: VideoRequest) -> list[tuple[str, float]]:
+        if request.mode not in {"extend_clip", "video_bridge"}:
+            return []
+        conditionings: list[tuple[str, float]] = []
+        left_path = source_asset_media_path(project_path, request.source_clip_asset_id)
+        if left_path is None:
+            raise RuntimeError(f"{request.mode.replace('_', ' ').title()} requires a readable source clip.")
+        conditionings.append((str(left_path), self._advanced_float(request, "videoConditioningStrength", 1.0)))
+        if request.mode == "video_bridge":
+            right_path = source_asset_media_path(project_path, request.bridge_right_clip_asset_id)
+            if right_path is None:
+                raise RuntimeError("Video Bridge requires a readable right-side source clip.")
+            conditionings.append((str(right_path), self._advanced_float(request, "bridgeRightVideoConditioningStrength", 1.0)))
+        return conditionings
 
     def _load_ltx_pipeline(self, request: VideoRequest, resources: LtxPipelinesResources) -> Any:
         key = self._pipeline_key(request, resources)
@@ -555,14 +603,21 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         install_ltx_pipelines_multigpu_compat()
         loader = importlib.import_module("ltx_core.loader")
         offload_mode = self._offload_mode(request)
+        loras = self._ltx_loras(loader, request)
         common_kwargs = {
             "gemma_root": str(resources.gemma_root),
             "spatial_upsampler_path": str(resources.spatial_upsampler_path),
-            "loras": (),
+            "loras": loras,
             "torch_compile": bool(request.advanced.get("compile", False)),
             "offload_mode": offload_mode,
         }
-        if self._pipeline_module(request) == "ltx_pipelines.distilled":
+        if self._pipeline_module(request) == "ltx_pipelines.ic_lora":
+            pipeline_module = importlib.import_module("ltx_pipelines.ic_lora")
+            pipeline = pipeline_module.ICLoraPipeline(
+                distilled_checkpoint_path=str(resources.checkpoint_path),
+                **common_kwargs,
+            )
+        elif self._pipeline_module(request) == "ltx_pipelines.distilled":
             pipeline_module = importlib.import_module("ltx_pipelines.distilled")
             pipeline = pipeline_module.DistilledPipeline(
                 distilled_checkpoint_path=str(resources.checkpoint_path),
@@ -594,6 +649,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         seed: int,
         num_frames: int,
         conditioning_images: list[Any],
+        video_conditioning: list[tuple[str, float]],
     ) -> tuple[Any, Any, int, Any]:
         install_ltx_pipelines_multigpu_compat()
         video_vae = importlib.import_module("ltx_core.model.video_vae")
@@ -611,7 +667,15 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             "tiling_config": tiling_config,
             "enhance_prompt": bool(request.advanced.get("enhancePrompt", False)),
         }
-        if self._pipeline_module(request) == "ltx_pipelines.distilled":
+        if self._pipeline_module(request) == "ltx_pipelines.ic_lora":
+            video, audio = pipeline(
+                **base_kwargs,
+                video_conditioning=video_conditioning,
+                conditioning_attention_strength=self._advanced_float(request, "conditioningAttentionStrength", 1.0),
+                skip_stage_2=bool(request.advanced.get("skipStage2", False)),
+                conditioning_attention_mask=None,
+            )
+        elif self._pipeline_module(request) == "ltx_pipelines.distilled":
             video, audio = pipeline(**base_kwargs)
         else:
             guiders = importlib.import_module("ltx_core.components.guiders")
@@ -640,9 +704,16 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         return video, audio, video_chunks_number, media_io.encode_video
 
     def _pipeline_module(self, request: VideoRequest) -> str:
+        if self._uses_ic_lora_pipeline(request):
+            return "ltx_pipelines.ic_lora"
         if request.quality == "fast":
             return "ltx_pipelines.distilled"
         return "ltx_pipelines.ti2vid_two_stages"
+
+    def _uses_ic_lora_pipeline(self, request: VideoRequest) -> bool:
+        return request.mode in {"image_to_video", "first_last_frame", "extend_clip", "video_bridge"} or bool(
+            request.advanced.get("useIcLoraPipeline", False)
+        )
 
     def _num_inference_steps(self, request: VideoRequest, target: dict[str, Any]) -> int:
         default_steps = target["steps"].get(request.quality, target["steps"]["balanced"])
@@ -660,7 +731,19 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 str(resources.distilled_lora_path),
                 str(resources.gemma_root),
                 str(request.advanced.get("offloadMode", "none")),
+                lora_cache_key(request.loras) if request.loras else "",
             ]
+        )
+
+    def _ltx_loras(self, loader: Any, request: VideoRequest) -> tuple[Any, ...]:
+        specs = normalize_lora_specs(request.loras)
+        return tuple(
+            loader.LoraPathStrengthAndSDOps(
+                spec.path,
+                spec.weight,
+                loader.LTXV_LORA_COMFY_RENAMING_MAP,
+            )
+            for spec in specs
         )
 
     def _offload_mode(self, request: VideoRequest) -> Any:
@@ -695,7 +778,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         settings = self._settings or WorkerSettings()
         entry = ltx_model_manifest_entry(settings, request.model)
         resources = entry.get("resources", {}) if isinstance(entry.get("resources"), dict) else {}
-        checkpoint_resource_key = "distilledCheckpoint" if self._pipeline_module(request) == "ltx_pipelines.distilled" else "checkpoint"
+        checkpoint_resource_key = "distilledCheckpoint" if self._pipeline_module(request) in {"ltx_pipelines.distilled", "ltx_pipelines.ic_lora"} else "checkpoint"
         return LtxPipelinesResources(
             checkpoint_path=self._resource_path(
                 settings,
@@ -794,7 +877,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             ("spatialUpscalerPath", resources.spatial_upsampler_path, "file"),
             ("gemmaRoot", resources.gemma_root, "dir"),
         ]
-        if self._pipeline_module(request) != "ltx_pipelines.distilled":
+        if self._pipeline_module(request) == "ltx_pipelines.ti2vid_two_stages":
             required.insert(2, ("distilledLoraPath", resources.distilled_lora_path, "file"))
         missing = [
             (label, path)
@@ -815,7 +898,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         entry = ltx_model_manifest_entry(settings, request.model)
         manifest_resources = entry.get("resources", {}) if isinstance(entry.get("resources"), dict) else {}
         resource_names = {
-            "checkpointPath": "distilledCheckpoint" if self._pipeline_module(request) == "ltx_pipelines.distilled" else "checkpoint",
+            "checkpointPath": "distilledCheckpoint" if self._pipeline_module(request) in {"ltx_pipelines.distilled", "ltx_pipelines.ic_lora"} else "checkpoint",
             "spatialUpscalerPath": "spatialUpscaler",
             "distilledLoraPath": "distilledLora",
             "temporalUpscalerPath": "temporalUpscaler",
@@ -861,6 +944,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 return False
             install_ltx_pipelines_multigpu_compat()
             importlib.import_module("ltx_pipelines.distilled")
+            importlib.import_module("ltx_pipelines.ic_lora")
             return True
         except (ImportError, ValueError):
             return False

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -8,6 +8,8 @@
       "family": "ltx-video",
       "triggerWords": [],
       "compatibility": { "families": ["ltx-video"] },
+      "icLora": true,
+      "conditioningRole": "ic_lora",
       "defaultWeight": 0.8,
       "source": {
         "provider": "huggingface",
@@ -21,6 +23,8 @@
       "family": "ltx-video",
       "triggerWords": [],
       "compatibility": { "families": ["ltx-video"] },
+      "icLora": true,
+      "conditioningRole": "ic_lora",
       "defaultWeight": 0.8,
       "source": {
         "provider": "huggingface",
@@ -34,6 +38,8 @@
       "family": "ltx-video",
       "triggerWords": [],
       "compatibility": { "families": ["ltx-video"] },
+      "icLora": true,
+      "conditioningRole": "ic_lora",
       "defaultWeight": 0.8,
       "source": {
         "provider": "huggingface",
@@ -47,6 +53,8 @@
       "family": "ltx-video",
       "triggerWords": [],
       "compatibility": { "families": ["ltx-video"] },
+      "icLora": true,
+      "conditioningRole": "ic_lora",
       "defaultWeight": 0.8,
       "source": {
         "provider": "huggingface",

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -1,5 +1,58 @@
 {
   "$schema": "../../packages/schemas/lora-manifest.schema.json",
   "schemaVersion": 1,
-  "loras": []
+  "loras": [
+    {
+      "id": "ltx_2_3_ic_union_control",
+      "name": "LTX-2.3 IC-LoRA Union Control",
+      "family": "ltx-video",
+      "triggerWords": [],
+      "compatibility": { "families": ["ltx-video"] },
+      "defaultWeight": 0.8,
+      "source": {
+        "provider": "huggingface",
+        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
+        "file": "ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors"
+      }
+    },
+    {
+      "id": "ltx_2_3_ic_motion_track_control",
+      "name": "LTX-2.3 IC-LoRA Motion Track Control",
+      "family": "ltx-video",
+      "triggerWords": [],
+      "compatibility": { "families": ["ltx-video"] },
+      "defaultWeight": 0.8,
+      "source": {
+        "provider": "huggingface",
+        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-Motion-Track-Control",
+        "file": "ltx-2.3-22b-ic-lora-motion-track-control-ref0.5.safetensors"
+      }
+    },
+    {
+      "id": "ltx_2_3_ic_hdr",
+      "name": "LTX-2.3 IC-LoRA HDR",
+      "family": "ltx-video",
+      "triggerWords": [],
+      "compatibility": { "families": ["ltx-video"] },
+      "defaultWeight": 0.8,
+      "source": {
+        "provider": "huggingface",
+        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
+        "file": "ltx-2.3-22b-ic-lora-hdr-0.9.safetensors"
+      }
+    },
+    {
+      "id": "ltx_2_3_ic_lipdub",
+      "name": "LTX-2.3 IC-LoRA LipDub",
+      "family": "ltx-video",
+      "triggerWords": [],
+      "compatibility": { "families": ["ltx-video"] },
+      "defaultWeight": 0.8,
+      "source": {
+        "provider": "huggingface",
+        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
+        "file": "ltx-2.3-22b-ic-lora-lipdub-0.9.safetensors"
+      }
+    }
+  ]
 }

--- a/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
+++ b/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
@@ -87,7 +87,7 @@ SceneWorks must manage these as model resources, not hidden one-off paths:
   - or a validated lower-memory upscaler variant.
 - Distilled LoRA for two-stage pipelines:
   - `ltx-2.3-22b-distilled-lora-384-1.1.safetensors`
-- IC-LoRA for source-conditioned pipelines:
+- IC-LoRA for IC-conditioned pipelines:
   - one or more installed LTX-compatible IC-LoRA `.safetensors` files selected through a preset.
 - Gemma text encoder assets:
   - full local Gemma 3-12B repo or local text encoder path required by `ltx-pipelines`.
@@ -130,7 +130,7 @@ Recommended shape:
 }
 ```
 
-The official `ltx-pipelines` stack expects the Gemma 3-12B text encoder family; using Gemma 3-4B causes tensor shape mismatches during text encoder load. Source-conditioned modes should route through `ltx_pipelines.ic_lora.ICLoraPipeline` so image/video references can use IC-LoRA attention conditioning for better identity consistency.
+The official `ltx-pipelines` stack expects the Gemma 3-12B text encoder family; using Gemma 3-4B causes tensor shape mismatches during text encoder load. Image-conditioned modes should route through `ltx_pipelines.ic_lora.ICLoraPipeline` when an IC-LoRA preset is selected so references can use IC-LoRA attention conditioning for better identity consistency, and otherwise fall back to the standard distilled/two-stage LTX pipelines. Video-conditioned modes should require IC-LoRA because their video conditioning path depends on the IC-LoRA pipeline.
 
 ## Worker Dependency Plan
 

--- a/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
+++ b/documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md
@@ -87,6 +87,8 @@ SceneWorks must manage these as model resources, not hidden one-off paths:
   - or a validated lower-memory upscaler variant.
 - Distilled LoRA for two-stage pipelines:
   - `ltx-2.3-22b-distilled-lora-384-1.1.safetensors`
+- IC-LoRA for source-conditioned pipelines:
+  - one or more installed LTX-compatible IC-LoRA `.safetensors` files selected through a preset.
 - Gemma text encoder assets:
   - full local Gemma 3-12B repo or local text encoder path required by `ltx-pipelines`.
 
@@ -128,7 +130,7 @@ Recommended shape:
 }
 ```
 
-The official `ltx-pipelines` stack expects the Gemma 3-12B text encoder family; using Gemma 3-4B causes tensor shape mismatches during text encoder load.
+The official `ltx-pipelines` stack expects the Gemma 3-12B text encoder family; using Gemma 3-4B causes tensor shape mismatches during text encoder load. Source-conditioned modes should route through `ltx_pipelines.ic_lora.ICLoraPipeline` so image/video references can use IC-LoRA attention conditioning for better identity consistency.
 
 ## Worker Dependency Plan
 

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -8,7 +8,17 @@
     "schemaVersion": { "type": "integer", "minimum": 1 },
     "loras": {
       "type": "array",
-      "items": { "type": "object" }
+      "items": {
+        "type": "object",
+        "properties": {
+          "icLora": { "type": "boolean" },
+          "conditioningRole": {
+            "type": "string",
+            "enum": ["ic_lora"]
+          }
+        },
+        "additionalProperties": true
+      }
     }
   }
 }

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1782,6 +1782,7 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
             "loras": [
                 {
                     "id": "identity_ic",
+                    "name": "LTX-2.3 IC-LoRA Identity",
                     "installedPath": str(ic_lora),
                     "weight": 0.65,
                     "families": ["ltx-video"],
@@ -1810,13 +1811,85 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
     assert result["assets"][0]["recipe"]["rawAdapterSettings"]["realModelInference"] is True
 
 
-def test_native_ltx_image_to_video_requires_ic_lora(tmp_path):
+def test_native_ltx_image_to_video_falls_back_without_ic_lora(monkeypatch, tmp_path):
     data_dir = tmp_path / "data"
     config_dir = tmp_path / "config"
+    project_path = tmp_path / "project"
     data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    image_rel = "assets/images/source.png"
+    (project_path / "assets" / "images").mkdir(parents=True)
+    Image.new("RGB", (16, 16), "teal").save(project_path / image_rel)
+    (project_path / "assets" / "images" / "source.sceneworks.json").write_text(
+        json.dumps({"id": "asset-source", "file": {"path": image_rel}}),
+        encoding="utf-8",
+    )
     checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
     write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+    style_lora = tmp_path / "cinematic-style.safetensors"
+    style_lora.write_bytes(b"style-lora")
+    calls = {"init": None, "run": None}
+
+    class FakePipeline:
+        def __init__(self, **kwargs):
+            calls["init"] = kwargs
+
+        def __call__(self, **kwargs):
+            calls["run"] = kwargs
+            return ["video-chunk"], None
+
+    class FakeConditioningInput(NamedTuple):
+        path: str
+        frame_idx: int
+        strength: float
+
+    class FakeTilingConfig:
+        @staticmethod
+        def default():
+            return "tiling-config"
+
+    class FakeOffloadMode:
+        NONE = "none"
+        CPU = "cpu"
+        DISK = "disk"
+
+    class FakeGuiderParams:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def fake_encode_video(**kwargs):
+        Path(kwargs["output_path"]).write_bytes(b"mp4")
+
+    def fake_import_module(name):
+        if name == "ltx_core.loader":
+            return SimpleNamespace(
+                LoraPathStrengthAndSDOps=lambda path, strength, sd_ops: (path, strength, sd_ops),
+                LTXV_LORA_COMFY_RENAMING_MAP={"rename": "map"},
+            )
+        if name == "ltx_pipelines.utils.types":
+            return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_pipelines.ti2vid_two_stages":
+            return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
+        if name == "ltx_core.model.video_vae":
+            return SimpleNamespace(
+                TilingConfig=FakeTilingConfig,
+                get_video_chunks_number=lambda _frames, _tiling: 1,
+            )
+        if name == "ltx_pipelines.utils.media_io":
+            return SimpleNamespace(encode_video=fake_encode_video)
+        if name == "ltx_core.components.guiders":
+            return SimpleNamespace(MultiModalGuiderParams=FakeGuiderParams)
+        if name == "ltx_pipelines.utils.args":
+            return SimpleNamespace(ImageConditioningInput=FakeConditioningInput)
+        raise ImportError(name)
+
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
     adapter = LtxPipelinesVideoAdapter()
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
     request = adapter.prepare(
         settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
         job={
@@ -1827,13 +1900,40 @@ def test_native_ltx_image_to_video_requires_ic_lora(tmp_path):
                 "prompt": "Make the harbor move",
                 "model": "ltx_2_3",
                 "sourceAssetId": "asset-source",
-                "advanced": {},
+                "duration": 1,
+                "fps": 12,
+                "width": 320,
+                "height": 256,
+                "quality": "balanced",
+                "loras": [
+                    {
+                        "id": "cinematic_style",
+                        "name": "Cinematic Style",
+                        "installedPath": str(style_lora),
+                        "weight": 0.55,
+                        "families": ["ltx-video"],
+                    }
+                ],
+                "advanced": {"imageConditioningStrength": 0.75},
             },
         },
     )
 
-    with pytest.raises(RuntimeError, match="IC-LoRA video conditioning requires at least one"):
-        adapter.ensure_models(request)
+    adapter.ensure_models(request)
+    result = adapter.run(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job={"id": "job-i2v-missing-lora"},
+        request=request,
+        progress=lambda *_args: None,
+        cancel_requested=lambda: False,
+    )
+
+    assert calls["init"]["checkpoint_path"] == str(checkpoint)
+    assert calls["init"]["distilled_lora"] == [(str(lora), 0.8, {"rename": "map"})]
+    assert calls["init"]["loras"] == ((str(style_lora), 0.55, {"rename": "map"}),)
+    assert calls["run"]["images"] == [FakeConditioningInput(str(project_path / image_rel), 0, 0.75)]
+    assert "video_conditioning" not in calls["run"]
+    assert result["requirements"]["pipeline"] == "ltx_pipelines.ti2vid_two_stages"
 
 
 def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp_path):
@@ -1919,6 +2019,7 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
             "loras": [
                 {
                     "id": "identity_ic",
+                    "name": "LTX-2.3 IC-LoRA Identity",
                     "installedPath": str(ic_lora),
                     "weight": 0.7,
                     "families": ["ltx-video"],

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -524,6 +524,30 @@ def test_lora_specs_resolve_huggingface_cache_snapshot(monkeypatch, tmp_path):
     assert specs[0].weight == 0.7
 
 
+def test_lora_specs_prefer_huggingface_ref_main_snapshot(monkeypatch, tmp_path):
+    cache_root = tmp_path / "hf" / "hub"
+    repo = "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control"
+    file_name = "ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors"
+    write_huggingface_cache_resource(cache_root, repo, file_name, revision="aaa111")
+    main_snapshot = write_huggingface_cache_resource(cache_root, repo, file_name, revision="zzz999", refs_main=True)
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(cache_root))
+
+    specs = normalize_lora_specs(
+        [
+            {
+                "id": "ltx_2_3_ic_union_control",
+                "source": {
+                    "provider": "huggingface",
+                    "repo": repo,
+                    "file": file_name,
+                },
+            }
+        ]
+    )
+
+    assert specs[0].path == str(main_snapshot / file_name)
+
+
 def test_image_adapter_env_aliases_and_unknown_values(monkeypatch):
     monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "procedural")
     assert create_image_adapter({"payload": {"model": "z_image_turbo"}}).__class__.__name__ == "ProceduralImageAdapter"
@@ -1227,10 +1251,14 @@ def write_native_ltx_resource_files(tmp_path):
     return checkpoint, spatial, lora, gemma
 
 
-def write_huggingface_cache_resource(cache_root, repo, file_name=None):
+def write_huggingface_cache_resource(cache_root, repo, file_name=None, revision="abc123", refs_main=False):
     safe_repo = "".join(char if char.isalnum() or char in "._-" else "--" for char in repo).strip("-")
-    snapshot = cache_root / f"models--{safe_repo}" / "snapshots" / "abc123"
+    repo_root = cache_root / f"models--{safe_repo}"
+    snapshot = repo_root / "snapshots" / revision
     snapshot.mkdir(parents=True, exist_ok=True)
+    if refs_main:
+        (repo_root / "refs").mkdir(parents=True, exist_ok=True)
+        (repo_root / "refs" / "main").write_text(revision, encoding="utf-8")
     if file_name is not None:
         path = snapshot / file_name
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -1640,7 +1668,7 @@ def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, 
 
     monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
     adapter = LtxPipelinesVideoAdapter()
-    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda *_args: True)
     job = {
         "id": "job-real-ltx",
         "payload": {
@@ -1686,6 +1714,49 @@ def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, 
     assert result["requirements"]["mockedInference"] is False
 
 
+def test_native_ltx_dependency_probe_only_imports_selected_pipeline(monkeypatch):
+    imported = []
+
+    def fake_import_module(name):
+        imported.append(name)
+        if name == "ltx_pipelines.ic_lora":
+            raise ImportError(name)
+        return SimpleNamespace()
+
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.util.find_spec", lambda _name: object())
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
+    monkeypatch.setattr("scene_worker.video_adapters.install_ltx_pipelines_multigpu_compat", lambda: None)
+
+    adapter = LtxPipelinesVideoAdapter()
+    text_request = video_request_from_job(
+        {
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_video",
+                "prompt": "Neon harbor",
+                "model": "ltx_2_3",
+                "quality": "balanced",
+            }
+        }
+    )
+    ic_request = video_request_from_job(
+        {
+            "payload": {
+                "projectId": "project-1",
+                "mode": "image_to_video",
+                "prompt": "Neon harbor",
+                "model": "ltx_2_3",
+                "loras": [{"id": "identity", "icLora": True}],
+            }
+        }
+    )
+
+    assert adapter._dependencies_available(text_request) is True
+    assert "ltx_pipelines.ti2vid_two_stages" in imported
+    assert "ltx_pipelines.ic_lora" not in imported
+    assert adapter._dependencies_available(ic_request) is False
+
+
 def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch, tmp_path):
     data_dir = tmp_path / "data"
     config_dir = tmp_path / "config"
@@ -1705,7 +1776,7 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
     )
     checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
     write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
-    ic_lora = tmp_path / "identity-ic-lora.safetensors"
+    ic_lora = tmp_path / "identity-control.safetensors"
     ic_lora.write_bytes(b"ic-lora")
     calls = {"run": None, "encode": None}
 
@@ -1765,7 +1836,7 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
 
     monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
     adapter = LtxPipelinesVideoAdapter()
-    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda *_args: True)
     job = {
         "id": "job-i2v",
         "payload": {
@@ -1782,7 +1853,8 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
             "loras": [
                 {
                     "id": "identity_ic",
-                    "name": "LTX-2.3 IC-LoRA Identity",
+                    "name": "Identity Control",
+                    "icLora": True,
                     "installedPath": str(ic_lora),
                     "weight": 0.65,
                     "families": ["ltx-video"],
@@ -1889,7 +1961,7 @@ def test_native_ltx_image_to_video_falls_back_without_ic_lora(monkeypatch, tmp_p
 
     monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
     adapter = LtxPipelinesVideoAdapter()
-    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda *_args: True)
     request = adapter.prepare(
         settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
         job={
@@ -1955,7 +2027,7 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
     )
     checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
     write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
-    ic_lora = tmp_path / "identity-ic-lora.safetensors"
+    ic_lora = tmp_path / "identity-control.safetensors"
     ic_lora.write_bytes(b"ic-lora")
     calls = {"init": None, "run": None, "encode": None}
 
@@ -2002,7 +2074,7 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
 
     monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
     adapter = LtxPipelinesVideoAdapter()
-    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda *_args: True)
     job = {
         "id": "job-extend-ic",
         "payload": {
@@ -2019,7 +2091,8 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
             "loras": [
                 {
                     "id": "identity_ic",
-                    "name": "LTX-2.3 IC-LoRA Identity",
+                    "name": "Identity Control",
+                    "icLora": True,
                     "installedPath": str(ic_lora),
                     "weight": 0.7,
                     "families": ["ltx-video"],
@@ -2109,7 +2182,7 @@ def test_native_ltx_cleanup_deletes_temp_output_and_evicts_pipeline(monkeypatch,
 
     monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
     adapter = LtxPipelinesVideoAdapter()
-    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda *_args: True)
     job = {
         "id": "job-cleanup",
         "payload": {

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1489,7 +1489,7 @@ def test_native_ltx_adapter_rejects_unsupported_modes():
             "id": "job-1",
             "payload": {
                 "projectId": "project-1",
-                "mode": "video_bridge",
+                "mode": "replace_person",
                 "prompt": "city",
                 "model": "ltx_2_3",
                 "advanced": {},
@@ -1678,6 +1678,8 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
     )
     checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
     write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+    ic_lora = tmp_path / "identity-ic-lora.safetensors"
+    ic_lora.write_bytes(b"ic-lora")
     calls = {"run": None, "encode": None}
 
     class FakePipeline:
@@ -1719,8 +1721,8 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
             )
         if name == "ltx_pipelines.utils.types":
             return SimpleNamespace(OffloadMode=FakeOffloadMode)
-        if name == "ltx_pipelines.ti2vid_two_stages":
-            return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
+        if name == "ltx_pipelines.ic_lora":
+            return SimpleNamespace(ICLoraPipeline=FakePipeline)
         if name == "ltx_core.model.video_vae":
             return SimpleNamespace(
                 TilingConfig=FakeTilingConfig,
@@ -1750,6 +1752,14 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
             "width": 320,
             "height": 256,
             "quality": "balanced",
+            "loras": [
+                {
+                    "id": "identity_ic",
+                    "installedPath": str(ic_lora),
+                    "weight": 0.65,
+                    "families": ["ltx-video"],
+                }
+            ],
             "advanced": {"imageConditioningStrength": 0.7},
         },
     }
@@ -1765,11 +1775,149 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
     )
 
     image_condition = calls["run"]["images"][0]
+    assert calls["run"]["video_conditioning"] == []
     assert image_condition.path == str(project_path / image_rel)
     assert image_condition.frame_idx == 0
     assert image_condition.strength == 0.7
     assert result["assets"][0]["lineage"]["sourceAssetId"] == "asset-source"
     assert result["assets"][0]["recipe"]["rawAdapterSettings"]["realModelInference"] is True
+
+
+def test_native_ltx_image_to_video_requires_ic_lora(tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    data_dir.mkdir()
+    checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+    adapter = LtxPipelinesVideoAdapter()
+    request = adapter.prepare(
+        settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir),
+        job={
+            "id": "job-i2v-missing-lora",
+            "payload": {
+                "projectId": "project-1",
+                "mode": "image_to_video",
+                "prompt": "Make the harbor move",
+                "model": "ltx_2_3",
+                "sourceAssetId": "asset-source",
+                "advanced": {},
+            },
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="IC-LoRA video conditioning requires at least one"):
+        adapter.ensure_models(request)
+
+
+def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    project_path = tmp_path / "project"
+    data_dir.mkdir()
+    project_path.mkdir()
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": "project-1", "path": str(project_path)}]),
+        encoding="utf-8",
+    )
+    video_rel = "assets/videos/source.mp4"
+    (project_path / "assets" / "videos").mkdir(parents=True)
+    (project_path / video_rel).write_bytes(b"source-video")
+    (project_path / "assets" / "videos" / "source.sceneworks.json").write_text(
+        json.dumps({"id": "asset-source-video", "type": "video", "file": {"path": video_rel}}),
+        encoding="utf-8",
+    )
+    checkpoint, spatial, lora, gemma = write_native_ltx_resource_files(tmp_path)
+    write_native_ltx_manifest(config_dir, checkpoint=checkpoint, spatial=spatial, lora=lora, gemma=gemma)
+    ic_lora = tmp_path / "identity-ic-lora.safetensors"
+    ic_lora.write_bytes(b"ic-lora")
+    calls = {"init": None, "run": None, "encode": None}
+
+    class FakePipeline:
+        def __init__(self, **kwargs):
+            calls["init"] = kwargs
+
+        def __call__(self, **kwargs):
+            calls["run"] = kwargs
+            return ["video-chunk"], None
+
+    class FakeTilingConfig:
+        @staticmethod
+        def default():
+            return "tiling-config"
+
+    class FakeOffloadMode:
+        NONE = "none"
+        CPU = "cpu"
+        DISK = "disk"
+
+    def fake_encode_video(**kwargs):
+        calls["encode"] = kwargs
+        Path(kwargs["output_path"]).write_bytes(b"mp4")
+
+    def fake_import_module(name):
+        if name == "ltx_core.loader":
+            return SimpleNamespace(
+                LoraPathStrengthAndSDOps=lambda path, strength, sd_ops: (path, strength, sd_ops),
+                LTXV_LORA_COMFY_RENAMING_MAP={"rename": "map"},
+            )
+        if name == "ltx_pipelines.utils.types":
+            return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_pipelines.ic_lora":
+            return SimpleNamespace(ICLoraPipeline=FakePipeline)
+        if name == "ltx_core.model.video_vae":
+            return SimpleNamespace(
+                TilingConfig=FakeTilingConfig,
+                get_video_chunks_number=lambda _frames, _tiling: 1,
+            )
+        if name == "ltx_pipelines.utils.media_io":
+            return SimpleNamespace(encode_video=fake_encode_video)
+        raise ImportError(name)
+
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import_module)
+    adapter = LtxPipelinesVideoAdapter()
+    monkeypatch.setattr(adapter, "_dependencies_available", lambda: True)
+    job = {
+        "id": "job-extend-ic",
+        "payload": {
+            "projectId": "project-1",
+            "mode": "extend_clip",
+            "prompt": "Keep the character walking",
+            "model": "ltx_2_3",
+            "sourceClipAssetId": "asset-source-video",
+            "duration": 1,
+            "fps": 12,
+            "width": 320,
+            "height": 256,
+            "quality": "balanced",
+            "loras": [
+                {
+                    "id": "identity_ic",
+                    "installedPath": str(ic_lora),
+                    "weight": 0.7,
+                    "families": ["ltx-video"],
+                }
+            ],
+            "advanced": {"videoConditioningStrength": 0.85, "conditioningAttentionStrength": 0.9},
+        },
+    }
+    request = adapter.prepare(settings=SimpleNamespace(data_dir=data_dir, config_dir=config_dir), job=job)
+
+    adapter.ensure_models(request)
+    result = adapter.run(
+        settings=SimpleNamespace(data_dir=data_dir),
+        job=job,
+        request=request,
+        progress=lambda *_args: None,
+        cancel_requested=lambda: False,
+    )
+
+    assert calls["init"]["distilled_checkpoint_path"] == str(checkpoint)
+    assert calls["init"]["loras"] == ((str(ic_lora), 0.7, {"rename": "map"}),)
+    assert calls["run"]["images"] == []
+    assert calls["run"]["video_conditioning"] == [(str(project_path / video_rel), 0.85)]
+    assert calls["run"]["conditioning_attention_strength"] == 0.9
+    assert result["requirements"]["pipeline"] == "ltx_pipelines.ic_lora"
+    assert result["assets"][0]["lineage"]["sourceClipAssetId"] == "asset-source-video"
 
 
 def test_native_ltx_cleanup_deletes_temp_output_and_evicts_pipeline(monkeypatch, tmp_path):

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -497,6 +497,33 @@ def test_lora_specs_fail_before_inference_for_missing_or_excess_loras(tmp_path):
         normalize_lora_specs(many)
 
 
+def test_lora_specs_resolve_huggingface_cache_snapshot(monkeypatch, tmp_path):
+    cache_root = tmp_path / "hf" / "hub"
+    snapshot = write_huggingface_cache_resource(
+        cache_root,
+        "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
+        "ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors",
+    )
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(cache_root))
+
+    specs = normalize_lora_specs(
+        [
+            {
+                "id": "ltx_2_3_ic_union_control",
+                "weight": 0.7,
+                "source": {
+                    "provider": "huggingface",
+                    "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
+                    "file": "ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors",
+                },
+            }
+        ]
+    )
+
+    assert specs[0].path == str(snapshot / "ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors")
+    assert specs[0].weight == 0.7
+
+
 def test_image_adapter_env_aliases_and_unknown_values(monkeypatch):
     monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "procedural")
     assert create_image_adapter({"payload": {"model": "z_image_turbo"}}).__class__.__name__ == "ProceduralImageAdapter"


### PR DESCRIPTION
## Summary

- Route native LTX image/video conditioning through `ltx_pipelines.ic_lora.ICLoraPipeline` when an installed IC-LoRA preset is present or required.
- Let LTX image-to-video and first/last frame fall back to the existing `DistilledPipeline` / `TI2VidTwoStagesPipeline` path when no preset is selected or the selected preset has no IC-LoRA.
- Keep IC-LoRA required for LTX video-conditioned modes such as extend/bridge, where the video conditioning path depends on the IC-LoRA pipeline.
- Add explicit `icLora` / `conditioningRole` metadata, preserve it through preset/job serialization, and keep legacy name detection only as a compatibility fallback.
- Add built-in LTX-2.3 IC-LoRA catalog entries backed by Hugging Face cache paths, so cached IC-LoRAs appear installed without local import.
- Resolve Hugging Face LoRA cache snapshots through `refs/main`, avoid deleting shared HF cache files, and avoid repeated native LoRA normalization per prepared request.
- Probe only the native LTX pipeline module required by the current request so missing `ic_lora` does not disable plain text-to-video or fallback I2V.

## Why

Plain image conditioning can let people in the starting image drift or morph, so IC-LoRA should be used whenever an IC-LoRA preset is available. But I2V should still be usable without an IC-LoRA preset, so those image-conditioned jobs now fall back to the standard native LTX pipelines instead of being blocked. The follow-up review fixes reduce version-drift risk, make IC-LoRA detection explicit, and keep shared Hugging Face cache state from being treated as SceneWorks-owned deleteable data.

## Validation

- `python -m pytest tests/test_worker_runtime.py -q`
- `cargo test -p sceneworks-rust-api`
- `npm test` in `apps/web`