### PR TITLE
First-run setup wizard: storage, model downloads, first project [sc-1473]

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -14,6 +14,11 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             setup::start_setup,
             settings::get_app_settings,
+            settings::get_storage_setup,
+            settings::save_storage_setup,
+            settings::complete_setup,
+            settings::reset_setup,
+            settings::choose_folder,
             settings::set_data_dir,
             settings::choose_data_dir,
             settings::reveal_in_os,

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::DialogExt;
 
-use crate::setup::{app_support_dir, Managed};
+use crate::setup::{app_support_dir, default_data_dir, shared_huggingface_home, Managed};
 
 const KEYRING_SERVICE: &str = "SceneWorks";
 const HF_TOKEN_ACCOUNT: &str = "huggingface_token";
@@ -17,9 +17,22 @@ const HF_TOKEN_ACCOUNT: &str = "huggingface_token";
 #[derive(Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSettings {
-    /// Override for the data directory; `None` uses the platform default.
+    /// Override for the workspace data directory (projects, generated assets,
+    /// imported/non-HF models, jobs.db); `None` uses the platform default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_dir: Option<String>,
+    /// Hugging Face cache home (`HF_HOME`) for HF-downloaded model weights;
+    /// `None` uses the shared per-user cache (`~/.cache/huggingface`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hf_home: Option<String>,
+    /// Set once the first-run splash storage step (sc-1473 Step 1) has run, so
+    /// later launches skip straight to provisioning instead of re-prompting.
+    #[serde(default)]
+    pub storage_configured: bool,
+    /// Set once the in-app setup wizard (sc-1473 Steps 2-3) has completed, so the
+    /// studio shows directly. Cleared by `reset_setup` to re-run the wizard.
+    #[serde(default)]
+    pub setup_completed: bool,
 }
 
 fn settings_path() -> PathBuf {
@@ -74,6 +87,88 @@ fn run_capture(program: &str, args: &[&str]) -> Option<String> {
 #[tauri::command]
 pub fn get_app_settings() -> AppSettings {
     load_settings()
+}
+
+/// First-run storage state for the splash Step 1 + the in-app wizard gate. The
+/// `*Default` fields let the splash pre-fill the pickers with the locations the
+/// app would use today so a new user can just continue.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageSetup {
+    data_dir: Option<String>,
+    data_dir_default: String,
+    hf_home: Option<String>,
+    hf_home_default: String,
+    storage_configured: bool,
+    setup_completed: bool,
+}
+
+#[tauri::command]
+pub fn get_storage_setup() -> StorageSetup {
+    let settings = load_settings();
+    StorageSetup {
+        data_dir: settings.data_dir,
+        data_dir_default: default_data_dir().to_string_lossy().into_owned(),
+        hf_home: settings.hf_home,
+        hf_home_default: shared_huggingface_home().to_string_lossy().into_owned(),
+        storage_configured: settings.storage_configured,
+        setup_completed: settings.setup_completed,
+    }
+}
+
+/// Persist the splash Step 1 storage choice and mark storage configured. Empty
+/// strings clear the override (fall back to the platform default). This runs
+/// before the API/worker are spawned, so the chosen paths take effect with no
+/// restart.
+#[tauri::command]
+pub fn save_storage_setup(data_dir: String, hf_home: String) -> Result<AppSettings, String> {
+    let mut settings = load_settings();
+    let data_trimmed = data_dir.trim();
+    settings.data_dir = if data_trimmed.is_empty() {
+        None
+    } else {
+        Some(data_trimmed.to_owned())
+    };
+    let hf_trimmed = hf_home.trim();
+    settings.hf_home = if hf_trimmed.is_empty() {
+        None
+    } else {
+        Some(hf_trimmed.to_owned())
+    };
+    settings.storage_configured = true;
+    save_settings(&settings)?;
+    Ok(settings)
+}
+
+/// Mark the in-app setup wizard (Steps 2-3) complete so the studio shows on
+/// subsequent loads.
+#[tauri::command]
+pub fn complete_setup() -> Result<(), String> {
+    let mut settings = load_settings();
+    settings.setup_completed = true;
+    save_settings(&settings)
+}
+
+/// Clear the wizard-completed marker so the wizard re-runs (Settings → Re-run
+/// setup wizard). Storage configuration is left in place — relocating the data
+/// dir is a separate, restart-bound action handled by the data-directory control.
+#[tauri::command]
+pub fn reset_setup() -> Result<(), String> {
+    let mut settings = load_settings();
+    settings.setup_completed = false;
+    save_settings(&settings)
+}
+
+/// Generic folder picker for the splash storage step (workspace + HF cache
+/// pickers). Returns the chosen absolute path, or `None` if the dialog was
+/// dismissed.
+#[tauri::command]
+pub async fn choose_folder(app: AppHandle) -> Option<String> {
+    app.dialog()
+        .file()
+        .blocking_pick_folder()
+        .and_then(|file| file.into_path().ok())
+        .map(|path| path.to_string_lossy().into_owned())
 }
 
 #[tauri::command]

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -179,12 +179,54 @@ fn requirements_mlx_path(app: &AppHandle) -> PathBuf {
         .join("requirements-mlx.txt")
 }
 
-fn data_dir() -> PathBuf {
+/// Platform default workspace data directory, used when the user hasn't picked a
+/// custom location in the first-run splash / Settings.
+pub fn default_data_dir() -> PathBuf {
     app_support_dir().join("data")
 }
 
 fn config_dir() -> PathBuf {
     app_support_dir().join("config")
+}
+
+/// Shared per-user Hugging Face cache (`~/.cache/huggingface`) — the default
+/// `HF_HOME` when the user hasn't chosen a custom location. Dedups with other
+/// HF-based tools on the machine and reuses anything already downloaded.
+pub fn shared_huggingface_home() -> PathBuf {
+    if let Some(home) = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return PathBuf::from(home).join(".cache").join("huggingface");
+    }
+    app_support_dir().join("cache").join("huggingface")
+}
+
+/// Hugging Face cache home injected into both sidecars so the rust-api model
+/// catalog and the Python inference worker resolve weights from the same root.
+/// Without this the API falls back to `<data_dir>/cache/huggingface` while the
+/// worker uses huggingface_hub's default `~/.cache/huggingface`, so they
+/// disagree and every catalog entry shows "missing" (sc-1473 Step 1 gap).
+/// Resolution order: an explicit `HF_HOME` in the environment (useful under
+/// `tauri dev`), then the user's persisted choice from the first-run splash, then
+/// the shared per-user cache. Because the splash persists this *before* the
+/// sidecars spawn, the chosen location takes effect with no app restart.
+fn huggingface_home() -> PathBuf {
+    if let Ok(value) = std::env::var("HF_HOME") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    if let Some(dir) = crate::settings::load_settings()
+        .hf_home
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(dir);
+    }
+    shared_huggingface_home()
 }
 
 /// Builtin model/LoRA/recipe-preset catalogs the rust-api reads from
