### PR TITLE
Correction UI for tracked boxes/masks [sc-1485]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -618,6 +618,10 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
             "/api/v1/projects/:project_id/person-tracks/:track_id",
             get(get_person_track),
         )
+        .route(
+            "/api/v1/projects/:project_id/person-tracks/:track_id/corrections",
+            post(save_person_track_corrections),
+        )
         .route("/api/v1/image/jobs", post(create_image_job))
         .route("/api/v1/video/jobs", post(create_video_job))
         .route("/api/v1/models", get(list_models))
@@ -940,6 +944,17 @@ struct PersonTrackJobRequest {
     preview: bool,
     #[serde(default = "default_requested_gpu")]
     requested_gpu: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersonTrackCorrectionsRequest {
+    /// The UI's full correction set for the track. Each entry targets a frame by
+    /// index and adjusts its box and/or rejects the frame; the store validates
+    /// ranges and stamps author/createdAt/source. Kept as raw values so the
+    /// schema-flexible `corrections` array can evolve without an API change.
+    #[serde(default)]
+    corrections: Vec<Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2318,6 +2333,19 @@ async fn get_person_track(
     Ok(Json(
         project_call(state, move |store| {
             store.get_person_track(&project_id, &track_id)
+        })
+        .await?,
+    ))
+}
+
+async fn save_person_track_corrections(
+    State(state): State<AppState>,
+    Path((project_id, track_id)): Path<(String, String)>,
+    ApiJson(payload): ApiJson<PersonTrackCorrectionsRequest>,
+) -> Result<Json<Value>, ApiError> {
+    Ok(Json(
+        project_call(state, move |store| {
+            store.set_person_track_corrections(&project_id, &track_id, payload.corrections)
         })
         .await?,
     ))

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1495,6 +1495,29 @@ export function App() {
     }
   }
 
+  async function saveTrackCorrections(trackId, corrections) {
+    if (!activeProject) {
+      setError("Create or open a project first.");
+      return null;
+    }
+    try {
+      const track = await apiFetch(
+        `/api/v1/projects/${activeProject.id}/person-tracks/${trackId}/corrections`,
+        token,
+        {
+          method: "POST",
+          body: JSON.stringify({ corrections }),
+        },
+      );
+      setPersonTracks((items) => items.map((item) => (item.id === track.id ? track : item)));
+      setError("");
+      return track;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
   function sendCharacterToImage(character, lookId = null) {
     if (!character) {
       return;
@@ -1940,6 +1963,7 @@ export function App() {
             personReadiness={personReadiness}
             presets={presets}
             requestedGpu={requestedGpu}
+            saveTrackCorrections={saveTrackCorrections}
             selectedAsset={selectedAsset}
             setRequestedGpu={setRequestedGpu}
             updateAssetStatus={updateAssetStatus}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -9,6 +9,7 @@ import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
+import { ReplacePersonPanel } from "./screens/ReplacePersonPanel.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
 import { TrainingStudio } from "./screens/TrainingStudio.jsx";
 
@@ -4230,5 +4231,103 @@ describe("SceneWorks app shell", () => {
     expect(field(container, "Weight").disabled).toBe(true);
     expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Save Preset").disabled).toBe(true);
     expect(updatePreset).not.toHaveBeenCalled();
+  });
+
+  function replacePanelProps(overrides = {}) {
+    const track = {
+      id: "track_1",
+      projectId: "project-1",
+      name: "Hero",
+      sourceAssetId: "clip-1",
+      frames: [
+        { timestamp: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.5 }, confidence: 0.92, detected: true, mask: "person-tracks/track_1/masks/frame_000001.png", flags: [] },
+        { timestamp: 0.5, box: { x: 0.3, y: 0.1, width: 0.2, height: 0.5 }, confidence: 0.3, detected: true, mask: null, flags: ["low_confidence"] },
+      ],
+      corrections: [],
+      status: { maskState: "active", averageConfidence: 0.6, correctionState: "ready_for_box_corrections" },
+    };
+    const props = {
+      createPersonDetectionJob: () => {},
+      createPersonTrackJob: () => {},
+      detectionResult: null,
+      matchingTracks: [track],
+      representativeFrame: null,
+      selectedDetection: null,
+      selectedTrack: track,
+      setPersonTrackId: () => {},
+      setReplacementMode: () => {},
+      setSelectedDetectionId: () => {},
+      setSourceClipAssetId: () => {},
+      setTrackName: () => {},
+      sourceClipAssetId: "clip-1",
+      trackName: "Hero",
+      personTrackId: "track_1",
+      replacementMode: "full_person_keep_outfit",
+      videoAssets: [{ id: "clip-1", type: "video", projectId: "project-1", file: { path: "clip.mp4", mimeType: "video/mp4" } }],
+      personReadiness: {},
+      ...overrides,
+    };
+    return { track, props };
+  }
+
+  it("scrubs tracked frames and persists a corrected box", async () => {
+    const saveTrackCorrections = vi.fn(() => Promise.resolve(null));
+    const { props } = replacePanelProps({ saveTrackCorrections });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<ReplacePersonPanel {...props} />);
+    });
+
+    expect(container.textContent).toContain("Review & correct track");
+    expect(container.textContent).toContain("Frame 1 / 2");
+
+    // Scrub to the second (low-confidence) frame and confirm the quality flag shows.
+    const scrubber = container.querySelector('input[type="range"]');
+    await changeField(scrubber, "1");
+    expect(container.textContent).toContain("Frame 2 / 2");
+    expect(container.textContent).toContain("low confidence");
+
+    // Scrub back and nudge the box X, then save the correction set.
+    await changeField(scrubber, "0");
+    await changeField(container.querySelector('input[aria-label="Box x"]'), "0.5");
+
+    const save = [...container.querySelectorAll("button")].find((button) => button.textContent === "Save corrections");
+    expect(save.disabled).toBe(false);
+    await act(async () => {
+      save.click();
+    });
+
+    expect(saveTrackCorrections).toHaveBeenCalledWith("track_1", [
+      { frameIndex: 0, rejected: false, author: "ui", source: "manual", box: { x: 0.5, y: 0.1, width: 0.2, height: 0.5 } },
+    ]);
+  });
+
+  it("rejects a low-quality frame and records it as a correction", async () => {
+    const saveTrackCorrections = vi.fn(() => Promise.resolve(null));
+    const { props } = replacePanelProps({ saveTrackCorrections });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<ReplacePersonPanel {...props} />);
+    });
+
+    const scrubber = container.querySelector('input[type="range"]');
+    await changeField(scrubber, "1");
+
+    const reject = container.querySelector('.person-correction-reject input[type="checkbox"]');
+    await act(async () => {
+      reject.click();
+    });
+
+    // Rejecting a frame disables its box inputs — replacement borrows a neighbor box.
+    expect(container.querySelector('input[aria-label="Box x"]').disabled).toBe(true);
+
+    const save = [...container.querySelectorAll("button")].find((button) => button.textContent === "Save corrections");
+    await act(async () => {
+      save.click();
+    });
+
+    expect(saveTrackCorrections).toHaveBeenCalledWith("track_1", [
+      { frameIndex: 1, rejected: true, author: "ui", source: "manual" },
+    ]);
   });
 });

