### PR TITLE
Real person detection/tracking/masks + active LTX Replace Person (sc-1480–1483)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -914,6 +914,10 @@ struct PersonDetectionJobRequest {
     source_asset_id: String,
     #[serde(default)]
     source_timestamp: Option<f64>,
+    /// Opt into the Rust utility worker's procedural preview instead of real,
+    /// model-backed detection on the Python GPU worker. Defaults to real.
+    #[serde(default)]
+    preview: bool,
     #[serde(default = "default_requested_gpu")]
     requested_gpu: String,
 }
@@ -926,6 +930,10 @@ struct PersonTrackJobRequest {
     detection: JsonObject,
     #[serde(default = "default_track_name")]
     track_name: String,
+    /// Opt into the Rust utility worker's procedural preview instead of real,
+    /// model-backed tracking on the Python GPU worker. Defaults to real.
+    #[serde(default)]
+    preview: bool,
     #[serde(default = "default_requested_gpu")]
     requested_gpu: String,
 }
@@ -2332,6 +2340,9 @@ async fn create_person_detection_job(
         "sourceTimestamp".to_owned(),
         payload.source_timestamp.map_or(Value::Null, Value::from),
     );
+    if payload.preview {
+        job_payload.insert("preview".to_owned(), Value::Bool(true));
+    }
     let job = create_generation_job(
         state,
         JobType::PersonDetect,
@@ -2367,6 +2378,9 @@ async fn create_person_track_job(
     );
     job_payload.insert("detection".to_owned(), Value::Object(payload.detection));
     job_payload.insert("trackName".to_owned(), Value::String(payload.track_name));
+    if payload.preview {
+        job_payload.insert("preview".to_owned(), Value::Bool(true));
+    }
     let job = create_generation_job(
         state,
         JobType::PersonTrack,

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -44,6 +44,41 @@ override them through matching advanced settings.
 Use `advanced.mockNativeInference=true` only for adapter smoke tests; otherwise
 the native adapter loads `ltx-pipelines` and writes MP4 video assets.
 
+## Replace Person: detection, tracking, segmentation (`person_detect` / `person_track`)
+
+Real person detection and tracking run here, in the GPU worker, replacing the
+Rust utility worker's procedural placeholders (epic sc-1090). The backends live
+in `scene_worker/person_adapters.py` and are imported lazily, so the worker stays
+importable without them:
+
+- **Detection (`person_detect`)** runs Ultralytics YOLO over a representative
+  frame and returns pixel-derived candidate boxes with confidence and
+  adapter/model/runtime metadata. No-person frames return no candidates.
+- **Tracking (`person_track`)** follows the selected detection through real
+  source-video frames with YOLO + ByteTrack/BoT-SORT, samples the track, and
+  writes a reusable person-track sidecar. Lost/low-confidence frames are recorded
+  honestly (`detected: false`, flagged) rather than fabricated.
+- **Segmentation** generates per-frame person masks with SAM2 (or MatAnyone),
+  stored under `person-tracks/{id}/masks/`. Without a segmenter the track records
+  `maskState: degraded` and replacement falls back to box masks.
+
+Install these backends with `apps/worker/requirements-person.txt` (Docker Compose
+builds them by default; opt out with `INCLUDE_PERSON_BACKENDS=0`). A GPU worker
+advertises `person_detect` / `person_track` / `person_segment` only when the
+corresponding backend is installed, so a real job never routes to a worker that
+cannot run it. The Rust utility worker advertises `person_detect_preview` /
+`person_track_preview` and serves the procedural preview only for jobs created
+with `preview: true`.
+
+**Replace Person (`replace_person`)** on LTX-2.3 runs through the native
+`ltx_pipelines` adapter: it builds a masked control clip from the source frames +
+person-track masks + masking strength and injects it through the IC-LoRA
+video-conditioning path. The output sidecar sets `replacementActive: true` only
+when that real masked-control path ran (mocked/preview runs leave it false). Wan
+remains a secondary VACE/masked-conditioning path. Replacement requires a source
+clip, a saved person track, an approved character reference, and an installed
+LTX IC-LoRA; the job fails clearly when any are missing.
+
 ## Native LoRA training (`lora_train`)
 
 Training jobs carry a fully normalized, Rust-resolved `TrainingPlan` (see

--- a/apps/worker/requirements-person.txt
+++ b/apps/worker/requirements-person.txt
@@ -1,0 +1,16 @@
+# Real person detection / tracking / segmentation for the Replace Person workflow
+# (epic sc-1090). Install in the GPU worker image; these backends are imported
+# lazily by scene_worker/person_adapters.py, so the worker stays importable
+# without them (the capability is simply not advertised, and replacement masks
+# degrade to boxes). Validated in the CUDA worker container, not on host Python.
+#
+# Detection + tracking: Ultralytics ships YOLO detection and the ByteTrack /
+# BoT-SORT trackers in-package (lap provides the tracker's assignment solver).
+# Pin under the torch>=2.8,<2.9 range in requirements.txt.
+ultralytics>=8.3,<9
+lap>=0.5
+#
+# Segmentation / matting (per-frame person masks). SAM2 is the primary backend;
+# MatAnyone (Wan2GP's reference video matter) is an accepted alternative. Either
+# one advertises the person_segment capability; absence degrades masks to boxes.
+sam2 @ git+https://github.com/facebookresearch/sam2.git@main

--- a/apps/worker/scene_worker/person_adapters.py
+++ b/apps/worker/scene_worker/person_adapters.py
@@ -1,0 +1,1044 @@
+"""Real person detection, tracking, and segmentation for the Replace Person workflow.
+
+Epic sc-1090 originally shipped procedural placeholders in the Rust CPU utility
+worker (``candidate_people`` / ``track_frames_from_detection``): hard-coded
+candidate boxes and synthetic x-drift that never inspected video pixels. This
+module replaces those with model-backed detection (sc-1480), content-based
+tracking (sc-1481), and per-frame segmentation masks (sc-1482) running in the
+Python GPU worker, where torch/ultralytics/SAM2 live.
+
+Design notes
+------------
+* The heavy backends (ultralytics, SAM2/MatAnyone, torch, numpy) are imported
+  lazily inside the model seams so this module stays importable on a host that
+  only has Pillow + the standard library. That keeps the orchestration and the
+  pure geometry/cadence helpers unit-testable without a GPU image, exactly like
+  the video/training adapters.
+* Geometry is normalized (0..1) box math in plain Python; only the model seams
+  and mask rasterization touch numpy/PIL. Tests inject fake detectors/trackers/
+  segmenters that read pixel content, so coverage proves the pipeline is
+  content-dependent rather than template-driven.
+* The orchestration functions return a result dict and write the same sidecar
+  shapes the Rust worker produced, so the API/UI keep working — but successful
+  real jobs set ``personDetectionActive``/``personTrackingActive`` to ``True``
+  and record adapter/model/runtime metadata instead of the old inactive flags.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any, Callable, Protocol
+from uuid import uuid4
+
+from PIL import Image, ImageDraw
+
+from sceneworks_shared import (
+    find_asset_sidecar_path,
+    find_project_path,
+    index_asset,
+    read_json,
+    safe_float,
+    utc_now,
+)
+
+ProgressCallback = Callable[[str, str, float, str], None]
+CancelCallback = Callable[[], bool]
+
+# COCO "person" class index, shared by the Ultralytics detection and tracking models.
+PERSON_CLASS_INDEX = 0
+# Default confidence floor for accepting a detection/track box.
+DEFAULT_DETECTION_CONFIDENCE = 0.25
+# Representative-frame analysis resolution, matching the Rust placeholder frame size.
+DETECTION_FRAME_WIDTH = 1280
+DETECTION_FRAME_HEIGHT = 720
+# Tracking sample cadence (frames per second of source). Matches the V1 sidecar
+# cadence so existing track consumers keep working; replacement resamples as needed.
+PERSON_TRACK_SAMPLE_RATE_FPS = 2.0
+PERSON_TRACK_MIN_SAMPLES = 3
+PERSON_TRACK_MAX_SAMPLES = 24
+# A track frame whose confidence falls below this is flagged for correction
+# rather than silently trusted; the box is still recorded honestly.
+TRACK_LOW_CONFIDENCE = 0.40
+
+DETECTOR_ADAPTER_ID = "ultralytics_person_detect"
+TRACKER_ADAPTER_ID = "ultralytics_person_track"
+SEGMENTER_ADAPTER_ID = "sam2_person_segment"
+
+
+# ---------------------------------------------------------------------------
+# Backend availability (advertised as worker capabilities only when installed)
+# ---------------------------------------------------------------------------
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def detector_backend_available() -> bool:
+    """True when a real person detector (Ultralytics YOLO) can be imported."""
+    return _module_available("ultralytics")
+
+
+def tracker_backend_available() -> bool:
+    """True when content-based tracking is available.
+
+    Ultralytics ships ByteTrack/BoT-SORT trackers in-package, so the detector
+    backend is also the tracker backend.
+    """
+    return _module_available("ultralytics")
+
+
+def segmenter_backend_available() -> bool:
+    """True when a video segmentation/matting backend is importable.
+
+    SAM2 is the primary target; MatAnyone (Wan2GP's reference video matter) is an
+    accepted alternative. Either presence advertises the segmenter capability;
+    its absence degrades masks to boxes instead of failing the track job.
+    """
+    return _module_available("sam2") or _module_available("matanyone")
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NormalizedBox:
+    x: float
+    y: float
+    width: float
+    height: float
+
+    def to_dict(self) -> dict[str, float]:
+        return {"x": self.x, "y": self.y, "width": self.width, "height": self.height}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "NormalizedBox":
+        return cls(
+            x=clamp01(safe_float(value.get("x"), 0.0, 0.0, 1.0)),
+            y=clamp01(safe_float(value.get("y"), 0.0, 0.0, 1.0)),
+            width=clamp01(safe_float(value.get("width"), 0.0, 0.0, 1.0)),
+            height=clamp01(safe_float(value.get("height"), 0.0, 0.0, 1.0)),
+        )
+
+
+@dataclass(frozen=True)
+class PersonDetection:
+    id: str
+    label: str
+    box: NormalizedBox
+    confidence: float
+
+    def to_dict(self, *, frame_width: int, frame_height: int) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "box": self.box.to_dict(),
+            "confidence": round(self.confidence, 4),
+            "frameWidth": frame_width,
+            "frameHeight": frame_height,
+            "maskState": "missing",
+        }
+
+
+@dataclass
+class TrackFrame:
+    timestamp: float
+    box: NormalizedBox
+    confidence: float
+    detected: bool = True
+    mask: str | None = None
+    flags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "timestamp": round(self.timestamp, 4),
+            "box": self.box.to_dict(),
+            "confidence": round(self.confidence, 4),
+            "detected": self.detected,
+            "mask": self.mask,
+        }
+        if self.flags:
+            payload["flags"] = list(self.flags)
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Pure geometry / cadence helpers (unit-tested directly, no models)
+# ---------------------------------------------------------------------------
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def box_iou(a: NormalizedBox, b: NormalizedBox) -> float:
+    """Intersection-over-union of two normalized boxes."""
+    ax2, ay2 = a.x + a.width, a.y + a.height
+    bx2, by2 = b.x + b.width, b.y + b.height
+    inter_x1, inter_y1 = max(a.x, b.x), max(a.y, b.y)
+    inter_x2, inter_y2 = min(ax2, bx2), min(ay2, by2)
+    inter_w, inter_h = max(0.0, inter_x2 - inter_x1), max(0.0, inter_y2 - inter_y1)
+    intersection = inter_w * inter_h
+    union = a.width * a.height + b.width * b.height - intersection
+    return intersection / union if union > 0 else 0.0
+
+
+def xyxy_to_normalized(x1: float, y1: float, x2: float, y2: float, width: int, height: int) -> NormalizedBox:
+    """Convert pixel xyxy to a normalized x/y/width/height box."""
+    if width <= 0 or height <= 0:
+        return NormalizedBox(0.0, 0.0, 0.0, 0.0)
+    left, right = sorted((x1, x2))
+    top, bottom = sorted((y1, y2))
+    return NormalizedBox(
+        x=clamp01(left / width),
+        y=clamp01(top / height),
+        width=clamp01((right - left) / width),
+        height=clamp01((bottom - top) / height),
+    )
+
+
+def sample_count_for_duration(duration: float) -> int:
+    raw = round(max(0.0, duration) * PERSON_TRACK_SAMPLE_RATE_FPS)
+    return int(max(PERSON_TRACK_MIN_SAMPLES, min(PERSON_TRACK_MAX_SAMPLES, raw)))
+
+
+def sample_timestamps(duration: float) -> list[float]:
+    """Evenly spaced sample timestamps across the clip, inclusive of both ends."""
+    count = sample_count_for_duration(duration)
+    span = max(0.0, duration)
+    if count <= 1 or span <= 0:
+        return [0.0]
+    return [round(span * index / (count - 1), 4) for index in range(count)]
+
+
+def select_target_index(detections: list[PersonDetection], selected: NormalizedBox) -> int | None:
+    """Pick the detection that best matches the user-selected box by IoU.
+
+    Returns None when nothing overlaps, so callers can fail honestly instead of
+    snapping to an unrelated person.
+    """
+    best_index: int | None = None
+    best_iou = 0.0
+    for index, detection in enumerate(detections):
+        score = box_iou(detection.box, selected)
+        if score > best_iou:
+            best_iou = score
+            best_index = index
+    return best_index if best_iou > 0.0 else None
+
+
+def frame_sha256(image: Image.Image) -> str:
+    """Stable content hash of a frame, recorded in lineage so detection results
+    can be tied to the exact pixels analyzed."""
+    digest = hashlib.sha256()
+    digest.update(f"{image.width}x{image.height}:".encode())
+    digest.update(image.convert("RGB").tobytes())
+    return digest.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Model seams (lazy heavy imports; monkeypatched in tests)
+# ---------------------------------------------------------------------------
+
+
+class DetectorRuntime(Protocol):
+    """A loaded person detector. Real impl wraps an Ultralytics YOLO model."""
+
+    model_ref: str
+    runtime: dict[str, Any]
+
+    def detect(self, image: Image.Image, *, confidence: float) -> list[PersonDetection]:
+        ...
+
+
+def resolve_detector_model(settings: Any, override: str | None) -> str:
+    """Resolve the detector weights reference.
+
+    Order: explicit override -> env -> local data-dir weight -> bundled default
+    name (Ultralytics resolves/downloads bare names into its own cache).
+    """
+    if override:
+        return override
+    env_ref = os.getenv("SCENEWORKS_PERSON_DETECTOR_MODEL")
+    if env_ref:
+        return env_ref
+    data_dir = getattr(settings, "data_dir", None)
+    if data_dir is not None:
+        for candidate in ("yolo11x.pt", "yolo11l.pt", "yolo11m.pt", "yolov8x.pt"):
+            local = Path(data_dir) / "models" / "person-detect" / candidate
+            if local.exists():
+                return str(local)
+    return "yolo11m.pt"
+
+
+def load_person_detector(settings: Any, *, model_ref: str | None = None) -> DetectorRuntime:
+    """Load a real Ultralytics person detector. Raises a clear error when the
+    backend or weights are unavailable so the job fails honestly."""
+    if not detector_backend_available():
+        raise RuntimeError(
+            "Person detection requires the Ultralytics backend. Install "
+            "apps/worker/requirements-person.txt in the GPU worker image."
+        )
+    ultralytics = importlib.import_module("ultralytics")
+    resolved = resolve_detector_model(settings, model_ref)
+    yolo = ultralytics.YOLO(resolved)
+    runtime = {
+        "backend": "ultralytics",
+        "ultralytics": getattr(ultralytics, "__version__", "unknown"),
+        "device": getattr(settings, "gpu_id", "cpu"),
+    }
+    return _UltralyticsDetector(model=yolo, model_ref=resolved, runtime=runtime)
+
+
+@dataclass
+class _UltralyticsDetector:
+    model: Any
+    model_ref: str
+    runtime: dict[str, Any]
+
+    def detect(self, image: Image.Image, *, confidence: float) -> list[PersonDetection]:
+        results = self.model.predict(
+            source=image,
+            classes=[PERSON_CLASS_INDEX],
+            conf=confidence,
+            verbose=False,
+        )
+        detections: list[PersonDetection] = []
+        for result in results:
+            boxes = getattr(result, "boxes", None)
+            if boxes is None:
+                continue
+            xyxy = boxes.xyxy.tolist()
+            confs = boxes.conf.tolist()
+            for index, (coords, conf) in enumerate(zip(xyxy, confs)):
+                box = xyxy_to_normalized(coords[0], coords[1], coords[2], coords[3], image.width, image.height)
+                if box.width <= 0 or box.height <= 0:
+                    continue
+                detections.append(
+                    PersonDetection(
+                        id=f"person_{index + 1}",
+                        label=f"Person {index + 1}",
+                        box=box,
+                        confidence=float(conf),
+                    )
+                )
+        detections.sort(key=lambda detection: detection.confidence, reverse=True)
+        return detections
+
+
+# ---------------------------------------------------------------------------
+# Detection orchestration (sc-1480)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DetectionRequest:
+    project_id: str
+    source_asset_id: str
+    source_timestamp: float | None
+    detector_model: str | None
+    confidence: float
+
+
+def _require(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Person detection job payload is missing '{key}'.")
+    return value
+
+
+def detection_request_from_job(job: dict[str, Any]) -> DetectionRequest:
+    payload = job.get("payload") or {}
+    advanced = payload.get("advanced") or {}
+    timestamp = payload.get("sourceTimestamp")
+    return DetectionRequest(
+        project_id=_require(payload, "projectId"),
+        source_asset_id=_require(payload, "sourceAssetId"),
+        source_timestamp=None if timestamp is None else safe_float(timestamp, 0.0, 0.0, 3600.0),
+        detector_model=advanced.get("detectorModel") or payload.get("detectorModel"),
+        confidence=safe_float(advanced.get("confidence"), DEFAULT_DETECTION_CONFIDENCE, 0.01, 1.0),
+    )
+
+
+def _source_duration(project_path: Path, asset_id: str) -> float:
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        raise RuntimeError(f"Source clip asset not found: {asset_id}.")
+    payload = read_json(sidecar_path)
+    return safe_float(payload.get("file", {}).get("duration"), 6.0, 0.0, 3600.0)
+
+
+def _source_display_name(project_path: Path, asset_id: str) -> str:
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        return "clip"
+    payload = read_json(sidecar_path)
+    return str(payload.get("displayName") or "clip")
+
+
+def run_person_detect(
+    settings: Any,
+    job: dict[str, Any],
+    *,
+    progress: ProgressCallback | None = None,
+    cancel_requested: CancelCallback | None = None,
+    detector_factory: Callable[..., DetectorRuntime] = load_person_detector,
+) -> dict[str, Any]:
+    """Detect selectable people in a representative source frame using a real
+    detector, persisting the selection-frame asset and returning pixel-derived
+    candidates with adapter/model/runtime metadata (sc-1480)."""
+    from .video_adapters import load_source_frame  # lazy: keeps this module light
+
+    def report(stage: str, value: float, message: str) -> None:
+        if progress is not None:
+            progress("running", stage, value, message)
+
+    def check_cancel() -> None:
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Person detection canceled.")
+
+    request = detection_request_from_job(job)
+    project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
+    duration = _source_duration(project_path, request.source_asset_id)
+    timestamp = request.source_timestamp
+    if timestamp is None:
+        timestamp = round(duration * 0.25, 4) if duration > 0 else 0.0
+    timestamp = float(max(0.0, min(timestamp, max(duration, 0.0))))
+
+    report("extracting", 0.25, "Extracting representative frame.")
+    check_cancel()
+    frame = load_source_frame(
+        project_path,
+        request.source_asset_id,
+        timestamp,
+        DETECTION_FRAME_WIDTH,
+        DETECTION_FRAME_HEIGHT,
+    )
+    if frame is None:
+        raise RuntimeError(
+            f"Could not extract a representative frame from source asset {request.source_asset_id}."
+        )
+
+    report("loading_model", 0.45, "Loading person detector.")
+    check_cancel()
+    detector = detector_factory(settings, model_ref=request.detector_model)
+
+    report("running", 0.6, "Detecting people in representative frame.")
+    detections = detector.detect(frame, confidence=request.confidence)
+
+    report("saving", 0.82, "Saving representative frame and candidate boxes.")
+    check_cancel()
+    asset_id = f"asset_{uuid4().hex}"
+    created_at = utc_now()
+    media_rel = f"assets/frames/{created_at[:10]}_person-frame_{asset_id[-8:]}.png"
+    media_path = project_path / media_rel
+    media_path.parent.mkdir(parents=True, exist_ok=True)
+    frame.save(media_path, format="PNG")
+    source_hash = frame_sha256(frame)
+    display_name = _source_display_name(project_path, request.source_asset_id)
+
+    detection_dicts = [
+        detection.to_dict(frame_width=DETECTION_FRAME_WIDTH, frame_height=DETECTION_FRAME_HEIGHT)
+        for detection in detections
+    ]
+    runtime_meta = dict(getattr(detector, "runtime", {}) or {})
+    asset = {
+        "schemaVersion": 1,
+        "id": asset_id,
+        "projectId": request.project_id,
+        "generationSetId": None,
+        "type": "frame",
+        "displayName": f"Person selection frame from {display_name}",
+        "createdAt": created_at,
+        "file": {
+            "path": media_rel,
+            "mimeType": "image/png",
+            "width": DETECTION_FRAME_WIDTH,
+            "height": DETECTION_FRAME_HEIGHT,
+            "duration": None,
+            "fps": None,
+        },
+        "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
+        "recipe": {
+            "mode": "person_detect",
+            "model": getattr(detector, "model_ref", "unknown"),
+            "adapter": DETECTOR_ADAPTER_ID,
+            "prompt": "Detect selectable people in representative frame",
+            "negativePrompt": "",
+            "seed": 0,
+            "loras": [],
+            "stylePreset": "none",
+            "normalizedSettings": {
+                "sourceTimestamp": timestamp,
+                "detectionCount": len(detection_dicts),
+                "confidence": request.confidence,
+                "personDetectionActive": True,
+                "detector": runtime_meta,
+            },
+            "rawAdapterSettings": {"sourceFrameHash": source_hash},
+        },
+        "lineage": {
+            "parents": [request.source_asset_id],
+            "sourceAssetId": request.source_asset_id,
+            "sourceTimestamp": timestamp,
+            "sourceFrameHash": source_hash,
+            "jobId": job.get("id"),
+        },
+    }
+    from .image_adapters import write_json  # lazy import to avoid a heavy import chain
+
+    write_json(media_path.with_suffix(".sceneworks.json"), asset)
+    write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
+    index_asset(project_path, asset)
+
+    return {
+        "frameAssetId": asset_id,
+        "frameAsset": asset,
+        "sourceAssetId": request.source_asset_id,
+        "sourceTimestamp": timestamp,
+        "sourceFrameHash": source_hash,
+        "detections": detection_dicts,
+        "detector": runtime_meta,
+        "personDetectionActive": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tracking (sc-1481): content-based selected-person tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FrameObservation:
+    """Person boxes observed in one processed source frame, keyed by tracker id."""
+
+    timestamp: float
+    boxes: dict[int, tuple[NormalizedBox, float]]
+
+
+class TrackerRuntime(Protocol):
+    model_ref: str
+    runtime: dict[str, Any]
+
+    def observe(self, video_path: Path, *, confidence: float) -> list[FrameObservation]:
+        ...
+
+
+@dataclass
+class TrackAssembly:
+    frames: list[TrackFrame]
+    target_track_id: int | None
+    quality: dict[str, Any]
+
+
+def _nearest_observation(observations: list[FrameObservation], timestamp: float) -> FrameObservation | None:
+    if not observations:
+        return None
+    return min(observations, key=lambda obs: abs(obs.timestamp - timestamp))
+
+
+def choose_target_track_id(
+    observations: list[FrameObservation],
+    selected_box: NormalizedBox,
+    selected_timestamp: float,
+    *,
+    min_iou: float = 0.1,
+) -> int | None:
+    """Match the user-selected detection to a tracker identity by IoU at the
+    observation nearest the selection frame. Returns None when nothing overlaps
+    so tracking fails honestly instead of locking onto the wrong person."""
+    observation = _nearest_observation(observations, selected_timestamp)
+    if observation is None:
+        return None
+    best_id: int | None = None
+    best_iou = min_iou
+    for track_id, (box, _conf) in observation.boxes.items():
+        score = box_iou(box, selected_box)
+        if score >= best_iou:
+            best_iou = score
+            best_id = track_id
+    return best_id
+
+
+def assemble_track(
+    observations: list[FrameObservation],
+    selected_box: NormalizedBox,
+    selected_timestamp: float,
+    timestamps: list[float],
+) -> TrackAssembly:
+    """Resample a chosen tracker identity onto the requested sample cadence.
+
+    Detected frames carry the tracker's real box/confidence; frames where the
+    target is absent are recorded as ``detected=False`` and flagged, never
+    fabricated into plausible motion the way the V1 placeholder did.
+    """
+    target_id = choose_target_track_id(observations, selected_box, selected_timestamp)
+    frames: list[TrackFrame] = []
+    detected_count = 0
+    lost_frames: list[int] = []
+    last_box = selected_box
+    for index, stamp in enumerate(timestamps):
+        observation = _nearest_observation(observations, stamp)
+        entry = observation.boxes.get(target_id) if (observation and target_id is not None) else None
+        if entry is not None:
+            box, confidence = entry
+            last_box = box
+            flags = ["low_confidence"] if confidence < TRACK_LOW_CONFIDENCE else []
+            frames.append(TrackFrame(timestamp=stamp, box=box, confidence=confidence, detected=True, flags=flags))
+            detected_count += 1
+        else:
+            lost_frames.append(index)
+            frames.append(
+                TrackFrame(
+                    timestamp=stamp,
+                    box=last_box,
+                    confidence=0.0,
+                    detected=False,
+                    flags=["lost_target"],
+                )
+            )
+    quality = {
+        "trackId": target_id,
+        "sampledFrames": len(timestamps),
+        "detectedFrames": detected_count,
+        "lostFrames": lost_frames,
+        "detectedRatio": round(detected_count / len(timestamps), 4) if timestamps else 0.0,
+    }
+    return TrackAssembly(frames=frames, target_track_id=target_id, quality=quality)
+
+
+def resolve_tracker_model(settings: Any, override: str | None) -> str:
+    if override:
+        return override
+    env_ref = os.getenv("SCENEWORKS_PERSON_TRACKER_MODEL")
+    if env_ref:
+        return env_ref
+    return resolve_detector_model(settings, None)
+
+
+def load_person_tracker(settings: Any, *, model_ref: str | None = None) -> TrackerRuntime:
+    if not tracker_backend_available():
+        raise RuntimeError(
+            "Person tracking requires the Ultralytics backend. Install "
+            "apps/worker/requirements-person.txt in the GPU worker image."
+        )
+    ultralytics = importlib.import_module("ultralytics")
+    resolved = resolve_tracker_model(settings, model_ref)
+    yolo = ultralytics.YOLO(resolved)
+    tracker_cfg = os.getenv("SCENEWORKS_PERSON_TRACKER_CFG", "bytetrack.yaml")
+    runtime = {
+        "backend": "ultralytics",
+        "ultralytics": getattr(ultralytics, "__version__", "unknown"),
+        "tracker": tracker_cfg,
+        "device": getattr(settings, "gpu_id", "cpu"),
+    }
+    return _UltralyticsTracker(model=yolo, model_ref=resolved, runtime=runtime, tracker_cfg=tracker_cfg)
+
+
+@dataclass
+class _UltralyticsTracker:
+    model: Any
+    model_ref: str
+    runtime: dict[str, Any]
+    tracker_cfg: str
+
+    def observe(self, video_path: Path, *, confidence: float) -> list[FrameObservation]:
+        results = self.model.track(
+            source=str(video_path),
+            classes=[PERSON_CLASS_INDEX],
+            conf=confidence,
+            tracker=self.tracker_cfg,
+            persist=True,
+            stream=True,
+            verbose=False,
+        )
+        observations: list[FrameObservation] = []
+        for index, result in enumerate(results):
+            boxes = getattr(result, "boxes", None)
+            timestamp = self._result_timestamp(result, index)
+            entries: dict[int, tuple[NormalizedBox, float]] = {}
+            if boxes is not None and getattr(boxes, "id", None) is not None:
+                shape = getattr(result, "orig_shape", (DETECTION_FRAME_HEIGHT, DETECTION_FRAME_WIDTH))
+                height, width = int(shape[0]), int(shape[1])
+                ids = boxes.id.tolist()
+                xyxy = boxes.xyxy.tolist()
+                confs = boxes.conf.tolist()
+                for track_id, coords, conf in zip(ids, xyxy, confs):
+                    box = xyxy_to_normalized(coords[0], coords[1], coords[2], coords[3], width, height)
+                    entries[int(track_id)] = (box, float(conf))
+            observations.append(FrameObservation(timestamp=timestamp, boxes=entries))
+        return observations
+
+    def _result_timestamp(self, result: Any, index: int) -> float:
+        speed = getattr(result, "speed", None)
+        fps = None
+        if isinstance(speed, dict):
+            fps = speed.get("fps")
+        if not fps:
+            fps = PERSON_TRACK_SAMPLE_RATE_FPS
+        return round(index / float(fps), 4) if fps else float(index)
+
+
+# ---------------------------------------------------------------------------
+# Segmentation (sc-1482): per-frame person masks
+# ---------------------------------------------------------------------------
+
+
+class SegmenterRuntime(Protocol):
+    model_ref: str
+    runtime: dict[str, Any]
+
+    def segment(self, image: Image.Image, box: NormalizedBox) -> Image.Image:
+        ...
+
+
+def load_person_segmenter(settings: Any, *, model_ref: str | None = None) -> SegmenterRuntime:
+    """Load a video segmentation/matting backend (SAM2 primary, MatAnyone
+    accepted). Raises when unavailable so callers can degrade to box masks."""
+    if not segmenter_backend_available():
+        raise RuntimeError(
+            "Person segmentation requires SAM2 or MatAnyone. Install "
+            "apps/worker/requirements-person.txt in the GPU worker image."
+        )
+    if _module_available("sam2"):
+        return _build_sam2_segmenter(settings, model_ref)
+    return _build_matanyone_segmenter(settings, model_ref)
+
+
+def _build_sam2_segmenter(settings: Any, model_ref: str | None) -> SegmenterRuntime:
+    sam2 = importlib.import_module("sam2.sam2_image_predictor")
+    build = importlib.import_module("sam2.build_sam")
+    checkpoint = model_ref or os.getenv("SCENEWORKS_PERSON_SEGMENTER_MODEL", "sam2_hiera_large.pt")
+    config = os.getenv("SCENEWORKS_PERSON_SEGMENTER_CFG", "sam2_hiera_l.yaml")
+    model = build.build_sam2(config, checkpoint, device=getattr(settings, "gpu_id", "cpu"))
+    predictor = sam2.SAM2ImagePredictor(model)
+    runtime = {"backend": "sam2", "checkpoint": str(checkpoint), "config": config}
+    return _Sam2Segmenter(predictor=predictor, model_ref=str(checkpoint), runtime=runtime)
+
+
+def _build_matanyone_segmenter(settings: Any, model_ref: str | None) -> SegmenterRuntime:
+    raise RuntimeError("MatAnyone segmenter integration is not yet wired; install SAM2.")
+
+
+@dataclass
+class _Sam2Segmenter:
+    predictor: Any
+    model_ref: str
+    runtime: dict[str, Any]
+
+    def segment(self, image: Image.Image, box: NormalizedBox) -> Image.Image:
+        import numpy as np  # lazy: only the real backend needs numpy
+
+        self.predictor.set_image(np.asarray(image.convert("RGB")))
+        width, height = image.width, image.height
+        prompt = np.array(
+            [
+                box.x * width,
+                box.y * height,
+                (box.x + box.width) * width,
+                (box.y + box.height) * height,
+            ]
+        )
+        masks, scores, _ = self.predictor.predict(box=prompt, multimask_output=False)
+        mask = masks[int(np.argmax(scores))]
+        return Image.fromarray((np.asarray(mask) > 0).astype("uint8") * 255, mode="L")
+
+
+def mask_relative_path(track_id: str, index: int) -> str:
+    return f"person-tracks/{track_id}/masks/frame_{index:06d}.png"
+
+
+def segment_track(
+    settings: Any,
+    project_path: Path,
+    source_asset_id: str,
+    track_id: str,
+    frames: list[TrackFrame],
+    *,
+    segmenter_factory: Callable[..., SegmenterRuntime] = load_person_segmenter,
+    frame_loader: Callable[..., Image.Image | None] | None = None,
+) -> str:
+    """Generate per-frame person masks for the detected track frames and write
+    them under ``person-tracks/{track_id}/masks/``. Returns the resulting
+    ``maskState`` (active/generated/degraded/missing). Box-derived fallback is
+    left to the replacement loader and only used in explicit degraded mode."""
+    detected = [frame for frame in frames if frame.detected]
+    if not detected:
+        return "missing"
+    if not segmenter_backend_available():
+        return "degraded"
+
+    if frame_loader is None:
+        from .video_adapters import load_source_frame
+
+        def frame_loader(timestamp: float) -> Image.Image | None:  # type: ignore[misc]
+            return load_source_frame(
+                project_path, source_asset_id, timestamp, DETECTION_FRAME_WIDTH, DETECTION_FRAME_HEIGHT
+            )
+
+    try:
+        segmenter = segmenter_factory(settings)
+    except RuntimeError:
+        return "degraded"
+
+    masks_dir = project_path / "person-tracks" / track_id / "masks"
+    masks_dir.mkdir(parents=True, exist_ok=True)
+    generated = 0
+    for index, frame in enumerate(frames):
+        if not frame.detected:
+            continue
+        image = frame_loader(frame.timestamp)
+        if image is None:
+            continue
+        try:
+            mask = segmenter.segment(image, frame.box)
+        except Exception:
+            continue
+        rel = mask_relative_path(track_id, index + 1)
+        mask.convert("L").save(project_path / rel, format="PNG")
+        frame.mask = rel
+        generated += 1
+
+    if generated == 0:
+        return "degraded"
+    return "active" if generated == len(detected) else "generated"
+
+
+# ---------------------------------------------------------------------------
+# Track orchestration (sc-1481 + sc-1482)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrackRequest:
+    project_id: str
+    source_asset_id: str
+    representative_frame_asset_id: str | None
+    selected_box: NormalizedBox
+    selected_detection: dict[str, Any]
+    selected_timestamp: float
+    track_name: str
+    tracker_model: str | None
+    confidence: float
+    segment: bool
+
+
+def track_request_from_job(job: dict[str, Any], project_path: Path) -> TrackRequest:
+    payload = job.get("payload") or {}
+    advanced = payload.get("advanced") or {}
+    detection = payload.get("detection")
+    if not isinstance(detection, dict) or not isinstance(detection.get("box"), dict):
+        raise ValueError("Person track job payload requires a selected detection with a box.")
+    representative_id = payload.get("representativeFrameAssetId")
+    selected_timestamp = _representative_timestamp(project_path, representative_id)
+    return TrackRequest(
+        project_id=_require(payload, "projectId"),
+        source_asset_id=_require(payload, "sourceAssetId"),
+        representative_frame_asset_id=representative_id if isinstance(representative_id, str) else None,
+        selected_box=NormalizedBox.from_dict(detection["box"]),
+        selected_detection=detection,
+        selected_timestamp=selected_timestamp,
+        track_name=str(payload.get("trackName") or "Selected person"),
+        tracker_model=advanced.get("trackerModel") or payload.get("trackerModel"),
+        confidence=safe_float(advanced.get("confidence"), DEFAULT_DETECTION_CONFIDENCE, 0.01, 1.0),
+        segment=bool(advanced.get("segment", True)),
+    )
+
+
+def _representative_timestamp(project_path: Path, asset_id: Any) -> float:
+    if not isinstance(asset_id, str):
+        return 0.0
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        return 0.0
+    payload = read_json(sidecar_path)
+    return safe_float(payload.get("lineage", {}).get("sourceTimestamp"), 0.0, 0.0, 3600.0)
+
+
+def run_person_track(
+    settings: Any,
+    job: dict[str, Any],
+    *,
+    progress: ProgressCallback | None = None,
+    cancel_requested: CancelCallback | None = None,
+    tracker_factory: Callable[..., TrackerRuntime] = load_person_tracker,
+    segmenter_factory: Callable[..., SegmenterRuntime] = load_person_segmenter,
+) -> dict[str, Any]:
+    """Track the selected person through real source-video content, generate
+    per-frame masks, and persist a reusable person-track sidecar (sc-1481/1482).
+
+    Successful tracks set ``personTrackingActive: True`` and record per-frame
+    timestamp/box/confidence plus model/runtime metadata and quality. A selected
+    person that never matches a real track fails honestly.
+    """
+
+    def report(stage: str, value: float, message: str) -> None:
+        if progress is not None:
+            progress("running", stage, value, message)
+
+    def check_cancel() -> None:
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Person tracking canceled.")
+
+    project_path = find_project_path(settings.data_dir / "recent-projects.json", job["payload"]["projectId"])
+    request = track_request_from_job(job, project_path)
+    video_path = _require_source_media(project_path, request.source_asset_id)
+    duration = _source_duration(project_path, request.source_asset_id)
+    timestamps = sample_timestamps(duration)
+
+    report("loading_model", 0.3, "Loading person tracker.")
+    check_cancel()
+    tracker = tracker_factory(settings, model_ref=request.tracker_model)
+
+    report("tracking", 0.45, "Tracking selected person through source frames.")
+    observations = tracker.observe(video_path, confidence=request.confidence)
+    assembly = assemble_track(observations, request.selected_box, request.selected_timestamp, timestamps)
+    if assembly.target_track_id is None or assembly.quality["detectedFrames"] == 0:
+        raise RuntimeError(
+            "Selected person was not found in the source video. Re-run detection or adjust the selection."
+        )
+
+    mask_state = "missing"
+    if request.segment:
+        report("running", 0.7, "Generating per-frame person masks.")
+        check_cancel()
+        mask_state = segment_track(
+            settings,
+            project_path,
+            request.source_asset_id,
+            _pending_track_id(job),
+            assembly.frames,
+            segmenter_factory=segmenter_factory,
+        )
+
+    report("saving", 0.85, "Saving reusable person track.")
+    check_cancel()
+    track_id = _pending_track_id(job)
+    detected_confidences = [frame.confidence for frame in assembly.frames if frame.detected]
+    average_confidence = round(sum(detected_confidences) / len(detected_confidences), 4) if detected_confidences else 0.0
+    created_at = utc_now()
+    runtime_meta = dict(getattr(tracker, "runtime", {}) or {})
+    track = {
+        "schemaVersion": 1,
+        "id": track_id,
+        "projectId": request.project_id,
+        "name": request.track_name,
+        "createdAt": created_at,
+        "sourceAssetId": request.source_asset_id,
+        "sourceDisplayName": _source_display_name(project_path, request.source_asset_id),
+        "representativeFrameAssetId": request.representative_frame_asset_id,
+        "selectedDetection": request.selected_detection,
+        "frames": [frame.to_dict() for frame in assembly.frames],
+        "corrections": [],
+        "status": {
+            "sampleRateFps": PERSON_TRACK_SAMPLE_RATE_FPS,
+            "maskState": mask_state,
+            "averageConfidence": average_confidence,
+            "correctionState": "ready_for_box_corrections",
+            "personTrackingActive": True,
+            "quality": assembly.quality,
+            "tracker": runtime_meta,
+        },
+        "recipe": {
+            "mode": "person_track",
+            "model": getattr(tracker, "model_ref", "unknown"),
+            "adapter": TRACKER_ADAPTER_ID,
+            "prompt": f"Track {request.track_name}",
+            "negativePrompt": "",
+            "seed": 0,
+            "loras": [],
+            "stylePreset": "none",
+            "normalizedSettings": {
+                "sampleRateFps": PERSON_TRACK_SAMPLE_RATE_FPS,
+                "personDetectionActive": True,
+                "personTrackingActive": True,
+                "maskState": mask_state,
+                "tracker": runtime_meta,
+            },
+            "rawAdapterSettings": {"selectedDetection": request.selected_detection},
+        },
+        "lineage": {
+            "jobId": job.get("id"),
+            "parents": [request.source_asset_id, request.representative_frame_asset_id],
+            "sourceAssetId": request.source_asset_id,
+        },
+    }
+    track_rel = f"person-tracks/{track_id}.sceneworks.person-track.json"
+    from .image_adapters import write_json  # lazy import to avoid a heavy import chain
+
+    write_json(project_path / track_rel, track)
+    return {"trackId": track_id, "track": track, "path": track_rel, "personTrackingActive": True}
+
+
+def _pending_track_id(job: dict[str, Any]) -> str:
+    """Deterministic per-job track id so masks written during a job land under
+    the same folder the sidecar references."""
+    cached = job.get("_personTrackId")
+    if not cached:
+        cached = f"track_{uuid4().hex}"
+        job["_personTrackId"] = cached
+    return cached
+
+
+def _require_source_media(project_path: Path, asset_id: str) -> Path:
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        raise RuntimeError(f"Source clip asset not found: {asset_id}.")
+    payload = read_json(sidecar_path)
+    media_path = project_path / payload.get("file", {}).get("path", "")
+    if not media_path.exists():
+        raise RuntimeError(f"Source clip media is missing for asset {asset_id}.")
+    return media_path
+
+
+def load_track_masks(
+    project_path: Path,
+    track: dict[str, Any],
+    width: int,
+    height: int,
+    count: int,
+) -> tuple[list[Image.Image], str]:
+    """Load per-frame masks for replacement, resampled to ``count`` frames.
+
+    Returns ``(masks, mode)`` where mode is ``"segmentation"`` when stored masks
+    were loaded or ``"degraded_box"`` when falling back to rectangular box masks
+    derived from the track frames. Box fallback is the explicit degraded path.
+    """
+    frames = track.get("frames") or []
+    if not frames:
+        raise RuntimeError("Person track has no frames; cannot build replacement masks.")
+    indices = _resample_indices(len(frames), count)
+    stored = [frames[index].get("mask") for index in indices]
+    if all(isinstance(ref, str) and (project_path / ref).exists() for ref in stored):
+        masks = [Image.open(project_path / ref).convert("L").resize((width, height)) for ref in stored]
+        return masks, "segmentation"
+    masks = [_box_mask(frames[index].get("box") or {}, width, height) for index in indices]
+    return masks, "degraded_box"
+
+
+def _resample_indices(total: int, count: int) -> list[int]:
+    if count <= 1 or total <= 1:
+        return [0] * max(count, 1)
+    return [min(total - 1, round((total - 1) * index / (count - 1))) for index in range(count)]
+
+
+def _box_mask(box: dict[str, Any], width: int, height: int) -> Image.Image:
+    mask = Image.new("L", (width, height), 0)
+    if box:
+        pad_x, pad_y = int(width * 0.03), int(height * 0.03)
+        left = max(0, int(safe_float(box.get("x"), 0.0, 0.0, 1.0) * width) - pad_x)
+        top = max(0, int(safe_float(box.get("y"), 0.0, 0.0, 1.0) * height) - pad_y)
+        right = min(width, int((safe_float(box.get("x"), 0.0, 0.0, 1.0) + safe_float(box.get("width"), 0.0, 0.0, 1.0)) * width) + pad_x)
+        bottom = min(height, int((safe_float(box.get("y"), 0.0, 0.0, 1.0) + safe_float(box.get("height"), 0.0, 0.0, 1.0)) * height) + pad_y)
+        ImageDraw.Draw(mask).rectangle((left, top, right, bottom), fill=255)
+    return mask

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -15,6 +15,13 @@ import httpx
 
 from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_utilization, gpu_worker_id
 from .image_adapters import ProceduralImageAdapter, QwenImageAdapter, ZImageDiffusersAdapter, create_image_adapter
+from .person_adapters import (
+    detector_backend_available,
+    run_person_detect,
+    run_person_track,
+    segmenter_backend_available,
+    tracker_backend_available,
+)
 from .settings import WorkerSettings
 from .training_adapters import (
     SUPPORTED_TRAINING_PLAN_VERSION,
@@ -28,6 +35,12 @@ from .video_adapters import create_video_adapter
 LoadedModelsSource = Callable[[], list[str]] | None
 IMAGE_JOB_TYPES = ("image_generate", "image_edit")
 VIDEO_JOB_TYPES = ("video_generate", "video_extend", "video_bridge", "person_replace")
+# Real person detection/tracking run in the Python GPU worker (YOLO/ByteTrack/SAM2),
+# replacing the Rust CPU procedural placeholders. Advertised only when the backend
+# is installed; the Rust utility worker keeps procedural previews under the distinct
+# person_detect_preview / person_track_preview capabilities. Keep in sync with
+# crates/sceneworks-core/src/contracts.rs::WorkerCapability and jobs_store::worker_supports_job.
+PERSON_JOB_TYPES = ("person_detect", "person_track")
 # Keep GPU-required job types in sync with
 # crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
 # apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
@@ -83,6 +96,14 @@ def worker_capabilities(gpu: dict) -> list[str]:
             # Only a backend-capable worker advertises real training execution, so
             # the queue won't route a dryRun:false job to a worker that can't train.
             capabilities |= set(TRAINING_EXECUTE_CAPABILITIES)
+        # Real detection/tracking/segmentation are advertised per installed backend
+        # so the queue never routes a real person job to a worker that can't run it.
+        if detector_backend_available():
+            capabilities.add("person_detect")
+        if tracker_backend_available():
+            capabilities.add("person_track")
+        if segmenter_backend_available():
+            capabilities.add("person_segment")
     return sorted(capabilities)
 
 
@@ -589,6 +610,65 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
 # live in training_adapters; the kernels there consume the Rust-resolved plan.
 
 
+def run_person_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    """Run a real person_detect or person_track job in the GPU worker.
+
+    Detection and tracking now use model-backed adapters (YOLO/ByteTrack with
+    SAM2 masks) instead of the Rust procedural placeholders, so completed jobs
+    report active detection/tracking metadata and content-derived results.
+    """
+    job_id = job["id"]
+    job_type = job["type"]
+    needs_oom_restart = False
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        update_job(api, job_id, {"status": status, "stage": stage, "progress": value, "message": message})
+
+    runner = run_person_detect if job_type == "person_detect" else run_person_track
+    done_message = "Person candidates detected." if job_type == "person_detect" else "Reusable person track saved."
+
+    try:
+        progress("preparing", "preparing", 0.06, "Preparing person analysis.")
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda: runner(
+                settings,
+                job,
+                progress=progress,
+                cancel_requested=lambda: job_cancel_requested(api, job_id),
+            ),
+            loaded_models=lambda: [],
+        )
+        update_job(
+            api,
+            job_id,
+            {"status": "completed", "stage": "completed", "progress": 1, "message": done_message, "result": result},
+        )
+    except InterruptedError as exc:
+        update_job(
+            api,
+            job_id,
+            {"status": "canceled", "stage": "canceled", "progress": 1, "message": str(exc)},
+        )
+    except Exception as exc:
+        needs_oom_restart = is_cuda_oom(exc)
+        kind = "Person detection" if job_type == "person_detect" else "Person tracking"
+        message, error = friendly_failure(kind, exc)
+        update_job(
+            api,
+            job_id,
+            {"status": "failed", "stage": "failed", "progress": 1, "message": message, "error": error},
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+        if needs_oom_restart:
+            restart_worker_after_oom(settings, job_id)
+
+
 def run_lora_train_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     """Run a lora_train job: validate the plan, then either report a dry-run
     summary or execute the real training kernel.
@@ -779,6 +859,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
                 run_image_job(api, settings, job, image_adapters)
             elif job["type"] in VIDEO_JOB_TYPES:
                 run_video_job(api, settings, job)
+            elif job["type"] in PERSON_JOB_TYPES:
+                run_person_job(api, settings, job)
             elif job["type"] in TRAINING_JOB_TYPES:
                 run_lora_train_job(api, settings, job)
             else:
@@ -882,8 +964,8 @@ def run_check(settings: WorkerSettings) -> None:
             "workerId": settings.worker_id,
             "gpu": gpu,
             "capabilities": capabilities,
-            "jobTypes": [job_type for job_type in SUPPORTED_JOB_TYPES if job_type in capabilities],
-            "supportedJobTypes": list(SUPPORTED_JOB_TYPES),
+            "jobTypes": [job_type for job_type in SUPPORTED_JOB_TYPES + PERSON_JOB_TYPES if job_type in capabilities],
+            "supportedJobTypes": list(SUPPORTED_JOB_TYPES + PERSON_JOB_TYPES),
             "reportedAt": now(),
         }
     )

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -629,7 +629,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         replacement_control: LtxReplacementControl | None = None
         replacement_status: dict[str, Any] | None = None
         if request.mode == "replace_person":
-            control_clip = media_path.with_suffix(".control.webp")
+            control_clip = media_path.with_suffix(".control.mp4")
             self._temporary_outputs.setdefault(job["id"], []).append(control_clip)
             progress("preparing", "building_control", 0.24, "Building masked control clip from person track.")
             replacement_control = self._ltx_replacement_control(project_path, request, num_frames, control_clip)
@@ -848,7 +848,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             self._apply_replacement_mask(frame, mask, masking_strength)
             for frame, mask in zip(source_frames, masks)
         ]
-        save_animated_preview(masked_frames, clip_path, request.duration)
+        self._write_control_clip(masked_frames, clip_path, request.fps)
         status = track.get("status", {}) if isinstance(track.get("status"), dict) else {}
         return LtxReplacementControl(
             track_id=str(track.get("id") or request.person_track_id),
@@ -860,6 +860,25 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             frame_count=len(masked_frames),
             character_reference_count=len(references),
         )
+
+    def _write_control_clip(self, frames: list[Image.Image], path: Path, fps: int) -> None:
+        """Write the masked control frames as a clip the native LTX video
+        conditioner can decode. LTX reads ``video_conditioning`` with PyAV/ffmpeg,
+        which cannot frame-decode an animated WebP, so real runs (``.mp4``) are
+        encoded with imageio/ffmpeg; tests pass ``.webp`` for a Pillow-only host.
+        """
+        if path.suffix.lower() in {".webp", ".gif"}:
+            save_animated_preview(frames, path, max(1.0, len(frames) / max(1, fps)))
+            return
+        import imageio
+        import numpy as np
+
+        writer = imageio.get_writer(str(path), fps=max(1, int(fps)), codec="libx264", macro_block_size=None)
+        try:
+            for frame in frames:
+                writer.append_data(np.asarray(frame.convert("RGB")))
+        finally:
+            writer.close()
 
     def _apply_replacement_mask(self, frame: Image.Image, mask: Image.Image, strength: float) -> Image.Image:
         """Blend the masked person region toward neutral gray by ``strength`` so

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -77,7 +77,7 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "adapter": "ltx_video",
         "repo": "Lightricks/LTX-2.3",
         "fallbackRepo": "Lightricks/LTX-Video",
-        "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
+        "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
         "recommendedMaxDuration": 10,
         "hardMaxDuration": 15,
         "steps": {"fast": 6, "balanced": 8, "best": 20},
@@ -161,6 +161,25 @@ class LtxPipelinesResources:
     distilled_lora_path: Path
     gemma_root: Path
     temporal_upsampler_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class LtxReplacementControl:
+    """The shared source/control/mask package the native LTX replacement path
+    consumes (sc-1483). It is the model-agnostic product object the epic calls
+    for: source frames + per-frame person masks + masking strength, plus the
+    masked control clip built from them. ``mask_mode`` is ``"segmentation"`` when
+    real masks were loaded or ``"degraded_box"`` for the explicit box fallback.
+    """
+
+    track_id: str
+    masked_clip_path: Path
+    mask_mode: str
+    mask_state: str
+    person_tracking_active: bool
+    masking_strength: float
+    frame_count: int
+    character_reference_count: int
 
 
 def install_ltx_pipelines_multigpu_compat() -> None:
@@ -361,7 +380,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
 class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
     id = "ltx_pipelines"
 
-    _supported_modes = {"text_to_video", "image_to_video", "first_last_frame", "extend_clip", "video_bridge"}
+    _supported_modes = {"text_to_video", "image_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"}
 
     # ltx-core builds each stage (text encoder, transformer, upscaler, VAE) inside
     # a gpu_model() context that frees it before the next stage, so the components
@@ -407,6 +426,8 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             raise RuntimeError(f"{target['label']} is limited to {target['hardMaxDuration']}s clips in this adapter.")
         validate_lora_compatibility(request.loras, model_family=target["family"], adapter_id=self.id)
         self._ltx_lora_specs(request)
+        if request.mode == "replace_person" and not self._mock_inference_enabled(request):
+            self._validate_replacement_inputs(request)
         if self._uses_ic_lora_pipeline(request) and not self._has_ic_lora(request) and not self._mock_inference_enabled(request):
             raise RuntimeError(
                 "Native LTX IC-LoRA video conditioning requires at least one installed LTX-compatible LoRA. "
@@ -605,8 +626,18 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         self._temporary_outputs.setdefault(job["id"], []).append(temp_path)
 
         progress("preparing", "validating_inputs", 0.2, "Validating native LTX-2.3 inputs.")
-        conditioning_images = self._ltx_conditioning_images(project_path, request, num_frames)
-        video_conditioning = self._ltx_video_conditioning(project_path, request)
+        replacement_control: LtxReplacementControl | None = None
+        replacement_status: dict[str, Any] | None = None
+        if request.mode == "replace_person":
+            control_clip = media_path.with_suffix(".control.webp")
+            self._temporary_outputs.setdefault(job["id"], []).append(control_clip)
+            progress("preparing", "building_control", 0.24, "Building masked control clip from person track.")
+            replacement_control = self._ltx_replacement_control(project_path, request, num_frames, control_clip)
+            conditioning_images = []
+            video_conditioning = [(str(replacement_control.masked_clip_path), replacement_control.masking_strength)]
+        else:
+            conditioning_images = self._ltx_conditioning_images(project_path, request, num_frames)
+            video_conditioning = self._ltx_video_conditioning(project_path, request)
         if cancel_requested():
             raise InterruptedError("Video generation canceled before native LTX pipeline load.")
 
@@ -652,6 +683,22 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             )
         temp_path.replace(media_path)
 
+        if replacement_control is not None:
+            # replacementActive is true ONLY here: the masked-control package was
+            # built from a real person track and run through the native LTX path.
+            replacement_status = {
+                "personDetectionActive": True,
+                "personTrackingActive": replacement_control.person_tracking_active,
+                "replacementActive": True,
+                "replacementAdapter": self.id,
+                "maskMode": replacement_control.mask_mode,
+                "maskState": replacement_control.mask_state,
+                "maskingStrength": replacement_control.masking_strength,
+                "personTrackId": replacement_control.track_id,
+                "characterReferenceCount": replacement_control.character_reference_count,
+                "controlFrameCount": replacement_control.frame_count,
+            }
+
         generation_set = {
             "schemaVersion": 1,
             "id": generation_set_id,
@@ -677,6 +724,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             adapter_id=self.id,
             mime_type="video/mp4",
             raw_settings=self.map_settings(request, target),
+            replacement_status=replacement_status,
         )
         write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
         write_json(media_path.with_suffix(".sceneworks.json"), asset)
@@ -749,6 +797,78 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 raise RuntimeError("Video Bridge requires a readable right-side source clip.")
             conditionings.append((str(right_path), self._advanced_float(request, "bridgeRightVideoConditioningStrength", 1.0)))
         return conditionings
+
+    def _validate_replacement_inputs(self, request: VideoRequest) -> None:
+        """Fail clearly when the required Replace Person inputs are missing,
+        before loading the LTX pipeline."""
+        settings = self._settings or WorkerSettings()
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
+        if source_asset_media_path(project_path, request.source_clip_asset_id) is None:
+            raise RuntimeError("Replace Person requires a readable source clip.")
+        track = read_person_track(project_path, request.person_track_id)
+        if not track:
+            raise RuntimeError(
+                "Replace Person requires a saved person track. Run detection and tracking on the source clip first."
+            )
+        if not track.get("frames") and not track.get("selectedDetection", {}).get("box"):
+            raise RuntimeError("The selected person track has no usable boxes or masks.")
+        if not character_reference_images(
+            project_path, request.character_id, request.character_look_id, request.width, request.height
+        ):
+            raise RuntimeError("Replace Person requires at least one approved character reference image.")
+
+    def _ltx_replacement_control(
+        self,
+        project_path: Path,
+        request: VideoRequest,
+        num_frames: int,
+        clip_path: Path,
+    ) -> LtxReplacementControl:
+        """Assemble the source/control/mask package and write a masked control
+        clip that bakes the person masks into the source frames (the masked
+        region is neutralized by ``maskingStrength`` so the IC-LoRA path
+        regenerates it). This is the SceneWorks-native equivalent of Wan2GP's
+        masked control-video injection."""
+        from .person_adapters import load_track_masks  # local: avoids an import cycle
+
+        track = read_person_track(project_path, request.person_track_id)
+        if not track:
+            raise RuntimeError("Replace Person requires a saved person track.")
+        source_frames = load_source_video_frames(
+            project_path, request.source_clip_asset_id, request.width, request.height, num_frames
+        )
+        masks, mask_mode = load_track_masks(project_path, track, request.width, request.height, len(source_frames))
+        references = character_reference_images(
+            project_path, request.character_id, request.character_look_id, request.width, request.height
+        )
+        if not references:
+            raise RuntimeError("Replace Person requires at least one approved character reference image.")
+        masking_strength = self._advanced_float(request, "maskingStrength", 1.0)
+        masked_frames = [
+            self._apply_replacement_mask(frame, mask, masking_strength)
+            for frame, mask in zip(source_frames, masks)
+        ]
+        save_animated_preview(masked_frames, clip_path, request.duration)
+        status = track.get("status", {}) if isinstance(track.get("status"), dict) else {}
+        return LtxReplacementControl(
+            track_id=str(track.get("id") or request.person_track_id),
+            masked_clip_path=clip_path,
+            mask_mode=mask_mode,
+            mask_state=str(status.get("maskState", "missing")),
+            person_tracking_active=bool(status.get("personTrackingActive", False)),
+            masking_strength=masking_strength,
+            frame_count=len(masked_frames),
+            character_reference_count=len(references),
+        )
+
+    def _apply_replacement_mask(self, frame: Image.Image, mask: Image.Image, strength: float) -> Image.Image:
+        """Blend the masked person region toward neutral gray by ``strength`` so
+        the control video preserves the background and clears the replacement
+        region for regeneration."""
+        strength = max(0.0, min(1.0, strength))
+        neutral = Image.new("RGB", frame.size, (118, 118, 118))
+        gate = mask.convert("L").resize(frame.size).point(lambda value: int(value * strength))
+        return Image.composite(neutral, frame.convert("RGB"), gate)
 
     def _load_ltx_pipeline(self, request: VideoRequest, resources: LtxPipelinesResources) -> Any:
         key = self._pipeline_key(request, resources)
@@ -889,7 +1009,9 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
     def _uses_ic_lora_pipeline(self, request: VideoRequest) -> bool:
         if bool(request.advanced.get("useIcLoraPipeline", False)):
             return True
-        if request.mode in {"extend_clip", "video_bridge"}:
+        # Replace Person rides the IC-LoRA video-conditioning path: the masked
+        # control clip is injected as video_conditioning during denoising.
+        if request.mode in {"extend_clip", "video_bridge", "replace_person"}:
             return True
         return request.mode in {"image_to_video", "first_last_frame"} and self._has_ic_lora(request)
 
@@ -2207,37 +2329,20 @@ def ltx_conditions(
 
 
 def person_track_masks(project_path: Path, track_id: str | None, width: int, height: int, count: int) -> list[Image.Image]:
-    track = read_person_track(project_path, track_id)
-    boxes = []
-    if track:
-        boxes = [frame.get("box") for frame in track.get("frames", []) if isinstance(frame, dict) and isinstance(frame.get("box"), dict)]
-        selected_box = track.get("selectedDetection", {}).get("box")
-        if not boxes and isinstance(selected_box, dict):
-            boxes = [selected_box]
-    if not boxes:
-        raise RuntimeError(f"Person track has no usable boxes: {track_id}.")
+    """Load per-frame replacement masks for a track, preferring stored
+    segmentation masks and only falling back to rectangular box masks in the
+    explicit degraded path (sc-1482)."""
+    from .person_adapters import load_track_masks  # local: avoids an import cycle
 
-    masks = []
-    for index in range(count):
-        box = boxes[min(len(boxes) - 1, round(index * (len(boxes) - 1) / max(1, count - 1)))]
-        mask = Image.new("L", (width, height), 0)
-        draw = ImageDraw.Draw(mask)
-        left = int(safe_float(box.get("x"), 0, 0, 1) * width)
-        top = int(safe_float(box.get("y"), 0, 0, 1) * height)
-        right = int((safe_float(box.get("x"), 0, 0, 1) + safe_float(box.get("width"), 0, 0, 1)) * width)
-        bottom = int((safe_float(box.get("y"), 0, 0, 1) + safe_float(box.get("height"), 0, 0, 1)) * height)
-        padding_x = max(8, int(width * 0.03))
-        padding_y = max(8, int(height * 0.03))
-        draw.rectangle(
-            (
-                max(0, left - padding_x),
-                max(0, top - padding_y),
-                min(width, right + padding_x),
-                min(height, bottom + padding_y),
-            ),
-            fill=255,
-        )
-        masks.append(mask)
+    track = read_person_track(project_path, track_id)
+    if not track:
+        raise RuntimeError(f"Person track not found: {track_id}.")
+    if not track.get("frames"):
+        selected_box = track.get("selectedDetection", {}).get("box")
+        if not isinstance(selected_box, dict):
+            raise RuntimeError(f"Person track has no usable boxes: {track_id}.")
+        track = {**track, "frames": [{"box": selected_box, "mask": None}]}
+    masks, _mode = load_track_masks(project_path, track, width, height, count)
     return masks
 
 
@@ -2325,6 +2430,7 @@ def build_video_asset_sidecar(
     raw_settings: dict[str, Any],
     adapter_id: str,
     mime_type: str,
+    replacement_status: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     parents = [
         asset_id
@@ -2355,13 +2461,18 @@ def build_video_asset_sidecar(
         "timelineContextRef": "lineage.timeline",
     }
     if request.mode == "replace_person":
-        normalized_settings.update(
-            {
-                "personDetectionActive": False,
-                "personTrackingActive": False,
-                "replacementActive": False,
-            }
-        )
+        # Honest defaults: a replacement asset only claims active detection/
+        # tracking/replacement when the adapter actually ran a real masked-control
+        # path and reported it via replacement_status (sc-1483/sc-1487). Adapters
+        # that did not (mocked previews, not-yet-upgraded paths) leave these false.
+        replacement_settings = {
+            "personDetectionActive": False,
+            "personTrackingActive": False,
+            "replacementActive": False,
+        }
+        if replacement_status:
+            replacement_settings.update(replacement_status)
+        normalized_settings.update(replacement_settings)
     return {
         "schemaVersion": 1,
         "id": asset_id,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -161,7 +161,7 @@
       "family": "ltx-video",
       "type": "video",
       "adapter": "ltx_video",
-      "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
+      "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
       "downloads": [
         {
           "provider": "huggingface",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -145,7 +145,14 @@ string_enum! {
 
 string_enum! {
     pub enum PersonTrackMaskState {
+        // "deferred" is the legacy procedural-preview state. Real tracks report
+        // segmentation mask states: active (masks for all detected frames),
+        // generated (partial), degraded (box fallback / no segmenter), or missing.
         Deferred => "deferred",
+        Active => "active",
+        Generated => "generated",
+        Degraded => "degraded",
+        Missing => "missing",
     }
 }
 
@@ -252,6 +259,16 @@ string_enum! {
         PersonDetect => "person_detect",
         PersonTrack => "person_track",
         PersonReplace => "person_replace",
+        // Procedural detection/tracking previews served by the Rust utility worker.
+        // Real, model-backed PersonDetect/PersonTrack jobs are served by the Python
+        // GPU worker (YOLO/ByteTrack/SAM2); these preview capabilities keep the CPU
+        // procedural path claimable only for explicit `preview: true` jobs, so a
+        // real job never routes to the placeholder. Segment availability is its own
+        // capability for replacement readiness. See jobs_store::worker_supports_job
+        // and apps/worker/scene_worker/runtime.py.
+        PersonDetectPreview => "person_detect_preview",
+        PersonTrackPreview => "person_track_preview",
+        PersonSegment => "person_segment",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1265,7 +1265,7 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
             .iter()
             .any(|owned| owned.as_str() == capability)
     };
-    if !advertises(job.job_type.as_str()) {
+    if !advertises(required_capability(job)) {
         return false;
     }
     // A real (non-dry-run) LoRA training job additionally needs the execute
@@ -1284,6 +1284,30 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
 fn is_real_training_job(job: &JobSnapshot) -> bool {
     matches!(job.job_type, JobType::LoraTrain)
         && job.payload.get("dryRun").and_then(Value::as_bool) == Some(false)
+}
+
+/// The worker capability a job requires. Person detection/tracking default to
+/// the real, model-backed capability served by the Python GPU worker; an
+/// explicit `preview: true` payload requests the Rust utility worker's
+/// procedural preview capability instead — so a real job never routes to the
+/// placeholder. Mirrors the dry-run training capability split.
+fn required_capability(job: &JobSnapshot) -> &str {
+    match job.job_type {
+        JobType::PersonDetect if person_job_is_preview(job) => {
+            WorkerCapability::PersonDetectPreview.as_str()
+        }
+        JobType::PersonTrack if person_job_is_preview(job) => {
+            WorkerCapability::PersonTrackPreview.as_str()
+        }
+        _ => job.job_type.as_str(),
+    }
+}
+
+/// True when a person detection/tracking job explicitly opts into the procedural
+/// preview path (`preview: true`); real model-backed runs are the default.
+fn person_job_is_preview(job: &JobSnapshot) -> bool {
+    matches!(job.job_type, JobType::PersonDetect | JobType::PersonTrack)
+        && job.payload.get("preview").and_then(Value::as_bool) == Some(true)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -633,8 +633,12 @@ fn worker_capabilities_with_utility(
             WorkerCapability::ModelDownload,
             WorkerCapability::ModelImport,
             WorkerCapability::LoraImport,
-            WorkerCapability::PersonDetect,
-            WorkerCapability::PersonTrack,
+            // Procedural detection/tracking is a preview only. Real, model-backed
+            // PersonDetect/PersonTrack run on the Python GPU worker; advertising the
+            // preview capabilities here keeps the CPU placeholder claimable solely
+            // for explicit `preview: true` jobs (jobs_store::worker_supports_job).
+            WorkerCapability::PersonDetectPreview,
+            WorkerCapability::PersonTrackPreview,
         ]);
     }
     capabilities.sort();
@@ -4719,10 +4723,18 @@ mod tests {
         assert!(cpu_capabilities
             .iter()
             .any(|capability| capability.as_str() == "timeline_export"));
+        // The CPU utility worker advertises only the procedural *preview*
+        // capabilities; real detection/tracking route to the Python GPU worker.
         assert!(cpu_capabilities
             .iter()
-            .any(|capability| capability.as_str() == "person_detect"));
+            .any(|capability| capability.as_str() == "person_detect_preview"));
         assert!(cpu_capabilities
+            .iter()
+            .any(|capability| capability.as_str() == "person_track_preview"));
+        assert!(!cpu_capabilities
+            .iter()
+            .any(|capability| capability.as_str() == "person_detect"));
+        assert!(!cpu_capabilities
             .iter()
             .any(|capability| capability.as_str() == "person_track"));
         assert!(!cpu_capabilities

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -4,6 +4,9 @@ ARG PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
 ARG PYTORCH_SPEC=torch>=2.8,<2.9
 ARG PYTORCH_AUDIO_SPEC=torchaudio>=2.8,<2.9
 ARG INCLUDE_LTX_PIPELINES=1
+# Real person detection/tracking/segmentation backends (ultralytics + SAM2) for
+# the Replace Person workflow (epic sc-1090). Opt-in like the LTX pipelines.
+ARG INCLUDE_PERSON_BACKENDS=1
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -19,11 +22,13 @@ ENV PATH="/opt/venv/bin:${PATH}"
 
 COPY apps/worker/requirements.txt ./requirements.txt
 COPY apps/worker/requirements-ltx.txt ./requirements-ltx.txt
+COPY apps/worker/requirements-person.txt ./requirements-person.txt
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir --no-compile --index-url "${PYTORCH_INDEX_URL}" "${PYTORCH_SPEC}" "${PYTORCH_AUDIO_SPEC}" \
     && pip freeze | grep -E '^(torch|torchaudio|torchvision|nvidia-|triton)==.*' > /tmp/torch-constraints.txt \
     && pip install --no-cache-dir --no-compile -c /tmp/torch-constraints.txt -r requirements.txt \
     && if [ "${INCLUDE_LTX_PIPELINES}" = "1" ]; then pip install --no-cache-dir --no-compile -c /tmp/torch-constraints.txt -r requirements-ltx.txt; fi \
+    && if [ "${INCLUDE_PERSON_BACKENDS}" = "1" ]; then pip install --no-cache-dir --no-compile -c /tmp/torch-constraints.txt -r requirements-person.txt; fi \
     && find /opt/venv -type d -name "__pycache__" -prune -exec rm -rf {} + \
     && rm -rf /opt/venv/lib/python3.12/site-packages/torch/include \
         /opt/venv/lib/python3.12/site-packages/torch/test \

--- a/tests/test_person_adapters.py
+++ b/tests/test_person_adapters.py
@@ -26,6 +26,13 @@ from scene_worker.person_adapters import (
     select_target_index,
     xyxy_to_normalized,
 )
+from scene_worker.video_adapters import (
+    LtxPipelinesResources,
+    LtxPipelinesVideoAdapter,
+    build_video_asset_sidecar,
+    person_track_masks,
+    video_request_from_job,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -384,3 +391,208 @@ def test_load_track_masks_prefers_segmentation_then_degrades(tmp_path):
     masks, mode = pa.load_track_masks(project_path, track_no_masks, 32, 32, 1)
     assert mode == "degraded_box"
     assert masks[0].getbbox() is not None
+
+
+# ---------------------------------------------------------------------------
+# Active LTX masked-control replacement tests (sc-1483 / sc-1486)
+# ---------------------------------------------------------------------------
+
+
+def _write_person_track(project_path: Path, track_id: str, *, with_masks: bool) -> None:
+    masks_dir = project_path / "person-tracks" / track_id / "masks"
+    frames = []
+    for index in range(3):
+        box = {"x": 0.2 + index * 0.05, "y": 0.15, "width": 0.2, "height": 0.6}
+        mask_rel = None
+        if with_masks:
+            masks_dir.mkdir(parents=True, exist_ok=True)
+            mask_rel = pa.mask_relative_path(track_id, index + 1)
+            mask_img = Image.new("L", (CLIP_W, CLIP_H), 0)
+            ImageDraw.Draw(mask_img).ellipse((200, 100, 400, 520), fill=255)
+            mask_img.save(project_path / mask_rel)
+        frames.append({"timestamp": float(index), "box": box, "confidence": 0.9, "detected": True, "mask": mask_rel})
+    track = {
+        "schemaVersion": 1,
+        "id": track_id,
+        "projectId": "proj_1",
+        "name": "Hero",
+        "sourceAssetId": "asset_source_clip",
+        "selectedDetection": {"id": "person_1", "box": frames[0]["box"], "confidence": 0.9},
+        "frames": frames,
+        "status": {
+            "maskState": "active" if with_masks else "degraded",
+            "personTrackingActive": True,
+            "averageConfidence": 0.9,
+        },
+    }
+    write_json(project_path / "person-tracks" / f"{track_id}.sceneworks.person-track.json", track)
+
+
+def _write_character(project_path: Path, character_id: str) -> None:
+    ref_id = "asset_char_ref_1"
+    ref_rel = "assets/images/char_ref.png"
+    (project_path / "assets" / "images").mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (512, 512), (200, 120, 90)).save(project_path / ref_rel)
+    ref_asset = {
+        "schemaVersion": 1,
+        "id": ref_id,
+        "projectId": "proj_1",
+        "type": "image",
+        "displayName": "Character ref",
+        "createdAt": "2026-05-21T00:00:00Z",
+        "file": {"path": ref_rel, "mimeType": "image/png", "width": 512, "height": 512, "duration": None, "fps": None},
+        "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
+        "recipe": {},
+        "lineage": {},
+    }
+    write_json((project_path / ref_rel).with_suffix(".sceneworks.json"), ref_asset)
+    index_asset(project_path, ref_asset)
+    character = {
+        "schemaVersion": 1,
+        "id": character_id,
+        "name": "Mira",
+        "references": [{"assetId": ref_id, "approved": True}],
+        "looks": [],
+    }
+    write_json(project_path / "characters" / f"{character_id}.sceneworks.character.json", character)
+
+
+def _replacement_job(settings, *, mock: bool = False) -> dict:
+    advanced = {"mockNativeInference": True} if mock else {}
+    return {
+        "id": "job_replace_1",
+        "payload": {
+            "projectId": "proj_1",
+            "mode": "replace_person",
+            "model": "ltx_2_3",
+            "prompt": "replace the hero",
+            "duration": 1,
+            "fps": 8,
+            "width": 512,
+            "height": 320,
+            "sourceClipAssetId": settings.source_asset_id,
+            "personTrackId": "track_repl",
+            "characterId": "char_1",
+            "replacementMode": "full_person_keep_outfit",
+            "advanced": advanced,
+        },
+    }
+
+
+def _seed_replacement_project(tmp_path, *, with_masks: bool = True) -> SimpleNamespace:
+    settings = _make_project(tmp_path, _synthetic_clip(frames=8, present=True))
+    project_path = Path(settings.data_dir) / "project"
+    _write_person_track(project_path, "track_repl", with_masks=with_masks)
+    _write_character(project_path, "char_1")
+    return settings
+
+
+def test_person_track_masks_prefers_stored_segmentation(tmp_path):
+    settings = _seed_replacement_project(tmp_path, with_masks=True)
+    project_path = Path(settings.data_dir) / "project"
+    masks = person_track_masks(project_path, "track_repl", 256, 256, 3)
+    # Stored ellipse masks are non-rectangular; a box fallback would fill its bbox.
+    mask = masks[0]
+    nonzero = sum(mask.histogram()[1:])
+    bbox = mask.getbbox()
+    assert bbox is not None
+    assert nonzero < (bbox[2] - bbox[0]) * (bbox[3] - bbox[1]) * 0.95
+
+
+def test_build_sidecar_marks_replacement_inactive_without_status(tmp_path):
+    settings = _seed_replacement_project(tmp_path)
+    request = video_request_from_job(_replacement_job(settings))
+    asset = build_video_asset_sidecar(
+        asset_id="asset_x",
+        project_id="proj_1",
+        generation_set_id="gen_x",
+        request=request,
+        job_id="job_replace_1",
+        media_rel="assets/videos/out.mp4",
+        created_at="2026-05-21T00:00:00Z",
+        seed=1,
+        target={"family": "ltx-video"},
+        raw_settings={},
+        adapter_id="ltx_pipelines",
+        mime_type="video/mp4",
+    )
+    assert asset["recipe"]["normalizedSettings"]["replacementActive"] is False
+
+
+def test_ltx_replacement_control_builds_segmentation_package(tmp_path):
+    settings = _seed_replacement_project(tmp_path, with_masks=True)
+    project_path = Path(settings.data_dir) / "project"
+    adapter = LtxPipelinesVideoAdapter()
+    adapter._settings = settings
+    request = video_request_from_job(_replacement_job(settings))
+    clip_path = project_path / "cache" / "control.webp"
+    clip_path.parent.mkdir(parents=True, exist_ok=True)
+    control = adapter._ltx_replacement_control(project_path, request, 9, clip_path)
+    assert control.mask_mode == "segmentation"
+    assert control.character_reference_count == 1
+    assert control.person_tracking_active is True
+    assert clip_path.exists()
+
+
+def test_ltx_replace_person_active_run_marks_replacement_active(tmp_path, monkeypatch):
+    settings = _seed_replacement_project(tmp_path, with_masks=True)
+    project_path = Path(settings.data_dir) / "project"
+    adapter = LtxPipelinesVideoAdapter()
+    adapter._settings = settings
+    adapter._resources_by_model["ltx_2_3"] = LtxPipelinesResources(
+        checkpoint_path=Path("ckpt"),
+        spatial_upsampler_path=Path("ups"),
+        distilled_lora_path=Path("lora"),
+        gemma_root=Path("gemma"),
+    )
+    monkeypatch.setattr(adapter, "_load_ltx_pipeline", lambda request, resources: object())
+
+    def fake_encode(*, video, fps, audio, output_path, video_chunks_number):
+        Path(output_path).write_bytes(b"fake-mp4")
+
+    monkeypatch.setattr(
+        adapter,
+        "_run_ltx_pipeline",
+        lambda **_kwargs: (None, None, 1, fake_encode),
+    )
+
+    job = _replacement_job(settings)
+    request = video_request_from_job(job)
+    result = adapter._run_real_ltx_video(
+        settings=settings,
+        job=job,
+        request=request,
+        progress=lambda *_a, **_k: None,
+        cancel_requested=lambda: False,
+    )
+    normalized = result["assets"][0]["recipe"]["normalizedSettings"]
+    assert normalized["replacementActive"] is True
+    assert normalized["maskMode"] == "segmentation"
+    assert normalized["replacementAdapter"] == "ltx_pipelines"
+    assert normalized["personTrackId"] == "track_repl"
+
+
+def test_ltx_replace_person_mock_run_stays_inactive(tmp_path, monkeypatch):
+    settings = _seed_replacement_project(tmp_path, with_masks=True)
+    adapter = LtxPipelinesVideoAdapter()
+    adapter._settings = settings
+    job = _replacement_job(settings, mock=True)
+    request = video_request_from_job(job)
+    result = adapter.run(
+        settings=settings,
+        job=job,
+        request=request,
+        progress=lambda *_a, **_k: None,
+        cancel_requested=lambda: False,
+    )
+    asset = result["assets"][0]
+    assert asset["recipe"]["normalizedSettings"]["replacementActive"] is False
+
+
+def test_ensure_models_replace_person_requires_track_and_character(tmp_path):
+    settings = _make_project(tmp_path, _synthetic_clip(frames=4, present=True))
+    adapter = LtxPipelinesVideoAdapter()
+    adapter._settings = settings
+    request = video_request_from_job(_replacement_job(settings))
+    with pytest.raises(RuntimeError, match="saved person track"):
+        adapter.ensure_models(request)

--- a/tests/test_person_adapters.py
+++ b/tests/test_person_adapters.py
@@ -546,6 +546,9 @@ def test_ltx_replace_person_active_run_marks_replacement_active(tmp_path, monkey
         gemma_root=Path("gemma"),
     )
     monkeypatch.setattr(adapter, "_load_ltx_pipeline", lambda request, resources: object())
+    # Real MP4 control-clip encoding (imageio/ffmpeg) is verified in-container; on
+    # the host stub the writer so the test stays focused on the active-flag contract.
+    monkeypatch.setattr(adapter, "_write_control_clip", lambda frames, path, fps: Path(path).write_bytes(b"clip"))
 
     def fake_encode(*, video, fps, audio, output_path, video_chunks_number):
         Path(output_path).write_bytes(b"fake-mp4")

--- a/tests/test_person_adapters.py
+++ b/tests/test_person_adapters.py
@@ -1,0 +1,386 @@
+"""Tests for real person detection/tracking/segmentation (epic sc-1090).
+
+These exercise the orchestration and pure helpers on the host with fake,
+content-reading model backends. The fakes inspect pixels, so the tests fail
+against the old procedural placeholders (hard-coded candidate boxes / synthetic
+x-drift) that ignored frame content. Real model execution is validated in the
+GPU worker container; see sc-1486.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image, ImageDraw
+
+from sceneworks_shared import index_asset, write_json
+from scene_worker import person_adapters as pa
+from scene_worker.person_adapters import (
+    NormalizedBox,
+    PersonDetection,
+    box_iou,
+    sample_timestamps,
+    select_target_index,
+    xyxy_to_normalized,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic CI fixture clip (no committed binary): a bright "person" rectangle
+# that translates left-to-right across a dark background.
+# ---------------------------------------------------------------------------
+
+CLIP_W, CLIP_H = 1280, 720
+BACKGROUND = (18, 17, 15)
+
+
+def _person_frame(progress: float, *, present: bool = True) -> Image.Image:
+    frame = Image.new("RGB", (CLIP_W, CLIP_H), BACKGROUND)
+    if present:
+        box_w, box_h = 200, 420
+        left = int((CLIP_W - box_w) * progress)
+        top = (CLIP_H - box_h) // 2
+        ImageDraw.Draw(frame).rectangle((left, top, left + box_w, top + box_h), fill=(235, 220, 205))
+    return frame
+
+
+def _synthetic_clip(frames: int = 8, *, present: bool = True) -> list[Image.Image]:
+    if frames <= 1:
+        return [_person_frame(0.0, present=present)]
+    return [_person_frame(index / (frames - 1), present=present) for index in range(frames)]
+
+
+def _write_clip(path: Path, frames: list[Image.Image]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    head, *tail = frames
+    head.save(path, format="WEBP", save_all=True, append_images=tail, duration=500, loop=0)
+
+
+def _make_project(tmp_path: Path, frames: list[Image.Image], duration: float = 4.0) -> SimpleNamespace:
+    project_path = tmp_path / "project"
+    (project_path / "assets" / "videos").mkdir(parents=True, exist_ok=True)
+    source_id = "asset_source_clip"
+    media_rel = "assets/videos/source.webp"
+    _write_clip(project_path / media_rel, frames)
+    source_asset = {
+        "schemaVersion": 1,
+        "id": source_id,
+        "projectId": "proj_1",
+        "type": "video",
+        "displayName": "Synthetic source",
+        "createdAt": "2026-05-21T00:00:00Z",
+        "file": {"path": media_rel, "mimeType": "image/webp", "width": CLIP_W, "height": CLIP_H, "duration": duration, "fps": 2},
+        "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
+        "recipe": {},
+        "lineage": {},
+    }
+    write_json((project_path / media_rel).with_suffix(".sceneworks.json"), source_asset)
+    index_asset(project_path, source_asset)
+    (tmp_path / "recent-projects.json").write_text(
+        f'[{{"id": "proj_1", "path": "{project_path.as_posix()}"}}]', encoding="utf-8"
+    )
+    return SimpleNamespace(data_dir=tmp_path, gpu_id="cpu", source_asset_id=source_id)
+
+
+def _bright_bbox(image: Image.Image) -> tuple[int, int, int, int] | None:
+    mask = image.convert("L").point(lambda value: 255 if value > 80 else 0)
+    return mask.getbbox()
+
+
+class FakeContentDetector:
+    """A detector that reads pixels: returns one box around the bright region,
+    nothing when the frame is empty. Proves the pipeline is content-dependent."""
+
+    model_ref = "fake-content-detector"
+
+    def __init__(self) -> None:
+        self.runtime = {"backend": "fake", "device": "cpu"}
+
+    def detect(self, image: Image.Image, *, confidence: float) -> list[PersonDetection]:
+        bbox = _bright_bbox(image)
+        if bbox is None:
+            return []
+        box = xyxy_to_normalized(*bbox, image.width, image.height)
+        return [PersonDetection(id="person_1", label="Person 1", box=box, confidence=0.93)]
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_box_iou_identical_is_one_and_disjoint_is_zero():
+    a = NormalizedBox(0.1, 0.1, 0.2, 0.2)
+    assert box_iou(a, a) == pytest.approx(1.0)
+    b = NormalizedBox(0.7, 0.7, 0.2, 0.2)
+    assert box_iou(a, b) == 0.0
+
+
+def test_xyxy_to_normalized_orders_and_clamps():
+    box = xyxy_to_normalized(640, 360, 320, 180, 1280, 720)
+    assert box.x == pytest.approx(0.25)
+    assert box.y == pytest.approx(0.25)
+    assert box.width == pytest.approx(0.25)
+    assert box.height == pytest.approx(0.25)
+
+
+def test_sample_timestamps_span_clip_and_clamp_count():
+    stamps = sample_timestamps(4.0)
+    assert stamps[0] == 0.0
+    assert stamps[-1] == pytest.approx(4.0)
+    assert pa.PERSON_TRACK_MIN_SAMPLES <= len(stamps) <= pa.PERSON_TRACK_MAX_SAMPLES
+    assert len(sample_timestamps(0.0)) == 1
+
+
+def test_select_target_index_returns_none_when_no_overlap():
+    detections = [PersonDetection("person_1", "Person 1", NormalizedBox(0.0, 0.0, 0.1, 0.1), 0.9)]
+    assert select_target_index(detections, NormalizedBox(0.8, 0.8, 0.1, 0.1)) is None
+    assert select_target_index(detections, NormalizedBox(0.0, 0.0, 0.12, 0.12)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Detection orchestration tests (sc-1480)
+# ---------------------------------------------------------------------------
+
+
+def _detect_job(settings: SimpleNamespace) -> dict:
+    return {
+        "id": "job_detect_1",
+        "payload": {"projectId": "proj_1", "sourceAssetId": settings.source_asset_id, "sourceTimestamp": 0.0},
+    }
+
+
+def test_detection_is_content_dependent_and_marks_active(tmp_path):
+    settings = _make_project(tmp_path, _synthetic_clip(present=True))
+    result = pa.run_person_detect(
+        settings,
+        _detect_job(settings),
+        detector_factory=lambda *_args, **_kwargs: FakeContentDetector(),
+    )
+    assert result["personDetectionActive"] is True
+    assert len(result["detections"]) == 1
+    assert result["detector"]["backend"] == "fake"
+    assert result["sourceFrameHash"]
+    detection = result["detections"][0]
+    assert detection["box"]["width"] > 0 and detection["box"]["height"] > 0
+    # frame asset persisted + indexed
+    frame_path = Path(settings.data_dir) / "project" / result["frameAsset"]["file"]["path"]
+    assert frame_path.exists()
+    with sqlite3.connect(Path(settings.data_dir) / "project" / "project.db") as connection:
+        row = connection.execute("select type from assets where id = ?", (result["frameAssetId"],)).fetchone()
+    assert row is not None and row[0] == "frame"
+
+
+def test_detection_returns_no_candidates_for_empty_frame(tmp_path):
+    settings = _make_project(tmp_path, _synthetic_clip(present=False))
+    result = pa.run_person_detect(
+        settings,
+        _detect_job(settings),
+        detector_factory=lambda *_args, **_kwargs: FakeContentDetector(),
+    )
+    # No fake boxes for a person-free frame — the old template detector always returned 3.
+    assert result["detections"] == []
+    assert result["personDetectionActive"] is True
+
+
+def test_detection_never_marks_inactive_on_success(tmp_path):
+    settings = _make_project(tmp_path, _synthetic_clip(present=True))
+    result = pa.run_person_detect(
+        settings,
+        _detect_job(settings),
+        detector_factory=lambda *_args, **_kwargs: FakeContentDetector(),
+    )
+    normalized = result["frameAsset"]["recipe"]["normalizedSettings"]
+    assert normalized["personDetectionActive"] is True
+    assert result["frameAsset"]["recipe"]["adapter"] == pa.DETECTOR_ADAPTER_ID
+
+
+def test_load_person_detector_errors_clearly_without_backend(monkeypatch):
+    monkeypatch.setattr(pa, "detector_backend_available", lambda: False)
+    with pytest.raises(RuntimeError, match="Ultralytics backend"):
+        pa.load_person_detector(SimpleNamespace(data_dir=Path("."), gpu_id="cpu"))
+
+
+# ---------------------------------------------------------------------------
+# Tracking tests (sc-1481)
+# ---------------------------------------------------------------------------
+
+
+class FakeContentTracker:
+    """Reads the source video and tracks the bright region as id 1, dropping it
+    when it leaves the frame — so output follows real pixel motion, not drift."""
+
+    model_ref = "fake-content-tracker"
+
+    def __init__(self) -> None:
+        self.runtime = {"backend": "fake", "tracker": "fake-bytetrack", "device": "cpu"}
+
+    def observe(self, video_path: Path, *, confidence: float) -> list[pa.FrameObservation]:
+        image = Image.open(video_path)
+        total = getattr(image, "n_frames", 1)
+        observations = []
+        for index in range(total):
+            image.seek(index)
+            frame = image.convert("RGB")
+            bbox = _bright_bbox(frame)
+            entries = {}
+            if bbox is not None:
+                entries[1] = (xyxy_to_normalized(*bbox, frame.width, frame.height), 0.9)
+            observations.append(pa.FrameObservation(timestamp=round(index / 2.0, 4), boxes=entries))
+        return observations
+
+
+class FakeEllipseSegmenter:
+    model_ref = "fake-ellipse-segmenter"
+    runtime = {"backend": "fake-seg"}
+
+    def segment(self, image: Image.Image, box: NormalizedBox) -> Image.Image:
+        mask = Image.new("L", (image.width, image.height), 0)
+        left, top = box.x * image.width, box.y * image.height
+        right, bottom = (box.x + box.width) * image.width, (box.y + box.height) * image.height
+        ImageDraw.Draw(mask).ellipse((left, top, right, bottom), fill=255)
+        return mask
+
+
+def _selected_box_from_first_frame(frames: list[Image.Image]) -> NormalizedBox:
+    bbox = _bright_bbox(frames[0])
+    assert bbox is not None
+    return xyxy_to_normalized(*bbox, frames[0].width, frames[0].height)
+
+
+def test_choose_target_returns_none_without_overlap():
+    obs = [pa.FrameObservation(0.0, {1: (NormalizedBox(0.0, 0.0, 0.1, 0.8), 0.9)})]
+    assert pa.choose_target_track_id(obs, NormalizedBox(0.9, 0.0, 0.05, 0.05), 0.0) is None
+    assert pa.choose_target_track_id(obs, NormalizedBox(0.0, 0.0, 0.12, 0.8), 0.0) == 1
+
+
+def test_assemble_track_marks_lost_frames_honestly():
+    selected = NormalizedBox(0.0, 0.1, 0.15, 0.6)
+    observations = [
+        pa.FrameObservation(0.0, {1: (NormalizedBox(0.0, 0.1, 0.15, 0.6), 0.9)}),
+        pa.FrameObservation(1.0, {}),  # target lost
+        pa.FrameObservation(2.0, {1: (NormalizedBox(0.4, 0.1, 0.15, 0.6), 0.8)}),
+    ]
+    assembly = pa.assemble_track(observations, selected, 0.0, [0.0, 1.0, 2.0])
+    assert assembly.target_track_id == 1
+    assert [frame.detected for frame in assembly.frames] == [True, False, True]
+    assert "lost_target" in assembly.frames[1].flags
+    assert assembly.frames[1].confidence == 0.0  # not a synthetic box
+    assert assembly.quality["detectedFrames"] == 2
+
+
+def _track_job(settings, frames) -> tuple[dict, NormalizedBox]:
+    selected = _selected_box_from_first_frame(frames)
+    job = {
+        "id": "job_track_1",
+        "payload": {
+            "projectId": "proj_1",
+            "sourceAssetId": settings.source_asset_id,
+            "trackName": "Hero",
+            "detection": {"id": "person_1", "label": "Person 1", "box": selected.to_dict(), "confidence": 0.93},
+        },
+    }
+    return job, selected
+
+
+def test_tracking_follows_real_motion_and_marks_active(tmp_path, monkeypatch):
+    frames = _synthetic_clip(frames=8, present=True)
+    settings = _make_project(tmp_path, frames)
+    job, _selected = _track_job(settings, frames)
+    monkeypatch.setattr(pa, "segmenter_backend_available", lambda: True)
+
+    result = pa.run_person_track(
+        settings,
+        job,
+        tracker_factory=lambda *_a, **_k: FakeContentTracker(),
+        segmenter_factory=lambda *_a, **_k: FakeEllipseSegmenter(),
+    )
+    track = result["track"]
+    assert result["personTrackingActive"] is True
+    assert track["status"]["personTrackingActive"] is True
+    detected = [frame for frame in track["frames"] if frame["detected"]]
+    assert len(detected) >= 4
+    # Boxes follow the rightward motion in the pixels, not a fixed synthetic drift.
+    assert detected[-1]["box"]["x"] > detected[0]["box"]["x"] + 0.2
+    assert track["status"]["maskState"] == "active"
+    assert track["status"]["averageConfidence"] > 0
+
+
+def test_tracking_fails_honestly_when_selection_absent(tmp_path):
+    frames = _synthetic_clip(frames=8, present=True)
+    settings = _make_project(tmp_path, frames)
+    job = {
+        "id": "job_track_2",
+        "payload": {
+            "projectId": "proj_1",
+            "sourceAssetId": settings.source_asset_id,
+            "trackName": "Ghost",
+            # A selection box in a region the person never occupies at t=0.
+            "detection": {"id": "person_9", "box": {"x": 0.85, "y": 0.0, "width": 0.05, "height": 0.05}},
+        },
+    }
+    with pytest.raises(RuntimeError, match="not found in the source video"):
+        pa.run_person_track(
+            settings,
+            job,
+            tracker_factory=lambda *_a, **_k: FakeContentTracker(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Segmentation + mask-loading tests (sc-1482)
+# ---------------------------------------------------------------------------
+
+
+def test_segment_track_writes_non_rectangular_masks(tmp_path, monkeypatch):
+    frames_imgs = _synthetic_clip(frames=4, present=True)
+    settings = _make_project(tmp_path, frames_imgs)
+    monkeypatch.setattr(pa, "segmenter_backend_available", lambda: True)
+    selected = _selected_box_from_first_frame(frames_imgs)
+    track_frames = [pa.TrackFrame(timestamp=float(i), box=selected, confidence=0.9, detected=True) for i in range(4)]
+    project_path = Path(settings.data_dir) / "project"
+
+    state = pa.segment_track(
+        settings,
+        project_path,
+        settings.source_asset_id,
+        "track_test",
+        track_frames,
+        segmenter_factory=lambda *_a, **_k: FakeEllipseSegmenter(),
+        frame_loader=lambda timestamp: frames_imgs[0],
+    )
+    assert state == "active"
+    assert all(frame.mask for frame in track_frames)
+    mask_img = Image.open(project_path / track_frames[0].mask).convert("L")
+    bbox = mask_img.getbbox()
+    nonzero = sum(mask_img.histogram()[1:])
+    bbox_area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+    assert nonzero < bbox_area * 0.95  # an ellipse fills < its bounding rectangle
+
+
+def test_segment_track_degrades_without_backend(tmp_path, monkeypatch):
+    settings = _make_project(tmp_path, _synthetic_clip(frames=2, present=True))
+    monkeypatch.setattr(pa, "segmenter_backend_available", lambda: False)
+    track_frames = [pa.TrackFrame(0.0, NormalizedBox(0.1, 0.1, 0.2, 0.5), 0.9, detected=True)]
+    state = pa.segment_track(settings, Path(settings.data_dir) / "project", settings.source_asset_id, "t", track_frames)
+    assert state == "degraded"
+
+
+def test_load_track_masks_prefers_segmentation_then_degrades(tmp_path):
+    project_path = tmp_path / "project"
+    masks_dir = project_path / "person-tracks" / "track_x" / "masks"
+    masks_dir.mkdir(parents=True, exist_ok=True)
+    rel = "person-tracks/track_x/masks/frame_000001.png"
+    Image.new("L", (64, 64), 255).save(project_path / rel)
+    track_with_masks = {"frames": [{"box": {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": rel}]}
+    masks, mode = pa.load_track_masks(project_path, track_with_masks, 32, 32, 1)
+    assert mode == "segmentation"
+    assert masks[0].size == (32, 32)
+
+    track_no_masks = {"frames": [{"box": {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": None}]}
+    masks, mode = pa.load_track_masks(project_path, track_no_masks, 32, 32, 1)
+    assert mode == "degraded_box"
+    assert masks[0].getbbox() is not None

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2383,7 +2383,7 @@ def test_native_ltx_adapter_rejects_unsupported_modes():
             "id": "job-1",
             "payload": {
                 "projectId": "project-1",
-                "mode": "replace_person",
+                "mode": "edit_image",
                 "prompt": "city",
                 "model": "ltx_2_3",
                 "advanced": {},

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -204,6 +204,34 @@ def test_python_cpu_worker_does_not_advertise_person_tracking_jobs():
     assert capabilities == ["cpu"]
 
 
+def test_gpu_worker_advertises_real_person_jobs_when_backends_installed(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.segmenter_backend_available", lambda: True)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    assert "person_detect" in capabilities
+    assert "person_track" in capabilities
+    assert "person_segment" in capabilities
+
+
+def test_gpu_worker_omits_person_jobs_without_detector_backend(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: False)
+    monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: False)
+    monkeypatch.setattr("scene_worker.runtime.segmenter_backend_available", lambda: False)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    assert "person_detect" not in capabilities
+    assert "person_track" not in capabilities
+
+
+def test_cpu_worker_never_advertises_real_person_jobs_even_with_backends(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: True)
+    capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
+    assert capabilities == ["cpu"]
+
+
 def test_python_cpu_child_disables_cuda():
     env = child_environment(SimpleNamespace(), worker_id="python-inference-worker-cpu", gpu_id="cpu")
 
@@ -895,6 +923,9 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
     events = []
     monkeypatch.setattr("scene_worker.runtime.emit", events.append)
     monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.segmenter_backend_available", lambda: True)
     monkeypatch.setattr(
         "scene_worker.runtime.discover_gpu",
         lambda _gpu_id: {"id": "0", "name": "GPU 0", "capabilities": ["gpu"]},
@@ -910,6 +941,8 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         "video_extend",
         "video_bridge",
         "person_replace",
+        "person_detect",
+        "person_track",
     ]
     assert events[0]["supportedJobTypes"] == events[0]["jobTypes"]
 


### PR DESCRIPTION
Picks up the **real** implementation that V1 of epic [sc-1090](https://app.shortcut.com/trefry/epic/1090) left as procedural placeholders. Replaces hard-coded `candidate_people`, synthetic-drift `track_frames_from_detection`, rectangle masks, and `replacementActive: false` with model-backed detection, tracking, segmentation, and an active LTX masked-control replacement path.

## What's implemented
- **sc-1480 — real detection:** new `apps/worker/scene_worker/person_adapters.py` runs Ultralytics YOLO over the representative frame → pixel-derived candidates with confidence + adapter/model/runtime metadata + source-frame hash. No-person frames → no candidates. Sets `personDetectionActive: true`.
- **sc-1481 — real tracking:** YOLO + ByteTrack/BoT-SORT matched to the selected detection; lost/low-confidence frames are honest (`detected: false`, flagged), not synthetic. Sets `personTrackingActive: true` with per-frame box/confidence + quality.
- **sc-1482 — real masks:** SAM2 (MatAnyone accepted) per-frame masks under `person-tracks/{id}/masks/`; `maskState` active/generated/degraded/missing. `person_track_masks` loads stored masks, box fallback only in explicit degraded mode.
- **sc-1483 — active LTX replace:** native `LtxPipelinesVideoAdapter.replace_person` builds the shared source/mask/strength package + a masked control clip and injects it through the IC-LoRA `video_conditioning` path. `replacementActive: true` only when the real path ran; fails clearly without source clip / track / character / IC-LoRA. Wan stays the secondary VACE path.
- **Routing (sc-1480/1481 + sc-1484 groundwork):** detection/tracking moved Rust CPU → Python GPU worker. Rust worker advertises `person_detect_preview`/`person_track_preview`; `jobs_store::worker_supports_job` resolves real-vs-preview via a payload `preview` flag (mirrors the dry-run training split). New `requirements-person.txt` + Dockerfile wiring; LTX manifest declares `replace_person`.

## Verified end-to-end on GPU (RTX PRO 6000, cached LTX-2.3 + Union-Control IC-LoRA)
LTX `text_to_video` → real YOLO detect (1 person, conf 0.90) → real ByteTrack track (4/4 frames) → native LTX masked-control `replace_person` → valid 17-frame MP4, `replacementActive: true`, full lineage, mean pixel diff 96/255 vs source (genuinely regenerated). This run caught a real bug (control clip must be MP4, not WebP — PyAV can't frame-decode WebP), fixed in this PR.

Also green: `cargo fmt --check` + clippy + core/worker tests, the parity contract-snapshot gate, `npm run check`/`check:compose`, and 153 worker/person host tests (mocked-runtime + a synthetic CI fixture).

## Notes / follow-ups
- SAM2 weights weren't in the cache during verification → masks ran in degraded box mode; dropping a SAM2 checkpoint in enables real segmentation masks.
- Remaining epic stories: **sc-1484** (readiness UI gating — capability split landed here), **sc-1485** (correction UI), **sc-1486** (fuller fixtures), **sc-1487** (remove "V1 placeholder tracking" UX + inactive-success metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)