### PR TITLE
Epic 1330 Phase 4: MPS support in Python worker [sc-1332/1334/1335/1336]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,10 @@ SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1
 # Worker connection and polling defaults.
 SCENEWORKS_API_URL=http://localhost:8010
 SCENEWORKS_WORKER_ID=worker-local-0
+# Inference device. When unset the default is platform-aware: "auto" on
+# Windows/Linux (supervise visible NVIDIA GPUs), "mps" on macOS (Apple Silicon).
+# Set "cpu" to force CPU on any platform, or an index (e.g. "0") for a specific
+# NVIDIA card. An explicit value here always wins.
 SCENEWORKS_GPU_ID=auto
 SCENEWORKS_WORKER_HEARTBEAT_SECONDS=30
 SCENEWORKS_WORKER_POLL_SECONDS=3
@@ -87,5 +91,6 @@ SCENEWORKS_IMAGE_ADAPTER=auto
 # adapter-development checks.
 SCENEWORKS_VIDEO_ADAPTER=
 
-# Docker/NVIDIA runtime GPU selection.
+# Docker/NVIDIA runtime GPU selection. CUDA/Linux only — ignored on macOS,
+# where MPS is the sole accelerator (sc-1335).
 NVIDIA_VISIBLE_DEVICES=all

--- a/apps/worker/scene_worker/gpu.py
+++ b/apps/worker/scene_worker/gpu.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 
 
 def gpu_worker_id(base_worker_id: str, gpu_id: str) -> str:
@@ -75,6 +76,28 @@ def query_nvidia_gpus() -> list[dict]:
         return []
 
 
+def query_mps_gpus() -> list[dict]:
+    """Detect an Apple Silicon MPS device, mirroring the nvidia-smi probe shape.
+
+    Returns a single-entry list when torch reports MPS available, otherwise [].
+    macOS-only — a no-op (empty) on every other platform (sc-1334).
+    """
+    if sys.platform != "darwin":
+        return []
+    try:
+        import torch
+    except Exception:
+        return []
+    mps = getattr(getattr(torch, "backends", None), "mps", None)
+    try:
+        available = bool(mps and mps.is_available())
+    except Exception:
+        available = False
+    if not available:
+        return []
+    return [{"id": "mps", "name": "Apple GPU (unified)", "capabilities": ["gpu", "mps"]}]
+
+
 def gpu_utilization(gpu_id: str) -> dict | None:
     if gpu_id == "cpu":
         return None
@@ -94,7 +117,9 @@ def visible_gpu_ids() -> list[str] | None:
 
 
 def discover_gpus() -> list[dict]:
-    ids = visible_gpu_ids()
+    # NVIDIA_VISIBLE_DEVICES is a CUDA/Linux concept; ignore it on macOS, where
+    # the only accelerator is the unified-memory MPS device (sc-1334/sc-1335).
+    ids = None if sys.platform == "darwin" else visible_gpu_ids()
     if ids == []:
         return []
 
@@ -105,7 +130,10 @@ def discover_gpus() -> list[dict]:
             by_id.get(gpu_id, {"id": gpu_id, "name": f"GPU {gpu_id}", "capabilities": ["gpu"]})
             for gpu_id in ids
         ]
-    return gpus
+    if gpus:
+        return gpus
+    # No NVIDIA GPUs → fall back to MPS on Apple Silicon (empty elsewhere → CPU).
+    return query_mps_gpus()
 
 
 def discover_gpu(requested_gpu_id: str) -> dict:

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1079,6 +1079,13 @@ def select_torch_dtype(torch: Any, device: str, requested: Any) -> Any:
         return torch.float16
     if requested == "float32" or device == "cpu":
         return torch.float32
+    if device == "mps":
+        # bfloat16 coverage on the MPS backend is incomplete and frequently
+        # forces slow CPU fallbacks (via PYTORCH_ENABLE_MPS_FALLBACK) or hard
+        # errors; float16 is the well-supported half-precision path on Apple
+        # Silicon. Explicit float16/float32 requests above still take priority
+        # (sc-1336).
+        return torch.float16
     return torch.bfloat16
 
 

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -623,8 +623,7 @@ class ZImageDiffusersAdapter:
         self._empty_cuda_cache(torch)
 
     def _empty_cuda_cache(self, torch: Any) -> None:
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        empty_torch_cache(torch)
 
     def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
         torch = importlib.import_module("torch")
@@ -877,8 +876,7 @@ class QwenImageAdapter:
         return pipe
 
     def _empty_cuda_cache(self, torch: Any) -> None:
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        empty_torch_cache(torch)
 
     def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
         torch = importlib.import_module("torch")
