### PR TITLE
Add Wan2.2 14B (A14B) video models

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -64,4 +64,38 @@ export const fallbackModels = [
       durationHint: "Keep clips short until local looping behavior is validated.",
     },
   },
+  {
+    id: "wan_2_2_t2v_14b",
+    name: "Wan2.2 14B (T2V)",
+    type: "video",
+    capabilities: ["text_to_video"],
+    defaults: { duration: 5, fps: 16, resolution: "1280x720", quality: "balanced" },
+    limits: {
+      durations: [3, 4, 5],
+      recommendedMaxDuration: 5,
+      fps: [16],
+      resolutions: ["832x480", "480x832", "1280x720", "720x1280"],
+    },
+    ui: {
+      description: "Wan2.2 A14B text-to-video (high/low-noise mixture-of-experts).",
+      durationHint: "Heavier than 5B — keep clips at 5s or less. Generates at 16fps.",
+    },
+  },
+  {
+    id: "wan_2_2_i2v_14b",
+    name: "Wan2.2 14B (I2V)",
+    type: "video",
+    capabilities: ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
+    defaults: { duration: 5, fps: 16, resolution: "1280x720", quality: "balanced" },
+    limits: {
+      durations: [3, 4, 5],
+      recommendedMaxDuration: 5,
+      fps: [16],
+      resolutions: ["832x480", "480x832", "1280x720", "720x1280"],
+    },
+    ui: {
+      description: "Wan2.2 A14B image-to-video (high/low-noise mixture-of-experts).",
+      durationHint: "Heavier than 5B — keep clips at 5s or less. Generates at 16fps.",
+    },
+  },
 ];

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -94,6 +94,38 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "steps": {"fast": 12, "balanced": 20, "best": 30},
         "durationHint": "Keep clips shorter until local looping behavior is validated.",
     },
+    # Wan2.2 A14B is a mixture-of-experts checkpoint split into separate text-to-video and
+    # image-to-video repos, registered here as two single-repo models. Each repo ships a
+    # high-noise expert (transformer) and a low-noise expert (transformer_2); diffusers' Wan
+    # pipelines load both and switch at the config boundary_ratio, so no custom dual-model
+    # sampling loop is required.
+    "wan_2_2_t2v_14b": {
+        "label": "Wan2.2 14B (T2V)",
+        "family": "wan-video",
+        "adapter": "wan_video",
+        "repo": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+        "capabilities": ["text_to_video"],
+        "recommendedMaxDuration": 5,
+        "hardMaxDuration": 5,
+        "steps": {"fast": 20, "balanced": 30, "best": 40},
+        "guidanceScale": 4.0,
+        "durationHint": "A14B is heavier than 5B; keep clips at 5s or less. Native cadence is 16fps.",
+    },
+    "wan_2_2_i2v_14b": {
+        "label": "Wan2.2 14B (I2V)",
+        "family": "wan-video",
+        "adapter": "wan_video",
+        "repo": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
+        "capabilities": ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
+        "recommendedMaxDuration": 5,
+        "hardMaxDuration": 5,
+        "steps": {"fast": 20, "balanced": 30, "best": 40},
+        "guidanceScale": 4.0,
+        # Wan2.2 A14B conditions image modes on VAE latents rather than a CLIP image encoder,
+        # so the repo ships no image_encoder subfolder to pre-load.
+        "noImageEncoder": True,
+        "durationHint": "A14B is heavier than 5B; keep clips at 5s or less. Native cadence is 16fps.",
+    },
 }
 
 
@@ -1328,11 +1360,16 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             vae_class = getattr(diffusers, "AutoencoderKLWan", None)
             if vae_class is not None:
                 kwargs["vae"] = vae_class.from_pretrained(repo, subfolder="vae", torch_dtype=dtype)
