### PR TITLE
[codex] Add training config UI

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -38,7 +38,9 @@ use sceneworks_core::project_store::{
     CharacterReferenceUpdateInput, CharacterUpdateInput, ProjectStore, ProjectStoreError,
     UploadAsset,
 };
-use sceneworks_core::training::TrainingDataset;
+use sceneworks_core::training::{
+    builtin_training_targets, TrainingDataset, TrainingTargetRegistry,
+};
 use sceneworks_core::training_store::{
     TrainingCaptionSidecarsResult, TrainingDatasetBatchRenameInput,
     TrainingDatasetCaptionSidecarsInput, TrainingDatasetCreateInput, TrainingDatasetMutationResult,
@@ -485,6 +487,7 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         .route("/api/v1/health", get(health))
         .route("/api/v1/access", get(access))
         .route("/api/v1/auth/verify", post(verify_access))
+        .route("/api/v1/training/targets", get(list_training_targets))
         .route("/api/v1/projects", get(list_projects).post(create_project))
         .route("/api/v1/projects/:project_id", get(get_project))
         .route(
@@ -1264,6 +1267,10 @@ async fn purge_asset(
         })
         .await?,
     ))
+}
+
+async fn list_training_targets() -> Json<TrainingTargetRegistry> {
+    Json(builtin_training_targets())
 }
 
 async fn list_training_datasets(
@@ -7246,6 +7253,24 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(purged, json!({ "id": asset_id, "status": "purged" }));
+    }
+
+    #[tokio::test]
+    async fn training_targets_route_returns_builtin_registry() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let settings = test_settings(&temp_dir);
+        let app = create_app(settings).expect("app creates");
+
+        let (status, registry) = request(app, "GET", "/api/v1/training/targets", Value::Null).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(registry["schemaVersion"], 1);
+        assert_eq!(registry["targets"][0]["id"], "z_image_turbo_lora");
+        assert_eq!(registry["targets"][0]["defaults"]["rank"], 16);
+        assert_eq!(
+            registry["targets"][0]["defaults"]["advanced"]["qualityPreset"],
+            "balanced"
+        );
     }
 
     #[tokio::test]

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -340,6 +340,8 @@ export function App() {
   const [models, setModels] = useState([]);
   const [loras, setLoras] = useState([]);
   const [presets, setPresets] = useState([]);
+  const [trainingTargets, setTrainingTargets] = useState({ schemaVersion: 1, targets: [] });
+  const [trainingTargetsError, setTrainingTargetsError] = useState("");
   const [trainingDatasets, setTrainingDatasets] = useState([]);
   const [trainingDatasetsProjectId, setTrainingDatasetsProjectId] = useState(null);
   const [loadingTrainingDatasets, setLoadingTrainingDatasets] = useState(false);
@@ -516,6 +518,7 @@ export function App() {
       setTimelines([]);
       setTimelinesProjectId(null);
       setPresets([]);
+      setTrainingTargetsError("");
       setTrainingDatasets([]);
       setTrainingDatasetsProjectId(null);
       setTrainingDatasetsError("");
@@ -667,14 +670,16 @@ export function App() {
         return { label, value: fallback, error: optional ? "" : `${label}: ${err.message}` };
       }
     };
-    const [projectsResult, jobsResult, workersResult, modelsResult, lorasResult, presetsResult] = await Promise.all([
-      fetchInitial("Projects", "/api/v1/projects", []),
-      fetchInitial("Jobs", "/api/v1/jobs", []),
-      fetchInitial("Workers", "/api/v1/workers", []),
-      fetchInitial("Models", "/api/v1/models", []),
-      fetchInitial("LoRAs", "/api/v1/loras", []),
-      fetchInitial("Presets", "/api/v1/recipe-presets", [], true),
-    ]);
+    const [projectsResult, jobsResult, workersResult, modelsResult, lorasResult, presetsResult, trainingTargetsResult] =
+      await Promise.all([
+        fetchInitial("Projects", "/api/v1/projects", []),
+        fetchInitial("Jobs", "/api/v1/jobs", []),
+        fetchInitial("Workers", "/api/v1/workers", []),
+        fetchInitial("Models", "/api/v1/models", []),
+        fetchInitial("LoRAs", "/api/v1/loras", []),
+        fetchInitial("Presets", "/api/v1/recipe-presets", [], true),
+        fetchInitial("Training targets", "/api/v1/training/targets", { schemaVersion: 1, targets: [] }),
+      ]);
     const projectItems = projectsResult.value;
     setProjects(projectItems);
     setProjectsLoaded(true);
@@ -685,7 +690,14 @@ export function App() {
     setModels(modelsResult.value);
     setLoras(lorasResult.value);
     setPresets(presetsResult.value);
-    setError([projectsResult, jobsResult, workersResult, modelsResult, lorasResult, presetsResult].map((result) => result.error).filter(Boolean).join("; "));
+    setTrainingTargets(trainingTargetsResult.value);
+    setTrainingTargetsError(trainingTargetsResult.error);
+    setError(
+      [projectsResult, jobsResult, workersResult, modelsResult, lorasResult, presetsResult, trainingTargetsResult]
+        .map((result) => result.error)
+        .filter(Boolean)
+        .join("; "),
+    );
   }
 
   async function refreshAssets(projectId = activeProject?.id) {
@@ -1912,8 +1924,11 @@ export function App() {
             importAsset={(file) => importAsset(file, { throwOnError: true })}
             loadDataset={loadTrainingDataset}
             loadingDatasets={loadingTrainingDatasets}
+            gpuOptions={gpuOptions}
             onPreview={setPreviewAsset}
             onRefreshDatasets={() => refreshTrainingDatasets(activeProject?.id)}
+            trainingTargets={trainingTargets.targets ?? []}
+            trainingTargetsError={trainingTargetsError}
             updateDataset={updateTrainingDataset}
             writeCaptionSidecars={writeTrainingDatasetCaptionSidecars}
           />

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1921,10 +1921,10 @@ export function App() {
             createDataset={createTrainingDataset}
             datasets={trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : []}
             datasetsError={trainingDatasetsError}
+            gpuOptions={gpuOptions}
             importAsset={(file) => importAsset(file, { throwOnError: true })}
             loadDataset={loadTrainingDataset}
             loadingDatasets={loadingTrainingDatasets}
-            gpuOptions={gpuOptions}
             onPreview={setPreviewAsset}
             onRefreshDatasets={() => refreshTrainingDatasets(activeProject?.id)}
             trainingTargets={trainingTargets.targets ?? []}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -68,6 +68,45 @@ function buttonInside(scope, label) {
   return [...scope.querySelectorAll("button")].find((button) => button.textContent === label);
 }
 
+const zImageTrainingTarget = {
+  id: "z_image_turbo_lora",
+  name: "Z-Image-Turbo LoRA",
+  modality: "image",
+  outputKind: "lora",
+  family: "z-image",
+  baseModel: "z_image_turbo",
+  kernel: "z_image_lora",
+  defaults: {
+    rank: 16,
+    alpha: 16,
+    learningRate: 0.0001,
+    steps: 2000,
+    batchSize: 1,
+    gradientAccumulation: 1,
+    resolution: 1024,
+    saveEvery: 250,
+    seed: 42,
+    optimizer: "adamw8bit",
+    advanced: {
+      mixedPrecision: "bf16",
+      scheduler: "constant",
+      epochs: 1,
+      repeats: 10,
+      bucketStrategy: "aspect",
+      sampleEvery: 250,
+      qualityPreset: "balanced",
+      outputScope: "project",
+      requestedGpu: "auto",
+    },
+  },
+  limits: {
+    resolutions: [512, 768, 1024],
+    qualityPresets: ["speed", "balanced", "quality"],
+    outputScopes: ["project", "global"],
+  },
+  ui: { label: "Z-Image-Turbo LoRA" },
+};
+
 async function changeField(input, value) {
   await act(async () => {
     const setter = Object.getOwnPropertyDescriptor(input.constructor.prototype, "value")?.set;
@@ -514,6 +553,79 @@ describe("SceneWorks app shell", () => {
       ],
     });
     expect(container.textContent).toContain("Caption sidecars written (1)");
+  });
+
+  it("builds a training config snapshot from registry defaults", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 5,
+      items: [
+        {
+          id: "item_0001",
+          assetId: "asset-a",
+          path: "images/item_0001.png",
+          displayName: "item_0001.png",
+          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+        },
+      ],
+    }));
+    const prepareTrainingConfig = vi.fn(async (snapshot) => snapshot);
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          gpuOptions={["auto", "0"]}
+          loadDataset={loadDataset}
+          prepareTrainingConfig={prepareTrainingConfig}
+          trainingTargets={[zImageTrainingTarget]}
+        />,
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector("#training-tab-configure").click();
+    });
+    await changeField(field(container, "Dataset"), "dataset-a");
+    await settle();
+    await changeField(field(container, "Trigger phrase"), "miraStyle");
+
+    expect(field(container, "Target").value).toBe("z_image_turbo_lora");
+    expect(field(container, "Base model").value).toBe("z_image_turbo");
+    expect(field(container, "Rank").value).toBe("16");
+    expect(field(container, "Precision").value).toBe("bf16");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Prepare config").click();
+    });
+    await settle();
+
+    expect(prepareTrainingConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetId: "z_image_turbo_lora",
+        datasetId: "dataset-a",
+        datasetVersion: 5,
+        outputName: "Portrait Set LoRA",
+        requestedGpu: "auto",
+        config: expect.objectContaining({
+          rank: 16,
+          alpha: 16,
+          learningRate: 0.0001,
+          optimizer: "adamw8bit",
+          triggerWord: "miraStyle",
+          advanced: expect.objectContaining({
+            mixedPrecision: "bf16",
+            qualityPreset: "balanced",
+            outputScope: "project",
+          }),
+        }),
+      }),
+    );
+    expect(container.textContent).toContain("Config snapshot ready");
   });
 
   it("selects duplicate-titled assets through the thumbnail asset picker", async () => {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -628,6 +628,122 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Config snapshot ready");
   });
 
