### PR TITLE
fix(worker): stop spurious "Waiting for an available GPU worker" stalls

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -7,6 +7,10 @@ mod setup;
 use tauri::RunEvent;
 
 fn main() {
+    // Kill any sidecars orphaned by a prior crash/force-quit before spawning
+    // fresh ones, so API processes don't accumulate and contend on jobs.db.
+    setup::reap_stale_sidecars();
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
@@ -27,8 +27,19 @@ pub struct Managed {
     pub worker: Mutex<Option<CommandChild>>,
     /// OS-assigned API port, discovered from the sidecar's startup line.
     api_port: Mutex<Option<u16>>,
+    /// PIDs of the spawned sidecars, persisted to disk so an unclean exit
+    /// (crash/force-quit) doesn't leave them orphaned — the next launch reaps
+    /// any survivors before spawning fresh ones.
+    pids: Mutex<SidecarPids>,
     running: AtomicBool,
     pub shutting_down: AtomicBool,
+}
+
+/// PIDs of the API + Python worker sidecars owned by this launch.
+#[derive(Default, Clone, Serialize, Deserialize)]
+struct SidecarPids {
+    api: Option<u32>,
+    worker: Option<u32>,
 }
 
 #[derive(Clone, Serialize)]
@@ -579,6 +590,7 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
     let (mut events, child) = command
         .spawn()
         .map_err(|error| format!("spawn api: {error}"))?;
+    record_api_pid(app, child.pid());
     app.state::<Managed>()
         .api
         .lock()
@@ -679,6 +691,18 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
         // Match the API sidecar's HF cache root so downloaded weights land where
         // the catalog looks for them (and reuse anything already cached there).
         let hf_home = huggingface_home().to_string_lossy().to_string();
+        // Unique per app launch (stable across in-launch respawns) so a worker
+        // from a prior/overlapping session can't impersonate this one in the
+        // shared jobs.db. A fixed "worker-local-0" let two incarnations collide:
+        // one claims a job, the other's idle heartbeat instantly interrupts it.
+        let worker_id = format!(
+            "worker-local-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|elapsed| elapsed.as_millis())
+                .unwrap_or_default()
+        );
         let mut backoff = 1u64;
         loop {
             if app.state::<Managed>().shutting_down.load(Ordering::SeqCst) {
@@ -697,6 +721,7 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
                 .args(["-m", "scene_worker"])
                 .current_dir(&src)
                 .env("PYTHONPATH", &pythonpath)
+                .env("SCENEWORKS_WORKER_ID", &worker_id)
                 .env("SCENEWORKS_API_URL", &api_url)
                 .env("HF_HOME", &hf_home)
                 .env(
@@ -723,6 +748,7 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
                     continue;
                 }
             };
+            record_worker_pid(&app, Some(child.pid()));
             app.state::<Managed>()
                 .worker
                 .lock()
@@ -758,6 +784,7 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
                 .lock()
                 .expect("worker lock")
                 .take();
+            record_worker_pid(&app, None);
             if app.state::<Managed>().shutting_down.load(Ordering::SeqCst) {
                 return;
             }
@@ -779,6 +806,112 @@ fn supervise_worker(app: AppHandle, api_port: u16) {
 #[cfg(unix)]
 fn pid_alive(pid: u32) -> bool {
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_ok()
+}
+
+/// File holding this launch's sidecar PIDs, used to reap orphans left by a prior
+/// unclean exit. Lives alongside the app's data so it survives across launches.
+fn sidecar_pidfile() -> PathBuf {
+    app_support_dir().join("desktop-sidecars.json")
+}
+
+/// Persist the current sidecar PIDs (best effort, atomic via temp+rename).
+fn write_sidecar_pidfile(pids: &SidecarPids) {
+    let path = sidecar_pidfile();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let Ok(json) = serde_json::to_vec_pretty(pids) else {
+        return;
+    };
+    let tmp = path.with_extension("json.tmp");
+    if std::fs::write(&tmp, &json).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+fn record_api_pid(app: &AppHandle, pid: u32) {
+    let state = app.state::<Managed>();
+    let mut pids = state.pids.lock().expect("pids lock");
+    pids.api = Some(pid);
+    write_sidecar_pidfile(&pids);
+}
+
+fn record_worker_pid(app: &AppHandle, pid: Option<u32>) {
+    let state = app.state::<Managed>();
+    let mut pids = state.pids.lock().expect("pids lock");
+    pids.worker = pid;
+    write_sidecar_pidfile(&pids);
+}
+
+/// True when `pid` is one of our sidecars (not a recycled, unrelated PID). The
+/// command line must reference the API binary or the Python worker module.
+#[cfg(unix)]
+fn is_our_sidecar(pid: u32) -> bool {
+    let Ok(output) = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let command = String::from_utf8_lossy(&output.stdout);
+    command.contains("sceneworks-api") || command.contains("scene_worker")
+}
+
+#[cfg(windows)]
+fn is_our_sidecar(pid: u32) -> bool {
+    // tasklist exposes the image name (sceneworks-api.exe) but not arguments, so
+    // the Python worker (python.exe -m scene_worker) can't be matched here; the
+    // worker exits on its own when its parent/API is gone, so only the API needs
+    // reaping on Windows.
+    let Ok(output) = std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+        .output()
+    else {
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout).contains("sceneworks-api")
+}
+
+/// SIGTERM then SIGKILL a confirmed-stale sidecar.
+#[cfg(unix)]
+fn kill_pid(pid: u32) {
+    let target = nix::unistd::Pid::from_raw(pid as i32);
+    let _ = nix::sys::signal::kill(target, nix::sys::signal::Signal::SIGTERM);
+    for _ in 0..20 {
+        if !pid_alive(pid) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let _ = nix::sys::signal::kill(target, nix::sys::signal::Signal::SIGKILL);
+}
+
+#[cfg(windows)]
+fn kill_pid(pid: u32) {
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .output();
+}
+
+/// Kill sidecars left running by a prior unclean exit before spawning fresh
+/// ones. Without this, a crash/force-quit (which skips `begin_shutdown`) leaves
+/// orphaned API processes that accumulate, hold ports, and contend on jobs.db.
+/// Each recorded PID is identity-checked so a recycled PID is never killed.
+pub fn reap_stale_sidecars() {
+    let path = sidecar_pidfile();
+    let Ok(bytes) = std::fs::read(&path) else {
+        return;
+    };
+    let pids: SidecarPids = serde_json::from_slice(&bytes).unwrap_or_default();
+    for pid in [pids.api, pids.worker].into_iter().flatten() {
+        if is_our_sidecar(pid) {
+            kill_pid(pid);
+        }
+    }
+    let _ = std::fs::remove_file(&path);
 }
 
 /// Begin graceful shutdown: stop the Python worker then the API sidecar. On Unix
@@ -826,6 +959,9 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
         if let Some(child) = api_child {
             let _ = child.kill();
         }
+        // Clean exit: drop the pidfile so the next launch doesn't try to reap
+        // PIDs we already terminated.
+        let _ = std::fs::remove_file(sidecar_pidfile());
         handle.exit(0);
     });
     true

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -12576,6 +12576,18 @@ mod tests {
         )
         .await;
 
+        let job_id = created["id"].as_str().expect("job id is string");
+        // The owning worker reports at least one heartbeat for the job, so a
+        // later idle heartbeat is a genuine restart (not a claim race) and must
+        // reclaim the now-orphaned active job.
+        request(
+            app.clone(),
+            "POST",
+            "/api/v1/workers/worker-1/heartbeat",
+            json!({ "status": "busy", "currentJobId": job_id, "loadedModels": [] }),
+        )
+        .await;
+
         let (status, worker) = request(
             app.clone(),
             "POST",
@@ -12586,7 +12598,6 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(worker["currentJobId"], Value::Null);
 
-        let job_id = created["id"].as_str().expect("job id is string");
         let (status, job) =
             request(app, "GET", &format!("/api/v1/jobs/{job_id}"), Value::Null).await;
         assert_eq!(status, StatusCode::OK);

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -486,7 +486,15 @@ impl JobsStore {
         if request.current_job_id.is_none() {
             if let Some(previous_job_id) = worker.current_job_id {
                 let previous_job = self.get_job_on_connection(&transaction, &previous_job_id)?;
-                if is_active_status(previous_job.status.as_str()) {
+                // Only interrupt a worker's previous active job on an idle heartbeat
+                // if that job has already heartbeated at least once. A job that was
+                // *just* claimed (no heartbeat yet) may be one another incarnation of
+                // the same worker_id claimed microseconds ago — an idle heartbeat
+                // racing the claim must not kill it. The time-based stale sweep still
+                // reclaims a job abandoned before its first heartbeat.
+                if is_active_status(previous_job.status.as_str())
+                    && previous_job.last_heartbeat_at.is_some()
+                {
                     transaction.execute(
                         "
                         update jobs

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -546,8 +546,57 @@ fn cpu_utility_worker_does_not_claim_gpu_generation_job() {
 }
 
 #[test]
-fn idle_heartbeat_interrupts_previous_active_job() {
+fn idle_heartbeat_interrupts_previous_heartbeated_job() {
     let store = store("idle-heartbeat");
+    register_image_worker(&store);
+    let created = store
+        .create_job(image_job(Map::new()))
+        .expect("job creates");
+    let claimed = store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+
+    assert_eq!(claimed.id, created.id);
+
+    // The owning worker reports at least one heartbeat for the job (records
+    // last_heartbeat_at), so a later idle heartbeat is a genuine restart and
+    // must reclaim the now-orphaned active job.
+    store
+        .heartbeat_worker(WorkerHeartbeat {
+            worker_id: "worker-1".to_owned(),
+            status: WorkerStatus::Busy,
+            current_job_id: Some(created.id.clone()),
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("busy heartbeat succeeds");
+
+    let worker = store
+        .heartbeat_worker(WorkerHeartbeat {
+            worker_id: "worker-1".to_owned(),
+            status: WorkerStatus::Idle,
+            current_job_id: None,
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("heartbeat succeeds");
+    let job = store.get_job(&created.id).expect("job loads");
+
+    assert_eq!(worker.status, WorkerStatus::Idle);
+    assert_eq!(worker.current_job_id, None);
+    assert_eq!(job.status, JobStatus::Interrupted);
+    assert_eq!(job.worker_id, None);
+}
+
+#[test]
+fn idle_heartbeat_does_not_interrupt_just_claimed_job() {
+    // A job claimed by one worker incarnation must survive an idle heartbeat
+    // (currentJobId=null) that races the claim — e.g. from another process
+    // sharing the same worker_id, or a restart firing its first idle heartbeat
+    // before any progress is reported. Without a recorded heartbeat there is no
+    // evidence the job was abandoned, so it must not be interrupted here.
+    let store = store("idle-heartbeat-race");
     register_image_worker(&store);
     let created = store
         .create_job(image_job(Map::new()))
@@ -571,9 +620,12 @@ fn idle_heartbeat_interrupts_previous_active_job() {
     let job = store.get_job(&created.id).expect("job loads");
 
     assert_eq!(worker.status, WorkerStatus::Idle);
-    assert_eq!(worker.current_job_id, None);
-    assert_eq!(job.status, JobStatus::Interrupted);
-    assert_eq!(job.worker_id, None);
+    assert!(
+        matches!(job.status, JobStatus::Preparing),
+        "just-claimed job should stay active, got {:?}",
+        job.status
+    );
+    assert_eq!(job.worker_id.as_deref(), Some("worker-1"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Generations could stall on **"Waiting for an available GPU worker"** even with no other jobs running — the previous generation appeared to "not let go of the GPU." Investigation against the live desktop install showed this is **not** a GPU-memory release problem (MPS reports no utilization, so no claim is gated on memory). The real cause is **identity collision between worker process incarnations sharing one `jobs.db`**, turned into instantly-killed jobs by an over-eager interrupt path.

Evidence from the live DB/logs: an `image_generate` job was claimed and **interrupted 1s later**, `last_heartbeat_at` empty, error `"Worker heartbeat no longer referenced the active job."` Plus **5 orphaned `sceneworks-api` processes** (PPID=1) from prior sessions were still running.

### Root causes
- **Fixed worker id.** The desktop spawned the Python worker without `SCENEWORKS_WORKER_ID`, so every session/incarnation registered as `worker-local-0` and collided in the shared DB.
- **Over-eager interrupt.** `JobsStore::heartbeat_worker` interrupted a worker's current job on *any* idle heartbeat (`currentJobId=null`) while the DB still showed it owning an active job. With a colliding id, one process claims a job and another's idle heartbeat kills it before any progress is reported.
- **Sidecar leak.** `begin_shutdown` only runs on a clean `RunEvent::ExitRequested`; crash/force-quit orphans the API sidecars, which accumulate and contend on `jobs.db`.

## Changes
- **Guard the interrupt** ([jobs_store.rs](crates/sceneworks-core/src/jobs_store.rs)): an idle heartbeat only interrupts a previous active job that has already heartbeated (`last_heartbeat_at` set). Just-claimed jobs are protected; jobs abandoned before their first heartbeat still fall to the existing 90s stale sweep.
- **Unique per-launch worker id** ([setup.rs](apps/desktop/src/setup.rs)): `worker-local-<pid>-<ms>`, stable across in-launch respawns so legitimate restart-recovery still works.
- **Reap orphaned sidecars** ([setup.rs](apps/desktop/src/setup.rs), [main.rs](apps/desktop/src/main.rs)): record sidecar PIDs to `desktop-sidecars.json`; on startup, identity-verify and kill survivors before spawning; clear on clean shutdown.

## Test plan
- [x] `cargo test -p sceneworks-core` (30/26/16/6/6 across suites) — incl. new `idle_heartbeat_does_not_interrupt_just_claimed_job` and renamed `idle_heartbeat_interrupts_previous_heartbeated_job`
- [x] `cargo test -p sceneworks-rust-api` (50 passing) — updated `worker_heartbeat_interrupts_previous_active_job_through_http` to the restart-recovery semantics
- [x] `cargo clippy --all-targets -- -D warnings` clean on core, rust-api, desktop
- [ ] **Reviewer note:** the worker-id and reaping fixes live in the desktop Rust binary, so a **rebuild/reinstall of the desktop app** is required to take effect; the running app keeps old behavior until then.

## Notes
- Scope is limited to the 5 worker/dispatch/desktop files; unrelated in-progress training changes in the working tree were intentionally left out of this PR.
- Windows reaping verifies only the API sidecar (tasklist exposes the image name, not args); the Python worker exits on its own when its parent/API is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)