-            if request.mode != "text_to_video":
+            if request.mode != "text_to_video" and not target.get("noImageEncoder"):
                 transformers = importlib.import_module("transformers")
                 image_encoder_class = getattr(transformers, "CLIPVisionModel", None)
                 if image_encoder_class is not None:
-                    kwargs["image_encoder"] = image_encoder_class.from_pretrained(repo, subfolder="image_encoder", torch_dtype=dtype)
+                    try:
+                        kwargs["image_encoder"] = image_encoder_class.from_pretrained(repo, subfolder="image_encoder", torch_dtype=dtype)
+                    except (OSError, ValueError):
+                        # Repos that condition on VAE latents instead of CLIP (e.g. Wan2.2 A14B)
+                        # ship no image_encoder subfolder; the pipeline loads any components it needs.
+                        pass
 
         pipe = pipeline_class.from_pretrained(repo, **kwargs)
         if bool(request.advanced.get("cpuOffload", False)) and hasattr(pipe, "enable_model_cpu_offload"):
@@ -1456,7 +1493,16 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             "generator": generator,
         }
         if target["adapter"] == "wan_video":
-            kwargs["guidance_scale"] = self._guidance_scale(request, 5.0)
+            kwargs["guidance_scale"] = self._guidance_scale(request, float(target.get("guidanceScale", 5.0)))
+            # A14B exposes a second CFG scale for the low-noise expert and the high/low expert
+            # boundary. Pass them through when supplied; filter_call_kwargs drops them for
+            # single-expert pipelines (e.g. the 5B TI2V model) that don't accept them.
+            guidance_scale_2 = request.advanced.get("guidanceScale2", target.get("guidanceScale2"))
+            if guidance_scale_2 is not None:
+                kwargs["guidance_scale_2"] = float(guidance_scale_2)
+            boundary_ratio = request.advanced.get("boundaryRatio", target.get("boundaryRatio"))
+            if boundary_ratio is not None:
+                kwargs["boundary_ratio"] = float(boundary_ratio)
             if request.mode == "replace_person":
                 kwargs["video"] = load_source_video_frames(project_path, request.source_clip_asset_id, request.width, request.height, num_frames)
                 kwargs["mask"] = person_track_masks(project_path, request.person_track_id, request.width, request.height, num_frames)
@@ -2105,6 +2151,21 @@ def save_animated_preview(frames: list[Image.Image], path: Path, duration: float
     )
 
 
+def _frame_to_image(frame: Any) -> Image.Image:
+    if hasattr(frame, "convert"):
+        return frame.convert("RGB")
+    import numpy as np
+
+    array = np.asarray(frame)
+    # Diffusers video pipelines default to output_type="np", which returns
+    # float32 frames in [0, 1]. PIL cannot build an RGB image from float data
+    # ("Cannot handle this data type: (1, 1, 3), <f4"), so scale to uint8 the
+    # same way diffusers.utils.export_to_video does internally.
+    if np.issubdtype(array.dtype, np.floating):
+        array = (np.clip(array, 0.0, 1.0) * 255).round().astype(np.uint8)
+    return Image.fromarray(array).convert("RGB")
+
+
 def frames_from_output(output: Any) -> list[Image.Image]:
     frames = getattr(output, "frames", None)
     if frames is None and isinstance(output, tuple) and output:
@@ -2119,11 +2180,11 @@ def frames_from_output(output: Any) -> list[Image.Image]:
         array = np.asarray(frames)
         if array.ndim == 5:
             array = array[0]
-        return [Image.fromarray(frame).convert("RGB") for frame in array]
+        return [_frame_to_image(frame) for frame in array]
     if isinstance(frames, list) and frames and isinstance(frames[0], list):
-        return [frame.convert("RGB") if hasattr(frame, "convert") else Image.fromarray(frame).convert("RGB") for frame in frames[0]]
+        return [_frame_to_image(frame) for frame in frames[0]]
     if isinstance(frames, list):
