### PR TITLE
fix(worker): wire weightDecay through to LTX MLX optimizer

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -116,8 +116,10 @@ SceneWorks storage, config defaults, or the target registry directly.
   Z-Image path above, the LTX `to_denoised` consumes the output directly). The
   adapter is saved keyed by the real module paths (`{module}.lora_A.weight` /
   `.lora_B.weight` + scalar `.alpha`) so `mlx_video.lora` round-trips at
-  inference with no key remap. Validated end-to-end: a rank-32 / 1500-step run on
-  ~76 stills (res 512, trigger-focused captions) produces a clearly attributable
+  inference with no key remap. The AdamW optimizer honors
+  `config.advanced.weightDecay` (passed through to MLX `AdamW`; plain `Adam` has
+  no decoupled decay). Validated end-to-end: a rank-32 / 1500-step run on
+  ~76 stills (res 512, weight decay 0.01, trigger-focused captions) produces a clearly attributable
   identity effect through the real `MlxVideoAdapter` generation path. Practical
   footprint: ~1.35 s/step. The gemma text encoder (~28 GB) is released after
   caption caching, so the **training loop peaks ~27 GB**; the whole-run ceiling

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -1497,12 +1497,13 @@ def inject_video_attention_lora(transformer: Any, config: TrainingRunConfig) -> 
     return target_paths
 
 
-def _build_mlx_optimizer(name: str, learning_rate: float) -> Any:
+def _build_mlx_optimizer(name: str, learning_rate: float, weight_decay: float = 0.0) -> Any:
     optim = importlib.import_module("mlx.optimizers")
     normalized = (name or "").strip().lower().replace("-", "").replace("_", "")
     if normalized == "adam":
+        # Plain Adam has no decoupled weight decay; the parameter applies to AdamW only.
         return optim.Adam(learning_rate=learning_rate)
-    return optim.AdamW(learning_rate=learning_rate)
+    return optim.AdamW(learning_rate=learning_rate, weight_decay=weight_decay)
 
 
 def ltx_flow_target(clean: Any, noise: Any) -> Any:
@@ -1592,7 +1593,9 @@ class _LtxMlxLoraBackend:
 
         progress("loading_model", "loading_model", 0.18, "Attaching LoRA adapters to the transformer.")
         lora_paths = inject_video_attention_lora(transformer, config)
-        self._optimizer = _build_mlx_optimizer(config.optimizer, config.learning_rate)
+        self._optimizer = _build_mlx_optimizer(
+            config.optimizer, config.learning_rate, config.weight_decay
+        )
         self._accumulated_grads = None
 
         self._transformer = transformer

--- a/documents/TRAINING_QUICKSTART.md
+++ b/documents/TRAINING_QUICKSTART.md
@@ -157,8 +157,9 @@ under-fit; use earlier checkpoints if a 3000-step balanced run starts overfittin
 > **Apple Silicon — LTX-2.3 video LoRA:** the `ltx_mlx_lora` kernel
 > (`target.kernel`, gated to Apple Silicon) trains an LTX-2.3 *video* LoRA
 > natively in MLX from the same still-image dataset, registered under the
-> `ltx-video` family. Validated recipe: rank 32 / alpha 32 / lr 1e-4 / res 512
-> with short trigger-focused captions (`"a photo of <trigger>"`), ~1500 steps
+> `ltx-video` family. Validated recipe: rank 32 / alpha 32 / lr 1e-4 / weight
+> decay 0.01 / res 512 with short trigger-focused captions
+> (`"a photo of <trigger>"`), ~1500 steps
 > (~1.35 s/step). The gemma text encoder (~28 GB) is freed after caption
 > caching, so the training loop peaks ~27 GB; the whole-run ceiling is the
 > dataset-caching phase at ~42 GB (text encoder still resident), which fits a


### PR DESCRIPTION
## Summary
Follow-up to epic 1532 (PR #127). The LTX MLX kernel's `_build_mlx_optimizer` previously passed only the learning rate, so the resolved `config.weight_decay` (from the **Weight Decay** UI field / `advanced.weightDecay`) was silently ignored — MLX `AdamW`'s built-in `0.01` default applied no matter what the user entered.

- Pass `config.weight_decay` through to MLX `AdamW` (plain `Adam` has no decoupled weight decay, so it's intentionally not applied there), matching the Z-Image path.
- An empty field now resolves to `0.0` as the plan implies (previously the effective value was MLX's `0.01`). The validated v2 recipe used `0.01`, so the worker README and TRAINING_QUICKSTART recipe now pin `weight decay 0.01` for reproducibility.

## Verification
- Confirmed against the installed MLX: `_build_mlx_optimizer("adamw", 1e-4, 0.05)` → `AdamW.weight_decay == 0.05`; `0.0` → `0.0`; `Adam` correctly carries none.
- Worker training tests pass (`tests/test_worker_runtime.py -k "ltx_mlx or z_image_trainer or training_kernel or read_run_config or training_plan or preset"`).

## Test plan
- [ ] CI green (Rust + Python parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)