### PR TITLE
[codex] Add training rename caption editor

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -805,6 +805,38 @@ export function App() {
     return updated;
   }
 
+  async function batchRenameTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      throw new Error("Select a training dataset first.");
+    }
+    const updated = await apiFetch(
+      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/batch-rename`,
+      token,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    await refreshTrainingDatasets(projectId);
+    return updated;
+  }
+
+  async function writeTrainingDatasetCaptionSidecars(datasetId, payload, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      throw new Error("Select a training dataset first.");
+    }
+    const result = await apiFetch(
+      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-sidecars`,
+      token,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    await refreshTrainingDatasets(projectId);
+    return result;
+  }
+
   function presetQuery(scope = null) {
     const params = new URLSearchParams();
     if (scope) {
@@ -1873,6 +1905,7 @@ export function App() {
             activeProject={activeProject}
             authenticated={authenticated}
             assets={assets}
+            batchRenameDataset={batchRenameTrainingDataset}
             createDataset={createTrainingDataset}
             datasets={trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : []}
             datasetsError={trainingDatasetsError}
@@ -1882,6 +1915,7 @@ export function App() {
             onPreview={setPreviewAsset}
             onRefreshDatasets={() => refreshTrainingDatasets(activeProject?.id)}
             updateDataset={updateTrainingDataset}
+            writeCaptionSidecars={writeTrainingDatasetCaptionSidecars}
           />
         ) : null}
 

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -420,6 +420,102 @@ describe("SceneWorks app shell", () => {
     expect(updateDataset).not.toHaveBeenCalled();
   });
 
+  it("renames dataset items and writes caption sidecars", async () => {
+    const renamedDataset = {
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 4,
+      items: [
+        {
+          id: "item_0007",
+          assetId: "asset-a",
+          path: "images/mira_0007.png",
+          displayName: "mira_0007.png",
+          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+        },
+      ],
+    };
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 3,
+      items: [
+        {
+          id: "item_0001",
+          assetId: "asset-a",
+          path: "images/item_0001.png",
+          displayName: "item_0001.png",
+          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+        },
+      ],
+    }));
+    const batchRenameDataset = vi.fn(async () => renamedDataset);
+    const writeCaptionSidecars = vi.fn(async () => ({
+      dataset: {
+        ...renamedDataset,
+        version: 5,
+        items: [
+          {
+            ...renamedDataset.items[0],
+            caption: { text: "mira studio portrait", source: "manual", triggerWords: ["mira", "studio"] },
+          },
+        ],
+      },
+      sidecars: [{ itemId: "item_0007", captionPath: "training/datasets/dataset-a/images/mira_0007.txt" }],
+    }));
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          assets={[{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }]}
+          batchRenameDataset={batchRenameDataset}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          loadDataset={loadDataset}
+          writeCaptionSidecars={writeCaptionSidecars}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector("#training-tab-rename-caption").click();
+    });
+    await changeField(field(container, "Item ID"), "item_0007");
+    await changeField(field(container, "File stem"), "mira_0007");
+    await changeField(field(container, "Display name"), "mira_0007.png");
+    await changeField(field(container, "Caption"), "mira studio portrait");
+    await changeField(field(container, "Trigger words"), "mira, studio");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Write sidecars").click();
+    });
+    await settle();
+
+    expect(batchRenameDataset).toHaveBeenCalledWith("dataset-a", {
+      items: [
+        {
+          itemId: "item_0001",
+          newItemId: "item_0007",
+          fileStem: "mira_0007",
+          displayName: "mira_0007.png",
+        },
+      ],
+    });
+    expect(writeCaptionSidecars).toHaveBeenCalledWith("dataset-a", {
+      items: [
+        {
+          itemId: "item_0007",
+          caption: { text: "mira studio portrait", source: "manual", triggerWords: ["mira", "studio"] },
+        },
+      ],
+    });
+    expect(container.textContent).toContain("Caption sidecars written (1)");
+  });
+
   it("selects duplicate-titled assets through the thumbnail asset picker", async () => {
     const onChange = vi.fn();
     const assets = [

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -30,6 +30,66 @@ function captionText(item) {
   return String(item?.caption?.text ?? "").trim();
 }
 
+function itemFileStem(item) {
+  const name = String(item?.path ?? item?.displayName ?? item?.id ?? "item").replaceAll("\\", "/").split("/").pop() || "item";
+  const dotIndex = name.lastIndexOf(".");
+  return dotIndex > 0 ? name.slice(0, dotIndex) : name;
+}
+
+function triggerWordsText(caption) {
+  return (caption?.triggerWords ?? caption?.trigger_words ?? []).join(", ");
+}
+
+function parseTriggerWords(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((word) => word.trim())
+    .filter(Boolean);
+}
+
+function safeSlug(value, fallback = "item") {
+  const slug = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 48);
+  return slug || fallback;
+}
+
+function orderedName(index, prefix) {
+  return `${safeSlug(prefix, "item")}_${String(index + 1).padStart(4, "0")}`;
+}
+
+function renameCaptionDrafts(dataset) {
+  return (dataset?.items ?? []).map((item, index) => ({
+    originalItemId: item.id ?? `item_${String(index + 1).padStart(4, "0")}`,
+    itemId: item.id ?? `item_${String(index + 1).padStart(4, "0")}`,
+    fileStem: itemFileStem(item),
+    displayName: item.displayName ?? imageAssetName(item),
+    captionText: item.caption?.text ?? "",
+    captionSource: item.caption?.source ?? "manual",
+    triggerWords: triggerWordsText(item.caption),
+    assetId: item.assetId ?? "",
+    path: item.path ?? "",
+  }));
+}
+
+function renameFieldsDirty(drafts, dataset) {
+  const items = dataset?.items ?? [];
+  if (drafts.length !== items.length) {
+    return true;
+  }
+  return drafts.some((draft, index) => {
+    const item = items[index] ?? {};
+    return (
+      draft.itemId !== item.id ||
+      draft.fileStem !== itemFileStem(item) ||
+      draft.displayName !== (item.displayName ?? imageAssetName(item))
+    );
+  });
+}
+
 function normalizeDatasetAssetIds(dataset) {
   return (dataset?.items ?? []).map((item) => item.assetId).filter(Boolean);
 }
@@ -109,6 +169,7 @@ export function TrainingStudio({
   activeProject,
   authenticated = true,
   assets = [],
+  batchRenameDataset = async () => null,
   createDataset = async () => null,
   datasets = [],
   datasetsError = "",
@@ -118,6 +179,7 @@ export function TrainingStudio({
   onPreview = () => {},
   onRefreshDatasets = () => {},
   updateDataset = async () => null,
+  writeCaptionSidecars = async () => null,
 }) {
   const [activeTab, setActiveTab] = useState("dataset");
   const [activeDataset, setActiveDataset] = useState(null);
@@ -129,6 +191,9 @@ export function TrainingStudio({
   const [savingDataset, setSavingDataset] = useState(false);
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
   const [selectedDatasetId, setSelectedDatasetId] = useState("");
+  const [renamePrefix, setRenamePrefix] = useState("");
+  const [renameCaptionDraftItems, setRenameCaptionDraftItems] = useState([]);
+  const [savingRenameCaption, setSavingRenameCaption] = useState(false);
   const tabRefs = useRef({});
 
   const activeIndex = tabs.findIndex((tab) => tab.id === activeTab);
@@ -156,6 +221,12 @@ export function TrainingStudio({
     health.disabledItems === 0 &&
     !savingDataset &&
     (!activeDataset || dirty);
+  const renameCaptionHasDraft = renameCaptionDraftItems.length > 0;
+  const renameCaptionHasInvalidDraft = renameCaptionDraftItems.some(
+    (item) => !item.itemId.trim() || !item.fileStem.trim() || !item.displayName.trim(),
+  );
+  const canSaveRenameCaption =
+    Boolean(activeDataset?.id) && renameCaptionHasDraft && !renameCaptionHasInvalidDraft && !savingRenameCaption;
 
   useEffect(() => {
     setActiveDataset(null);
@@ -164,7 +235,14 @@ export function TrainingStudio({
     setDraftName("");
     setSelectedAssetIds([]);
     setSelectedDatasetId("");
+    setRenamePrefix("");
+    setRenameCaptionDraftItems([]);
   }, [activeProject?.id]);
+
+  useEffect(() => {
+    setRenameCaptionDraftItems(renameCaptionDrafts(activeDataset));
+    setRenamePrefix(safeSlug(activeDataset?.name, "item"));
+  }, [activeDataset]);
 
   function focusTab(index) {
     const next = tabs[(index + tabs.length) % tabs.length];
@@ -236,6 +314,29 @@ export function TrainingStudio({
     setSelectedDatasetId("");
   }
 
+  function updateRenameCaptionDraft(originalItemId, patch) {
+    setDatasetMessage("");
+    setRenameCaptionDraftItems((current) =>
+      current.map((item) => (item.originalItemId === originalItemId ? { ...item, ...patch } : item)),
+    );
+  }
+
+  function applyOrderedNames() {
+    setDatasetMessage("");
+    setRenameCaptionDraftItems((current) =>
+      current.map((item, index) => {
+        const nextName = orderedName(index, renamePrefix || activeDataset?.name);
+        const extension = String(item.path).split(".").pop() || "png";
+        return {
+          ...item,
+          itemId: nextName,
+          fileStem: nextName,
+          displayName: `${nextName}.${extension}`,
+        };
+      }),
+    );
+  }
+
   async function handleImport(event) {
     const files = Array.from(event.target.files ?? []);
     if (!files.length) {
@@ -285,6 +386,47 @@ export function TrainingStudio({
       setDatasetError(err.message);
     } finally {
       setSavingDataset(false);
+    }
+  }
+
+  async function saveRenameCaption() {
+    if (!canSaveRenameCaption) {
+      return;
+    }
+    setSavingRenameCaption(true);
+    setDatasetError("");
+    setDatasetMessage("");
+    try {
+      let dataset = activeDataset;
+      const renameItems = renameCaptionDraftItems.map((item) => ({
+        itemId: item.originalItemId,
+        newItemId: item.itemId.trim(),
+        fileStem: item.fileStem.trim(),
+        displayName: item.displayName.trim(),
+      }));
+      if (renameFieldsDirty(renameCaptionDraftItems, activeDataset)) {
+        dataset = await batchRenameDataset(activeDataset.id, { items: renameItems });
+      }
+      const result = await writeCaptionSidecars(activeDataset.id, {
+        items: renameCaptionDraftItems.map((item) => ({
+          itemId: item.itemId.trim(),
+          caption: {
+            text: item.captionText,
+            source: item.captionSource,
+            triggerWords: parseTriggerWords(item.triggerWords),
+          },
+        })),
+      });
+      const nextDataset = result?.dataset ?? dataset;
+      setActiveDataset(nextDataset);
+      setDraftName(nextDataset?.name ?? draftName);
+      setSelectedAssetIds(normalizeDatasetAssetIds(nextDataset));
+      setSelectedDatasetId(nextDataset?.id ?? activeDataset.id);
+      setDatasetMessage(`Caption sidecars written${result?.sidecars?.length ? ` (${result.sidecars.length})` : ""}`);
+    } catch (err) {
+      setDatasetError(err.message);
+    } finally {
+      setSavingRenameCaption(false);
     }
   }
 
@@ -500,18 +642,106 @@ export function TrainingStudio({
                       <p className="eyebrow">Rename & Caption</p>
                       <h3>{active.title}</h3>
                     </div>
-                    <span className="training-status-pill">{health.valid ? "Dataset ready" : "Blocked"}</span>
+                    <span className="training-status-pill">{activeDataset ? `Version ${activeDataset.version}` : "Select dataset"}</span>
                   </div>
-                  <div className="training-workflow-grid">
-                    <div className="training-step-block">
-                      <strong>Batch rename</strong>
-                      <span>Stable filenames and ordered item ids will be prepared from the selected dataset.</span>
+                  {datasetError ? <p className="inline-warning">{datasetError}</p> : null}
+                  {datasetMessage ? <p className="inline-success">{datasetMessage}</p> : null}
+                  {!activeDataset ? (
+                    <div className="empty-panel compact-panel">Open a saved dataset to edit captions.</div>
+                  ) : (
+                    <div className="training-caption-editor">
+                      <div className="training-caption-toolbar">
+                        <label>
+                          Rename prefix
+                          <input onChange={(event) => setRenamePrefix(event.target.value)} value={renamePrefix} />
+                        </label>
+                        <button className="secondary-action" onClick={applyOrderedNames} type="button">
+                          <Icon.Sliders size={14} />
+                          Apply ordered names
+                        </button>
+                        <button
+                          className="primary-action"
+                          disabled={!canSaveRenameCaption}
+                          onClick={saveRenameCaption}
+                          type="button"
+                        >
+                          {savingRenameCaption ? "Writing" : "Write sidecars"}
+                        </button>
+                      </div>
+                      <div className="training-caption-list" aria-label="Rename and caption dataset items">
+                        {renameCaptionDraftItems.map((item, index) => {
+                          const asset = assetsById.get(item.assetId);
+                          return (
+                            <article className="training-caption-row" key={item.originalItemId}>
+                              <div className="training-caption-preview">
+                                <button disabled={!asset} onClick={() => asset && onPreview(asset)} type="button">
+                                  {asset ? <AssetThumbnail asset={asset} /> : <Icon.Image size={22} />}
+                                </button>
+                                <span>{String(index + 1).padStart(2, "0")}</span>
+                              </div>
+                              <div className="training-caption-fields">
+                                <label>
+                                  Item ID
+                                  <input
+                                    onChange={(event) => updateRenameCaptionDraft(item.originalItemId, { itemId: event.target.value })}
+                                    value={item.itemId}
+                                  />
+                                </label>
+                                <label>
+                                  File stem
+                                  <input
+                                    onChange={(event) => updateRenameCaptionDraft(item.originalItemId, { fileStem: event.target.value })}
+                                    value={item.fileStem}
+                                  />
+                                </label>
+                                <label>
+                                  Display name
+                                  <input
+                                    onChange={(event) =>
+                                      updateRenameCaptionDraft(item.originalItemId, { displayName: event.target.value })
+                                    }
+                                    value={item.displayName}
+                                  />
+                                </label>
+                                <label className="training-caption-text">
+                                  Caption
+                                  <textarea
+                                    onChange={(event) =>
+                                      updateRenameCaptionDraft(item.originalItemId, { captionText: event.target.value })
+                                    }
+                                    rows={3}
+                                    value={item.captionText}
+                                  />
+                                </label>
+                                <label>
+                                  Trigger words
+                                  <input
+                                    onChange={(event) =>
+                                      updateRenameCaptionDraft(item.originalItemId, { triggerWords: event.target.value })
+                                    }
+                                    value={item.triggerWords}
+                                  />
+                                </label>
+                                <label>
+                                  Source
+                                  <select
+                                    onChange={(event) =>
+                                      updateRenameCaptionDraft(item.originalItemId, { captionSource: event.target.value })
+                                    }
+                                    value={item.captionSource}
+                                  >
+                                    <option value="manual">Manual</option>
+                                    <option value="imported">Imported</option>
+                                    <option value="auto">Auto</option>
+                                  </select>
+                                </label>
+                              </div>
+                            </article>
+                          );
+                        })}
+                      </div>
                     </div>
-                    <div className="training-step-block">
-                      <strong>Caption sidecars</strong>
-                      <span>Caption metadata will stay attached to SceneWorks dataset items before sidecar export.</span>
-                    </div>
-                  </div>
+                  )}
                 </>
               ) : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1499,7 +1499,9 @@ label {
 
 .training-dataset-list,
 .training-workflow-grid,
-.training-config-preview {
+.training-config-preview,
+.training-caption-editor,
+.training-caption-list {
   display: grid;
   gap: 10px;
 }
@@ -1742,6 +1744,83 @@ label {
 .training-config-preview label {
   display: grid;
   gap: 7px;
+}
+
+.training-caption-toolbar {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) auto auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.training-caption-toolbar label,
+.training-caption-fields label {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.training-caption-row {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 12px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+}
+
+.training-caption-preview {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+}
+
+.training-caption-preview button {
+  overflow: hidden;
+  width: 96px;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--text-muted);
+}
+
+.training-caption-preview img,
+.training-caption-preview video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.training-caption-preview span {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.training-caption-fields {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 10px;
+  min-width: 0;
+}
+
+.training-caption-text {
+  grid-column: 1 / -1;
+}
+
+.training-caption-fields textarea {
+  resize: vertical;
+  min-height: 76px;
 }
 
 .preset-rail-head {
@@ -4990,6 +5069,9 @@ label {
   .training-health-grid,
   .training-workflow-grid,
   .training-config-preview,
+  .training-caption-toolbar,
+  .training-caption-row,
+  .training-caption-fields,
   .preset-layout,
   .character-layout,
   .queue-header,


### PR DESCRIPTION
﻿## Summary
- wires the Train screen to the Rust batch rename and caption sidecar endpoints
- replaces the Rename & Caption placeholder with a per-item editor for ids, file stems, display names, captions, trigger words, and caption source
- adds responsive styling plus a focused UI test for renaming an item and writing sidecars

## Validation
- npm test -- src/main.test.jsx
- npm run build
- cargo test -p sceneworks-rust-api training_dataset_routes_persist_and_validate_project_assets -- --nocapture
- browser smoke against local API: opened Train, edited a dataset item, and saw `Caption sidecars written (1)`

## Shortcut
- sc-1414
