### PR TITLE
feat(ltx): FP8 precision toggle + free GPU memory on failure

### DIFF
--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -83,6 +83,7 @@ export function VideoStudio({
   const [quality, setQuality] = useState("balanced");
   const [ltxPipeline, setLtxPipeline] = useState("auto");
   const [distilledVariant, setDistilledVariant] = useState("1.1");
+  const [precision, setPrecision] = useState("fp8");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(videoModels[0]?.id ?? ltxVideoModelId);
   const [selectedPresetId, setSelectedPresetId] = useState(null);
@@ -401,7 +402,7 @@ export function VideoStudio({
           recipePresetPrompt: selectedPreset?.prompt ?? null,
           selectedPersonTrack: selectedTrack ?? null,
           replacementModeLabel: replacementModeLabels[replacementMode],
-          ...(model === ltxVideoModelId ? { ltxPipeline, distilledVariant } : {}),
+          ...(model === ltxVideoModelId ? { ltxPipeline, distilledVariant, precision } : {}),
         },
       });
       onLocalJobCreated?.(job);
@@ -804,6 +805,13 @@ export function VideoStudio({
                         <select onChange={(event) => setDistilledVariant(event.target.value)} value={distilledVariant}>
                           <option value="1.1">1.1 (newer aesthetic + audio)</option>
                           <option value="1.0">1.0 (original)</option>
+                        </select>
+                      </label>
+                      <label>
+                        Precision
+                        <select onChange={(event) => setPrecision(event.target.value)} value={precision}>
+                          <option value="fp8">FP8 (lower VRAM)</option>
+                          <option value="bf16">BF16 (higher quality, CPU offload)</option>
                         </select>
                       </label>
                     </>

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -375,6 +375,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
 def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     job_id = job["id"]
     adapter = create_video_adapter(job)
+    job_failed = False
 
     def adapter_loaded_models() -> list[str]:
         return loaded_models_from_adapter(adapter, job_id=job_id)
@@ -453,7 +454,7 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             },
         )
     except Exception as exc:
-        adapter.cleanup(job_id)
+        job_failed = True
         message, error = friendly_failure("Video generation", exc)
         update_job(
             api,
@@ -467,6 +468,13 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             },
         )
     finally:
+        # Free GPU memory only after the except block exits: while the handler
+        # runs, the interpreter keeps the active exception (and its traceback)
+        # alive, and that traceback references the OOM tensors — so an
+        # empty_cache() inside the handler reclaims nothing and the memory stays
+        # held until the worker restarts.
+        if job_failed:
+            adapter.cleanup(job_id)
         heartbeat(api, settings, "idle", loaded_models=adapter_loaded_models())
 
 

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import gc
 import hashlib
 import importlib
 import importlib.util
@@ -319,6 +320,12 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
     # peak VRAM); callers can override via advanced.offloadMode.
     _default_offload_mode = "cpu"
 
+    # FP8 quantizes the transformer weights (~half their VRAM) and is the native
+    # stack's primary memory-reduction lever — it matches ComfyUI's footprint and
+    # works on the bf16 checkpoints we ship. FP8 and weight offloading are mutually
+    # exclusive in the loader, so enabling FP8 forces offload_mode=none.
+    _default_precision = "fp8"
+
     def __init__(self) -> None:
         super().__init__()
         self._loaded_models: set[str] = set()
@@ -613,7 +620,10 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
 
         install_ltx_pipelines_multigpu_compat()
         loader = importlib.import_module("ltx_core.loader")
-        offload_mode = self._offload_mode(request)
+        quantization = self._quantization(request)
+        # FP8 and weight offloading are mutually exclusive in the native loader
+        # (offloading silently disables FP8), so force offload off when FP8 is on.
+        offload_mode = self._offload_mode(request, override="none" if quantization is not None else None)
         loras = self._ltx_loras(loader, request)
         # The native Lightricks constructors expose `loras` across distilled,
         # two-stage, and IC-LoRA pipelines; `distilled_lora` remains separate.
@@ -621,6 +631,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             "gemma_root": str(resources.gemma_root),
             "spatial_upsampler_path": str(resources.spatial_upsampler_path),
             "loras": loras,
+            "quantization": quantization,
             "torch_compile": bool(request.advanced.get("compile", False)),
             "offload_mode": offload_mode,
         }
