### PR TITLE
Add lora_train job type, GPU routing, and dry-run plan [sc-1416]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1370,6 +1370,14 @@ async fn create_training_job(
     Path(project_id): Path<String>,
     ApiJson(payload): ApiJson<LoraTrainingRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    // Only dry-run plan validation exists today; refuse to queue a job that would
+    // complete without producing weights (real execution arrives in story 1417).
+    if !payload.dry_run {
+        return Err(ApiError::bad_request(
+            "Real LoRA training is not available yet. Submit with \"dryRun\": true to validate the training plan.",
+        ));
+    }
+
     // Targets come from the Rust-owned registry; the request only names one.
     let registry = builtin_training_targets();
     let target = registry
@@ -7852,6 +7860,54 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(error["detail"], "Training dataset not found");
+    }
+
+    #[tokio::test]
+    async fn create_training_job_rejects_non_dry_run_until_execution_exists() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (_, project) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/projects",
+            json!({ "name": "Training Project" }),
+        )
+        .await;
+        let project_id = project["id"].as_str().expect("project id").to_owned();
+        let (_, registry) =
+            request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
+        let target_id = registry["targets"][0]["id"].as_str().unwrap().to_owned();
+
+        // dryRun:false must be refused before any job is queued — real training
+        // execution does not exist yet, so a "completed" job would be a false success.
+        let (status, error) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/training/jobs"),
+            json!({
+                "targetId": target_id,
+                "datasetId": "ds_missing",
+                "config": registry["targets"][0]["defaults"].clone(),
+                "outputName": "Aurora",
+                "dryRun": false
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error["detail"]
+            .as_str()
+            .unwrap()
+            .contains("Real LoRA training is not available yet"));
+
+        let (status, queued) = request(
+            app.clone(),
+            "GET",
+            "/api/v1/jobs?status=queued",
+            Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(queued.as_array().expect("jobs list").len(), 0);
     }
 
     #[tokio::test]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1428,7 +1428,8 @@ async fn create_training_job(
     })
     .map_err(|error| ApiError::bad_request(error.to_string()))?;
 
-    let plan_value = serde_json::to_value(&plan).map_err(|error| ApiError::internal(error.to_string()))?;
+    let plan_value =
+        serde_json::to_value(&plan).map_err(|error| ApiError::internal(error.to_string()))?;
     let mut job_payload = JsonObject::new();
     job_payload.insert("dryRun".to_owned(), Value::Bool(payload.dry_run));
     job_payload.insert("outputName".to_owned(), Value::String(output_name));
