### PR TITLE
Fix: apply the trained LoRA at inference instead of a step checkpoint

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4122,7 +4122,7 @@ describe("SceneWorks app shell", () => {
           loras={[
             { id: "built_in", name: "Built In", family: "z-image", scope: "builtin", defaultWeight: 0.6 },
             { id: "global_style", name: "Global Style", family: "z-image", scope: "global" },
-            { id: "project_mira", name: "Project Mira", family: "z-image", scope: "project" },
+            { id: "project_mira", name: "Project Mira", family: "z-image", scope: "project", files: ["mira.safetensors"] },
             { id: "third_user", name: "Third User", family: "z-image", scope: "global" },
             { id: "qwen_only", name: "Qwen Only", family: "qwen-image", scope: "global" },
             { id: "missing_lora", name: "Missing LoRA", family: "z-image", scope: "global", installState: "missing" },
@@ -4171,7 +4171,7 @@ describe("SceneWorks app shell", () => {
         loras: [
           expect.objectContaining({ id: "built_in", scope: "builtin", weight: 0.6 }),
           expect.objectContaining({ id: "global_style", scope: "global" }),
-          expect.objectContaining({ id: "project_mira", scope: "project" }),
+          expect.objectContaining({ id: "project_mira", scope: "project", files: ["mira.safetensors"] }),
         ],
       }),
     );

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -166,6 +166,13 @@ export function ImageStudio({
       installedPath: lora.installedPath ?? null,
       sourcePath: lora.sourcePath ?? null,
       source: lora.source ?? null,
+      // `installedPath` points at the LoRA directory; for trained LoRAs that
+      // directory also holds step checkpoints, so the worker must be told the
+      // exact adapter file. Forward the manifest's declared `files`/`file` —
+      // without them the worker falls back to the first .safetensors on disk and
+      // can load an early checkpoint instead of the final adapter.
+      files: lora.files ?? null,
+      file: lora.file ?? null,
       presetManaged: Boolean(lora.presetManaged),
     };
   }

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -315,12 +315,30 @@ def path_stem(path: Path | None) -> str | None:
     return path.stem if path else None
 
 
+# SceneWorks training writes per-step checkpoints (`<stem>-step000250.safetensors`)
+# next to the final adapter. Recognize them so the fallback never auto-selects a
+# checkpoint over the final weights.
+_LORA_CHECKPOINT_RE = re.compile(r"-step\d{6}\.safetensors$", re.IGNORECASE)
+
+
 def first_safetensors_path(path: Path) -> Path | None:
     if path.is_file() and path.suffix.lower() == ".safetensors":
         return path
     if not path.is_dir():
         return None
-    return next((candidate for candidate in path.rglob("*.safetensors") if candidate.is_file()), None)
+    candidates = sorted(
+        (candidate for candidate in path.rglob("*.safetensors") if candidate.is_file()),
+        key=lambda candidate: candidate.as_posix(),
+    )
+    if not candidates:
+        return None
+    # Prefer a non-checkpoint adapter; the name-sorted first file is the *earliest*
+    # (least-trained) checkpoint, which is exactly the wrong one to load. If only
+    # checkpoints exist, fall back to the highest step (most-trained).
+    finals = [candidate for candidate in candidates if not _LORA_CHECKPOINT_RE.search(candidate.name)]
+    if finals:
+        return finals[0]
+    return max(candidates, key=lambda candidate: candidate.name)
 
 
 def lora_weight(lora: dict[str, Any]) -> float:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -40,10 +40,12 @@ from scene_worker.image_adapters import (
 )
 from scene_worker.lora_adapters import (
     apply_loras_to_pipeline,
+    first_safetensors_path,
     lora_cache_key,
     lora_weight,
     normalize_lora_specs,
     reject_loras_if_unsupported,
+    resolve_lora_file,
     validate_lora_compatibility,
 )
 from scene_worker.runtime import (
@@ -504,6 +506,33 @@ def test_lora_cache_key_is_stable_for_reordered_loras(tmp_path):
     key = lora_cache_key(left)
     assert key == lora_cache_key(right)
     assert len(key) == 64
+
+
+def test_first_safetensors_path_prefers_final_over_step_checkpoints(tmp_path):
+    # A trained-LoRA directory holds the final adapter plus per-step checkpoints.
+    for step in (250, 500, 3000):
+        (tmp_path / f"kelsie_lora-step{step:06d}.safetensors").write_bytes(b"ckpt")
+    final = tmp_path / "kelsie_lora.safetensors"
+    final.write_bytes(b"final")
+
+    assert first_safetensors_path(tmp_path) == final
+
+
+def test_first_safetensors_path_picks_latest_checkpoint_when_no_final(tmp_path):
+    for step in (250, 500, 3000):
+        (tmp_path / f"kelsie_lora-step{step:06d}.safetensors").write_bytes(b"ckpt")
+
+    assert first_safetensors_path(tmp_path) == tmp_path / "kelsie_lora-step003000.safetensors"
+
+
+def test_resolve_lora_file_uses_declared_files_over_checkpoints(tmp_path):
+    (tmp_path / "kelsie_lora-step000250.safetensors").write_bytes(b"ckpt")
+    final = tmp_path / "kelsie_lora.safetensors"
+    final.write_bytes(b"final")
+
+    resolved = resolve_lora_file(tmp_path, {"files": ["kelsie_lora.safetensors"]})
+
+    assert resolved == final
 
 
 def test_lora_loader_allows_single_implicit_weight_without_set_adapters(tmp_path):


### PR DESCRIPTION
## Problem

Selecting a trained LoRA in Image Studio appeared to have **no effect** — "Kelsie in the park" returned generic people (even a child) with zero likeness. Inspecting the actual generation recipe, the LoRA *was* in the request (correct id, family, weight 0.8, 1024 / 9-step / CFG 0), so the wiring looked fine.

The bug is in **which file the worker loads**. A project-scoped trained LoRA's `installedPath` is the LoRA **directory**, which also contains every per-step checkpoint:

```
kelsie_lora-step000250.safetensors   ← loaded (weakest!)
…
kelsie_lora-step002750.safetensors
kelsie_lora.safetensors              ← the actual final adapter
```

Image Studio's `serializeLora` dropped the manifest's `files`, so the payload named only the directory. The worker fallback `first_safetensors_path()` returns the name-sorted-first `.safetensors`, and `kelsie_lora-step000250.safetensors` sorts before `kelsie_lora.safetensors` (`-` = 0x2D < `.` = 0x2E). **So every generation silently used the weakest 250-step checkpoint** (≈ base model), masking the trained adapter entirely. The manifest had the right `files: ["kelsie_lora.safetensors"]` — the web just wasn't forwarding it.

## Fix

- **Web** (`apps/web/src/screens/ImageStudio.jsx`): `serializeLora` forwards `files`/`file`, so the worker resolves the exact declared adapter (`resolve_lora_file` already prefers declared files).
- **Worker** (`apps/worker/scene_worker/lora_adapters.py`): `first_safetensors_path` no longer auto-selects a `-step\d{6}.safetensors` checkpoint — it prefers the final adapter, and if *only* checkpoints exist, picks the highest step (most-trained). Defense-in-depth for any caller that omits `files`.

## Why it matters

This almost certainly masked earlier training improvements: inference kept loading the 250-step checkpoint regardless of how well training went, so trained LoRAs always looked inert.

## Tests
- Web: the generate payload forwards `files` for a selected LoRA. **90 pass**, `vite build` clean.
- Worker: `first_safetensors_path` prefers the final over checkpoints / picks highest step when only checkpoints exist; `resolve_lora_file` honors declared `files`. **165 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