@@ -233,7 +275,7 @@ fn resolved_data_dir() -> PathBuf {
     crate::settings::load_settings()
         .data_dir
         .map(PathBuf::from)
-        .unwrap_or_else(data_dir)
+        .unwrap_or_else(default_data_dir)
 }
 
 /// Directory containing the Python `scene_worker` package + requirements: the
@@ -420,17 +462,27 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
         std::fs::create_dir_all(parent).map_err(|error| format!("create python dir: {error}"))?;
     }
 
-    emit(app, "creating", "Creating the Python environment…", false);
-    run_uv(
-        app,
-        vec![
-            "venv".to_owned(),
-            "--python".to_owned(),
-            "3.12".to_owned(),
-            venv.to_string_lossy().into_owned(),
-        ],
-    )
-    .await?;
+    // Create the venv only when its interpreter is missing. A prior run that
+    // created the venv but failed during dependency install (e.g. an
+    // unsatisfiable resolution) or was interrupted leaves a venv that `uv venv`
+    // refuses to overwrite — without this guard every retry dies on "a virtual
+    // environment already exists". When the interpreter is present we skip
+    // creation and let the install below reconcile the env. `--clear` wipes any
+    // partial/corrupt directory when we do (re)create from scratch.
+    if !python.exists() {
+        emit(app, "creating", "Creating the Python environment…", false);
+        run_uv(
+            app,
+            vec![
+                "venv".to_owned(),
+                "--clear".to_owned(),
+                "--python".to_owned(),
+                "3.12".to_owned(),
+                venv.to_string_lossy().into_owned(),
+            ],
+        )
+        .await?;
+    }
 
     emit(
         app,
@@ -509,7 +561,10 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         .env(
             "SCENEWORKS_CONFIG_DIR",
             config_dir().to_string_lossy().to_string(),
-        );
+        )
+        // The catalog's install-state detection resolves the HF cache from this;
+        // it must match the worker's download root or every model reads "missing".
+        .env("HF_HOME", huggingface_home().to_string_lossy().to_string());
     // The in-process utility worker shells out to ffmpeg; point it at the venv's
     // bundled binary since the desktop has no system ffmpeg on PATH.
     if let Some(ffmpeg) = resolve_bundled_ffmpeg() {
@@ -621,6 +676,9 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
             shared_parent_dir(&app).to_string_lossy()
         );
         let api_url = format!("http://127.0.0.1:{api_port}");
