### PR TITLE
fix(worker): resolve installed LoRA directory to its .safetensors file

### DIFF
--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -213,8 +213,31 @@ def lora_path(lora: dict[str, Any]) -> Path | None:
         return huggingface_cached_lora_path(lora)
     path = Path(str(value)).expanduser()
     if path.exists():
-        return path
+        return resolve_lora_file(path, lora)
     return huggingface_cached_lora_path(lora) or path
+
+
+def resolve_lora_file(path: Path, lora: dict[str, Any]) -> Path:
+    # Installed LoRAs are stored as a directory (the manifest keeps the file name
+    # in `files`; `source.path`/`installedPath` point at the directory). The native
+    # ltx-core loader mmaps the given path directly, and mmap on a directory fails
+    # with ENODEV ("No such device (os error 19)"), so descend to the actual
+    # .safetensors file. Diffusers accepts a file too, so this is safe for every
+    # adapter.
+    if not path.is_dir():
+        return path
+    for name in lora_declared_files(lora):
+        candidate = path / name
+        if candidate.is_file():
+            return candidate
+    return first_safetensors_path(path) or path
+
+
+def lora_declared_files(lora: dict[str, Any]) -> list[str]:
+    source = lora.get("source") if isinstance(lora.get("source"), dict) else {}
+    raw = lora.get("files") or source.get("files") or source.get("file") or lora.get("file") or []
+    files = raw if isinstance(raw, list) else [raw]
+    return [str(name).strip() for name in files if str(name).strip()]
 
 
 def huggingface_cached_lora_path(lora: dict[str, Any]) -> Path | None:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -497,6 +497,31 @@ def test_lora_specs_fail_before_inference_for_missing_or_excess_loras(tmp_path):
         normalize_lora_specs(many)
 
 
+def test_lora_specs_resolve_installed_directory_to_safetensors_file(tmp_path):
+    # Installed LoRAs are stored as a directory and the Rust API reports the
+    # directory as `installedPath`. The native ltx-core loader mmaps the path
+    # directly, and mmap on a directory raises ENODEV ("No such device (os error
+    # 19)"), so the spec path must point at the .safetensors file, not the dir.
+    lora_dir = tmp_path / "loras" / "lauren"
+    lora_dir.mkdir(parents=True)
+    weights = lora_dir / "Lauren_ltx2.3.safetensors"
+    weights.write_bytes(b"")
+
+    specs = normalize_lora_specs(
+        [
+            {
+                "id": "lauren",
+                "weight": 0.8,
+                "files": ["Lauren_ltx2.3.safetensors"],
+                "installedPath": str(lora_dir),
+                "source": {"provider": "local", "path": "loras/lauren"},
+            }
+        ]
+    )
+
+    assert specs[0].path == str(weights)
+
+
 def test_lora_specs_resolve_huggingface_cache_snapshot(monkeypatch, tmp_path):
     cache_root = tmp_path / "hf" / "hub"
     snapshot = write_huggingface_cache_resource(


### PR DESCRIPTION
## Problem

Adding a local (imported) LoRA to an **LTX-2.3 video** job fails with:

```
No such device (os error 19)
```

The base model loads fine (~40 GB allocated), then the job dies while applying the LoRA.

## Root cause

The error is **mmap on a directory**, not a filesystem/VRAM issue.

Imported LoRAs are stored as a *folder* (e.g. `data/loras/lauren/Lauren_ltx2.3.safetensors`). The Rust API's `lora_is_installed()` counts a folder as installed if it *contains* any `.safetensors`, so it reports `installedPath` as the **directory** — never the file. The worker passed that directory straight to ltx-core's native loader, which does `safe_open(path)` → `mmap()` on a directory fd → Linux returns `ENODEV` = "No such device (os error 19)".

Reproduced inside the running worker:
- `safe_open(".../lauren/Lauren_ltx2.3.safetensors")` → **OK**
- `safe_open(".../lauren")` (the directory) → **`OSError('No such device (os error 19)')`**

Why it only surfaced now:
- **Base model & distilled-LoRA** paths already point at concrete files.
- **HuggingFace LoRAs** dodge it — `lora_huggingface_cached_file()` joins the filename and returns a file.
- **Image (z-image) LoRAs** dodge it — diffusers' `load_lora_weights` tolerates a directory.
- Only the **native LTX loader** mmaps the path directly, so the bug appeared the first time a local LoRA was attached to LTX-2.3 video.

## Fix

`apps/worker/scene_worker/lora_adapters.py` — `lora_path()` now resolves a LoRA directory down to the actual `.safetensors` file (preferring the manifest's declared `files[]`, falling back to the first `.safetensors`). Diffusers also accepts a file, so this is safe for every adapter. Adds `resolve_lora_file()` + `lora_declared_files()` helpers.

## Testing

- New regression test `test_lora_specs_resolve_installed_directory_to_safetensors_file` covering the installed-directory layout.
- All 34 LoRA / native-LTX tests pass (`pytest -k "lora or native_ltx"`).
- Verified against the real on-disk LoRA: `normalize_lora_specs` now returns the `.safetensors` file path, which mmaps cleanly.

## Reviewer notes

- The underlying asymmetry is the Rust API reporting a *directory* as `installedPath` for local LoRAs. Fixed in the worker because that's the single chokepoint covering every path source (`installedPath`/`sourcePath`/`source.path`) and every adapter. Making `installedPath` point at the file API-side is a possible separate, optional cleanup.
- Requires a worker image rebuild to take effect (`docker compose build worker && docker compose up -d worker`); the worker source is baked into the image, not bind-mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)