### PR TITLE
Add first-run gate: require a workspace before studio access

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -273,6 +273,53 @@ function ProjectSwitcher({ activeProject, projects, onSelect, onCreate, disabled
   );
 }
 
+function FirstRunProjectGate({ onCreate, disabled }) {
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit(event) {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await onCreate(trimmed);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="first-run-gate">
+      <div className="first-run-card">
+        <span className="first-run-mark" aria-hidden="true">
+          <img src="/sceneworks-logo.svg" alt="" />
+        </span>
+        <h2>Create your first workspace</h2>
+        <p className="first-run-lede">
+          SceneWorks keeps your images, videos, characters, and timelines inside a
+          workspace. Create one to start generating.
+        </p>
+        <form className="first-run-form" onSubmit={submit}>
+          <input
+            aria-label="Workspace name"
+            autoFocus
+            disabled={disabled || submitting}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="e.g. My First Project"
+            value={name}
+          />
+          <button className="first-run-cta" disabled={disabled || submitting || !name.trim()} type="submit">
+            {submitting ? "Creating…" : "Create workspace"}
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}
+
 function uploadLimitLabel(bytes) {
   const gib = bytes / (1024 * 1024 * 1024);
   return Number.isInteger(gib) ? `${gib}GB` : `${gib.toFixed(1)}GB`;
@@ -283,6 +330,7 @@ export function App() {
   const [access, setAccess] = useState({ authRequired: false });
   const [token, setToken] = useState(() => window.localStorage.getItem("sceneworks-token") ?? "");
   const [projects, setProjects] = useState([]);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
   const [jobs, setJobs] = useState([]);
@@ -629,6 +677,7 @@ export function App() {
     ]);
     const projectItems = projectsResult.value;
     setProjects(projectItems);
+    setProjectsLoaded(true);
     setActiveProject((current) => current ?? projectItems[0] ?? null);
     setJobs((current) => mergeFreshJobs(current, jobsResult.value));
     setWorkers(workersResult.value.sort(sortWorkers));
@@ -1625,6 +1674,9 @@ export function App() {
     Editor: timelines.length > 0,
     Queue: queueCounts.active > 0,
   };
+  // First-run gate: until at least one workspace exists, replace the studio area
+  // with a create prompt so navigation never lands on dead, project-scoped controls.
+  const needsFirstProject = authenticated && projectsLoaded && projects.length === 0;
 
   return (
     <main className="app">
@@ -1730,6 +1782,10 @@ export function App() {
           </section>
         ) : null}
 
+        {needsFirstProject ? (
+          <FirstRunProjectGate disabled={!authenticated} onCreate={createProject} />
+        ) : (
+          <>
         {activeView === "Library" ? (
           <LibraryScreen
             activeProject={activeProject}
@@ -1929,6 +1985,8 @@ export function App() {
             updateCharacterReference={updateCharacterReference}
           />
         ) : null}
+          </>
+        )}
       </section>
 
       {previewedAsset ? (

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -105,6 +105,9 @@ describe("SceneWorks app shell", () => {
       if (path.endsWith("/jobs/events/ticket")) {
         return Promise.resolve(response({ ticket: "stream-ticket" }));
       }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
       return Promise.resolve(response([]));
     });
   });
@@ -127,6 +130,46 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Library");
     expect(container.textContent).toContain("Train");
     expect(container.textContent).toContain("Queue");
+  });
+
+  it("gates the studios behind workspace creation when no projects exist", async () => {
+    const requests = [];
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      requests.push({ path, method: options.method ?? "GET" });
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects") && options.method === "POST") {
+        return Promise.resolve(response({ id: "project-new", name: "My First Project" }));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    // With zero workspaces the studio area is replaced by the create gate.
+    expect(container.textContent).toContain("Create your first workspace");
+
+    await changeField(container.querySelector('[aria-label="Workspace name"]'), "My First Project");
+    await act(async () => {
+      buttonInside(container, "Create workspace").click();
+    });
+    await settle();
+
+    // Creating the first workspace clears the gate and lands in a studio.
+    expect(requests.some((request) => request.path.endsWith("/projects") && request.method === "POST")).toBe(true);
+    expect(container.textContent).not.toContain("Create your first workspace");
   });
 
   it("opens the Train navigation item without exposing a queue action", async () => {
@@ -1223,6 +1266,9 @@ describe("SceneWorks app shell", () => {
       if (path.endsWith("/access")) {
         return Promise.resolve(response({ authRequired: false }));
       }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Project One" }]));
+      }
       if (path.endsWith("/models")) {
         return Promise.resolve(
           response([
@@ -2183,6 +2229,9 @@ describe("SceneWorks app shell", () => {
       }
       if (path.endsWith("/jobs/events/ticket")) {
         return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Project One" }]));
       }
       if (path.endsWith("/workers")) {
         return Promise.resolve(

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5033,3 +5033,96 @@ label {
     grid-column: auto;
   }
 }
+
+/* First-run gate: shown in the studio area until a workspace exists. */
+.first-run-gate {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 48px 24px;
+}
+
+.first-run-card {
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  padding: 40px 32px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: var(--shadow-glow);
+}
+
+.first-run-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: var(--accent-soft);
+}
+
+.first-run-mark img {
+  width: 32px;
+  height: 32px;
+}
+
+.first-run-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--text);
+}
+
+.first-run-lede {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.first-run-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  margin-top: 8px;
+}
+
+.first-run-form input {
+  width: 100%;
+  padding: 11px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.first-run-form input:focus {
+  outline: 2px solid var(--accent);
+  border-color: var(--accent);
+}
+
+.first-run-cta {
+  padding: 11px 16px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.first-run-cta:hover:not(:disabled) {
+  background: var(--accent-strong);
+}
+
+.first-run-cta:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

Landing on a studio (Image, Video, …) with **no project** showed a silently-disabled Generate button and no explanation — the only "create a project" affordance was buried inside the ProjectSwitcher dropdown. This adds a **first-run gate**: when no workspaces exist, the studio area is replaced by a "Create your first workspace" prompt. Creating the first workspace clears the gate and lands in the Image studio (the existing auto-select/redirect behavior).

Found while testing #101 on Windows — a fresh stack has zero projects, so every studio's primary action is dead with no guidance.

## Changes
- **App.jsx**: a `projectsLoaded` flag (so the gate doesn't flash during the initial fetch), a `needsFirstProject` guard wrapping the studio render, and a `FirstRunProjectGate` component that reuses `createProject`.
- **styles.css**: centered gate card styled with existing design tokens.
- **main.test.jsx**: new test (empty → gate → create → studio); the existing studio-navigation tests now seed a project to match the new contract.

## Test plan
- [x] `npm test` (vitest) — **67 passed**
- [x] `npm run build` (vite) — clean
- [x] `npm run check` (scaffold) — pass

## Open question
The gate currently covers **all** views, including the global **Models** and **Queue** screens. If those should remain reachable before a workspace exists (e.g. download models first), the guard can be scoped to project-bound views — easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
