### PR TITLE
Run Lens-Turbo on Apple Silicon via MPS [sc-1558]

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -20,12 +20,13 @@ use tauri_plugin_shell::ShellExt;
 const SETUP_VERSION: &str = "3";
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Lens sidecar venv torch stack. cu128 for Blackwell (sm_120); torchvision MUST
-/// match the CUDA torch build or diffusers 0.38's Flux.2 VAE import fails with
-/// "operator torchvision::nms does not exist". Mirrors the Docker /opt/lens-venv.
-#[cfg(not(target_os = "macos"))]
+/// Lens sidecar venv torch stack. Same versions on every platform; only the
+/// install index differs (see `provision_lens_venv`): macOS pulls the default
+/// PyPI wheels (MPS), Windows/Linux pull cu128 (Blackwell sm_120) where
+/// torchvision MUST match the CUDA torch build or diffusers 0.38's Flux.2 VAE
+/// import fails with "operator torchvision::nms does not exist". Mirrors the
+/// Docker /opt/lens-venv.
 const LENS_TORCH_SPEC: &str = "torch>=2.11,<2.12";
-#[cfg(not(target_os = "macos"))]
 const LENS_TORCHVISION_SPEC: &str = "torchvision>=0.26,<0.27";
 
 /// Process handles + run guards shared across the app.
@@ -121,7 +122,6 @@ fn marker_path() -> PathBuf {
     app_support_dir().join("python").join(".venv-marker")
 }
 
-#[cfg(not(target_os = "macos"))]
 fn lens_marker_path() -> PathBuf {
     app_support_dir().join("python").join(".lens-venv-marker")
 }