@@ -7730,7 +7731,8 @@ mod tests {
         .await;
         let dataset_id = dataset["id"].as_str().expect("dataset id").to_owned();
 
-        let (_, registry) = request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
+        let (_, registry) =
+            request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
         let target = registry["targets"][0].clone();
         let target_id = target["id"].as_str().expect("target id").to_owned();
         let config = target["defaults"].clone();
@@ -7788,7 +7790,13 @@ mod tests {
         );
 
         // The job is queued and visible to the queue/worker surface.
-        let (status, queued) = request(app.clone(), "GET", "/api/v1/jobs?status=queued", Value::Null).await;
+        let (status, queued) = request(
+            app.clone(),
+            "GET",
+            "/api/v1/jobs?status=queued",
+            Value::Null,
+        )
+        .await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(queued[0]["id"], job_id);
         assert_eq!(queued[0]["type"], "lora_train");
@@ -7807,7 +7815,8 @@ mod tests {
         .await;
         let project_id = project["id"].as_str().expect("project id").to_owned();
 
-        let (_, registry) = request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
+        let (_, registry) =
+            request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
         let config = registry["targets"][0]["defaults"].clone();
 
         let (status, error) = request(

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -39,7 +39,8 @@ use sceneworks_core::project_store::{
     UploadAsset,
 };
 use sceneworks_core::training::{
-    builtin_training_targets, TrainingDataset, TrainingTargetRegistry,
+    build_training_plan, builtin_training_targets, BuildTrainingPlan, LoraTrainingRequest,
+    TrainingDataset, TrainingTarget, TrainingTargetRegistry,
 };
 use sceneworks_core::training_store::{
     TrainingCaptionSidecarsResult, TrainingDatasetBatchRenameInput,
@@ -527,6 +528,10 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         .route(
             "/api/v1/projects/:project_id/training/datasets/:dataset_id/caption-sidecars",
             post(write_training_dataset_caption_sidecars),
+        )
+        .route(
+            "/api/v1/projects/:project_id/training/jobs",
+            post(create_training_job),
         )
         .route(
             "/api/v1/projects/:project_id/files/*relative_path",
@@ -1358,6 +1363,130 @@ async fn delete_training_dataset(
         })
         .await?,
     ))
+}
+
+async fn create_training_job(
+    State(state): State<AppState>,
+    Path(project_id): Path<String>,
+    ApiJson(payload): ApiJson<LoraTrainingRequest>,
+) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    // Targets come from the Rust-owned registry; the request only names one.
+    let registry = builtin_training_targets();
+    let target = registry
+        .targets
+        .iter()
+        .find(|target| target.id == payload.target_id)
+        .ok_or_else(|| {
+            ApiError::bad_request(format!("Unknown training target: {}", payload.target_id))
+        })?;
+
+    let output_name = payload.output_name.trim().to_owned();
+    if output_name.is_empty() {
+        return Err(ApiError::bad_request("Training output name is required."));
+    }
+
+    // Load the dataset, its absolute root, and the project name for the queue.
+    let dataset_id = payload.dataset_id.clone();
+    let (dataset, dataset_root, project_name) = project_call(state.clone(), {
+        let project_id = project_id.clone();
+        move |store| store.training_dataset_for_plan(&project_id, &dataset_id)
+    })
+    .await?;
+
+    // We persist only the dataset's current version, so an older pin is unrunnable.
+    if let Some(requested_version) = payload.dataset_version {
+        if requested_version != dataset.version {
+            return Err(ApiError::bad_request(format!(
+                "Dataset {} is at version {}, but the request pinned version {requested_version}.",
+                dataset.id, dataset.version
+            )));
+        }
+    }
+
+    // Resolve absolute on-host paths and ids the kernel will consume. The job id
+    // is pre-allocated so the plan can embed its own `jobId`/`sourceJobId`.
+    let data_dir = state.settings.data_dir.clone();
+    let base_model_path = resolve_base_model_path(target, &data_dir);
+    let lora_id = format!("lora_{}", Uuid::new_v4().simple());
+    let output_dir = data_dir.join("loras").join(&lora_id);
+    let file_name = format!("{}.safetensors", slugify_lora_id(&output_name));
+    let job_id = format!("job_{}", Uuid::new_v4().simple());
+    let requested_gpu = training_requested_gpu(&payload.config.advanced);
+
+    // Rust resolves and validates the normalized plan before any job is queued.
+    let plan = build_training_plan(BuildTrainingPlan {
+        job_id: &job_id,
+        target,
+        dataset: &dataset,
+        config: payload.config,
+        lora_id: &lora_id,
+        base_model_path,
+        dataset_root: &dataset_root,
+        output_dir: &output_dir,
+        file_name,
+        created_at: now_rfc3339(),
+    })
+    .map_err(|error| ApiError::bad_request(error.to_string()))?;
+
+    let plan_value = serde_json::to_value(&plan).map_err(|error| ApiError::internal(error.to_string()))?;
+    let mut job_payload = JsonObject::new();
+    job_payload.insert("dryRun".to_owned(), Value::Bool(payload.dry_run));
+    job_payload.insert("outputName".to_owned(), Value::String(output_name));
+    job_payload.insert("plan".to_owned(), plan_value);
+
+    let job = store_call(state.clone(), move |store, _timeout| {
+        store.create_job_with_id(
+            job_id,
+            CreateJob {
+                job_type: JobType::LoraTrain,
+                project_id: Some(project_id),
+                project_name: Some(project_name),
+                payload: job_payload,
+                requested_gpu,
+                source_job_id: None,
+                duplicate_of_job_id: None,
+                attempts: 1,
+            },
+        )
+    })
+    .await?;
+    publish(&state, "job.updated", &job);
+    publish_queue(&state).await?;
+    Ok((StatusCode::CREATED, Json(job)))
+}
+
+/// Absolute path to the target's base model weights on the worker host. Prefers
+/// the Hugging Face hub cache for the target's repo, falling back to the local
+/// models directory. The path need not exist yet — model installation is a
+/// separate job; the dry-run plan only records where the kernel will read from.
+fn resolve_base_model_path(target: &TrainingTarget, data_dir: &FsPath) -> String {
+    if let Some(repo) = target
+        .base_model_repo
+        .as_deref()
+        .map(str::trim)
+        .filter(|repo| !repo.is_empty())
+    {
+        if let Some(cache_path) = huggingface_repo_cache_path(data_dir, repo) {
+            return cache_path.display().to_string();
+        }
+    }
+    data_dir
+        .join("models")
+        .join(safe_download_dir(&target.base_model))
+        .display()
+        .to_string()
+}
+
+/// GPU selection for a training job, read from the config's advanced bag (the
+/// request has no top-level field). Defaults to `auto`; `lora_train` is
+/// GPU-required, so a `cpu` value is rejected downstream when the job is created.
+fn training_requested_gpu(advanced: &JsonObject) -> String {
+    let raw = advanced
+        .get("requestedGpu")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    requested_gpu_or_auto(raw)
 }
 
 async fn get_project_file(
@@ -7560,6 +7689,160 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(listed_after_delete, json!([]));
+    }
+
+    #[tokio::test]
+    async fn create_training_job_resolves_plan_and_queues_lora_train() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let settings = test_settings(&temp_dir);
+        let data_dir = settings.data_dir.clone();
+        let app = create_app(settings).expect("app creates");
+
+        let (_, project) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/projects",
+            json!({ "name": "Training Project" }),
+        )
+        .await;
+        let project_id = project["id"].as_str().expect("project id").to_owned();
+        let project_path = std::path::PathBuf::from(project["path"].as_str().unwrap());
+
+        let (_, asset) = request_multipart_upload(
+            app.clone(),
+            &format!("/api/v1/projects/{project_id}/assets"),
+            "Portrait.PNG",
+            "image/png",
+            b"png-bytes",
+        )
+        .await;
+        let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+
+        let (_, dataset) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/training/datasets"),
+            json!({
+                "name": "Aurora set",
+                "items": [{ "assetId": asset_id, "caption": { "text": "auroraStyle portrait" } }]
+            }),
+        )
+        .await;
+        let dataset_id = dataset["id"].as_str().expect("dataset id").to_owned();
+
+        let (_, registry) = request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
+        let target = registry["targets"][0].clone();
+        let target_id = target["id"].as_str().expect("target id").to_owned();
+        let config = target["defaults"].clone();
+
+        let (status, job) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/training/jobs"),
+            json!({
+                "targetId": target_id,
+                "datasetId": dataset_id,
+                "config": config,
+                "outputName": "Aurora Style",
+                "dryRun": true
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(job["type"], "lora_train");
+        assert_eq!(job["status"], "queued");
+        assert_eq!(job["requestedGpu"], "auto");
+        assert_eq!(job["projectId"], project_id);
+        assert_eq!(job["payload"]["dryRun"], true);
+
+        let job_id = job["id"].as_str().expect("job id").to_owned();
+        let plan = &job["payload"]["plan"];
+        // The resolved plan is self-referential and fully normalized in Rust.
+        assert_eq!(plan["jobId"], job_id);
+        assert_eq!(plan["provenance"]["sourceJobId"], job_id);
+        assert_eq!(plan["target"]["targetId"], target_id);
+        assert_eq!(plan["dataset"]["datasetId"], dataset_id);
+        assert_eq!(plan["dataset"]["datasetVersion"], 1);
+        assert_eq!(plan["dataset"]["items"].as_array().unwrap().len(), 1);
+        let lora_id = plan["output"]["loraId"].as_str().expect("lora id");
+        assert!(lora_id.starts_with("lora_"));
+        assert_eq!(plan["output"]["fileName"], "aurora_style.safetensors");
+
+        // Item image paths resolve under the dataset root on disk.
+        let expected_image = project_path
+            .join("training")
+            .join("datasets")
+            .join(&dataset_id)
+            .join("images")
+            .join("item_0001.png");
+        assert_eq!(
+            plan["dataset"]["items"][0]["imagePath"]
+                .as_str()
+                .expect("image path"),
+            expected_image.display().to_string()
+        );
+        // Output dir resolves under the data dir's loras folder.
+        assert_eq!(
+            plan["output"]["outputDir"].as_str().expect("output dir"),
+            data_dir.join("loras").join(lora_id).display().to_string()
+        );
+
+        // The job is queued and visible to the queue/worker surface.
+        let (status, queued) = request(app.clone(), "GET", "/api/v1/jobs?status=queued", Value::Null).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(queued[0]["id"], job_id);
+        assert_eq!(queued[0]["type"], "lora_train");
+    }
+
+    #[tokio::test]
+    async fn create_training_job_rejects_unknown_target_and_missing_dataset() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (_, project) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/projects",
+            json!({ "name": "Training Project" }),
+        )
+        .await;
+        let project_id = project["id"].as_str().expect("project id").to_owned();
+
+        let (_, registry) = request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
+        let config = registry["targets"][0]["defaults"].clone();
+
+        let (status, error) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/training/jobs"),
+            json!({
+                "targetId": "not_a_target",
+                "datasetId": "ds_missing",
+                "config": config,
+                "outputName": "Aurora"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error["detail"]
+            .as_str()
+            .unwrap()
+            .contains("Unknown training target"));
+
+        let target_id = registry["targets"][0]["id"].as_str().unwrap().to_owned();
+        let (status, error) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/training/jobs"),
+            json!({
+                "targetId": target_id,
+                "datasetId": "ds_missing",
+                "config": registry["targets"][0]["defaults"].clone(),
+                "outputName": "Aurora"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(error["detail"], "Training dataset not found");
     }
 
     #[tokio::test]

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -849,6 +849,19 @@ export function App() {
     return result;
   }
 
+  async function createTrainingJob(request, projectId = activeProject?.id) {
+    if (!projectId) {
+      throw new Error("Select a workspace before creating a training job.");
+    }
+    const job = await apiFetch(`/api/v1/projects/${projectId}/training/jobs`, token, {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    setError("");
+    return job;
+  }
+
   function presetQuery(scope = null) {
     const params = new URLSearchParams();
     if (scope) {
@@ -1919,6 +1932,7 @@ export function App() {
             assets={assets}
             batchRenameDataset={batchRenameTrainingDataset}
             createDataset={createTrainingDataset}
+            createTrainingJob={createTrainingJob}
             datasets={trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : []}
             datasetsError={trainingDatasetsError}
             gpuOptions={gpuOptions}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -275,7 +275,7 @@ describe("SceneWorks app shell", () => {
     });
 
     expect(container.querySelector("#training-tab-configure").getAttribute("aria-selected")).toBe("true");
-    expect(container.textContent).toContain("Training submission is disabled");
+    expect(container.textContent).toContain("Queuing a dry run validates");
   });
 
   it("creates a training dataset from selected image assets", async () => {
@@ -626,6 +626,63 @@ describe("SceneWorks app shell", () => {
       }),
     );
     expect(container.textContent).toContain("Config snapshot ready");
+  });
+
+  it("queues a dry-run training job from the configure tab", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 5,
+      items: [
+        {
+          id: "item_0001",
+          assetId: "asset-a",
+          path: "images/item_0001.png",
+          displayName: "item_0001.png",
+          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+        },
+      ],
+    }));
+    const createTrainingJob = vi.fn(async () => ({ id: "job_dryrun_1", type: "lora_train", status: "queued" }));
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          createTrainingJob={createTrainingJob}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          gpuOptions={["auto", "0"]}
+          loadDataset={loadDataset}
+          trainingTargets={[zImageTrainingTarget]}
+        />,
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector("#training-tab-configure").click();
+    });
+    await changeField(field(container, "Dataset"), "dataset-a");
+    await settle();
+    await changeField(field(container, "Trigger phrase"), "miraStyle");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Queue dry-run job").click();
+    });
+    await settle();
+
+    expect(createTrainingJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetId: "z_image_turbo_lora",
+        datasetId: "dataset-a",
+        datasetVersion: 5,
+        outputName: "Portrait Set LoRA",
+        dryRun: true,
+        config: expect.objectContaining({ rank: 16, triggerWord: "miraStyle" }),
+      }),
+    );
+    expect(container.textContent).toContain("Queued dry-run job job_dryrun_1");
   });
 
   it("keeps config edits when GPU options are recomputed", async () => {

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -4,10 +4,10 @@ import { actionStatuses, terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
 
 const nonGpuJobTypes = new Set(["model_download", "lora_import"]);
-// Keep GPU-required generation types in sync with
+// Keep GPU-required job types in sync with
 // crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
-// apps/worker/scene_worker/runtime.py::SUPPORTED_JOB_TYPES.
-const gpuRequiredJobTypes = new Set(["image_generate", "image_edit", "video_generate", "video_extend", "video_bridge", "person_replace"]);
+// apps/worker/scene_worker/runtime.py (SUPPORTED_JOB_TYPES + TRAINING_JOB_TYPES).
+const gpuRequiredJobTypes = new Set(["image_generate", "image_edit", "video_generate", "video_extend", "video_bridge", "person_replace", "lora_train"]);
 const terminalStatusesForBlocking = new Set(["completed", "failed", "canceled", "interrupted"]);
 
 function formatJobType(type) {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -5,7 +5,7 @@ import { Icon } from "../components/Icons.jsx";
 const tabs = [
   { id: "dataset", label: "Dataset", title: "Dataset intake", status: "Rust dataset store" },
   { id: "rename-caption", label: "Rename & Caption", title: "Rename and caption pass", status: "Needs valid dataset" },
-  { id: "configure", label: "Configure Job", title: "Configure training job", status: "Queue disabled" },
+  { id: "configure", label: "Configure Job", title: "Configure training job", status: "Queue dry run" },
 ];
 const defaultGpuOptions = ["auto"];
 
@@ -310,6 +310,7 @@ export function TrainingStudio({
   assets = [],
   batchRenameDataset = async () => null,
   createDataset = async () => null,
+  createTrainingJob = async () => null,
   datasets = [],
   datasetsError = "",
   gpuOptions = defaultGpuOptions,
@@ -344,6 +345,7 @@ export function TrainingStudio({
   const [configMessage, setConfigMessage] = useState("");
   const [configError, setConfigError] = useState("");
   const [preparingConfig, setPreparingConfig] = useState(false);
+  const [submittingJob, setSubmittingJob] = useState(false);
   const configBasisRef = useRef("");
   const tabRefs = useRef({});
 
@@ -664,6 +666,32 @@ export function TrainingStudio({
       setConfigError(err.message);
     } finally {
       setPreparingConfig(false);
+    }
+  }
+
+  async function submitTrainingJob() {
+    if (!canPrepareConfig || submittingJob) {
+      return;
+    }
+    setSubmittingJob(true);
+    setConfigError("");
+    setConfigMessage("");
+    try {
+      const snapshot = trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget });
+      const job = await createTrainingJob({
+        targetId: snapshot.targetId,
+        datasetId: snapshot.datasetId,
+        datasetVersion: snapshot.datasetVersion,
+        outputName: snapshot.outputName,
+        dryRun: true,
+        config: snapshot.config,
+      });
+      setConfigSnapshot(snapshot);
+      setConfigMessage(`Queued dry-run job ${job?.id ?? ""}`.trim() + ". Track it in the Queue.");
+    } catch (err) {
+      setConfigError(err.message);
+    } finally {
+      setSubmittingJob(false);
     }
   }
 
@@ -1171,14 +1199,25 @@ export function TrainingStudio({
                         <button className="secondary-action" onClick={resetConfigDefaults} type="button">
                           Reset defaults
                         </button>
-                        <button className="primary-action" disabled={!canPrepareConfig} onClick={prepareConfig} type="button">
+                        <button className="secondary-action" disabled={!canPrepareConfig} onClick={prepareConfig} type="button">
                           {preparingConfig ? "Preparing" : "Prepare config"}
+                        </button>
+                        <button
+                          className="primary-action"
+                          disabled={!canPrepareConfig || submittingJob}
+                          onClick={submitTrainingJob}
+                          type="button"
+                        >
+                          {submittingJob ? "Queuing" : "Queue dry-run job"}
                         </button>
                       </div>
                       {configSnapshot ? <pre className="training-config-snapshot">{JSON.stringify(configSnapshot, null, 2)}</pre> : null}
                     </div>
                   )}
-                  <p className="inline-warning">Training submission is disabled until the dry-run plan story wires queue semantics.</p>
+                  <p className="view-copy">
+                    Queuing a dry run validates the Rust-resolved training plan and dataset on a GPU worker without training; real
+                    training execution arrives in a later story.
+                  </p>
                 </>
               ) : null}
             </section>

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -576,6 +576,12 @@ def run_lora_train_dry_run_job(api: ApiClient, settings: WorkerSettings, job: di
     try:
         progress("preparing", "preparing", 0.1, "Validating training plan.")
         payload = job.get("payload") or {}
+        # Real training execution does not exist yet; never let a non-dry-run job
+        # report success without producing weights (the API also rejects this).
+        if not payload.get("dryRun", True):
+            raise ValueError(
+                "Real LoRA training execution is not available yet; this worker only validates dry-run plans."
+            )
         plan = payload.get("plan")
         if not isinstance(plan, dict):
             raise ValueError("Training job payload is missing a resolved plan.")

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -22,10 +22,14 @@ from .video_adapters import create_video_adapter
 LoadedModelsSource = Callable[[], list[str]] | None
 IMAGE_JOB_TYPES = ("image_generate", "image_edit")
 VIDEO_JOB_TYPES = ("video_generate", "video_extend", "video_bridge", "person_replace")
-# Keep GPU-required generation types in sync with
+# Keep GPU-required job types in sync with
 # crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
 # apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
 SUPPORTED_JOB_TYPES = IMAGE_JOB_TYPES + VIDEO_JOB_TYPES
+# Training is GPU-required like generation, but a GPU worker advertises it even
+# without an inference backend: the story 1416 dry-run only validates a Rust-
+# resolved plan (no torch needed). Real execution is gated per platform in 1417.
+TRAINING_JOB_TYPES = ("lora_train",)
 
 
 def now() -> str:
@@ -57,8 +61,13 @@ class ApiClient:
 def worker_capabilities(gpu: dict) -> list[str]:
     gpu_capabilities = set(gpu["capabilities"])
     capabilities = set(gpu["capabilities"]) - {"placeholder"}
-    if "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities and torch_inference_backend_available():
-        capabilities |= set(SUPPORTED_JOB_TYPES)
+    is_gpu_worker = "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities
+    if is_gpu_worker:
+        # Dry-run plan validation needs no inference backend, so a GPU worker can
+        # claim lora_train even before torch/CUDA is installed (e.g. on Mac).
+        capabilities |= set(TRAINING_JOB_TYPES)
+        if torch_inference_backend_available():
+            capabilities |= set(SUPPORTED_JOB_TYPES)
     return sorted(capabilities)
 
 
@@ -540,6 +549,108 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             restart_worker_after_oom(settings, job_id)
 
 
+# Highest training plan version this worker understands. Plans are resolved in
+# Rust (crates/sceneworks-core/src/training.rs::TRAINING_PLAN_VERSION); the worker
+# rejects any version it cannot interpret rather than guessing.
+SUPPORTED_TRAINING_PLAN_VERSION = 1
+
+
+def run_lora_train_dry_run_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    """Validate a Rust-resolved training plan and complete with a dry-run summary.
+
+    This is the story 1416 stub: it claims a lora_train job, checks the embedded
+    plan and that its dataset inputs exist on the worker, and reports what a real
+    run would produce — without loading a model or training. Story 1417 replaces
+    the body with the narrow Z-Image LoRA execution kernel.
+    """
+    job_id = job["id"]
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        update_job(
+            api,
+            job_id,
+            {"status": status, "stage": stage, "progress": value, "message": message},
+        )
+
+    try:
+        progress("preparing", "preparing", 0.1, "Validating training plan.")
+        payload = job.get("payload") or {}
+        plan = payload.get("plan")
+        if not isinstance(plan, dict):
+            raise ValueError("Training job payload is missing a resolved plan.")
+        plan_version = plan.get("planVersion")
+        if plan_version != SUPPORTED_TRAINING_PLAN_VERSION:
+            raise ValueError(
+                f"Unsupported training plan version {plan_version!r}; this worker "
+                f"understands version {SUPPORTED_TRAINING_PLAN_VERSION}."
+            )
+
+        dataset = plan.get("dataset") or {}
+        items = dataset.get("items") or []
+        if not items:
+            raise ValueError("Training plan dataset has no items to train on.")
+
+        progress("running", "running", 0.5, f"Checking {len(items)} dataset item(s).")
+        missing = [
+            item.get("imagePath")
+            for item in items
+            if not (item.get("imagePath") and os.path.exists(item["imagePath"]))
+        ]
+        if missing:
+            preview = ", ".join(str(path) for path in missing[:3])
+            raise FileNotFoundError(
+                f"{len(missing)} dataset image(s) are missing on the worker, e.g. {preview}."
+            )
+
+        output = plan.get("output") or {}
+        target = plan.get("target") or {}
+        base_model_path = target.get("baseModelPath")
+        summary = {
+            "mode": "dry_run",
+            "validated": True,
+            "dryRun": bool(payload.get("dryRun", True)),
+            "datasetItemCount": len(items),
+            "datasetId": dataset.get("datasetId"),
+            "datasetVersion": dataset.get("datasetVersion"),
+            "targetId": target.get("targetId"),
+            "kernel": target.get("kernel"),
+            "loraId": output.get("loraId"),
+            "outputDir": output.get("outputDir"),
+            "fileName": output.get("fileName"),
+            "baseModelPath": base_model_path,
+            "baseModelInstalled": bool(base_model_path and os.path.exists(base_model_path)),
+            "planVersion": plan_version,
+            "completedAt": now(),
+        }
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "completed",
+                "stage": "completed",
+                "progress": 1,
+                "message": f"Dry run validated {len(items)} dataset item(s); training plan is ready.",
+                "result": summary,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 - report any validation failure cleanly
+        message, error = friendly_failure("Training dry run", exc)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "failed",
+                "stage": "failed",
+                "progress": 1,
+                "message": message,
+                "error": error,
+            },
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def run_worker_loop(settings: WorkerSettings) -> None:
     gpu = discover_gpu(settings.gpu_id)
     api = ApiClient(settings)
@@ -587,6 +698,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
                 run_image_job(api, settings, job, image_adapters)
             elif job["type"] in VIDEO_JOB_TYPES:
                 run_video_job(api, settings, job)
+            elif job["type"] in TRAINING_JOB_TYPES:
+                run_lora_train_dry_run_job(api, settings, job)
             else:
                 update_job(
                     api,

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -185,6 +185,7 @@ string_enum! {
         ModelDownload => "model_download",
         ModelImport => "model_import",
         LoraImport => "lora_import",
+        LoraTrain => "lora_train",
     }
 }
 
@@ -251,6 +252,7 @@ string_enum! {
         ModelDownload => "model_download",
         ModelImport => "model_import",
         LoraImport => "lora_import",
+        LoraTrain => "lora_train",
     }
 }
 

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -819,8 +819,9 @@ impl JobsStore {
         let job_id = match job_id {
             Some(job_id) => job_id,
             None => {
-                let job_hex: String = connection
-                    .query_row("select lower(hex(randomblob(16)))", [], |row| row.get(0))?;
+                let job_hex: String =
+                    connection
+                        .query_row("select lower(hex(randomblob(16)))", [], |row| row.get(0))?;
                 format!("job_{job_hex}")
             }
         };

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -265,7 +265,24 @@ impl JobsStore {
         let _guard = self.lock.lock();
         let mut connection = self.connect()?;
         let transaction = connection.transaction()?;
-        let job = self.create_job_on_connection(&transaction, request)?;
+        let job = self.create_job_on_connection(&transaction, request, None)?;
+        transaction.commit()?;
+        Ok(job)
+    }
+
+    /// Create a job under a caller-supplied id. Used when the payload must
+    /// reference its own job id before insertion — e.g. a `lora_train` job whose
+    /// resolved [`crate::training::TrainingPlan`] embeds `jobId`/`sourceJobId`.
+    /// The id must be unique; a collision surfaces as a SQLite error.
+    pub fn create_job_with_id(
+        &self,
+        id: String,
+        request: CreateJob,
+    ) -> JobsStoreResult<JobSnapshot> {
+        let _guard = self.lock.lock();
+        let mut connection = self.connect()?;
+        let transaction = connection.transaction()?;
+        let job = self.create_job_on_connection(&transaction, request, Some(id))?;
         transaction.commit()?;
         Ok(job)
     }
@@ -385,6 +402,7 @@ impl JobsStore {
                 duplicate_of_job_id: None,
                 attempts: job.attempts + 1,
             },
+            None,
         )?;
         transaction.commit()?;
         Ok(job)
@@ -413,6 +431,7 @@ impl JobsStore {
                 duplicate_of_job_id: Some(job.id),
                 attempts: 1,
             },
+            None,
         )?;
         transaction.commit()?;
         Ok(job)
@@ -787,6 +806,7 @@ impl JobsStore {
         &self,
         connection: &Connection,
         request: CreateJob,
+        job_id: Option<String>,
     ) -> JobsStoreResult<JobSnapshot> {
         let requested_gpu = normalize_requested_gpu(&request.requested_gpu);
         if job_requires_gpu(&request.job_type) && requested_gpu == "cpu" {
@@ -796,9 +816,14 @@ impl JobsStore {
             )));
         }
         let now = utc_now();
-        let job_hex: String =
-            connection.query_row("select lower(hex(randomblob(16)))", [], |row| row.get(0))?;
-        let job_id = format!("job_{job_hex}");
+        let job_id = match job_id {
+            Some(job_id) => job_id,
+            None => {
+                let job_hex: String = connection
+                    .query_row("select lower(hex(randomblob(16)))", [], |row| row.get(0))?;
+                format!("job_{job_hex}")
+            }
+        };
         connection.execute(
             "
             insert into jobs (
@@ -1381,9 +1406,11 @@ fn normalize_requested_gpu(value: &str) -> String {
     }
 }
 
-// Keep GPU-required generation types in sync with
-// apps/worker/scene_worker/runtime.py::SUPPORTED_JOB_TYPES and
-// apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
+// Keep GPU-required job types in sync with
+// apps/worker/scene_worker/runtime.py (SUPPORTED_JOB_TYPES + TRAINING_JOB_TYPES) and
+// apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes. `lora_train` is GPU-required
+// like generation, but its worker capability is advertised separately (the dry-run plan
+// validation needs no inference backend; real execution is gated per platform in story 1417).
 fn job_requires_gpu(job_type: &JobType) -> bool {
     matches!(
         job_type,
@@ -1393,6 +1420,7 @@ fn job_requires_gpu(job_type: &JobType) -> bool {
             | JobType::VideoExtend
             | JobType::VideoBridge
             | JobType::PersonReplace
+            | JobType::LoraTrain
     )
 }
 

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -299,6 +299,27 @@ impl ProjectStore {
         TrainingDatasetStore::new(project_path).get_dataset(project_id, dataset_id)
     }
 
+    /// Loads a training dataset together with its absolute on-disk root and the
+    /// project stem — the inputs the Rust API needs to resolve a
+    /// [`crate::training::TrainingPlan`] and label the queued job. Resolves the
+    /// project path once rather than re-reading the registry per value.
+    pub fn training_dataset_for_plan(
+        &self,
+        project_id: &str,
+        dataset_id: &str,
+    ) -> ProjectStoreResult<(TrainingDataset, PathBuf, String)> {
+        let project_path = self.find_project_path(project_id)?;
+        let dataset =
+            TrainingDatasetStore::new(project_path.clone()).get_dataset(project_id, dataset_id)?;
+        let root = crate::training_store::dataset_root(&project_path, dataset_id);
+        let project_stem = project_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or_default()
+            .to_owned();
+        Ok((dataset, root, project_stem))
+    }
+
     pub fn update_training_dataset(
         &self,
         project_id: &str,

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -218,12 +218,17 @@ pub struct LoraTrainingRequest {
     pub config: TrainingConfig,
     /// Human-facing name for the resulting LoRA.
     pub output_name: String,
-    /// When true, the queue produces a [`TrainingPlan`] and stops short of
-    /// running the kernel (story 1416).
-    #[serde(default)]
+    /// When true, the queue resolves a [`TrainingPlan`] and stops short of
+    /// running the kernel. Defaults to true: dry-run is the only mode supported
+    /// today, so the API rejects `false` until real execution exists.
+    #[serde(default = "default_dry_run")]
     pub dry_run: bool,
     #[serde(flatten)]
     pub extra: ExtraFields,
+}
+
+fn default_dry_run() -> bool {
+    true
 }
 
 /// The fully normalized plan Rust hands to the Python execution kernel.

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -458,7 +458,9 @@ impl std::error::Error for TrainingPlanError {}
 /// Normalizes resolved request inputs into the [`TrainingPlan`] the Python
 /// kernel consumes. Validates the dataset is non-empty and the config is
 /// runnable; absolute paths and ids are resolved by the caller.
-pub fn build_training_plan(input: BuildTrainingPlan<'_>) -> Result<TrainingPlan, TrainingPlanError> {
+pub fn build_training_plan(
+    input: BuildTrainingPlan<'_>,
+) -> Result<TrainingPlan, TrainingPlanError> {
     validate_training_config(&input.config)?;
     if input.dataset.items.is_empty() {
         return Err(TrainingPlanError::EmptyDataset);

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -21,6 +21,8 @@
 //! trailing flattened [`ExtraFields`] for forward compatibility, and string
 //! enums that round-trip unknown values via an `Unknown(String)` variant.
 
+use std::path::Path;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};
 
@@ -401,4 +403,168 @@ fn object(value: Value) -> JsonObject {
         Value::Object(map) => map,
         _ => JsonObject::new(),
     }
+}
+
+/// Resolved inputs the [`build_training_plan`] resolver normalizes into a
+/// [`TrainingPlan`]. The caller (the Rust API) owns I/O — loading the dataset,
+/// allocating the output LoRA id, and resolving absolute on-host paths — so the
+/// builder itself stays a pure, testable normalization step.
+#[derive(Debug)]
+pub struct BuildTrainingPlan<'a> {
+    /// Id the job will be created under; embedded as the plan's `jobId` and
+    /// provenance `sourceJobId` so the plan is self-describing.
+    pub job_id: &'a str,
+    pub target: &'a TrainingTarget,
+    pub dataset: &'a TrainingDataset,
+    /// Resolved config (target defaults already merged with user overrides).
+    pub config: TrainingConfig,
+    /// Pre-allocated SceneWorks LoRA id the output registers under.
+    pub lora_id: &'a str,
+    /// Absolute path to the base model weights on the worker host.
+    pub base_model_path: String,
+    /// Absolute dataset root the worker reads images and captions from.
+    pub dataset_root: &'a Path,
+    /// Absolute directory the kernel writes the adapter into.
+    pub output_dir: &'a Path,
+    /// Adapter file name, e.g. `aurora_style.safetensors`.
+    pub file_name: String,
+    pub created_at: String,
+}
+
+/// Error produced when a [`LoraTrainingRequest`] cannot be resolved into a valid
+/// [`TrainingPlan`]. These map to client errors: the request is structurally
+/// fine but the dataset or config cannot produce a runnable plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrainingPlanError {
+    /// The dataset has no items to train on.
+    EmptyDataset,
+    /// A hyperparameter is out of range; carries a human-facing reason.
+    InvalidConfig(String),
+}
+
+impl std::fmt::Display for TrainingPlanError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyDataset => {
+                formatter.write_str("Training dataset has no items. Add at least one image.")
+            }
+            Self::InvalidConfig(detail) => formatter.write_str(detail),
+        }
+    }
+}
+
+impl std::error::Error for TrainingPlanError {}
+
+/// Normalizes resolved request inputs into the [`TrainingPlan`] the Python
+/// kernel consumes. Validates the dataset is non-empty and the config is
+/// runnable; absolute paths and ids are resolved by the caller.
+pub fn build_training_plan(input: BuildTrainingPlan<'_>) -> Result<TrainingPlan, TrainingPlanError> {
+    validate_training_config(&input.config)?;
+    if input.dataset.items.is_empty() {
+        return Err(TrainingPlanError::EmptyDataset);
+    }
+
+    let items = input
+        .dataset
+        .items
+        .iter()
+        .map(|item| TrainingPlanItem {
+            image_path: resolve_item_path(input.dataset_root, &item.path),
+            caption: item.caption.text.clone(),
+            width: item.width,
+            height: item.height,
+            extra: ExtraFields::new(),
+        })
+        .collect::<Vec<_>>();
+
+    let trigger_words = match input.config.trigger_word.as_deref().map(str::trim) {
+        Some(word) if !word.is_empty() => vec![word.to_owned()],
+        _ => Vec::new(),
+    };
+
+    let config_snapshot = match serde_json::to_value(&input.config) {
+        Ok(Value::Object(map)) => map,
+        _ => JsonObject::new(),
+    };
+
+    Ok(TrainingPlan {
+        schema_version: TRAINING_CONTRACT_SCHEMA_VERSION,
+        plan_version: TRAINING_PLAN_VERSION,
+        job_id: input.job_id.to_owned(),
+        target: TrainingPlanTarget {
+            target_id: input.target.id.clone(),
+            kernel: input.target.kernel.clone(),
+            family: input.target.family.clone(),
+            modality: input.target.modality.clone(),
+            output_kind: input.target.output_kind.clone(),
+            base_model: input.target.base_model.clone(),
+            base_model_path: input.base_model_path,
+            extra: ExtraFields::new(),
+        },
+        dataset: TrainingPlanDataset {
+            dataset_id: input.dataset.id.clone(),
+            dataset_version: input.dataset.version,
+            root_path: input.dataset_root.display().to_string(),
+            items,
+            extra: ExtraFields::new(),
+        },
+        config: input.config,
+        output: TrainingPlanOutput {
+            lora_id: input.lora_id.to_owned(),
+            output_dir: input.output_dir.display().to_string(),
+            file_name: input.file_name,
+            format: "safetensors".to_owned(),
+            trigger_words,
+            extra: ExtraFields::new(),
+        },
+        provenance: TrainingProvenance {
+            dataset_id: input.dataset.id.clone(),
+            dataset_version: input.dataset.version,
+            target_id: input.target.id.clone(),
+            base_model: input.target.base_model.clone(),
+            config_snapshot,
+            output_lora_id: input.lora_id.to_owned(),
+            source_job_id: input.job_id.to_owned(),
+            created_at: input.created_at,
+            extra: ExtraFields::new(),
+        },
+        extra: ExtraFields::new(),
+    })
+}
+
+/// Joins a dataset item's forward-slash relative path onto the absolute root
+/// using the host's path separator. Dataset item paths are stored POSIX-style
+/// (the store forbids backslashes), so joining the whole string would leave
+/// mixed separators on Windows; pushing each component normalizes them.
+fn resolve_item_path(dataset_root: &Path, relative_path: &str) -> String {
+    let mut path = dataset_root.to_path_buf();
+    for component in Path::new(relative_path).components() {
+        path.push(component);
+    }
+    path.display().to_string()
+}
+
+fn validate_training_config(config: &TrainingConfig) -> Result<(), TrainingPlanError> {
+    let positive = |value: u32, field: &str| {
+        if value == 0 {
+            Err(TrainingPlanError::InvalidConfig(format!(
+                "{field} must be at least 1."
+            )))
+        } else {
+            Ok(())
+        }
+    };
+    positive(config.rank, "rank")?;
+    positive(config.alpha, "alpha")?;
+    positive(config.steps, "steps")?;
+    positive(config.resolution, "resolution")?;
+    positive(config.batch_size, "batchSize")?;
+    positive(config.gradient_accumulation, "gradientAccumulation")?;
+    let learning_rate = config.learning_rate.as_f64().unwrap_or(f64::NAN);
+    if !(learning_rate.is_finite() && learning_rate > 0.0) {
+        return Err(TrainingPlanError::InvalidConfig(
+            "learningRate must be a positive finite number.".to_owned(),
+        ));
+    }
+    Ok(())
 }

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -1006,7 +1006,7 @@ where
         .expect("string enum deserialization is infallible")
 }
 