@@ -754,6 +765,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 str(resources.distilled_lora_path),
                 str(resources.gemma_root),
                 str(request.advanced.get("offloadMode", self._default_offload_mode)),
+                str(request.advanced.get("precision", self._default_precision)),
                 lora_cache_key_for_specs(self._ltx_lora_specs(request)) if request.loras else "",
             ]
         )
@@ -796,8 +808,9 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 updated[key] = {**entry, "file": variants[variant]}
         return updated
 
-    def _offload_mode(self, request: VideoRequest) -> Any:
-        offload_value = str(request.advanced.get("offloadMode", self._default_offload_mode)).strip().lower()
+    def _offload_mode(self, request: VideoRequest, *, override: str | None = None) -> Any:
+        raw = override if override is not None else request.advanced.get("offloadMode", self._default_offload_mode)
+        offload_value = str(raw).strip().lower()
         install_ltx_pipelines_multigpu_compat()
         types_module = importlib.import_module("ltx_pipelines.utils.types")
         offload_mode = getattr(types_module, "OffloadMode")
@@ -806,6 +819,14 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         if offload_value == "disk":
             return offload_mode.DISK
         return offload_mode.NONE
+
+    def _quantization(self, request: VideoRequest) -> Any:
+        precision = str(request.advanced.get("precision", self._default_precision)).strip().lower()
+        if precision != "fp8":
+            return None
+        install_ltx_pipelines_multigpu_compat()
+        quant_module = importlib.import_module("ltx_core.quantization")
+        return quant_module.QuantizationPolicy.fp8_cast()
 
     def _advanced_float(self, request: VideoRequest, key: str, fallback: float) -> float:
         try:
@@ -816,6 +837,10 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
     def _evict_pipeline(self) -> None:
         self._pipeline = None
         self._pipeline_key_value = None
+        # Drop reference cycles (e.g. frames retained by a failed run) before
+        # asking the CUDA allocator to release blocks — empty_cache() can only
+        # reclaim memory that is no longer referenced by any live Python object.
+        gc.collect()
         try:
             torch = importlib.import_module("torch")
             cuda = getattr(torch, "cuda", None)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      # Reduces CUDA fragmentation OOM; recommended by the LTX stack alongside FP8.
