### PR TITLE
Fix MLX image-to-video source image resolution [sc-1530]

### DIFF
--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -1803,34 +1803,26 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         return module_to_loras
 
     def _first_condition_image(self, project_path: Path, request: VideoRequest) -> Any:
-        if request.source_asset_id:
-            asset_path = find_asset_sidecar_path(project_path, request.source_asset_id)
-            if asset_path and asset_path.exists():
-                sidecar = read_json(asset_path)
-                if sidecar and "mediaPath" in sidecar:
-                    image_path = (project_path / sidecar["mediaPath"]).resolve()
-                    if image_path.exists():
-                        try:
-                            from PIL import Image
-                            return Image.open(image_path).convert("RGB")
-                        except Exception:
-                            pass
-        return None
+        return self._condition_image(project_path, request.source_asset_id)
 
     def _last_condition_image(self, project_path: Path, request: VideoRequest) -> Any:
-        if request.last_frame_asset_id:
-            asset_path = find_asset_sidecar_path(project_path, request.last_frame_asset_id)
-            if asset_path and asset_path.exists():
-                sidecar = read_json(asset_path)
-                if sidecar and "mediaPath" in sidecar:
-                    image_path = (project_path / sidecar["mediaPath"]).resolve()
-                    if image_path.exists():
-                        try:
-                            from PIL import Image
-                            return Image.open(image_path).convert("RGB")
-                        except Exception:
-                            pass
-        return None
+        return self._condition_image(project_path, request.last_frame_asset_id)
+
+    def _condition_image(self, project_path: Path, asset_id: str | None) -> Any:
+        # Resolve via the shared helper: asset sidecars store the media path at
+        # `file.path`. The previous custom lookup read a non-existent top-level
+        # `mediaPath` key, so it always returned None and every MLX
+        # image_to_video / first_last_frame job failed the source-image check.
+        # Return the raw RGB image (the MLX pipeline does its own resizing).
+        media_path = source_asset_media_path(project_path, asset_id)
+        if media_path is None:
+            return None
+        try:
+            from PIL import Image
+
+            return Image.open(media_path).convert("RGB")
+        except Exception:
+            return None
 
     def _validate_inputs(
         self, project_path: Path, request: VideoRequest, first_image: Any, last_image: Any

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -562,6 +562,53 @@ def test_mlx_adapter_rejects_incompatible_lora_family(tmp_path):
         MlxVideoAdapter().ensure_models(request)
 
 
+def test_mlx_condition_image_resolves_source_asset_from_file_path(tmp_path):
+    # Regression: MLX image_to_video / first_last_frame jobs failed with
+    # "Image-to-video mode requires a source image asset." because the adapter
+    # read a non-existent top-level `mediaPath` sidecar key instead of the real
+    # nested `file.path`, so the source image never resolved.
+    project_path = tmp_path / "project"
+    (project_path / "assets" / "images").mkdir(parents=True)
+    image_rel = "assets/images/source.png"
+    Image.new("RGB", (16, 16), "teal").save(project_path / image_rel)
+    (project_path / "assets" / "images" / "source.sceneworks.json").write_text(
+        json.dumps({"id": "asset-source", "file": {"path": image_rel}}),
+        encoding="utf-8",
+    )
+    adapter = MlxVideoAdapter()
+
+    i2v_request = video_request_from_job(
+        {
+            "id": "job-i2v",
+            "payload": {
+                "projectId": "project-1",
+                "model": "ltx_2_3",
+                "mode": "image_to_video",
+                "sourceAssetId": "asset-source",
+            },
+        }
+    )
+    first_image = adapter._first_condition_image(project_path, i2v_request)
+    assert first_image is not None
+    assert first_image.mode == "RGB"
+    # Validation now passes instead of raising the source-image error.
+    adapter._validate_inputs(project_path, i2v_request, first_image, None)
+
+    flf_request = video_request_from_job(
+        {
+            "id": "job-flf",
+            "payload": {
+                "projectId": "project-1",
+                "model": "ltx_2_3",
+                "mode": "first_last_frame",
+                "sourceAssetId": "asset-source",
+                "lastFrameAssetId": "asset-source",
+            },
+        }
+    )
+    assert adapter._last_condition_image(project_path, flf_request) is not None
+
+
 def test_mlx_wan_user_loras_resolved_to_path_strength_tuples(tmp_path):
     lora_file = tmp_path / "wan_motion.safetensors"
     lora_file.write_bytes(b"lora")


### PR DESCRIPTION
## Summary

On Apple Silicon (MLX video path, "GPU mps"), every `image_to_video` and `first_last_frame` job failed almost immediately with **"Image-to-video mode requires a source image asset."** — even with a first frame selected (including the common case where Video Studio auto-populates it from the just-generated image).

**Root cause:** `MlxVideoAdapter._first_condition_image` / `_last_condition_image` read the media path from a non-existent top-level `mediaPath` sidecar key. Asset sidecars store it at nested **`file.path`** (`build_asset_sidecar` writes `"file": {"path": ...}` — [image_adapters.py:1177](../blob/main/apps/worker/scene_worker/image_adapters.py)). So the condition image always resolved to `None` and `_validate_inputs` raised the error. The MLX adapter was the lone outlier; every other adapter/helper (`source_asset_media_path`, `load_source_image`) reads `file.path`, so the native LTX/Diffusers paths were unaffected. (The rust-api already rejects a missing `sourceAssetId` for `image_to_video`, so the job only reached the worker because the asset id *was* present — the failure was purely the wrong sidecar key.)

**Fix:** route both methods through a shared `_condition_image` helper that resolves via `source_asset_media_path` (correct `file.path` lookup), preserving the MLX adapter's raw-RGB-image behavior.

## Test plan
- [x] Added pytest regression test (`test_mlx_condition_image_resolves_source_asset_from_file_path`) covering `image_to_video` and `first_last_frame`
- [x] Verified end-to-end against the real worker code on a desktop venv: a generated-image sidecar now resolves and `_validate_inputs` passes (it returned `None` before the fix)
- [ ] Reviewer: confirm an Image→Video render now starts on Apple Silicon with an auto-selected first frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)