### PR TITLE
feat(worker): recover from CUDA OOM and gate GPU claims on free VRAM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,11 @@ SCENEWORKS_WORKER_ID=worker-local-0
 SCENEWORKS_GPU_ID=auto
 SCENEWORKS_WORKER_HEARTBEAT_SECONDS=30
 SCENEWORKS_WORKER_POLL_SECONDS=3
+# A GPU worker won't claim a job when its card has less free VRAM than this (MB),
+# so jobs flow to a free GPU when another tool (e.g. ComfyUI) is using one. The API
+# also prefers the emptiest GPU for auto jobs; this is the per-worker absolute floor
+# that also covers single-GPU / all-GPUs-busy cases. 0 disables. CPU is never gated.
+SCENEWORKS_MIN_FREE_VRAM_MB=24000
 
 # Rust utility worker mode. Keep this at cpu unless explicitly testing the Rust
 # worker's GPU supervisor path.

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -298,9 +298,62 @@ def run_blocking_job_step(
         thread.join(timeout=1)
 
 
+def is_cuda_oom(exc: BaseException) -> bool:
+    """True if exc is a CUDA out-of-memory error (torch.OutOfMemoryError or a
+    RuntimeError carrying 'out of memory')."""
+    if type(exc).__name__ == "OutOfMemoryError":
+        return True
+    return "out of memory" in str(exc).lower()
+
+
+# Exit code used when a worker child restarts itself after a CUDA OOM so the
+# supervisor respawns it with a fresh (non-poisoned) CUDA context.
+OOM_RESTART_EXIT_CODE = 75
+
+
+def restart_worker_after_oom(settings: WorkerSettings, job_id: str) -> None:
+    """Exit the worker child after a CUDA OOM so the supervisor respawns it with a
+    fresh CUDA context — releasing VRAM the poisoned context can't reclaim in place.
+    Raises SystemExit, which propagates out of the claim loop and ends the process."""
+    emit(
+        {
+            "event": "worker_restart_after_oom",
+            "workerId": getattr(settings, "worker_id", None),
+            "gpuId": getattr(settings, "gpu_id", None),
+            "jobId": job_id,
+            "reportedAt": now(),
+        }
+    )
+    raise SystemExit(OOM_RESTART_EXIT_CODE)
+
+
+def should_skip_claim_low_vram(settings: WorkerSettings) -> bool:
+    """True if this GPU worker should defer claiming because its card is nearly
+    full — typically another process (e.g. ComfyUI) is using it — so jobs flow to
+    a free GPU instead. Never gates the CPU worker or when the threshold is 0."""
+    threshold = getattr(settings, "min_free_vram_mb", 0)
+    if threshold <= 0 or settings.gpu_id == "cpu":
+        return False
+    utilization = gpu_utilization(settings.gpu_id)
+    free_mb = utilization.get("memoryFreeMb") if utilization else None
+    if free_mb is None or free_mb >= threshold:
+        return False
+    emit(
+        {
+            "event": "claim_skipped_low_vram",
+            "gpuId": settings.gpu_id,
+            "memoryFreeMb": free_mb,
+            "thresholdMb": threshold,
+            "reportedAt": now(),
+        }
+    )
+    return True
+
+
 def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_adapters: dict[str, object]) -> None:
     job_id = job["id"]
     adapter = create_image_adapter(job, image_adapters)
+    needs_oom_restart = False
 
     def adapter_loaded_models() -> list[str]:
         return loaded_models_from_adapter(adapter, job_id=job_id)
@@ -356,6 +409,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
             },
         )
     except Exception as exc:
+        needs_oom_restart = is_cuda_oom(exc)
         message, error = friendly_failure("Image generation", exc)
         update_job(
             api,
@@ -370,12 +424,15 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
         )
     finally:
         heartbeat(api, settings, "idle", loaded_models=loaded_models_from_adapters(image_adapters))
+        if needs_oom_restart:
+            restart_worker_after_oom(settings, job_id)
 
 
 def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     job_id = job["id"]
     adapter = create_video_adapter(job)
     job_failed = False
+    needs_oom_restart = False
 
     def adapter_loaded_models() -> list[str]:
         return loaded_models_from_adapter(adapter, job_id=job_id)
@@ -455,6 +512,7 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
         )
     except Exception as exc:
         job_failed = True
+        needs_oom_restart = is_cuda_oom(exc)
         message, error = friendly_failure("Video generation", exc)
         update_job(
             api,
@@ -476,6 +534,10 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
         if job_failed:
             adapter.cleanup(job_id)
         heartbeat(api, settings, "idle", loaded_models=adapter_loaded_models())
+        # A CUDA OOM can leave the allocator/context unable to reclaim VRAM in
+        # place; restart the child so the supervisor gives it a fresh context.
+        if needs_oom_restart:
+            restart_worker_after_oom(settings, job_id)
 
 
 def run_worker_loop(settings: WorkerSettings) -> None:
@@ -511,6 +573,9 @@ def run_worker_loop(settings: WorkerSettings) -> None:
     while True:
         try:
             heartbeat(api, settings, "idle", loaded_models=loaded_models_from_adapters(image_adapters))
+            if should_skip_claim_low_vram(settings):
+                time.sleep(settings.poll_seconds)
+                continue
             claimed = api.post("/api/v1/jobs/claim", {"workerId": settings.worker_id})
             job = claimed.get("job")
             if job is None:

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -12,6 +12,10 @@ class WorkerSettings:
         self.access_token = os.getenv("SCENEWORKS_ACCESS_TOKEN", "").strip()
         self.heartbeat_seconds = int(os.getenv("SCENEWORKS_WORKER_HEARTBEAT_SECONDS", "30"))
         self.poll_seconds = int(os.getenv("SCENEWORKS_WORKER_POLL_SECONDS", "3"))
+        # A GPU worker won't claim a job when its GPU has less free VRAM than this
+        # (MB), so jobs flow to a free card when another tool (e.g. ComfyUI) is using
+        # one. 0 disables the gate. CPU workers are never gated.
+        self.min_free_vram_mb = int(os.getenv("SCENEWORKS_MIN_FREE_VRAM_MB", "24000"))
 
     def for_worker(self, *, worker_id: str, gpu_id: str) -> "WorkerSettings":
         settings = object.__new__(WorkerSettings)
@@ -23,4 +27,5 @@ class WorkerSettings:
         settings.access_token = self.access_token
         settings.heartbeat_seconds = self.heartbeat_seconds
         settings.poll_seconds = self.poll_seconds
+        settings.min_free_vram_mb = self.min_free_vram_mb
         return settings

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1128,14 +1128,67 @@ def test_video_job_failure_runs_cleanup_to_free_gpu(monkeypatch):
         lambda *_args, **_kwargs: _args[4](),
     )
 