-fn dataset_root(project_path: &Path, dataset_id: &str) -> PathBuf {
+pub(crate) fn dataset_root(project_path: &Path, dataset_id: &str) -> PathBuf {
     project_path
         .join("training")
         .join("datasets")

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -613,3 +613,120 @@ fn elapsed_seconds_accepts_fractional_rfc3339_timestamps() {
         Some(5)
     );
 }
+
+fn lora_train_job(requested_gpu: &str) -> CreateJob {
+    CreateJob {
+        job_type: JobType::LoraTrain,
+        project_id: Some("project-1".to_owned()),
+        project_name: Some("Project 1".to_owned()),
+        payload: object(json!({ "dryRun": true })),
+        requested_gpu: requested_gpu.to_owned(),
+        source_job_id: None,
+        duplicate_of_job_id: None,
+        attempts: 1,
+    }
+}
+
+#[test]
+fn lora_train_rejects_cpu_requested_gpu() {
+    let store = store("lora-train-rejects-cpu");
+
+    let error = store
+        .create_job(lora_train_job("cpu"))
+        .expect_err("cpu requestedGpu should be rejected for lora_train");
+
+    assert!(matches!(error, JobsStoreError::InvalidRequestedGpu(_)));
+    assert!(error.to_string().contains("cannot target CPU workers"));
+}
+
+#[test]
+fn cpu_worker_cannot_claim_lora_train_even_with_capability() {
+    let store = store("cpu-cannot-claim-lora-train");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-cpu".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            gpu_name: Some("CPU inference worker".to_owned()),
+            capabilities: vec![WorkerCapability::Cpu, WorkerCapability::LoraTrain],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+    store
+        .create_job(lora_train_job("auto"))
+        .expect("lora_train job creates");
+
+    assert!(store
+        .claim_next_job("worker-cpu")
+        .expect("claim succeeds")
+        .is_none());
+}
+
+#[test]
+fn gpu_worker_with_capability_claims_lora_train() {
+    let store = store("gpu-claims-lora-train");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-gpu".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: Some("GPU 0".to_owned()),
+            capabilities: vec![WorkerCapability::Gpu, WorkerCapability::LoraTrain],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+    let created = store
+        .create_job(lora_train_job("auto"))
+        .expect("lora_train job creates");
+
+    let claimed = store
+        .claim_next_job("worker-gpu")
+        .expect("claim succeeds")
+        .expect("job claimed");
+
+    assert_eq!(claimed.id, created.id);
+    assert_eq!(claimed.job_type, JobType::LoraTrain);
+    assert_eq!(claimed.status, JobStatus::Preparing);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("gpu-0"));
+}
+
+#[test]
+fn gpu_worker_without_training_capability_skips_lora_train() {
+    let store = store("gpu-without-training-cap");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-gpu".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: Some("GPU 0".to_owned()),
+            capabilities: vec![WorkerCapability::Gpu, WorkerCapability::ImageGenerate],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+    store
+        .create_job(lora_train_job("auto"))
+        .expect("lora_train job creates");
+
+    assert!(store
+        .claim_next_job("worker-gpu")
+        .expect("claim succeeds")
+        .is_none());
+}
+
+#[test]
+fn create_job_with_id_uses_supplied_id() {
+    let store = store("create-job-with-id");
+
+    let job = store
+        .create_job_with_id("job_lora_train_fixture".to_owned(), lora_train_job("auto"))
+        .expect("job creates with supplied id");
+
+    assert_eq!(job.id, "job_lora_train_fixture");
+    assert_eq!(
+        store
+            .get_job("job_lora_train_fixture")
+            .expect("job loads")
+            .job_type,
+        JobType::LoraTrain
+    );
+}

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use sceneworks_core::training::{
     build_training_plan, builtin_training_targets, BuildTrainingPlan, LoraTrainingRequest,
     TrainingConfig, TrainingDataset, TrainingModality, TrainingOutputKind, TrainingPlan,
-    TrainingPlanError, TrainingProvenance, TrainingTargetRegistry, TRAINING_CONTRACT_SCHEMA_VERSION,
-    TRAINING_PLAN_VERSION,
+    TrainingPlanError, TrainingProvenance, TrainingTargetRegistry,
+    TRAINING_CONTRACT_SCHEMA_VERSION, TRAINING_PLAN_VERSION,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -1,10 +1,11 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use sceneworks_core::training::{
-    builtin_training_targets, LoraTrainingRequest, TrainingConfig, TrainingDataset,
-    TrainingModality, TrainingOutputKind, TrainingPlan, TrainingProvenance, TrainingTargetRegistry,
-    TRAINING_CONTRACT_SCHEMA_VERSION, TRAINING_PLAN_VERSION,
+    build_training_plan, builtin_training_targets, BuildTrainingPlan, LoraTrainingRequest,
+    TrainingConfig, TrainingDataset, TrainingModality, TrainingOutputKind, TrainingPlan,
+    TrainingPlanError, TrainingProvenance, TrainingTargetRegistry, TRAINING_CONTRACT_SCHEMA_VERSION,
+    TRAINING_PLAN_VERSION,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -131,4 +132,133 @@ fn training_plan_fixture_pins_current_plan_version() {
         plan["planVersion"].as_u64(),
         Some(u64::from(TRAINING_PLAN_VERSION))
     );
+}
+
+fn dataset_fixture() -> TrainingDataset {
+    serde_json::from_value(load_fixture("dataset.json")).expect("dataset fixture parses")
+}
+
+#[test]
+fn build_training_plan_resolves_paths_ids_and_provenance() {
+    let dataset = dataset_fixture();
+    let registry = builtin_training_targets();
+    let target = registry.targets.first().expect("a builtin target exists");
+    let dataset_root = Path::new("/data/training/ds_abc123");
+    let output_dir = Path::new("/data/loras/lora_new");
+    let mut config = target.defaults.clone();
+    config.trigger_word = Some("auroraStyle".to_owned());
+
+    let plan = build_training_plan(BuildTrainingPlan {
+        job_id: "job_test",
+        target,
+        dataset: &dataset,
+        config,
+        lora_id: "lora_new",
+        base_model_path: "/data/cache/huggingface/Tongyi-MAI/Z-Image-Turbo".to_owned(),
+        dataset_root,
+        output_dir,
+        file_name: "aurora_style.safetensors".to_owned(),
+        created_at: "2026-05-21T00:00:00Z".to_owned(),
+    })
+    .expect("plan resolves");
+
+    assert_eq!(plan.plan_version, TRAINING_PLAN_VERSION);
+    assert_eq!(plan.job_id, "job_test");
+    // The plan is self-referential so the kernel never needs the job record.
+    assert_eq!(plan.provenance.source_job_id, "job_test");
+    assert_eq!(plan.target.target_id, target.id);
+    assert_eq!(plan.target.kernel, target.kernel);
+    assert_eq!(
+        plan.target.base_model_path,
+        "/data/cache/huggingface/Tongyi-MAI/Z-Image-Turbo"
+    );
+    assert_eq!(plan.dataset.dataset_id, "ds_abc123");
+    assert_eq!(plan.dataset.dataset_version, 3);
+    assert_eq!(plan.dataset.items.len(), 2);
+    // Item paths resolve under the dataset root with the host separator.
+    let mut expected_image = dataset_root.to_path_buf();
+    for component in Path::new("images/001.png").components() {
+        expected_image.push(component);
+    }
+    assert_eq!(
+        plan.dataset.items[0].image_path,
+        expected_image.display().to_string()
+    );
+    assert_eq!(plan.output.lora_id, "lora_new");
+    assert_eq!(plan.output.file_name, "aurora_style.safetensors");
+    assert_eq!(plan.output.trigger_words, vec!["auroraStyle".to_owned()]);
+    assert_eq!(plan.provenance.output_lora_id, "lora_new");
+    assert_eq!(plan.provenance.dataset_version, 3);
+}
+
+#[test]
+fn build_training_plan_omits_trigger_words_when_unset() {
+    let dataset = dataset_fixture();
+    let registry = builtin_training_targets();
+    let target = registry.targets.first().expect("a builtin target exists");
+
+    let plan = build_training_plan(BuildTrainingPlan {
+        job_id: "job_test",
+        target,
+        dataset: &dataset,
+        config: target.defaults.clone(),
+        lora_id: "lora_new",
+        base_model_path: "/data/models/z_image_turbo".to_owned(),
+        dataset_root: Path::new("/data/training/ds_abc123"),
+        output_dir: Path::new("/data/loras/lora_new"),
+        file_name: "aurora.safetensors".to_owned(),
+        created_at: "2026-05-21T00:00:00Z".to_owned(),
+    })
+    .expect("plan resolves");
+
+    assert!(plan.output.trigger_words.is_empty());
+}
+
+#[test]
+fn build_training_plan_rejects_empty_dataset() {
+    let mut dataset = dataset_fixture();
+    dataset.items.clear();
+    let registry = builtin_training_targets();
+    let target = registry.targets.first().expect("a builtin target exists");
+
+    let error = build_training_plan(BuildTrainingPlan {
+        job_id: "job_test",
+        target,
+        dataset: &dataset,
+        config: target.defaults.clone(),
+        lora_id: "lora_new",
+        base_model_path: "/data/models/z_image_turbo".to_owned(),
+        dataset_root: Path::new("/data/training/ds_abc123"),
+        output_dir: Path::new("/data/loras/lora_new"),
+        file_name: "aurora.safetensors".to_owned(),
+        created_at: "2026-05-21T00:00:00Z".to_owned(),
+    })
+    .expect_err("empty dataset is rejected");
+
+    assert_eq!(error, TrainingPlanError::EmptyDataset);
+}
+
+#[test]
+fn build_training_plan_rejects_invalid_config() {
+    let dataset = dataset_fixture();
+    let registry = builtin_training_targets();
+    let target = registry.targets.first().expect("a builtin target exists");
+    let mut config = target.defaults.clone();
+    config.rank = 0;
+
+    let error = build_training_plan(BuildTrainingPlan {
+        job_id: "job_test",
+        target,
+        dataset: &dataset,
+        config,
+        lora_id: "lora_new",
+        base_model_path: "/data/models/z_image_turbo".to_owned(),
+        dataset_root: Path::new("/data/training/ds_abc123"),
+        output_dir: Path::new("/data/loras/lora_new"),
+        file_name: "aurora.safetensors".to_owned(),
+        created_at: "2026-05-21T00:00:00Z".to_owned(),
+    })
+    .expect_err("zero rank is rejected");
+
+    assert!(matches!(error, TrainingPlanError::InvalidConfig(_)));
 }

--- a/tests/fixtures/rust_migration_contracts/job_protocol.json
+++ b/tests/fixtures/rust_migration_contracts/job_protocol.json
@@ -14,7 +14,8 @@
     "timeline_export",
     "model_download",
     "model_import",
-    "lora_import"
+    "lora_import",
+    "lora_train"
   ],
   "statuses": [
     "queued",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -950,6 +950,24 @@ def test_lora_train_dry_run_fails_on_unsupported_plan_version(monkeypatch):
     assert "version" in terminal["error"].lower()
 
 
+def test_lora_train_refuses_non_dry_run_job(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    api = _DryRunApi()
+    # Defense-in-depth: even if a non-dry-run job reaches the worker, it must not
+    # report success without producing weights (real execution is not implemented).
+    job = {
+        "id": "job-train-1",
+        "type": "lora_train",
+        "payload": {"dryRun": False, "plan": {"planVersion": 1, "dataset": {"items": []}}},
+    }
+
+    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), job)
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "failed"
+    assert "not available" in terminal["error"].lower()
+
+
 def test_main_check_exits_without_api_loop(monkeypatch):
     calls = []
     monkeypatch.setattr("scene_worker.runtime.run_check", lambda settings: calls.append(settings.worker_id))

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -47,6 +47,7 @@ from scene_worker.runtime import (
     main,
     resolve_loaded_models,
     run_check,
+    run_lora_train_dry_run_job,
     run_video_job,
     worker_capabilities,
 )
