### PR TITLE
Fix desktop video playback and gray thumbnails on macOS

### DIFF
--- a/apps/rust-api/build.rs
+++ b/apps/rust-api/build.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+// The `embed-web` feature bakes apps/web/dist into the binary via rust-embed at
+// compile time. Cargo otherwise has no idea that bundle is a build input, so a
+// web-only change (e.g. rebuilding apps/web without touching any .rs file) leaves
+// the crate "fresh" and ships a STALE embedded UI. Emit rerun-if-changed for every
+// file under the bundle so a rebuilt bundle always forces a recompile + re-embed.
+fn main() {
+    let dist = Path::new("../web/dist");
+    println!("cargo:rerun-if-changed=../web/dist");
+    if dist.is_dir() {
+        emit_rerun_for_tree(dist);
+    }
+}
+
+fn emit_rerun_for_tree(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        println!("cargo:rerun-if-changed={}", path.display());
+        if path.is_dir() {
+            emit_rerun_for_tree(&path);
+        }
+    }
+}

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::convert::Infallible;
+use std::io::SeekFrom;
 use std::net::SocketAddr;
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
@@ -52,7 +53,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tokio::time::{Instant as TokioInstant, MissedTickBehavior};
 use tokio_stream::wrappers::ReceiverStream;
@@ -1804,20 +1805,102 @@ fn is_plain_relative_file(name: &str) -> bool {
 async fn get_project_file(
     State(state): State<AppState>,
     Path((project_id, relative_path)): Path<(String, String)>,
+    headers: HeaderMap,
 ) -> Result<Response, ApiError> {
     let project_file = project_call(state, move |store| {
         store.project_file(&project_id, &relative_path)
     })
     .await?;
-    let file = tokio::fs::File::open(&project_file.path)
+    let mut file = tokio::fs::File::open(&project_file.path)
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
+    let total = file
+        .metadata()
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?
+        .len();
+    let content_type = project_file.content_type;
+
+    // WebKit/WKWebView (the macOS desktop webview) requires HTTP byte-range
+    // responses to play <video>: it probes with `Range: bytes=0-1` and treats
+    // any 200 reply as a non-seekable source it won't play. Honor a single
+    // range with 206 Partial Content; advertise Accept-Ranges otherwise.
+    if let Some(range_header) = headers.get(header::RANGE).and_then(|v| v.to_str().ok()) {
+        match parse_single_byte_range(range_header, total) {
+            Some((start, end)) => {
+                let len = end - start + 1;
+                file.seek(SeekFrom::Start(start))
+                    .await
+                    .map_err(|error| ApiError::internal(error.to_string()))?;
+                let stream = ReaderStream::new(file.take(len));
+                return Ok((
+                    StatusCode::PARTIAL_CONTENT,
+                    [
+                        (header::CONTENT_TYPE, content_type),
+                        (header::ACCEPT_RANGES, "bytes".to_string()),
+                        (
+                            header::CONTENT_RANGE,
+                            format!("bytes {start}-{end}/{total}"),
+                        ),
+                        (header::CONTENT_LENGTH, len.to_string()),
+                    ],
+                    Body::from_stream(stream),
+                )
+                    .into_response());
+            }
+            None => {
+                return Ok((
+                    StatusCode::RANGE_NOT_SATISFIABLE,
+                    [(header::CONTENT_RANGE, format!("bytes */{total}"))],
+                )
+                    .into_response());
+            }
+        }
+    }
+
     let stream = ReaderStream::new(file);
     Ok((
-        [(header::CONTENT_TYPE, project_file.content_type)],
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::ACCEPT_RANGES, "bytes".to_string()),
+            (header::CONTENT_LENGTH, total.to_string()),
+        ],
         Body::from_stream(stream),
     )
         .into_response())