+      PYTORCH_CUDA_ALLOC_CONF: ${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
       - ${SCENEWORKS_HF_CACHE_BIND:-./data/cache/huggingface}:/sceneworks/data/cache/huggingface

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1088,6 +1088,58 @@ def test_video_job_estimate_progress_accepts_non_preview_frame_requirements(monk
     assert "Estimated 121 frames for this clip." in progress_messages
 
 
+def test_video_job_failure_runs_cleanup_to_free_gpu(monkeypatch):
+    events = {"cleanup": 0, "status": None}
+
+    class Api:
+        def post(self, path, payload):
+            if path.endswith("/heartbeat"):
+                return {}
+            if path.endswith("/progress"):
+                events["status"] = payload.get("status")
+                return {"status": payload["status"], "stage": payload.get("stage")}
+            raise AssertionError(path)
+
+        def get(self, _path):
+            return {"cancelRequested": False}
+
+    class VideoAdapter:
+        def prepare(self, *, settings, job):
+            return {"job": job["id"]}
+
+        def ensure_models(self, _request):
+            return None
+
+        def estimate_requirements(self, _request):
+            return {"estimatedFrames": 121, "requestedFrames": 120}
+
+        def run(self, *, settings, job, request, progress, cancel_requested):
+            raise RuntimeError("CUDA error: out of memory")
+
+        def cancel(self, _job_id):
+            raise AssertionError("cancel should not be called")
+
+        def cleanup(self, _job_id):
+            events["cleanup"] += 1
+
+    monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda _job=None: VideoAdapter())
+    monkeypatch.setattr(
+        "scene_worker.runtime.run_blocking_job_step",
+        lambda *_args, **_kwargs: _args[4](),
+    )
+
+    run_video_job(
+        Api(),
+        SimpleNamespace(worker_id="worker-1"),
+        {"id": "job-oom", "payload": {"projectId": "project-1", "prompt": "clip"}},
+    )
+
+    # On failure the adapter is cleaned up (pipeline evicted + CUDA cache freed)
+    # so the GPU does not stay pinned until a worker restart.
+    assert events["cleanup"] == 1
+    assert events["status"] == "failed"
+
+
 def test_random_batch_seeds_are_used_per_image():
     assert resolve_seed(None, "city at night", 2, [101, 202, 303, 404]) == 303
 
@@ -1193,6 +1245,12 @@ def test_ltx_pipelines_multigpu_compat_installs_missing_type_module(monkeypatch)
     module = importlib.import_module("ltx_pipelines.multigpu.delegating_builder")
     with pytest.raises(RuntimeError, match="optional multigpu DelegatingBuilder"):
         module.DelegatingBuilder()
+
+
+class _FakeQuantizationPolicy:
+    @staticmethod
+    def fp8_cast():
+        return "fp8-cast"
 
 
 def write_native_ltx_manifest(config_dir, *, checkpoint=None, spatial=None, lora=None, gemma=None):
@@ -1336,6 +1394,35 @@ def test_native_ltx_pipeline_override_decouples_from_quality(tmp_path):
     # Auto preserves the quality-driven default.
     assert pipeline_for("balanced", {"ltxPipeline": "auto"}) == "ltx_pipelines.ti2vid_two_stages"
     assert pipeline_for("fast", {}) == "ltx_pipelines.distilled"
+
+
+def test_native_ltx_precision_selects_quantization_and_offload(monkeypatch):
+    import scene_worker.video_adapters as va
+
+    fake_offload = SimpleNamespace(CPU="cpu", DISK="disk", NONE="none")
+
+    def fake_import(name):
+        if name == "ltx_pipelines.utils.types":
+            return SimpleNamespace(OffloadMode=fake_offload)
+        if name == "ltx_core.quantization":
+            return SimpleNamespace(QuantizationPolicy=_FakeQuantizationPolicy)
+        raise ImportError(name)
+
+    monkeypatch.setattr("scene_worker.video_adapters.install_ltx_pipelines_multigpu_compat", lambda: None)
+    monkeypatch.setattr("scene_worker.video_adapters.importlib.import_module", fake_import)
+    adapter = va.LtxPipelinesVideoAdapter()
+
+    def req(advanced):
+        return SimpleNamespace(advanced=advanced)
+
+    # Default precision is fp8 -> a quantization policy is built.
+    assert adapter._quantization(req({})) == "fp8-cast"
+    # Explicit bf16 -> no quantization.
+    assert adapter._quantization(req({"precision": "bf16"})) is None
+    # bf16 keeps the default CPU offload.
+    assert adapter._offload_mode(req({"precision": "bf16"})) == "cpu"
+    # The fp8 path forces offload off (mutual exclusion in the loader).
+    assert adapter._offload_mode(req({}), override="none") == "none"
 
 
 def test_native_ltx_distilled_variant_switches_files(tmp_path):
@@ -1772,6 +1859,8 @@ def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, 
             )
         if name == "ltx_pipelines.utils.types":
             return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_core.quantization":
+            return SimpleNamespace(QuantizationPolicy=_FakeQuantizationPolicy)
         if name == "ltx_pipelines.ti2vid_two_stages":
             return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
         if name == "ltx_core.model.video_vae":
@@ -1820,6 +1909,10 @@ def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, 
     assert media_path.read_bytes() == b"mp4"
     assert calls["init"]["checkpoint_path"] == str(checkpoint)
     assert calls["init"]["distilled_lora"] == [(str(lora), 0.6, {"rename": "map"})]
+    # Default precision is fp8: quantization is passed and offload is forced off
+    # (FP8 and weight offloading are mutually exclusive in the native loader).
+    assert calls["init"]["quantization"] == "fp8-cast"
+    assert calls["init"]["offload_mode"] == "none"
     assert calls["run"]["prompt"] == "Neon harbor"
     assert calls["run"]["negative_prompt"] == "rain"
     assert calls["run"]["num_inference_steps"] == 7
@@ -1938,6 +2031,8 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
             )
         if name == "ltx_pipelines.utils.types":
             return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_core.quantization":
+            return SimpleNamespace(QuantizationPolicy=_FakeQuantizationPolicy)
         if name == "ltx_pipelines.ic_lora":
             return SimpleNamespace(ICLoraPipeline=FakePipeline)
         if name == "ltx_core.model.video_vae":