@@ -133,7 +134,24 @@ def test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs(monkeypatc
     monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: False)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu", "nvidia"]})
 
-    assert capabilities == ["gpu", "nvidia"]
+    # lora_train dry-run validation needs no inference backend, so it is
+    # advertised even without torch; generation job types are not.
+    assert capabilities == ["gpu", "lora_train", "nvidia"]
+    for job_type in ("image_generate", "image_edit", "video_generate"):
+        assert job_type not in capabilities
+
+
+def test_gpu_worker_advertises_lora_train_without_inference_backend(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: False)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+
+    assert "lora_train" in capabilities
+
+
+def test_cpu_worker_does_not_advertise_lora_train():
+    capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
+
+    assert "lora_train" not in capabilities
 
 
 def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
@@ -144,6 +162,7 @@ def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
     assert job_capabilities == [
         "image_edit",
         "image_generate",
+        "lora_train",
         "person_replace",
         "video_bridge",
         "video_extend",
@@ -837,6 +856,98 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         "person_replace",
     ]
     assert events[0]["supportedJobTypes"] == events[0]["jobTypes"]
+
+
+class _DryRunApi:
+    """Records job progress posts; heartbeats are accepted and ignored."""
+
+    def __init__(self):
+        self.progress = []
+
+    def post(self, path, payload):
+        if path.endswith("/heartbeat"):
+            return {}
+        if path.endswith("/progress"):
+            self.progress.append(payload)
+            return {"status": payload["status"], "stage": payload["stage"]}
+        raise AssertionError(path)
+
+
+def _lora_train_job(plan):
+    return {
+        "id": "job-train-1",
+        "type": "lora_train",
+        "payload": {"dryRun": True, "plan": plan},
+    }
+
+
+def test_lora_train_dry_run_completes_with_plan_summary(monkeypatch, tmp_path):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    image = tmp_path / "images" / "001.png"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"png")
+    api = _DryRunApi()
+    plan = {
+        "planVersion": 1,
+        "dataset": {
+            "datasetId": "ds_1",
+            "datasetVersion": 2,
+            "items": [{"imagePath": str(image), "caption": "auroraStyle portrait"}],
+        },
+        "target": {
+            "targetId": "z_image_turbo_lora",
+            "kernel": "z_image_lora",
+            "baseModelPath": str(tmp_path / "uninstalled-model"),
+        },
+        "output": {
+            "loraId": "lora_1",
+            "outputDir": str(tmp_path / "loras" / "lora_1"),
+            "fileName": "aurora.safetensors",
+        },
+    }
+
+    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "completed"
+    assert terminal["stage"] == "completed"
+    result = terminal["result"]
+    assert result["mode"] == "dry_run"
+    assert result["validated"] is True
+    assert result["datasetItemCount"] == 1
+    assert result["loraId"] == "lora_1"
+    assert result["fileName"] == "aurora.safetensors"
+    # The base model is not installed yet; the dry run records that without failing.
+    assert result["baseModelInstalled"] is False
+
+
+def test_lora_train_dry_run_fails_cleanly_on_missing_dataset_image(monkeypatch, tmp_path):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    api = _DryRunApi()
+    plan = {
+        "planVersion": 1,
+        "dataset": {"items": [{"imagePath": str(tmp_path / "missing.png"), "caption": "x"}]},
+        "target": {},
+        "output": {},
+    }
+
+    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "failed"
+    assert "missing" in terminal["error"].lower()
+
+
+def test_lora_train_dry_run_fails_on_unsupported_plan_version(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    api = _DryRunApi()
+    plan = {"planVersion": 999, "dataset": {"items": []}, "target": {}, "output": {}}
+
+    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "failed"
+    assert "version" in terminal["error"].lower()
 
 
 def test_main_check_exits_without_api_loop(monkeypatch):


### PR DESCRIPTION
## Summary

Implements [sc-1416](https://app.shortcut.com/trefry/story/1416) (Training 08 of epic [1408](https://app.shortcut.com/trefry/epic/1408)): make LoRA training a first-class **queued GPU job with a Rust-resolved dry-run plan**, before any real ML execution (which lands in story 09).

## What changed

- **Contracts** — `JobType::LoraTrain` + `WorkerCapability::LoraTrain` (`lora_train`).
- **Queue routing** — `LoraTrain` added to `job_requires_gpu()`, so training jobs route to GPU workers and reject `cpu`. Worker capability matching already keys off the job-type string. New `JobsStore::create_job_with_id` lets the API pre-allocate the job id so the resolved plan can embed its own `jobId`/`sourceJobId` and stay self-describing.
- **Plan resolver** — pure `build_training_plan(...)` in `sceneworks-core` normalizes a `LoraTrainingRequest` + dataset + registry target into the existing `TrainingPlan` contract, validating empty datasets and out-of-range config.
- **API** — `POST /api/v1/projects/:project_id/training/jobs` resolves the plan in Rust (absolute on-host paths, allocated LoRA id) and queues a `lora_train` job with the plan in the payload.
- **Worker stub** — Python `scene_worker` claims `lora_train`, validates the resolved plan and that its dataset images exist on the worker, and completes with a dry-run summary; fails cleanly on missing inputs. GPU workers advertise `lora_train` **independent of torch** so plan validation works before the training stack is installed.
- **Queue UI** — `lora_train` added to `gpuRequiredJobTypes` for correct "waiting for a GPU worker" messaging.

## Acceptance criteria

- ✅ Training jobs appear in the queue and respect GPU worker selection (cpu / no-capability workers can't claim — covered by tests).
- ✅ Dry-run jobs validate dataset/config and fail cleanly on missing inputs.
- ✅ Existing image/video/model/LoRA jobs are unaffected (full Rust + worker suites pass).

## Tests

`cargo test -p sceneworks-core -p sceneworks-rust-api` and `pytest tests/test_worker_runtime.py tests/test_worker_gpu.py` all pass; clippy clean. Added: jobs_store GPU-routing tests, plan-builder tests, two API endpoint tests, and worker capability/dry-run tests; updated the `job_protocol.json` contract fixture.

## Reviewer notes

- **Cross-platform:** `lora_train` is GPU-required per the story. On macOS the worker (no `nvidia-smi`) currently registers only a CPU worker, so the dry-run is claimable on Docker/NVIDIA today; MPS GPU-worker registration is a story-09 / cross-platform concern.
- The new endpoint is ready for the Train config UI (story 07) to call; wiring a "Start training" button was out of scope for this story (UI scope was Queue messaging only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)