### PR TITLE
Epic 1330 Phase 3: Windows packaging + validated happy path [sc-1356 sc-1358 sc-1359]

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -1,0 +1,56 @@
+name: Desktop (Windows)
+
+# Builds the Windows desktop installer (NSIS) on a real windows-latest runner.
+# This is the Windows build coverage for epic 1330 Phase 3 (sc-1356): the Linux
+# `parity` job (check.yml) excludes the Tauri desktop crate, so this job is the
+# only place the desktop bundle is compiled + packaged in CI. Path-filtered so it
+# only runs when desktop-relevant code changes; heavy (release build + NSIS).
+
+on:
+  pull_request:
+    paths: &desktop_paths
+      - "apps/desktop/**"
+      - "apps/web/**"
+      - "apps/rust-api/**"
+      - "apps/rust-worker/**"
+      - "apps/worker/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/desktop-windows.yml"
+  push:
+    branches:
+      - main
+    paths: *desktop_paths
+  workflow_dispatch:
+
+concurrency:
+  group: desktop-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install web dependencies
+        run: npm ci --prefix apps/web
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+      # `tauri build` runs the beforeBuildCommand (build-sidecar/fetch-uv/
+      # stage-python), then compiles the Tauri shell and packages the NSIS
+      # installer. --bundles nsis pins the release pipeline to NSIS (the .exe
+      # installer) and skips WiX/MSI. Output lands in the workspace target dir.
+      - name: Build Windows installer (NSIS)
+        run: npm --prefix apps/desktop run build -- --bundles nsis
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sceneworks-windows-nsis
+          path: target/release/bundle/nsis/*.exe
+          if-no-files-found: error

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -15,8 +15,16 @@ on:
       - "apps/rust-worker/**"
       - "apps/worker/**"
       - "crates/**"
+      # Also bundled into the installer: sceneworks_shared (staged by
+      # stage-python.mjs) and the builtin model catalog (embedded via
+      # include_str! in setup.rs). Changes here can break the packaged app, so
+      # they must trigger the only job that compiles + packages the desktop.
+      - "packages/shared/**"
+      - "config/manifests/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      # Root build script (api:build:embedded) driven by build-sidecar.mjs.
+      - "package.json"
       - ".github/workflows/desktop-windows.yml"
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -179,3 +179,28 @@ data/
   cache/     Runtime cache
 docker/      Service Dockerfiles
 ```
+
+## Desktop App (Tauri)
+
+`apps/desktop` packages SceneWorks as a standalone desktop app (no Docker). It
+bundles the Rust API, the Python worker source (`scene_worker` +
+`sceneworks_shared`), the builtin model/LoRA manifests, and a pinned `uv`. On
+first run it provisions a CUDA-enabled Python venv under the per-user app data
+dir (`%APPDATA%\SceneWorks` on Windows), then starts the API + worker. Build the
+Windows installer (NSIS) with:
+
+```powershell
+npm --prefix apps/desktop run build -- --bundles nsis
+```
+
+First-run installs CUDA torch wheels from `cu128` by default (override with
+`SCENEWORKS_PYTORCH_INDEX_URL`). Blackwell (sm_120) requires `cu128`; older
+`cu121` wheels will not run on it.
+
+### Windows GPU support
+
+| Tier | GPU | Status | Notes |
+| --- | --- | --- | --- |
+| High-end | NVIDIA RTX PRO 6000 Blackwell (96 GB) | ✅ Validated | torch 2.8 `cu128`; Qwen image (~36 s incl. load), native LTX-2.3 text-to-video (~80 s for a 2 s clip), and timeline export verified end-to-end |
+| Other CUDA | RTX 30/40-series, etc. | ⏳ Untested | Expected to work via the `cu128` wheels with a recent driver; not yet validated |
+| CPU-only | — | ⚠️ Limited | No GPU inference; image/video generation unavailable |

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -2,7 +2,7 @@
 // Builds the sceneworks-rust-api binary (with the embedded web UI) and stages it
 // as a Tauri sidecar named for the host target triple. Wired as the
 // tauri.conf.json `beforeBuildCommand` so `tauri build` is self-contained.
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { copyFileSync, mkdirSync, chmodSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -2,7 +2,7 @@
 // Builds the sceneworks-rust-api binary (with the embedded web UI) and stages it
 // as a Tauri sidecar named for the host target triple. Wired as the
 // tauri.conf.json `beforeBuildCommand` so `tauri build` is self-contained.
-import { execFileSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { copyFileSync, mkdirSync, chmodSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,8 +14,9 @@ const repoRoot = resolve(desktopDir, "..", ".."); // repository root
 const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function run(cmd, args, extraEnv = {}) {
-  console.log(`> ${cmd} ${args.join(" ")}`);
-  execFileSync(cmd, args, {
+  const cmdStr = `${cmd} ${args.join(" ")}`;
+  console.log(`> ${cmdStr}`);
+  execSync(cmdStr, {
     stdio: "inherit",
     cwd: repoRoot,
     env: { ...process.env, ...extraEnv },

--- a/apps/desktop/scripts/stage-python.mjs
+++ b/apps/desktop/scripts/stage-python.mjs
@@ -27,4 +27,17 @@ cpSync(join(workerDir, "scene_worker"), join(outDir, "scene_worker"), {
   filter: (src) => !src.includes("__pycache__") && !src.endsWith(".pyc"),
 });
 
+// Copy the sceneworks_shared package alongside scene_worker. scene_worker
+// imports it at startup (image_adapters/video_adapters); in Docker it's provided
+// via PYTHONPATH=/app/packages/shared. Bundling it into python-src keeps the
+// packaged worker importable (setup.rs also puts python-src on PYTHONPATH).
+cpSync(
+  join(repoRoot, "packages", "shared", "sceneworks_shared"),
+  join(outDir, "sceneworks_shared"),
+  {
+    recursive: true,
+    filter: (src) => !src.includes("__pycache__") && !src.endsWith(".pyc"),
+  },
+);
+
 console.log(`stage-python: staged worker source into ${outDir}`);

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -17,7 +17,7 @@ use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 
 /// Bump to force a re-provision even if requirements.txt is unchanged.
-const SETUP_VERSION: &str = "1";
+const SETUP_VERSION: &str = "2";
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Process handles + run guards shared across the app.
@@ -145,12 +145,64 @@ fn requirements_path(app: &AppHandle) -> PathBuf {
         .join("requirements.txt")
 }
 
+/// requirements-ltx.txt location (native LTX pipelines deps): the bundled
+/// resource in a packaged app, or the repo copy during development. Optional —
+/// absent in older worker checkouts, in which case LTX video is unavailable.
+fn requirements_ltx_path(app: &AppHandle) -> PathBuf {
+    if let Ok(resources) = app.path().resource_dir() {
+        let bundled = resources.join("python-src").join("requirements-ltx.txt");
+        if bundled.exists() {
+            return bundled;
+        }
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("worker")
+        .join("requirements-ltx.txt")
+}
+
 fn data_dir() -> PathBuf {
     app_support_dir().join("data")
 }
 
 fn config_dir() -> PathBuf {
     app_support_dir().join("config")
+}
+
+/// Builtin model/LoRA/recipe-preset catalogs the rust-api reads from
+/// `config_dir/manifests`. In the server stack these ship in the repo's
+/// `config/`, but the desktop must provide them itself or Model Manager is empty
+/// and the native LTX/Wan adapters can't map model resources to files. Embedded
+/// at compile time from the canonical repo copies.
+const BUILTIN_MANIFESTS: &[(&str, &str)] = &[
+    (
+        "builtin.models.jsonc",
+        include_str!("../../../config/manifests/builtin.models.jsonc"),
+    ),
+    (
+        "builtin.loras.jsonc",
+        include_str!("../../../config/manifests/builtin.loras.jsonc"),
+    ),
+    (
+        "builtin.recipe-presets.jsonc",
+        include_str!("../../../config/manifests/builtin.recipe-presets.jsonc"),
+    ),
+];
+
+/// Write the builtin manifests into `config_dir/manifests`, overwriting on every
+/// launch so they track the app version. User customizations live in the
+/// separate `user.*.jsonc` files, which this never touches.
+fn seed_builtin_manifests() {
+    let dir = config_dir().join("manifests");
+    if let Err(error) = std::fs::create_dir_all(&dir) {
+        eprintln!("[desktop] seed manifests: create dir failed: {error}");
+        return;
+    }
+    for (name, contents) in BUILTIN_MANIFESTS {
+        if let Err(error) = std::fs::write(dir.join(name), contents) {
+            eprintln!("[desktop] seed manifests: write {name} failed: {error}");
+        }
+    }
 }
 
 /// Data directory: the settings override if set, otherwise the platform default.
@@ -173,6 +225,24 @@ fn worker_src_dir(app: &AppHandle) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("worker")
+}
+
+/// Directory to add to PYTHONPATH so the worker can import `sceneworks_shared`
+/// (scene_worker depends on it at startup). Bundled: it's staged into python-src
+/// alongside scene_worker. Development: it lives in the repo's packages/shared.
+/// Mirrors the Docker worker's `PYTHONPATH=...:/app/packages/shared`.
+fn shared_parent_dir(app: &AppHandle) -> PathBuf {
+    if let Ok(resources) = app.path().resource_dir() {
+        let bundled = resources.join("python-src");
+        if bundled.join("sceneworks_shared").exists() {
+            return bundled;
+        }
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("packages")
+        .join("shared")
 }
 
 fn append_log(path: &Path, line: &str) {
@@ -263,6 +333,33 @@ async fn run_uv(app: &AppHandle, args: Vec<String>) -> Result<(), String> {
     }
 }
 
+/// Build `uv pip install -r <req>…` args for the given requirement files. On
+/// Windows it adds the CUDA extra index so torch/torchaudio resolve to CUDA
+/// wheels (other packages still come from PyPI); macOS torch wheels include MPS
+/// by default. All requirement files are installed in one pass so torch and its
+/// companions (e.g. torchaudio) resolve to a single, ABI-compatible version set.
+fn pip_install_args(python: &Path, requirement_files: &[PathBuf]) -> Vec<String> {
+    #[cfg_attr(not(target_os = "windows"), allow(unused_mut))]
+    let mut args = vec![
+        "pip".to_owned(),
+        "install".to_owned(),
+        "--python".to_owned(),
+        python.to_string_lossy().into_owned(),
+    ];
+    for requirements in requirement_files {
+        args.push("-r".to_owned());
+        args.push(requirements.to_string_lossy().into_owned());
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let index = std::env::var("SCENEWORKS_PYTORCH_INDEX_URL")
+            .unwrap_or_else(|_| "https://download.pytorch.org/whl/cu128".to_owned());
+        args.push("--extra-index-url".to_owned());
+        args.push(index);
+    }
+    args
+}
+
 /// Provision the venv if missing or stale (requirements / setup version changed).
 async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     let venv = venv_dir();
@@ -270,8 +367,12 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     let requirements = requirements_path(app);
     let requirements_body = std::fs::read_to_string(&requirements)
         .map_err(|error| format!("read requirements: {error}"))?;
+    // Native LTX pipelines deps (ltx-core/ltx-pipelines + a torch-matched
+    // torchaudio). Optional: absent in older worker checkouts.
+    let requirements_ltx = requirements_ltx_path(app);
+    let requirements_ltx_body = std::fs::read_to_string(&requirements_ltx).unwrap_or_default();
     let marker = marker_path();
-    let expected = format!("v{SETUP_VERSION}\n{requirements_body}");
+    let expected = format!("v{SETUP_VERSION}\n{requirements_body}\n# ltx\n{requirements_ltx_body}");
 
     if python.exists() {
         if let Ok(found) = std::fs::read_to_string(&marker) {
@@ -304,35 +405,54 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
         "Installing dependencies — this can take several minutes on first run…",
         false,
     );
-    // `args` is only mutated on Windows (CUDA index); keep `mut` for that path.
-    #[cfg_attr(not(target_os = "windows"), allow(unused_mut))]
-    let mut args = vec![
-        "pip".to_owned(),
-        "install".to_owned(),
-        "--python".to_owned(),
-        python.to_string_lossy().into_owned(),
-        "-r".to_owned(),
-        requirements.to_string_lossy().into_owned(),
-    ];
-    // Windows: pull CUDA-enabled torch wheels; other packages still resolve from
-    // PyPI via the default index. macOS torch wheels include MPS by default.
-    #[cfg(target_os = "windows")]
-    {
-        let index = std::env::var("SCENEWORKS_PYTORCH_INDEX_URL")
-            .unwrap_or_else(|_| "https://download.pytorch.org/whl/cu128".to_owned());
-        args.push("--extra-index-url".to_owned());
-        args.push(index);
+    // Install the base requirements together with the LTX pipelines deps (when
+    // bundled) in a single resolution pass: a separate LTX pass pulls a newer
+    // torchaudio whose native extension fails to load against the pinned torch.
+    let mut requirement_files = vec![requirements.clone()];
+    if requirements_ltx.exists() {
+        requirement_files.push(requirements_ltx.clone());
     }
-    run_uv(app, args).await?;
+    run_uv(app, pip_install_args(&python, &requirement_files)).await?;
 
     std::fs::write(&marker, &expected).map_err(|error| format!("write marker: {error}"))?;
     emit(app, "ready", "Python environment ready.", false);
     Ok(())
 }
 
+/// Resolve the ffmpeg binary bundled with the venv's imageio-ffmpeg, used by the
+/// API's in-process utility worker for timeline export / frame extraction. The
+/// desktop ships no system ffmpeg, so without this those jobs fail. Returns None
+/// if the venv or imageio-ffmpeg isn't available yet.
+fn resolve_bundled_ffmpeg() -> Option<String> {
+    let python = venv_python(&venv_dir());
+    if !python.exists() {
+        return None;
+    }
+    let mut command = std::process::Command::new(&python);
+    command.args([
+        "-c",
+        "import imageio_ffmpeg,sys; sys.stdout.write(imageio_ffmpeg.get_ffmpeg_exe())",
+    ]);
+    // Don't flash a console window when probing from the GUI app.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if path.is_empty() || !Path::new(&path).exists() {
+        return None;
+    }
+    Some(path)
+}
+
 /// Spawn the API sidecar, pipe its output to api.log, and return the chosen port.
 fn spawn_api(app: &AppHandle) -> Result<(), String> {
-    let (mut events, child) = app
+    let mut command = app
         .shell()
         .sidecar("sceneworks-api")
         .map_err(|error| format!("locate api: {error}"))?
@@ -350,7 +470,13 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         .env(
             "SCENEWORKS_CONFIG_DIR",
             config_dir().to_string_lossy().to_string(),
-        )
+        );
+    // The in-process utility worker shells out to ffmpeg; point it at the venv's
+    // bundled binary since the desktop has no system ffmpeg on PATH.
+    if let Some(ffmpeg) = resolve_bundled_ffmpeg() {
+        command = command.env("SCENEWORKS_FFMPEG", ffmpeg);
+    }
+    let (mut events, child) = command
         .spawn()
         .map_err(|error| format!("spawn api: {error}"))?;
     app.state::<Managed>()
@@ -438,6 +564,17 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
         let log_path = logs_dir().join("worker.log");
         let python = venv_python(&venv_dir());
         let src = worker_src_dir(&app);
+        // Ensure the worker can import sceneworks_shared (staged into python-src
+        // when bundled, or packages/shared in dev). Mirrors the Docker worker's
+        // PYTHONPATH; `-m` already adds the cwd but we set it explicitly so the
+        // dev (unbundled) path resolves too.
+        let path_sep = if cfg!(windows) { ";" } else { ":" };
+        let pythonpath = format!(
+            "{}{}{}",
+            src.to_string_lossy(),
+            path_sep,
+            shared_parent_dir(&app).to_string_lossy()
+        );
         let api_url = format!("http://127.0.0.1:{api_port}");
         let mut backoff = 1u64;
         loop {
@@ -456,6 +593,7 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
                 .command(python.to_string_lossy().to_string())
                 .args(["-m", "scene_worker"])
                 .current_dir(&src)
+                .env("PYTHONPATH", &pythonpath)
                 .env("SCENEWORKS_API_URL", &api_url)
                 .env(
                     "SCENEWORKS_DATA_DIR",
@@ -590,6 +728,9 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
 }
 
 async fn run_startup(app: AppHandle) {
+    // Provide the builtin model catalog the rust-api/worker expect before they
+    // start, so Model Manager is populated and native video resources resolve.
+    seed_builtin_manifests();
     if let Err(error) = provision_venv(&app).await {
         emit(&app, "error", format!("Setup failed: {error}"), true);
         return;

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -191,18 +191,23 @@ const BUILTIN_MANIFESTS: &[(&str, &str)] = &[
 
 /// Write the builtin manifests into `config_dir/manifests`, overwriting on every
 /// launch so they track the app version. User customizations live in the
-/// separate `user.*.jsonc` files, which this never touches.
-fn seed_builtin_manifests() {
+/// separate `user.*.jsonc` files, which this never touches. Each file is written
+/// atomically (temp + rename) so a crash or partial write can't leave a
+/// truncated manifest that parses to an empty/broken catalog. Returns an error
+/// if any required manifest can't be installed — the catalog is mandatory, so
+/// the caller aborts setup rather than starting with missing model mappings.
+fn seed_builtin_manifests() -> Result<(), String> {
     let dir = config_dir().join("manifests");
-    if let Err(error) = std::fs::create_dir_all(&dir) {
-        eprintln!("[desktop] seed manifests: create dir failed: {error}");
-        return;
-    }
+    std::fs::create_dir_all(&dir).map_err(|error| format!("create manifests dir: {error}"))?;
     for (name, contents) in BUILTIN_MANIFESTS {
-        if let Err(error) = std::fs::write(dir.join(name), contents) {
-            eprintln!("[desktop] seed manifests: write {name} failed: {error}");
-        }
+        let temp = dir.join(format!("{name}.tmp"));
+        std::fs::write(&temp, contents).map_err(|error| format!("write {name}: {error}"))?;
+        std::fs::rename(&temp, dir.join(name)).map_err(|error| {
+            let _ = std::fs::remove_file(&temp);
+            format!("install {name}: {error}")
+        })?;
     }
+    Ok(())
 }
 
 /// Data directory: the settings override if set, otherwise the platform default.
@@ -730,7 +735,11 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
 async fn run_startup(app: AppHandle) {
     // Provide the builtin model catalog the rust-api/worker expect before they
     // start, so Model Manager is populated and native video resources resolve.
-    seed_builtin_manifests();
+    // Mandatory: abort (rather than start a half-working app) if it can't be written.
+    if let Err(error) = seed_builtin_manifests() {
+        emit(&app, "error", format!("Setup failed: {error}"), true);
+        return;
+    }
     if let Err(error) = provision_venv(&app).await {
         emit(&app, "error", format!("Setup failed: {error}"), true);
         return;

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -38,6 +38,17 @@
     ],
     "macOS": {
       "minimumSystemVersion": "11.0"
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper",
+        "silent": true
+      },
+      "nsis": {
+        "installMode": "both",
+        "displayLanguageSelector": false,
+        "languages": ["English"]
+      }
     }
   }
 }

--- a/apps/worker/requirements-ltx.txt
+++ b/apps/worker/requirements-ltx.txt
@@ -1,4 +1,10 @@
 # Native LTX-2.3 dependencies for SCENEWORKS_VIDEO_ADAPTER=ltx_pipelines.
 # Pinned to the official Lightricks/LTX-2 HEAD inspected on 2026-05-19.
+# torchaudio is a transitive ltx-core dep; pin it to the torch range
+# (requirements.txt: torch>=2.8,<2.9) so its native extension is ABI-compatible.
+# Unconstrained, the resolver pulls the latest torchaudio (e.g. 2.11) against the
+# pinned torch 2.8 and the worker fails to load it (Windows: WinError 127). Mirrors
+# the Docker worker's PYTORCH_AUDIO_SPEC.
+torchaudio>=2.8,<2.9
 ltx-core @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-core
 ltx-pipelines @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-pipelines

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -4132,7 +4132,15 @@ async fn run_ffmpeg(args: Vec<String>, context: Option<FfmpegContext<'_>>) -> Wo
             "FFmpeg command is empty.".to_owned(),
         ));
     };
-    let mut child = Command::new(program)
+    // Let the host override the default ffmpeg binary via SCENEWORKS_FFMPEG. The
+    // desktop app sets this to the venv's bundled imageio-ffmpeg (it ships no
+    // system ffmpeg); the server stack / Docker leave it unset and use the
+    // caller's "ffmpeg" on PATH.
+    let resolved_program = match std::env::var("SCENEWORKS_FFMPEG") {
+        Ok(path) if program.as_str() == "ffmpeg" && !path.trim().is_empty() => path,
+        _ => program.clone(),
+    };
+    let mut child = Command::new(&resolved_program)
         .args(arguments)
         .stdout(Stdio::null())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary

Phase 3 (Windows packaging + release) of epic 1330.

### sc-1356 — Configure Tauri Windows build with WebView2 + NSIS installer ✅
- `tauri.conf.json` `bundle.windows`:
  - `webviewInstallMode: downloadBootstrapper` (silent) — installer detects
    WebView2 and downloads the bootstrapper if absent.
  - NSIS `installMode: "both"` — per-user install by default, optional all-users.
- New `.github/workflows/desktop-windows.yml`: `windows-latest` job runs
  `tauri build --bundles nsis`, producing + validating the versioned NSIS `.exe`
  installer on a real Windows runner. First CI coverage of the desktop bundle.

### Windows validation session (Blackwell host) — sc-1358 + sc-1359

Ran the installed app end-to-end on an **NVIDIA RTX PRO 6000 Blackwell (96 GB,
sm_120, driver 596.36)**. This surfaced four desktop-bundle defects that broke
the packaged generation happy path — all platform-independent (the bundled
worker had never been run end-to-end before). Fixed in this PR:

1. **Worker crashed at startup** — `scene_worker` imports `sceneworks_shared`,
   which `stage-python.mjs` never bundled (Docker provides it via
   `PYTHONPATH=…/packages/shared`). Now staged into `python-src` + added to the
   worker `PYTHONPATH` in `setup.rs`.
2. **LTX video deps** — installing `requirements-ltx.txt` in a separate pass
   pulled `torchaudio 2.11` against the pinned `torch 2.8` → `OSError [WinError
   127]` loading the native extension. Pin `torchaudio>=2.8,<2.9` and install
   base + LTX requirements in a single `uv` resolution pass at first run.
3. **Empty model catalog** — the desktop never provided `config/manifests`, so
   the native LTX/Wan adapters couldn't map model resources to files. Embed
   `builtin.*.jsonc` via `include_str!` and seed them into
   `config_dir/manifests` on startup.
4. **Timeline export** — the Rust utility worker shells out to `ffmpeg`, absent
   on the desktop. Added a `SCENEWORKS_FFMPEG` override to `sceneworks-worker`
   (default unchanged, so Docker is unaffected) and the desktop points it at the
   venv's bundled `imageio-ffmpeg`.

**Validated out-of-box after the fixes** (signed `.exe` not used — unsigned NSIS):
install → first-run venv (`torch 2.8.0+cu128`, `torch.cuda.is_available()`
True, both Blackwell GPUs registered) → **Qwen image** (~36 s incl. model load)
→ **native LTX-2.3 text-to-video** (~80 s for a 2 s 768×512 clip) → **timeline
export** (1280×720 MP4) → clean shutdown (app + API + worker tear down).

`cu128` is correct for Blackwell — torch's arch list includes `sm_120`; the
`cu121` wheels the sc-1358 description guessed at would not run.

### Remaining Phase 3 work
- **sc-1357** Authenticode signing — still blocked (no code-signing cert
  available). The unsigned NSIS installer is validated.
- **sc-1359** — only the high-end Blackwell tier was validated on this host; a
  second (mid-range) tier is still wanted.
- **sc-1360** Ship Windows release — gated on signing + a second tier.

## Test plan
- [x] `desktop-windows` CI builds the NSIS installer green (sc-1356).
- [x] Install on Windows, first-run reaches a working CUDA venv + API + worker (sc-1358).
- [x] Qwen image + native LTX-2.3 video + timeline export complete end-to-end on Blackwell (sc-1359, high-end tier).
- [ ] Second GPU tier (mid-range) validation (sc-1359).
- [ ] Signed installer (sc-1357) + clean-VM WebView2 bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
