### PR TITLE
fix(compose): disable WSL2-incompatible CUDA allocator; default port 8010 + user HF cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # API bind address and exposed port. In Docker, keep the bind host at 0.0.0.0;
 # use the published port and access token to control host/LAN access.
+# Default is 8010 (8000 commonly collides with ComfyUI on the same machine).
 SCENEWORKS_API_HOST=0.0.0.0
-SCENEWORKS_API_PORT=8000
+SCENEWORKS_API_PORT=8010
 
 # Docker API image. The Rust API is the only supported backend runtime.
 
@@ -24,6 +25,12 @@ SCENEWORKS_CONFIG_DIR=config
 SCENEWORKS_DATA_BIND=./data
 SCENEWORKS_CONFIG_BIND=./config
 
+# Host path bind-mounted as the Hugging Face cache. Defaults to the user's
+# standard HF cache (%USERPROFILE%\.cache\huggingface on Windows, $HOME/.cache/
+# huggingface on Linux/macOS) so models are shared with other HF tools instead
+# of re-downloaded into the repo. Override for an isolated/alternate cache.
+SCENEWORKS_HF_CACHE_BIND=
+
 # Optional API metadata and storage overrides.
 SCENEWORKS_APP_VERSION=0.2.0
 SCENEWORKS_JOBS_DB_PATH=
@@ -31,7 +38,7 @@ SCENEWORKS_WORKER_TIMEOUT_SECONDS=90
 SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1
 
 # Worker connection and polling defaults.
-SCENEWORKS_API_URL=http://localhost:8000
+SCENEWORKS_API_URL=http://localhost:8010
 SCENEWORKS_WORKER_ID=worker-local-0
 SCENEWORKS_GPU_ID=auto
 SCENEWORKS_WORKER_HEARTBEAT_SECONDS=30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: docker/rust-api.Dockerfile
     environment:
       SCENEWORKS_API_HOST: ${SCENEWORKS_API_HOST:-0.0.0.0}
-      SCENEWORKS_API_PORT: ${SCENEWORKS_API_PORT:-8000}
+      SCENEWORKS_API_PORT: ${SCENEWORKS_API_PORT:-8010}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
       SCENEWORKS_JOBS_DB_PATH: /sceneworks/data/cache/jobs.db
@@ -17,13 +17,13 @@ services:
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
     ports:
-      - "${SCENEWORKS_API_PORT:-8000}:${SCENEWORKS_API_PORT:-8000}"
+      - "${SCENEWORKS_API_PORT:-8010}:${SCENEWORKS_API_PORT:-8010}"
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
-      - ${SCENEWORKS_HF_CACHE_BIND:-./data/cache/huggingface}:/sceneworks/data/cache/huggingface
+      - ${SCENEWORKS_HF_CACHE_BIND:-${USERPROFILE:-$HOME}/.cache/huggingface}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS \"http://127.0.0.1:$${SCENEWORKS_API_PORT:-8000}/api/v1/health\" >/dev/null"]
+      test: ["CMD-SHELL", "curl -fsS \"http://127.0.0.1:$${SCENEWORKS_API_PORT:-8010}/api/v1/health\" >/dev/null"]
       interval: 20s
       timeout: 5s
       retries: 3
@@ -39,7 +39,7 @@ services:
         PYTORCH_AUDIO_SPEC: ${SCENEWORKS_PYTORCH_AUDIO_SPEC:-torchaudio>=2.8,<2.9}
         INCLUDE_LTX_PIPELINES: ${SCENEWORKS_INCLUDE_LTX_PIPELINES:-1}
     environment:
-      SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8000}
+      SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8010}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
       SCENEWORKS_WORKER_ID: python-inference-worker-0