@@ -1031,8 +1029,27 @@ def select_torch_device(torch: Any, gpu_id: str | None = None) -> str:
                 return f"cuda:{physical_index}"
         return "cuda"
     if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        # Route the few diffusers ops that lack an MPS kernel to CPU instead of
+        # erroring out. Set only when MPS is actually selected — never on CUDA
+        # or CPU hosts (sc-1332).
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
         return "mps"
     return "cpu"
+
+
+def empty_torch_cache(torch: Any) -> None:
+    """Release cached accelerator memory on whichever backend is active.
+
+    Clears the CUDA allocator cache on NVIDIA and the MPS allocator cache on
+    Apple Silicon; a no-op on CPU-only hosts (sc-1332).
+    """
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    mps = getattr(getattr(torch, "backends", None), "mps", None)
+    if mps and mps.is_available():
+        mps_backend = getattr(torch, "mps", None)
+        if mps_backend is not None and hasattr(mps_backend, "empty_cache"):
+            mps_backend.empty_cache()
 
 
 def torch_inference_backend_available(torch: Any) -> bool:

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1017,6 +1017,10 @@ def image_batch_progress(completed_count: int, total: int) -> float:
 
 
 def select_torch_device(torch: Any, gpu_id: str | None = None) -> str:
+    # An explicit "cpu" forces CPU on any platform, including Apple Silicon where
+    # MPS would otherwise be picked (honors SCENEWORKS_GPU_ID=cpu, sc-1335).
+    if str(gpu_id or "").strip().lower() == "cpu":
+        return "cpu"
     if torch.cuda.is_available():
         gpu_id = str(gpu_id or "").strip()
         if gpu_id.isdigit():

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1083,13 +1083,13 @@ def select_torch_dtype(torch: Any, device: str, requested: Any) -> Any:
         return torch.float16
     if requested == "float32" or device == "cpu":
         return torch.float32
-    if device == "mps":
-        # bfloat16 coverage on the MPS backend is incomplete and frequently
-        # forces slow CPU fallbacks (via PYTORCH_ENABLE_MPS_FALLBACK) or hard
-        # errors; float16 is the well-supported half-precision path on Apple
-        # Silicon. Explicit float16/float32 requests above still take priority
-        # (sc-1336).
-        return torch.float16
+    # bfloat16 for both CUDA and MPS. On MPS, float16 overflows to NaN and yields
+    # all-black images — the denoiser latents go NaN before the VAE, so upcasting
+    # only the VAE does not help. bfloat16 keeps float32's exponent range (no
+    # overflow) at half float32's memory and renders correctly + fast on Apple
+    # Silicon. Verified on an M-series Mac with Z-Image-Turbo: fp16 = black,
+    # bf16 = OK (~18s), fp32 = OK but ~2x memory and slower. Explicit
+    # float16/float32 requests above still win (sc-1336).
     return torch.bfloat16
 
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -730,6 +730,10 @@ def child_environment(settings: WorkerSettings, *, worker_id: str, gpu_id: str) 
     env["SCENEWORKS_GPU_ID"] = gpu_id
     if gpu_id == "cpu":
         env["CUDA_VISIBLE_DEVICES"] = ""
+    elif gpu_id == "mps":
+        # MPS is not a CUDA device; leave CUDA_VISIBLE_DEVICES untouched rather
+        # than pinning it to a bogus "mps" value (sc-1335).
+        pass
     else:
         env["CUDA_VISIBLE_DEVICES"] = gpu_id
     return env

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -1,11 +1,16 @@
 import os
+import sys
 from pathlib import Path
 
 
 class WorkerSettings:
     def __init__(self) -> None:
         self.worker_id = os.getenv("SCENEWORKS_WORKER_ID", "worker-local-0")