+}
+
+/// Parse a single HTTP byte range (`bytes=start-end`, `bytes=start-`, or
+/// `bytes=-suffix`) against a known total size, returning an inclusive
+/// `(start, end)` clamped to the file. Returns `None` for unsatisfiable or
+/// multi-range requests (callers answer 416).
+fn parse_single_byte_range(value: &str, total: u64) -> Option<(u64, u64)> {
+    let spec = value.strip_prefix("bytes=")?.trim();
+    if spec.is_empty() || spec.contains(',') || total == 0 {
+        return None;
+    }
+    let (start_str, end_str) = spec.split_once('-')?;
+    let (start, end) = if start_str.is_empty() {
+        // Suffix range: last `suffix` bytes.
+        let suffix: u64 = end_str.parse().ok()?;
+        if suffix == 0 {
+            return None;
+        }
+        let start = total.saturating_sub(suffix);
+        (start, total - 1)
+    } else {
+        let start: u64 = start_str.parse().ok()?;
+        let end = if end_str.is_empty() {
+            total - 1
+        } else {
+            end_str.parse::<u64>().ok()?.min(total - 1)
+        };
+        (start, end)
+    };
+    if start > end || start >= total {
+        return None;
+    }
+    Some((start, end))
 }
 
 async fn list_characters(
@@ -12192,6 +12275,72 @@ mod tests {
         let error: Value = serde_json::from_slice(&bytes).expect("json error parses");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(error["detail"], "Invalid project file path");
+    }
+
+    #[tokio::test]
+    async fn project_file_route_serves_byte_ranges() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (_, created) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/projects",
+            json!({ "name": "Ranges" }),
+        )
+        .await;
+        let project_id = created["id"].as_str().expect("project id").to_owned();
+        let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
+        let media_path = project_path.join("assets/videos/clip.mp4");
+        std::fs::write(&media_path, b"0123456789").expect("media writes");
+        let uri = format!("/api/v1/projects/{project_id}/files/assets/videos/clip.mp4");
+
+        // A full request advertises range support so WebKit knows it can seek.
+        let (status, headers, bytes) =
+            request_raw(app.clone(), "GET", &uri, Body::empty(), &[]).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(bytes, b"0123456789");
+        assert_eq!(
+            headers.get("accept-ranges").and_then(|v| v.to_str().ok()),
+            Some("bytes")
+        );
+
+        // A bounded range yields 206 with the exact slice and Content-Range.
+        let (status, headers, bytes) = request_raw(
+            app.clone(),
+            "GET",
+            &uri,
+            Body::empty(),
+            &[("range", "bytes=2-5")],
+        )
+        .await;
+        assert_eq!(status, StatusCode::PARTIAL_CONTENT);
+        assert_eq!(bytes, b"2345");
+        assert_eq!(
+            headers.get("content-range").and_then(|v| v.to_str().ok()),
+            Some("bytes 2-5/10")
+        );
+        assert_eq!(
+            headers.get("accept-ranges").and_then(|v| v.to_str().ok()),
+            Some("bytes")
+        );
+
+        // An open-ended range serves to EOF (this is how WebKit fetches the
+        // trailing moov atom on a non-faststart MP4).
+        let (status, _, bytes) = request_raw(
+            app.clone(),
+            "GET",
+            &uri,
+            Body::empty(),
+            &[("range", "bytes=7-")],
+        )
+        .await;
+        assert_eq!(status, StatusCode::PARTIAL_CONTENT);
+        assert_eq!(bytes, b"789");
+
+        // An unsatisfiable range is rejected with 416.
+        let (status, _, _) =
+            request_raw(app, "GET", &uri, Body::empty(), &[("range", "bytes=99-")]).await;
+        assert_eq!(status, StatusCode::RANGE_NOT_SATISFIABLE);
     }
 
     #[tokio::test]

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -20,6 +20,17 @@ export function assetCanRenderAsVideo(asset) {
   return asset?.type === "video" || asset?.file?.mimeType?.startsWith("video/");
 }
 
