### PR TITLE
fix(worker): force UTF-8 stdio so the Windows worker survives transformers' auto_docstring emoji [sc-1515]

### DIFF
--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1042,7 +1042,31 @@ def run_check(settings: WorkerSettings) -> None:
     )
 
 
+def _force_utf8_stdio() -> None:
+    """Force stdout/stderr to UTF-8 so the worker survives non-ASCII library output.
+
+    On Windows the worker's stdout/stderr default to the locale code page (cp1252
+    for en-US), so any dependency that ``print()``s a non-Latin-1 character raises
+    UnicodeEncodeError and kills the process. transformers' ``@auto_docstring``
+    decorator unconditionally prints an "undocumented parameters" developer notice
+    containing a 🚨 emoji while decorating the vendored SenseNova-U1 model classes
+    (and would for other models too), which crashed ``import sensenova_u1`` on
+    Windows. UTF-8 is already the default on Linux/macOS, so this is a no-op there.
+    The JSON events the worker emits on stdout are ASCII (json.dumps ensure_ascii),
+    so widening the encoding never changes the IPC bytes.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
+
+
 def main(argv: list[str] | None = None) -> None:
+    _force_utf8_stdio()
     args = list(sys.argv[1:] if argv is None else argv)
     settings = WorkerSettings()
     if args == ["--check"]:


### PR DESCRIPTION
## What

Adds `_force_utf8_stdio()` to `apps/worker/scene_worker/runtime.py`, called first in `main()`, to reconfigure the worker's stdout/stderr to UTF-8 (`errors="replace"`) at startup.

## Why

Validating the in-process **SenseNova-U1** T2I adapter on **Windows + CUDA** (RTX PRO 6000 — the analogue of the M5 Max/MPS validation in `fdd6c0a`) surfaced a Windows-only crash macOS could not:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f6a8' (🚨)
```

transformers' `@auto_docstring` decorator unconditionally `print()`s an "undocumented parameters" developer notice containing a 🚨 emoji while decorating the vendored Qwen3/Qwen3-MoE classes. On Windows the worker's stdout/stderr default to the locale code page (**cp1252**), which can't encode the emoji, so the print raises and kills `import sensenova_u1` — and thus any SenseNova-U1 job. macOS/Linux default to UTF-8 and never hit it. The desktop sidecar launch sets only `PYTHONPATH` (not `PYTHONUTF8`), so the **shipped Windows app is affected too**.

This is **not specific to SenseNova-U1**: any transformers/diffusers model class with "undocumented" forward params triggers the same print, making it a worker-wide Windows hazard.

## Notes for reviewers

- **No-op on Linux/macOS** (already UTF-8).
- **Safe for the IPC channel:** the JSON events the worker emits on stdout are ASCII (`json.dumps` `ensure_ascii`), so widening the encoding never changes the bytes the Rust host parses; the host already tolerates non-JSON library output on the stream (model loading prints to it constantly).
- The companion missing-`torchvision` dependency was fixed separately in #140 (already on `main`); this branch is merged up to it, so the diff here is just the stdio fix.
- **Follow-up:** the Lens sidecar (`lens_runner.py`) is a separate process that bypasses `runtime.main()` and will hit the same cp1252 crash on Windows — should get the same reconfigure.

## Validation

Clean cu128 venv (`torch 2.8.0+cu128` / `torchvision 0.23.0+cu128` / `transformers 4.57.6`), mirroring the desktop install. The adapter's exact generation path produced a coherent **2048²** image — bf16 + SDPA (no flash-attn), **~0.96 s/step** over 50 steps, **peak 34.8 GiB**. `runtime.py` byte-compiles and `scene_worker.runtime` imports cleanly with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)