-        return [frame.convert("RGB") if hasattr(frame, "convert") else Image.fromarray(frame).convert("RGB") for frame in frames]
+        return [_frame_to_image(frame) for frame in frames]
     return []
 
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -270,6 +270,93 @@
         "recommendedFor": ["image_to_video", "text_to_video"],
         "durationHint": "Use shorter clips until local looping behavior is validated."
       }
+    },
+    // Wan2.2 A14B is a high/low-noise mixture-of-experts model split into separate
+    // text-to-video and image-to-video repos. Each is registered as its own single-repo
+    // model so the download/readiness check (one repo per entry) tracks them accurately.
+    {
+      "id": "wan_2_2_t2v_14b",
+      "name": "Wan2.2 14B (T2V)",
+      "family": "wan-video",
+      "type": "video",
+      "adapter": "wan_video",
+      "capabilities": ["text_to_video"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+          "files": [],
+          "estimatedSizeBytes": 72000000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+      },
+      "defaults": {
+        "duration": 5,
+        "fps": 16,
+        "resolution": "1280x720",
+        "quality": "balanced"
+      },
+      "limits": {
+        "durations": [3, 4, 5],
+        "recommendedMaxDuration": 5,
+        "hardMaxDuration": 5,
+        "fps": [16],
+        "resolutions": ["832x480", "480x832", "1280x720", "720x1280"]
+      },
+      "loraCompatibility": {
+        "families": ["wan-video"],
+        "types": ["style", "motion", "character", "enhance"]
+      },
+      "ui": {
+        "label": "Wan2.2 14B (T2V)",
+        "description": "Wan2.2 A14B text-to-video (high/low-noise mixture-of-experts). Higher fidelity than the 5B model; needs ample VRAM for both experts.",
+        "recommendedFor": ["text_to_video"],
+        "durationHint": "Heavier than 5B — keep clips at 5s or less. Generates at 16fps."
+      }
+    },
+    {
+      "id": "wan_2_2_i2v_14b",
+      "name": "Wan2.2 14B (I2V)",
+      "family": "wan-video",
+      "type": "video",
+      "adapter": "wan_video",
+      "capabilities": ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
+          "files": [],
+          "estimatedSizeBytes": 72000000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+      },
+      "defaults": {
+        "duration": 5,
+        "fps": 16,
+        "resolution": "1280x720",
+        "quality": "balanced"
+      },
+      "limits": {
+        "durations": [3, 4, 5],
+        "recommendedMaxDuration": 5,
+        "hardMaxDuration": 5,
+        "fps": [16],
+        "resolutions": ["832x480", "480x832", "1280x720", "720x1280"]
+      },
+      "loraCompatibility": {
+        "families": ["wan-video"],
+        "types": ["style", "motion", "character", "enhance"]
+      },
+      "ui": {
+        "label": "Wan2.2 14B (I2V)",
+        "description": "Wan2.2 A14B image-to-video (high/low-noise mixture-of-experts). Higher fidelity than the 5B model; needs ample VRAM for both experts.",
+        "recommendedFor": ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
+        "durationHint": "Heavier than 5B — keep clips at 5s or less. Generates at 16fps."
+      }
     }
   ]
 }

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1230,6 +1230,8 @@ def test_video_adapter_override_aliases_and_unknown_values(monkeypatch):
     monkeypatch.delenv("SCENEWORKS_VIDEO_ADAPTER", raising=False)
     assert create_video_adapter({"payload": {"model": "ltx_2_3"}}).__class__.__name__ == "LtxPipelinesVideoAdapter"
     assert create_video_adapter({"payload": {"model": "wan_2_2"}}).__class__.__name__ == "DiffusersVideoAdapter"