--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { API_BASE_URL } from "../api.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 
@@ -14,9 +15,319 @@ const MASK_STATE_COPY = {
   deferred: "Procedural preview track — not real tracking output.",
 };
 
+const BOX_FIELDS = [
+  ["x", "X"],
+  ["y", "Y"],
+  ["width", "W"],
+  ["height", "H"],
+];
+
 function maskStateCopy(track) {
   const state = track?.status?.maskState;
   return MASK_STATE_COPY[state] ?? "Tracked boxes are stored in the track sidecar.";
+}
+
+function clamp01(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function roundComponent(value) {
+  return Math.round(clamp01(value) * 10000) / 10000;
+}
+
+function normalizeBox(box) {
+  return {
+    x: roundComponent(box?.x ?? 0),
+    y: roundComponent(box?.y ?? 0),
+    width: roundComponent(box?.width ?? 0),
+    height: roundComponent(box?.height ?? 0),
+  };
+}
+
+function boxesEqual(a, b) {
+  if (!a || !b) {
+    return false;
+  }
+  return BOX_FIELDS.every(([key]) => Math.abs((a[key] ?? 0) - (b[key] ?? 0)) < 1e-4);
+}
+
+function maskUrl(projectId, relPath) {
+  if (!projectId || !relPath) {
+    return "";
+  }
+  const normalized = String(relPath).replaceAll("\\", "/");
+  return `${API_BASE_URL}/api/v1/projects/${projectId}/files/${normalized}`;
+}
+
+/**
+ * Sparse correction surface for a tracked person (sc-1485). Scrub sampled
+ * tracking frames, inspect the box/mask overlay, nudge a box, and reject low
+ * quality frames; the corrections persist in the track sidecar and the
+ * replacement pipeline regenerates masks from corrected boxes.
+ */
+function PersonTrackCorrections({ track, sourceClip, saveTrackCorrections }) {
+  const frames = useMemo(() => track?.frames ?? [], [track]);
+  const [frameIndex, setFrameIndex] = useState(0);
+  const [drafts, setDrafts] = useState({});
+  const [saving, setSaving] = useState(false);
+  const videoRef = useRef(null);
+
+  const correctionsSignature = JSON.stringify(track?.corrections ?? []);
+  // Seed working drafts from the persisted corrections so reopening a track
+  // shows its saved adjustments, and re-seed after a save converges the UI.
+  useEffect(() => {
+    const seeded = {};
+    for (const correction of track?.corrections ?? []) {
+      const index = correction?.frameIndex;
+      if (!Number.isInteger(index) || index < 0 || index >= frames.length) {
+        continue;
+      }
+      seeded[index] = {
+        box: correction.box ? normalizeBox(correction.box) : null,
+        rejected: Boolean(correction.rejected),
+      };
+    }
+    setDrafts(seeded);
+    setFrameIndex((current) => (current < frames.length ? current : 0));
+  }, [track?.id, correctionsSignature, frames.length]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    const timestamp = frames[frameIndex]?.timestamp;
+    if (!video || !Number.isFinite(timestamp)) {
+      return;
+    }
+    try {
+      video.currentTime = timestamp;
+    } catch {
+      // Seeking before metadata loads is retried by onLoadedMetadata below.
+    }
+  }, [frameIndex, frames]);
+
+  if (!frames.length) {
+    return (
+      <div className="empty-panel compact-panel">
+        This track has no sampled frames to correct yet.
+      </div>
+    );
+  }
+
+  const safeIndex = Math.min(frameIndex, frames.length - 1);
+  const frame = frames[safeIndex];
+  const draft = drafts[safeIndex];
+  const workingBox = normalizeBox(draft?.box ?? frame.box ?? {});
+  const rejected = Boolean(draft?.rejected);
+  const flags = frame.flags ?? [];
+  const overlayMask = frame.mask ? maskUrl(track.projectId, frame.mask) : "";
+
+  function updateDraft(index, updater) {
+    setDrafts((current) => {
+      const base = current[index] ?? {
+        box: normalizeBox(frames[index]?.box ?? {}),
+        rejected: false,
+      };
+      const next = updater({ box: base.box ? normalizeBox(base.box) : normalizeBox(frames[index]?.box ?? {}), rejected: base.rejected });
+      return { ...current, [index]: next };
+    });
+  }
+
+  function setBoxComponent(key, rawValue) {
+    const value = roundComponent(Number.parseFloat(rawValue));
+    updateDraft(safeIndex, (entry) => ({ ...entry, box: { ...entry.box, [key]: value } }));
+  }
+
+  function setRejected(value) {
+    updateDraft(safeIndex, (entry) => ({ ...entry, rejected: value }));
+  }
+
+  function resetFrame() {
+    setDrafts((current) => {
+      const next = { ...current };
+      delete next[safeIndex];
+      return next;
+    });
+  }
+
+  // The corrections payload is the UI's full view: only frames whose box drifted
+  // from the tracked box or that are rejected carry intent worth persisting.
+  const pendingCorrections = Object.entries(drafts)
+    .map(([key, entry]) => {
+      const index = Number(key);
+      const original = frames[index]?.box;
+      const boxChanged = entry.box && original && !boxesEqual(entry.box, original);
+      const isRejected = Boolean(entry.rejected);
+      if (!boxChanged && !isRejected) {
+        return null;
+      }
+      const correction = { frameIndex: index, rejected: isRejected, author: "ui", source: "manual" };
+      if (boxChanged) {
+        correction.box = normalizeBox(entry.box);
+      }
+      return correction;
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.frameIndex - b.frameIndex);
+
+  const persistedCount = (track?.corrections ?? []).length;
+  const frameCorrected = pendingCorrections.some((correction) => correction.frameIndex === safeIndex);
+
+  // Compare the working set against what is persisted (ignoring stamped
+  // author/createdAt/source) so Save only lights up when something changed.
+  const comparable = (correction) =>
+    JSON.stringify({
+      frameIndex: correction.frameIndex,
+      box: correction.box ? normalizeBox(correction.box) : null,
+      rejected: Boolean(correction.rejected),
+    });
+  const persistedComparable = (track?.corrections ?? [])
+    .filter((correction) => Number.isInteger(correction?.frameIndex))
+    .map(comparable)
+    .sort();
+  const pendingComparable = pendingCorrections.map(comparable).sort();
+  const dirty = JSON.stringify(persistedComparable) !== JSON.stringify(pendingComparable);
+
+  async function save() {
+    if (saving || typeof saveTrackCorrections !== "function") {
+      return;
+    }
+    setSaving(true);
+    try {
+      await saveTrackCorrections(track.id, pendingCorrections);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="person-track-corrections" aria-label="Track corrections">
+      <div className="person-correction-header">
+        <strong>Review &amp; correct track</strong>
+        <span>
+          Frame {safeIndex + 1} / {frames.length}
+          {Number.isFinite(frame.timestamp) ? ` • ${frame.timestamp.toFixed(2)}s` : ""}
+          {Number.isFinite(frame.confidence) ? ` • ${Math.round(frame.confidence * 100)}% conf` : ""}
+        </span>
+      </div>
+
+      <div className="person-selection-frame">
+        {sourceClip ? (
+          <AssetMedia
+            asset={sourceClip}
+            controls={false}
+            muted
+            onLoadedMetadata={() => {
+              const video = videoRef.current;
+              if (video && Number.isFinite(frame.timestamp)) {
+                try {
+                  video.currentTime = frame.timestamp;
+                } catch {
+                  // Ignore: some browsers reject seeks until the buffer is ready.
+                }
+              }
+            }}
+            ref={videoRef}
+          />
+        ) : null}
+        {overlayMask ? <img alt="" className="person-track-mask-overlay" src={overlayMask} /> : null}
+        <div
+          className={rejected ? "person-box rejected" : "person-box active"}
+          style={{
+            left: `${workingBox.x * 100}%`,
+            top: `${workingBox.y * 100}%`,
+            width: `${workingBox.width * 100}%`,
+            height: `${workingBox.height * 100}%`,
+          }}
+        >
+          <span>{rejected ? "rejected" : "corrected box"}</span>
+        </div>
+      </div>
+
+      <div className="person-correction-scrubber">
+        <button
+          aria-label="Previous frame"
+          disabled={safeIndex <= 0}
+          onClick={() => setFrameIndex(Math.max(0, safeIndex - 1))}
+          type="button"
+        >
+          ‹
+        </button>
+        <input
+          aria-label="Scrub tracking frames"
+          max={frames.length - 1}
+          min={0}
+          onChange={(event) => setFrameIndex(Number.parseInt(event.target.value, 10) || 0)}
+          step={1}
+          type="range"
+          value={safeIndex}
+        />
+        <button
+          aria-label="Next frame"
+          disabled={safeIndex >= frames.length - 1}
+          onClick={() => setFrameIndex(Math.min(frames.length - 1, safeIndex + 1))}
+          type="button"
+        >
+          ›
+        </button>
+      </div>
+
+      {flags.length ? (
+        <div className="person-correction-flags" role="status">
+          {flags.map((flag) => (
+            <span className="person-correction-flag" key={flag}>
+              {flag.replaceAll("_", " ")}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="control-grid person-correction-box">
+        {BOX_FIELDS.map(([key, label]) => (
+          <label key={key}>
+            {label}
+            <input
+              aria-label={`Box ${key}`}
+              disabled={rejected}
+              max={1}
+              min={0}
+              onChange={(event) => setBoxComponent(key, event.target.value)}
+              step={0.01}
+              type="number"
+              value={workingBox[key]}
+            />
+          </label>
+        ))}
+      </div>
+
+      <label className="person-correction-reject">
+        <input checked={rejected} onChange={(event) => setRejected(event.target.checked)} type="checkbox" />
+        Reject this frame (low quality — replacement borrows the nearest good frame)
+      </label>
+
+      <div className="guidance-strip">
+        <span>
+          Adjusting a box regenerates that frame&apos;s mask from the corrected box at replacement time. Saved
+          corrections record author and time in the track sidecar.
+        </span>
+      </div>
+
+      <div className="replace-actions">
+        <div className="person-correction-actions">
+          <button disabled={!frameCorrected} onClick={resetFrame} type="button">
+            Reset frame
+          </button>
+          <button className="primary" disabled={saving || !dirty} onClick={save} type="button">
+            {saving ? "Saving…" : "Save corrections"}
+          </button>
+        </div>
+        <span>
+          {dirty ? `${pendingCorrections.length} unsaved` : `${persistedCount} saved`}
+        </span>
+      </div>
+    </div>
+  );
 }
 
 export function ReplacePersonPanel({
@@ -36,6 +347,7 @@ export function ReplacePersonPanel({
   trackName,
   personTrackId,
   replacementMode,
+  saveTrackCorrections,
   videoAssets,
   personReadiness = {},
 }) {
@@ -50,6 +362,10 @@ export function ReplacePersonPanel({
       : !replaceReady
         ? "Replacement unavailable: no live GPU worker can run person replacement yet."
         : "";
+
+  const selectedTrackSourceClip = selectedTrack
+    ? videoAssets.find((asset) => asset.id === selectedTrack.sourceAssetId) ?? null
+    : null;
 
   function analyzeSource() {
     if (!sourceClipAssetId) {
@@ -155,6 +471,15 @@ export function ReplacePersonPanel({
           <strong>{selectedTrack.status?.averageConfidence ? `${Math.round(selectedTrack.status.averageConfidence * 100)}% track` : "Reusable track"}</strong>
           <span>{maskStateCopy(selectedTrack)}</span>
         </div>
+      ) : null}
+
+      {selectedTrack ? (
+        <PersonTrackCorrections
+          key={selectedTrack.id}
+          saveTrackCorrections={saveTrackCorrections}
+          sourceClip={selectedTrackSourceClip}
+          track={selectedTrack}
+        />
       ) : null}
 
       <label>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -77,6 +77,7 @@ export function VideoStudio({
   personReadiness = {},
   presets = [],
   requestedGpu,
+  saveTrackCorrections,
   selectedAsset,
   setRequestedGpu,
   updateAssetStatus,
@@ -562,6 +563,7 @@ export function VideoStudio({
                 personTrackId={personTrackId}
                 replacementMode={replacementMode}
                 representativeFrame={representativeFrame}
+                saveTrackCorrections={saveTrackCorrections}
                 selectedDetection={selectedDetection}
                 selectedTrack={selectedTrack}
                 setPersonTrackId={setPersonTrackId}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4163,6 +4163,89 @@ label {
   color: var(--text);
 }
 
+.person-box.rejected {
+  border-color: var(--danger, #d4534e);
+  border-style: dashed;
+  background: color-mix(in oklch, var(--danger, #d4534e) 20%, transparent);
+}
+
+.person-track-corrections {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-2);
+}
+
+.person-correction-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.person-correction-header span {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.person-track-mask-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  opacity: 0.4;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.person-correction-scrubber {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.person-correction-scrubber input[type="range"] {
+  flex: 1;
+}
+
+.person-correction-scrubber button {
+  min-width: 34px;
+}
+
+.person-correction-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.person-correction-flag {
+  padding: 2px 8px;
+  border-radius: var(--r-xs);
+  font-size: 0.72rem;
+  background: color-mix(in oklch, var(--warm) 22%, transparent);
+  color: var(--text);
+}
+
+.person-correction-box {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.person-correction-reject {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.person-correction-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .comparison-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/worker/scene_worker/person_adapters.py
+++ b/apps/worker/scene_worker/person_adapters.py
@@ -1001,6 +1001,60 @@ def _require_source_media(project_path: Path, asset_id: str) -> Path:
     return media_path
 
 
+def apply_track_corrections(track: dict[str, Any]) -> list[dict[str, Any]]:
+    """Apply persisted box/reject corrections to a track's frames (sc-1485).
+
+    Returns copies of the track frames with corrections applied so replacement
+    consumes corrected geometry without mutating the sidecar:
+
+    * A corrected box overrides the tracked box and clears that frame's stored
+      segmentation mask — the old mask no longer matches the new box, so the
+      mask loader regenerates a box mask from the corrected box (corrected-box-
+      driven mask regeneration, which the story accepts in lieu of mask paint).
+    * A rejected frame is excluded: its box/mask is replaced by the nearest
+      accepted frame's box (mask cleared), so the masked control clip never
+      neutralizes a region using geometry the user flagged as wrong.
+
+    Corrections are keyed by ``frameIndex``; out-of-range or malformed entries are
+    ignored so a stale sidecar never breaks replacement.
+    """
+    frames = [dict(frame) for frame in (track.get("frames") or [])]
+    if not frames:
+        return frames
+    by_index: dict[int, dict[str, Any]] = {}
+    for correction in track.get("corrections") or []:
+        if not isinstance(correction, dict):
+            continue
+        index = correction.get("frameIndex")
+        if isinstance(index, bool) or not isinstance(index, int):
+            continue
+        if 0 <= index < len(frames):
+            by_index[index] = correction
+
+    rejected = [False] * len(frames)
+    for index, correction in by_index.items():
+        frame = frames[index]
+        box = correction.get("box")
+        if isinstance(box, dict):
+            frame["box"] = box
+            frame["mask"] = None
+            frame["corrected"] = True
+        if correction.get("rejected"):
+            rejected[index] = True
+            frame["rejected"] = True
+
+    accepted = [index for index, flag in enumerate(rejected) if not flag]
+    if accepted and len(accepted) < len(frames):
+        accepted_boxes = {index: frames[index].get("box") for index in accepted}
+        for index, flag in enumerate(rejected):
+            if not flag:
+                continue
+            nearest = min(accepted, key=lambda candidate: (abs(candidate - index), candidate))
+            frames[index]["box"] = accepted_boxes[nearest]
+            frames[index]["mask"] = None
+    return frames
+
+
 def load_track_masks(
     project_path: Path,
     track: dict[str, Any],
@@ -1010,20 +1064,37 @@ def load_track_masks(
 ) -> tuple[list[Image.Image], str]:
     """Load per-frame masks for replacement, resampled to ``count`` frames.
 
-    Returns ``(masks, mode)`` where mode is ``"segmentation"`` when stored masks
-    were loaded or ``"degraded_box"`` when falling back to rectangular box masks
-    derived from the track frames. Box fallback is the explicit degraded path.
+    Persisted corrections are applied first (corrected boxes override tracked
+    boxes; rejected frames borrow the nearest accepted box). Masks are then
+    chosen per frame: a frame keeps its stored segmentation mask only when the
+    file still exists and the box was not corrected, otherwise it falls back to a
+    rectangular box mask from the (possibly corrected) box.
+
+    Returns ``(masks, mode)`` where mode is ``"segmentation"`` (all stored masks),
+    ``"degraded_box"`` (all box-derived), or ``"mixed"`` (some of each, e.g. a
+    corrected frame regenerated as a box mask alongside untouched seg masks).
     """
-    frames = track.get("frames") or []
+    frames = apply_track_corrections(track)
     if not frames:
         raise RuntimeError("Person track has no frames; cannot build replacement masks.")
     indices = _resample_indices(len(frames), count)
-    stored = [frames[index].get("mask") for index in indices]
-    if all(isinstance(ref, str) and (project_path / ref).exists() for ref in stored):
-        masks = [Image.open(project_path / ref).convert("L").resize((width, height)) for ref in stored]
-        return masks, "segmentation"
-    masks = [_box_mask(frames[index].get("box") or {}, width, height) for index in indices]
-    return masks, "degraded_box"
+    masks: list[Image.Image] = []
+    segmentation = 0
+    for index in indices:
+        frame = frames[index]
+        ref = frame.get("mask")
+        if isinstance(ref, str) and (project_path / ref).exists():
+            masks.append(Image.open(project_path / ref).convert("L").resize((width, height)))
+            segmentation += 1
+        else:
+            masks.append(_box_mask(frame.get("box") or {}, width, height))
+    if segmentation == len(indices):
+        mode = "segmentation"
+    elif segmentation == 0:
+        mode = "degraded_box"
+    else:
+        mode = "mixed"
+    return masks, mode
 
 
 def _resample_indices(total: int, count: int) -> list[int]:

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -180,6 +180,8 @@ class LtxReplacementControl:
     masking_strength: float
     frame_count: int
     character_reference_count: int
+    used_corrections: bool = False
+    correction_count: int = 0
 
 
 def install_ltx_pipelines_multigpu_compat() -> None:
@@ -697,6 +699,10 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 "personTrackId": replacement_control.track_id,
                 "characterReferenceCount": replacement_control.character_reference_count,
                 "controlFrameCount": replacement_control.frame_count,
+                # Record that corrected boxes/masks drove this replacement so the
+                # asset sidecar proves the correction UI fed the render (sc-1485).
+                "usedCorrections": replacement_control.used_corrections,
+                "correctionCount": replacement_control.correction_count,
             }
 
         generation_set = {
@@ -850,6 +856,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         ]
         self._write_control_clip(masked_frames, clip_path, request.fps)
         status = track.get("status", {}) if isinstance(track.get("status"), dict) else {}
+        corrections = track.get("corrections") or []
         return LtxReplacementControl(
             track_id=str(track.get("id") or request.person_track_id),
             masked_clip_path=clip_path,
@@ -859,6 +866,8 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
             masking_strength=masking_strength,
             frame_count=len(masked_frames),
             character_reference_count=len(references),
+            used_corrections=bool(corrections),
+            correction_count=len(corrections) if isinstance(corrections, list) else 0,
         )
 
     def _write_control_clip(self, frames: list[Image.Image], path: Path, fps: int) -> None:

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -158,7 +158,11 @@ string_enum! {
 
 string_enum! {
     pub enum PersonTrackCorrectionState {
+        // A freshly tracked sidecar advertises that it accepts box corrections.
         ReadyForBoxCorrections => "ready_for_box_corrections",
+        // Set once the correction UI has persisted at least one box adjustment or
+        // frame rejection into the sidecar's `corrections` array (sc-1485).
+        BoxCorrectionsApplied => "box_corrections_applied",
     }
 }
 

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -862,6 +862,81 @@ impl ProjectStore {
         normalize_person_track(&project_path, &track_path)
     }
 
+    /// Replace the correction set on a person track (sc-1485). Each incoming
+    /// correction targets a frame by index and either adjusts its box or rejects
+    /// the frame; the server stamps author/createdAt/source so the sidecar always
+    /// records who corrected it and when. The corrections array is the UI's full
+    /// view, so it is written wholesale (a frame omitted from the set is treated
+    /// as having no correction). Returns the normalized, updated track.
+    pub fn set_person_track_corrections(
+        &self,
+        project_id: &str,
+        track_id: &str,
+        corrections: Vec<Value>,
+    ) -> ProjectStoreResult<Value> {
+        if !is_safe_track_id(track_id) {
+            return Err(ProjectStoreError::BadRequest(
+                "Invalid person track ID".to_owned(),
+            ));
+        }
+        let project_path = self.find_project_path(project_id)?;
+        let tracks_dir = project_path.join("person-tracks");
+        let track_path = tracks_dir.join(format!("{track_id}.sceneworks.person-track.json"));
+        if !track_path.exists() {
+            return Err(ProjectStoreError::NotFound(
+                "Person track not found".to_owned(),
+            ));
+        }
+        let tracks_root = fs::canonicalize(&tracks_dir)?;
+        let resolved_path = fs::canonicalize(&track_path)?;
+        if !resolved_path.starts_with(&tracks_root) {
+            return Err(ProjectStoreError::BadRequest(
+                "Invalid person track ID".to_owned(),
+            ));
+        }
+
+        let mut track = read_json(&track_path)?;
+        let frame_count = track
+            .get("frames")
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(0);
+        let mut normalized = normalize_person_track_corrections(corrections, frame_count)?;
+        let has_corrections = !normalized.is_empty();
+        normalized.sort_by_key(|correction| {
+            correction
+                .get("frameIndex")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        });
+
+        let object = track.as_object_mut().ok_or_else(|| {
+            ProjectStoreError::BadRequest("Person track sidecar must be an object".to_owned())
+        })?;
+        object.insert("corrections".to_owned(), Value::Array(normalized));
+        let status = object
+            .entry("status")
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+            .ok_or_else(|| {
+                ProjectStoreError::BadRequest("Person track status must be an object".to_owned())
+            })?;
+        status.insert(
+            "correctionState".to_owned(),
+            Value::String(
+                if has_corrections {
+                    "box_corrections_applied"
+                } else {
+                    "ready_for_box_corrections"
+                }
+                .to_owned(),
+            ),
+        );
+
+        write_json(&track_path, &track)?;
+        normalize_person_track(&project_path, &track_path)
+    }
+
     pub fn import_asset(&self, project_id: &str, upload: UploadAsset) -> ProjectStoreResult<Value> {
         if fs::metadata(&upload.source_path)?.len() == 0 {
             return Err(ProjectStoreError::BadRequest(
@@ -2096,6 +2171,109 @@ fn normalize_person_track(project_path: &Path, track_path: &Path) -> ProjectStor
     Ok(track)
 }
 
+/// Validate and canonicalize the incoming correction set for a person track.
+/// Each entry targets an in-range frame and carries a box adjustment, a
+/// rejection, or both; the server stamps author/createdAt/source. Entries that
+/// neither adjust a box nor reject the frame are dropped (a reset frame).
+/// Duplicate frame indices keep the last occurrence so the set is one entry per
+/// frame.
+fn normalize_person_track_corrections(
+    corrections: Vec<Value>,
+    frame_count: usize,
+) -> ProjectStoreResult<Vec<Value>> {
+    let created_at = utc_now();
+    let mut normalized: Vec<(u64, Value)> = Vec::with_capacity(corrections.len());
+    for correction in corrections {
+        let object = correction.as_object().ok_or_else(|| {
+            ProjectStoreError::BadRequest("Each correction must be an object".to_owned())
+        })?;
+        let frame_index = object
+            .get("frameIndex")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                ProjectStoreError::BadRequest(
+                    "Correction frameIndex must be a non-negative integer".to_owned(),
+                )
+            })?;
+        if frame_count == 0 || frame_index as usize >= frame_count {
+            return Err(ProjectStoreError::BadRequest(format!(
+                "Correction frameIndex {frame_index} is outside the track's {frame_count} frames"
+            )));
+        }
+        let rejected = object
+            .get("rejected")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let box_value = match object.get("box") {
+            Some(Value::Null) | None => None,
+            Some(value) => Some(validate_normalized_box(value)?),
+        };
+        if box_value.is_none() && !rejected {
+            continue;
+        }
+        let author = object
+            .get("author")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("ui")
+            .to_owned();
+        let source = object
+            .get("source")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("manual")
+            .to_owned();
+        let mut entry = serde_json::Map::new();
+        entry.insert("frameIndex".to_owned(), json!(frame_index));
+        if let Some(box_value) = box_value {
+            entry.insert("box".to_owned(), box_value);
+        }
+        entry.insert("rejected".to_owned(), Value::Bool(rejected));
+        entry.insert("author".to_owned(), Value::String(author));
+        entry.insert("source".to_owned(), Value::String(source));
+        entry.insert("createdAt".to_owned(), Value::String(created_at.clone()));
+        if let Some(slot) = normalized
+            .iter_mut()
+            .find(|(index, _)| *index == frame_index)
+        {
+            slot.1 = Value::Object(entry);
+        } else {
+            normalized.push((frame_index, Value::Object(entry)));
+        }
+    }
+    Ok(normalized.into_iter().map(|(_, value)| value).collect())
+}
+
+/// Validate a normalized 0..1 bounding box and return a canonical copy holding
+/// only x/y/width/height as finite numbers in range with positive extent.
+fn validate_normalized_box(value: &Value) -> ProjectStoreResult<Value> {
+    let object = value.as_object().ok_or_else(|| {
+        ProjectStoreError::BadRequest("Correction box must be an object".to_owned())
+    })?;
+    let mut box_out = serde_json::Map::new();
+    for key in ["x", "y", "width", "height"] {
+        let component = object.get(key).and_then(Value::as_f64).ok_or_else(|| {
+            ProjectStoreError::BadRequest(format!("Correction box.{key} must be a number"))
+        })?;
+        if !component.is_finite() || !(0.0..=1.0).contains(&component) {
+            return Err(ProjectStoreError::BadRequest(format!(
+                "Correction box.{key} must be between 0 and 1"
+            )));
+        }
+        box_out.insert(key.to_owned(), json!(component));
+    }
+    let width = box_out.get("width").and_then(Value::as_f64).unwrap_or(0.0);
+    let height = box_out.get("height").and_then(Value::as_f64).unwrap_or(0.0);
+    if width <= 0.0 || height <= 0.0 {
+        return Err(ProjectStoreError::BadRequest(
+            "Correction box must have positive width and height".to_owned(),
+        ));
+    }
+    Ok(Value::Object(box_out))
+}
+
 fn read_json(path: &Path) -> ProjectStoreResult<Value> {
     let payload = fs::read_to_string(path)?;
     Ok(serde_json::from_str(&payload)?)
@@ -2431,6 +2609,89 @@ mod tests {
         assert_eq!(track["name"], "Hero");
         assert!(store.get_person_track(&project.id, "../track_1").is_err());
         assert!(store.get_person_track(&project.id, "track~1").is_err());
+    }
+
+    #[test]
+    fn person_track_corrections_persist_validate_and_clear() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Fixture").expect("project creates");
+        let project_path = std::path::PathBuf::from(&project.path);
+        std::fs::write(
+            project_path.join("person-tracks/track_1.sceneworks.person-track.json"),
+            serde_json::to_string_pretty(&json!({
+                "schemaVersion": 1,
+                "id": "track_1",
+                "projectId": project.id,
+                "name": "Hero",
+                "createdAt": "2026-05-17T00:00:00Z",
+                "sourceAssetId": "asset-video",
+                "representativeFrameAssetId": "asset-frame",
+                "frames": [
+                    {"timestamp": 0.0, "box": {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.5}},
+                    {"timestamp": 0.5, "box": {"x": 0.3, "y": 0.1, "width": 0.2, "height": 0.5}}
+                ],
+                "corrections": [],
+                "status": {"correctionState": "ready_for_box_corrections"}
+            }))
+            .expect("json"),
+        )
+        .expect("track sidecar writes");
+
+        // A box adjustment and a rejection persist; the server stamps metadata and
+        // drops the trailing no-op entry (no box, not rejected) for frame 0.
+        let updated = store
+            .set_person_track_corrections(
+                &project.id,
+                "track_1",
+                vec![
+                    json!({"frameIndex": 0, "box": {"x": 0.5, "y": 0.2, "width": 0.25, "height": 0.4}, "author": "editor"}),
+                    json!({"frameIndex": 1, "rejected": true}),
+                    json!({"frameIndex": 0, "rejected": false}),
+                ],
+            )
+            .expect("corrections persist");
+        let corrections = updated["corrections"]
+            .as_array()
+            .expect("corrections array");
+        assert_eq!(corrections.len(), 2);
+        assert_eq!(corrections[0]["frameIndex"], 0);
+        assert_eq!(corrections[0]["box"]["x"], 0.5);
+        assert_eq!(corrections[0]["author"], "editor");
+        assert_eq!(corrections[0]["source"], "manual");
+        assert!(corrections[0]["createdAt"].is_string());
+        assert_eq!(corrections[1]["frameIndex"], 1);
+        assert_eq!(corrections[1]["rejected"], true);
+        assert_eq!(
+            updated["status"]["correctionState"],
+            "box_corrections_applied"
+        );
+
+        // Out-of-range frame indices and out-of-bounds boxes are rejected.
+        assert!(store
+            .set_person_track_corrections(
+                &project.id,
+                "track_1",
+                vec![json!({"frameIndex": 9, "rejected": true})]
+            )
+            .is_err());
+        assert!(store
+            .set_person_track_corrections(
+                &project.id,
+                "track_1",
+                vec![json!({"frameIndex": 0, "box": {"x": 1.5, "y": 0.0, "width": 0.2, "height": 0.2}})]
+            )
+            .is_err());
+
+        // Clearing corrections returns the track to the ready state.
+        let cleared = store
+            .set_person_track_corrections(&project.id, "track_1", vec![])
+            .expect("corrections clear");
+        assert!(cleared["corrections"].as_array().expect("array").is_empty());
+        assert_eq!(
+            cleared["status"]["correctionState"],
+            "ready_for_box_corrections"
+        );
     }
 
     #[test]

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2097,9 +2097,59 @@
     "updatedAt": "<timestamp>",
     "workerId": null
   },
-  "person track detail response": {
+  "person track corrections response": {
+    "corrections": [
+      {
+        "author": "ui",
+        "box": {
+          "height": 0.62,
+          "width": 0.21,
+          "x": 0.32,
+          "y": 0.18
+        },
+        "createdAt": "<timestamp>",
+        "frameIndex": 0,
+        "rejected": false,
+        "source": "manual"
+      },
+      {
+        "author": "ui",
+        "createdAt": "<timestamp>",
+        "frameIndex": 1,
+        "rejected": true,
+        "source": "manual"
+      }
+    ],
     "createdAt": "<timestamp>",
-    "frames": [],
+    "frames": [
+      {
+        "box": {
+          "height": 0.6,
+          "width": 0.2,
+          "x": 0.3,
+          "y": 0.2
+        },
+        "confidence": 0.91,
+        "detected": true,
+        "mask": null,
+        "timestamp": 0.0
+      },
+      {
+        "box": {
+          "height": 0.6,
+          "width": 0.2,
+          "x": 0.34,
+          "y": 0.2
+        },
+        "confidence": 0.42,
+        "detected": true,
+        "flags": [
+          "low_confidence"
+        ],
+        "mask": null,
+        "timestamp": 0.5
+      }
+    ],
     "id": "track_fixture",
     "name": "Hero",
     "path": "person-tracks/track_fixture.sceneworks.person-track.json",
@@ -2107,7 +2157,52 @@
     "representativeFrameAssetId": "asset-frame",
     "schemaVersion": 1,
     "sourceAssetId": "asset-video",
-    "status": {}
+    "status": {
+      "correctionState": "box_corrections_applied"
+    }
+  },
+  "person track detail response": {
+    "corrections": [],
+    "createdAt": "<timestamp>",
+    "frames": [
+      {
+        "box": {
+          "height": 0.6,
+          "width": 0.2,
+          "x": 0.3,
+          "y": 0.2
+        },
+        "confidence": 0.91,
+        "detected": true,
+        "mask": null,
+        "timestamp": 0.0
+      },
+      {
+        "box": {
+          "height": 0.6,
+          "width": 0.2,
+          "x": 0.34,
+          "y": 0.2
+        },
+        "confidence": 0.42,
+        "detected": true,
+        "flags": [
+          "low_confidence"
+        ],
+        "mask": null,
+        "timestamp": 0.5
+      }
+    ],
+    "id": "track_fixture",
+    "name": "Hero",
+    "path": "person-tracks/track_fixture.sceneworks.person-track.json",
+    "projectId": "project_fixture",
+    "representativeFrameAssetId": "asset-frame",
+    "schemaVersion": 1,
+    "sourceAssetId": "asset-video",
+    "status": {
+      "correctionState": "ready_for_box_corrections"
+    }
   },
   "person track job response": {
     "assignedGpu": null,
@@ -2153,8 +2248,37 @@
   },
   "person track list response": [
     {
+      "corrections": [],
       "createdAt": "<timestamp>",
-      "frames": [],
+      "frames": [
+        {
+          "box": {
+            "height": 0.6,
+            "width": 0.2,
+            "x": 0.3,
+            "y": 0.2
+          },
+          "confidence": 0.91,
+          "detected": true,
+          "mask": null,
+          "timestamp": 0.0
+        },
+        {
+          "box": {
+            "height": 0.6,
+            "width": 0.2,
+            "x": 0.34,
+            "y": 0.2
+          },
+          "confidence": 0.42,
+          "detected": true,
+          "flags": [
+            "low_confidence"
+          ],
+          "mask": null,
+          "timestamp": 0.5
+        }
+      ],
       "id": "track_fixture",
       "name": "Hero",
       "path": "person-tracks/track_fixture.sceneworks.person-track.json",
@@ -2162,7 +2286,9 @@
       "representativeFrameAssetId": "asset-frame",
       "schemaVersion": 1,
       "sourceAssetId": "asset-video",
-      "status": {}
+      "status": {
+        "correctionState": "ready_for_box_corrections"
+      }
     }
   ],
   "project create response": {

--- a/tests/test_person_adapters.py
+++ b/tests/test_person_adapters.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image, ImageDraw
 
-from sceneworks_shared import index_asset, write_json
+from sceneworks_shared import index_asset, read_json, write_json
 from scene_worker import person_adapters as pa
 from scene_worker.person_adapters import (
     NormalizedBox,
@@ -394,6 +394,104 @@ def test_load_track_masks_prefers_segmentation_then_degrades(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Correction application (sc-1485): corrected boxes / rejected frames drive masks
+# ---------------------------------------------------------------------------
+
+
+def test_apply_track_corrections_overrides_box_and_clears_mask():
+    track = {
+        "frames": [
+            {"box": {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.3}, "mask": "person-tracks/t/masks/frame_000001.png", "detected": True},
+        ],
+        "corrections": [
+            {"frameIndex": 0, "box": {"x": 0.5, "y": 0.4, "width": 0.25, "height": 0.35}, "rejected": False, "author": "ui", "source": "manual"},
+        ],
+    }
+    frames = pa.apply_track_corrections(track)
+    assert frames[0]["box"] == {"x": 0.5, "y": 0.4, "width": 0.25, "height": 0.35}
+    # The corrected box no longer matches the stored segmentation mask, so it is
+    # cleared and regenerated as a box mask downstream.
+    assert frames[0]["mask"] is None
+    assert frames[0]["corrected"] is True
+
+
+def test_apply_track_corrections_replaces_rejected_frame_with_neighbor():
+    track = {
+        "frames": [
+            {"box": {"x": 0.10, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": "m0", "detected": True},
+            {"box": {"x": 0.50, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": "m1", "detected": True},
+            {"box": {"x": 0.80, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": "m2", "detected": True},
+        ],
+        "corrections": [{"frameIndex": 1, "rejected": True, "author": "ui", "source": "manual"}],
+    }
+    frames = pa.apply_track_corrections(track)
+    # The rejected middle frame borrows the nearest accepted box and drops its
+    # stale mask; accepted neighbors keep their own geometry.
+    assert frames[1]["rejected"] is True
+    assert frames[1]["mask"] is None
+    assert frames[1]["box"] == {"x": 0.10, "y": 0.1, "width": 0.2, "height": 0.5}
+    assert frames[0]["box"]["x"] == 0.10
+    assert frames[2]["box"]["x"] == 0.80
+
+
+def test_apply_track_corrections_ignores_out_of_range_entries():
+    track = {
+        "frames": [{"box": {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": None}],
+        "corrections": [
+            {"frameIndex": 7, "box": {"x": 0.3, "y": 0.3, "width": 0.2, "height": 0.2}},
+            {"frameIndex": "bad"},
+        ],
+    }
+    frames = pa.apply_track_corrections(track)
+    assert frames[0]["box"] == {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.5}
+    assert "corrected" not in frames[0]
+
+
+def test_load_track_masks_regenerates_box_mask_for_corrected_frame(tmp_path):
+    project_path = tmp_path / "project"
+    masks_dir = project_path / "person-tracks" / "track_c" / "masks"
+    masks_dir.mkdir(parents=True, exist_ok=True)
+    rel = "person-tracks/track_c/masks/frame_000001.png"
+    Image.new("L", (64, 64), 255).save(project_path / rel)  # full-frame stored mask
+    track = {
+        "frames": [{"box": {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": rel}],
+        "corrections": [{"frameIndex": 0, "box": {"x": 0.5, "y": 0.4, "width": 0.25, "height": 0.35}}],
+    }
+    masks, mode = pa.load_track_masks(project_path, track, 100, 100, 1)
+    # The only frame's box was corrected, invalidating its stored mask, so the
+    # whole set falls back to box masks regenerated from corrected geometry.
+    assert mode == "degraded_box"
+    bbox = masks[0].getbbox()
+    assert bbox is not None
+    left, top, right, bottom = bbox
+    # The box mask is anchored at the corrected box (~3% padding), not full-frame.
+    assert 40 < left and 30 < top
+    assert right < 80 and bottom < 80
+
+
+def test_load_track_masks_mixes_segmentation_and_corrected_box(tmp_path):
+    project_path = tmp_path / "project"
+    masks_dir = project_path / "person-tracks" / "track_m" / "masks"
+    masks_dir.mkdir(parents=True, exist_ok=True)
+    rels = []
+    for index in range(2):
+        rel = f"person-tracks/track_m/masks/frame_{index + 1:06d}.png"
+        Image.new("L", (64, 64), 255).save(project_path / rel)
+        rels.append(rel)
+    track = {
+        "frames": [
+            {"box": {"x": 0.1, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": rels[0]},
+            {"box": {"x": 0.6, "y": 0.1, "width": 0.2, "height": 0.5}, "mask": rels[1]},
+        ],
+        "corrections": [{"frameIndex": 0, "box": {"x": 0.4, "y": 0.4, "width": 0.2, "height": 0.2}}],
+    }
+    masks, mode = pa.load_track_masks(project_path, track, 64, 64, 2)
+    # Frame 0 regenerates a box mask; frame 1 keeps its stored segmentation mask.
+    assert mode == "mixed"
+    assert len(masks) == 2
+
+
+# ---------------------------------------------------------------------------
 # Active LTX masked-control replacement tests (sc-1483 / sc-1486)
 # ---------------------------------------------------------------------------
 
@@ -532,6 +630,47 @@ def test_ltx_replacement_control_builds_segmentation_package(tmp_path):
     assert control.character_reference_count == 1
     assert control.person_tracking_active is True
     assert clip_path.exists()
+    # A track with no corrections must not claim it used any.
+    assert control.used_corrections is False
+    assert control.correction_count == 0
+
+
+def _add_track_corrections(project_path: Path, track_id: str, corrections: list[dict]) -> None:
+    track_path = project_path / "person-tracks" / f"{track_id}.sceneworks.person-track.json"
+    track = read_json(track_path)
+    track["corrections"] = corrections
+    write_json(track_path, track)
+
+
+def test_ltx_replacement_records_used_corrections(tmp_path):
+    settings = _seed_replacement_project(tmp_path, with_masks=True)
+    project_path = Path(settings.data_dir) / "project"
+    _add_track_corrections(
+        project_path,
+        "track_repl",
+        [
+            {
+                "frameIndex": 0,
+                "box": {"x": 0.25, "y": 0.2, "width": 0.2, "height": 0.55},
+                "rejected": False,
+                "author": "ui",
+                "source": "manual",
+                "createdAt": "2026-05-21T00:00:00Z",
+            }
+        ],
+    )
+    adapter = LtxPipelinesVideoAdapter()
+    adapter._settings = settings
+    request = video_request_from_job(_replacement_job(settings))
+    clip_path = project_path / "cache" / "control.webp"
+    clip_path.parent.mkdir(parents=True, exist_ok=True)
+    control = adapter._ltx_replacement_control(project_path, request, 9, clip_path)
+    # The replacement package records that corrected geometry drove it (sc-1485).
+    assert control.used_corrections is True
+    assert control.correction_count == 1
+    # Frame 0's corrected box regenerates a box mask while the rest keep stored
+    # segmentation masks, so the package mixes both sources.
+    assert control.mask_mode == "mixed"
 
 
 def test_ltx_replace_person_active_run_marks_replacement_active(tmp_path, monkeypatch):

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -482,8 +482,25 @@ def write_person_track_sidecar(runtime: ContractRuntime) -> None:
                 "createdAt": "2026-05-17T00:00:00Z",
                 "sourceAssetId": "asset-video",
                 "representativeFrameAssetId": "asset-frame",
-                "frames": [],
-                "status": {},
+                "frames": [
+                    {
+                        "timestamp": 0.0,
+                        "box": {"x": 0.3, "y": 0.2, "width": 0.2, "height": 0.6},
+                        "confidence": 0.91,
+                        "detected": True,
+                        "mask": None,
+                    },
+                    {
+                        "timestamp": 0.5,
+                        "box": {"x": 0.34, "y": 0.2, "width": 0.2, "height": 0.6},
+                        "confidence": 0.42,
+                        "detected": True,
+                        "mask": None,
+                        "flags": ["low_confidence"],
+                    },
+                ],
+                "corrections": [],
+                "status": {"correctionState": "ready_for_box_corrections"},
             },
             indent=2,
         )
@@ -1310,6 +1327,26 @@ def test_person_tracking_and_replace_person_contracts(contract_runtimes):
         for runtime in contract_runtimes
     ]
     assert_response_contract("person track detail response", baseline_runtime, candidate_runtime, track_details[0], track_details[1], expected_status=200, snapshot=True)
+
+    correction_responses = [
+        runtime.request(
+            "POST",
+            f"/api/v1/projects/{runtime.project_id}/person-tracks/track_fixture/corrections",
+            json_payload={
+                "corrections": [
+                    {
+                        "frameIndex": 0,
+                        "box": {"x": 0.32, "y": 0.18, "width": 0.21, "height": 0.62},
+                        "author": "ui",
+                        "source": "manual",
+                    },
+                    {"frameIndex": 1, "rejected": True},
+                ]
+            },
+        )
+        for runtime in contract_runtimes
+    ]
+    assert_response_contract("person track corrections response", baseline_runtime, candidate_runtime, correction_responses[0], correction_responses[1], expected_status=200, snapshot=True)
 
     detection_jobs = [
         runtime.request(


### PR DESCRIPTION
Closes the last follow-up of epic sc-1090 (Person Tracking & Replace Person V1): the sparse correction UI for tracked boxes and masks (sc-1485). PRs #112/#113 already landed sc-1480–1484, 1486, 1487.

## What this delivers (per the story)
- Scrub sampled tracking frames and inspect the current box/mask overlay.
- Adjust a box and mark/reject low-quality frames.
- Corrected boxes drive **mask regeneration** at replacement time (mask painting deferred — the story accepts corrected-box-driven regeneration).
- Corrections persist in the person-track sidecar with **author / time / source**.
- Replacement uses corrected track data and **records that it did** (`usedCorrections`).

## Changes by layer
**API (`apps/rust-api`, `crates/sceneworks-core`)**
- `POST /api/v1/projects/{id}/person-tracks/{track_id}/corrections` → validates normalized 0..1 boxes and in-range frame indices, stamps `author`/`createdAt`/`source`, dedupes by `frameIndex`, drops no-op entries (reset frames), and bumps `status.correctionState`.
- New forward-compatible contract enum variant `BoxCorrectionsApplied` (`box_corrections_applied`).
- Replace-semantics: the UI persists its full correction set; an omitted frame clears.

**Worker (`apps/worker`)**
- `apply_track_corrections()` applies persisted corrections to a copy of the frames: a corrected box overrides the tracked box and **drops the now-stale segmentation mask** so it regenerates from the corrected box; a rejected frame borrows the nearest accepted box.
- `load_track_masks()` is now per-frame (`segmentation` / `degraded_box` / `mixed`).
- `replacement_status` records `usedCorrections` + `correctionCount`.

**Web (`apps/web`)**
- `ReplacePersonPanel` gains a frame scrubber, box/mask overlay (source clip seeked to the frame timestamp + mask PNG), box-nudge number inputs, a reject toggle, quality-flag chips, and a dirty-aware **Save corrections**.

## Verification
- `pytest -m parity` — **12 passed** (new `person track corrections response` snapshot + enriched fixture).
- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test`: sceneworks-core **30** (incl. new store test), sceneworks-rust-api **48**.
- Worker `pytest tests/test_person_adapters.py` — **27** (6 new correction tests).
- Web `vitest` — **77** (2 new), `vite build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)