-        self.gpu_id = os.getenv("SCENEWORKS_GPU_ID", "auto")
+        # Apple Silicon has no NVIDIA card to supervise, so default straight to
+        # the MPS backend. Windows/Linux keep "auto" (supervise visible NVIDIA
+        # GPUs). An explicit SCENEWORKS_GPU_ID always wins, including "cpu" (sc-1335).
+        default_gpu_id = "mps" if sys.platform == "darwin" else "auto"
+        self.gpu_id = os.getenv("SCENEWORKS_GPU_ID", default_gpu_id)
         self.api_url = os.getenv("SCENEWORKS_API_URL", "http://localhost:8000")
         self.data_dir = Path(os.getenv("SCENEWORKS_DATA_DIR", "data")).resolve()
         self.config_dir = Path(os.getenv("SCENEWORKS_CONFIG_DIR", "config")).resolve()

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -30,7 +30,7 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import filter_call_kwargs
-from .image_adapters import emit_worker_event, gpu_memory_snapshot, require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
+from .image_adapters import emit_worker_event, empty_torch_cache, gpu_memory_snapshot, require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
 from .lora_adapters import (
     LoraPipelineState,
     LoraSpec,
@@ -990,9 +990,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         gc.collect()
         try:
             torch = importlib.import_module("torch")
-            cuda = getattr(torch, "cuda", None)
-            if cuda is not None and cuda.is_available():
-                cuda.empty_cache()
+            empty_torch_cache(torch)
         except Exception:
             return
 
@@ -1391,8 +1389,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         self._pipeline_key_value = None
         self._loaded_models.clear()
         self._loaded_lora_state = LoraPipelineState()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        empty_torch_cache(torch)
 
     def _apply_loras(self, pipe: Any, request: VideoRequest, target: dict[str, Any]) -> None:
         self._loaded_lora_state = apply_loras_to_pipeline(


### PR DESCRIPTION
## Summary

Phase 4 of epic 1330 — adds MPS (Apple Silicon) as an alternative GPU backend in the Python inference worker, **without touching the CUDA path**. Validated end-to-end on real hardware (M-series Mac, 128 GB, torch 2.8, diffusers git): real image **and** video generations run on MPS.

### Changes
- **sc-1332** (`c1626bb`) — `empty_torch_cache(torch)` helper clears the CUDA *or* MPS allocator cache; both image `_empty_cuda_cache` paths + both video `_evict_pipeline` paths delegate to it. `select_torch_device` sets `PYTORCH_ENABLE_MPS_FALLBACK=1` only when MPS is selected. (Device priority `cuda→mps→cpu` and CPU-generator-on-MPS already existed.)
- **sc-1334** (`027549b`) — `gpu.py` `query_mps_gpus()` (a `torch.backends.mps` probe, macOS-only); `discover_gpus()` falls back to MPS when no NVIDIA, ignores `NVIDIA_VISIBLE_DEVICES` on macOS. No Rust change needed — routing is job-type based and the API has no nvidia/device-tag branching.
- **sc-1335** (`bfdf610`) — `SCENEWORKS_GPU_ID` defaults to `mps` on macOS / `auto` elsewhere; `select_torch_device` honors `gpu_id="cpu"` to force CPU on any platform; `child_environment` no longer pins `CUDA_VISIBLE_DEVICES` for MPS; `.env.example` documents both branches.
- **sc-1336** (`d38926e`, corrected by `d2609ba`) — `select_torch_dtype` returns **bfloat16** on MPS. The initial commit used float16; real-hardware validation showed **float16 on MPS overflows to NaN → all-black images**. bf16 has float32's exponent range (no overflow) at half the memory; CUDA stays bf16 (no regression), CPU stays float32.

### Real-hardware validation (not committed — throwaway harnesses)
- **Image:** Z-Image-Turbo 1024² (~18 s) and Qwen-Image 20B 1024² (~49 s) — coherent images, bf16.
- **Video:** Wan2.2-TI2V-5B (~102 s) and Wan2.2-T2V-A14B 14B MoE (~10.5 min) at 704×480 — coherent clips; the A14B high→low-noise expert switch runs correctly on MPS. 5B is the practical interactive tier; A14B is heavy.
- The fp16→black bug was caught **only** by a real generation — the logic harnesses passed it.

### Not in this PR (follow-up, taken to a separate session)
- **sc-1338** LTX video — its adapter uses the native Lightricks LTX pipeline (needs `requirements-ltx.txt`).
- **sc-1340** VACE person-replace on Mac.
- **sc-1333** full API + worker-loop round-trip (loop needs Python ≥3.11; the desktop uv venv provides it).

## Test plan
- [x] Device/dtype/cache logic — fake-torch + ast-extract harness (mps/cuda/cpu, cpu-force, CUDA no-regression)
- [x] Real device selection + MPS tensor op + worker capabilities on actual Apple Silicon
- [x] Real image generation on MPS (Z-Image-Turbo, Qwen-Image) — coherent output
- [x] Real video generation on MPS (Wan-5B, Wan-A14B) — coherent output
- [ ] CUDA path unchanged on Windows/Linux (no code change to CUDA branch; verify on a CUDA host)
- [ ] LTX (sc-1338), VACE (sc-1340), full API round-trip (sc-1333) — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)