### PR TITLE
[sc-1411] Add Train studio shell

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -8,6 +8,7 @@ import { LibraryScreen } from "./screens/LibraryScreen.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
+import { TrainingStudio } from "./screens/TrainingStudio.jsx";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { EditorScreen } from "./screens/EditorScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
@@ -90,6 +91,7 @@ const navSections = [
       { id: "Library", icon: Icon.Library },
       { id: "Image", icon: Icon.Image },
       { id: "Video", icon: Icon.Video },
+      { id: "Train", icon: Icon.Train },
       { id: "Editor", icon: Icon.Editor },
     ],
   },
@@ -111,6 +113,7 @@ const viewTitles = {
   Library: { title: "Library", blurb: "Browse stills and clips across all your projects." },
   Image: { title: "Image Studio", blurb: "Describe what you want — we'll render variations side by side." },
   Video: { title: "Video Studio", blurb: "Bring stills to life, or render new clips from scratch." },
+  Train: { title: "Training Studio", blurb: "Build datasets and prepare LoRA training plans." },
   Editor: { title: "Editor", blurb: "Cut, sequence and export your timeline." },
   Characters: { title: "Characters", blurb: "Keep the same face across every shot." },
   Presets: { title: "Presets", blurb: "Save and share recurring generation setups." },
@@ -289,6 +292,10 @@ export function App() {
   const [models, setModels] = useState([]);
   const [loras, setLoras] = useState([]);
   const [presets, setPresets] = useState([]);
+  const [trainingDatasets, setTrainingDatasets] = useState([]);
+  const [trainingDatasetsProjectId, setTrainingDatasetsProjectId] = useState(null);
+  const [loadingTrainingDatasets, setLoadingTrainingDatasets] = useState(false);
+  const [trainingDatasetsError, setTrainingDatasetsError] = useState("");
   const [assets, setAssets] = useState([]);
   const [characters, setCharacters] = useState([]);
   const [personTracks, setPersonTracks] = useState([]);
@@ -461,6 +468,9 @@ export function App() {
       setTimelines([]);
       setTimelinesProjectId(null);
       setPresets([]);
+      setTrainingDatasets([]);
+      setTrainingDatasetsProjectId(null);
+      setTrainingDatasetsError("");
       setSelectedTimelineId(null);
       setActiveTimeline(null);
       return;
@@ -469,6 +479,7 @@ export function App() {
     refreshCharacters(activeProject.id);
     refreshLoras(activeProject.id);
     refreshPresets(activeProject.id);
+    refreshTrainingDatasets(activeProject.id);
     refreshPersonTracks(activeProject.id);
     refreshTimelines(activeProject.id);
   }, [activeProject?.id, authenticated, token]);
@@ -687,6 +698,30 @@ export function App() {
     } catch (err) {
       setError(err.message);
       return [];
+    }
+  }
+
+  async function refreshTrainingDatasets(projectId = activeProject?.id) {
+    if (!projectId) {
+      setTrainingDatasets([]);
+      setTrainingDatasetsProjectId(null);
+      setTrainingDatasetsError("");
+      return [];
+    }
+    setLoadingTrainingDatasets(true);
+    try {
+      const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token);
+      setTrainingDatasets(items);
+      setTrainingDatasetsProjectId(projectId);
+      setTrainingDatasetsError("");
+      return items;
+    } catch (err) {
+      setTrainingDatasets([]);
+      setTrainingDatasetsProjectId(projectId);
+      setTrainingDatasetsError(err.message);
+      return [];
+    } finally {
+      setLoadingTrainingDatasets(false);
     }
   }
 
