### PR TITLE
[codex] Fix SAM2 person backend requirement

### DIFF
--- a/apps/worker/requirements-person.txt
+++ b/apps/worker/requirements-person.txt
@@ -13,4 +13,5 @@ lap>=0.5
 # Segmentation / matting (per-frame person masks). SAM2 is the primary backend;
 # MatAnyone (Wan2GP's reference video matter) is an accepted alternative. Either
 # one advertises the person_segment capability; absence degrades masks to boxes.
-sam2 @ git+https://github.com/facebookresearch/sam2.git@main
+# The distribution metadata is named "sam-2" while the import package is "sam2".
+sam-2 @ git+https://github.com/facebookresearch/sam2.git@main


### PR DESCRIPTION
## Summary
- Fix the SAM2 direct URL requirement used by the optional person backend install.
- Use the distribution metadata name `sam-2` while keeping the runtime import package as `sam2`.

## Root Cause
Pip rejects `sam2 @ git+https://github.com/facebookresearch/sam2.git@main` because the repository metadata identifies the project as `sam-2`, producing an inconsistent-name resolver error during the Docker worker build.

## Validation
- `pip install --dry-run --no-deps "sam-2 @ git+https://github.com/facebookresearch/sam2.git@main"`
- Same dry-run inside `python:3.12-slim`, which reported `Would install SAM-2-1.0`
- `git diff --check`