### PR TITLE
Run a configurable pool of CPU utility workers (default 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ Compose `worker` service is the Python inference worker and the `rust-worker`
 service is the Rust utility worker; both use the same HTTP contract.
 The `sceneworks-rust-worker` binary handles CPU utility jobs for model downloads,
 LoRA imports, FFmpeg frame extraction, and timeline MP4 exports. The Rust worker
-defaults to `SCENEWORKS_GPU_ID=cpu` so it registers one CPU utility worker and
-does not duplicate the Python inference GPU workers. Set
+defaults to `SCENEWORKS_GPU_ID=cpu` and does not duplicate the Python inference
+GPU workers. Utility jobs are I/O-bound and serialize per worker, so in cpu mode
+it supervises a small pool of CPU utility workers (`SCENEWORKS_UTILITY_WORKERS`,
+default 4) — this lets a quick upload run alongside a long download instead of
+queueing behind it. Set it to `1` to restore single-worker behavior. Set
 `SCENEWORKS_RUST_WORKER_GPU_ID=auto` in Compose, or `SCENEWORKS_GPU_ID=auto` in
 host mode, only if you want the Rust worker to supervise one child per visible
 NVIDIA GPU plus a CPU utility child; use `NVIDIA_VISIBLE_DEVICES=none` for a CPU

--- a/apps/rust-worker/src/lib.rs
+++ b/apps/rust-worker/src/lib.rs
@@ -58,6 +58,12 @@ pub struct Settings {
     pub max_lora_url_bytes: u64,
     pub max_model_url_bytes: u64,
     pub allow_private_lora_urls: bool,
+    /// Number of CPU/utility worker processes to run when this worker is in
+    /// dedicated `cpu` mode. Utility jobs (downloads, imports, frame extraction,
+    /// timeline export, person detect/track) are I/O-bound and serialize per
+    /// worker, so a small pool lets e.g. a quick upload run alongside a long
+    /// download instead of queueing behind it.
+    pub utility_workers: usize,
 }
 
 impl Settings {
@@ -107,15 +113,8 @@ impl Settings {
             ),
             allow_private_lora_urls: std::env::var("SCENEWORKS_ALLOW_PRIVATE_LORA_URLS")
                 .is_ok_and(|value| value.trim() == "1"),
+            utility_workers: env_u64_any(&["SCENEWORKS_UTILITY_WORKERS"], 4).max(1) as usize,
         }
-    }
-
-    fn for_worker(&self, worker_id: String, gpu_id: String) -> Self {
-        let mut settings = self.clone();
-        settings.worker_id = worker_id;
-        settings.gpu_id = gpu_id;
-        settings.is_child_worker = true;
-        settings
     }
 }
 