+// Generated videos get a sibling `<name>.poster.jpg` (the worker extracts frame 0).
+// WKWebView won't paint a <video>'s own first frame as a poster, so the UI shows
+// this real image instead — as the thumbnail and as the player's poster attribute.
+export function posterUrl(asset) {
+  const src = assetUrl(asset);
+  if (!src || !assetCanRenderAsVideo(asset)) {
+    return "";
+  }
+  return src.replace(/\.\w+$/, ".poster.jpg");
+}
+
 export function AssetThumbnail({ asset, className = "" }) {
   if (!asset) {
     return null;
@@ -29,12 +40,21 @@ export function AssetThumbnail({ asset, className = "" }) {
     return <span className={className}>{asset.type ?? "asset"}</span>;
   }
   if (assetCanRenderAsVideo(asset)) {
-    return <video className={className} muted playsInline preload="metadata" src={src} />;
+    return <VideoPoster asset={asset} className={className} />;
   }
   if (assetCanRenderAsImage(asset)) {
     return <img alt="" className={className} src={src} />;
   }
   return <span className={className}>{asset.type ?? "asset"}</span>;
+}
+
+function VideoPoster({ asset, className }) {
+  const [failed, setFailed] = React.useState(false);
+  const poster = posterUrl(asset);
+  if (!poster || failed) {
+    return <span className={className}>{asset.type ?? "video"}</span>;
+  }
+  return <img alt="" className={className} src={poster} onError={() => setFailed(true)} />;
 }
 
 export const AssetMedia = React.forwardRef(function AssetMedia({ asset, className = "", controls = true, ...mediaProps }, ref) {
@@ -46,7 +66,19 @@ export const AssetMedia = React.forwardRef(function AssetMedia({ asset, classNam
     return <span className={className}>{asset.type ?? "asset"}</span>;
   }
   if (assetCanRenderAsVideo(asset)) {
-    return <video className={className} controls={controls} muted playsInline preload="metadata" ref={ref} src={src} {...mediaProps} />;
+    return (
+      <video
+        className={className}
+        controls={controls}
+        muted
+        playsInline
+        poster={posterUrl(asset)}
+        preload="metadata"
+        ref={ref}
+        src={src}
+        {...mediaProps}
+      />
+    );
   }
   if (assetCanRenderAsImage(asset)) {
     return <img alt="" className={className} ref={ref} src={src} />;

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -781,7 +781,9 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 output_path=str(temp_path),
                 video_chunks_number=video_chunks_number,
             )
+        faststart_mp4(temp_path)
         temp_path.replace(media_path)
+        write_poster_frame(media_path)
 
         if replacement_control is not None:
             # replacementActive is true ONLY here: the masked-control package was
@@ -1510,6 +1512,73 @@ def _ensure_ffmpeg_on_path() -> None:
     os.environ["PATH"] = f"{link_dir}{os.pathsep}{os.environ.get('PATH', '')}"
 
 
+def _resolve_ffmpeg() -> str | None:
+    """Locate an ffmpeg executable: SCENEWORKS_FFMPEG, then a system ffmpeg, then
+    the binary bundled with imageio-ffmpeg (always present in the desktop venv)."""
+    import shutil
+
+    exe = os.environ.get("SCENEWORKS_FFMPEG", "").strip() or shutil.which("ffmpeg")
+    if not exe:
+        try:
+            import imageio_ffmpeg
+
+            exe = imageio_ffmpeg.get_ffmpeg_exe()
+        except Exception:
+            return None
+    return exe if exe and Path(exe).exists() else None
+
+
+def faststart_mp4(path: Path) -> None:
+    """Remux a finished MP4 in place with the moov atom moved to the front
+    (``-movflags +faststart``). The ffmpeg/imageio muxers used by every video
+    adapter leave moov at EOF, which forces WebKit/WKWebView to issue a byte-range
+    seek to the end before it can start playback. Faststart lets it begin from the
+    first bytes. Best-effort: a missing or failing ffmpeg leaves the original file
+    untouched — the API's byte-range support is the load-bearing guarantee."""
+    import subprocess
+
+    if path.suffix.lower() != ".mp4" or not path.exists():
+        return
+    exe = _resolve_ffmpeg()
+    if not exe:
+        return
+    remuxed = path.with_suffix(".faststart.mp4")
+    try:
+        subprocess.run(
+            [exe, "-nostdin", "-y", "-i", str(path), "-c", "copy", "-movflags", "+faststart", str(remuxed)],
+            check=True,
+            capture_output=True,
+        )
+        remuxed.replace(path)
+    except Exception:
+        remuxed.unlink(missing_ok=True)
+
+
+def write_poster_frame(media_path: Path) -> None:
+    """Extract the first frame of a finished video to a sibling ``<name>.poster.jpg``
+    so the UI can show a real thumbnail. WKWebView (the macOS desktop webview) does
+    not paint a ``<video>``'s first frame as a poster on its own — it shows a blank
+    gray box — and seeking it via JS/media-fragment doesn't reliably help, so the UI
+    uses this static image instead. Best-effort: a missing/failing ffmpeg leaves no
+    poster (the UI falls back to a placeholder)."""
+    import subprocess
+
+    if media_path.suffix.lower() != ".mp4" or not media_path.exists():
+        return
+    exe = _resolve_ffmpeg()
+    if not exe:
+        return
+    poster = media_path.with_suffix(".poster.jpg")
+    try:
+        subprocess.run(
+            [exe, "-nostdin", "-y", "-i", str(media_path), "-frames:v", "1", "-q:v", "3", str(poster)],
+            check=True,
+            capture_output=True,
+        )
+    except Exception:
+        poster.unlink(missing_ok=True)
+
+
 # LTX user-LoRA injection. mlx-video-with-audio's turnkey generate_video_with_audio
 # builds the LTX transformer (LTXModel) internally and exposes no loras kwarg, so we
 # wrap LTXModel.load_weights to merge the pending LoRAs (apply_loras_to_model: dequant
@@ -1737,7 +1806,9 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         if cancel_requested():
             temp_path.unlink(missing_ok=True)
             raise InterruptedError("Video generation canceled before saving.")
+        faststart_mp4(temp_path)
         temp_path.replace(media_path)
+        write_poster_frame(media_path)
 
         generation_set = {
             "schemaVersion": 1,
@@ -1964,7 +2035,9 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         if cancel_requested():
             temp_path.unlink(missing_ok=True)
             raise InterruptedError("Video generation canceled before saving.")
+        faststart_mp4(temp_path)
         temp_path.replace(media_path)
+        write_poster_frame(media_path)
 
         progress("saving", "saving", 0.9, "Saving video asset and recipe.")
         generation_set = {
@@ -2114,7 +2187,9 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         progress("saving", "saving", 0.9, "Saving generated MP4 asset and recipe.")
         diffusers_utils = importlib.import_module("diffusers.utils")
         diffusers_utils.export_to_video(frames, str(temp_path), fps=request.fps)
+        faststart_mp4(temp_path)
         temp_path.replace(media_path)
+        write_poster_frame(media_path)
 
         generation_set = {
             "schemaVersion": 1,


### PR DESCRIPTION
## Summary
Generated videos were unplayable in the macOS desktop app (Tauri/WKWebView) and showed as gray boxes in every list, despite the MP4s being valid. Three distinct issues, fixed here:

- **Playback** — `get_project_file` served media as a plain `200` with no HTTP Range support (the FastAPI→axum port silently dropped what `FileResponse` gave for free). WebKit requires `206` byte-range responses to play `<video>`, especially with the `moov` atom at EOF. Added single-range handling (`206` + `Content-Range` + `Accept-Ranges`, `416` for unsatisfiable) and write generated MP4s with `-movflags +faststart`.
- **Stale embedded UI** — the desktop embeds `apps/web/dist` into the API binary via rust-embed, but cargo had no build input for that folder, so web-only changes never triggered a recompile/re-embed (`cargo build` reported `Finished` without recompiling). Added `apps/rust-api/build.rs` emitting recursive `rerun-if-changed` over `../web/dist`.
- **Thumbnails** — WKWebView won't paint a `<video>`'s first frame as a poster; both a `#t=` media fragment and an `onLoadedMetadata` seek failed on-device. The worker now extracts frame 0 to a sibling `<name>.poster.jpg`; the UI renders that image as the thumbnail (`<img>`) and the `<video poster>` attribute.

Existing clips were backfilled with posters out-of-band; new videos get one at generation time.

## Test plan
- [x] `cargo test -p sceneworks-rust-api` — 50/50, incl. new `project_file_route_serves_byte_ranges` (206 slice, open-ended range, 416)
- [x] `cargo clippy -p sceneworks-rust-api --features embed-web -- -D warnings` clean; `cargo fmt --check` clean
- [x] Web `vitest` — 81/81; `vite build` succeeds
- [x] faststart moves `moov` before `mdat` on a real clip; `write_poster_frame` produces a valid frame JPEG
- [x] End-to-end: ran the embedded API binary, confirmed `206` range responses and that the served bundle contains the poster code (not the dropped seek)
- [x] On-device: rebuilt desktop and confirmed playback + non-gray thumbnails in WKWebView

🤖 Generated with [Claude Code](https://claude.com/claude-code)