+    assert create_video_adapter({"payload": {"model": "wan_2_2_t2v_14b"}}).__class__.__name__ == "DiffusersVideoAdapter"
+    assert create_video_adapter({"payload": {"model": "wan_2_2_i2v_14b"}}).__class__.__name__ == "DiffusersVideoAdapter"
     assert create_video_adapter().__class__.__name__ == "LtxPipelinesVideoAdapter"
 
     monkeypatch.setenv("SCENEWORKS_VIDEO_ADAPTER", "procedural")
@@ -2595,6 +2597,23 @@ def test_frames_from_output_accepts_nested_frames():
     frames = frames_from_output(SimpleNamespace(frames=[[red, blue]]))
 
     assert len(frames) == 2
+    assert frames[0].getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_frames_from_output_scales_float_numpy_frames():
+    np = pytest.importorskip("numpy")
+
+    # Diffusers video pipelines default to output_type="np": a float32 array in
+    # [0, 1] shaped (batch, frames, H, W, 3). PIL rejects float RGB data, so
+    # frames_from_output must scale to uint8 instead of raising
+    # "Cannot handle this data type: (1, 1, 3), <f4".
+    array = np.zeros((1, 2, 2, 2, 3), dtype=np.float32)
+    array[0, 0, :, :, 0] = 1.0  # first frame fully red
+
+    frames = frames_from_output(SimpleNamespace(frames=array))
+
+    assert len(frames) == 2
+    assert frames[0].mode == "RGB"
     assert frames[0].getpixel((0, 0)) == (255, 0, 0)
 
 


### PR DESCRIPTION
## Summary

Adds the Wan2.2 **A14B** mixture-of-experts checkpoint as builtin video models, registered as two single-repo entries:

| ID | Picker label | Repo | Modes |
|---|---|---|---|
| `wan_2_2_t2v_14b` | Wan2.2 14B (T2V) | `Wan-AI/Wan2.2-T2V-A14B-Diffusers` | text-to-video |
| `wan_2_2_i2v_14b` | Wan2.2 14B (I2V) | `Wan-AI/Wan2.2-I2V-A14B-Diffusers` | image-to-video, first/last-frame, extend, bridge |

A14B is a split high-noise/low-noise model, but **no custom sampler is needed** — each repo ships both a high-noise expert (`transformer`) and a low-noise expert (`transformer_2`) plus a `boundary_ratio`, and diffusers' Wan pipelines load both and switch at the boundary internally. The existing `DiffusersVideoAdapter` drives it with the same single `pipe()` call.

Split into two single-repo models (rather than one model with two repos) because the download/readiness flow tracks one repo per entry; this way each variant downloads and reports install state accurately with no API changes.

## Adapter changes
- Skip the CLIP image-encoder load for A14B (it conditions on VAE latents and ships no `image_encoder` subfolder) and tolerate its absence via try/except — also hardens the 5B path.
- Per-target `guidanceScale` default (4.0 for A14B) plus optional `guidanceScale2` / `boundaryRatio` passthrough for tuning the high/low-noise experts. These are dropped by `filter_call_kwargs` for the single-expert 5B pipeline.

## Also: Wan2.2 5B fix
diffusers video pipelines default to `output_type="np"` (float32 in `[0,1]`), which PIL can't turn into an RGB image (`Cannot handle this data type: (1, 1, 3), <f4`). `frames_from_output` now scales float frames to uint8 via a shared `_frame_to_image` helper.

## Notes / not yet validated
- Real model load + generation still needs verification on hardware (weights downloading). The open question is whether the A14B I2V repo truly lacks an `image_encoder` subfolder — the try/except covers either outcome.
- These are the first video models that don't support every mode, so picking the wrong variant for the current studio mode shows the existing "does not support this mode" gate. Filtering the picker by mode is a possible follow-up.

## Test plan
- [x] `tests/test_worker_runtime.py` — adapter routing for both new IDs; new `_frame_to_image` float→uint8 test
- [x] manifest parses; targets resolve to correct repo per mode; 5B/LTX unchanged
- [ ] download weights + generate a clip on each variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)