+  it("keeps config edits when GPU options are recomputed", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 5,
+      items: [
+        {
+          id: "item_0001",
+          assetId: "asset-a",
+          path: "images/item_0001.png",
+          displayName: "item_0001.png",
+          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+        },
+      ],
+    }));
+
+    function render(gpuOptions) {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          gpuOptions={gpuOptions}
+          loadDataset={loadDataset}
+          trainingTargets={[zImageTrainingTarget]}
+        />,
+      );
+    }
+
+    root = createRoot(container);
+    await act(async () => {
+      render(["auto", "0"]);
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector("#training-tab-configure").click();
+    });
+    await changeField(field(container, "Dataset"), "dataset-a");
+    await settle();
+    await changeField(field(container, "Trigger phrase"), "miraStyle");
+    await changeField(field(container, "Rank"), "24");
+    await changeField(field(container, "Requested GPU"), "0");
+
+    await act(async () => {
+      render(["auto", "0"]);
+    });
+    await settle();
+
+    expect(field(container, "Trigger phrase").value).toBe("miraStyle");
+    expect(field(container, "Rank").value).toBe("24");
+    expect(field(container, "Requested GPU").value).toBe("0");
+
+    await act(async () => {
+      render(["auto"]);
+    });
+    await settle();
+
+    expect(field(container, "Trigger phrase").value).toBe("miraStyle");
+    expect(field(container, "Rank").value).toBe("24");
+    expect(field(container, "Requested GPU").value).toBe("auto");
+  });
+
+  it("blocks config preparation until required fields are valid", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 5,
+      items: [
+        {
+          id: "item_0001",
+          assetId: "asset-a",
+          path: "images/item_0001.png",
+          displayName: "item_0001.png",
+          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+        },
+      ],
+    }));
+    const prepareTrainingConfig = vi.fn();
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          loadDataset={loadDataset}
+          prepareTrainingConfig={prepareTrainingConfig}
+          trainingTargets={[zImageTrainingTarget]}
+        />,
+      );
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector("#training-tab-configure").click();
+    });
+
+    expect(container.textContent).toContain("Select a saved dataset");
+    expect(container.textContent).toContain("Add a trigger phrase");
+    expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Prepare config").disabled).toBe(true);
+
+    await changeField(field(container, "Dataset"), "dataset-a");
+    await settle();
+    await changeField(field(container, "Trigger phrase"), "miraStyle");
+    await changeField(field(container, "Checkpoint cadence"), "");
+
+    const prepareButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Prepare config");
+    expect(container.textContent).toContain("Checkpoint cadence must be greater than zero");
+    expect(prepareButton.disabled).toBe(true);
+
+    await act(async () => {
+      prepareButton.click();
+    });
+    await settle();
+
+    expect(prepareTrainingConfig).not.toHaveBeenCalled();
+  });
+
   it("selects duplicate-titled assets through the thumbnail asset picker", async () => {
     const onChange = vi.fn();
     const assets = [

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -7,6 +7,7 @@ const tabs = [
   { id: "rename-caption", label: "Rename & Caption", title: "Rename and caption pass", status: "Needs valid dataset" },
   { id: "configure", label: "Configure Job", title: "Configure training job", status: "Queue disabled" },
 ];
+const defaultGpuOptions = ["auto"];
 
 function formatDatasetModality(dataset) {
   return String(dataset.modality ?? "image").replaceAll("_", " ");
@@ -142,6 +143,128 @@ function datasetPayload({ activeDataset, assetsById, name, selectedAssetIds }) {
   };
 }
 
+function asText(value) {
+  return value === null || value === undefined ? "" : String(value);
+}
+
+function numericDraft(value) {
+  return value === null || value === undefined ? "" : String(value);
+}
+
+function numberFromDraft(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function compactObject(object) {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => value !== "" && value !== null && value !== undefined),
+  );
+}
+
+function rangeOptions(limits, key) {
+  return Array.isArray(limits?.[key]) ? limits[key] : [];
+}
+
+function configDraftFromTarget(target, dataset, gpuOptions) {
+  const defaults = target?.defaults ?? {};
+  const advanced = defaults.advanced ?? {};
+  const firstGpu = gpuOptions[0] ?? "";
+  const requestedGpu = asText(advanced.requestedGpu || firstGpu);
+  return {
+    outputName: dataset?.name ? `${dataset.name} LoRA` : "",
+    triggerWord: asText(defaults.triggerWord),
+    outputScope: asText(advanced.outputScope),
+    qualityPreset: asText(advanced.qualityPreset),
+    requestedGpu: gpuOptions.includes(requestedGpu) ? requestedGpu : firstGpu,
+    rank: numericDraft(defaults.rank),
+    alpha: numericDraft(defaults.alpha),
+    optimizer: asText(defaults.optimizer),
+    learningRate: numericDraft(defaults.learningRate),
+    scheduler: asText(advanced.scheduler),
+    steps: numericDraft(defaults.steps),
+    epochs: numericDraft(advanced.epochs),
+    repeats: numericDraft(advanced.repeats),
+    resolution: numericDraft(defaults.resolution),
+    bucketStrategy: asText(advanced.bucketStrategy),
+    precision: asText(advanced.mixedPrecision),
+    saveEvery: numericDraft(defaults.saveEvery),
+    sampleEvery: numericDraft(advanced.sampleEvery),
+    batchSize: numericDraft(defaults.batchSize),
+    gradientAccumulation: numericDraft(defaults.gradientAccumulation),
+    seed: numericDraft(defaults.seed),
+  };
+}
+
+function configValidation({ activeDataset, configDraft, selectedTarget }) {
+  const warnings = [];
+  if (!selectedTarget) {
+    warnings.push("Select a training target");
+  }
+  if (!activeDataset?.id) {
+    warnings.push("Select a saved dataset");
+  }
+  if (!configDraft.outputName?.trim()) {
+    warnings.push("Name the LoRA output");
+  }
+  if (!configDraft.triggerWord?.trim()) {
+    warnings.push("Add a trigger phrase");
+  }
+  for (const [field, label] of [
+    ["rank", "Rank"],
+    ["alpha", "Alpha"],
+    ["learningRate", "Learning rate"],
+    ["steps", "Steps"],
+    ["resolution", "Resolution"],
+  ]) {
+    const value = numberFromDraft(configDraft[field]);
+    if (!value || value <= 0) {
+      warnings.push(`${label} must be greater than zero`);
+    }
+  }
+  return warnings;
+}
+
+function trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget }) {
+  const defaults = selectedTarget?.defaults ?? {};
+  const advanced = compactObject({
+    ...(defaults.advanced ?? {}),
+    scheduler: asText(configDraft.scheduler).trim(),
+    epochs: numberFromDraft(configDraft.epochs),
+    repeats: numberFromDraft(configDraft.repeats),
+    bucketStrategy: asText(configDraft.bucketStrategy).trim(),
+    mixedPrecision: asText(configDraft.precision).trim(),
+    sampleEvery: numberFromDraft(configDraft.sampleEvery),
+    qualityPreset: configDraft.qualityPreset,
+    outputScope: configDraft.outputScope,
+    requestedGpu: configDraft.requestedGpu,
+  });
+  return {
+    targetId: selectedTarget.id,
+    datasetId: activeDataset.id,
+    datasetVersion: activeDataset.version,
+    outputName: configDraft.outputName.trim(),
+    dryRun: true,
+    outputScope: configDraft.outputScope,
+    qualityPreset: configDraft.qualityPreset,
+    requestedGpu: configDraft.requestedGpu,
+    config: {
+      rank: numberFromDraft(configDraft.rank),
+      alpha: numberFromDraft(configDraft.alpha),
+      learningRate: numberFromDraft(configDraft.learningRate),
+      steps: numberFromDraft(configDraft.steps),
+      batchSize: numberFromDraft(configDraft.batchSize),
+      gradientAccumulation: numberFromDraft(configDraft.gradientAccumulation),
+      resolution: numberFromDraft(configDraft.resolution),
+      saveEvery: numberFromDraft(configDraft.saveEvery),
+      seed: numberFromDraft(configDraft.seed),
+      optimizer: asText(configDraft.optimizer).trim(),
+      triggerWord: asText(configDraft.triggerWord).trim(),
+      advanced,
+    },
+  };
+}
+
 function DatasetHealth({ health }) {
   return (
     <div className="training-health-grid" aria-label="Dataset health">
@@ -176,8 +299,12 @@ export function TrainingStudio({
   importAsset = async () => null,
   loadDataset = async () => null,
   loadingDatasets = false,
+  gpuOptions = defaultGpuOptions,
   onPreview = () => {},
+  prepareTrainingConfig = async (snapshot) => snapshot,
   onRefreshDatasets = () => {},
+  trainingTargets = [],
+  trainingTargetsError = "",
   updateDataset = async () => null,
   writeCaptionSidecars = async () => null,
 }) {
@@ -194,6 +321,13 @@ export function TrainingStudio({
   const [renamePrefix, setRenamePrefix] = useState("");
   const [renameCaptionDraftItems, setRenameCaptionDraftItems] = useState([]);
   const [savingRenameCaption, setSavingRenameCaption] = useState(false);
+  const [selectedTargetId, setSelectedTargetId] = useState("");
+  const [configDraft, setConfigDraft] = useState({});
+  const [showAdvancedConfig, setShowAdvancedConfig] = useState(false);
+  const [configSnapshot, setConfigSnapshot] = useState(null);
+  const [configMessage, setConfigMessage] = useState("");
+  const [configError, setConfigError] = useState("");
+  const [preparingConfig, setPreparingConfig] = useState(false);
   const tabRefs = useRef({});
 
   const activeIndex = tabs.findIndex((tab) => tab.id === activeTab);
@@ -227,6 +361,16 @@ export function TrainingStudio({
   );
   const canSaveRenameCaption =
     Boolean(activeDataset?.id) && renameCaptionHasDraft && !renameCaptionHasInvalidDraft && !savingRenameCaption;
+  const firstTarget = trainingTargets[0] ?? null;
+  const selectedTarget = useMemo(
+    () => trainingTargets.find((target) => target.id === selectedTargetId) ?? firstTarget,
+    [firstTarget, selectedTargetId, trainingTargets],
+  );
+  const qualityPresets = rangeOptions(selectedTarget?.limits, "qualityPresets");
+  const outputScopes = rangeOptions(selectedTarget?.limits, "outputScopes");
+  const resolutionOptions = rangeOptions(selectedTarget?.limits, "resolutions");
+  const configWarnings = configValidation({ activeDataset, configDraft, selectedTarget });
+  const canPrepareConfig = configWarnings.length === 0 && !preparingConfig;
 
   useEffect(() => {
     setActiveDataset(null);
@@ -237,12 +381,33 @@ export function TrainingStudio({
     setSelectedDatasetId("");
     setRenamePrefix("");
     setRenameCaptionDraftItems([]);
+    setConfigDraft({});
+    setConfigSnapshot(null);
+    setConfigMessage("");
+    setConfigError("");
   }, [activeProject?.id]);
 
   useEffect(() => {
     setRenameCaptionDraftItems(renameCaptionDrafts(activeDataset));
     setRenamePrefix(safeSlug(activeDataset?.name, "item"));
   }, [activeDataset]);
+
+  useEffect(() => {
+    if (!selectedTargetId && firstTarget?.id) {
+      setSelectedTargetId(firstTarget.id);
+    }
+  }, [firstTarget?.id, selectedTargetId]);
+
+  useEffect(() => {
+    if (!selectedTarget) {
+      setConfigDraft({});
+      return;
+    }
+    setConfigDraft(configDraftFromTarget(selectedTarget, activeDataset, gpuOptions));
+    setConfigSnapshot(null);
+    setConfigMessage("");
+    setConfigError("");
+  }, [activeDataset?.id, gpuOptions, selectedTarget]);
 
   function focusTab(index) {
     const next = tabs[(index + tabs.length) % tabs.length];
@@ -319,6 +484,23 @@ export function TrainingStudio({
     setRenameCaptionDraftItems((current) =>
       current.map((item) => (item.originalItemId === originalItemId ? { ...item, ...patch } : item)),
     );
+  }
+
+  function updateConfigDraft(field, value) {
+    setConfigMessage("");
+    setConfigError("");
+    setConfigSnapshot(null);
+    setConfigDraft((current) => ({ ...current, [field]: value }));
+  }
+
+  function resetConfigDefaults() {
+    if (!selectedTarget) {
+      return;
+    }
+    setConfigDraft(configDraftFromTarget(selectedTarget, activeDataset, gpuOptions));
+    setConfigSnapshot(null);
+    setConfigMessage("Defaults restored");
+    setConfigError("");
   }
 
   function applyOrderedNames() {
@@ -427,6 +609,25 @@ export function TrainingStudio({
       setDatasetError(err.message);
     } finally {
       setSavingRenameCaption(false);
+    }
+  }
+
+  async function prepareConfig() {
+    if (!canPrepareConfig) {
+      return;
+    }
+    setPreparingConfig(true);
+    setConfigError("");
+    setConfigMessage("");
+    try {
+      const snapshot = trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget });
+      const result = await prepareTrainingConfig(snapshot);
+      setConfigSnapshot(result ?? snapshot);
+      setConfigMessage("Config snapshot ready");
+    } catch (err) {
+      setConfigError(err.message);
+    } finally {
+      setPreparingConfig(false);
     }
   }
 
@@ -752,29 +953,195 @@ export function TrainingStudio({
                       <p className="eyebrow">Configure Job</p>
                       <h3>{active.title}</h3>
                     </div>
-                    <span className="training-status-pill">{health.valid ? "Dry run pending" : "Needs dataset"}</span>
+                    <span className="training-status-pill">{canPrepareConfig ? "Ready" : "Needs input"}</span>
                   </div>
-                  <div className="training-config-preview" aria-label="Training job placeholder settings">
-                    <label>
-                      Target
-                      <select defaultValue="z_image_turbo" disabled>
-                        <option value="z_image_turbo">Z-Image Turbo LoRA</option>
-                      </select>
-                    </label>
-                    <label>
-                      Dataset
-                      <select value={activeDataset?.id ?? ""} disabled>
-                        <option value="">{health.valid ? "Save to select dataset" : "Valid dataset required"}</option>
-                        {activeDataset ? <option value={activeDataset.id}>{activeDataset.name}</option> : null}
-                      </select>
-                    </label>
-                    <label>
-                      Preset
-                      <select defaultValue="simple" disabled>
-                        <option value="simple">Simple defaults</option>
-                      </select>
-                    </label>
-                  </div>
+                  {trainingTargetsError ? <p className="inline-warning">{trainingTargetsError}</p> : null}
+                  {configError ? <p className="inline-warning">{configError}</p> : null}
+                  {configMessage ? <p className="inline-success">{configMessage}</p> : null}
+                  {!selectedTarget ? (
+                    <div className="empty-panel compact-panel">Training target registry unavailable</div>
+                  ) : (
+                    <div className="training-config-form" aria-label="Training job configuration">
+                      <div className="training-config-grid">
+                        <label>
+                          Target
+                          <select onChange={(event) => setSelectedTargetId(event.target.value)} value={selectedTarget.id}>
+                            {trainingTargets.map((target) => (
+                              <option key={target.id} value={target.id}>
+                                {target.ui?.label ?? target.name}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        <label>
+                          Base model
+                          <input disabled readOnly value={selectedTarget.baseModel ?? ""} />
+                        </label>
+                        <label>
+                          Dataset
+                          <select onChange={(event) => openDataset(event.target.value)} value={activeDataset?.id ?? ""}>
+                            <option value="">Select a saved dataset</option>
+                            {datasets.map((dataset) => (
+                              <option key={dataset.id} value={dataset.id}>
+                                {dataset.name ?? dataset.id}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        <label>
+                          LoRA name
+                          <input onChange={(event) => updateConfigDraft("outputName", event.target.value)} value={configDraft.outputName ?? ""} />
+                        </label>
+                        <label>
+                          Trigger phrase
+                          <input onChange={(event) => updateConfigDraft("triggerWord", event.target.value)} value={configDraft.triggerWord ?? ""} />
+                        </label>
+                        <label>
+                          Output scope
+                          <select onChange={(event) => updateConfigDraft("outputScope", event.target.value)} value={configDraft.outputScope ?? ""}>
+                            {outputScopes.length ? null : <option value={configDraft.outputScope ?? ""}>{configDraft.outputScope || "Default"}</option>}
+                            {outputScopes.map((scope) => (
+                              <option key={scope} value={scope}>
+                                {scope}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        <label>
+                          Quality preset
+                          <select
+                            onChange={(event) => updateConfigDraft("qualityPreset", event.target.value)}
+                            value={configDraft.qualityPreset ?? ""}
+                          >
+                            {qualityPresets.length ? null : (
+                              <option value={configDraft.qualityPreset ?? ""}>{configDraft.qualityPreset || "Default"}</option>
+                            )}
+                            {qualityPresets.map((preset) => (
+                              <option key={preset} value={preset}>
+                                {preset}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        <label>
+                          Requested GPU
+                          <select onChange={(event) => updateConfigDraft("requestedGpu", event.target.value)} value={configDraft.requestedGpu ?? ""}>
+                            {gpuOptions.map((gpu) => (
+                              <option key={gpu} value={gpu}>
+                                {gpu === "auto" ? "Auto" : `GPU ${gpu}`}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      </div>
+
+                      <details
+                        className="training-advanced-panel"
+                        onToggle={(event) => setShowAdvancedConfig(event.currentTarget.open)}
+                        open={showAdvancedConfig}
+                      >
+                        <summary>
+                          <Icon.Sliders size={14} />
+                          Advanced
+                        </summary>
+                        <div className="training-advanced-grid">
+                          <label>
+                            Rank
+                            <input onChange={(event) => updateConfigDraft("rank", event.target.value)} type="number" value={configDraft.rank ?? ""} />
+                          </label>
+                          <label>
+                            Alpha
+                            <input onChange={(event) => updateConfigDraft("alpha", event.target.value)} type="number" value={configDraft.alpha ?? ""} />
+                          </label>
+                          <label>
+                            Optimizer
+                            <input onChange={(event) => updateConfigDraft("optimizer", event.target.value)} value={configDraft.optimizer ?? ""} />
+                          </label>
+                          <label>
+                            Learning rate
+                            <input
+                              onChange={(event) => updateConfigDraft("learningRate", event.target.value)}
+                              step="0.00001"
+                              type="number"
+                              value={configDraft.learningRate ?? ""}
+                            />
+                          </label>
+                          <label>
+                            Scheduler
+                            <input onChange={(event) => updateConfigDraft("scheduler", event.target.value)} value={configDraft.scheduler ?? ""} />
+                          </label>
+                          <label>
+                            Steps
+                            <input onChange={(event) => updateConfigDraft("steps", event.target.value)} type="number" value={configDraft.steps ?? ""} />
+                          </label>
+                          <label>
+                            Epochs
+                            <input onChange={(event) => updateConfigDraft("epochs", event.target.value)} type="number" value={configDraft.epochs ?? ""} />
+                          </label>
+                          <label>
+                            Repeats
+                            <input onChange={(event) => updateConfigDraft("repeats", event.target.value)} type="number" value={configDraft.repeats ?? ""} />
+                          </label>
+                          <label>
+                            Resolution
+                            <select onChange={(event) => updateConfigDraft("resolution", event.target.value)} value={configDraft.resolution ?? ""}>
+                              {resolutionOptions.length ? null : <option value={configDraft.resolution ?? ""}>{configDraft.resolution ?? ""}</option>}
+                              {resolutionOptions.map((resolution) => (
+                                <option key={resolution} value={resolution}>
+                                  {resolution}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <label>
+                            Buckets
+                            <input
+                              onChange={(event) => updateConfigDraft("bucketStrategy", event.target.value)}
+                              value={configDraft.bucketStrategy ?? ""}
+                            />
+                          </label>
+                          <label>
+                            Precision
+                            <input onChange={(event) => updateConfigDraft("precision", event.target.value)} value={configDraft.precision ?? ""} />
+                          </label>
+                          <label>
+                            Checkpoint cadence
+                            <input
+                              onChange={(event) => updateConfigDraft("saveEvery", event.target.value)}
+                              type="number"
+                              value={configDraft.saveEvery ?? ""}
+                            />
+                          </label>
+                          <label>
+                            Sample cadence
+                            <input
+                              onChange={(event) => updateConfigDraft("sampleEvery", event.target.value)}
+                              type="number"
+                              value={configDraft.sampleEvery ?? ""}
+                            />
+                          </label>
+                        </div>
+                      </details>
+
+                      {configWarnings.length ? (
+                        <div className="training-config-warnings" aria-label="Configuration warnings">
+                          {configWarnings.map((warning) => (
+                            <span key={warning}>{warning}</span>
+                          ))}
+                        </div>
+                      ) : null}
+
+                      <div className="training-config-actions">
+                        <button className="secondary-action" onClick={resetConfigDefaults} type="button">
+                          Reset defaults
+                        </button>
+                        <button className="primary-action" disabled={!canPrepareConfig} onClick={prepareConfig} type="button">
+                          {preparingConfig ? "Preparing" : "Prepare config"}
+                        </button>
+                      </div>
+                      {configSnapshot ? <pre className="training-config-snapshot">{JSON.stringify(configSnapshot, null, 2)}</pre> : null}
+                    </div>
+                  )}
                   <p className="inline-warning">Training submission is disabled until the dry-run plan story wires queue semantics.</p>
                 </>
               ) : null}

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -152,7 +152,11 @@ function numericDraft(value) {
 }
 
 function numberFromDraft(value) {
-  const number = Number(value);
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  const number = Number(trimmed);
   return Number.isFinite(number) ? number : null;
 }
 
@@ -171,8 +175,9 @@ function configDraftFromTarget(target, dataset, gpuOptions) {
   const advanced = defaults.advanced ?? {};
   const firstGpu = gpuOptions[0] ?? "";
   const requestedGpu = asText(advanced.requestedGpu || firstGpu);
+  const outputLabel = outputKindLabel(target);
   return {
-    outputName: dataset?.name ? `${dataset.name} LoRA` : "",
+    outputName: dataset?.name ? `${dataset.name} ${outputLabel}` : "",
     triggerWord: asText(defaults.triggerWord),
     outputScope: asText(advanced.outputScope),
     qualityPreset: asText(advanced.qualityPreset),
@@ -205,7 +210,7 @@ function configValidation({ activeDataset, configDraft, selectedTarget }) {
     warnings.push("Select a saved dataset");
   }
   if (!configDraft.outputName?.trim()) {
-    warnings.push("Name the LoRA output");
+    warnings.push(`Name the ${outputKindLabel(selectedTarget)} output`);
   }
   if (!configDraft.triggerWord?.trim()) {
     warnings.push("Add a trigger phrase");
@@ -216,6 +221,9 @@ function configValidation({ activeDataset, configDraft, selectedTarget }) {
     ["learningRate", "Learning rate"],
     ["steps", "Steps"],
     ["resolution", "Resolution"],
+    ["batchSize", "Batch size"],
+    ["gradientAccumulation", "Gradient accumulation"],
+    ["saveEvery", "Checkpoint cadence"],
   ]) {
     const value = numberFromDraft(configDraft[field]);
     if (!value || value <= 0) {
@@ -223,6 +231,14 @@ function configValidation({ activeDataset, configDraft, selectedTarget }) {
     }
   }
   return warnings;
+}
+
+function outputKindLabel(target) {
+  const kind = String(target?.outputKind ?? "output").toLowerCase();
+  if (kind === "lora") {
+    return "LoRA";
+  }
+  return kind.replaceAll("_", " ");
 }
 
 function trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget }) {
@@ -296,13 +312,13 @@ export function TrainingStudio({
   createDataset = async () => null,
   datasets = [],
   datasetsError = "",
+  gpuOptions = defaultGpuOptions,
   importAsset = async () => null,
   loadDataset = async () => null,
   loadingDatasets = false,
-  gpuOptions = defaultGpuOptions,
   onPreview = () => {},
-  prepareTrainingConfig = async (snapshot) => snapshot,
   onRefreshDatasets = () => {},
+  prepareTrainingConfig = async (snapshot) => snapshot,
   trainingTargets = [],
   trainingTargetsError = "",
   updateDataset = async () => null,
@@ -328,6 +344,7 @@ export function TrainingStudio({
   const [configMessage, setConfigMessage] = useState("");
   const [configError, setConfigError] = useState("");
   const [preparingConfig, setPreparingConfig] = useState(false);
+  const configBasisRef = useRef("");
   const tabRefs = useRef({});
 
   const activeIndex = tabs.findIndex((tab) => tab.id === activeTab);
@@ -369,6 +386,7 @@ export function TrainingStudio({
   const qualityPresets = rangeOptions(selectedTarget?.limits, "qualityPresets");
   const outputScopes = rangeOptions(selectedTarget?.limits, "outputScopes");
   const resolutionOptions = rangeOptions(selectedTarget?.limits, "resolutions");
+  const gpuOptionsKey = gpuOptions.join("\u0000");
   const configWarnings = configValidation({ activeDataset, configDraft, selectedTarget });
   const canPrepareConfig = configWarnings.length === 0 && !preparingConfig;
 
@@ -385,6 +403,7 @@ export function TrainingStudio({
     setConfigSnapshot(null);
     setConfigMessage("");
     setConfigError("");
+    configBasisRef.current = "";
   }, [activeProject?.id]);
 
   useEffect(() => {
@@ -400,14 +419,31 @@ export function TrainingStudio({
 
   useEffect(() => {
     if (!selectedTarget) {
-      setConfigDraft({});
+      if (configBasisRef.current) {
+        configBasisRef.current = "";
+        setConfigDraft({});
+      }
       return;
     }
+    const basis = `${selectedTarget.id}\u0000${activeDataset?.id ?? ""}`;
+    if (configBasisRef.current === basis) {
+      return;
+    }
+    configBasisRef.current = basis;
     setConfigDraft(configDraftFromTarget(selectedTarget, activeDataset, gpuOptions));
     setConfigSnapshot(null);
     setConfigMessage("");
     setConfigError("");
-  }, [activeDataset?.id, gpuOptions, selectedTarget]);
+  }, [activeDataset?.id, selectedTarget?.id]);
+
+  useEffect(() => {
+    setConfigDraft((current) => {
+      if (!current.requestedGpu || gpuOptions.includes(current.requestedGpu)) {
+        return current;
+      }
+      return { ...current, requestedGpu: gpuOptions[0] ?? "" };
+    });
+  }, [gpuOptionsKey]);
 
   function focusTab(index) {
     const next = tabs[(index + tabs.length) % tabs.length];

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1383,6 +1383,7 @@ label {
 .training-step-block,
 .training-dataset-list-panel,
 .training-dataset-editor,
+.training-advanced-panel,
 .training-asset-card {
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
@@ -1500,6 +1501,9 @@ label {
 .training-dataset-list,
 .training-workflow-grid,
 .training-config-preview,
+.training-config-form,
+.training-config-grid,
+.training-advanced-grid,
 .training-caption-editor,
 .training-caption-list {
   display: grid;
@@ -1741,9 +1745,74 @@ label {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.training-config-preview label {
+.training-config-preview label,
+.training-config-grid label,
+.training-advanced-grid label {
   display: grid;
   gap: 7px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.training-config-grid {
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+}
+
+.training-advanced-panel {
+  padding: 12px;
+  background: var(--surface);
+}
+
+.training-advanced-panel summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.training-advanced-grid {
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  margin-top: 12px;
+}
+
+.training-config-warnings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.training-config-warnings span {
+  padding: 5px 8px;
+  border: 1px solid color-mix(in oklch, var(--danger) 40%, var(--border));
+  border-radius: var(--r-pill);
+  background: color-mix(in oklch, var(--danger) 8%, var(--surface));
+  color: color-mix(in oklch, var(--danger) 75%, var(--text));
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.training-config-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.training-config-snapshot {
+  overflow: auto;
+  max-height: 280px;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .training-caption-toolbar {
@@ -5069,6 +5138,8 @@ label {
   .training-health-grid,
   .training-workflow-grid,
   .training-config-preview,
+  .training-config-grid,
+  .training-advanced-grid,
   .training-caption-toolbar,
   .training-caption-row,
   .training-caption-fields,

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -363,7 +363,15 @@ fn z_image_turbo_lora_target() -> TrainingTarget {
             advanced: object(json!({
                 "mixedPrecision": "bf16",
                 "cacheLatents": true,
-                "networkType": "lora"
+                "networkType": "lora",
+                "scheduler": "constant",
+                "epochs": 1,
+                "repeats": 10,
+                "bucketStrategy": "aspect",
+                "sampleEvery": 250,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
             })),
             extra: ExtraFields::new(),
         },
@@ -372,7 +380,9 @@ fn z_image_turbo_lora_target() -> TrainingTarget {
             "alpha": [1, 128],
             "steps": [200, 6000],
             "resolutions": [512, 768, 1024],
-            "batchSize": [1, 4]
+            "batchSize": [1, 4],
+            "qualityPresets": ["speed", "balanced", "quality"],
+            "outputScopes": ["project", "global"]
         })),
         ui: object(json!({
             "label": "Z-Image-Turbo LoRA",

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -24,7 +24,15 @@
         "advanced": {
           "mixedPrecision": "bf16",
           "cacheLatents": true,
-          "networkType": "lora"
+          "networkType": "lora",
+          "scheduler": "constant",
+          "epochs": 1,
+          "repeats": 10,
+          "bucketStrategy": "aspect",
+          "sampleEvery": 250,
+          "qualityPreset": "balanced",
+          "outputScope": "project",
+          "requestedGpu": "auto"
         }
       },
       "limits": {
@@ -32,7 +40,9 @@
         "alpha": [1, 128],
         "steps": [200, 6000],
         "resolutions": [512, 768, 1024],
-        "batchSize": [1, 4]
+        "batchSize": [1, 4],
+        "qualityPresets": ["speed", "balanced", "quality"],
+        "outputScopes": ["project", "global"]
       },
       "ui": {
         "label": "Z-Image-Turbo LoRA",


### PR DESCRIPTION
## Summary
- expose the Rust-owned training target registry through the API
- build the Training Studio Configure Job tab from target defaults, including visible fields, Advanced overrides, validation, and a prepared config snapshot
- extend target registry defaults and coverage for config UI values

## Tests
- npm --prefix apps/web test
- npm run web:build
- cargo fmt --all -- --check
- cargo test -p sceneworks-rust-api training_targets_route_returns_builtin_registry
- cargo test -p sceneworks-core --test training_contracts

Shortcut: https://app.shortcut.com/trefry/story/1415