### PR TITLE
Add native LoRA training contracts and target registry [sc-1409]

### DIFF
--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -104,6 +104,11 @@ macro_rules! string_enum {
     };
 }
 
+// Re-exported within the crate so sibling contract modules (for example
+// `training`) can declare their own forward-compatible string enums with the
+// same `Unknown(String)` fallback semantics.
+pub(crate) use string_enum;
+
 string_enum! {
     pub enum ContractMode {
         TextToImage => "text_to_image",

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod jobs_store;
 pub mod lora_family;
 pub mod lora_url;
 pub mod project_store;
+pub mod training;
 
 pub const API_PREFIX: &str = "/api/v1";
 pub const HEALTH_ROUTE: &str = "/health";

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1,0 +1,394 @@
+//! Rust-owned contracts for SceneWorks native LoRA training.
+//!
+//! SceneWorks owns its training product surface: dataset storage, manifests,
+//! validation, queue semantics, the target registry, and LoRA registration all
+//! live in Rust. Python is a narrow execution kernel that consumes a fully
+//! normalized [`TrainingPlan`] and produces weights — it never reads SceneWorks
+//! storage, config defaults, or this registry directly.
+//!
+//! These contracts are intentionally generic over `modality`, `output kind`,
+//! and `family` so the same shapes serve future image, video, and audio
+//! targets. The first production target is an image LoRA for Z-Image-Turbo,
+//! exposed by [`builtin_training_targets`].
+//!
+//! `ai-toolkit` is reference material only — a source of sensible defaults and
+//! terminology. None of its YAML config format or runtime option set is
+//! embedded here: hyperparameters use generic LoRA terms (`rank`, `alpha`,
+//! `learningRate`, `steps`) and free-form `advanced`/`limits`/`ui` bags carry
+//! anything engine-specific without coupling the contract to a trainer.
+//!
+//! All shapes follow the crate's contract conventions: `camelCase` JSON, a
+//! trailing flattened [`ExtraFields`] for forward compatibility, and string
+//! enums that round-trip unknown values via an `Unknown(String)` variant.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{json, Value};
+
+use crate::contracts::{string_enum, ContractNumber, ExtraFields, JsonObject};
+
+/// Schema version stamped on persisted training contracts.
+pub const TRAINING_CONTRACT_SCHEMA_VERSION: u32 = 1;
+
+/// Version of the normalized [`TrainingPlan`] handed to the Python kernel. The
+/// kernel rejects plans whose `planVersion` it does not understand.
+pub const TRAINING_PLAN_VERSION: u32 = 1;
+
+string_enum! {
+    /// Output modality of a training target. `Image` is the first production
+    /// target; `Video` and `Audio` are reserved so the contract stays generic.
+    pub enum TrainingModality {
+        Image => "image",
+        Video => "video",
+        Audio => "audio",
+    }
+}
+
+string_enum! {
+    /// What a training run produces. Only LoRA adapters are produced today.
+    pub enum TrainingOutputKind {
+        Lora => "lora",
+    }
+}
+
+string_enum! {
+    /// Lifecycle state of a training dataset.
+    pub enum TrainingDatasetStatus {
+        Draft => "draft",
+        Ready => "ready",
+        Archived => "archived",
+    }
+}
+
+string_enum! {
+    /// Origin of a dataset item's caption.
+    pub enum CaptionSource {
+        Manual => "manual",
+        Imported => "imported",
+        Auto => "auto",
+    }
+}
+
+/// A training dataset: an ordered collection of captioned items owned and
+/// persisted by Rust (see story 1410 for the store).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingDataset {
+    pub schema_version: u32,
+    pub id: String,
+    /// Monotonic version bumped whenever items or captions change. Provenance
+    /// pins an exact version so a re-train is reproducible.
+    pub version: u32,
+    /// Owning project, when the dataset is project-scoped. `None` means global.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    pub name: String,
+    pub modality: TrainingModality,
+    pub status: TrainingDatasetStatus,
+    pub created_at: String,
+    pub updated_at: String,
+    pub items: Vec<TrainingDatasetItem>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// A single captioned training example.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingDatasetItem {
+    pub id: String,
+    /// Source SceneWorks asset, when the item was selected from the library.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_id: Option<String>,
+    /// Path relative to the dataset root (Rust owns dataset storage layout).
+    pub path: String,
+    pub display_name: String,
+    pub caption: Caption,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+    pub added_at: String,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Caption text and provenance for a dataset item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Caption {
+    pub text: String,
+    pub source: CaptionSource,
+    pub trigger_words: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// A registered training target: the combination of a base model, output kind,
+/// and execution kernel, plus the defaults and bounds the UI builds on.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingTarget {
+    /// Stable target id, e.g. `z_image_turbo_lora`.
+    pub id: String,
+    pub name: String,
+    pub modality: TrainingModality,
+    pub output_kind: TrainingOutputKind,
+    /// SceneWorks LoRA/model family, e.g. `z-image`. Drives downstream
+    /// generation-side compatibility of the produced LoRA.
+    pub family: String,
+    /// Manifest model id this target trains against.
+    pub base_model: String,
+    /// Optional source repository for the base model weights.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_model_repo: Option<String>,
+    /// Identifier of the Python execution kernel that runs this target.
+    pub kernel: String,
+    /// Visible (simple-panel) config defaults for this target.
+    pub defaults: TrainingConfig,
+    /// Bounds and choices for advanced fields; free-form to stay generic.
+    pub limits: JsonObject,
+    /// Presentation hints (labels, descriptions); free-form.
+    pub ui: JsonObject,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// The registry of available training targets. Rust owns the built-in set
+/// returned by [`builtin_training_targets`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingTargetRegistry {
+    pub schema_version: u32,
+    pub targets: Vec<TrainingTarget>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Generic LoRA training hyperparameters.
+///
+/// The visible fields back the simple config panel; engine-specific knobs live
+/// in the free-form `advanced` bag so the contract never couples to a specific
+/// trainer's option set. This shape doubles as a target's `defaults` and as the
+/// resolved config inside a [`TrainingPlan`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingConfig {
+    /// LoRA network rank (dimension).
+    pub rank: u32,
+    /// LoRA alpha scaling factor.
+    pub alpha: u32,
+    pub learning_rate: ContractNumber,
+    /// Total training steps.
+    pub steps: u32,
+    pub batch_size: u32,
+    pub gradient_accumulation: u32,
+    /// Square training resolution edge in pixels (e.g. `1024`). Aspect-ratio
+    /// bucketing details, when used, live in `advanced`.
+    pub resolution: u32,
+    /// Checkpoint cadence, in steps.
+    pub save_every: u32,
+    pub seed: i64,
+    /// Optimizer name, kept a free string to stay engine-agnostic.
+    pub optimizer: String,
+    /// Trigger word baked into captions and surfaced on the output LoRA.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_word: Option<String>,
+    /// Advanced, collapsed-by-default fields. Free-form by design.
+    pub advanced: JsonObject,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Payload contract for submitting a LoRA training job.
+///
+/// The matching `JobType`, queue routing, and dry-run plan builder are added in
+/// story 1416; this is only the request shape.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoraTrainingRequest {
+    pub target_id: String,
+    pub dataset_id: String,
+    /// Pin a dataset version; `None` means "use the dataset's current version".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_version: Option<u32>,
+    pub config: TrainingConfig,
+    /// Human-facing name for the resulting LoRA.
+    pub output_name: String,
+    /// When true, the queue produces a [`TrainingPlan`] and stops short of
+    /// running the kernel (story 1416).
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// The fully normalized plan Rust hands to the Python execution kernel.
+///
+/// Every path is absolute and every hyperparameter concrete: the kernel reads
+/// only this document. `planVersion` lets the kernel reject formats it does not
+/// understand.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingPlan {
+    pub schema_version: u32,
+    pub plan_version: u32,
+    pub job_id: String,
+    pub target: TrainingPlanTarget,
+    pub dataset: TrainingPlanDataset,
+    pub config: TrainingConfig,
+    pub output: TrainingPlanOutput,
+    pub provenance: TrainingProvenance,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Resolved target details inside a [`TrainingPlan`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingPlanTarget {
+    pub target_id: String,
+    pub kernel: String,
+    pub family: String,
+    pub modality: TrainingModality,
+    pub output_kind: TrainingOutputKind,
+    pub base_model: String,
+    /// Absolute, resolved path to the base model weights on the worker.
+    pub base_model_path: String,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Resolved dataset details inside a [`TrainingPlan`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingPlanDataset {
+    pub dataset_id: String,
+    pub dataset_version: u32,
+    /// Absolute root directory the kernel reads images and captions from.
+    pub root_path: String,
+    pub items: Vec<TrainingPlanItem>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// A single resolved training example inside a [`TrainingPlan`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingPlanItem {
+    /// Absolute image path resolved by Rust.
+    pub image_path: String,
+    pub caption: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Where and how the kernel writes the produced adapter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingPlanOutput {
+    /// Pre-allocated SceneWorks LoRA id the output registers under.
+    pub lora_id: String,
+    /// Absolute directory the kernel writes the adapter into.
+    pub output_dir: String,
+    /// File name for the produced adapter, e.g. `my_style.safetensors`.
+    pub file_name: String,
+    /// Serialized weight format; `safetensors` today.
+    pub format: String,
+    pub trigger_words: Vec<String>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Provenance captured for a training run, linking the output LoRA back to its
+/// dataset, config, base model, and job.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrainingProvenance {
+    pub dataset_id: String,
+    pub dataset_version: u32,
+    pub target_id: String,
+    pub base_model: String,
+    /// Full config snapshot captured at submit time for reproducibility.
+    pub config_snapshot: JsonObject,
+    /// SceneWorks LoRA id the run produced (or will produce).
+    pub output_lora_id: String,
+    /// Job that produced this output.
+    pub source_job_id: String,
+    pub created_at: String,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// The built-in training targets Rust owns out of the box.
+///
+/// The first target is an image LoRA for Z-Image-Turbo. Defaults are informed
+/// by common LoRA practice (and `ai-toolkit` as reference), not derived from
+/// any external config format.
+pub fn builtin_training_targets() -> TrainingTargetRegistry {
+    TrainingTargetRegistry {
+        schema_version: TRAINING_CONTRACT_SCHEMA_VERSION,
+        targets: vec![z_image_turbo_lora_target()],
+        extra: ExtraFields::new(),
+    }
+}
+
+fn z_image_turbo_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "z_image_turbo_lora".to_owned(),
+        name: "Z-Image-Turbo LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "z-image".to_owned(),
+        base_model: "z_image_turbo".to_owned(),
+        base_model_repo: Some("Tongyi-MAI/Z-Image-Turbo".to_owned()),
+        kernel: "z_image_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 2000,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "networkType": "lora"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            "resolutions": [512, 768, 1024],
+            "batchSize": [1, 4]
+        })),
+        ui: object(json!({
+            "label": "Z-Image-Turbo LoRA",
+            "description": "Train an image LoRA for the Z-Image-Turbo base model.",
+            "recommendedFor": ["character", "style"]
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Converts a JSON value known to be an object literal into a [`JsonObject`].
+/// Non-object inputs yield an empty map; all call sites here pass object
+/// literals.
+fn object(value: Value) -> JsonObject {
+    match value {
+        Value::Object(map) => map,
+        _ => JsonObject::new(),
+    }
+}

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -1,0 +1,134 @@
+use std::fs;
+use std::path::PathBuf;
+
+use sceneworks_core::training::{
+    builtin_training_targets, LoraTrainingRequest, TrainingConfig, TrainingDataset,
+    TrainingModality, TrainingOutputKind, TrainingPlan, TrainingProvenance, TrainingTargetRegistry,
+    TRAINING_CONTRACT_SCHEMA_VERSION, TRAINING_PLAN_VERSION,
+};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+
+fn fixture_path(relative_path: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests")
+        .join("fixtures")
+        .join("rust_migration_contracts")
+        .join("training")
+        .join(relative_path)
+}
+
+fn load_fixture(relative_path: &str) -> Value {
+    let path = fixture_path(relative_path);
+    let payload = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    serde_json::from_str(&payload)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()))
+}
+
+fn assert_round_trip<T>(relative_path: &str)
+where
+    T: DeserializeOwned + Serialize,
+{
+    let original = load_fixture(relative_path);
+    let typed: T = serde_json::from_value(original.clone())
+        .unwrap_or_else(|error| panic!("failed to deserialize {relative_path}: {error}"));
+    let encoded = serde_json::to_value(typed)
+        .unwrap_or_else(|error| panic!("failed to serialize {relative_path}: {error}"));
+
+    assert_eq!(
+        encoded, original,
+        "{relative_path} drifted after typed round-trip"
+    );
+}
+
+#[test]
+fn training_dataset_round_trips() {
+    assert_round_trip::<TrainingDataset>("dataset.json");
+}
+
+#[test]
+fn training_config_round_trips() {
+    assert_round_trip::<TrainingConfig>("training-config.json");
+}
+
+#[test]
+fn lora_training_request_round_trips() {
+    assert_round_trip::<LoraTrainingRequest>("lora-training-request.json");
+}
+
+#[test]
+fn training_plan_round_trips() {
+    assert_round_trip::<TrainingPlan>("training-plan.json");
+}
+
+#[test]
+fn training_provenance_round_trips() {
+    assert_round_trip::<TrainingProvenance>("training-provenance.json");
+}
+
+#[test]
+fn training_target_registry_round_trips() {
+    assert_round_trip::<TrainingTargetRegistry>("target-registry.json");
+}
+
+#[test]
+fn builtin_registry_matches_committed_snapshot() {
+    let expected = load_fixture("target-registry.json");
+    let encoded =
+        serde_json::to_value(builtin_training_targets()).expect("builtin registry serializes");
+
+    assert_eq!(
+        encoded, expected,
+        "builtin target registry drifted from committed snapshot"
+    );
+}
+
+#[test]
+fn builtin_registry_exposes_z_image_turbo_target() {
+    let registry = builtin_training_targets();
+    assert_eq!(registry.schema_version, TRAINING_CONTRACT_SCHEMA_VERSION);
+
+    let target = registry
+        .targets
+        .iter()
+        .find(|target| target.id == "z_image_turbo_lora")
+        .expect("z_image_turbo_lora target present");
+
+    assert_eq!(target.modality, TrainingModality::Image);
+    assert_eq!(target.output_kind, TrainingOutputKind::Lora);
+    assert_eq!(target.family, "z-image");
+    assert_eq!(target.base_model, "z_image_turbo");
+    assert_eq!(target.kernel, "z_image_lora");
+    assert_eq!(target.defaults.rank, 16);
+    assert_eq!(target.defaults.resolution, 1024);
+    assert_eq!(target.defaults.trigger_word, None);
+}
+
+#[test]
+fn unknown_training_fields_and_values_are_preserved() {
+    let mut dataset = load_fixture("dataset.json");
+    // Unknown enum value falls back to the string-enum `Unknown` variant.
+    dataset["status"] = Value::String("curating".to_owned());
+    // Unknown top-level and nested keys survive via flattened `extra` maps.
+    dataset["futureField"] = Value::String("kept".to_owned());
+    dataset["items"][0]["caption"]["futureCaptionField"] = Value::Bool(true);
+
+    let typed: TrainingDataset =
+        serde_json::from_value(dataset.clone()).expect("unknown dataset fields parse");
+    let encoded = serde_json::to_value(typed).expect("unknown dataset fields serialize");
+
+    assert_eq!(encoded, dataset);
+}
+
+#[test]
+fn training_plan_fixture_pins_current_plan_version() {
+    let plan = load_fixture("training-plan.json");
+    assert_eq!(
+        plan["planVersion"].as_u64(),
+        Some(u64::from(TRAINING_PLAN_VERSION))
+    );
+}

--- a/tests/fixtures/rust_migration_contracts/training/dataset.json
+++ b/tests/fixtures/rust_migration_contracts/training/dataset.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "id": "ds_abc123",
+  "version": 3,
+  "projectId": "proj_001",
+  "name": "Aurora style set",
+  "modality": "image",
+  "status": "ready",
+  "createdAt": "2026-05-20T10:00:00Z",
+  "updatedAt": "2026-05-20T12:30:00Z",
+  "items": [
+    {
+      "id": "item_001",
+      "assetId": "asset_900",
+      "path": "images/001.png",
+      "displayName": "001.png",
+      "caption": {
+        "text": "a portrait of auroraStyle woman, soft light",
+        "source": "manual",
+        "triggerWords": ["auroraStyle"],
+        "updatedAt": "2026-05-20T12:00:00Z"
+      },
+      "width": 1024,
+      "height": 1024,
+      "addedAt": "2026-05-20T11:00:00Z"
+    },
+    {
+      "id": "item_002",
+      "path": "images/002.png",
+      "displayName": "002.png",
+      "caption": {
+        "text": "auroraStyle landscape, distant mountains",
+        "source": "auto",
+        "triggerWords": ["auroraStyle"]
+      },
+      "addedAt": "2026-05-20T11:05:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/rust_migration_contracts/training/lora-training-request.json
+++ b/tests/fixtures/rust_migration_contracts/training/lora-training-request.json
@@ -1,0 +1,24 @@
+{
+  "targetId": "z_image_turbo_lora",
+  "datasetId": "ds_abc123",
+  "datasetVersion": 3,
+  "config": {
+    "rank": 32,
+    "alpha": 16,
+    "learningRate": 0.0002,
+    "steps": 2500,
+    "batchSize": 2,
+    "gradientAccumulation": 1,
+    "resolution": 1024,
+    "saveEvery": 250,
+    "seed": 7,
+    "optimizer": "adamw8bit",
+    "triggerWord": "auroraStyle",
+    "advanced": {
+      "mixedPrecision": "bf16",
+      "cacheLatents": true
+    }
+  },
+  "outputName": "Aurora Style",
+  "dryRun": true
+}

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "targets": [
+    {
+      "id": "z_image_turbo_lora",
+      "name": "Z-Image-Turbo LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "z-image",
+      "baseModel": "z_image_turbo",
+      "baseModelRepo": "Tongyi-MAI/Z-Image-Turbo",
+      "kernel": "z_image_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 2000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "mixedPrecision": "bf16",
+          "cacheLatents": true,
+          "networkType": "lora"
+        }
+      },
+      "limits": {
+        "rank": [4, 128],
+        "alpha": [1, 128],
+        "steps": [200, 6000],
+        "resolutions": [512, 768, 1024],
+        "batchSize": [1, 4]
+      },
+      "ui": {
+        "label": "Z-Image-Turbo LoRA",
+        "description": "Train an image LoRA for the Z-Image-Turbo base model.",
+        "recommendedFor": ["character", "style"]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/rust_migration_contracts/training/training-config.json
+++ b/tests/fixtures/rust_migration_contracts/training/training-config.json
@@ -1,0 +1,17 @@
+{
+  "rank": 32,
+  "alpha": 16,
+  "learningRate": 0.0002,
+  "steps": 2500,
+  "batchSize": 2,
+  "gradientAccumulation": 1,
+  "resolution": 1024,
+  "saveEvery": 250,
+  "seed": 7,
+  "optimizer": "adamw8bit",
+  "triggerWord": "auroraStyle",
+  "advanced": {
+    "mixedPrecision": "bf16",
+    "cacheLatents": true
+  }
+}

--- a/tests/fixtures/rust_migration_contracts/training/training-plan.json
+++ b/tests/fixtures/rust_migration_contracts/training/training-plan.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "planVersion": 1,
+  "jobId": "job_777",
+  "target": {
+    "targetId": "z_image_turbo_lora",
+    "kernel": "z_image_lora",
+    "family": "z-image",
+    "modality": "image",
+    "outputKind": "lora",
+    "baseModel": "z_image_turbo",
+    "baseModelPath": "/sceneworks/data/cache/huggingface/Tongyi-MAI/Z-Image-Turbo"
+  },
+  "dataset": {
+    "datasetId": "ds_abc123",
+    "datasetVersion": 3,
+    "rootPath": "/sceneworks/data/training/ds_abc123",
+    "items": [
+      {
+        "imagePath": "/sceneworks/data/training/ds_abc123/images/001.png",
+        "caption": "a portrait of auroraStyle woman, soft light",
+        "width": 1024,
+        "height": 1024
+      },
+      {
+        "imagePath": "/sceneworks/data/training/ds_abc123/images/002.png",
+        "caption": "auroraStyle landscape, distant mountains"
+      }
+    ]
+  },
+  "config": {
+    "rank": 32,
+    "alpha": 16,
+    "learningRate": 0.0002,
+    "steps": 2500,
+    "batchSize": 2,
+    "gradientAccumulation": 1,
+    "resolution": 1024,
+    "saveEvery": 250,
+    "seed": 7,
+    "optimizer": "adamw8bit",
+    "triggerWord": "auroraStyle",
+    "advanced": {
+      "mixedPrecision": "bf16",
+      "cacheLatents": true
+    }
+  },
+  "output": {
+    "loraId": "lora_aurora_001",
+    "outputDir": "/sceneworks/data/loras/lora_aurora_001",
+    "fileName": "aurora_style.safetensors",
+    "format": "safetensors",
+    "triggerWords": ["auroraStyle"]
+  },
+  "provenance": {
+    "datasetId": "ds_abc123",
+    "datasetVersion": 3,
+    "targetId": "z_image_turbo_lora",
+    "baseModel": "z_image_turbo",
+    "configSnapshot": {
+      "rank": 32,
+      "alpha": 16,
+      "learningRate": 0.0002,
+      "steps": 2500,
+      "batchSize": 2,
+      "gradientAccumulation": 1,
+      "resolution": 1024,
+      "saveEvery": 250,
+      "seed": 7,
+      "optimizer": "adamw8bit",
+      "triggerWord": "auroraStyle",
+      "advanced": {
+        "mixedPrecision": "bf16",
+        "cacheLatents": true
+      }
+    },
+    "outputLoraId": "lora_aurora_001",
+    "sourceJobId": "job_777",
+    "createdAt": "2026-05-20T13:00:00Z"
+  }
+}

--- a/tests/fixtures/rust_migration_contracts/training/training-provenance.json
+++ b/tests/fixtures/rust_migration_contracts/training/training-provenance.json
@@ -1,0 +1,26 @@
+{
+  "datasetId": "ds_abc123",
+  "datasetVersion": 3,
+  "targetId": "z_image_turbo_lora",
+  "baseModel": "z_image_turbo",
+  "configSnapshot": {
+    "rank": 32,
+    "alpha": 16,
+    "learningRate": 0.0002,
+    "steps": 2500,
+    "batchSize": 2,
+    "gradientAccumulation": 1,
+    "resolution": 1024,
+    "saveEvery": 250,
+    "seed": 7,
+    "optimizer": "adamw8bit",
+    "triggerWord": "auroraStyle",
+    "advanced": {
+      "mixedPrecision": "bf16",
+      "cacheLatents": true
+    }
+  },
+  "outputLoraId": "lora_aurora_001",
+  "sourceJobId": "job_777",
+  "createdAt": "2026-05-20T13:00:00Z"
+}


### PR DESCRIPTION
## Summary

First story of epic [SceneWorks: Native LoRA Training Studio (1408)](https://app.shortcut.com/trefry/epic/1408). Defines the Rust-owned training contracts that the rest of the epic builds on — datasets, captions, the target registry, training config, the normalized plan handed to Python, and provenance — without touching any existing contract.

Implements [sc-1409](https://app.shortcut.com/trefry/story/1409).

## What's included

- **New `sceneworks-core::training` module** with `camelCase` JSON, flattened `extra` forward-compat fields, and `Unknown`-fallback string enums (same conventions as `contracts.rs`):
  - `TrainingDataset` / `TrainingDatasetItem` / `Caption`
  - `TrainingTarget` + `TrainingTargetRegistry` (generic over `modality` / `outputKind` / `family`)
  - `TrainingConfig` (generic LoRA hyperparameters + free-form `advanced` bag)
  - `LoraTrainingRequest` (job payload shape)
  - `TrainingPlan` (+ `target` / `dataset` / `item` / `output` sub-shapes) — the fully-resolved document the Python kernel consumes
  - `TrainingProvenance` — dataset id/version, config snapshot, base model, output LoRA, source job
- **Built-in target registry** `builtin_training_targets()` exposing the first production target, **Z-Image-Turbo image LoRA** (`family: z-image`, `baseModel: z_image_turbo`, `kernel: z_image_lora`).
- **Tests**: round-trip per shape against new JSON fixtures, a snapshot test pinning the built-in registry, and a forward-compat test proving unknown fields/enum values survive.

## Design notes / boundaries

- **Backward compatible**: no changes to existing job/model/LoRA contracts. `string_enum!` is made crate-visible (`pub(crate) use`) so the new module reuses the Unknown-fallback enum machinery.
- **ai-toolkit is reference only**: generic LoRA terminology and free-form `advanced`/`limits`/`ui` bags; no ai-toolkit config or runtime format is embedded.
- **Deferred to later stories** (intentionally not here): dataset store/CRUD (1410), `JobType::LoraTrain` + queue routing + dry-run plan builder (1416), Python kernel (1417), output LoRA registration (1418), and JSON-schema/Python mirrors (land with their consuming stories).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all pass (incl. existing `contract_roundtrip` suite → backward-compat guard)
- `cargo build --workspace` — clean
- New `training_contracts` suite: 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)