### PR TITLE
Polish studio and asset preview UI

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -329,6 +329,19 @@ export function App() {
     () => (previewAsset ? assets.find((asset) => asset.id === previewAsset.id) ?? previewAsset : null),
     [assets, previewAsset],
   );
+  const previewNavigation = useMemo(() => {
+    if (!previewedAsset || assets.length < 2) {
+      return { previous: null, next: null };
+    }
+    const currentIndex = assets.findIndex((asset) => asset.id === previewedAsset.id);
+    if (currentIndex < 0) {
+      return { previous: null, next: null };
+    }
+    return {
+      previous: currentIndex > 0 ? assets[currentIndex - 1] : null,
+      next: currentIndex < assets.length - 1 ? assets[currentIndex + 1] : null,
+    };
+  }, [assets, previewedAsset]);
   const latestAssets = useMemo(
     () => assets.filter((asset) => asset.generationSetId === latestGenerationSetId),
     [assets, latestGenerationSetId],
@@ -1833,7 +1846,10 @@ export function App() {
             await deleteAsset(asset);
             setPreviewAsset(null);
           }}
+          nextAsset={previewNavigation.next}
           onClose={() => setPreviewAsset(null)}
+          onPreviewAsset={setPreviewAsset}
+          previousAsset={previewNavigation.previous}
           purgeAsset={async (asset) => {
             await purgeAsset(asset);
             setPreviewAsset(null);

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -325,6 +325,10 @@ export function App() {
     () => assets.find((asset) => asset.id === selectedAssetId) ?? assets[0] ?? null,
     [assets, selectedAssetId],
   );
+  const previewedAsset = useMemo(
+    () => (previewAsset ? assets.find((asset) => asset.id === previewAsset.id) ?? previewAsset : null),
+    [assets, previewAsset],
+  );
   const latestAssets = useMemo(
     () => assets.filter((asset) => asset.generationSetId === latestGenerationSetId),
     [assets, latestGenerationSetId],
@@ -1822,7 +1826,21 @@ export function App() {
         ) : null}
       </section>
 
-      {previewAsset ? <FullscreenPreview asset={previewAsset} onClose={() => setPreviewAsset(null)} /> : null}
+      {previewedAsset ? (
+        <FullscreenPreview
+          asset={previewedAsset}
+          deleteAsset={async (asset) => {
+            await deleteAsset(asset);
+            setPreviewAsset(null);
+          }}
+          onClose={() => setPreviewAsset(null)}
+          purgeAsset={async (asset) => {
+            await purgeAsset(asset);
+            setPreviewAsset(null);
+          }}
+          updateAssetStatus={updateAssetStatus}
+        />
+      ) : null}
     </main>
   );
 }

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -41,6 +41,7 @@ export const Icon = {
   ArrowLeft: (p) => <I {...p} d="M19 12H5M11 6l-6 6 6 6" />,
   ArrowRight: (p) => <I {...p} d="M5 12h14M13 6l6 6-6 6" />,
   Wand: (p) => <I {...p} d="M15 4l5 5L9 20l-5-5zM14 5l5 5M3 14l3 3" />,
+  Star: ({ filled = false, ...p }) => <I {...p} fill={filled} d="M12 2l2.4 7.4H22l-6.2 4.5L18 21l-6-4.4L6 21l2.2-7.1L2 9.4h7.6z" />,
   Stars: (p) => <I {...p} fill d="M12 2l2.4 7.4H22l-6.2 4.5L18 21l-6-4.4L6 21l2.2-7.1L2 9.4h7.6z" />,
   Trash: (p) => <I {...p} d="M4 7h16M9 7V4h6v3M6 7l1 13h10l1-13" />,
 };

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -38,6 +38,7 @@ export const Icon = {
   ChevDown: (p) => <I {...p} d="M6 9l6 6 6-6" />,
   Sliders: (p) => <I {...p} d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h14M18 18h2M14 4v4M6 10v4M16 16v4" />,
   Play: (p) => <I {...p} fill d="M7 4l13 8-13 8z" />,
+  Pause: (p) => <I {...p} fill d="M7 5h4v14H7zM13 5h4v14h-4z" />,
   ArrowLeft: (p) => <I {...p} d="M19 12H5M11 6l-6 6 6 6" />,
   ArrowRight: (p) => <I {...p} d="M5 12h14M13 6l6 6-6 6" />,
   Wand: (p) => <I {...p} d="M15 4l5 5L9 20l-5-5zM14 5l5 5M3 14l3 3" />,

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -37,7 +37,7 @@ export function AssetThumbnail({ asset, className = "" }) {
   return <span className={className}>{asset.type ?? "asset"}</span>;
 }
 
-export function AssetMedia({ asset, className = "", controls = true }) {
+export const AssetMedia = React.forwardRef(function AssetMedia({ asset, className = "", controls = true, ...mediaProps }, ref) {
   if (!asset) {
     return null;
   }
@@ -46,10 +46,10 @@ export function AssetMedia({ asset, className = "", controls = true }) {
     return <span className={className}>{asset.type ?? "asset"}</span>;
   }
   if (assetCanRenderAsVideo(asset)) {
-    return <video className={className} controls={controls} muted playsInline src={src} />;
+    return <video className={className} controls={controls} muted playsInline preload="metadata" ref={ref} src={src} {...mediaProps} />;
   }
   if (assetCanRenderAsImage(asset)) {
-    return <img alt="" className={className} src={src} />;
+    return <img alt="" className={className} ref={ref} src={src} />;
   }
   return <span className={className}>{asset.type}</span>;
-}
+});

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -1,5 +1,34 @@
 import React from "react";
 import { AssetMedia } from "./assetMedia.jsx";
+import { Icon } from "./Icons.jsx";
+
+function RatingControl({ asset, updateAssetStatus }) {
+  const currentRating = Number(asset.status?.rating) || 0;
+
+  return (
+    <div aria-label="Rating" className="rating-control" role="group">
+      <span className="rating-label">Rating</span>
+      <div className="rating-stars">
+        {[1, 2, 3, 4, 5].map((rating) => {
+          const active = currentRating >= rating;
+          return (
+            <button
+              aria-label={`Set rating to ${rating} ${rating === 1 ? "star" : "stars"}`}
+              aria-pressed={active}
+              className={active ? "star-rating-button active" : "star-rating-button"}
+              key={rating}
+              onClick={() => updateAssetStatus(asset, { rating })}
+              title={`${rating} ${rating === 1 ? "star" : "stars"}`}
+              type="button"
+            >
+              <Icon.Star filled={active} size={18} />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
   if (!assets.length) {
@@ -36,18 +65,7 @@ export function AssetDetail({ asset, deleteAsset, purgeAsset, onPreview, onSendI
       </button>
       <h3>{asset.displayName}</h3>
       <p>{asset.recipe?.prompt ?? "No prompt"}</p>
-      <div className="rating-row">
-        {[1, 2, 3, 4, 5].map((rating) => (
-          <button
-            className={asset.status?.rating >= rating ? "active" : ""}
-            key={rating}
-            onClick={() => updateAssetStatus(asset, { rating })}
-            type="button"
-          >
-            {rating}
-          </button>
-        ))}
-      </div>
+      <RatingControl asset={asset} updateAssetStatus={updateAssetStatus} />
       <div className="detail-actions">
         <button onClick={() => updateAssetStatus(asset, { favorite: !asset.status?.favorite })} type="button">
           {asset.status?.favorite ? "Unfavorite" : "Favorite"}

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -146,14 +146,43 @@ export function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAss
   );
 }
 
-export function FullscreenPreview({ asset, deleteAsset, onClose, purgeAsset, updateAssetStatus }) {
+export function FullscreenPreview({
+  asset,
+  deleteAsset,
+  nextAsset,
+  onClose,
+  onPreviewAsset,
+  previousAsset,
+  purgeAsset,
+  updateAssetStatus,
+}) {
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true">
       <div className="preview-modal">
         <button className="modal-close" onClick={onClose} type="button">
           Close
         </button>
-        <AssetMedia asset={asset} />
+        <div className="preview-modal-stage">
+          <button
+            aria-label="Previous asset"
+            className="preview-nav-button previous"
+            disabled={!previousAsset}
+            onClick={() => previousAsset && onPreviewAsset(previousAsset)}
+            type="button"
+          >
+            <Icon.ArrowLeft size={18} />
+          </button>
+          <AssetMedia asset={asset} />
+          <button
+            aria-label="Next asset"
+            className="preview-nav-button next"
+            disabled={!nextAsset}
+            onClick={() => nextAsset && onPreviewAsset(nextAsset)}
+            type="button"
+          >
+            <Icon.ArrowRight size={18} />
+          </button>
+        </div>
         <footer>
           <div className="preview-modal-meta">
             <strong>{asset.displayName}</strong>

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -146,7 +146,7 @@ export function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAss
   );
 }
 
-export function FullscreenPreview({ asset, onClose }) {
+export function FullscreenPreview({ asset, deleteAsset, onClose, purgeAsset, updateAssetStatus }) {
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true">
       <div className="preview-modal">
@@ -155,8 +155,27 @@ export function FullscreenPreview({ asset, onClose }) {
         </button>
         <AssetMedia asset={asset} />
         <footer>
-          <strong>{asset.displayName}</strong>
-          <span>{asset.recipe?.model}</span>
+          <div className="preview-modal-meta">
+            <strong>{asset.displayName}</strong>
+            <span>{asset.recipe?.model}</span>
+          </div>
+          <div className="preview-actions">
+            <button onClick={() => updateAssetStatus(asset, { favorite: !asset.status?.favorite })} type="button">
+              {asset.status?.favorite ? "Saved" : "Favorite"}
+            </button>
+            <button onClick={() => updateAssetStatus(asset, { rejected: !asset.status?.rejected })} type="button">
+              {asset.status?.rejected ? "Restore" : "Reject"}
+            </button>
+            {asset.status?.trashed ? (
+              <button className="danger-action" onClick={() => purgeAsset(asset)} type="button">
+                Purge
+              </button>
+            ) : (
+              <button className="danger-action" onClick={() => deleteAsset(asset)} type="button">
+                Discard
+              </button>
+            )}
+          </div>
         </footer>
       </div>
     </div>

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { AssetMedia, assetCanRenderAsImage } from "../components/assetMedia.jsx";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { AssetMedia, assetCanRenderAsImage, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
 import { formatSeconds } from "../formatting.js";
 import {
   aspectOptions,
@@ -41,6 +41,7 @@ export function EditorScreen({
   const [generationPrompt, setGenerationPrompt] = useState("Continue the action with matching motion and lighting");
   const [extensionDuration, setExtensionDuration] = useState(4);
   const [timelineNotice, setTimelineNotice] = useState("");
+  const previewVideoRef = useRef(null);
 
   const selectedItem = useMemo(() => {
     if (!activeTimeline) {
@@ -64,8 +65,22 @@ export function EditorScreen({
     if (selectedItem) {
       setPlayheadSeconds(Number(selectedItem.timelineStart) || 0);
     }
+    setIsPlaying(false);
     setTimelineNotice("");
   }, [selectedItem?.id]);
+
+  useEffect(() => {
+    const video = previewVideoRef.current;
+    if (!assetCanRenderAsVideo(selectedAsset) || !video) {
+      setIsPlaying(false);
+      return;
+    }
+    if (isPlaying) {
+      video.play().catch(() => setIsPlaying(false));
+      return;
+    }
+    video.pause();
+  }, [isPlaying, selectedAsset?.id]);
 
   useEffect(() => {
     function onKeyDown(event) {
@@ -438,10 +453,21 @@ export function EditorScreen({
         <div className="editor-layout">
           <section className="editor-preview">
             <div className={`preview-canvas aspect-${activeTimeline.aspectRatio.replace(":", "-")}`}>
-              {selectedAsset ? <AssetMedia asset={selectedAsset} /> : <span>Select a timeline item</span>}
+              {selectedAsset ? (
+                <AssetMedia
+                  asset={selectedAsset}
+                  controls={false}
+                  onEnded={() => setIsPlaying(false)}
+                  onPause={() => setIsPlaying(false)}
+                  onPlay={() => setIsPlaying(true)}
+                  ref={previewVideoRef}
+                />
+              ) : (
+                <span>Select a timeline item</span>
+              )}
             </div>
             <div className="playback-bar">
-              <button onClick={() => setIsPlaying((value) => !value)} type="button">
+              <button disabled={!assetCanRenderAsVideo(selectedAsset)} onClick={() => setIsPlaying((value) => !value)} type="button">
                 {isPlaying ? "Pause" : "Play"}
               </button>
               <span>{formatSeconds(Math.round(duration))}</span>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
-import { AssetMedia } from "../components/assetMedia.jsx";
+import { AssetMedia, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 
@@ -29,6 +29,12 @@ function estimateRenderSeconds(durationSeconds, quality) {
   if (quality === "fast") return Math.round(base * 0.5);
   if (quality === "best") return Math.round(base * 1.5);
   return Math.round(base);
+}
+
+function formatPlaybackTime(seconds) {
+  const safeSeconds = Math.max(0, Math.round(Number(seconds) || 0));
+  const minutes = Math.floor(safeSeconds / 60);
+  return `${minutes}:${String(safeSeconds % 60).padStart(2, "0")}`;
 }
 import {
   clearPresetDefault,
@@ -106,6 +112,10 @@ export function VideoStudio({
   const [abSide, setAbSide] = useState("replacement");
   const [submitting, setSubmitting] = useState(false);
   const [resultFallbackTick, setResultFallbackTick] = useState(0);
+  const previewVideoRef = useRef(null);
+  const [previewPlaying, setPreviewPlaying] = useState(false);
+  const [previewTime, setPreviewTime] = useState(0);
+  const [previewDuration, setPreviewDuration] = useState(0);
   const presetDefaultSnapshots = useRef({});
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
@@ -416,6 +426,27 @@ export function VideoStudio({
   const previewAsset = latestAssets[0] ?? null;
   const estimateSeconds = estimateRenderSeconds(duration, quality);
   const gpuLabel = formatGpuLabel(requestedGpu);
+  const previewCanPlay = assetCanRenderAsVideo(previewAsset);
+  const previewTotalSeconds = previewDuration || Number(previewAsset?.file?.duration) || Number(duration) || 0;
+  const previewProgress = previewTotalSeconds ? `${Math.min(100, (previewTime / previewTotalSeconds) * 100)}%` : "0%";
+
+  useEffect(() => {
+    setPreviewPlaying(false);
+    setPreviewTime(0);
+    setPreviewDuration(0);
+  }, [previewAsset?.id]);
+
+  function togglePreviewPlayback() {
+    const video = previewVideoRef.current;
+    if (!video || !previewCanPlay) {
+      return;
+    }
+    if (video.paused) {
+      video.play().catch(() => setPreviewPlaying(false));
+      return;
+    }
+    video.pause();
+  }
 
   function onPromptKeyDown(event) {
     if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
@@ -551,20 +582,37 @@ export function VideoStudio({
             <div className="video-preview-card">
               <div className="video-preview-stage">
                 {previewAsset ? (
-                  <AssetMedia asset={previewAsset} />
+                  <AssetMedia
+                    asset={previewAsset}
+                    controls={false}
+                    onEnded={() => setPreviewPlaying(false)}
+                    onLoadedMetadata={(event) => setPreviewDuration(event.currentTarget.duration || 0)}
+                    onPause={() => setPreviewPlaying(false)}
+                    onPlay={() => setPreviewPlaying(true)}
+                    onTimeUpdate={(event) => setPreviewTime(event.currentTarget.currentTime || 0)}
+                    ref={previewVideoRef}
+                  />
                 ) : (
                   <span className="video-preview-empty">No clip rendered yet — set up the prompt above and hit Render</span>
                 )}
               </div>
 
               <div className="video-playback-bar">
-                <button aria-label="Play preview" className="play-btn" type="button">
-                  <Icon.Play size={14} />
+                <button
+                  aria-label={previewPlaying ? "Pause preview" : "Play preview"}
+                  className="play-btn"
+                  disabled={!previewCanPlay}
+                  onClick={togglePreviewPlayback}
+                  type="button"
+                >
+                  {previewPlaying ? <Icon.Pause size={14} /> : <Icon.Play size={14} />}
                 </button>
                 <div aria-hidden="true" className="video-playback-scrub">
-                  <span className="video-playback-scrub-fill" />
+                  <span className="video-playback-scrub-fill" style={{ width: previewProgress }} />
                 </div>
-                <span className="video-playback-time">0:00 / 0:{String(Math.round(Number(duration) || 0)).padStart(2, "0")}</span>
+                <span className="video-playback-time">
+                  {formatPlaybackTime(previewTime)} / {formatPlaybackTime(previewTotalSeconds)}
+                </span>
                 <span className="video-playback-estimate">~{estimateSeconds}s on {gpuLabel}</span>
                 <button
                   className="send-editor-btn"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -802,7 +802,6 @@ label {
 .advanced-toggle,
 .detail-actions button,
 .review-actions button,
-.rating-row button,
 .file-upload-button,
 .modal-close,
 .asset-picker-head button,
@@ -844,7 +843,6 @@ label {
 .advanced-toggle:hover:not(:disabled),
 .detail-actions button:hover:not(:disabled),
 .review-actions button:hover:not(:disabled),
-.rating-row button:hover:not(:disabled),
 .file-upload-button:hover,
 .modal-close:hover:not(:disabled),
 .asset-picker-head button:hover:not(:disabled),
@@ -973,7 +971,6 @@ label {
 }
 
 .segmented-control button.active,
-.rating-row button.active,
 .compact-segment button.active {
   background: var(--surface);
   color: var(--text);
@@ -994,7 +991,6 @@ label {
 .toolbar,
 .review-actions,
 .detail-actions,
-.rating-row,
 .editor-actions,
 .timeline-create,
 .playback-bar,
@@ -1010,6 +1006,54 @@ label {
 .editor-header,
 .export-strip {
   align-items: end;
+}
+
+.rating-control {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
+
+.rating-label {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.rating-stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.star-rating-button {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-faint);
+  transition: background var(--t-fast), color var(--t-fast), transform var(--t-fast);
+}
+
+.star-rating-button:hover {
+  background: var(--surface-hover);
+  color: var(--warm);
+}
+
+.star-rating-button.active {
+  color: var(--warm);
+}
+
+.star-rating-button:active {
+  transform: translateY(1px);
 }
 
 .surface-header {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3423,8 +3423,9 @@ label {
 
 .editable-lora-choice {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(80px, 120px);
-  align-items: end;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 10px 14px;
+  align-items: center;
 }
 
 .lora-add-row {
@@ -3432,9 +3433,25 @@ label {
 }
 
 .lora-selection-actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: 96px auto;
   gap: 8px;
   align-items: flex-end;
+}
+
+.lora-selection-actions label {
+  min-width: 0;
+  width: 96px;
+}
+
+.lora-selection-actions input[type="number"] {
+  width: 100%;
+  min-width: 0;
+  text-align: right;
+}
+
+.lora-selection-actions button {
+  white-space: nowrap;
 }
 
 .editable-lora-choice > label:first-child {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1653,6 +1653,11 @@ label {
   border-color: var(--border-strong);
 }
 
+.video-playback-bar .play-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .video-playback-scrub {
   flex: 1;
   height: 6px;
@@ -3264,6 +3269,11 @@ label {
 .preview-button video {
   aspect-ratio: 16 / 11;
   border-radius: 0;
+}
+
+.preview-button video {
+  object-fit: contain;
+  background: var(--bg-2);
 }
 
 /* ---------- Studio screens (image + video) ---------- */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -802,6 +802,7 @@ label {
 .advanced-toggle,
 .detail-actions button,
 .review-actions button,
+.preview-actions button,
 .file-upload-button,
 .modal-close,
 .asset-picker-head button,
@@ -843,6 +844,7 @@ label {
 .advanced-toggle:hover:not(:disabled),
 .detail-actions button:hover:not(:disabled),
 .review-actions button:hover:not(:disabled),
+.preview-actions button:hover:not(:disabled),
 .file-upload-button:hover,
 .modal-close:hover:not(:disabled),
 .asset-picker-head button:hover:not(:disabled),
@@ -991,6 +993,7 @@ label {
 .toolbar,
 .review-actions,
 .detail-actions,
+.preview-actions,
 .editor-actions,
 .timeline-create,
 .playback-bar,
@@ -3948,10 +3951,36 @@ label {
 
 .preview-modal footer {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   gap: 12px;
+  align-items: center;
   color: var(--text-muted);
   font-size: 13px;
+}
+
+.preview-modal-meta {
+  display: grid;
+  gap: 3px;
+  min-width: min(100%, 280px);
+}
+
+.preview-modal-meta strong,
+.preview-modal-meta span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preview-actions {
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.preview-actions button {
+  min-height: 32px;
+  padding: 0 12px;
+  font-size: 12.5px;
 }
 
 .modal-close {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3194,6 +3194,12 @@ label {
 }
 
 /* ---------- Studio screens (image + video) ---------- */
+.studio-shell {
+  display: grid;
+  gap: var(--gap-4);
+  align-content: start;
+}
+
 .studio-layout {
   display: grid;
   grid-template-columns: minmax(300px, 420px) minmax(0, 1fr);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -803,6 +803,7 @@ label {
 .detail-actions button,
 .review-actions button,
 .preview-actions button,
+.preview-nav-button,
 .file-upload-button,
 .modal-close,
 .asset-picker-head button,
@@ -845,6 +846,7 @@ label {
 .detail-actions button:hover:not(:disabled),
 .review-actions button:hover:not(:disabled),
 .preview-actions button:hover:not(:disabled),
+.preview-nav-button:hover:not(:disabled),
 .file-upload-button:hover,
 .modal-close:hover:not(:disabled),
 .asset-picker-head button:hover:not(:disabled),
@@ -3947,6 +3949,34 @@ label {
   object-fit: contain;
   background: var(--bg-2);
   border-radius: var(--r-sm);
+}
+
+.preview-modal-stage {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+}
+
+.preview-modal-stage img,
+.preview-modal-stage video {
+  min-width: 0;
+  width: 100%;
+}
+
+.preview-nav-button {
+  width: 40px;
+  height: 64px;
+  padding: 0;
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  color: var(--text-muted);
+}
+
+.preview-nav-button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 
 .preview-modal footer {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2065,11 +2065,12 @@ label {
 
 .local-job-card {
   display: grid;
-  gap: 9px;
+  gap: 12px;
   border: 1px solid var(--border);
   background: var(--surface-2);
   border-radius: var(--r-md);
   padding: 12px;
+  min-width: 0;
 }
 
 .local-job-card.failed,
@@ -2080,11 +2081,14 @@ label {
 }
 
 .local-job-main {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 10px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px 12px;
   align-items: start;
+}
+
+.local-job-main > div {
+  min-width: 0;
 }
 
 .local-job-main h3 {
@@ -2096,6 +2100,25 @@ label {
   font-size: 15px;
   font-weight: 600;
   line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.local-job-card .job-meta {
+  gap: 6px;
+}
+
+.local-job-card .job-meta span {
+  min-width: 0;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.local-job-card .job-message {
+  line-height: 1.45;
   overflow-wrap: anywhere;
 }
 
@@ -2118,6 +2141,7 @@ label {
   font-weight: 600;
   text-transform: capitalize;
   letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 .status-badge.installed,


### PR DESCRIPTION
## Summary
- add consistent spacing below Image/Video Studio hero blocks
- replace numeric asset rating buttons with a star control
- improve video generation status card wrapping and spacing
- add quick actions plus previous/next navigation to the asset preview modal
- fix video preview playback controls and video aspect handling across preview surfaces
- tighten Applied LoRA row spacing and weight input sizing on the Preset screen

## Verification
- npm run build

## Shortcut
- sc-1400
- sc-1401
- sc-1402
- sc-1404
- sc-1405
- sc-1406
- sc-1407