@@ -49,11 +49,16 @@ services:
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
-      # Reduces CUDA fragmentation OOM; recommended by the LTX stack alongside FP8.
-      PYTORCH_CUDA_ALLOC_CONF: ${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+      # expandable_segments reduces CUDA fragmentation OOM and is recommended by
+      # the LTX stack alongside FP8, BUT it relies on the CUDA virtual-memory
+      # (cuMem*) API, which is unsupported under Docker Desktop's WSL2/WDDM
+      # backend and fails every CUDA op with "CUDA driver error: unknown error".
+      # Leave unset by default; opt in on native-Linux GPU hosts via
+      # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True.
+      PYTORCH_CUDA_ALLOC_CONF: ${PYTORCH_CUDA_ALLOC_CONF:-}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
-      - ${SCENEWORKS_HF_CACHE_BIND:-./data/cache/huggingface}:/sceneworks/data/cache/huggingface
+      - ${SCENEWORKS_HF_CACHE_BIND:-${USERPROFILE:-$HOME}/.cache/huggingface}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config:ro
     depends_on:
       api:
@@ -72,7 +77,7 @@ services:
       dockerfile: docker/rust-worker.Dockerfile
     restart: unless-stopped
     environment:
-      SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8000}
+      SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8010}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
       SCENEWORKS_WORKER_ID: rust-utility-worker-0
@@ -85,7 +90,7 @@ services:
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
-      - ${SCENEWORKS_HF_CACHE_BIND:-./data/cache/huggingface}:/sceneworks/data/cache/huggingface
+      - ${SCENEWORKS_HF_CACHE_BIND:-${USERPROFILE:-$HOME}/.cache/huggingface}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
     depends_on:
       api:
@@ -104,7 +109,7 @@ services:
       context: .
       dockerfile: docker/web.Dockerfile
     environment:
-      VITE_API_BASE_URL: http://localhost:${SCENEWORKS_API_PORT:-8000}
+      VITE_API_BASE_URL: http://localhost:${SCENEWORKS_API_PORT:-8010}
     ports:
       - "${SCENEWORKS_WEB_PORT:-5173}:5173"
     volumes:


### PR DESCRIPTION
## What broke

Both **image and video** generation started failing with `CUDA driver error: unknown error` after the recent LTX-2.3 work. The host GPUs were healthy (idle, responsive to `nvidia-smi`), and the worker image was already on the proven cu128 + torch 2.8 wheel — so it wasn't the wheel version or a wedged GPU.

## Root cause

The FP8 commit added a **global** allocator env var to the worker:

```yaml
PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
```

`expandable_segments:True` makes PyTorch's caching allocator use the CUDA virtual-memory (`cuMem*`) driver API, which is **not supported under Docker Desktop's WSL2/WDDM backend** (this machine's GPUs show `WDDM` in `nvidia-smi`). The first real CUDA allocation in any job hits a VMM call that returns `cudaErrorUnknown`. Because it's a worker-wide setting, it broke every CUDA job — image and video alike.

Reproduced on the exact worker image + GPU, isolating the variable:

| `PYTORCH_CUDA_ALLOC_CONF` | `torch.randn(2048,2048,device='cuda')` |
|---|---|
| `expandable_segments:True` | ❌ `RuntimeError: CUDA driver error: unknown error` |
| unset (default) | ✅ returns a result |

## Changes

**`docker-compose.yml`**
- Default `PYTORCH_CUDA_ALLOC_CONF` to **unset** (the override is preserved, so native-Linux GPU hosts can still opt in via the env var). Comment explains the WSL2/WDDM incompatibility.
- Default API port `8000` → **`8010`** (8000 commonly collides with ComfyUI on the same machine).
- Default HF cache bind `./data/cache/huggingface` → **`${USERPROFILE:-$HOME}/.cache/huggingface`**, so models are shared with other HF tools instead of re-downloaded into the repo. Resolves to the user's profile on Windows and `$HOME` on Linux/macOS — no hardcoded path, override knob (`SCENEWORKS_HF_CACHE_BIND`) preserved.

**`.env.example`** — updated to match (port 8010 with a note about the ComfyUI collision; added the previously-undocumented `SCENEWORKS_HF_CACHE_BIND`).

## Reviewer notes

- A plain `docker compose up` now works without manually exporting `SCENEWORKS_API_PORT` / `SCENEWORKS_HF_CACHE_BIND`.
- Verified with `docker compose config` (no env vars set): all six port references resolve to `8010` and all three HF binds resolve to the user cache.
- Nested-default interpolation (`${VAR:-${OTHER:-$HOME}/...}`) confirmed working on Compose v5.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)