### PR TITLE
fix(worker): revert CUDA runtime to cu128, keep torch 2.8 / Triton 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ container and is exposed on the same host port.
 service receives `VITE_API_BASE_URL=http://localhost:${SCENEWORKS_API_PORT}`,
 and workers call `http://api:${SCENEWORKS_API_PORT}` on the compose network.
 Compose builds the Python inference worker with CUDA PyTorch wheels by default
-using `SCENEWORKS_PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu129`.
+using `SCENEWORKS_PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu128`.
 Set `SCENEWORKS_PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu` before
 building only when you intentionally want a CPU-only worker; CPU-only PyTorch
 workers do not advertise image or video inference capabilities.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       context: .
       dockerfile: docker/worker.Dockerfile
       args:
-        PYTORCH_INDEX_URL: ${SCENEWORKS_PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu129}
+        PYTORCH_INDEX_URL: ${SCENEWORKS_PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu128}
         PYTORCH_SPEC: ${SCENEWORKS_PYTORCH_SPEC:-torch>=2.8,<2.9}
         PYTORCH_AUDIO_SPEC: ${SCENEWORKS_PYTORCH_AUDIO_SPEC:-torchaudio>=2.8,<2.9}
         INCLUDE_LTX_PIPELINES: ${SCENEWORKS_INCLUDE_LTX_PIPELINES:-1}


### PR DESCRIPTION
## Summary

Follow-up to #82. That PR moved the worker to torch 2.8 (→ Triton 3.4) to fix LTX-2.3 faults on Blackwell sm_120, and switched the CUDA wheel to **cu129** to match `ltx-core`'s pyproject hint. On the RTX PRO 6000 Blackwell box that surfaced a *new* failure — `CUDA driver error: unknown error` at load (~6s) — whereas diffusers image generation runs cleanly on cu128.

**The Blackwell fix is Triton 3.4, which ships with torch 2.8 regardless of the CUDA wheel variant** — cu129 was never required for it. So this reverts the runtime to **cu128** (the version image gen already runs on) while keeping **torch 2.8 / Triton 3.4** intact.

- `docker-compose.yml`: `PYTORCH_INDEX_URL` cu129 → cu128.
- `README.md`: cu129 → cu128.
- `requirements.txt` / Dockerfile pins stay at torch 2.8 (unchanged from #82).

## Reviewer notes
- Net toolchain after this: **torch 2.8.0+cu128, Triton 3.4.0** — confirmed installed in the worker (`pip show torch triton`).
- **Not yet verified to fix the runtime fault** on hardware — building this on the Blackwell box is the test. If `unknown error` persists on cu128 + torch 2.8, it's not the CUDA runtime, and the next step is a clean reboot (to rule out a wedged WDDM driver after repeated crashes) plus a `CUDA_LAUNCH_BLOCKING=1` run to unmask the real error.

## Test plan
- [x] `docker compose config` validates; no remaining cu129 references.
- [x] `pytest tests/test_worker_runtime.py` — 104 pass (mock torch).
- [ ] Rebuild worker on the Blackwell box; confirm `torch 2.8+cu128` / `triton 3.4`; rerun the LTX job.
- [ ] Image-gen sanity check on torch 2.8 + cu128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)