-    run_video_job(
-        Api(),
-        SimpleNamespace(worker_id="worker-1"),
-        {"id": "job-oom", "payload": {"projectId": "project-1", "prompt": "clip"}},
+    # A CUDA OOM cleans up, marks the job failed, then exits (SystemExit) so the
+    # supervisor restarts the child with a fresh CUDA context — the poisoned
+    # context can't reliably reclaim VRAM in place.
+    with pytest.raises(SystemExit):
+        run_video_job(
+            Api(),
+            SimpleNamespace(worker_id="worker-1", gpu_id="0"),
+            {"id": "job-oom", "payload": {"projectId": "project-1", "prompt": "clip"}},
+        )
+
+    assert events["cleanup"] == 1
+    assert events["status"] == "failed"
+
+
+def test_video_job_nonoom_failure_does_not_restart(monkeypatch):
+    events = {"cleanup": 0, "status": None}
+
+    class Api:
+        def post(self, path, payload):
+            if path.endswith("/heartbeat"):
+                return {}
+            if path.endswith("/progress"):
+                events["status"] = payload.get("status")
+                return {"status": payload["status"], "stage": payload.get("stage")}
+            raise AssertionError(path)
+
+        def get(self, _path):
+            return {"cancelRequested": False}
+
+    class VideoAdapter:
+        def prepare(self, *, settings, job):
+            return {"job": job["id"]}
+
+        def ensure_models(self, _request):
+            return None
+
+        def estimate_requirements(self, _request):
+            return {"estimatedFrames": 121, "requestedFrames": 120}
+
+        def run(self, *, settings, job, request, progress, cancel_requested):
+            raise RuntimeError("num_frames must be divisible by 8 + 1")
+
+        def cancel(self, _job_id):
+            raise AssertionError("cancel should not be called")
+
+        def cleanup(self, _job_id):
+            events["cleanup"] += 1
+
+    monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda _job=None: VideoAdapter())
+    monkeypatch.setattr(
+        "scene_worker.runtime.run_blocking_job_step",
+        lambda *_args, **_kwargs: _args[4](),
     )
 
-    # On failure the adapter is cleaned up (pipeline evicted + CUDA cache freed)
-    # so the GPU does not stay pinned until a worker restart.
+    # A non-OOM failure cleans up and marks failed but returns normally (no restart).
+    run_video_job(
+        Api(),
+        SimpleNamespace(worker_id="worker-1", gpu_id="0"),
+        {"id": "job-fail", "payload": {"projectId": "project-1", "prompt": "clip"}},
+    )
+
     assert events["cleanup"] == 1
     assert events["status"] == "failed"
 


### PR DESCRIPTION
Two robustness fixes for the GPU inference worker, the deferred follow-ups from the LTX `inference_mode` fix (#85).

## 1. Recover from CUDA OOM automatically

A genuine CUDA OOM can leave the allocator/context unable to reclaim VRAM in place — previously the worker stayed wedged (holding tens of GB) until a **manual container restart**.

Now the image and video job handlers detect a CUDA OOM (`torch.OutOfMemoryError` or a `RuntimeError` carrying `"out of memory"`), mark the job failed, run cleanup, then **exit the worker child** (`SystemExit`). The existing supervisor (`supervise_auto_workers`) respawns it with a **fresh CUDA context**, releasing the held memory. No manual restart, ever.

## 2. Free-VRAM claim gate

A GPU worker now skips claiming a job when its card has less than **`SCENEWORKS_MIN_FREE_VRAM_MB`** (default **24000**) free — so jobs flow to a free GPU when another tool (e.g. ComfyUI) is occupying one. CPU workers are never gated; `0` disables it.

This **complements** the store's existing auto-GPU "prefer emptiest" dispatch scoring (`should_defer_auto_gpu_claim` / `dispatch_score_is_better` in `jobs_store.rs`), which already routes `auto` jobs to the idle GPU with the most free VRAM. The relative scoring can't cover the *absolute floor* — single-GPU machines, or all GPUs busy — which this gate does.

## Layered defense (with #85)
- `inference_mode` (#85) — eliminates the autograd-graph leak that caused the OOMs in the first place.
- Free-VRAM gate — don't claim onto a near-full card.
- `dispatch_score` (already present) — among claimable workers, prefer the emptiest GPU.
- OOM restart — if a claim still OOMs, recover cleanly.

## Tests
`tests/test_worker_runtime.py`: OOM failure → cleanup + `SystemExit` (restart); non-OOM failure → cleanup, no restart. Full worker suite passes (105). Documents `SCENEWORKS_MIN_FREE_VRAM_MB` in `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)