@@ -195,7 +195,6 @@ fn requirements_ltx_path(app: &AppHandle) -> PathBuf {
 /// requirements-lens.txt location (Microsoft Lens sidecar venv deps): the bundled
 /// resource in a packaged app, or the repo copy during development. Optional —
 /// absent in older worker checkouts, in which case Lens is unavailable.
-#[cfg(not(target_os = "macos"))]
 fn requirements_lens_path(app: &AppHandle) -> PathBuf {
     if let Ok(resources) = app.path().resource_dir() {
         let bundled = resources.join("python-src").join("requirements-lens.txt");
@@ -558,13 +557,14 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Provision the separate Lens sidecar venv (cu128 torch 2.11 + torchvision +
+/// Provision the separate Lens sidecar venv (torch 2.11 + torchvision +
 /// requirements-lens.txt). Runs in the BACKGROUND after the app is up so the large
-/// torch download never blocks launch; non-macOS only (Lens needs CUDA). Idempotent
-/// via its own marker. Failures are non-fatal: Lens stays unavailable (LensTurboAdapter
-/// reports a clear error) while the rest of the app works. Opt out with
-/// SCENEWORKS_DISABLE_LENS=1.
-#[cfg(not(target_os = "macos"))]
+/// torch download never blocks launch. macOS pulls MPS wheels from PyPI and runs
+/// the gpt-oss-20b text encoder dequantized to bf16 (mxfp4 needs CUDA + Triton, so
+/// `LensTurboAdapter` forces dequantization on non-CUDA devices); Windows/Linux use
+/// the cu128 stack. Idempotent via its own marker. Failures are non-fatal: Lens
+/// stays unavailable (LensTurboAdapter reports a clear error) while the rest of the
+/// app works. Opt out with SCENEWORKS_DISABLE_LENS=1.
 async fn provision_lens_venv(app: &AppHandle) -> Result<(), String> {
     if std::env::var("SCENEWORKS_DISABLE_LENS")
         .map(|value| matches!(value.trim(), "1" | "true" | "yes"))
@@ -582,13 +582,25 @@ async fn provision_lens_venv(app: &AppHandle) -> Result<(), String> {
     let venv = lens_venv_dir();
     let python = venv_python(&venv);
     let marker = lens_marker_path();
-    let index = std::env::var("SCENEWORKS_PYTORCH_INDEX_URL")
+    // torch / torchvision source: macOS uses the default PyPI index (its wheels
+    // bundle MPS), Windows/Linux use the cu128 index (Blackwell sm_120), where a
+    // CPU torchvision would ABI-mismatch the CUDA torch and break diffusers 0.38's
+    // Flux.2 VAE import. An explicit SCENEWORKS_PYTORCH_INDEX_URL overrides either.
+    let torch_index: Option<String> = std::env::var("SCENEWORKS_PYTORCH_INDEX_URL")
         .ok()
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "https://download.pytorch.org/whl/cu128".to_owned());
-    let expected =
-        format!("v{SETUP_VERSION}\n{LENS_TORCH_SPEC} {LENS_TORCHVISION_SPEC} @ {index}\n{body}");
+        .or_else(|| {
+            if cfg!(target_os = "macos") {
+                None
+            } else {
+                Some("https://download.pytorch.org/whl/cu128".to_owned())
+            }
+        });
+    let index_label = torch_index.as_deref().unwrap_or("pypi");
+    let expected = format!(
+        "v{SETUP_VERSION}\n{LENS_TORCH_SPEC} {LENS_TORCHVISION_SPEC} @ {index_label}\n{body}"
+    );
 
     if python.exists() {
         if let Ok(found) = std::fs::read_to_string(&marker) {
@@ -613,24 +625,25 @@ async fn provision_lens_venv(app: &AppHandle) -> Result<(), String> {
         )
         .await?;
     }
-    // torch + torchvision from the CUDA index first so they are an ABI-matched
-    // CUDA build (a CPU torchvision breaks diffusers 0.38's Flux.2 VAE import).
-    run_uv(
-        app,
-        vec![
-            "pip".to_owned(),
-            "install".to_owned(),
-            "--python".to_owned(),
-            python.to_string_lossy().into_owned(),
-            "--index-url".to_owned(),
-            index,
-            LENS_TORCH_SPEC.to_owned(),
-            LENS_TORCHVISION_SPEC.to_owned(),
-        ],
-    )
-    .await?;
+    // torch + torchvision from the resolved index first so they are an ABI-matched
+    // build (on CUDA a CPU torchvision breaks diffusers 0.38's Flux.2 VAE import;
+    // on macOS the default PyPI wheels carry MPS).
+    let mut torch_args = vec![
+        "pip".to_owned(),
+        "install".to_owned(),
+        "--python".to_owned(),
+        python.to_string_lossy().into_owned(),
+    ];
+    if let Some(ref index) = torch_index {
+        torch_args.push("--index-url".to_owned());
+        torch_args.push(index.clone());
+    }
+    torch_args.push(LENS_TORCH_SPEC.to_owned());
+    torch_args.push(LENS_TORCHVISION_SPEC.to_owned());
+    run_uv(app, torch_args).await?;
     // Then the remaining Lens deps from PyPI — they don't pin torch, so the
-    // cu128 torch/torchvision installed above stay put.
+    // torch/torchvision installed above stay put. (`kernels` installs as a no-op
+    // on macOS; the dequantized mxfp4 path never invokes its CUDA kernels.)
     run_uv(
         app,
         vec![
@@ -1129,12 +1142,11 @@ async fn run_startup(app: AppHandle) {
         return;
     }
     gate_window(app.clone());
-    // Provision the Lens sidecar venv in the background so its large cu128 torch
-    // download never blocks startup; Lens becomes usable once it finishes, while
-    // the rest of the app (incl. LTX/Z-Image/Qwen) is available immediately.
-    // Non-macOS only — Lens needs CUDA. Non-fatal: failures only mean Lens stays
+    // Provision the Lens sidecar venv in the background so its large torch download
+    // never blocks startup; Lens becomes usable once it finishes, while the rest of
+    // the app (incl. LTX/Z-Image/Qwen) is available immediately. macOS pulls MPS
+    // wheels, Windows/Linux pull cu128. Non-fatal: failures only mean Lens stays
     // unavailable.
-    #[cfg(not(target_os = "macos"))]
     {
         let lens_app = app.clone();
         tauri::async_runtime::spawn(async move {

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1034,8 +1034,13 @@ class LensTurboAdapter:
         guidance_scale = self._guidance_scale(request)
         base_resolution, aspect_ratio = lens_resolution_for(request.width, request.height)
         seeds = [resolve_seed(request.seed, request.prompt, index, request.seeds) for index in range(total)]
-        device = "cpu" if str(getattr(settings, "gpu_id", "")).strip().lower() == "cpu" else "cuda"
-        disable_mxfp4 = bool(request.advanced.get("disableMxfp4", False))
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, getattr(settings, "gpu_id", None))
+        # mxfp4 keeps the gpt-oss-20b text encoder small but needs CUDA + Triton
+        # kernels, which exist only on NVIDIA. On MPS/CPU the encoder must load
+        # dequantized to bf16 (transformers auto-falls back, but force it here so
+        # a non-CUDA host never reaches the Triton path).
+        disable_mxfp4 = bool(request.advanced.get("disableMxfp4", False)) or not device.startswith("cuda")
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']} (sidecar venv).")
         work_dir = Path(tempfile.mkdtemp(prefix="lens_sidecar_"))

--- a/apps/worker/scene_worker/lens_runner.py
+++ b/apps/worker/scene_worker/lens_runner.py
@@ -54,6 +54,12 @@ def main() -> int:
             "Lens sidecar requested a CUDA device but torch.cuda.is_available() is False in the "
             "lens venv. Rebuild the worker image with a CUDA (cu128) torch in /opt/lens-venv."
         )
+    if requested_device == "mps":
+        # Route the few ops without an MPS kernel (in the mxfp4-dequantized
+        # gpt-oss / Flux.2 VAE paths) to CPU instead of erroring. The adapter
+        # sets this too via select_torch_device; set it here so a standalone
+        # runner invocation is safe on Apple Silicon as well.
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
     dtype = {
         "float16": torch.float16,
         "float32": torch.float32,


### PR DESCRIPTION
## Summary
Extends the Windows Lens sidecar venv ([sc-1558](https://github.com/michaeltrefry/SceneWorks/pull/135) / f110c3e) to macOS. Lens-Turbo (gpt-oss-20b mxfp4 text encoder + Lens DiT + FLUX.2 VAE) now runs on Apple Silicon via PyTorch/MPS, with the text encoder dequantized to bf16 since mxfp4 needs CUDA + Triton kernels that don't exist on Mac.

- **`apps/desktop/src/setup.rs`** — un-gate `provision_lens_venv` (+ marker / requirements / spec consts) for macOS. The torch install index is now optional: `None` on macOS so torch/torchvision come from the default PyPI wheels (which carry MPS), cu128 on Windows/Linux. `requirements-lens.txt` is reused as-is — `kernels` installs as a pure-Python no-op on Mac (no Triton), and the dequantized path never invokes it.
- **`apps/worker/scene_worker/image_adapters.py`** — `LensTurboAdapter` routes via `select_torch_device` (Mac picks `mps`) instead of a hardcoded `cuda`, and forces `disableMxfp4` on any non-CUDA device. Platform-agnostic; benefits the Docker build too.
- **`apps/worker/scene_worker/lens_runner.py`** — self-sets `PYTORCH_ENABLE_MPS_FALLBACK=1` on the mps path so a standalone runner invocation is safe on Apple Silicon.

## Verification
- M5 Max (128 GB): coherent 1024×1024 image, 4 steps, `device=mps` / bf16, ~90 GB peak — so this realistically targets **96 GB+ Macs**.
- A Mac-equivalent venv (full `requirements-lens.txt` incl. `kernels` + PyPI torch 2.11) generates a byte-identical image; `kernels`' presence does not divert onto a CUDA path.
- `cargo clippy -p sceneworks-desktop --all-targets -- -D warnings` and `cargo fmt --check`: clean.
- Existing Lens unit tests unaffected (they raise before the changed adapter line).

## Test plan
- [ ] Packaged macOS launch: confirm the Lens venv provisions in the background and a queued Lens-Turbo job produces an image.
- [ ] Confirm Windows/Linux cu128 path is unchanged (regression).
- [ ] Decide whether to gate Lens-Turbo on Mac by available RAM (~90 GB peak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)