@@ -261,13 +260,19 @@ struct SupervisedChild {
 async fn supervise_auto_workers(settings: Settings) -> WorkerResult<()> {
     let gpus = discover_gpus().await;
     if gpus.is_empty() {
-        let cpu_settings =
-            settings.for_worker(cpu_worker_id(&settings.worker_id), "cpu".to_owned());
-        return run_worker_loop(cpu_settings).await;
+        let specs = utility_worker_specs(&settings.worker_id, settings.utility_workers);
+        return supervise_children(settings, specs).await;
     }
 
+    let specs = auto_worker_specs(&settings.worker_id, &gpus);
+    supervise_children(settings, specs).await
+}
+
+/// Spawn the given child workers and keep them running, restarting any that exit
+/// (with backoff) until a shutdown signal arrives.
+async fn supervise_children(settings: Settings, specs: Vec<WorkerSpec>) -> WorkerResult<()> {
     let mut children = HashMap::new();
-    for spec in auto_worker_specs(&settings.worker_id, &gpus) {
+    for spec in specs {
         let process = start_child_worker(&settings, &spec)?;
         children.insert(
             spec.worker_id.clone(),
@@ -434,6 +439,27 @@ fn auto_worker_specs(base_worker_id: &str, gpus: &[DiscoveredGpu]) -> Vec<Worker
         gpu_id: "cpu".to_owned(),
     });
     specs
+}
+
+/// Specs for the dedicated CPU/utility worker pool. The first worker keeps the
+/// historical `<base>-cpu` id (so a single-worker setup is unchanged); each
+/// additional worker is suffixed `-1`, `-2`, ... A count of 0 still yields one.
+fn utility_worker_specs(base_worker_id: &str, count: usize) -> Vec<WorkerSpec> {
+    (0..count.max(1))
+        .map(|index| WorkerSpec {
+            worker_id: utility_worker_id(base_worker_id, index),
+            gpu_id: "cpu".to_owned(),
+        })
+        .collect()
+}
+
+fn utility_worker_id(base_worker_id: &str, index: usize) -> String {
+    let cpu_id = cpu_worker_id(base_worker_id);
+    if index == 0 {
+        cpu_id
+    } else {
+        format!("{cpu_id}-{index}")
+    }
 }
 
 async fn discover_gpu(requested_gpu_id: &str) -> DiscoveredGpu {
@@ -684,8 +710,14 @@ fn emit_json(payload: Value) {
 
 pub async fn run() -> WorkerResult<()> {
     let settings = Settings::from_env();
-    if settings.gpu_id == "auto" && !settings.is_child_worker {
-        return supervise_auto_workers(settings).await;
+    if !settings.is_child_worker {
+        if settings.gpu_id == "auto" {
+            return supervise_auto_workers(settings).await;
+        }
+        if settings.gpu_id == "cpu" && settings.utility_workers > 1 {
+            let specs = utility_worker_specs(&settings.worker_id, settings.utility_workers);
+            return supervise_children(settings, specs).await;
+        }
     }
     run_worker_loop(settings).await
 }
@@ -4501,7 +4533,8 @@ mod tests {
         download_progress_payload, fallback_gpu, fresh_asset_id, gpu_worker_id,
         import_lora_source_path, now_rfc3339, output_dimensions, parse_nvidia_smi_gpus,
         restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
-        value_f64, visible_gpu_ids, worker_capabilities_with_utility, write_model_install_marker,
+        utility_worker_specs, value_f64, visible_gpu_ids, worker_capabilities_with_utility,
+        write_model_install_marker,
         ApiClient, DownloadContext, HuggingFaceSnapshot, Settings, SupervisedChild, WorkerError,
         WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
         DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
@@ -4632,6 +4665,35 @@ mod tests {
         });
         assert_eq!(cpu_env["SCENEWORKS_UTILITY_JOBS"], "1");
         assert_eq!(cpu_env["CUDA_VISIBLE_DEVICES"], "");
+    }
+
+    #[test]
+    fn utility_worker_specs_scale_to_requested_count() {
+        let single = utility_worker_specs("rust-utility-worker-0", 1);
+        assert_eq!(
+            single
+                .iter()
+                .map(|spec| spec.worker_id.as_str())
+                .collect::<Vec<_>>(),
+            ["rust-utility-worker-cpu"]
+        );
+
+        let pool = utility_worker_specs("rust-utility-worker-0", 4);
+        assert_eq!(
+            pool.iter()
+                .map(|spec| spec.worker_id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "rust-utility-worker-cpu",
+                "rust-utility-worker-cpu-1",
+                "rust-utility-worker-cpu-2",
+                "rust-utility-worker-cpu-3",
+            ]
+        );
+        assert!(pool.iter().all(|spec| spec.gpu_id == "cpu"));
+
+        // A count of 0 must still yield a single worker rather than an empty pool.
+        assert_eq!(utility_worker_specs("rust-utility-worker-0", 0).len(), 1);
     }
 
     #[test]
@@ -5293,6 +5355,7 @@ mod tests {
             max_lora_url_bytes: DEFAULT_MAX_LORA_URL_BYTES,
             max_model_url_bytes: DEFAULT_MAX_MODEL_URL_BYTES,
             allow_private_lora_urls: true,
+            utility_workers: 1,
         }
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,10 @@ services:
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
       SCENEWORKS_WORKER_ID: rust-utility-worker-0
       SCENEWORKS_GPU_ID: ${SCENEWORKS_RUST_WORKER_GPU_ID:-cpu}
+      # Utility jobs (downloads, imports, frame extract, exports) are I/O-bound and
+      # serialize per worker. Run a small pool so a quick upload isn't stuck behind
+      # a long download. Only applies in dedicated cpu mode.
+      SCENEWORKS_UTILITY_WORKERS: ${SCENEWORKS_UTILITY_WORKERS:-4}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       HF_TOKEN: ${HF_TOKEN:-}
       HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}


### PR DESCRIPTION
## What

Make the number of CPU/utility worker processes configurable via `SCENEWORKS_UTILITY_WORKERS` (default **4**, minimum 1). In dedicated `cpu` mode the Rust worker now supervises that many CPU children instead of running a single in-process loop.

## Why

All CPU utility jobs — `model_download`, `model_import`, `lora_import`, `frame_extract`, `timeline_export`, `person_detect`, `person_track` — were handled by a single `rust-utility-worker-0` that claims and runs one job at a time in strict FIFO order (`claim_next_job`, ordered by `created_at`). That meant a quick file upload (a `lora_import`/`model_import`) could sit blocked behind a multi-GB `model_download` even though the two don't contend for any genuinely scarce resource.

These jobs are **I/O-bound** (network bandwidth, disk throughput), not CPU-bound, so serializing them at one worker was an arbitrary limit rather than a deliberate throttle. (The video-generation job a user might also see in the queue runs on the separate Python GPU worker and was never the blocker.) A small pool lets light jobs run alongside long ones.

## How

- Added `utility_workers` to `Settings`, read from `SCENEWORKS_UTILITY_WORKERS` (default 4, clamped to ≥1).
- `run()` now spawns a supervised pool of CPU children in dedicated `cpu` mode when the count > 1. Worker IDs: `rust-utility-worker-cpu`, `-cpu-1`, `-cpu-2`, `-cpu-3`. Each registers the full utility capability set, so all of them can claim utility jobs concurrently.
- Extracted the supervisor body into a reusable `supervise_children()`; added `utility_worker_specs()` / `utility_worker_id()`.
- `docker-compose.yml`: `SCENEWORKS_UTILITY_WORKERS: ${SCENEWORKS_UTILITY_WORKERS:-4}` on the `rust-worker` service (tunable via `.env`).
- Updated `README.md`; removed the now-dead `Settings::for_worker` helper.

## Reviewer notes

- **Auto (GPU) mode is unchanged** — it still spawns one CPU utility child, so the Python-supervisor ID-parity test still passes.
- Set `SCENEWORKS_UTILITY_WORKERS=1` to restore the previous single-worker behavior.
- This adds **parallelism, not priority**: an upload only waits if all workers are genuinely busy. Strict "light jobs jump the line" prioritization in `claim_next_job` is a possible follow-up.
- After deploy, the old `rust-utility-worker-0` worker row goes stale and is cleaned by the existing stale-worker sweep.
- Server-side claim path is already mutex + transaction guarded, so concurrent claims from multiple workers are safe.

## Testing

- `cargo test -p sceneworks-rust-worker --lib worker` — passes (incl. new `utility_worker_specs_scale_to_requested_count` and the existing supervisor parity test).
- `cargo clippy -p sceneworks-rust-worker --lib --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)