### PR TITLE
fix(worker): add torchvision dependency for SenseNova-U1 [sc-1515]

### DIFF
--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -5,6 +5,12 @@ numpy>=2.0,<3
 imageio>=2.37,<3
 imageio-ffmpeg>=0.6,<1
 torch>=2.8,<2.9
+# Required by the vendored sensenova_u1 (models/neo_unify/utils.py imports
+# torchvision.transforms). Pinned to the torch range so the build matches —
+# a CPU torchvision ABI-mismatches a CUDA torch ("operator torchvision::nms
+# does not exist"). The Docker worker installs it from the cu128 index alongside
+# torch (PYTORCH_VISION_SPEC); desktop resolves it via the same index as torch.
+torchvision>=0.23,<0.24
 # Upper bound: the vendored sensenova_u1 (NEO-unify) and ltx-core both subclass
 # transformers' Qwen3/Gemma internals, which 4.58+ may rearrange; keep on 4.57.x.
 transformers>=4.57,<4.58

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
         PYTORCH_INDEX_URL: ${SCENEWORKS_PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu128}
         PYTORCH_SPEC: ${SCENEWORKS_PYTORCH_SPEC:-torch>=2.8,<2.9}
         PYTORCH_AUDIO_SPEC: ${SCENEWORKS_PYTORCH_AUDIO_SPEC:-torchaudio>=2.8,<2.9}
+        # torchvision (matched to torch) for the vendored sensenova_u1 (SenseNova-U1).
+        PYTORCH_VISION_SPEC: ${SCENEWORKS_PYTORCH_VISION_SPEC:-torchvision>=0.23,<0.24}
         INCLUDE_LTX_PIPELINES: ${SCENEWORKS_INCLUDE_LTX_PIPELINES:-1}
         # Lens sidecar venv (/opt/lens-venv): its own cu128 torch 2.11 +
         # torchvision + transformers 5.8 + diffusers 0.38, isolated from the main

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.12-slim AS builder
 ARG PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
 ARG PYTORCH_SPEC=torch>=2.8,<2.9
 ARG PYTORCH_AUDIO_SPEC=torchaudio>=2.8,<2.9
+# torchvision is required by the vendored sensenova_u1 (SenseNova-U1 T2I). Install
+# it from the same index as torch so it's an ABI-matched build — a CPU torchvision
+# against a CUDA torch breaks with "operator torchvision::nms does not exist".
+ARG PYTORCH_VISION_SPEC=torchvision>=0.23,<0.24
 ARG INCLUDE_LTX_PIPELINES=1
 # Real person detection/tracking/segmentation backends (ultralytics + SAM2) for
 # the Replace Person workflow (epic sc-1090). Opt-in like the LTX pipelines.
@@ -32,7 +36,7 @@ COPY apps/worker/requirements.txt ./requirements.txt
 COPY apps/worker/requirements-ltx.txt ./requirements-ltx.txt
 COPY apps/worker/requirements-person.txt ./requirements-person.txt
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --no-compile --index-url "${PYTORCH_INDEX_URL}" "${PYTORCH_SPEC}" "${PYTORCH_AUDIO_SPEC}" \
+    && pip install --no-cache-dir --no-compile --index-url "${PYTORCH_INDEX_URL}" "${PYTORCH_SPEC}" "${PYTORCH_AUDIO_SPEC}" "${PYTORCH_VISION_SPEC}" \
     && pip freeze | grep -E '^(torch|torchaudio|torchvision|nvidia-|triton)==.*' > /tmp/torch-constraints.txt \
     && pip install --no-cache-dir --no-compile -c /tmp/torch-constraints.txt -r requirements.txt \
     && if [ "${INCLUDE_LTX_PIPELINES}" = "1" ]; then pip install --no-cache-dir --no-compile -c /tmp/torch-constraints.txt -r requirements-ltx.txt; fi \


### PR DESCRIPTION
## Summary
Follow-up to [#139](https://github.com/michaeltrefry/SceneWorks/pull/139). The vendored `sensenova_u1` imports `torchvision.transforms` (`models/neo_unify/utils.py`) at module load, but `torchvision` wasn't in the main worker venv — no other adapter needs it — so a SenseNova-U1 T2I job failed at generation time with **`No module named 'torchvision'`**. (The pre-merge import check passed only because the spike venv happened to have torchvision installed.)

- **`requirements.txt`**: add `torchvision>=0.23,<0.24` (matched to `torch>=2.8,<2.9`).
- **`docker/worker.Dockerfile`**: install it from the cu128 index alongside torch via a new `PYTORCH_VISION_SPEC` arg — a CPU torchvision ABI-mismatches a CUDA torch (`operator torchvision::nms does not exist`). The constraints grep already covers torchvision, so the second requirements pass keeps the cu128 build.
- **`docker-compose.yml`**: pass `PYTORCH_VISION_SPEC` (env-overridable).

Confirmed `torchvision` is the only module-level dep the vendored package needs beyond the existing worker stack (PIL/httpx/numpy/safetensors/torch/transformers all present).

## Verification
- Installed `torchvision==0.23.0` into the local desktop worker venv (torch 2.8) → `import sensenova_u1` now resolves; the SenseNova-U1 T2I path is unblocked on Apple Silicon (MPS).
- Desktop auto-re-provisions: the venv marker hashes `requirements.txt`, so this change invalidates it and reinstalls on next launch. Docker picks it up from the cu128 index on rebuild.

## Test plan
- [ ] Docker worker rebuild: confirm `torchvision` resolves to the cu128 build (not CPU) and a SenseNova-U1 job runs on CUDA.
- [ ] Desktop relaunch (Windows + Mac): confirm re-provision installs torchvision and a SenseNova-U1 T2I job completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)