+        // Match the API sidecar's HF cache root so downloaded weights land where
+        // the catalog looks for them (and reuse anything already cached there).
+        let hf_home = huggingface_home().to_string_lossy().to_string();
         let mut backoff = 1u64;
         loop {
             if app.state::<Managed>().shutting_down.load(Ordering::SeqCst) {
@@ -640,6 +698,7 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
                 .current_dir(&src)
                 .env("PYTHONPATH", &pythonpath)
                 .env("SCENEWORKS_API_URL", &api_url)
+                .env("HF_HOME", &hf_home)
                 .env(
                     "SCENEWORKS_DATA_DIR",
                     resolved_data_dir().to_string_lossy().to_string(),

--- a/apps/desktop/ui/index.html
+++ b/apps/desktop/ui/index.html
@@ -67,7 +67,6 @@
         display: none;
       }
       button {
-        margin-top: 1.25rem;
         padding: 0.55rem 1.4rem;
         font-size: 0.95rem;
         border: 0;
@@ -76,28 +75,181 @@
         color: #0a0c11;
         font-weight: 600;
         cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.55;
+        cursor: default;
+      }
+      #retry {
+        margin-top: 1.25rem;
         display: none;
+      }
+
+      /* Both sections start hidden; main() reveals exactly one once it knows
+         whether the first-run storage step is needed. */
+      #provision {
+        display: none;
+      }
+
+      /* First-run storage step (sc-1473 Step 1) */
+      #storage {
+        display: none;
+        text-align: left;
+      }
+      #storage.visible {
+        display: block;
+      }
+      #storage .lede {
+        margin: 0.25rem 0 1.5rem;
+        color: #9aa1ad;
+        text-align: center;
+      }
+      .field {
+        margin-bottom: 1.25rem;
+        background: #161922;
+        border: 1px solid #1d222c;
+        border-radius: 12px;
+        padding: 1rem 1.1rem;
+      }
+      .field-label {
+        font-weight: 600;
+        font-size: 0.98rem;
+        margin: 0 0 0.25rem;
+      }
+      .field-help {
+        margin: 0 0 0.7rem;
+        font-size: 0.82rem;
+        line-height: 1.45;
+        color: #8b93a1;
+      }
+      .field-row {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .field-row input {
+        flex: 1;
+        min-width: 0;
+        padding: 0.5rem 0.7rem;
+        background: #0a0c11;
+        border: 1px solid #2a2f3a;
+        border-radius: 8px;
+        color: #e7e9ee;
+        font-size: 0.85rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      .field-row input:focus {
+        outline: 2px solid #6c8cff;
+        border-color: #6c8cff;
+      }
+      .browse {
+        background: #2a2f3a;
+        color: #e7e9ee;
+        font-weight: 500;
+        white-space: nowrap;
+        padding: 0.5rem 0.9rem;
+      }
+      #storage-continue {
+        width: 100%;
+        margin-top: 0.25rem;
+        padding: 0.7rem;
+        font-size: 1rem;
+      }
+      .footnote {
+        margin: 0.9rem 0 0;
+        font-size: 0.78rem;
+        color: #6b7280;
+        text-align: center;
       }
     </style>
   </head>
   <body>
     <main>
-      <div class="spinner" id="spinner"></div>
       <h1>SceneWorks</h1>
-      <p id="status">Starting&hellip;</p>
-      <pre id="log"></pre>
-      <button id="retry">Retry</button>
+
+      <section id="storage">
+        <p class="lede">
+          Choose where to keep your files. The defaults work for most people — you
+          can change these later in Settings.
+        </p>
+
+        <div class="field">
+          <p class="field-label">Your workspace</p>
+          <p class="field-help">
+            Your projects, the images and videos you create, and any models you
+            import or download from sites like Civitai are stored here. Pick a
+            drive with plenty of free space.
+          </p>
+          <div class="field-row">
+            <input id="data-dir" type="text" spellcheck="false" aria-label="Workspace folder" />
+            <button class="browse" id="data-dir-browse" type="button">Browse…</button>
+          </div>
+        </div>
+
+        <div class="field">
+          <p class="field-label">Downloaded AI models</p>
+          <p class="field-help">
+            Large model files downloaded from Hugging Face are cached here. They're
+            kept in a shared folder by default so other AI apps on your computer
+            can reuse them — but you can store them anywhere, even inside your
+            workspace folder.
+          </p>
+          <div class="field-row">
+            <input id="hf-home" type="text" spellcheck="false" aria-label="AI model cache folder" />
+            <button class="browse" id="hf-home-browse" type="button">Browse…</button>
+          </div>
+        </div>
+
+        <button id="storage-continue" type="button">Continue</button>
+        <p class="footnote">You can change the model cache anytime; moving your workspace later needs a restart.</p>
+      </section>
+
+      <section id="provision">
+        <div class="spinner" id="spinner"></div>
+        <p id="status">Starting&hellip;</p>
+        <pre id="log"></pre>
+        <button id="retry">Retry</button>
+      </section>
     </main>
     <script>
       const statusEl = document.getElementById("status");
       const logEl = document.getElementById("log");
       const spinnerEl = document.getElementById("spinner");
       const retryEl = document.getElementById("retry");
+      const storageEl = document.getElementById("storage");
+      const provisionEl = document.getElementById("provision");
+      const dataDirEl = document.getElementById("data-dir");
+      const hfHomeEl = document.getElementById("hf-home");
+      const continueEl = document.getElementById("storage-continue");
+
+      const invoke = (command, args) => window.__TAURI__.core.invoke(command, args);
 
       function appendLog(line) {
         logEl.style.display = "block";
         logEl.textContent += line + "\n";
         logEl.scrollTop = logEl.scrollHeight;
+      }
+
+      function showProvision() {
+        storageEl.classList.remove("visible");
+        provisionEl.style.display = "block";
+      }
+
+      function showStorage(setup) {
+        provisionEl.style.display = "none";
+        dataDirEl.value = setup.dataDir || setup.dataDirDefault || "";
+        hfHomeEl.value = setup.hfHome || setup.hfHomeDefault || "";
+        storageEl.classList.add("visible");
+      }
+
+      async function browse(targetEl) {
+        try {
+          const picked = await invoke("choose_folder");
+          if (picked) {
+            targetEl.value = picked;
+          }
+        } catch (err) {
+          showError(String(err));
+        }
       }
 
       async function start() {
@@ -111,6 +263,23 @@
         }
       }
 
