### PR TITLE
[Training 09] Implement narrow Python Z-Image LoRA training kernel [sc-1417]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1370,14 +1370,10 @@ async fn create_training_job(
     Path(project_id): Path<String>,
     ApiJson(payload): ApiJson<LoraTrainingRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
-    // Only dry-run plan validation exists today; refuse to queue a job that would
-    // complete without producing weights (real execution arrives in story 1417).
-    if !payload.dry_run {
-        return Err(ApiError::bad_request(
-            "Real LoRA training is not available yet. Submit with \"dryRun\": true to validate the training plan.",
-        ));
-    }
-
+    // Both dry-run plan validation and real execution exist (story 1417). A
+    // dry-run resolves and validates the plan without producing weights; a real
+    // run hands the same plan to the worker's Z-Image LoRA kernel.
+    //
     // Targets come from the Rust-owned registry; the request only names one.
     let registry = builtin_training_targets();
     let target = registry
@@ -7863,7 +7859,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_training_job_rejects_non_dry_run_until_execution_exists() {
+    async fn create_training_job_queues_real_run_when_not_dry_run() {
         let temp_dir = tempfile::tempdir().expect("temp dir creates");
         let app = create_app(test_settings(&temp_dir)).expect("app creates");
         let (_, project) = request(
@@ -7874,31 +7870,59 @@ mod tests {
         )
         .await;
         let project_id = project["id"].as_str().expect("project id").to_owned();
+
+        let (_, asset) = request_multipart_upload(
+            app.clone(),
+            &format!("/api/v1/projects/{project_id}/assets"),
+            "Portrait.PNG",
+            "image/png",
+            b"png-bytes",
+        )
+        .await;
+        let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+
+        let (_, dataset) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/projects/{project_id}/training/datasets"),
+            json!({
+                "name": "Aurora set",
+                "items": [{ "assetId": asset_id, "caption": { "text": "auroraStyle portrait" } }]
+            }),
+        )
+        .await;
+        let dataset_id = dataset["id"].as_str().expect("dataset id").to_owned();
+
         let (_, registry) =
             request(app.clone(), "GET", "/api/v1/training/targets", Value::Null).await;
-        let target_id = registry["targets"][0]["id"].as_str().unwrap().to_owned();
+        let target = registry["targets"][0].clone();
+        let target_id = target["id"].as_str().expect("target id").to_owned();
+        let config = target["defaults"].clone();
 
-        // dryRun:false must be refused before any job is queued — real training
-        // execution does not exist yet, so a "completed" job would be a false success.
-        let (status, error) = request(
+        // Real execution exists (story 1417): a non-dry-run job resolves the same
+        // plan and queues for the worker's Z-Image LoRA kernel.
+        let (status, job) = request(
             app.clone(),
             "POST",
             &format!("/api/v1/projects/{project_id}/training/jobs"),
             json!({
                 "targetId": target_id,
-                "datasetId": "ds_missing",
-                "config": registry["targets"][0]["defaults"].clone(),
-                "outputName": "Aurora",
+                "datasetId": dataset_id,
+                "config": config,
+                "outputName": "Aurora Style",
                 "dryRun": false
             }),
         )
         .await;
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert!(error["detail"]
-            .as_str()
-            .unwrap()
-            .contains("Real LoRA training is not available yet"));
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(job["type"], "lora_train");
+        assert_eq!(job["status"], "queued");
+        assert_eq!(job["payload"]["dryRun"], false);
+        // The plan is resolved and embedded just like the dry-run path.
+        assert_eq!(job["payload"]["plan"]["planVersion"], 1);
+        assert_eq!(job["payload"]["plan"]["target"]["kernel"], "z_image_lora");
 
+        let job_id = job["id"].as_str().expect("job id").to_owned();
         let (status, queued) = request(
             app.clone(),
             "GET",
@@ -7907,7 +7931,8 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(queued.as_array().expect("jobs list").len(), 0);
+        assert_eq!(queued[0]["id"], job_id);
+        assert_eq!(queued[0]["type"], "lora_train");
     }
 
     #[tokio::test]

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -275,7 +275,7 @@ describe("SceneWorks app shell", () => {
     });
 
     expect(container.querySelector("#training-tab-configure").getAttribute("aria-selected")).toBe("true");
-    expect(container.textContent).toContain("Queuing a dry run validates");
+    expect(container.textContent).toContain("A dry run validates the Rust-resolved training plan");
   });
 
   it("creates a training dataset from selected image assets", async () => {
@@ -683,6 +683,63 @@ describe("SceneWorks app shell", () => {
       }),
     );
     expect(container.textContent).toContain("Queued dry-run job job_dryrun_1");
+  });
+
+  it("queues a real training job when run mode is set to training", async () => {
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-a",
+      name: "Portrait Set",
+      version: 5,
+      items: [
+        {
+          id: "item_0001",
+          assetId: "asset-a",
+          path: "images/item_0001.png",
+          displayName: "item_0001.png",
+          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+        },
+      ],
+    }));
+    const createTrainingJob = vi.fn(async () => ({ id: "job_train_1", type: "lora_train", status: "queued" }));
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <TrainingStudio
+          activeProject={{ id: "project-a", name: "Project A" }}
+          createTrainingJob={createTrainingJob}
+          datasets={[{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }]}
+          gpuOptions={["auto", "0"]}
+          loadDataset={loadDataset}
+          trainingTargets={[zImageTrainingTarget]}
+        />,
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector("#training-tab-configure").click();
+    });
+    await changeField(field(container, "Dataset"), "dataset-a");
+    await settle();
+    await changeField(field(container, "Trigger phrase"), "miraStyle");
+    await changeField(field(container, "Run mode"), "real");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Start training").click();
+    });
+    await settle();
+
+    expect(createTrainingJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetId: "z_image_turbo_lora",
+        datasetId: "dataset-a",
+        outputName: "Portrait Set LoRA",
+        dryRun: false,
+        config: expect.objectContaining({ rank: 16, triggerWord: "miraStyle" }),
+      }),
+    );
+    expect(container.textContent).toContain("Queued training job job_train_1");
   });
 
   it("keeps config edits when GPU options are recomputed", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -241,7 +241,7 @@ function outputKindLabel(target) {
   return kind.replaceAll("_", " ");
 }
 
-function trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget }) {
+function trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget, dryRun = true }) {
   const defaults = selectedTarget?.defaults ?? {};
   const advanced = compactObject({
     ...(defaults.advanced ?? {}),
@@ -260,7 +260,7 @@ function trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget }) 
     datasetId: activeDataset.id,
     datasetVersion: activeDataset.version,
     outputName: configDraft.outputName.trim(),
-    dryRun: true,
+    dryRun,
     outputScope: configDraft.outputScope,
     qualityPreset: configDraft.qualityPreset,
     requestedGpu: configDraft.requestedGpu,
@@ -346,6 +346,9 @@ export function TrainingStudio({
   const [configError, setConfigError] = useState("");
   const [preparingConfig, setPreparingConfig] = useState(false);
   const [submittingJob, setSubmittingJob] = useState(false);
+  // Dry run validates the Rust-resolved plan without training; a real run hands
+  // the plan to the worker's Z-Image LoRA kernel. Default to the safe dry run.
+  const [trainingRunMode, setTrainingRunMode] = useState("dry_run");
   const configBasisRef = useRef("");
   const tabRefs = useRef({});
 
@@ -658,7 +661,8 @@ export function TrainingStudio({
     setConfigError("");
     setConfigMessage("");
     try {
-      const snapshot = trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget });
+      const dryRun = trainingRunMode === "dry_run";
+      const snapshot = trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget, dryRun });
       const result = await prepareTrainingConfig(snapshot);
       setConfigSnapshot(result ?? snapshot);
       setConfigMessage("Config snapshot ready");
@@ -677,17 +681,19 @@ export function TrainingStudio({
     setConfigError("");
     setConfigMessage("");
     try {
-      const snapshot = trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget });
+      const dryRun = trainingRunMode === "dry_run";
+      const snapshot = trainingConfigSnapshot({ activeDataset, configDraft, selectedTarget, dryRun });
       const job = await createTrainingJob({
         targetId: snapshot.targetId,
         datasetId: snapshot.datasetId,
         datasetVersion: snapshot.datasetVersion,
         outputName: snapshot.outputName,
-        dryRun: true,
+        dryRun,
         config: snapshot.config,
       });
       setConfigSnapshot(snapshot);
-      setConfigMessage(`Queued dry-run job ${job?.id ?? ""}`.trim() + ". Track it in the Queue.");
+      const label = dryRun ? "dry-run" : "training";
+      setConfigMessage(`Queued ${label} job ${job?.id ?? ""}`.trim() + ". Track it in the Queue.");
     } catch (err) {
       setConfigError(err.message);
     } finally {
@@ -1196,6 +1202,18 @@ export function TrainingStudio({
                       ) : null}
 
                       <div className="training-config-actions">
+                        <label className="training-run-mode">
+                          <span>Run mode</span>
+                          <select
+                            aria-label="Training run mode"
+                            disabled={submittingJob}
+                            onChange={(event) => setTrainingRunMode(event.target.value)}
+                            value={trainingRunMode}
+                          >
+                            <option value="dry_run">Validate (dry run)</option>
+                            <option value="real">Run training (beta)</option>
+                          </select>
+                        </label>
                         <button className="secondary-action" onClick={resetConfigDefaults} type="button">
                           Reset defaults
                         </button>
@@ -1208,15 +1226,19 @@ export function TrainingStudio({
                           onClick={submitTrainingJob}
                           type="button"
                         >
-                          {submittingJob ? "Queuing" : "Queue dry-run job"}
+                          {submittingJob
+                            ? "Queuing"
+                            : trainingRunMode === "dry_run"
+                              ? "Queue dry-run job"
+                              : "Start training"}
                         </button>
                       </div>
                       {configSnapshot ? <pre className="training-config-snapshot">{JSON.stringify(configSnapshot, null, 2)}</pre> : null}
                     </div>
                   )}
                   <p className="view-copy">
-                    Queuing a dry run validates the Rust-resolved training plan and dataset on a GPU worker without training; real
-                    training execution arrives in a later story.
+                    A dry run validates the Rust-resolved training plan and dataset on a GPU worker without training. Run training
+                    (beta) hands the same plan to the worker's Z-Image LoRA kernel to produce a real .safetensors adapter.
                   </p>
                 </>
               ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1800,6 +1800,19 @@ label {
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 8px;
+  align-items: flex-end;
+}
+
+.training-run-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-right: auto;
+  font-size: 0.78rem;
+}
+
+.training-run-mode > span {
+  color: var(--text-muted, #94a3b8);
 }
 
 .training-config-snapshot {

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -60,8 +60,9 @@ SceneWorks storage, config defaults, or the target registry directly.
   (:class:`ZImageLoraTrainer`), an image LoRA trainer for Z-Image-Turbo. It loads
   the diffusers `ZImagePipeline` components (transformer, VAE, Qwen3 text encoder)
   via `from_pretrained`, attaches a PEFT LoRA to the transformer, caches per-item
-  latents and prompt embeddings, runs a flow-matching loop (velocity target
-  `noise - latents`, timestep `(1000 - t) / 1000`), and writes a `.safetensors`
+  latents and prompt embeddings, runs a flow-matching loop (the raw transformer-output
+  target is `latents - noise` — the negated velocity, since the pipeline negates the
+  output before the scheduler — at timestep `(1000 - t) / 1000`), and writes a `.safetensors`
   adapter with `ZImagePipeline.save_lora_weights`. It reports preparing,
   loading, caching, training, checkpointing (every `saveEvery` steps), and saving
   stages, and honors cancellation between steps. A real run requires the

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -44,6 +44,39 @@ override them through matching advanced settings.
 Use `advanced.mockNativeInference=true` only for adapter smoke tests; otherwise
 the native adapter loads `ltx-pipelines` and writes MP4 video assets.
 
+## Native LoRA training (`lora_train`)
+
+Training jobs carry a fully normalized, Rust-resolved `TrainingPlan` (see
+`crates/sceneworks-core/src/training.rs`). The worker's kernels in
+`scene_worker/training_adapters.py` consume only that plan — they never read
+SceneWorks storage, config defaults, or the target registry directly.
+
+- **Dry run** (`payload.dryRun == true`, the default) validates the plan and that
+  its dataset images exist on the worker, then reports what a real run would
+  produce. It loads no model and needs no inference backend, so a GPU worker
+  advertises `lora_train` even without torch/CUDA.
+- **Real run** (`payload.dryRun == false`) routes to the kernel named by
+  `plan.target.kernel`. The first kernel is `z_image_lora`
+  (:class:`ZImageLoraTrainer`), an image LoRA trainer for Z-Image-Turbo. It loads
+  the diffusers `ZImagePipeline` components (transformer, VAE, Qwen3 text encoder)
+  via `from_pretrained`, attaches a PEFT LoRA to the transformer, caches per-item
+  latents and prompt embeddings, runs a flow-matching loop (velocity target
+  `noise - latents`, timestep `(1000 - t) / 1000`), and writes a `.safetensors`
+  adapter with `ZImagePipeline.save_lora_weights`. It reports preparing,
+  loading, caching, training, checkpointing (every `saveEvery` steps), and saving
+  stages, and honors cancellation between steps. A real run requires the
+  inference backend; the kernel reports clearly when it is missing.
+
+Registering the produced adapter as a usable SceneWorks LoRA (with provenance and
+Image Studio compatibility) is a separate step (story 1418); this kernel produces
+the weights file and a result summary.
+
+Training reuses the runtime dependencies in `requirements.txt` (torch, diffusers,
+transformers, peft, accelerate, safetensors). The `adamw8bit` optimizer uses
+`bitsandbytes` when present and falls back to torch AdamW otherwise. Override
+PEFT target modules per job via `config.advanced.loraTargetModules` when a base
+model names its attention layers differently.
+
 Use a local smoke check without contacting the API:
 
 ```powershell

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -16,6 +16,12 @@ import httpx
 from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_utilization, gpu_worker_id
 from .image_adapters import ProceduralImageAdapter, QwenImageAdapter, ZImageDiffusersAdapter, create_image_adapter
 from .settings import WorkerSettings
+from .training_adapters import (
+    SUPPORTED_TRAINING_PLAN_VERSION,
+    create_training_kernel,
+    dry_run_training_summary,
+    validate_training_plan,
+)
 from .video_adapters import create_video_adapter
 
 
@@ -27,8 +33,9 @@ VIDEO_JOB_TYPES = ("video_generate", "video_extend", "video_bridge", "person_rep
 # apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
 SUPPORTED_JOB_TYPES = IMAGE_JOB_TYPES + VIDEO_JOB_TYPES
 # Training is GPU-required like generation, but a GPU worker advertises it even
-# without an inference backend: the story 1416 dry-run only validates a Rust-
-# resolved plan (no torch needed). Real execution is gated per platform in 1417.
+# without an inference backend: the dry-run path only validates a Rust-resolved
+# plan (no torch needed). A real (non-dry-run) run loads the kernel and requires
+# the inference backend, which the kernel enforces and reports clearly if absent.
 TRAINING_JOB_TYPES = ("lora_train",)
 
 
@@ -549,20 +556,28 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             restart_worker_after_oom(settings, job_id)
 
 
-# Highest training plan version this worker understands. Plans are resolved in
-# Rust (crates/sceneworks-core/src/training.rs::TRAINING_PLAN_VERSION); the worker
-# rejects any version it cannot interpret rather than guessing.
-SUPPORTED_TRAINING_PLAN_VERSION = 1
+# The supported training plan version and shared plan validation/summary helpers
+# live in training_adapters; the kernels there consume the Rust-resolved plan.
 
 
-def run_lora_train_dry_run_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
-    """Validate a Rust-resolved training plan and complete with a dry-run summary.
+def run_lora_train_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    """Run a lora_train job: validate the plan, then either report a dry-run
+    summary or execute the real training kernel.
 
-    This is the story 1416 stub: it claims a lora_train job, checks the embedded
-    plan and that its dataset inputs exist on the worker, and reports what a real
-    run would produce — without loading a model or training. Story 1417 replaces
-    the body with the narrow Z-Image LoRA execution kernel.
+    Dry-run (the default) validates the Rust-resolved plan and its dataset inputs
+    and reports what a real run would produce — no model load, no backend needed
+    (so a GPU worker without torch can still validate). A real run loads the
+    target's narrow execution kernel and trains an actual LoRA, reporting staged
+    progress and honoring cancellation.
     """
+    payload = job.get("payload") or {}
+    if bool(payload.get("dryRun", True)):
+        _run_lora_train_dry_run(api, settings, job, payload)
+    else:
+        _run_lora_train_execution(api, settings, job, payload)
+
+
+def _run_lora_train_dry_run(api: ApiClient, settings: WorkerSettings, job: dict, payload: dict) -> None:
     job_id = job["id"]
 
     def progress(status: str, stage: str, value: float, message: str) -> None:
@@ -575,60 +590,10 @@ def run_lora_train_dry_run_job(api: ApiClient, settings: WorkerSettings, job: di
 
     try:
         progress("preparing", "preparing", 0.1, "Validating training plan.")
-        payload = job.get("payload") or {}
-        # Real training execution does not exist yet; never let a non-dry-run job
-        # report success without producing weights (the API also rejects this).
-        if not payload.get("dryRun", True):
-            raise ValueError(
-                "Real LoRA training execution is not available yet; this worker only validates dry-run plans."
-            )
         plan = payload.get("plan")
-        if not isinstance(plan, dict):
-            raise ValueError("Training job payload is missing a resolved plan.")
-        plan_version = plan.get("planVersion")
-        if plan_version != SUPPORTED_TRAINING_PLAN_VERSION:
-            raise ValueError(
-                f"Unsupported training plan version {plan_version!r}; this worker "
-                f"understands version {SUPPORTED_TRAINING_PLAN_VERSION}."
-            )
-
-        dataset = plan.get("dataset") or {}
-        items = dataset.get("items") or []
-        if not items:
-            raise ValueError("Training plan dataset has no items to train on.")
-
-        progress("running", "running", 0.5, f"Checking {len(items)} dataset item(s).")
-        missing = [
-            item.get("imagePath")
-            for item in items
-            if not (item.get("imagePath") and os.path.exists(item["imagePath"]))
-        ]
-        if missing:
-            preview = ", ".join(str(path) for path in missing[:3])
-            raise FileNotFoundError(
-                f"{len(missing)} dataset image(s) are missing on the worker, e.g. {preview}."
-            )
-
-        output = plan.get("output") or {}
-        target = plan.get("target") or {}
-        base_model_path = target.get("baseModelPath")
-        summary = {
-            "mode": "dry_run",
-            "validated": True,
-            "dryRun": bool(payload.get("dryRun", True)),
-            "datasetItemCount": len(items),
-            "datasetId": dataset.get("datasetId"),
-            "datasetVersion": dataset.get("datasetVersion"),
-            "targetId": target.get("targetId"),
-            "kernel": target.get("kernel"),
-            "loraId": output.get("loraId"),
-            "outputDir": output.get("outputDir"),
-            "fileName": output.get("fileName"),
-            "baseModelPath": base_model_path,
-            "baseModelInstalled": bool(base_model_path and os.path.exists(base_model_path)),
-            "planVersion": plan_version,
-            "completedAt": now(),
-        }
+        items = validate_training_plan(plan, require_images=True)
+        progress("running", "running", 0.5, f"Checked {len(items)} dataset item(s).")
+        summary = dry_run_training_summary(plan, dry_run=True)
         update_job(
             api,
             job_id,
@@ -655,6 +620,87 @@ def run_lora_train_dry_run_job(api: ApiClient, settings: WorkerSettings, job: di
         )
     finally:
         heartbeat(api, settings, "idle")
+
+
+def _run_lora_train_execution(api: ApiClient, settings: WorkerSettings, job: dict, payload: dict) -> None:
+    job_id = job["id"]
+    trainer_holder: dict[str, Any] = {"trainer": None}
+    needs_oom_restart = False
+
+    def trainer_loaded_models() -> list[str]:
+        trainer = trainer_holder["trainer"]
+        return trainer.loaded_models() if trainer is not None else []
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat_with_loaded_models(api, settings, "busy", job_id, trainer_loaded_models)
+        update_job(
+            api,
+            job_id,
+            {"status": status, "stage": stage, "progress": value, "message": message},
+        )
+
+    try:
+        plan = payload.get("plan")
+        if not isinstance(plan, dict):
+            raise ValueError("Training job payload is missing a resolved plan.")
+        kernel_id = (plan.get("target") or {}).get("kernel")
+        trainer = create_training_kernel(kernel_id)
+        trainer_holder["trainer"] = trainer
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda: trainer.train(
+                settings=settings,
+                plan=plan,
+                progress=progress,
+                cancel_requested=lambda: job_cancel_requested(api, job_id),
+            ),
+            loaded_models=trainer_loaded_models,
+        )
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "completed",
+                "stage": "completed",
+                "progress": 1,
+                "message": f"Trained LoRA saved as {result.get('fileName')}.",
+                "result": result,
+            },
+        )
+    except InterruptedError as exc:
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "canceled",
+                "stage": "canceled",
+                "progress": 1,
+                "message": str(exc),
+            },
+        )
+    except Exception as exc:
+        needs_oom_restart = is_cuda_oom(exc)
+        message, error = friendly_failure("LoRA training", exc)
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "failed",
+                "stage": "failed",
+                "progress": 1,
+                "message": message,
+                "error": error,
+            },
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+        # A CUDA OOM can leave the allocator/context unable to reclaim VRAM in
+        # place; restart the child so the supervisor gives it a fresh context.
+        if needs_oom_restart:
+            restart_worker_after_oom(settings, job_id)
 
 
 def run_worker_loop(settings: WorkerSettings) -> None:
@@ -705,7 +751,7 @@ def run_worker_loop(settings: WorkerSettings) -> None:
             elif job["type"] in VIDEO_JOB_TYPES:
                 run_video_job(api, settings, job)
             elif job["type"] in TRAINING_JOB_TYPES:
-                run_lora_train_dry_run_job(api, settings, job)
+                run_lora_train_job(api, settings, job)
             else:
                 update_job(
                     api,

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -32,11 +32,16 @@ VIDEO_JOB_TYPES = ("video_generate", "video_extend", "video_bridge", "person_rep
 # crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
 # apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
 SUPPORTED_JOB_TYPES = IMAGE_JOB_TYPES + VIDEO_JOB_TYPES
-# Training is GPU-required like generation, but a GPU worker advertises it even
-# without an inference backend: the dry-run path only validates a Rust-resolved
-# plan (no torch needed). A real (non-dry-run) run loads the kernel and requires
-# the inference backend, which the kernel enforces and reports clearly if absent.
+# Training is GPU-required like generation, but a GPU worker advertises lora_train
+# even without an inference backend: the dry-run path only validates a Rust-resolved
+# plan (no torch needed). Real (non-dry-run) execution needs the backend, so it is
+# advertised as a distinct capability (TRAINING_EXECUTE_CAPABILITIES) only when the
+# backend is available — the Rust dispatcher routes dryRun:false jobs only to workers
+# that advertise it, instead of letting a torch-less worker claim and fail one. Keep
+# in sync with crates/sceneworks-core/src/contracts.rs::WorkerCapability and
+# jobs_store::worker_supports_job.
 TRAINING_JOB_TYPES = ("lora_train",)
+TRAINING_EXECUTE_CAPABILITIES = ("lora_train_execute",)
 
 
 def now() -> str:
@@ -75,6 +80,9 @@ def worker_capabilities(gpu: dict) -> list[str]:
         capabilities |= set(TRAINING_JOB_TYPES)
         if torch_inference_backend_available():
             capabilities |= set(SUPPORTED_JOB_TYPES)
+            # Only a backend-capable worker advertises real training execution, so
+            # the queue won't route a dryRun:false job to a worker that can't train.
+            capabilities |= set(TRAINING_EXECUTE_CAPABILITIES)
     return sorted(capabilities)
 
 

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -365,7 +365,7 @@ class ZImageLoraTrainer:
             _check_cancel(cancel_requested)
 
             progress(
-                "caching",
+                "running",
                 "caching_latents",
                 _CACHE_PROGRESS_START,
                 f"Encoding {len(items)} dataset item(s).",
@@ -698,7 +698,7 @@ class _ZImageLoraBackend:
 
                 if (index + 1) % 4 == 0 or index + 1 == count:
                     progress(
-                        "caching",
+                        "running",
                         "caching_latents",
                         _scaled(_CACHE_PROGRESS_START, _CACHE_PROGRESS_END, index + 1, count),
                         f"Encoded {index + 1} of {count} dataset item(s).",

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -500,6 +500,23 @@ def build_optimizer(name: str, params: list[Any], learning_rate: float) -> Any:
     return torch.optim.AdamW(params, lr=learning_rate)
 
 
+def flow_matching_velocity_target(latents: Any, noise: Any) -> Any:
+    """Training target for the RAW Z-Image transformer output: ``latents - noise``.
+
+    This is the **negated** flow-matching velocity, and the sign is load-bearing.
+    diffusers' ``ZImagePipeline`` negates the transformer output before handing it
+    to ``FlowMatchEulerDiscreteScheduler.step`` (``noise_pred = -noise_pred``), and
+    that scheduler integrates its input as the velocity ``noise - latents`` (for
+    ``x_sigma = (1 - sigma) * latents + sigma * noise``). So the raw output the
+    transformer is trained to produce is ``-(noise - latents) = latents - noise``.
+    Regressing toward ``noise - latents`` would train the LoRA to push the model in
+    the opposite denoising direction while the loss still looks like it converges.
+
+    Works on torch tensors (operator overloading) and plain numbers (for tests).
+    """
+    return latents - noise
+
+
 def bucket_resolution(resolution: int) -> int:
     """Floor a resolution to a multiple of 32 (Z-Image VAE factor 16 × patch 2),
     with a sane minimum."""
@@ -697,17 +714,18 @@ class _ZImageLoraBackend:
         embeds = self._embeds[index].to(device)
 
         # Rectified-flow / flow-matching training: interpolate between the clean
-        # latent (t=0) and noise (t=1); the velocity target is ``noise - latents``
-        # (ai-toolkit). The transformer takes the timestep scaled as
-        # ``(1000 - timestep) / 1000`` and per-item latent/embed lists, mirroring
-        # ZImagePipeline.__call__.
+        # latent (t=0) and noise (t=1). The transformer takes the timestep scaled
+        # as ``(1000 - timestep) / 1000`` and per-item latent/embed lists,
+        # mirroring ZImagePipeline.__call__. The target sign matches the diffusers
+        # pipeline, which negates the raw transformer output before the scheduler
+        # (see flow_matching_velocity_target).
         noise = torch.randn(
             latents.shape, generator=self._generator, device=device, dtype=latents.dtype
         )
         t = torch.rand(1, generator=self._generator, device=device, dtype=latents.dtype)
         t = t.clamp(1e-3, 1.0 - 1e-3)
         noisy = (1.0 - t) * latents + t * noise
-        target = noise - latents
+        target = flow_matching_velocity_target(latents, noise)
         timestep = t * 1000.0
         timestep_model_input = (1000.0 - timestep) / 1000.0
 

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -1,0 +1,802 @@
+"""Narrow Python execution kernels for SceneWorks native LoRA training.
+
+Rust owns the training product surface: dataset storage, manifests, validation,
+queue semantics, the target registry, and LoRA registration. A kernel here is a
+thin ML runtime that consumes a fully normalized, Rust-resolved ``TrainingPlan``
+(see ``crates/sceneworks-core/src/training.rs``) and produces adapter weights. It
+never reads SceneWorks storage, config defaults, or the target registry directly.
+
+The first production kernel is :class:`ZImageLoraTrainer`, an image LoRA trainer
+for Z-Image-Turbo. Its training mechanics follow the diffusers ``ZImagePipeline``
+and ``ostris/ai-toolkit`` as reference material (the epic treats ai-toolkit as a
+source of defaults and terminology only): a single-stream DiT transformer trained
+with a flow-matching objective whose velocity target is ``noise - latents`` and
+whose timestep input is ``(1000 - timestep) / 1000``.
+
+Heavy ML imports (``torch``, ``diffusers``, ``peft``) are deferred to call time so
+this module stays importable on a worker without an inference backend — the
+dry-run plan validation path needs no backend at all. All orchestration (stage
+progress, cancellation, checkpoint cadence, saving) lives in the trainer and is
+unit-tested with a fake backend; the model-specific work lives behind a small
+backend seam that real GPU runs exercise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import importlib
+import os
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from sceneworks_shared import utc_now
+
+from .image_adapters import (
+    activate_torch_device,
+    emit_worker_event,
+    gpu_memory_snapshot,
+    require_inference_backend_for_gpu_worker,
+    select_torch_device,
+    select_torch_dtype,
+)
+from .lora_adapters import huggingface_main_snapshot_dir, huggingface_snapshot_dirs
+from .settings import WorkerSettings
+
+
+ProgressCallback = Callable[[str, str, float, str], None]
+CancelCallback = Callable[[], bool]
+
+# Highest training plan version a kernel here understands. Plans are resolved in
+# Rust (crates/sceneworks-core/src/training.rs::TRAINING_PLAN_VERSION); a kernel
+# rejects any version it cannot interpret rather than guessing.
+SUPPORTED_TRAINING_PLAN_VERSION = 1
+
+# Default PEFT target modules for the Z-Image single-stream DiT attention blocks.
+# PEFT matches by suffix, so these select e.g. ``...attn.to_q`` without needing
+# the full module path. Override per job via ``advanced.loraTargetModules``.
+DEFAULT_LORA_TARGET_MODULES = ["to_q", "to_k", "to_v", "to_out.0"]
+
+
+class TrainingKernelError(RuntimeError):
+    """A training run cannot proceed for a kernel/runtime reason (bad plan,
+    missing model component, unsupported diffusers build, ...)."""
+
+
+def now() -> str:
+    return utc_now()
+
+
+# --------------------------------------------------------------------------- #
+# Shared plan validation + dry-run summary (used by the dry-run and real paths)
+# --------------------------------------------------------------------------- #
+
+
+def validate_training_plan(plan: Any, *, require_images: bool = True) -> list[dict[str, Any]]:
+    """Validate a resolved training plan and return its dataset items.
+
+    Raises ``ValueError`` for a structurally unusable plan and ``FileNotFoundError``
+    when dataset images are missing on the worker. Shared by the dry-run validator
+    and the real kernel so both reject the same bad inputs identically.
+    """
+
+    if not isinstance(plan, dict):
+        raise ValueError("Training job payload is missing a resolved plan.")
+    plan_version = plan.get("planVersion")
+    if plan_version != SUPPORTED_TRAINING_PLAN_VERSION:
+        raise ValueError(
+            f"Unsupported training plan version {plan_version!r}; this worker "
+            f"understands version {SUPPORTED_TRAINING_PLAN_VERSION}."
+        )
+    dataset = plan.get("dataset") or {}
+    items = dataset.get("items") or []
+    if not items:
+        raise ValueError("Training plan dataset has no items to train on.")
+    if require_images:
+        missing = [
+            item.get("imagePath")
+            for item in items
+            if not (item.get("imagePath") and os.path.exists(item["imagePath"]))
+        ]
+        if missing:
+            preview = ", ".join(str(path) for path in missing[:3])
+            raise FileNotFoundError(
+                f"{len(missing)} dataset image(s) are missing on the worker, e.g. {preview}."
+            )
+    return items
+
+
+def dry_run_training_summary(plan: dict[str, Any], *, dry_run: bool) -> dict[str, Any]:
+    """Build the dry-run completion summary: what a real run would produce,
+    without loading a model or training."""
+
+    dataset = plan.get("dataset") or {}
+    items = dataset.get("items") or []
+    output = plan.get("output") or {}
+    target = plan.get("target") or {}
+    base_model_path = target.get("baseModelPath")
+    return {
+        "mode": "dry_run",
+        "validated": True,
+        "dryRun": dry_run,
+        "datasetItemCount": len(items),
+        "datasetId": dataset.get("datasetId"),
+        "datasetVersion": dataset.get("datasetVersion"),
+        "targetId": target.get("targetId"),
+        "kernel": target.get("kernel"),
+        "loraId": output.get("loraId"),
+        "outputDir": output.get("outputDir"),
+        "fileName": output.get("fileName"),
+        "baseModel": target.get("baseModel"),
+        "baseModelRepo": target.get("baseModelRepo"),
+        "baseModelPath": base_model_path,
+        "baseModelInstalled": bool(base_model_path and os.path.exists(base_model_path)),
+        "planVersion": plan.get("planVersion"),
+        "completedAt": now(),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Resolved config + plan accessors
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class TrainingRunConfig:
+    """Concrete hyperparameters read from a plan's ``config`` block. Mirrors the
+    Rust ``TrainingConfig`` shape but is duck-typed from the plan dict so the
+    kernel never depends on the Rust crate."""
+
+    rank: int
+    alpha: int
+    learning_rate: float
+    steps: int
+    batch_size: int
+    gradient_accumulation: int
+    resolution: int
+    save_every: int
+    seed: int
+    optimizer: str
+    mixed_precision: Any
+    lora_target_modules: Any
+    advanced: dict[str, Any] = field(default_factory=dict)
+
+
+def _as_int(value: Any, default: int, *, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, parsed)
+
+
+def _as_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed
+
+
+def read_run_config(plan: dict[str, Any]) -> TrainingRunConfig:
+    config = plan.get("config") or {}
+    advanced = config.get("advanced") if isinstance(config.get("advanced"), dict) else {}
+    target_modules = advanced.get("loraTargetModules")
+    if not target_modules:
+        target_modules = list(DEFAULT_LORA_TARGET_MODULES)
+    return TrainingRunConfig(
+        rank=_as_int(config.get("rank"), 16, minimum=1),
+        alpha=_as_int(config.get("alpha"), 16, minimum=1),
+        learning_rate=_as_float(config.get("learningRate"), 1e-4),
+        steps=_as_int(config.get("steps"), 1000, minimum=1),
+        batch_size=_as_int(config.get("batchSize"), 1, minimum=1),
+        gradient_accumulation=_as_int(config.get("gradientAccumulation"), 1, minimum=1),
+        resolution=_as_int(config.get("resolution"), 1024, minimum=32),
+        save_every=_as_int(config.get("saveEvery"), 0, minimum=0),
+        seed=_as_int(config.get("seed"), 42),
+        optimizer=str(config.get("optimizer") or "adamw"),
+        mixed_precision=advanced.get("mixedPrecision"),
+        lora_target_modules=target_modules,
+        advanced=advanced,
+    )
+
+
+def trigger_words(plan: dict[str, Any]) -> list[str]:
+    output = plan.get("output") or {}
+    words = output.get("triggerWords") or []
+    return [str(word) for word in words if str(word).strip()]
+
+
+# --------------------------------------------------------------------------- #
+# Base-model source resolution
+# --------------------------------------------------------------------------- #
+
+
+def resolve_pretrained_source(target: dict[str, Any]) -> str:
+    """Resolve a ``from_pretrained`` source for the base model.
+
+    Prefers a directly loadable directory (a SceneWorks-managed import or an
+    explicit snapshot containing ``model_index.json``), then the main snapshot of
+    a Hugging Face cache repo root, then the repo id (so diffusers can use the
+    cache or download), then the raw path as a last resort.
+    """
+
+    repo = str(target.get("baseModelRepo") or "").strip()
+    base_path = str(target.get("baseModelPath") or "").strip()
+    if base_path:
+        path = Path(base_path)
+        if (path / "model_index.json").is_file():
+            return str(path)
+        snapshot = _snapshot_with_model_index(path)
+        if snapshot is not None:
+            return str(snapshot)
+    if repo:
+        return repo
+    if base_path:
+        return base_path
+    raise TrainingKernelError("Training plan has no base model repo or path to load.")
+
+
+def _snapshot_with_model_index(repo_root: Path) -> Path | None:
+    """Return the cache snapshot dir under an HF ``models--*`` root that holds a
+    ``model_index.json``, preferring the ``refs/main`` snapshot."""
+
+    main_snapshot = huggingface_main_snapshot_dir(repo_root)
+    if main_snapshot is not None and (main_snapshot / "model_index.json").is_file():
+        return main_snapshot
+    for snapshot in huggingface_snapshot_dirs(repo_root):
+        if (snapshot / "model_index.json").is_file():
+            return snapshot
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Backend seam
+# --------------------------------------------------------------------------- #
+
+
+class TrainingBackend(Protocol):
+    """The model-specific work behind the trainer's orchestration. The real
+    backend wraps torch/diffusers/peft; tests pass a fake implementation."""
+
+    def loaded_models(self) -> list[str]: ...
+
+    def load(
+        self,
+        *,
+        settings: WorkerSettings,
+        plan: dict[str, Any],
+        config: TrainingRunConfig,
+        progress: ProgressCallback,
+    ) -> None: ...
+
+    def prepare_dataset(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        config: TrainingRunConfig,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]: ...
+
+    def train_step(self, *, step: int, total_steps: int, config: TrainingRunConfig) -> float: ...
+
+    def save_checkpoint(self, *, step: int, output_dir: str, file_name: str) -> str | None: ...
+
+    def save_final(self, *, output_dir: str, file_name: str) -> str: ...
+
+    def cleanup(self) -> None: ...
+
+
+# Progress band: preparing 0.0-0.08, loading 0.08-0.18, caching 0.18-0.32,
+# training 0.32-0.92, saving 0.92-0.98, completed (posted by the runtime) 1.0.
+_TRAIN_PROGRESS_START = 0.32
+_TRAIN_PROGRESS_END = 0.92
+_CACHE_PROGRESS_START = 0.18
+_CACHE_PROGRESS_END = 0.32
+# Report a training-progress tick at most this often (in steps) to avoid flooding
+# the API on long runs; the final step always reports.
+PROGRESS_STEP_INTERVAL = 10
+
+
+def _scaled(start: float, end: float, completed: int, total: int) -> float:
+    safe_total = max(1, total)
+    fraction = min(max(0, completed), safe_total) / safe_total
+    return round(start + (end - start) * fraction, 4)
+
+
+def _check_cancel(cancel_requested: CancelCallback) -> None:
+    if cancel_requested():
+        raise InterruptedError("LoRA training canceled by user.")
+
+
+class ZImageLoraTrainer:
+    """Image LoRA trainer for Z-Image-Turbo.
+
+    Orchestrates the staged run (prepare → load → cache → train → checkpoint →
+    save) with cancellation and progress reporting. The model-specific work is
+    delegated to a :class:`TrainingBackend`; the real one is built lazily so the
+    trainer is importable and unit-testable without an inference backend.
+    """
+
+    kernel_id = "z_image_lora"
+
+    def __init__(self, backend: TrainingBackend | None = None) -> None:
+        self._backend = backend
+        self._active_backend: TrainingBackend | None = backend
+
+    def loaded_models(self) -> list[str]:
+        backend = self._active_backend
+        if backend is None:
+            return []
+        try:
+            return list(backend.loaded_models())
+        except Exception:
+            return []
+
+    def train(
+        self,
+        *,
+        settings: WorkerSettings,
+        plan: dict[str, Any],
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        items = validate_training_plan(plan, require_images=True)
+        config = read_run_config(plan)
+        output = plan.get("output") or {}
+        target = plan.get("target") or {}
+        output_dir = str(output.get("outputDir") or "")
+        file_name = str(output.get("fileName") or "lora.safetensors")
+        if not output_dir:
+            raise TrainingKernelError("Training plan output is missing an output directory.")
+
+        progress("preparing", "preparing", 0.04, "Preparing Z-Image LoRA training run.")
+        backend = self._backend or self._create_backend()
+        self._active_backend = backend
+        completed_steps = 0
+        try:
+            progress(
+                "loading_model",
+                "loading_model",
+                0.1,
+                f"Loading base model for {target.get('targetId') or self.kernel_id}.",
+            )
+            backend.load(settings=settings, plan=plan, config=config, progress=progress)
+            _check_cancel(cancel_requested)
+
+            progress(
+                "caching",
+                "caching_latents",
+                _CACHE_PROGRESS_START,
+                f"Encoding {len(items)} dataset item(s).",
+            )
+            prepared = backend.prepare_dataset(
+                items=items,
+                config=config,
+                progress=progress,
+                cancel_requested=cancel_requested,
+            )
+            _check_cancel(cancel_requested)
+
+            total_steps = max(1, config.steps)
+            checkpoints: list[dict[str, Any]] = []
+            for step in range(1, total_steps + 1):
+                _check_cancel(cancel_requested)
+                loss = backend.train_step(step=step, total_steps=total_steps, config=config)
+                completed_steps = step
+                if step == total_steps or step % PROGRESS_STEP_INTERVAL == 0:
+                    progress(
+                        "running",
+                        "training",
+                        _scaled(_TRAIN_PROGRESS_START, _TRAIN_PROGRESS_END, step, total_steps),
+                        _training_message(step, total_steps, loss),
+                    )
+                if config.save_every and step % config.save_every == 0 and step < total_steps:
+                    progress(
+                        "running",
+                        "checkpointing",
+                        _scaled(_TRAIN_PROGRESS_START, _TRAIN_PROGRESS_END, step, total_steps),
+                        f"Saving checkpoint at step {step} of {total_steps}.",
+                    )
+                    checkpoint_path = backend.save_checkpoint(
+                        step=step, output_dir=output_dir, file_name=file_name
+                    )
+                    if checkpoint_path:
+                        checkpoints.append({"step": step, "path": checkpoint_path})
+
+            _check_cancel(cancel_requested)
+            progress("saving", "saving", 0.95, "Saving trained LoRA weights.")
+            output_path = backend.save_final(output_dir=output_dir, file_name=file_name)
+            return self._result_summary(
+                plan=plan,
+                config=config,
+                prepared=prepared,
+                total_steps=total_steps,
+                completed_steps=completed_steps,
+                checkpoints=checkpoints,
+                output_path=output_path,
+            )
+        finally:
+            try:
+                backend.cleanup()
+            except Exception:
+                pass
+
+    def _create_backend(self) -> TrainingBackend:
+        return _ZImageLoraBackend()
+
+    def _result_summary(
+        self,
+        *,
+        plan: dict[str, Any],
+        config: TrainingRunConfig,
+        prepared: dict[str, Any],
+        total_steps: int,
+        completed_steps: int,
+        checkpoints: list[dict[str, Any]],
+        output_path: str,
+    ) -> dict[str, Any]:
+        dataset = plan.get("dataset") or {}
+        target = plan.get("target") or {}
+        output = plan.get("output") or {}
+        return {
+            "mode": "train",
+            "kernel": self.kernel_id,
+            "loraId": output.get("loraId"),
+            "outputDir": output.get("outputDir"),
+            "fileName": output.get("fileName"),
+            "outputPath": output_path,
+            "format": output.get("format") or "safetensors",
+            "datasetId": dataset.get("datasetId"),
+            "datasetVersion": dataset.get("datasetVersion"),
+            "datasetItemCount": (prepared or {}).get("itemCount") or len(dataset.get("items") or []),
+            "targetId": target.get("targetId"),
+            "baseModel": target.get("baseModel"),
+            "steps": total_steps,
+            "stepsCompleted": completed_steps,
+            "checkpoints": checkpoints,
+            "rank": config.rank,
+            "alpha": config.alpha,
+            "learningRate": config.learning_rate,
+            "resolution": (prepared or {}).get("resolution") or config.resolution,
+            "triggerWords": trigger_words(plan),
+            "planVersion": plan.get("planVersion"),
+            "completedAt": now(),
+        }
+
+
+def _training_message(step: int, total_steps: int, loss: float | None) -> str:
+    if loss is None:
+        return f"Training step {step} of {total_steps}."
+    return f"Training step {step} of {total_steps} (loss {loss:.4f})."
+
+
+# --------------------------------------------------------------------------- #
+# Real torch/diffusers/peft backend for Z-Image
+# --------------------------------------------------------------------------- #
+
+
+def build_optimizer(name: str, params: list[Any], learning_rate: float) -> Any:
+    """Build an optimizer for the LoRA parameters. ``adamw8bit`` uses
+    bitsandbytes when available and falls back to torch AdamW otherwise (the
+    8-bit optimizer is an optional, CUDA-only dependency)."""
+
+    torch = importlib.import_module("torch")
+    normalized = (name or "").strip().lower().replace("-", "").replace("_", "")
+    if normalized in {"adamw8bit", "adam8bit"}:
+        try:
+            bnb = importlib.import_module("bitsandbytes")
+            return bnb.optim.AdamW8bit(params, lr=learning_rate)
+        except Exception:
+            emit_worker_event(
+                "training_optimizer_fallback",
+                requested=name,
+                using="adamw",
+                reason="bitsandbytes unavailable",
+            )
+            return torch.optim.AdamW(params, lr=learning_rate)
+    if normalized == "adam":
+        return torch.optim.Adam(params, lr=learning_rate)
+    return torch.optim.AdamW(params, lr=learning_rate)
+
+
+def bucket_resolution(resolution: int) -> int:
+    """Floor a resolution to a multiple of 32 (Z-Image VAE factor 16 × patch 2),
+    with a sane minimum."""
+
+    bucket = (max(32, int(resolution)) // 32) * 32
+    return max(32, bucket)
+
+
+def _load_training_image(image_path: str, resolution: int) -> Any:
+    from PIL import Image
+
+    with Image.open(image_path) as handle:
+        image = handle.convert("RGB")
+    # Center-crop to a square, then resize to the bucket edge so aspect ratio is
+    # preserved without distortion. Simple and deterministic for a first kernel;
+    # aspect-ratio bucketing can come later via advanced settings.
+    width, height = image.size
+    edge = min(width, height)
+    left = (width - edge) // 2
+    top = (height - edge) // 2
+    square = image.crop((left, top, left + edge, top + edge))
+    return square.resize((resolution, resolution), Image.LANCZOS)
+
+
+def _image_to_tensor(torch: Any, image: Any, dtype: Any, device: str) -> Any:
+    import numpy as np
+
+    array = np.asarray(image, dtype=np.float32) / 127.5 - 1.0  # [-1, 1]
+    tensor = torch.from_numpy(array).permute(2, 0, 1).unsqueeze(0)
+    return tensor.to(device=device, dtype=dtype)
+
+
+class _ZImageLoraBackend:
+    """Real Z-Image LoRA training backend.
+
+    Loads the diffusers ``ZImagePipeline`` components, attaches a PEFT LoRA to the
+    transformer, caches per-item latents and prompt embeddings, and runs a
+    flow-matching training loop. The forward/loss in :meth:`train_step` follows
+    the pipeline's own transformer call and ai-toolkit's velocity target; it is
+    deliberately isolated so a real GPU run can be tuned without touching the
+    trainer's orchestration.
+    """
+
+    def __init__(self) -> None:
+        self._torch: Any | None = None
+        self._device: str | None = None
+        self._dtype: Any | None = None
+        self._pipeline: Any | None = None
+        self._transformer: Any | None = None
+        self._vae: Any | None = None
+        self._optimizer: Any | None = None
+        self._generator: Any | None = None
+        self._loaded_source: str | None = None
+        self._latents: list[Any] = []
+        self._embeds: list[Any] = []
+        self._vae_scaling: float = 1.0
+        self._vae_shift: float = 0.0
+        self._diagnosed_forward = False
+
+    def loaded_models(self) -> list[str]:
+        return [self._loaded_source] if self._loaded_source else []
+
+    def load(
+        self,
+        *,
+        settings: WorkerSettings,
+        plan: dict[str, Any],
+        config: TrainingRunConfig,
+        progress: ProgressCallback,
+    ) -> None:
+        torch = importlib.import_module("torch")
+        diffusers = importlib.import_module("diffusers")
+        peft = importlib.import_module("peft")
+        self._torch = torch
+
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        dtype = select_torch_dtype(torch, device, config.mixed_precision)
+        source = resolve_pretrained_source(plan.get("target") or {})
+
+        pipeline_class = getattr(diffusers, "ZImagePipeline", None)
+        if pipeline_class is None:
+            raise TrainingKernelError(
+                "The installed diffusers build does not expose ZImagePipeline; "
+                "install a diffusers build with Z-Image support."
+            )
+
+        emit_worker_event(
+            "training_pipeline_load_start",
+            kernel=ZImageLoraTrainer.kernel_id,
+            source=source,
+            device=device,
+            dtype=str(dtype),
+        )
+        progress("loading_model", "loading_model", 0.12, "Loading Z-Image base model files.")
+        pipe = pipeline_class.from_pretrained(source, torch_dtype=dtype)
+        pipe.to(device)
+
+        transformer = pipe.transformer
+        transformer.requires_grad_(False)
+        pipe.vae.requires_grad_(False)
+        text_encoder = getattr(pipe, "text_encoder", None)
+        if text_encoder is not None:
+            text_encoder.requires_grad_(False)
+
+        progress("loading_model", "loading_model", 0.16, "Attaching LoRA adapter to the transformer.")
+        lora_config = peft.LoraConfig(
+            r=config.rank,
+            lora_alpha=config.alpha,
+            init_lora_weights="gaussian",
+            target_modules=list(config.lora_target_modules)
+            if isinstance(config.lora_target_modules, (list, tuple))
+            else config.lora_target_modules,
+        )
+        transformer.add_adapter(lora_config)
+        transformer.train()
+        trainable = [param for param in transformer.parameters() if param.requires_grad]
+        if not trainable:
+            raise TrainingKernelError(
+                "LoRA adapter attached no trainable parameters; the configured "
+                "target modules did not match any transformer layers. Adjust "
+                "advanced.loraTargetModules for this base model."
+            )
+
+        self._optimizer = build_optimizer(config.optimizer, trainable, config.learning_rate)
+        self._optimizer.zero_grad()
+        vae_config = getattr(pipe.vae, "config", None)
+        self._vae_scaling = float(getattr(vae_config, "scaling_factor", 1.0) or 1.0)
+        self._vae_shift = float(getattr(vae_config, "shift_factor", 0.0) or 0.0)
+        self._pipeline = pipe
+        self._transformer = transformer
+        self._vae = pipe.vae
+        self._device = device
+        self._dtype = dtype
+        self._loaded_source = source
+        generator_device = device if str(device).startswith("cuda") else "cpu"
+        self._generator = torch.Generator(generator_device).manual_seed(int(config.seed))
+        emit_worker_event(
+            "training_pipeline_load_complete",
+            kernel=ZImageLoraTrainer.kernel_id,
+            source=source,
+            trainableTensors=len(trainable),
+            gpuMemory=gpu_memory_snapshot(torch, device),
+        )
+
+    def prepare_dataset(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        config: TrainingRunConfig,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        torch = self._torch
+        pipe = self._pipeline
+        vae = self._vae
+        resolution = bucket_resolution(config.resolution)
+        count = len(items)
+        self._latents = []
+        self._embeds = []
+        with torch.no_grad():
+            for index, item in enumerate(items):
+                if cancel_requested():
+                    raise InterruptedError("LoRA training canceled by user.")
+                image = _load_training_image(item["imagePath"], resolution)
+                pixel = _image_to_tensor(torch, image, self._dtype, self._device)
+                latent = vae.encode(pixel).latent_dist.sample(generator=self._generator)
+                latent = (latent - self._vae_shift) * self._vae_scaling
+                self._latents.append(latent.detach().to("cpu"))
+
+                prompt_embeds, _ = pipe.encode_prompt(
+                    str(item.get("caption") or ""),
+                    device=self._device,
+                    do_classifier_free_guidance=False,
+                )
+                embed = prompt_embeds[0] if isinstance(prompt_embeds, (list, tuple)) else prompt_embeds
+                self._embeds.append(embed.detach().to("cpu"))
+
+                if (index + 1) % 4 == 0 or index + 1 == count:
+                    progress(
+                        "caching",
+                        "caching_latents",
+                        _scaled(_CACHE_PROGRESS_START, _CACHE_PROGRESS_END, index + 1, count),
+                        f"Encoded {index + 1} of {count} dataset item(s).",
+                    )
+        return {"itemCount": count, "resolution": resolution}
+
+    def train_step(self, *, step: int, total_steps: int, config: TrainingRunConfig) -> float:
+        torch = self._torch
+        transformer = self._transformer
+        device = self._device
+        index = (step - 1) % len(self._latents)
+        latents = self._latents[index].to(device)
+        embeds = self._embeds[index].to(device)
+
+        # Rectified-flow / flow-matching training: interpolate between the clean
+        # latent (t=0) and noise (t=1); the velocity target is ``noise - latents``
+        # (ai-toolkit). The transformer takes the timestep scaled as
+        # ``(1000 - timestep) / 1000`` and per-item latent/embed lists, mirroring
+        # ZImagePipeline.__call__.
+        noise = torch.randn(
+            latents.shape, generator=self._generator, device=device, dtype=latents.dtype
+        )
+        t = torch.rand(1, generator=self._generator, device=device, dtype=latents.dtype)
+        t = t.clamp(1e-3, 1.0 - 1e-3)
+        noisy = (1.0 - t) * latents + t * noise
+        target = noise - latents
+        timestep = t * 1000.0
+        timestep_model_input = (1000.0 - timestep) / 1000.0
+
+        latent_model_input_list = list(noisy.unsqueeze(2).unbind(dim=0))
+        model_out = transformer(
+            latent_model_input_list, timestep_model_input, [embeds], return_dict=False
+        )[0]
+        prediction = self._stack_model_output(torch, model_out)
+        if prediction.dim() == target.dim() + 1:
+            prediction = prediction.squeeze(2)
+        if not self._diagnosed_forward:
+            emit_worker_event(
+                "training_forward_shapes",
+                kernel=ZImageLoraTrainer.kernel_id,
+                latent=list(latents.shape),
+                prediction=list(prediction.shape),
+                target=list(target.shape),
+            )
+            self._diagnosed_forward = True
+
+        loss = torch.nn.functional.mse_loss(prediction.float(), target.float())
+        accum = max(1, config.gradient_accumulation)
+        (loss / accum).backward()
+        if step % accum == 0 or step == total_steps:
+            self._optimizer.step()
+            self._optimizer.zero_grad()
+        return float(loss.detach().to("cpu"))
+
+    def _stack_model_output(self, torch: Any, model_out: Any) -> Any:
+        if isinstance(model_out, (list, tuple)):
+            return torch.stack(list(model_out), dim=0)
+        return model_out
+
+    def save_checkpoint(self, *, step: int, output_dir: str, file_name: str) -> str | None:
+        stem = Path(file_name).stem or "lora"
+        checkpoint_name = f"{stem}-step{step:06d}.safetensors"
+        return self._save_lora(output_dir=output_dir, file_name=checkpoint_name)
+
+    def save_final(self, *, output_dir: str, file_name: str) -> str:
+        return self._save_lora(output_dir=output_dir, file_name=file_name)
+
+    def _save_lora(self, *, output_dir: str, file_name: str) -> str:
+        from peft.utils import get_peft_model_state_dict
+
+        os.makedirs(output_dir, exist_ok=True)
+        lora_state_dict = get_peft_model_state_dict(self._transformer)
+        type(self._pipeline).save_lora_weights(
+            output_dir,
+            transformer_lora_layers=lora_state_dict,
+            weight_name=file_name,
+            safe_serialization=True,
+        )
+        return os.path.join(output_dir, file_name)
+
+    def cleanup(self) -> None:
+        torch = self._torch
+        self._latents = []
+        self._embeds = []
+        self._optimizer = None
+        self._transformer = None
+        self._vae = None
+        self._pipeline = None
+        self._loaded_source = None
+        if torch is not None:
+            try:
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:
+                pass
+
+
+# --------------------------------------------------------------------------- #
+# Kernel registry
+# --------------------------------------------------------------------------- #
+
+
+_TRAINING_KERNELS: dict[str, Callable[[], Any]] = {
+    ZImageLoraTrainer.kernel_id: ZImageLoraTrainer,
+}
+
+
+def create_training_kernel(kernel_id: Any) -> ZImageLoraTrainer:
+    """Return the trainer for a plan's ``target.kernel`` id, or raise for an
+    unknown kernel. Mirrors the image/video adapter factories."""
+
+    factory = _TRAINING_KERNELS.get(str(kernel_id or "").strip())
+    if factory is None:
+        known = ", ".join(sorted(_TRAINING_KERNELS)) or "(none)"
+        raise TrainingKernelError(
+            f"No training kernel for {kernel_id!r}. Known kernels: {known}."
+        )
+    return factory()

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -253,6 +253,11 @@ string_enum! {
         ModelImport => "model_import",
         LoraImport => "lora_import",
         LoraTrain => "lora_train",
+        // Real (non-dry-run) LoRA training execution. Advertised separately from
+        // `LoraTrain` (dry-run plan validation, which needs no inference backend)
+        // so a real run only routes to a worker that can actually train. See
+        // jobs_store::worker_supports_job and apps/worker/scene_worker/runtime.py.
+        LoraTrainExecute => "lora_train_execute",
     }
 }
 

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -214,6 +214,11 @@ string_enum! {
         Estimating => "estimating",
         Generating => "generating",
         Running => "running",
+        // LoRA training stages (status stays `running`); see
+        // apps/worker/scene_worker/training_adapters.py.
+        CachingLatents => "caching_latents",
+        Training => "training",
+        Checkpointing => "checkpointing",
         Rendering => "rendering",
         Extracting => "extracting",
         Tracking => "tracking",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1259,10 +1259,31 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     if job_requires_gpu(&job.job_type) && worker.gpu_id.eq_ignore_ascii_case("cpu") {
         return false;
     }
-    worker
-        .capabilities
-        .iter()
-        .any(|capability| capability.as_str() == job.job_type.as_str())
+    let advertises = |capability: &str| {
+        worker
+            .capabilities
+            .iter()
+            .any(|owned| owned.as_str() == capability)
+    };
+    if !advertises(job.job_type.as_str()) {
+        return false;
+    }
+    // A real (non-dry-run) LoRA training job additionally needs the execute
+    // capability, which a worker advertises only when its inference backend is
+    // available. Dry-run plan validation needs just the base `lora_train`
+    // capability. This keeps a real run queued for a capable worker instead of
+    // failing terminally after a torch-less worker claims it.
+    if is_real_training_job(job) {
+        return advertises(WorkerCapability::LoraTrainExecute.as_str());
+    }
+    true
+}
+
+/// True when a job is a real (non-dry-run) LoRA training run. The training
+/// payload defaults to dry-run; only an explicit `dryRun: false` is a real run.
+fn is_real_training_job(job: &JobSnapshot) -> bool {
+    matches!(job.job_type, JobType::LoraTrain)
+        && job.payload.get("dryRun").and_then(Value::as_bool) == Some(false)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -261,6 +261,11 @@ pub struct TrainingPlanTarget {
     pub modality: TrainingModality,
     pub output_kind: TrainingOutputKind,
     pub base_model: String,
+    /// Optional source repository for the base model weights. The kernel prefers
+    /// this for `from_pretrained` (matching the generation load path, cache or
+    /// download), falling back to `base_model_path` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_model_repo: Option<String>,
     /// Absolute, resolved path to the base model weights on the worker.
     pub base_model_path: String,
     #[serde(flatten)]
@@ -505,6 +510,7 @@ pub fn build_training_plan(
             modality: input.target.modality.clone(),
             output_kind: input.target.output_kind.clone(),
             base_model: input.target.base_model.clone(),
+            base_model_repo: input.target.base_model_repo.clone(),
             base_model_path: input.base_model_path,
             extra: ExtraFields::new(),
         },

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -259,6 +259,57 @@ fn dry_run_lora_train_does_not_require_execute_capability() {
 }
 
 #[test]
+fn training_progress_stages_persist_under_running_and_reject_unknown_status() {
+    let store = store("training-progress-stages");
+    let job = store
+        .create_job(lora_train_job("auto", false))
+        .expect("training job creates");
+
+    // The trainer reports caching/training/checkpointing stages under the running
+    // status; all must be accepted and persisted, not rejected as invalid.
+    for (stage, label) in [
+        (ProgressStage::CachingLatents, "caching_latents"),
+        (ProgressStage::Training, "training"),
+        (ProgressStage::Checkpointing, "checkpointing"),
+    ] {
+        let updated = store
+            .update_job_progress(
+                &job.id,
+                ProgressUpdate {
+                    status: JobStatus::Running,
+                    stage,
+                    progress: 0.5,
+                    message: "training".to_owned(),
+                    error: None,
+                    result: None,
+                    eta_seconds: None,
+                },
+            )
+            .expect("running status with a training stage is accepted");
+        assert_eq!(updated.status, JobStatus::Running);
+        assert_eq!(updated.stage.as_str(), label);
+    }
+
+    // A non-contract status like "caching" (an earlier kernel bug) must be rejected
+    // rather than silently persisted.
+    let error = store
+        .update_job_progress(
+            &job.id,
+            ProgressUpdate {
+                status: JobStatus::Unknown("caching".to_owned()),
+                stage: ProgressStage::CachingLatents,
+                progress: 0.5,
+                message: "caching".to_owned(),
+                error: None,
+                result: None,
+                eta_seconds: None,
+            },
+        )
+        .expect_err("an unknown status is rejected");
+    assert!(matches!(error, JobsStoreError::InvalidStatus(_)));
+}
+
+#[test]
 fn gpu_generation_jobs_reject_cpu_requested_gpu() {
     let store = store("gpu-jobs-reject-cpu");
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -182,6 +182,83 @@ fn claim_skips_jobs_not_supported_by_worker_capabilities() {
 }
 
 #[test]
+fn real_lora_train_requires_execute_capability() {
+    let store = store("lora-train-execute-routing");
+    // A GPU worker that can validate dry-run plans but lacks the inference backend
+    // advertises lora_train but not lora_train_execute.
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "dry-only".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: None,
+            capabilities: vec![WorkerCapability::Gpu, WorkerCapability::LoraTrain],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+    let real = store
+        .create_job(lora_train_job("auto", false))
+        .expect("real training job creates");
+
+    // The dry-run-only worker must not claim the real job; it stays queued for a
+    // backend-capable worker instead of being claimed and failed.
+    assert!(store
+        .claim_next_job("dry-only")
+        .expect("claim succeeds")
+        .is_none());
+
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "trainer".to_owned(),
+            gpu_id: "gpu-1".to_owned(),
+            gpu_name: None,
+            capabilities: vec![
+                WorkerCapability::Gpu,
+                WorkerCapability::LoraTrain,
+                WorkerCapability::LoraTrainExecute,
+            ],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+    assert_eq!(
+        store
+            .claim_next_job("trainer")
+            .expect("claim succeeds")
+            .expect("job claimed")
+            .id,
+        real.id
+    );
+}
+
+#[test]
+fn dry_run_lora_train_does_not_require_execute_capability() {
+    let store = store("lora-train-dry-routing");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "dry-only".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: None,
+            capabilities: vec![WorkerCapability::Gpu, WorkerCapability::LoraTrain],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+    let dry = store
+        .create_job(lora_train_job("auto", true))
+        .expect("dry-run training job creates");
+
+    assert_eq!(
+        store
+            .claim_next_job("dry-only")
+            .expect("claim succeeds")
+            .expect("job claimed")
+            .id,
+        dry.id
+    );
+}
+
+#[test]
 fn gpu_generation_jobs_reject_cpu_requested_gpu() {
     let store = store("gpu-jobs-reject-cpu");
 
@@ -614,12 +691,12 @@ fn elapsed_seconds_accepts_fractional_rfc3339_timestamps() {
     );
 }
 
-fn lora_train_job(requested_gpu: &str) -> CreateJob {
+fn lora_train_job(requested_gpu: &str, dry_run: bool) -> CreateJob {
     CreateJob {
         job_type: JobType::LoraTrain,
         project_id: Some("project-1".to_owned()),
         project_name: Some("Project 1".to_owned()),
-        payload: object(json!({ "dryRun": true })),
+        payload: object(json!({ "dryRun": dry_run, "plan": { "planVersion": 1 } })),
         requested_gpu: requested_gpu.to_owned(),
         source_job_id: None,
         duplicate_of_job_id: None,
@@ -632,7 +709,7 @@ fn lora_train_rejects_cpu_requested_gpu() {
     let store = store("lora-train-rejects-cpu");
 
     let error = store
-        .create_job(lora_train_job("cpu"))
+        .create_job(lora_train_job("cpu", true))
         .expect_err("cpu requestedGpu should be rejected for lora_train");
 
     assert!(matches!(error, JobsStoreError::InvalidRequestedGpu(_)));
@@ -653,7 +730,7 @@ fn cpu_worker_cannot_claim_lora_train_even_with_capability() {
         })
         .expect("worker registers");
     store
-        .create_job(lora_train_job("auto"))
+        .create_job(lora_train_job("auto", true))
         .expect("lora_train job creates");
 
     assert!(store
@@ -676,7 +753,7 @@ fn gpu_worker_with_capability_claims_lora_train() {
         })
         .expect("worker registers");
     let created = store
-        .create_job(lora_train_job("auto"))
+        .create_job(lora_train_job("auto", true))
         .expect("lora_train job creates");
 
     let claimed = store
@@ -704,7 +781,7 @@ fn gpu_worker_without_training_capability_skips_lora_train() {
         })
         .expect("worker registers");
     store
-        .create_job(lora_train_job("auto"))
+        .create_job(lora_train_job("auto", true))
         .expect("lora_train job creates");
 
     assert!(store
@@ -718,7 +795,10 @@ fn create_job_with_id_uses_supplied_id() {
     let store = store("create-job-with-id");
 
     let job = store
-        .create_job_with_id("job_lora_train_fixture".to_owned(), lora_train_job("auto"))
+        .create_job_with_id(
+            "job_lora_train_fixture".to_owned(),
+            lora_train_job("auto", true),
+        )
         .expect("job creates with supplied id");
 
     assert_eq!(job.id, "job_lora_train_fixture");

--- a/tests/fixtures/rust_migration_contracts/training/training-plan.json
+++ b/tests/fixtures/rust_migration_contracts/training/training-plan.json
@@ -9,6 +9,7 @@
     "modality": "image",
     "outputKind": "lora",
     "baseModel": "z_image_turbo",
+    "baseModelRepo": "Tongyi-MAI/Z-Image-Turbo",
     "baseModelPath": "/sceneworks/data/cache/huggingface/Tongyi-MAI/Z-Image-Turbo"
   },
   "dataset": {

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -59,6 +59,7 @@ from scene_worker.training_adapters import (
     bucket_resolution,
     create_training_kernel,
     dry_run_training_summary,
+    flow_matching_velocity_target,
     read_run_config,
     resolve_pretrained_source,
     validate_training_plan,
@@ -175,11 +176,25 @@ def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
         "image_edit",
         "image_generate",
         "lora_train",
+        "lora_train_execute",
         "person_replace",
         "video_bridge",
         "video_extend",
         "video_generate",
     ]
+
+
+def test_gpu_worker_advertises_lora_train_execute_only_with_inference_backend(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    with_backend = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    assert "lora_train" in with_backend
+    assert "lora_train_execute" in with_backend
+
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: False)
+    without_backend = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    # Dry-run validation stays claimable; real execution is not advertised.
+    assert "lora_train" in without_backend
+    assert "lora_train_execute" not in without_backend
 
 
 def test_python_cpu_worker_does_not_advertise_person_tracking_jobs():
@@ -1001,6 +1016,18 @@ def test_bucket_resolution_floors_to_multiple_of_32():
     assert bucket_resolution(1024) == 1024
     assert bucket_resolution(1000) == 992
     assert bucket_resolution(20) == 32
+
+
+def test_flow_matching_velocity_target_uses_negated_pipeline_sign():
+    # The raw transformer output target is latents - noise, NOT noise - latents:
+    # diffusers' ZImagePipeline negates the transformer output before the scheduler,
+    # so the trained raw output is the negated flow velocity. Pin the sign so a
+    # refactor can't silently flip the training direction.
+    assert flow_matching_velocity_target(0.0, 1.0) == -1.0
+    assert flow_matching_velocity_target(2.0, -1.0) == 3.0
+    latents, noise = 0.7, 0.2
+    assert flow_matching_velocity_target(latents, noise) == latents - noise
+    assert flow_matching_velocity_target(latents, noise) == -(noise - latents)
 
 
 def test_read_run_config_defaults_lora_target_modules_and_parses_advanced():

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1167,22 +1167,44 @@ def _real_train_plan(tmp_path, *, steps=4, save_every=2, item_count=1):
     }
 
 
+# Mirror crates/sceneworks-core/src/jobs_store.rs::JOB_STATUSES. The Rust API
+# rejects any other status with InvalidStatus, which would fail the job mid-run.
+_VALID_JOB_STATUSES = {
+    "queued",
+    "preparing",
+    "downloading",
+    "loading_model",
+    "running",
+    "saving",
+    "completed",
+    "failed",
+    "canceled",
+    "interrupted",
+}
+
+
 def test_z_image_trainer_runs_stages_checkpoints_and_saves(tmp_path):
     plan = _real_train_plan(tmp_path, steps=4, save_every=2)
     backend = FakeTrainingBackend()
     trainer = ZImageLoraTrainer(backend=backend)
-    stages = []
+    events_log = []
 
     result = trainer.train(
         settings=SimpleNamespace(worker_id="worker-1", gpu_id="0"),
         plan=plan,
-        progress=lambda status, stage, value, message: stages.append(stage),
+        progress=lambda status, stage, value, message: events_log.append((status, stage)),
         cancel_requested=lambda: False,
     )
 
+    stages = [stage for _status, stage in events_log]
+    statuses = {status for status, _stage in events_log}
     assert backend.events[0] == "load"
     assert ("step", 4) in backend.events
     assert {"loading_model", "caching_latents", "training", "saving"}.issubset(set(stages))
+    # Every emitted status must be a valid JobStatus; the Rust API rejects others.
+    # In particular, caching runs under "running" (not the invalid "caching").
+    assert statuses <= _VALID_JOB_STATUSES
+    assert ("running", "caching_latents") in events_log
     assert result["mode"] == "train"
     assert result["stepsCompleted"] == 4
     assert result["outputPath"] == backend.saved == os.path.join(plan["output"]["outputDir"], "mira.safetensors")

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import sys
 from pathlib import Path
 from typing import NamedTuple
@@ -47,9 +48,20 @@ from scene_worker.runtime import (
     main,
     resolve_loaded_models,
     run_check,
-    run_lora_train_dry_run_job,
+    run_lora_train_job,
     run_video_job,
     worker_capabilities,
+)
+from scene_worker.training_adapters import (
+    SUPPORTED_TRAINING_PLAN_VERSION,
+    TrainingKernelError,
+    ZImageLoraTrainer,
+    bucket_resolution,
+    create_training_kernel,
+    dry_run_training_summary,
+    read_run_config,
+    resolve_pretrained_source,
+    validate_training_plan,
 )
 from scene_worker.video_adapters import (
     DiffusersVideoAdapter,
@@ -859,10 +871,12 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
 
 
 class _DryRunApi:
-    """Records job progress posts; heartbeats are accepted and ignored."""
+    """Records job progress posts; heartbeats are accepted and ignored. Job GETs
+    report no cancellation so a real run completes unless a test says otherwise."""
 
-    def __init__(self):
+    def __init__(self, cancel_requested=False):
         self.progress = []
+        self._cancel_requested = cancel_requested
 
     def post(self, path, payload):
         if path.endswith("/heartbeat"):
@@ -871,6 +885,9 @@ class _DryRunApi:
             self.progress.append(payload)
             return {"status": payload["status"], "stage": payload["stage"]}
         raise AssertionError(path)
+
+    def get(self, _path):
+        return {"cancelRequested": self._cancel_requested}
 
 
 def _lora_train_job(plan):
@@ -906,7 +923,7 @@ def test_lora_train_dry_run_completes_with_plan_summary(monkeypatch, tmp_path):
         },
     }
 
-    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
+    run_lora_train_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
 
     terminal = api.progress[-1]
     assert terminal["status"] == "completed"
@@ -931,7 +948,7 @@ def test_lora_train_dry_run_fails_cleanly_on_missing_dataset_image(monkeypatch, 
         "output": {},
     }
 
-    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
+    run_lora_train_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
 
     terminal = api.progress[-1]
     assert terminal["status"] == "failed"
@@ -943,29 +960,322 @@ def test_lora_train_dry_run_fails_on_unsupported_plan_version(monkeypatch):
     api = _DryRunApi()
     plan = {"planVersion": 999, "dataset": {"items": []}, "target": {}, "output": {}}
 
-    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
+    run_lora_train_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), _lora_train_job(plan))
 
     terminal = api.progress[-1]
     assert terminal["status"] == "failed"
     assert "version" in terminal["error"].lower()
 
 
-def test_lora_train_refuses_non_dry_run_job(monkeypatch):
-    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
-    api = _DryRunApi()
-    # Defense-in-depth: even if a non-dry-run job reaches the worker, it must not
-    # report success without producing weights (real execution is not implemented).
-    job = {
-        "id": "job-train-1",
-        "type": "lora_train",
-        "payload": {"dryRun": False, "plan": {"planVersion": 1, "dataset": {"items": []}}},
+def test_dry_run_summary_records_base_model_repo_and_install_state(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    plan = {
+        "planVersion": 1,
+        "dataset": {"datasetId": "ds_1", "datasetVersion": 4, "items": [{"imagePath": "x"}]},
+        "target": {
+            "targetId": "z_image_turbo_lora",
+            "kernel": "z_image_lora",
+            "baseModel": "z_image_turbo",
+            "baseModelRepo": "Tongyi-MAI/Z-Image-Turbo",
+            "baseModelPath": str(model_dir),
+        },
+        "output": {"loraId": "lora_1", "outputDir": str(tmp_path / "out"), "fileName": "a.safetensors"},
     }
 
-    run_lora_train_dry_run_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="cpu"), job)
+    summary = dry_run_training_summary(plan, dry_run=True)
+
+    assert summary["baseModelRepo"] == "Tongyi-MAI/Z-Image-Turbo"
+    assert summary["baseModelInstalled"] is True
+    assert summary["datasetVersion"] == 4
+
+
+def test_validate_training_plan_rejects_bad_version_and_empty_dataset():
+    with pytest.raises(ValueError, match="version"):
+        validate_training_plan({"planVersion": 99, "dataset": {"items": [{"imagePath": "x"}]}})
+    with pytest.raises(ValueError, match="no items"):
+        validate_training_plan({"planVersion": SUPPORTED_TRAINING_PLAN_VERSION, "dataset": {"items": []}})
+
+
+def test_bucket_resolution_floors_to_multiple_of_32():
+    assert bucket_resolution(1024) == 1024
+    assert bucket_resolution(1000) == 992
+    assert bucket_resolution(20) == 32
+
+
+def test_read_run_config_defaults_lora_target_modules_and_parses_advanced():
+    config = read_run_config(
+        {
+            "config": {
+                "rank": 8,
+                "alpha": 12,
+                "learningRate": 0.0003,
+                "steps": 500,
+                "saveEvery": 100,
+                "optimizer": "adamw8bit",
+                "advanced": {"mixedPrecision": "bf16"},
+            }
+        }
+    )
+
+    assert config.rank == 8
+    assert config.alpha == 12
+    assert config.steps == 500
+    assert config.save_every == 100
+    assert config.mixed_precision == "bf16"
+    assert config.lora_target_modules == ["to_q", "to_k", "to_v", "to_out.0"]
+
+
+def test_create_training_kernel_resolves_known_and_rejects_unknown():
+    assert isinstance(create_training_kernel("z_image_lora"), ZImageLoraTrainer)
+    with pytest.raises(TrainingKernelError, match="No training kernel"):
+        create_training_kernel("not_a_kernel")
+
+
+def test_resolve_pretrained_source_prefers_loadable_model_dir(tmp_path):
+    model_dir = tmp_path / "models" / "z_image"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model_index.json").write_text("{}", encoding="utf-8")
+
+    source = resolve_pretrained_source(
+        {"baseModelPath": str(model_dir), "baseModelRepo": "Tongyi-MAI/Z-Image-Turbo"}
+    )
+
+    assert source == str(model_dir)
+
+
+def test_resolve_pretrained_source_uses_hf_cache_snapshot(tmp_path):
+    cache_root = tmp_path / "hub"
+    snapshot = write_huggingface_cache_resource(
+        cache_root, "Tongyi-MAI/Z-Image-Turbo", "model_index.json", refs_main=True
+    )
+    repo_root = snapshot.parent.parent
+
+    source = resolve_pretrained_source({"baseModelPath": str(repo_root)})
+
+    assert source == str(snapshot)
+
+
+def test_resolve_pretrained_source_falls_back_to_repo_when_path_missing(tmp_path):
+    source = resolve_pretrained_source(
+        {"baseModelPath": str(tmp_path / "absent"), "baseModelRepo": "Tongyi-MAI/Z-Image-Turbo"}
+    )
+
+    assert source == "Tongyi-MAI/Z-Image-Turbo"
+
+
+class FakeTrainingBackend:
+    """Stand-in for the torch/diffusers backend so trainer orchestration is
+    testable without an inference backend."""
+
+    def __init__(self):
+        self.events = []
+        self.checkpoints = []
+        self.saved = None
+        self.cleaned = False
+
+    def loaded_models(self):
+        return ["fake/z-image"]
+
+    def load(self, *, settings, plan, config, progress):
+        self.events.append("load")
+
+    def prepare_dataset(self, *, items, config, progress, cancel_requested):
+        self.events.append("prepare")
+        return {"itemCount": len(items), "resolution": bucket_resolution(config.resolution)}
+
+    def train_step(self, *, step, total_steps, config):
+        self.events.append(("step", step))
+        return 0.5
+
+    def save_checkpoint(self, *, step, output_dir, file_name):
+        path = os.path.join(output_dir, f"ckpt-{step}.safetensors")
+        self.checkpoints.append(path)
+        return path
+
+    def save_final(self, *, output_dir, file_name):
+        self.saved = os.path.join(output_dir, file_name)
+        return self.saved
+
+    def cleanup(self):
+        self.cleaned = True
+
+
+def _real_train_plan(tmp_path, *, steps=4, save_every=2, item_count=1):
+    items = []
+    for index in range(item_count):
+        image = tmp_path / "images" / f"{index:03d}.png"
+        image.parent.mkdir(parents=True, exist_ok=True)
+        image.write_bytes(b"png")
+        items.append({"imagePath": str(image), "caption": f"miraStyle portrait {index}"})
+    return {
+        "planVersion": 1,
+        "dataset": {"datasetId": "ds_1", "datasetVersion": 3, "items": items},
+        "target": {
+            "targetId": "z_image_turbo_lora",
+            "kernel": "z_image_lora",
+            "baseModel": "z_image_turbo",
+            "baseModelPath": str(tmp_path / "model"),
+        },
+        "config": {
+            "rank": 16,
+            "alpha": 16,
+            "learningRate": 0.0001,
+            "steps": steps,
+            "batchSize": 1,
+            "gradientAccumulation": 1,
+            "resolution": 1024,
+            "saveEvery": save_every,
+            "seed": 42,
+            "optimizer": "adamw",
+            "advanced": {},
+        },
+        "output": {
+            "loraId": "lora_1",
+            "outputDir": str(tmp_path / "loras" / "lora_1"),
+            "fileName": "mira.safetensors",
+            "format": "safetensors",
+            "triggerWords": ["miraStyle"],
+        },
+    }
+
+
+def test_z_image_trainer_runs_stages_checkpoints_and_saves(tmp_path):
+    plan = _real_train_plan(tmp_path, steps=4, save_every=2)
+    backend = FakeTrainingBackend()
+    trainer = ZImageLoraTrainer(backend=backend)
+    stages = []
+
+    result = trainer.train(
+        settings=SimpleNamespace(worker_id="worker-1", gpu_id="0"),
+        plan=plan,
+        progress=lambda status, stage, value, message: stages.append(stage),
+        cancel_requested=lambda: False,
+    )
+
+    assert backend.events[0] == "load"
+    assert ("step", 4) in backend.events
+    assert {"loading_model", "caching_latents", "training", "saving"}.issubset(set(stages))
+    assert result["mode"] == "train"
+    assert result["stepsCompleted"] == 4
+    assert result["outputPath"] == backend.saved == os.path.join(plan["output"]["outputDir"], "mira.safetensors")
+    assert result["triggerWords"] == ["miraStyle"]
+    # save_every=2, steps=4 -> a single mid-run checkpoint at step 2 (step 4 is final).
+    assert backend.checkpoints == [os.path.join(plan["output"]["outputDir"], "ckpt-2.safetensors")]
+    assert backend.cleaned is True
+
+
+def test_z_image_trainer_cancels_and_skips_save(tmp_path):
+    plan = _real_train_plan(tmp_path, steps=10, save_every=0)
+    backend = FakeTrainingBackend()
+    trainer = ZImageLoraTrainer(backend=backend)
+    checks = {"count": 0}
+
+    def cancel_requested():
+        checks["count"] += 1
+        return checks["count"] > 3
+
+    with pytest.raises(InterruptedError):
+        trainer.train(
+            settings=SimpleNamespace(worker_id="worker-1", gpu_id="0"),
+            plan=plan,
+            progress=lambda *args: None,
+            cancel_requested=cancel_requested,
+        )
+
+    assert backend.saved is None
+    assert backend.cleaned is True
+
+
+def test_run_lora_train_job_executes_real_run(monkeypatch, tmp_path):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
+    monkeypatch.setattr(
+        "scene_worker.runtime.run_blocking_job_step",
+        lambda api, settings, job_id, status, callback, *, loaded_models: callback(),
+    )
+    backend = FakeTrainingBackend()
+    trainer = ZImageLoraTrainer(backend=backend)
+    monkeypatch.setattr("scene_worker.runtime.create_training_kernel", lambda _kernel_id: trainer)
+
+    api = _DryRunApi()
+    plan = _real_train_plan(tmp_path, steps=2, save_every=0)
+    job = {"id": "job-train-real", "type": "lora_train", "payload": {"dryRun": False, "plan": plan}}
+
+    run_lora_train_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="0"), job)
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "completed"
+    assert terminal["stage"] == "completed"
+    assert terminal["result"]["mode"] == "train"
+    assert terminal["result"]["fileName"] == "mira.safetensors"
+    assert backend.saved is not None
+
+
+def test_run_lora_train_job_marks_canceled(monkeypatch, tmp_path):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
+    monkeypatch.setattr(
+        "scene_worker.runtime.run_blocking_job_step",
+        lambda api, settings, job_id, status, callback, *, loaded_models: callback(),
+    )
+
+    class CancelingTrainer:
+        kernel_id = "z_image_lora"
+
+        def loaded_models(self):
+            return []
+
+        def train(self, *, settings, plan, progress, cancel_requested):
+            raise InterruptedError("LoRA training canceled by user.")
+
+    monkeypatch.setattr("scene_worker.runtime.create_training_kernel", lambda _kernel_id: CancelingTrainer())
+
+    api = _DryRunApi()
+    job = {
+        "id": "job-train-cancel",
+        "type": "lora_train",
+        "payload": {"dryRun": False, "plan": {"planVersion": 1, "target": {"kernel": "z_image_lora"}}},
+    }
+
+    run_lora_train_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="0"), job)
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "canceled"
+    assert "canceled" in terminal["message"].lower()
+
+
+def test_run_lora_train_job_reports_friendly_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
+    monkeypatch.setattr(
+        "scene_worker.runtime.run_blocking_job_step",
+        lambda api, settings, job_id, status, callback, *, loaded_models: callback(),
+    )
+
+    class FailingTrainer:
+        kernel_id = "z_image_lora"
+
+        def loaded_models(self):
+            return []
+
+        def train(self, *, settings, plan, progress, cancel_requested):
+            raise RuntimeError("Repository not found: Tongyi-MAI/Z-Image-Turbo")
+
+    monkeypatch.setattr("scene_worker.runtime.create_training_kernel", lambda _kernel_id: FailingTrainer())
+
+    api = _DryRunApi()
+    job = {
+        "id": "job-train-fail",
+        "type": "lora_train",
+        "payload": {"dryRun": False, "plan": {"planVersion": 1, "target": {"kernel": "z_image_lora"}}},
+    }
+
+    run_lora_train_job(api, SimpleNamespace(worker_id="worker-1", gpu_id="0"), job)
 
     terminal = api.progress[-1]
     assert terminal["status"] == "failed"
-    assert "not available" in terminal["error"].lower()
+    assert "model files were not available" in terminal["message"].lower()
 
 
 def test_main_check_exits_without_api_loop(monkeypatch):


### PR DESCRIPTION
Implements [sc-1417](https://app.shortcut.com/trefry/story/1417) ([Training 09] of epic [1408](https://app.shortcut.com/trefry/epic/1408)): replace the dry-run stub with a real Python Z-Image-Turbo LoRA training kernel, and wire the full path so a non-dry-run job produces a `.safetensors` LoRA end-to-end.

## What changed
- **Kernel** (`apps/worker/scene_worker/training_adapters.py`): `ZImageLoraTrainer` + `_ZImageLoraBackend`. Loads diffusers `ZImagePipeline` components, attaches a PEFT LoRA to the transformer, caches per-item latents/prompt-embeds, runs a flow-matching loop with staged progress, cancellation, checkpoint cadence, and saves via `ZImagePipeline.save_lora_weights`. Orchestration sits behind a backend seam so it's unit-testable without torch.
- **Worker runtime**: `run_lora_train_job` dispatches dry-run vs. real execution (keepalive heartbeats, cancel→canceled, friendly failures, OOM-restart parity).
- **Rust**: remove the `dryRun:false` guard now that execution exists; add `baseModelRepo` to the plan target so the kernel loads via the same `from_pretrained` path as generation.
- **Train UI**: a "Validate (dry run)" / "Run training (beta)" toggle (defaults to dry run).

## Adversarial-review fixes (second commit)
- **Velocity sign**: diffusers' `ZImagePipeline` negates the raw transformer output before the scheduler (`noise_pred = -noise_pred`), so the raw-output training target is `latents - noise`, not `noise - latents`. The inverted target would train the LoRA in the wrong denoising direction while MSE still appeared to converge. Pinned by `flow_matching_velocity_target()` + a sign test.
- **Capability routing**: a torch-less GPU worker advertised `lora_train` and could claim a real `dryRun:false` job and fail it. Added `WorkerCapability::LoraTrainExecute` (advertised only when the inference backend is available); `worker_supports_job` requires it for non-dry-run jobs. Dry-run still routes to any GPU worker.

## Verification
- Real GPU run in the CUDA worker container against cached Z-Image-Turbo: loaded the model, 272 LoRA tensors, matching forward shapes, produced a 16.7 MB diffusers-format `.safetensors`.
- Python worker tests **126 passed**; Rust core (jobs_store 24, training_contracts 14) and rust-api lib (41) pass; `clippy --workspace --all-targets -D warnings` clean; web vitest 73; web build OK.

## Notes / follow-ups
- Output **quality** is unproven (the smoke test only proves the pipeline runs); Z-Image-Turbo is distilled and may need a de-distillation adapter for good results.
- Registering the produced adapter as a usable SceneWorks LoRA with provenance is the next story (1418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
