### PR TITLE
fix: Z-Image LoRA training on Apple Silicon (MPS generator crash) [sc-1557]

### DIFF
--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -683,6 +683,21 @@ def build_optimizer(name: str, params: list[Any], learning_rate: float, weight_d
     return torch.optim.AdamW(params, lr=learning_rate, weight_decay=weight_decay)
 
 
+def seeded_sample(torch: Any, fn: Any, shape: Any, *, generator: Any, device: Any, dtype: Any) -> Any:
+    """Draw seeded random values, MPS-safe.
+
+    ``torch.Generator`` only lives on cpu/cuda, so on Apple Silicon a seeded run
+    pairs a cpu generator with tensors on ``mps``. ``torch.randn`` / ``torch.rand``
+    reject a cpu generator alongside a non-cpu ``device=`` argument, so when the
+    generator's device differs from the target device we draw on the generator's
+    device and move — mirroring diffusers' ``randn_tensor``. ``fn`` is
+    ``torch.randn`` or ``torch.rand``.
+    """
+    if generator is not None and generator.device.type != torch.device(device).type:
+        return fn(shape, generator=generator, device=generator.device, dtype=dtype).to(device)
+    return fn(shape, generator=generator, device=device, dtype=dtype)
+
+
 def sample_training_timestep(
     torch: Any,
     *,
@@ -702,13 +717,17 @@ def sample_training_timestep(
 
     normalized_type = (timestep_type or "sigmoid").strip().lower().replace("-", "_")
     if normalized_type in {"linear", "uniform"}:
-        t = torch.rand(1, generator=generator, device=device, dtype=dtype)
+        t = seeded_sample(torch, torch.rand, 1, generator=generator, device=device, dtype=dtype)
     elif normalized_type == "weighted":
-        base = torch.rand(1, generator=generator, device=device, dtype=dtype)
-        center = torch.sigmoid(torch.randn(1, generator=generator, device=device, dtype=dtype))
+        base = seeded_sample(torch, torch.rand, 1, generator=generator, device=device, dtype=dtype)
+        center = torch.sigmoid(
+            seeded_sample(torch, torch.randn, 1, generator=generator, device=device, dtype=dtype)
+        )
         t = (base + center) / 2.0
     else:
-        t = torch.sigmoid(torch.randn(1, generator=generator, device=device, dtype=dtype))
+        t = torch.sigmoid(
+            seeded_sample(torch, torch.randn, 1, generator=generator, device=device, dtype=dtype)
+        )
 
     normalized_bias = (timestep_bias or "balanced").strip().lower().replace("-", "_").replace(" ", "_")
     if normalized_bias in {"high", "high_noise", "favor_high_noise"}:
@@ -1069,8 +1088,8 @@ class _ZImageLoraBackend:
         # mirroring ZImagePipeline.__call__. The target sign matches the diffusers
         # pipeline, which negates the raw transformer output before the scheduler
         # (see flow_matching_velocity_target).
-        noise = torch.randn(
-            latents.shape, generator=self._generator, device=device, dtype=latents.dtype
+        noise = seeded_sample(
+            torch, torch.randn, latents.shape, generator=self._generator, device=device, dtype=latents.dtype
         )
         t = sample_training_timestep(
             torch,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -78,6 +78,7 @@ from scene_worker.training_adapters import (
     resolve_pretrained_source,
     resolve_training_adapter_source,
     sample_training_timestep,
+    seeded_sample,
     training_adapter_weight_name,
     validate_training_plan,
 )
@@ -1336,6 +1337,33 @@ def test_sample_training_timestep_accepts_ai_toolkit_shape_and_bias():
     assert timestep.shape == (1,)
     assert float(timestep.item()) > 0.001
     assert float(timestep.item()) < 0.999
+
+
+def test_seeded_sample_draws_on_generator_device_then_moves():
+    """Regression for the MPS crash: a cpu ``torch.Generator`` cannot drive a
+    ``torch.randn(..., device='mps')`` call. ``seeded_sample`` must draw on the
+    generator's own device and move to the target when they differ, and pass the
+    device straight through when they match. (``meta`` stands in for a non-cpu
+    target so the routing is exercised without an actual GPU/MPS backend.)"""
+    torch = pytest.importorskip("torch")
+    generator = torch.Generator("cpu").manual_seed(11)
+
+    seen_devices: list[str] = []
+
+    def fake_fn(shape, *, generator, device, dtype):  # noqa: ARG001
+        seen_devices.append(str(device))
+        return torch.zeros(shape, dtype=dtype)
+
+    # Matching device type → pass through, no move.
+    out = seeded_sample(torch, fake_fn, (2,), generator=generator, device="cpu", dtype=torch.float32)
+    assert seen_devices == ["cpu"]
+    assert out.device.type == "cpu"
+
+    # Mismatched target (cpu generator → non-cpu device) → draw on cpu, then move.
+    seen_devices.clear()
+    moved = seeded_sample(torch, fake_fn, (2,), generator=generator, device="meta", dtype=torch.float32)
+    assert seen_devices == ["cpu"], "must generate on the generator's device, not the mismatched target"
+    assert moved.device.type == "meta", "result must be moved to the requested device"
 
 
 def test_build_optimizer_uses_prodigy_with_aitoolkit_lr_floor(monkeypatch):


### PR DESCRIPTION
## Summary
Fixes the crash when training a Z-Image-Turbo LoRA on an Apple Silicon Mac:
`RuntimeError: Expected a 'mps' device type for generator but found 'cpu'`.

`torch.Generator` only exists on cpu/cuda, so on MPS the seeded generator is a **cpu** generator. The `z_image_lora` trainer passed it to **direct** `torch.randn`/`torch.rand(..., device="mps")` calls in `sample_training_timestep` and `train_step`, which PyTorch rejects. Training was only validated on CUDA; the MPS path was never exercised.

- Adds `seeded_sample(torch, fn, shape, *, generator, device, dtype)` — draws on the generator's own device and moves to the target when they differ (mirroring diffusers' `randn_tensor`).
- Routes the two direct-draw sites through it. The VAE `latent_dist.sample` and sample-preview `pipe` already go through `randn_tensor`, and the MPS unsupported-op fallback is already set by the shared `select_torch_device` — so no other changes were needed.

## Validation
- **End-to-end on real Apple Silicon:** a 3-step Z-Image-Turbo LoRA run (de-distill v2 adapter, MPS, bf16) loads → caches → trains → saves; the LoRA learns (`loraBNorm` 0.0 → 0.55).
- Targeted real-MPS check: the old pattern raises the exact error; the fixed path runs on MPS across all timestep branches, deterministically.
- Added a CI-safe regression test for the device-routing logic; 16 existing training tests pass.

## Test plan
- [x] `tests/test_worker_runtime.py -k "seeded_sample or timestep or z_image_trainer or training_kernel"` (7 passed)
- [x] Real 3-step Z-Image-Turbo LoRA training completes on MPS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)