+      async function saveAndStart() {
+        continueEl.disabled = true;
+        try {
+          await invoke("save_storage_setup", {
+            dataDir: dataDirEl.value.trim(),
+            hfHome: hfHomeEl.value.trim(),
+          });
+        } catch (err) {
+          continueEl.disabled = false;
+          showProvision();
+          showError(String(err));
+          return;
+        }
+        showProvision();
+        start();
+      }
+
       function showError(message) {
         statusEl.textContent = message;
         statusEl.classList.add("error");
@@ -120,6 +289,7 @@
 
       async function main() {
         if (!window.__TAURI__) {
+          showProvision();
           statusEl.textContent = "Tauri bridge unavailable.";
           return;
         }
@@ -136,7 +306,26 @@
           statusEl.textContent = message;
         });
         retryEl.addEventListener("click", start);
-        start();
+        document.getElementById("data-dir-browse").addEventListener("click", () => browse(dataDirEl));
+        document.getElementById("hf-home-browse").addEventListener("click", () => browse(hfHomeEl));
+        continueEl.addEventListener("click", saveAndStart);
+
+        let setup = null;
+        try {
+          setup = await invoke("get_storage_setup");
+        } catch (err) {
+          // If we can't read the storage state, fall back to provisioning with
+          // whatever defaults are in effect rather than blocking launch.
+          showProvision();
+          start();
+          return;
+        }
+        if (setup.storageConfigured) {
+          showProvision();
+          start();
+        } else {
+          showStorage(setup);
+        }
       }
 
       main();

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -14,8 +14,16 @@ import { EditorScreen } from "./screens/EditorScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { SettingsScreen } from "./screens/SettingsScreen.jsx";
+import { SetupWizard } from "./screens/SetupWizard.jsx";
 import { sortNewest, sortWorkers } from "./sorters.js";
 import { ensureItemVersionFields } from "./timeline.js";
