### PR TITLE
[sc-1412] Build image dataset workflow

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -725,6 +725,37 @@ export function App() {
     }
   }
 
+  async function loadTrainingDataset(datasetId, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      return null;
+    }
+    return apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token);
+  }
+
+  async function createTrainingDataset(payload, projectId = activeProject?.id) {
+    if (!projectId) {
+      throw new Error("Create or open a project first.");
+    }
+    const created = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    await refreshTrainingDatasets(projectId);
+    return created;
+  }
+
+  async function updateTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      throw new Error("Select a training dataset first.");
+    }
+    const updated = await apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token, {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    });
+    await refreshTrainingDatasets(projectId);
+    return updated;
+  }
+
   function presetQuery(scope = null) {
     const params = new URLSearchParams();
     if (scope) {
@@ -1545,8 +1576,10 @@ export function App() {
       setAssets((items) => [imported, ...items.filter((item) => item.id !== imported.id)]);
       setSelectedAssetId(imported.id);
       setError("");
+      return imported;
     } catch (err) {
       setError(err.message);
+      return null;
     }
   }
 
@@ -1776,10 +1809,16 @@ export function App() {
           <TrainingStudio
             activeProject={activeProject}
             authenticated={authenticated}
+            assets={assets}
+            createDataset={createTrainingDataset}
             datasets={trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : []}
             datasetsError={trainingDatasetsError}
+            importAsset={importAsset}
+            loadDataset={loadTrainingDataset}
             loadingDatasets={loadingTrainingDatasets}
+            onPreview={setPreviewAsset}
             onRefreshDatasets={() => refreshTrainingDatasets(activeProject?.id)}
+            updateDataset={updateTrainingDataset}
           />
         ) : null}
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1561,9 +1561,13 @@ export function App() {
     }
   }
 
