### PR TITLE
fix(worker): install C compiler so Triton can JIT fp8 kernels

### DIFF
--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -37,6 +37,17 @@ ENV PYTHONUNBUFFERED=1
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
+# Triton (bundled with the CUDA torch wheels) JIT-compiles GPU kernels at
+# runtime — notably the fp8 path used by LTX-2.3 — and needs a host C compiler.
+# The slim runtime image ships none, so fp8 jobs failed with
+# "Failed to find C compiler. Please specify via CC environment variable...".
+# Triton bundles its own ptxas and CUDA headers and Python.h ships with the
+# base image, so gcc plus libc headers are all that is required.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+ENV CC=gcc
+
 WORKDIR /app
 
 COPY --from=builder /opt/venv /opt/venv


### PR DESCRIPTION
## Problem

After a couple of successful video generations, LTX-2.3 jobs started failing with:

```
Failed to find C compiler. Please specify via CC environment variable or set triton.knobs.build.impl.
```

Worker logs showed a clean split:
- every `precision: bf16` job → **succeeds**
- every `precision: fp8` job → **fails** with the error above, after ~22 GB had already been allocated (transformer loaded fine, died applying kernels)

## Root cause

Triton (bundled with the CUDA torch wheels) **JIT-compiles GPU kernels at runtime** and needs a host C compiler to build each kernel's launcher stub. The LTX-2.3 **fp8** path uses Triton kernels that compile on first use; the **bf16** path compiles nothing. The worker `runtime` image is `python:3.12-slim` and only the *builder* stage ever installed apt packages, so `cc`/`gcc`/`clang` were all absent at runtime — fp8 jobs failed the moment Triton tried to compile.

Confirmed in the running container: no compiler present, but `Python.h` ships with the base image and **Triton 3.4.0 bundles its own `ptxas` and `cuda.h`** (`triton/backends/nvidia/`). So the only missing piece is a C compiler + libc headers — no CUDA toolkit required.

## Fix

Install `gcc` + `libc6-dev` in the runtime stage and set `CC=gcc`.

## Testing

Validated live by installing the packages in the running worker and JIT-compiling + running a real Triton CUDA kernel:

```
torch 2.8.0+cu128 cuda True | triton 3.4.0
Triton JIT compile + run: OK
```

## Reviewer notes

- Requires a worker image rebuild to take effect (`docker compose build worker && docker compose up -d worker`).
- Minimal package set on purpose: Triton bundles ptxas + CUDA headers and the base image provides `Python.h`, so `build-essential`/CUDA toolkit are unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)