+
+// Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
+// web/Docker keep the existing first-run project gate. Tauri commands persist the
+// wizard state (the API binds a random port each launch, so localStorage — keyed
+// to the origin — can't be relied on across launches).
+const isDesktopShell = typeof window !== "undefined" && !!window.__TAURI__;
+const tauriInvoke = (command, args) => window.__TAURI__.core.invoke(command, args);
 
 function isActiveWorker(worker) {
   return worker.status !== "offline";
@@ -336,6 +344,9 @@ export function App() {
   const [token, setToken] = useState(() => window.localStorage.getItem("sceneworks-token") ?? "");
   const [projects, setProjects] = useState([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
+  // Desktop first-run wizard gate: null = unknown (still reading on desktop),
+  // true = no wizard needed (web, or already completed), false = show the wizard.
+  const [setupCompleted, setSetupCompleted] = useState(isDesktopShell ? null : true);
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
   const [jobs, setJobs] = useState([]);
@@ -522,6 +533,16 @@ export function App() {
     apiFetch("/api/v1/access", "")
       .then(setAccess)
       .catch((err) => setError(err.message));
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktopShell) {
+      return;
+    }
+    tauriInvoke("get_storage_setup")
+      .then((setup) => setSetupCompleted(Boolean(setup?.setupCompleted)))
+      // Never block the app on a storage-state read failure; fall through to the studio.
+      .catch(() => setSetupCompleted(true));
   }, []);
 
   useEffect(() => {
@@ -1150,6 +1171,16 @@ export function App() {
     window.localStorage.setItem("sceneworks-token", token);
     setError("");
     refreshData();
+  }
+
+  async function completeSetupWizard() {
+    try {
+      await tauriInvoke("complete_setup");
+    } catch {
+      // Persisting the marker failed; still dismiss the wizard so the user isn't
+      // trapped. Worst case it re-appears next launch.
+    }
+    setSetupCompleted(true);
   }
 
   async function createProject(name) {
@@ -1794,6 +1825,11 @@ export function App() {
   // First-run gate: until at least one workspace exists, replace the studio area
   // with a create prompt so navigation never lands on dead, project-scoped controls.
   const needsFirstProject = authenticated && projectsLoaded && projects.length === 0;
+  // Desktop first-run wizard (sc-1473): supersedes the project gate while the
+  // completion marker is unset. `null` means we're still reading the marker on
+  // desktop — hold the studio/gate back briefly to avoid a flash.
+  const setupGateLoading = isDesktopShell && setupCompleted === null;
+  const showSetupWizard = isDesktopShell && setupCompleted === false && authenticated;
 
   return (
     <main className="app">
@@ -1899,7 +1935,16 @@ export function App() {
           </section>
         ) : null}
 
-        {needsFirstProject ? (
+        {showSetupWizard ? (
+          <SetupWizard
+            jobs={jobs}
+            models={models}
+            onComplete={completeSetupWizard}
+            onCreateProject={createProject}
+            onDownloadModel={createModelDownloadJob}
+            onOpenQueue={() => setActiveView("Queue")}
+          />
+        ) : setupGateLoading ? null : needsFirstProject ? (
           <FirstRunProjectGate disabled={!authenticated} onCreate={createProject} />
         ) : (
           <>

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -7,6 +7,7 @@ import { liveElapsedSeconds } from "./formatting.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
+import { SetupWizard } from "./screens/SetupWizard.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { ReplacePersonPanel } from "./screens/ReplacePersonPanel.jsx";
@@ -158,6 +159,159 @@ describe("SceneWorks app shell", () => {
     });
     container.remove();
     vi.restoreAllMocks();
+  });
+
+  const wizardModels = [
+    {
+      id: "z_image_turbo",
+      name: "Z-Image-Turbo",
+      type: "image",
+      downloadable: true,
+      installState: "missing",
+      downloadSizeLabel: "30.6 GB",
+      downloadSizeBytes: 32899667397,
+      downloadSizeEstimated: true,
+      downloads: [{ repo: "Tongyi-MAI/Z-Image-Turbo" }],
+    },
+    {
+      id: "qwen_image",
+      name: "Qwen Image",
+      type: "image",
+      downloadable: true,
+      installState: "installed",
+      downloadSizeLabel: "53.7 GB",
+      downloadSizeBytes: 57704594653,
+      downloads: [{ repo: "Qwen/Qwen-Image" }],
+    },
+    {
+      id: "wan_2_2",
+      name: "Wan2.2",
+      type: "video",
+      downloadable: true,
+      installState: "missing",
+      downloadSizeLabel: "31.8 GB",
+      downloadSizeBytes: 34203021834,
+      downloadSizeEstimated: true,
+      downloads: [{ repo: "Wan-AI/Wan2.2-TI2V-5B" }],
+    },
+    {
+      id: "ltx_2_3",
+      name: "LTX-2.3",
+      type: "video",
+      downloadable: true,
+      installState: "missing",
+      downloadSizeLabel: "146 GB",
+      downloadSizeBytes: 157004895813,
+      downloads: [{ repo: "Lightricks/LTX-2.3" }],
+    },
+  ];
+
+  function renderWizard(overrides = {}) {
+    const props = {
+      models: wizardModels,
+      jobs: [],
+      onDownloadModel: vi.fn(),
+      onCreateProject: vi.fn(async (name) => ({ id: "project-new", name })),
+      onComplete: vi.fn(async () => {}),
+      onOpenQueue: vi.fn(),
+      ...overrides,
+    };
+    root = createRoot(container);
+    return props;
+  }
+
+  it("groups downloadable models, pre-checks recommended ones, and flags installed", async () => {
+    const props = renderWizard();
+    await act(async () => {
+      root.render(<SetupWizard {...props} />);
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Image models");
+    expect(container.textContent).toContain("Video models");
+    expect(container.textContent).toContain("Recommended");
+    expect(container.textContent).toContain("Already installed");
+    expect(container.textContent).toContain("~30.6 GB");
+
+    const checkboxes = [...container.querySelectorAll("input[type=checkbox]")];
+    // DOM order: image group (z_image_turbo, qwen_image[installed]), then video (wan_2_2, ltx_2_3).
+    expect(checkboxes[0].checked).toBe(true); // z_image_turbo — recommended, small enough to auto-select
+    expect(checkboxes[1].disabled).toBe(true); // qwen_image — installed, not selectable
+    expect(checkboxes[2].checked).toBe(false); // wan_2_2 — not recommended
+    expect(checkboxes[3].checked).toBe(false); // ltx_2_3 — recommended but too large to auto-select (~146 GB)
+    // LTX-2.3 is still surfaced as recommended (badge) and shows its size so the choice is informed.
+    expect(container.textContent).toContain("146 GB");
+    expect(container.querySelectorAll(".setup-wizard-tag").length).toBe(2); // z_image_turbo + ltx_2_3
+  });
+
+  it("auto-selects only the small recommended model, leaving huge ones opt-in", async () => {
+    const props = renderWizard();
+    await act(async () => {
+      root.render(<SetupWizard {...props} />);
+    });
+    await settle();
+
+    const downloadButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.startsWith("Download"),
+    );
+    expect(downloadButton.textContent).toContain("1");
+    await act(async () => {
+      downloadButton.click();
+    });
+    await settle();
+
+    // Only the pre-checked image model downloads; LTX-2.3 stays opt-in.
+    expect(props.onDownloadModel).toHaveBeenCalledTimes(1);
+    expect(props.onDownloadModel.mock.calls[0][0].id).toBe("z_image_turbo");
+    // Re-firing is guarded: the button disables once nothing is pending.
+    expect(downloadButton.disabled).toBe(true);
+  });
+
+  it("advances to the project step and creates a project then marks setup complete", async () => {
+    const props = renderWizard();
+    await act(async () => {
+      root.render(<SetupWizard {...props} />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Continue").click();
+    });
+    await settle();
+    expect(container.textContent).toContain("Create your first project");
+    // Skipping downloads is allowed — Continue advanced without firing any.
+    expect(props.onDownloadModel).not.toHaveBeenCalled();
+
+    const input = container.querySelector("input[type=text]") ?? container.querySelector("input");
+    await changeField(input, "My First Project");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Finish setup").click();
+    });
+    await settle();
+
+    expect(props.onCreateProject).toHaveBeenCalledWith("My First Project");
+    expect(props.onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark setup complete when project creation fails", async () => {
+    const props = renderWizard({ onCreateProject: vi.fn(async () => null) });
+    await act(async () => {
+      root.render(<SetupWizard {...props} />);
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Continue").click();
+    });
+    await settle();
+    const input = container.querySelector("input");
+    await changeField(input, "Doomed Project");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Finish setup").click();
+    });
+    await settle();
+
+    expect(props.onCreateProject).toHaveBeenCalledWith("Doomed Project");
+    expect(props.onComplete).not.toHaveBeenCalled();
   });
 
   it("renders the app navigation against mocked API calls", async () => {

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -85,6 +85,15 @@ export function SettingsScreen() {
     }
   }
 
+  async function rerunSetupWizard() {
+    try {
+      await invoke("reset_setup");
+      window.location.reload();
+    } catch (error) {
+      setStatus(String(error));
+    }
+  }
+
   return (
     <div className="settings-screen">
       {status ? <p className="settings-status">{status}</p> : null}
@@ -158,6 +167,18 @@ export function SettingsScreen() {
         <div className="settings-actions">
           <button type="button" onClick={restartWorker}>
             Restart worker
+          </button>
+        </div>
+      </section>
+
+      <section className="settings-card">
+        <h3>Setup wizard</h3>
+        <p className="settings-muted">
+          Re-open the guided setup to download more models or create another project.
+        </p>
+        <div className="settings-actions">
+          <button type="button" onClick={rerunSetupWizard}>
+            Re-run setup wizard
           </button>
         </div>
       </section>

--- a/apps/web/src/screens/SetupWizard.jsx
+++ b/apps/web/src/screens/SetupWizard.jsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { JobProgressCard } from "../components/JobProgress.jsx";
+import { terminalStatuses } from "../constants.js";
+
+// Models flagged "Recommended" in the wizard: the fast image target and LTX-2.3
+// as the headline video model. Anything not present in the live catalog is
+// silently ignored, so this stays correct as the catalog evolves.
+const RECOMMENDED_MODEL_IDS = new Set(["z_image_turbo", "ltx_2_3"]);
+// Recommended models are pre-checked — except very large ones (e.g. LTX-2.3 is
+// ~146 GB). Those stay recommended but unchecked so a new user opts into the big
+// download deliberately instead of having it auto-queued on first launch.
+const AUTO_SELECT_MAX_BYTES = 50 * 1024 * 1024 * 1024;
+
+function isDownloadable(model) {
+  return model.downloadable !== false && Boolean(model.downloads?.[0]?.repo ?? model.repo);
+}
+
+function isHugeDownload(model) {
+  return typeof model.downloadSizeBytes === "number" && model.downloadSizeBytes > AUTO_SELECT_MAX_BYTES;
+}
+
+function downloadSizeText(model) {
+  if (!model.downloadSizeLabel) {
+    return "Size unavailable";
+  }
+  return model.downloadSizeEstimated ? `~${model.downloadSizeLabel}` : model.downloadSizeLabel;
+}
+
+function defaultSelection(models) {
+  return new Set(
+    models
+      .filter(
+        (model) =>
+          isDownloadable(model) &&
+          model.installState !== "installed" &&
+          RECOMMENDED_MODEL_IDS.has(model.id) &&
+          !isHugeDownload(model),
+      )
+      .map((model) => model.id),
+  );
+}
+
+const TYPE_LABELS = { image: "Image models", video: "Video models" };
+
+export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, onComplete, onOpenQueue }) {
+  const [step, setStep] = useState("models");
+  const [selected, setSelected] = useState(() => defaultSelection(models));
+  const [started, setStarted] = useState(() => new Set());
+  const [projectName, setProjectName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const initializedRef = useRef(false);
+
+  // The catalog may arrive a tick after mount; seed the recommended selection
+  // once it does (without clobbering a choice the user already made).
+  useEffect(() => {
+    if (!initializedRef.current && models.length) {
+      setSelected(defaultSelection(models));
+      initializedRef.current = true;
+    }
+  }, [models]);
+
+  const downloadable = useMemo(() => models.filter(isDownloadable), [models]);
+  const grouped = useMemo(() => {
+    const byType = new Map();
+    for (const model of downloadable) {
+      const key = model.type ?? "other";
+      if (!byType.has(key)) {
+        byType.set(key, []);
+      }
+      byType.get(key).push(model);
+    }
+    return byType;
+  }, [downloadable]);
+
+  const activeDownloadJobs = useMemo(
+    () => jobs.filter((job) => job.type === "model_download" && !terminalStatuses.has(job.status)),
+    [jobs],
+  );
+
+  const pendingSelection = useMemo(
+    () =>
+      downloadable.filter(
+        (model) => selected.has(model.id) && model.installState !== "installed" && !started.has(model.id),
+      ),
+    [downloadable, selected, started],
+  );
+
+  function toggle(model) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(model.id)) {
+        next.delete(model.id);
+      } else {
+        next.add(model.id);
+      }
+      return next;
+    });
+  }
+
+  function downloadSelected() {
+    pendingSelection.forEach((model) => onDownloadModel(model));
+    setStarted((current) => new Set([...current, ...pendingSelection.map((model) => model.id)]));
+  }
+
+  async function finish(event) {
+    event.preventDefault();
+    const trimmed = projectName.trim();
+    if (!trimmed || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const created = await onCreateProject(trimmed);
+      if (created) {
+        await onComplete();
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="setup-wizard">
+      <div className="setup-wizard-card">
+        <span className="setup-wizard-mark" aria-hidden="true">
+          <img src="/sceneworks-logo.svg" alt="" />
+        </span>
+        <ol className="setup-wizard-steps" aria-hidden="true">
+          <li className={step === "models" ? "active" : "done"}>Models</li>
+          <li className={step === "project" ? "active" : ""}>First project</li>
+        </ol>
+
+        {step === "models" ? (
+          <>
+            <h2>Download starter models</h2>
+            <p className="setup-wizard-lede">
+              Pick the models to download now. Recommended ones are pre-selected — you can add
+              more later from Models. Downloads run in the background, so you can keep going.
+            </p>
+
+            <div className="setup-wizard-models">
+              {downloadable.length === 0 ? (
+                <p className="setup-wizard-empty">No downloadable models in the catalog yet.</p>
+              ) : (
+                [...grouped.entries()].map(([type, items]) => (
+                  <div className="setup-wizard-group" key={type}>
+                    <h3>{TYPE_LABELS[type] ?? type}</h3>
+                    {items.map((model) => {
+                      const installed = model.installState === "installed";
+                      const downloading = started.has(model.id) && !installed;
+                      const recommended = RECOMMENDED_MODEL_IDS.has(model.id);
+                      return (
+                        <label className={`setup-wizard-model${installed ? " installed" : ""}`} key={model.id}>
+                          <input
+                            type="checkbox"
+                            checked={installed || selected.has(model.id)}
+                            disabled={installed || downloading}
+                            onChange={() => toggle(model)}
+                          />
+                          <span className="setup-wizard-model-main">
+                            <span className="setup-wizard-model-name">
+                              {model.name}
+                              {recommended && !installed ? <span className="setup-wizard-tag">Recommended</span> : null}
+                            </span>
+                            <span className="setup-wizard-model-meta">
+                              {installed ? "Already installed" : downloading ? "Download started" : downloadSizeText(model)}
+                            </span>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
+
+            {activeDownloadJobs.length ? (
+              <div className="setup-wizard-progress">
+                {activeDownloadJobs.map((job) => (
+                  <JobProgressCard job={job} key={job.id} label="Model download" onOpenQueue={onOpenQueue} />
+                ))}
+              </div>
+            ) : null}
+
+            <div className="setup-wizard-actions">
+              <button
+                className="setup-wizard-secondary"
+                disabled={pendingSelection.length === 0}
+                onClick={downloadSelected}
+                type="button"
+              >
+                {pendingSelection.length ? `Download ${pendingSelection.length} selected` : "Download selected"}
+              </button>
+              <button className="setup-wizard-cta" onClick={() => setStep("project")} type="button">
+                Continue
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2>Create your first project</h2>
+            <p className="setup-wizard-lede">
+              SceneWorks keeps your images, videos, characters, and timelines inside a project.
+              Name your first one to jump into the studio.
+            </p>
+            <form className="setup-wizard-form" onSubmit={finish}>
+              <input
+                aria-label="Project name"
+                autoFocus
+                disabled={submitting}
+                onChange={(event) => setProjectName(event.target.value)}
+                placeholder="e.g. My First Project"
+                value={projectName}
+              />
+              <button className="setup-wizard-cta" disabled={submitting || !projectName.trim()} type="submit">
+                {submitting ? "Setting up…" : "Finish setup"}
+              </button>
+            </form>
+            <button className="setup-wizard-back" onClick={() => setStep("models")} type="button">
+              ← Back to models
+            </button>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5394,6 +5394,253 @@ label {
   cursor: not-allowed;
 }
 
+/* First-run setup wizard (sc-1473, desktop) */
+.setup-wizard {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 40px 24px;
+}
+
+.setup-wizard-card {
+  width: 100%;
+  max-width: 540px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  padding: 36px 32px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: var(--shadow-glow);
+}
+
+.setup-wizard-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: var(--accent-soft);
+}
+
+.setup-wizard-mark img {
+  width: 30px;
+  height: 30px;
+}
+
+.setup-wizard-steps {
+  display: flex;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.setup-wizard-steps li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.setup-wizard-steps li::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+}
+
+.setup-wizard-steps li.active::before {
+  background: var(--accent);
+}
+
+.setup-wizard-steps li.done::before {
+  background: var(--accent-strong, var(--accent));
+}
+
+.setup-wizard-steps li.active {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.setup-wizard-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--text);
+}
+
+.setup-wizard-lede {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.setup-wizard-models {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 8px;
+  text-align: left;
+}
+
+.setup-wizard-group h3 {
+  margin: 0 0 8px;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.setup-wizard-model {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-2);
+  cursor: pointer;
+  margin-bottom: 8px;
+}
+
+.setup-wizard-model.installed {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.setup-wizard-model input {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.setup-wizard-model-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.setup-wizard-model-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.setup-wizard-model-meta {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.setup-wizard-tag {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.setup-wizard-empty {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.setup-wizard-progress {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.setup-wizard-actions {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  margin-top: 12px;
+}
+
+.setup-wizard-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  margin-top: 8px;
+}
+
+.setup-wizard-form input {
+  width: 100%;
+  padding: 11px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.setup-wizard-form input:focus {
+  outline: 2px solid var(--accent);
+  border-color: var(--accent);
+}
+
+.setup-wizard-cta {
+  flex: 1;
+  padding: 11px 16px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.setup-wizard-cta:hover:not(:disabled) {
+  background: var(--accent-strong);
+}
+
+.setup-wizard-cta:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.setup-wizard-secondary {
+  flex: 1;
+  padding: 11px 16px;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.setup-wizard-secondary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.setup-wizard-back {
+  margin-top: 4px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
 /* Settings screen (sc-1350) */
 .settings-screen {
   display: flex;

--- a/apps/worker/requirements-mlx.txt
+++ b/apps/worker/requirements-mlx.txt
@@ -3,10 +3,17 @@
 # bootstrap on darwin (apps/desktop/src/setup.rs). Never installed on Windows /
 # Linux / Docker, which keep the PyTorch worker unchanged.
 #
-# Validated 2026-05-21 on M-series (137 GB): mlx 0.31, mlx-video-with-audio 0.1.36,
-# mlx-vlm 0.5. The package is a native-MLX reimplementation of LTX-2.3 and Wan2.2.
-# Pulls transitively: numpy, safetensors, huggingface_hub, transformers[tokenizers],
+# Validated 2026-05-21 on M-series (137 GB): mlx 0.31, mlx-video-with-audio 0.1.36.
+# The package is a native-MLX reimplementation of LTX-2.3 and Wan2.2. Pulls
+# transitively: numpy, safetensors, huggingface_hub, transformers[tokenizers],
 # opencv-python, Pillow, soundfile (most already pinned in requirements.txt).
+#
+# mlx-vlm is a transitive dep of mlx-video-with-audio. Cap it below 0.3.10: from
+# 0.3.10 on it requires transformers>=5, which pulls huggingface-hub>=1.5 and
+# collides with the shared requirements.txt pin (huggingface_hub<1) — both files
+# resolve in one uv pass (setup.rs). 0.3.9 is the last release on
+# transformers>=4.57, so the venv resolves to transformers 4.57.x +
+# huggingface-hub 0.36.x, matching the PyTorch worker stack.
 mlx-video-with-audio>=0.1.36,<0.2
 mlx>=0.31,<1
-mlx-vlm>=0.5,<1
+mlx-vlm>=0.3.6,<0.3.10


### PR DESCRIPTION
## Summary

Desktop-only first-run setup wizard ([sc-1473](https://app.shortcut.com/trefry/story/1473)), split across two surfaces so a custom storage location never forces an app restart:

- **Step 1 — Storage (native splash, pre-spawn).** Two free-form directory pickers — **workspace data dir** (`SCENEWORKS_DATA_DIR`: projects, generated assets, imported/Civitai models, `jobs.db`) and **HF model cache** (`HF_HOME`, default shared `~/.cache/huggingface`) — both defaulted, with plain-language copy. Persisted to `settings.json` *before* the sidecars spawn, so the choice takes effect with no restart.
- **Steps 2–3 — SPA (post-spawn).** Pick starter models from the catalog (recommended pre-selection, on-disk sizes, live download progress, skippable), then create the first project and enter the studio.

### Why the split
The rust-api reads `SCENEWORKS_DATA_DIR` once at startup into an immutable `AppState` and anchors `jobs.db` + the asset tree to it — a live db/tree can't be relocated under a running process. Deciding storage *before* spawn is the only way to avoid a mid-wizard relaunch. Steps 2–3 need the running API (catalog + `model_download` + project create), so they stay in the SPA.

### Notes
- Recommended models: **Z-Image-Turbo** + **LTX-2.3**. Only models under ~50 GB auto-check, so LTX-2.3 (~146 GB) is recommended but **opt-in** rather than auto-queued on first launch.
- `settings.json` gains `hf_home`, `storage_configured` (gates the splash step), `setup_completed` (gates the SPA steps). localStorage is unusable for the marker because the API binds a random port each launch (origin changes).
- `huggingface_home()` now resolves env `HF_HOME` → persisted choice → shared cache, closing the prior gap where desktop weights ignored the data-dir setting.
- Web/Docker unaffected — the existing first-run project gate is unchanged. Settings gains a **"Re-run setup wizard"** entry.
- Folds in the earlier `HF_HOME` sidecar injection and the `mlx-vlm` pin from the MLX work (uncommitted on main from a prior session).

## Test plan
- [x] `cargo check` / `clippy -D warnings` / `fmt` clean on the desktop crate
- [x] `vite build` clean; **81 vitest tests pass** (4 new wizard tests)
- [x] Local `tauri build` bundle — wizard verified end-to-end (storage step, model downloads, project creation, second-launch skip)
- [ ] Reviewer: confirm custom HF cache lands weights there and the catalog shows them installed/reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)