-  async function importAsset(file) {
+  async function importAsset(file, options = {}) {
     if (!activeProject || !file) {
-      setError("Create or open a project first.");
+      const error = new Error("Create or open a project first.");
+      if (options.throwOnError) {
+        throw error;
+      }
+      setError(error.message);
       return;
     }
     const body = new FormData();
@@ -1578,6 +1582,9 @@ export function App() {
       setError("");
       return imported;
     } catch (err) {
+      if (options.throwOnError) {
+        throw err;
+      }
       setError(err.message);
       return null;
     }
@@ -1813,7 +1820,7 @@ export function App() {
             createDataset={createTrainingDataset}
             datasets={trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : []}
             datasetsError={trainingDatasetsError}
-            importAsset={importAsset}
+            importAsset={(file) => importAsset(file, { throwOnError: true })}
             loadDataset={loadTrainingDataset}
             loadingDatasets={loadingTrainingDatasets}
             onPreview={setPreviewAsset}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -196,6 +196,102 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Training submission is disabled");
   });
 
+  it("creates a training dataset from selected image assets", async () => {
+    const createDataset = vi.fn(async (payload) => ({
+      id: "dataset-new",
+      name: payload.name,
+      version: 1,
+      items: payload.items.map((item) => ({ ...item, caption: { text: "", triggerWords: [] } })),
+    }));
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          assets={[{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }]}
+          createDataset={createDataset}
+          datasets={[]}
+        />,
+      );
+    });
+
+    await changeField(field(container, "Dataset name"), "Mira Set");
+    await act(async () => {
+      container.querySelector(".training-asset-card input").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Create dataset").click();
+    });
+
+    expect(createDataset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Mira Set",
+        modality: "image",
+        items: [expect.objectContaining({ assetId: "asset-a", displayName: "Mira.png" })],
+      }),
+    );
+    expect(container.textContent).toContain("Dataset created");
+  });
+
+  it("opens and saves an existing training dataset membership", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 3,
+      items: [{ assetId: "asset-a", displayName: "Mira.png", caption: { text: "mira portrait", triggerWords: [] } }],
+    }));
+    const updateDataset = vi.fn(async (datasetId, payload) => ({
+      id: datasetId,
+      name: payload.name,
+      version: 4,
+      items: payload.items.map((item) => ({ ...item, caption: item.caption ?? { text: "", triggerWords: [] } })),
+    }));
+    const assets = [
+      { id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } },
+      { id: "asset-b", type: "image", displayName: "Mira close.png", file: { path: "assets/images/Mira-close.png", mimeType: "image/png" } },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          assets={assets}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          loadDataset={loadDataset}
+          updateDataset={updateDataset}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+    });
+    await settle();
+    expect(loadDataset).toHaveBeenCalledWith("dataset-a");
+    expect(container.querySelectorAll(".training-asset-card input")[0].checked).toBe(true);
+
+    await act(async () => {
+      container.querySelectorAll(".training-asset-card input")[1].click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Save dataset").click();
+    });
+
+    expect(updateDataset).toHaveBeenCalledWith(
+      "dataset-a",
+      expect.objectContaining({
+        name: "Portrait Set",
+        items: [
+          expect.objectContaining({ assetId: "asset-a" }),
+          expect.objectContaining({ assetId: "asset-b" }),
+        ],
+      }),
+    );
+    expect(container.textContent).toContain("Dataset changes saved");
+  });
+
   it("selects duplicate-titled assets through the thumbnail asset picker", async () => {
     const onChange = vi.fn();
     const assets = [

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -292,6 +292,91 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Dataset changes saved");
   });
 
+  it("lets users remove unavailable dataset assets before saving", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 3,
+      items: [
+        { assetId: "asset-a", displayName: "Mira.png", caption: { text: "mira portrait", triggerWords: [] } },
+        { assetId: "asset-missing", displayName: "Missing.png", caption: { text: "missing portrait", triggerWords: [] } },
+      ],
+    }));
+    const updateDataset = vi.fn(async (datasetId, payload) => ({
+      id: datasetId,
+      name: payload.name,
+      version: 4,
+      items: payload.items,
+    }));
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          assets={[{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }]}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 2 }]}
+          loadDataset={loadDataset}
+          updateDataset={updateDataset}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Asset is no longer available");
+    expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Save dataset").disabled).toBe(true);
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Remove").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Save dataset").click();
+    });
+
+    expect(updateDataset).toHaveBeenCalledWith(
+      "dataset-a",
+      expect.objectContaining({
+        items: [expect.objectContaining({ assetId: "asset-a" })],
+      }),
+    );
+  });
+
+  it("does not save unchanged existing datasets", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 3,
+      items: [{ assetId: "asset-a", displayName: "Mira.png", caption: { text: "mira portrait", triggerWords: [] } }],
+    }));
+    const updateDataset = vi.fn();
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          assets={[{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }]}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          loadDataset={loadDataset}
+          updateDataset={updateDataset}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+    });
+    await settle();
+
+    const saveButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Save dataset");
+    expect(saveButton.disabled).toBe(true);
+    expect(updateDataset).not.toHaveBeenCalled();
+  });
+
   it("selects duplicate-titled assets through the thumbnail asset picker", async () => {
     const onChange = vi.fn();
     const assets = [

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1,9 +1,10 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { AssetThumbnail, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 
 const tabs = [
   { id: "dataset", label: "Dataset", title: "Dataset intake", status: "Rust dataset store" },
-  { id: "rename-caption", label: "Rename & Caption", title: "Rename and caption pass", status: "Workflow reserved" },
+  { id: "rename-caption", label: "Rename & Caption", title: "Rename and caption pass", status: "Needs valid dataset" },
   { id: "configure", label: "Configure Job", title: "Configure training job", status: "Queue disabled" },
 ];
 
@@ -20,19 +21,144 @@ function summarizeDatasets(datasets) {
   return datasets.reduce((summary, dataset) => ({ items: summary.items + datasetItemCount(dataset) }), { items: 0 });
 }
 
+function imageAssetName(asset) {
+  const path = asset?.file?.path ?? asset?.path ?? asset?.displayName ?? asset?.id ?? "asset";
+  return String(path).replaceAll("\\", "/").split("/").pop() || "asset";
+}
+
+function captionText(item) {
+  return String(item?.caption?.text ?? "").trim();
+}
+
+function normalizeDatasetAssetIds(dataset) {
+  return (dataset?.items ?? []).map((item) => item.assetId).filter(Boolean);
+}
+
+function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) {
+  const assetsById = new Map(imageAssets.map((asset) => [asset.id, asset]));
+  const selectedAssets = selectedAssetIds.map((id) => assetsById.get(id)).filter(Boolean);
+  const missingAssets = selectedAssetIds.filter((id) => !assetsById.has(id)).length;
+  const disabledItems = selectedAssets.filter((asset) => asset.status?.rejected || asset.status?.trashed).length + missingAssets;
+  const names = selectedAssets.map((asset) => imageAssetName(asset).toLowerCase());
+  const duplicateFilenames = names.filter((name, index) => names.indexOf(name) !== index).length;
+  const captionsByAssetId = new Map((activeDataset?.items ?? []).map((item) => [item.assetId, captionText(item)]));
+  const missingCaptions = selectedAssetIds.filter((id) => !captionsByAssetId.get(id)).length;
+  const valid = selectedAssetIds.length > 0 && disabledItems === 0 && duplicateFilenames === 0;
+
+  return {
+    disabledItems,
+    duplicateFilenames,
+    itemCount: selectedAssetIds.length,
+    missingCaptions,
+    valid,
+  };
+}
+
+function datasetPayload({ activeDataset, assetsById, name, selectedAssetIds }) {
+  const itemsByAssetId = new Map((activeDataset?.items ?? []).map((item) => [item.assetId, item]));
+  return {
+    name: name.trim(),
+    modality: "image",
+    items: selectedAssetIds
+      .map((assetId) => {
+        const asset = assetsById.get(assetId);
+        if (!asset) {
+          return null;
+        }
+        const previous = itemsByAssetId.get(assetId);
+        return {
+          assetId,
+          displayName: asset.displayName ?? imageAssetName(asset),
+          caption: previous?.caption
+            ? {
+                text: previous.caption.text ?? "",
+                source: previous.caption.source ?? "manual",
+                triggerWords: previous.caption.triggerWords ?? [],
+              }
+            : undefined,
+        };
+      })
+      .filter(Boolean),
+  };
+}
+
+function DatasetHealth({ health }) {
+  return (
+    <div className="training-health-grid" aria-label="Dataset health">
+      <div>
+        <strong>{health.itemCount}</strong>
+        <span>Items</span>
+      </div>
+      <div className={health.missingCaptions ? "needs-attention" : ""}>
+        <strong>{health.missingCaptions}</strong>
+        <span>Missing captions</span>
+      </div>
+      <div className={health.duplicateFilenames ? "needs-attention" : ""}>
+        <strong>{health.duplicateFilenames}</strong>
+        <span>Duplicate filenames</span>
+      </div>
+      <div className={health.disabledItems ? "needs-attention" : ""}>
+        <strong>{health.disabledItems}</strong>
+        <span>Disabled items</span>
+      </div>
+    </div>
+  );
+}
+
 export function TrainingStudio({
   activeProject,
   authenticated = true,
+  assets = [],
+  createDataset = async () => null,
   datasets = [],
   datasetsError = "",
+  importAsset = async () => null,
+  loadDataset = async () => null,
   loadingDatasets = false,
+  onPreview = () => {},
   onRefreshDatasets = () => {},
+  updateDataset = async () => null,
 }) {
   const [activeTab, setActiveTab] = useState("dataset");
+  const [activeDataset, setActiveDataset] = useState(null);
+  const [datasetError, setDatasetError] = useState("");
+  const [datasetMessage, setDatasetMessage] = useState("");
+  const [draftName, setDraftName] = useState("");
+  const [busyDatasetId, setBusyDatasetId] = useState("");
+  const [importingAssets, setImportingAssets] = useState(false);
+  const [savingDataset, setSavingDataset] = useState(false);
+  const [selectedAssetIds, setSelectedAssetIds] = useState([]);
+  const [selectedDatasetId, setSelectedDatasetId] = useState("");
   const tabRefs = useRef({});
+
   const activeIndex = tabs.findIndex((tab) => tab.id === activeTab);
   const active = tabs[activeIndex] ?? tabs[0];
   const datasetSummary = useMemo(() => summarizeDatasets(datasets), [datasets]);
+  const imageAssets = useMemo(
+    () => assets.filter((asset) => assetCanRenderAsImage(asset) && !asset.status?.trashed),
+    [assets],
+  );
+  const assetsById = useMemo(() => new Map(imageAssets.map((asset) => [asset.id, asset])), [imageAssets]);
+  const health = useMemo(
+    () => datasetHealth({ activeDataset, imageAssets, selectedAssetIds }),
+    [activeDataset, imageAssets, selectedAssetIds],
+  );
+  const originalAssetIds = useMemo(() => normalizeDatasetAssetIds(activeDataset), [activeDataset]);
+  const dirty =
+    Boolean(activeDataset) &&
+    (draftName.trim() !== activeDataset.name ||
+      selectedAssetIds.length !== originalAssetIds.length ||
+      selectedAssetIds.some((id, index) => id !== originalAssetIds[index]));
+  const canSave = draftName.trim().length > 0 && selectedAssetIds.length > 0 && health.disabledItems === 0 && !savingDataset;
+
+  useEffect(() => {
+    setActiveDataset(null);
+    setDatasetError("");
+    setDatasetMessage("");
+    setDraftName("");
+    setSelectedAssetIds([]);
+    setSelectedDatasetId("");
+  }, [activeProject?.id]);
 
   function focusTab(index) {
     const next = tabs[(index + tabs.length) % tabs.length];
@@ -56,6 +182,96 @@ export function TrainingStudio({
     if (event.key === "End") {
       event.preventDefault();
       focusTab(tabs.length - 1);
+    }
+  }
+
+  async function openDataset(datasetId) {
+    if (!datasetId) {
+      setActiveDataset(null);
+      setDraftName("");
+      setSelectedAssetIds([]);
+      setSelectedDatasetId("");
+      return;
+    }
+    setBusyDatasetId(datasetId);
+    setDatasetError("");
+    setDatasetMessage("");
+    try {
+      const dataset = await loadDataset(datasetId);
+      setActiveDataset(dataset);
+      setDraftName(dataset?.name ?? "");
+      setSelectedAssetIds(normalizeDatasetAssetIds(dataset));
+      setSelectedDatasetId(dataset?.id ?? datasetId);
+    } catch (err) {
+      setDatasetError(err.message);
+    } finally {
+      setBusyDatasetId("");
+    }
+  }
+
+  function toggleAsset(assetId) {
+    setDatasetMessage("");
+    setSelectedAssetIds((current) =>
+      current.includes(assetId) ? current.filter((id) => id !== assetId) : [...current, assetId],
+    );
+  }
+
+  function startNewDataset() {
+    setActiveDataset(null);
+    setDatasetError("");
+    setDatasetMessage("");
+    setDraftName("");
+    setSelectedAssetIds([]);
+    setSelectedDatasetId("");
+  }
+
+  async function handleImport(event) {
+    const files = Array.from(event.target.files ?? []);
+    if (!files.length) {
+      return;
+    }
+    setImportingAssets(true);
+    setDatasetError("");
+    try {
+      const imported = [];
+      for (const file of files) {
+        const asset = await importAsset(file);
+        if (asset?.id) {
+          imported.push(asset.id);
+        }
+      }
+      if (imported.length) {
+        setSelectedAssetIds((current) => Array.from(new Set([...current, ...imported])));
+      }
+    } catch (err) {
+      setDatasetError(err.message);
+    } finally {
+      setImportingAssets(false);
+      event.target.value = "";
+    }
+  }
+
+  async function saveDataset() {
+    if (!canSave) {
+      return;
+    }
+    setSavingDataset(true);
+    setDatasetError("");
+    setDatasetMessage("");
+    try {
+      const payload = datasetPayload({ activeDataset, assetsById, name: draftName, selectedAssetIds });
+      const dataset = activeDataset
+        ? await updateDataset(activeDataset.id, payload)
+        : await createDataset(payload);
+      setActiveDataset(dataset);
+      setDraftName(dataset?.name ?? draftName.trim());
+      setSelectedAssetIds(normalizeDatasetAssetIds(dataset));
+      setSelectedDatasetId(dataset?.id ?? "");
+      setDatasetMessage(activeDataset ? "Dataset changes saved" : "Dataset created");
+    } catch (err) {
+      setDatasetError(err.message);
+    } finally {
+      setSavingDataset(false);
     }
   }
 
@@ -140,32 +356,99 @@ export function TrainingStudio({
                       <p className="eyebrow">Dataset</p>
                       <h3>{active.title}</h3>
                     </div>
-                    <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
-                      <Icon.Search size={14} />
-                      {loadingDatasets ? "Refreshing" : "Refresh"}
-                    </button>
+                    <div className="training-head-actions">
+                      <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
+                        <Icon.Search size={14} />
+                        {loadingDatasets ? "Refreshing" : "Refresh"}
+                      </button>
+                      <button className="primary-action" onClick={startNewDataset} type="button">
+                        <Icon.Plus size={14} />
+                        New
+                      </button>
+                    </div>
                   </div>
                   {datasetsError ? <p className="inline-warning">{datasetsError}</p> : null}
-                  {loadingDatasets ? (
-                    <div className="empty-panel">Loading training datasets</div>
-                  ) : datasets.length ? (
-                    <div className="training-dataset-list">
+                  {datasetError ? <p className="inline-warning">{datasetError}</p> : null}
+                  {datasetMessage ? <p className="inline-success">{datasetMessage}</p> : null}
+                  <div className="training-dataset-workspace">
+                    <aside className="training-dataset-list-panel">
+                      {loadingDatasets ? <div className="empty-panel compact-panel">Loading training datasets</div> : null}
+                      {!loadingDatasets && datasets.length === 0 ? <div className="empty-panel compact-panel">No training datasets yet</div> : null}
                       {datasets.map((dataset) => {
                         const itemCount = datasetItemCount(dataset);
                         return (
-                          <article className="training-dataset-row" key={dataset.id}>
+                          <button
+                            aria-pressed={selectedDatasetId === dataset.id}
+                            className={selectedDatasetId === dataset.id ? "training-dataset-row active" : "training-dataset-row"}
+                            disabled={busyDatasetId === dataset.id}
+                            key={dataset.id}
+                            onClick={() => openDataset(dataset.id)}
+                            type="button"
+                          >
                             <div>
                               <strong>{dataset.name ?? dataset.id}</strong>
                               <span>{formatDatasetModality(dataset)} dataset</span>
                             </div>
-                            <span>{itemCount} item{itemCount === 1 ? "" : "s"}</span>
-                          </article>
+                            <span>{busyDatasetId === dataset.id ? "Opening" : `${itemCount} item${itemCount === 1 ? "" : "s"}`}</span>
+                          </button>
                         );
                       })}
+                    </aside>
+
+                    <div className="training-dataset-editor">
+                      <div className="training-dataset-form">
+                        <label>
+                          Dataset name
+                          <input
+                            onChange={(event) => setDraftName(event.target.value)}
+                            placeholder="Character portrait set"
+                            value={draftName}
+                          />
+                        </label>
+                        <label>
+                          Modality
+                          <select disabled value="image">
+                            <option value="image">Image</option>
+                          </select>
+                        </label>
+                        <label className="file-upload-button training-import-button">
+                          <input accept="image/*" disabled={importingAssets} multiple onChange={handleImport} type="file" />
+                          {importingAssets ? "Importing" : "Import images"}
+                        </label>
+                      </div>
+                      <DatasetHealth health={health} />
+                      <div className="training-validity">
+                        <span className={health.valid ? "training-valid-dot valid" : "training-valid-dot"} />
+                        <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets and resolve flagged items"}</span>
+                      </div>
+                      <div className="training-asset-picker" aria-label="Training dataset image assets">
+                        {imageAssets.length ? (
+                          imageAssets.map((asset) => {
+                            const selected = selectedAssetIds.includes(asset.id);
+                            return (
+                              <article className={selected ? "training-asset-card selected" : "training-asset-card"} key={asset.id}>
+                                <button onClick={() => onPreview(asset)} type="button">
+                                  <AssetThumbnail asset={asset} />
+                                </button>
+                                <label>
+                                  <input checked={selected} onChange={() => toggleAsset(asset.id)} type="checkbox" />
+                                  <span>{asset.displayName ?? imageAssetName(asset)}</span>
+                                </label>
+                              </article>
+                            );
+                          })
+                        ) : (
+                          <div className="empty-panel compact-panel">Import or create project images before building a dataset</div>
+                        )}
+                      </div>
+                      <div className="training-dataset-actions">
+                        <button className="primary-action" disabled={!canSave} onClick={saveDataset} type="button">
+                          {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
+                        </button>
+                        <span>{dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}</span>
+                      </div>
                     </div>
-                  ) : (
-                    <div className="empty-panel">No training datasets yet</div>
-                  )}
+                  </div>
                 </>
               ) : null}
 
@@ -176,7 +459,7 @@ export function TrainingStudio({
                       <p className="eyebrow">Rename & Caption</p>
                       <h3>{active.title}</h3>
                     </div>
-                    <span className="training-status-pill">Not queueable</span>
+                    <span className="training-status-pill">{health.valid ? "Dataset ready" : "Blocked"}</span>
                   </div>
                   <div className="training-workflow-grid">
                     <div className="training-step-block">
@@ -198,7 +481,7 @@ export function TrainingStudio({
                       <p className="eyebrow">Configure Job</p>
                       <h3>{active.title}</h3>
                     </div>
-                    <span className="training-status-pill">Dry run pending</span>
+                    <span className="training-status-pill">{health.valid ? "Dry run pending" : "Needs dataset"}</span>
                   </div>
                   <div className="training-config-preview" aria-label="Training job placeholder settings">
                     <label>
@@ -209,8 +492,9 @@ export function TrainingStudio({
                     </label>
                     <label>
                       Dataset
-                      <select defaultValue="" disabled>
-                        <option value="">Select after dataset workflow</option>
+                      <select value={activeDataset?.id ?? ""} disabled>
+                        <option value="">{health.valid ? "Save to select dataset" : "Valid dataset required"}</option>
+                        {activeDataset ? <option value={activeDataset.id}>{activeDataset.name}</option> : null}
                       </select>
                     </label>
                     <label>

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -43,7 +43,7 @@ function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) {
   const duplicateFilenames = names.filter((name, index) => names.indexOf(name) !== index).length;
   const captionsByAssetId = new Map((activeDataset?.items ?? []).map((item) => [item.assetId, captionText(item)]));
   const missingCaptions = selectedAssetIds.filter((id) => !captionsByAssetId.get(id)).length;
-  const valid = selectedAssetIds.length > 0 && disabledItems === 0 && duplicateFilenames === 0;
+  const valid = selectedAssetIds.length > 0 && disabledItems === 0;
 
   return {
     disabledItems,
@@ -134,11 +134,12 @@ export function TrainingStudio({
   const activeIndex = tabs.findIndex((tab) => tab.id === activeTab);
   const active = tabs[activeIndex] ?? tabs[0];
   const datasetSummary = useMemo(() => summarizeDatasets(datasets), [datasets]);
-  const imageAssets = useMemo(
-    () => assets.filter((asset) => assetCanRenderAsImage(asset) && !asset.status?.trashed),
-    [assets],
-  );
+  const imageAssets = useMemo(() => assets.filter((asset) => assetCanRenderAsImage(asset)), [assets]);
   const assetsById = useMemo(() => new Map(imageAssets.map((asset) => [asset.id, asset])), [imageAssets]);
+  const unavailableAssetIds = useMemo(
+    () => selectedAssetIds.filter((assetId) => !assetsById.has(assetId)),
+    [assetsById, selectedAssetIds],
+  );
   const health = useMemo(
     () => datasetHealth({ activeDataset, imageAssets, selectedAssetIds }),
     [activeDataset, imageAssets, selectedAssetIds],
@@ -149,7 +150,12 @@ export function TrainingStudio({
     (draftName.trim() !== activeDataset.name ||
       selectedAssetIds.length !== originalAssetIds.length ||
       selectedAssetIds.some((id, index) => id !== originalAssetIds[index]));
-  const canSave = draftName.trim().length > 0 && selectedAssetIds.length > 0 && health.disabledItems === 0 && !savingDataset;
+  const canSave =
+    draftName.trim().length > 0 &&
+    selectedAssetIds.length > 0 &&
+    health.disabledItems === 0 &&
+    !savingDataset &&
+    (!activeDataset || dirty);
 
   useEffect(() => {
     setActiveDataset(null);
@@ -216,6 +222,11 @@ export function TrainingStudio({
     );
   }
 
+  function removeUnavailableAsset(assetId) {
+    setDatasetMessage("");
+    setSelectedAssetIds((current) => current.filter((id) => id !== assetId));
+  }
+
   function startNewDataset() {
     setActiveDataset(null);
     setDatasetError("");
@@ -242,6 +253,8 @@ export function TrainingStudio({
       }
       if (imported.length) {
         setSelectedAssetIds((current) => Array.from(new Set([...current, ...imported])));
+      } else {
+        setDatasetError("No images were imported.");
       }
     } catch (err) {
       setDatasetError(err.message);
@@ -419,14 +432,39 @@ export function TrainingStudio({
                       <DatasetHealth health={health} />
                       <div className="training-validity">
                         <span className={health.valid ? "training-valid-dot valid" : "training-valid-dot"} />
-                        <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets and resolve flagged items"}</span>
+                        <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets and remove disabled items"}</span>
                       </div>
+                      {unavailableAssetIds.length ? (
+                        <div className="training-unavailable-list" aria-label="Unavailable dataset items">
+                          {unavailableAssetIds.map((assetId) => (
+                            <div className="training-unavailable-item" key={assetId}>
+                              <div>
+                                <strong>{assetId}</strong>
+                                <span>Asset is no longer available</span>
+                              </div>
+                              <button className="secondary-action" onClick={() => removeUnavailableAsset(assetId)} type="button">
+                                Remove
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
                       <div className="training-asset-picker" aria-label="Training dataset image assets">
                         {imageAssets.length ? (
                           imageAssets.map((asset) => {
                             const selected = selectedAssetIds.includes(asset.id);
+                            const disabled = asset.status?.rejected || asset.status?.trashed;
                             return (
-                              <article className={selected ? "training-asset-card selected" : "training-asset-card"} key={asset.id}>
+                              <article
+                                className={[
+                                  "training-asset-card",
+                                  selected ? "selected" : "",
+                                  disabled ? "disabled" : "",
+                                ]
+                                  .filter(Boolean)
+                                  .join(" ")}
+                                key={asset.id}
+                              >
                                 <button onClick={() => onPreview(asset)} type="button">
                                   <AssetThumbnail asset={asset} />
                                 </button>
@@ -434,6 +472,9 @@ export function TrainingStudio({
                                   <input checked={selected} onChange={() => toggleAsset(asset.id)} type="checkbox" />
                                   <span>{asset.displayName ?? imageAssetName(asset)}</span>
                                 </label>
+                                {disabled ? (
+                                  <span className="training-asset-badge">{asset.status?.trashed ? "Trashed" : "Rejected"}</span>
+                                ) : null}
                               </article>
                             );
                           })

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1380,7 +1380,10 @@ label {
 .training-empty-state,
 .training-panel,
 .training-dataset-row,
-.training-step-block {
+.training-step-block,
+.training-dataset-list-panel,
+.training-dataset-editor,
+.training-asset-card {
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface-2);
@@ -1470,6 +1473,13 @@ label {
   gap: 12px;
 }
 
+.training-head-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .training-panel-head h3 {
   margin: 2px 0 0;
   font-size: 18px;
@@ -1494,13 +1504,37 @@ label {
   gap: 10px;
 }
 
+.training-dataset-workspace {
+  display: grid;
+  grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.training-dataset-list-panel,
+.training-dataset-editor {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px;
+}
+
 .training-dataset-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  width: 100%;
   padding: 12px;
+  text-align: left;
   background: var(--surface);
+  color: var(--text);
+}
+
+.training-dataset-row:hover:not(:disabled),
+.training-dataset-row.active {
+  border-color: color-mix(in oklch, var(--accent) 55%, var(--border));
+  background: var(--surface-hover);
 }
 
 .training-dataset-row > div,
@@ -1514,6 +1548,135 @@ label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.training-dataset-form {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(120px, 160px) auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.training-dataset-form label:not(.file-upload-button) {
+  display: grid;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.training-import-button {
+  min-height: 40px;
+}
+
+.training-health-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.training-health-grid > div {
+  display: grid;
+  gap: 3px;
+  min-height: 62px;
+  align-content: center;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+}
+
+.training-health-grid strong {
+  font-size: 18px;
+}
+
+.training-health-grid span,
+.training-validity,
+.training-dataset-actions span {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.training-health-grid .needs-attention {
+  border-color: color-mix(in oklch, var(--danger) 42%, var(--border));
+  background: color-mix(in oklch, var(--danger) 8%, var(--surface));
+}
+
+.training-validity {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.training-valid-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--danger);
+}
+
+.training-valid-dot.valid {
+  background: var(--success);
+}
+
+.training-asset-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.training-asset-card {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px;
+  background: var(--surface);
+}
+
+.training-asset-card.selected {
+  border-color: color-mix(in oklch, var(--accent) 58%, var(--border));
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent) 34%, transparent);
+}
+
+.training-asset-card > button {
+  overflow: hidden;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.training-asset-card img,
+.training-asset-card video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.training-asset-card label {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  min-height: 24px;
+  font-size: 12px;
+}
+
+.training-asset-card label span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.training-dataset-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .training-workflow-grid {
@@ -4774,6 +4937,9 @@ label {
   .training-summary-band,
   .training-tabs,
   .training-metrics,
+  .training-dataset-workspace,
+  .training-dataset-form,
+  .training-health-grid,
   .training-workflow-grid,
   .training-config-preview,
   .preset-layout,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1619,6 +1619,39 @@ label {
   background: var(--success);
 }
 
+.training-unavailable-list {
+  display: grid;
+  gap: 8px;
+}
+
+.training-unavailable-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid color-mix(in oklch, var(--danger) 42%, var(--border));
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--danger) 8%, var(--surface));
+}
+
+.training-unavailable-item > div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.training-unavailable-item strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.training-unavailable-item span {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .training-asset-picker {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
@@ -1636,6 +1669,11 @@ label {
 .training-asset-card.selected {
   border-color: color-mix(in oklch, var(--accent) 58%, var(--border));
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent) 34%, transparent);
+}
+
+.training-asset-card.disabled {
+  border-color: color-mix(in oklch, var(--danger) 42%, var(--border));
+  background: color-mix(in oklch, var(--danger) 7%, var(--surface));
 }
 
 .training-asset-card > button {
@@ -1669,6 +1707,16 @@ label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.training-asset-badge {
+  justify-self: start;
+  padding: 3px 7px;
+  border-radius: var(--r-pill);
+  background: var(--danger-soft);
+  color: color-mix(in oklch, var(--danger) 75%, var(--text));
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .training-dataset-actions {


### PR DESCRIPTION
## Summary
- wire Training Studio to create, open, and update Rust-owned training datasets
- add image asset selection/import, dataset health metrics, and valid-dataset gating for later workflow tabs
- cover dataset creation and reopen/save behavior in web tests

## Verification
- npm --prefix apps/web test
- npm --prefix apps/web run build
- cargo test -p sceneworks-rust-api training_dataset_routes_persist_and_validate_project_assets
- git diff --check
- Browser visual check at desktop and 390px mobile widths