@@ -1734,6 +1769,17 @@ export function App() {
             setRequestedGpu={setRequestedGpu}
             updateAssetStatus={updateAssetStatus}
             videoModels={videoModels}
+          />
+        ) : null}
+
+        {activeView === "Train" ? (
+          <TrainingStudio
+            activeProject={activeProject}
+            authenticated={authenticated}
+            datasets={trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : []}
+            datasetsError={trainingDatasetsError}
+            loadingDatasets={loadingTrainingDatasets}
+            onRefreshDatasets={() => refreshTrainingDatasets(activeProject?.id)}
           />
         ) : null}
 

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -24,6 +24,7 @@ export const Icon = {
   Image: (p) => <I {...p} d="M4 5h16v14H4zM4 16l5-5 4 4 3-3 4 4" />,
   Video: (p) => <I {...p} d="M3 6h12v12H3zM15 9l6-3v12l-6-3z" />,
   Editor: (p) => <I {...p} d="M3 8h18M3 12h12M3 16h18M16 10l4 2-4 2z" />,
+  Train: (p) => <I {...p} d="M5 19V5M12 19V5M19 19V5M3 9h4M10 15h4M17 11h4" />,
   Character: (p) => <I {...p} d="M12 12a4 4 0 100-8 4 4 0 000 8zM4 20a8 8 0 0116 0" />,
   Preset: (p) => <I {...p} d="M4 7h16M7 12h10M10 17h4" />,
   Model: (p) => <I {...p} d="M12 3l8 4.5v9L12 21l-8-4.5v-9zM12 3v9M12 12l8-4.5M12 12l-8-4.5" />,

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -10,6 +10,7 @@ import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
+import { TrainingStudio } from "./screens/TrainingStudio.jsx";
 
 class FakeEventSource {
   static instances = [];
@@ -124,7 +125,75 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     expect(container.textContent).toContain("Library");
+    expect(container.textContent).toContain("Train");
     expect(container.textContent).toContain("Queue");
+  });
+
+  it("opens the Train navigation item without exposing a queue action", async () => {
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-a", name: "Project A" }]));
+      }
+      if (path.includes("/training/datasets")) {
+        return Promise.resolve(response([{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 2 }]));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Train").click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Training Studio");
+    expect(container.textContent).toContain("Portrait Set");
+    expect(container.textContent).toContain("Configure Job");
+    expect([...container.querySelectorAll("button")].some((button) => /queue training/i.test(button.textContent))).toBe(false);
+  });
+
+  it("supports keyboard navigation across Training Studio tabs", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 2 }]}
+          onRefreshDatasets={() => {}}
+        />,
+      );
+    });
+
+    const datasetTab = container.querySelector("#training-tab-dataset");
+    datasetTab.focus();
+
+    await act(async () => {
+      datasetTab.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+
+    expect(container.querySelector("#training-tab-rename-caption").getAttribute("aria-selected")).toBe("true");
+
+    await act(async () => {
+      container.querySelector("#training-tab-rename-caption").dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    });
+
+    expect(container.querySelector("#training-tab-configure").getAttribute("aria-selected")).toBe("true");
+    expect(container.textContent).toContain("Training submission is disabled");
   });
 
   it("selects duplicate-titled assets through the thumbnail asset picker", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -26,7 +26,7 @@ export function TrainingStudio({
   datasets = [],
   datasetsError = "",
   loadingDatasets = false,
-  onRefreshDatasets,
+  onRefreshDatasets = () => {},
 }) {
   const [activeTab, setActiveTab] = useState("dataset");
   const tabRefs = useRef({});
@@ -107,7 +107,7 @@ export function TrainingStudio({
             <div className="training-tabs" role="tablist" aria-label="Training workflow">
               {tabs.map((tab) => (
                 <button
-                  aria-controls={`training-panel-${tab.id}`}
+                  aria-controls={activeTab === tab.id ? `training-panel-${tab.id}` : undefined}
                   aria-selected={activeTab === tab.id}
                   className={activeTab === tab.id ? "active" : ""}
                   id={`training-tab-${tab.id}`}
@@ -150,15 +150,18 @@ export function TrainingStudio({
                     <div className="empty-panel">Loading training datasets</div>
                   ) : datasets.length ? (
                     <div className="training-dataset-list">
-                      {datasets.map((dataset) => (
-                        <article className="training-dataset-row" key={dataset.id}>
-                          <div>
-                            <strong>{dataset.name ?? dataset.id}</strong>
-                            <span>{formatDatasetModality(dataset)} dataset</span>
-                          </div>
-                          <span>{datasetItemCount(dataset)} item{datasetItemCount(dataset) === 1 ? "" : "s"}</span>
-                        </article>
-                      ))}
+                      {datasets.map((dataset) => {
+                        const itemCount = datasetItemCount(dataset);
+                        return (
+                          <article className="training-dataset-row" key={dataset.id}>
+                            <div>
+                              <strong>{dataset.name ?? dataset.id}</strong>
+                              <span>{formatDatasetModality(dataset)} dataset</span>
+                            </div>
+                            <span>{itemCount} item{itemCount === 1 ? "" : "s"}</span>
+                          </article>
+                        );
+                      })}
                     </div>
                   ) : (
                     <div className="empty-panel">No training datasets yet</div>

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1,0 +1,229 @@
+import React, { useMemo, useRef, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+
+const tabs = [
+  { id: "dataset", label: "Dataset", title: "Dataset intake", status: "Rust dataset store" },
+  { id: "rename-caption", label: "Rename & Caption", title: "Rename and caption pass", status: "Workflow reserved" },
+  { id: "configure", label: "Configure Job", title: "Configure training job", status: "Queue disabled" },
+];
+
+function formatDatasetModality(dataset) {
+  return String(dataset.modality ?? "image").replaceAll("_", " ");
+}
+
+function datasetItemCount(dataset) {
+  const value = Number(dataset.itemCount ?? dataset.items?.length ?? 0);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function summarizeDatasets(datasets) {
+  return datasets.reduce((summary, dataset) => ({ items: summary.items + datasetItemCount(dataset) }), { items: 0 });
+}
+
+export function TrainingStudio({
+  activeProject,
+  authenticated = true,
+  datasets = [],
+  datasetsError = "",
+  loadingDatasets = false,
+  onRefreshDatasets,
+}) {
+  const [activeTab, setActiveTab] = useState("dataset");
+  const tabRefs = useRef({});
+  const activeIndex = tabs.findIndex((tab) => tab.id === activeTab);
+  const active = tabs[activeIndex] ?? tabs[0];
+  const datasetSummary = useMemo(() => summarizeDatasets(datasets), [datasets]);
+
+  function focusTab(index) {
+    const next = tabs[(index + tabs.length) % tabs.length];
+    setActiveTab(next.id);
+    window.requestAnimationFrame(() => tabRefs.current[next.id]?.focus());
+  }
+
+  function onTabKeyDown(event) {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusTab(activeIndex + 1);
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusTab(activeIndex - 1);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      focusTab(0);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      focusTab(tabs.length - 1);
+    }
+  }
+
+  return (
+    <section className="main-surface training-studio">
+      <div className="training-studio-shell">
+        <div className="training-summary-band">
+          <div className="section-heading">
+            <p className="eyebrow">Training Studio</p>
+            <h2>Native LoRA training workflow</h2>
+            <p className="view-copy">
+              Build datasets, normalize captions, and prepare a Rust-owned training plan before any ML runtime work begins.
+            </p>
+          </div>
+          <div className="training-metrics" aria-label="Training workspace summary">
+            <div>
+              <strong>{activeProject?.name ?? "No workspace"}</strong>
+              <span>Project</span>
+            </div>
+            <div>
+              <strong>{datasets.length}</strong>
+              <span>Datasets</span>
+            </div>
+            <div>
+              <strong>{datasetSummary.items}</strong>
+              <span>Items</span>
+            </div>
+          </div>
+        </div>
+
+        {!authenticated ? (
+          <div className="training-empty-state" role="status">
+            <Icon.Train size={24} />
+            <div>
+              <strong>Pairing required</strong>
+              <span>Unlock SceneWorks to load project training datasets.</span>
+            </div>
+          </div>
+        ) : !activeProject ? (
+          <div className="training-empty-state" role="status">
+            <Icon.Folder size={24} />
+            <div>
+              <strong>No workspace open</strong>
+              <span>Create or select a workspace before building a training dataset.</span>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="training-tabs" role="tablist" aria-label="Training workflow">
+              {tabs.map((tab) => (
+                <button
+                  aria-controls={`training-panel-${tab.id}`}
+                  aria-selected={activeTab === tab.id}
+                  className={activeTab === tab.id ? "active" : ""}
+                  id={`training-tab-${tab.id}`}
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={onTabKeyDown}
+                  ref={(node) => {
+                    tabRefs.current[tab.id] = node;
+                  }}
+                  role="tab"
+                  tabIndex={activeTab === tab.id ? 0 : -1}
+                  type="button"
+                >
+                  <span>{tab.label}</span>
+                  <small>{tab.status}</small>
+                </button>
+              ))}
+            </div>
+
+            <section
+              aria-labelledby={`training-tab-${active.id}`}
+              className="training-panel"
+              id={`training-panel-${active.id}`}
+              role="tabpanel"
+            >
+              {activeTab === "dataset" ? (
+                <>
+                  <div className="training-panel-head">
+                    <div>
+                      <p className="eyebrow">Dataset</p>
+                      <h3>{active.title}</h3>
+                    </div>
+                    <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
+                      <Icon.Search size={14} />
+                      {loadingDatasets ? "Refreshing" : "Refresh"}
+                    </button>
+                  </div>
+                  {datasetsError ? <p className="inline-warning">{datasetsError}</p> : null}
+                  {loadingDatasets ? (
+                    <div className="empty-panel">Loading training datasets</div>
+                  ) : datasets.length ? (
+                    <div className="training-dataset-list">
+                      {datasets.map((dataset) => (
+                        <article className="training-dataset-row" key={dataset.id}>
+                          <div>
+                            <strong>{dataset.name ?? dataset.id}</strong>
+                            <span>{formatDatasetModality(dataset)} dataset</span>
+                          </div>
+                          <span>{datasetItemCount(dataset)} item{datasetItemCount(dataset) === 1 ? "" : "s"}</span>
+                        </article>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="empty-panel">No training datasets yet</div>
+                  )}
+                </>
+              ) : null}
+
+              {activeTab === "rename-caption" ? (
+                <>
+                  <div className="training-panel-head">
+                    <div>
+                      <p className="eyebrow">Rename & Caption</p>
+                      <h3>{active.title}</h3>
+                    </div>
+                    <span className="training-status-pill">Not queueable</span>
+                  </div>
+                  <div className="training-workflow-grid">
+                    <div className="training-step-block">
+                      <strong>Batch rename</strong>
+                      <span>Stable filenames and ordered item ids will be prepared from the selected dataset.</span>
+                    </div>
+                    <div className="training-step-block">
+                      <strong>Caption sidecars</strong>
+                      <span>Caption metadata will stay attached to SceneWorks dataset items before sidecar export.</span>
+                    </div>
+                  </div>
+                </>
+              ) : null}
+
+              {activeTab === "configure" ? (
+                <>
+                  <div className="training-panel-head">
+                    <div>
+                      <p className="eyebrow">Configure Job</p>
+                      <h3>{active.title}</h3>
+                    </div>
+                    <span className="training-status-pill">Dry run pending</span>
+                  </div>
+                  <div className="training-config-preview" aria-label="Training job placeholder settings">
+                    <label>
+                      Target
+                      <select defaultValue="z_image_turbo" disabled>
+                        <option value="z_image_turbo">Z-Image Turbo LoRA</option>
+                      </select>
+                    </label>
+                    <label>
+                      Dataset
+                      <select defaultValue="" disabled>
+                        <option value="">Select after dataset workflow</option>
+                      </select>
+                    </label>
+                    <label>
+                      Preset
+                      <select defaultValue="simple" disabled>
+                        <option value="simple">Simple defaults</option>
+                      </select>
+                    </label>
+                  </div>
+                  <p className="inline-warning">Training submission is disabled until the dry-run plan story wires queue semantics.</p>
+                </>
+              ) : null}
+            </section>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1516,8 +1516,7 @@ label {
   white-space: nowrap;
 }
 
-.training-workflow-grid,
-.training-config-preview {
+.training-workflow-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1356,6 +1356,184 @@ label {
   align-content: start;
 }
 
+/* ---------- Training Studio ---------- */
+.training-studio-shell {
+  display: grid;
+  gap: var(--gap-4);
+  align-content: start;
+}
+
+.training-summary-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 420px);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.training-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.training-metrics > div,
+.training-empty-state,
+.training-panel,
+.training-dataset-row,
+.training-step-block {
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.training-metrics > div {
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  min-height: 84px;
+  padding: 12px;
+}
+
+.training-metrics strong {
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.training-metrics span,
+.training-dataset-row span,
+.training-step-block span,
+.training-empty-state span,
+.training-tabs small {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.training-empty-state {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 120px;
+  padding: 18px;
+}
+
+.training-empty-state > div {
+  display: grid;
+  gap: 4px;
+}
+
+.training-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.training-tabs button {
+  display: grid;
+  min-height: 66px;
+  gap: 4px;
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.training-tabs button:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-hover);
+}
+
+.training-tabs button.active {
+  border-color: color-mix(in oklch, var(--accent) 55%, var(--border));
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.training-tabs span {
+  font-weight: 700;
+}
+
+.training-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.training-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.training-panel-head h3 {
+  margin: 2px 0 0;
+  font-size: 18px;
+}
+
+.training-status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: var(--r-pill);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.training-dataset-list,
+.training-workflow-grid,
+.training-config-preview {
+  display: grid;
+  gap: 10px;
+}
+
+.training-dataset-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  background: var(--surface);
+}
+
+.training-dataset-row > div,
+.training-step-block {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.training-dataset-row strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.training-workflow-grid,
+.training-config-preview {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.training-step-block {
+  padding: 14px;
+}
+
+.training-config-preview {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.training-config-preview label {
+  display: grid;
+  gap: 7px;
+}
+
 .preset-rail-head {
   display: flex;
   align-items: baseline;
@@ -4594,6 +4772,11 @@ label {
   .media-grid,
   .library-layout,
   .studio-layout,
+  .training-summary-band,
+  .training-tabs,
+  .training-metrics,
+  .training-workflow-grid,
+  .training-config-preview,
   .preset-layout,
   .character-layout,
   .queue-header,


### PR DESCRIPTION
## Summary
- add the Train navigation entry and Training Studio title/blurb
- add a generic Training Studio shell with Dataset, Rename & Caption, and Configure Job tabs
- load Rust training dataset summaries for the active project and keep queue submission unavailable
- cover navigation, tab keyboard behavior, and no-queue guardrails in web tests

## Verification
- npm --prefix apps/web test
- npm --prefix apps/web run build
- git diff --check
- browser visual check at desktop and 390px mobile widths