@@ -2063,6 +2158,8 @@ def test_native_ltx_image_to_video_falls_back_without_ic_lora(monkeypatch, tmp_p
             )
         if name == "ltx_pipelines.utils.types":
             return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_core.quantization":
+            return SimpleNamespace(QuantizationPolicy=_FakeQuantizationPolicy)
         if name == "ltx_pipelines.ti2vid_two_stages":
             return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
         if name == "ltx_core.model.video_vae":
@@ -2180,6 +2277,8 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
             )
         if name == "ltx_pipelines.utils.types":
             return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_core.quantization":
+            return SimpleNamespace(QuantizationPolicy=_FakeQuantizationPolicy)
         if name == "ltx_pipelines.ic_lora":
             return SimpleNamespace(ICLoraPipeline=FakePipeline)
         if name == "ltx_core.model.video_vae":
@@ -2286,6 +2385,8 @@ def test_native_ltx_cleanup_deletes_temp_output_and_evicts_pipeline(monkeypatch,
             )
         if name == "ltx_pipelines.utils.types":
             return SimpleNamespace(OffloadMode=FakeOffloadMode)
+        if name == "ltx_core.quantization":
+            return SimpleNamespace(QuantizationPolicy=_FakeQuantizationPolicy)
         if name == "ltx_pipelines.ti2vid_two_stages":
             return SimpleNamespace(TI2VidTwoStagesPipeline=FakePipeline)
         if name == "ltx_core.model.video_vae":


### PR DESCRIPTION
## Summary

Two LTX-2.3 GPU-memory fixes following continued CUDA OOM on a 96 GB card.

### FP8 quantization (the real ComfyUI-parity lever)
The native LTX stack's docs name FP8 — not offloading — as the primary memory reducer, and FP8/offload are mutually exclusive. ComfyUI's ~half footprint is FP8 (transformer ~22 GB vs bf16 ~44 GB).

- New advanced `precision` setting (**default `fp8`**) + a **Precision** dropdown in Video Studio (gated to LTX-2.3).
- `_quantization()` builds `QuantizationPolicy.fp8_cast()` and passes it as `quantization=` to all three pipelines. `fp8_cast` downcasts the transformer from the **bf16 checkpoints already shipped** — no fp8 download. API verified against the pinned `ltx` commit in `requirements-ltx.txt`.
- Because FP8 and weight offloading are mutually exclusive in the loader, the load path forces `offload_mode=none` whenever FP8 is active.
- `docker-compose.yml`: `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` on the worker (recommended alongside FP8).

### Free GPU memory on job failure
After an OOM the GPU stayed pinned until a worker restart. `cleanup()` was already called, but **inside the `except` block** — where the live exception's traceback still references the OOM tensors, so `empty_cache()` reclaimed nothing.

- Moved the failure cleanup into `finally` (gated on a `job_failed` flag), so it runs after the exception/traceback is cleared.
- `_evict_pipeline()` now `gc.collect()`s before `empty_cache()` to break the retained frame cycles and return blocks to the allocator.

## Reviewer notes
- **Default flips to FP8.** BF16 (with CPU offload) remains one toggle away for max quality. Expected peak ≈ FP8 transformer (~22 GB) + Gemma bf16 (~24 GB) ≈ ComfyUI's ~48 GB.
- **Not GPU-tested** (no GPU in dev). FP8 API is verified against the pinned commit; `fp8_cast` is documented to work on bf16 checkpoints. If FP8 misbehaves at runtime, toggle BF16.
- **Requires rebuilding the worker Docker image** to take effect (the Python code lives in the image).
- Scope: failure cleanup covers the **video** path. The image-job handler and the cancel path are unchanged — follow-up if desired.
- If memory still lingers post-OOM after this, the next suspect is a module-level model registry inside `ltx_pipelines`.

## Test plan
- [x] `pytest tests/test_worker_runtime.py` — 104 pass, incl. new `test_native_ltx_precision_selects_quantization_and_offload` and `test_video_job_failure_runs_cleanup_to_free_gpu`, plus fp8-default assertions on the two-stage real-run test.
- [x] `npm test` (apps/web) — 60 pass; Video Studio advanced panel renders the Precision toggle without regressions.
- [x] `docker compose config` validates.
- [ ] Manual: FP8 T2V on the 96 GB box drops peak to ~ComfyUI levels; force an OOM and confirm `nvidia-smi` frees without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)