### PR TITLE
feat(image): multi-aspect SenseNova-U1 output (model-aware resolution picker) [sc-1573]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2928,8 +2928,8 @@ fn apply_recipe_preset_defaults(
     }
     if let Some(resolution) = defaults.get("resolution").and_then(Value::as_str) {
         let (width, height) = parse_recipe_preset_resolution(resolution)?;
-        validate_dimension(width, "width", 2048)?;
-        validate_dimension(height, "height", 2048)?;
+        validate_dimension(width, "width", MAX_IMAGE_DIMENSION)?;
+        validate_dimension(height, "height", MAX_IMAGE_DIMENSION)?;
         job_payload.insert("width".to_owned(), json!(width));
         job_payload.insert("height".to_owned(), json!(height));
         let advanced = job_payload
@@ -5893,8 +5893,8 @@ fn validate_recipe_preset_defaults(value: Option<&Value>) -> Result<(), ApiError
         .ok_or_else(|| ApiError::bad_request("Recipe preset defaults must be an object"))?;
     if let Some(resolution) = object.get("resolution").and_then(Value::as_str) {
         let (width, height) = parse_recipe_preset_resolution(resolution)?;
-        validate_dimension(width, "width", 2048)?;
-        validate_dimension(height, "height", 2048)?;
+        validate_dimension(width, "width", MAX_IMAGE_DIMENSION)?;
+        validate_dimension(height, "height", MAX_IMAGE_DIMENSION)?;
     }
     if let Some(count) = object.get("count").and_then(Value::as_u64) {
         if !(1..=8).contains(&count) {
@@ -7539,8 +7539,8 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
     if !(1..=8).contains(&payload.count) {
         return Err(ApiError::bad_request("count must be between 1 and 8"));
     }
-    validate_dimension(payload.width, "width", 2048)?;
-    validate_dimension(payload.height, "height", 2048)?;
+    validate_dimension(payload.width, "width", MAX_IMAGE_DIMENSION)?;
+    validate_dimension(payload.height, "height", MAX_IMAGE_DIMENSION)?;
     Ok(())
 }
 
@@ -7553,8 +7553,8 @@ fn validate_character_test_job(payload: &CharacterTestRequest) -> Result<(), Api
     if !(1..=8).contains(&payload.count) {
         return Err(ApiError::bad_request("count must be between 1 and 8"));
     }
-    validate_dimension(payload.width, "width", 2048)?;
-    validate_dimension(payload.height, "height", 2048)?;
+    validate_dimension(payload.width, "width", MAX_IMAGE_DIMENSION)?;
+    validate_dimension(payload.height, "height", MAX_IMAGE_DIMENSION)?;
     Ok(())
 }
 
@@ -7625,6 +7625,11 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         _ => Ok(()),
     }
 }
+
+/// Upper bound for image width/height. A backstop only — per-model resolution is
+/// governed by manifest `limits.resolutions` + the UI. Covers SenseNova-U1's
+/// largest trained bucket (3456) with headroom; video uses its own lower cap.
+const MAX_IMAGE_DIMENSION: u32 = 4096;
 
 fn validate_dimension(value: u32, field: &'static str, max: u32) -> Result<(), ApiError> {
     if !(256..=max).contains(&value) {
@@ -12625,6 +12630,17 @@ mod tests {
         });
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn image_dimension_cap_covers_sensenova_buckets() {
+        // Raised so SenseNova-U1's true trained buckets (largest 3456) pass.
+        assert_eq!(super::MAX_IMAGE_DIMENSION, 4096);
+        assert!(super::validate_dimension(2720, "width", super::MAX_IMAGE_DIMENSION).is_ok());
+        assert!(super::validate_dimension(3456, "height", super::MAX_IMAGE_DIMENSION).is_ok());
+        assert!(super::validate_dimension(4096, "width", super::MAX_IMAGE_DIMENSION).is_ok());
+        assert!(super::validate_dimension(4097, "width", super::MAX_IMAGE_DIMENSION).is_err());
+        assert!(super::validate_dimension(255, "width", super::MAX_IMAGE_DIMENSION).is_err());
     }
 
     #[tokio::test]

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -42,6 +42,7 @@ export const fallbackModels = [
     name: "SenseNova-U1 8B",
     type: "image",
     capabilities: ["text_to_image"],
+    limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
     ui: { description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image with strong text rendering and infographics. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon." },
   },
   {
@@ -49,6 +50,7 @@ export const fallbackModels = [
     name: "SenseNova-U1 8B Fast",
     type: "image",
     capabilities: ["text_to_image"],
+    limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
     ui: { description: "8-step distilled SenseNova-U1; ~5-6x faster text-to-image (~50s/image on MPS) at a small quality trade-off. Shares the base 8B weights; a ~0.4GB distill LoRA downloads automatically." },
   },
   {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4367,6 +4367,48 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("aspect picker reflects the selected model's trained buckets", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[]}
+          characters={[]}
+          createImageJob={() => {}}
+          deleteAsset={() => {}}
+          gpuOptions={["auto", "1"]}
+          imageModels={[
+            {
+              id: "sensenova_u1_8b",
+              name: "SenseNova-U1 8B",
+              type: "image",
+              family: "sensenova-u1",
+              defaults: { resolution: "2048x2048" },
+              limits: { resolutions: ["2048x2048", "2720x1536", "1536x2720"] },
+            },
+          ]}
+          latestAssets={[]}
+          loras={[]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          presets={[]}
+          requestedGpu="auto"
+          selectedAsset={null}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    const aspect = field(container, "Aspect");
+    const optionValues = [...aspect.querySelectorAll("option")].map((option) => option.value);
+    expect(optionValues).toEqual(["2048x2048", "2720x1536", "1536x2720"]);
+    // 1024x1024 isn't a SenseNova bucket, so the picker snaps to the model default.
+    expect(aspect.value).toBe("2048x2048");
+  });
+
   it("surfaces model and preset first and lets image generation run with no preset", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -42,6 +42,14 @@ import {
 } from "../presetUtils.js";
 
 const completedResultFallbackMs = 30000;
+// Used only for models that don't declare limits.resolutions (e.g. user-imported).
+const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x1280"];
+
+function formatResolutionLabel(value) {
+  const [width, height] = String(value).split("x");
+  return height ? `${width} × ${height}` : value;
+}
+
 const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
 const localErrorLabels = {
   failed: "Failed",
@@ -223,6 +231,28 @@ export function ImageStudio({
     return item.type === "image";
   });
   const selectedModel = imageModels.find((item) => item.id === model);
+  const resolutionOptions = useMemo(
+    () =>
+      selectedModel?.limits?.resolutions?.length
+        ? selectedModel.limits.resolutions
+        : DEFAULT_RESOLUTION_OPTIONS,
+    [selectedModel],
+  );
+  // Keep the selected resolution valid for the current model's buckets. Switching
+  // to a model whose options exclude the current value snaps to its default (or
+  // 1024x1024, then the first option) rather than leaving a stale, unselectable value.
+  useEffect(() => {
+    if (resolutionOptions.includes(resolution)) {
+      return;
+    }
+    const modelDefault = selectedModel?.defaults?.resolution;
+    const preferred = resolutionOptions.includes(modelDefault)
+      ? modelDefault
+      : resolutionOptions.includes("1024x1024")
+        ? "1024x1024"
+        : resolutionOptions[0];
+    setResolution(preferred);
+  }, [resolutionOptions, resolution, selectedModel?.defaults?.resolution]);
   const availablePresets = useMemo(() => {
     return presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel));
   }, [mode, presets, selectedModel?.id]);
@@ -640,10 +670,9 @@ export function ImageStudio({
               <label>
                 Aspect
                 <select onChange={(event) => setResolution(event.target.value)} value={resolution}>
-                  <option value="768x768">768 × 768</option>
-                  <option value="1024x1024">1024 × 1024</option>
-                  <option value="1280x720">1280 × 720</option>
-                  <option value="720x1280">720 × 1280</option>
+                  {resolutionOptions.map((option) => (
+                    <option key={option} value={option}>{formatResolutionLabel(option)}</option>
+                  ))}
                 </select>
               </label>
             </div>

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -306,8 +306,11 @@ def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
         count=safe_int(payload.get("count"), 4, 1, 8),
         seed=payload.get("seed"),
         seeds=[int(seed) for seed in payload.get("seeds", []) if seed is not None],
-        width=safe_int(payload.get("width"), 1024, 256, 2048),
-        height=safe_int(payload.get("height"), 1024, 256, 2048),
+        # Backstop only — per-model resolution is governed by manifest limits + the UI.
+        # SenseNova-U1's trained buckets reach 3456 (the adapter snaps by aspect ratio),
+        # so this clamp must allow the requested ratio through rather than truncate it.
+        width=safe_int(payload.get("width"), 1024, 256, 4096),
+        height=safe_int(payload.get("height"), 1024, 256, 4096),
         style_preset=payload.get("stylePreset", "cinematic"),
         loras=payload.get("loras", []),
         character_id=payload.get("characterId"),

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -222,11 +222,10 @@
       },
       "limits": {
         // SenseNova-U1 renders at fixed trained buckets and degrades off them.
-        // Only the 1:1 (2048²) bucket fits the worker's ≤2048 W/H clamp today;
-        // the wider 16:9/3:2/4:3 buckets (2720×1536, …) need that clamp raised —
-        // tracked as a follow-up. The adapter snaps any request to the nearest
-        // bucket by aspect ratio regardless.
-        "resolutions": ["2048x2048"],
+        // These are the true output sizes; the adapter snaps any request to the
+        // nearest bucket by aspect ratio. (Panorama buckets 2:1/1:2/3:1/1:3 exist
+        // upstream but are omitted here.)
+        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
@@ -269,9 +268,9 @@
         "count": 1
       },
       "limits": {
-        // Same trained buckets as the base model; only 1:1 (2048²) fits the
-        // worker's ≤2048 W/H clamp today. The adapter snaps to the nearest bucket.
-        "resolutions": ["2048x2048"],
+        // Same trained buckets as the base model; true output sizes (the adapter
+        // snaps any request to the nearest bucket by aspect ratio).
+        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
         "count": [1, 2, 4]
       },
       "loraCompatibility": {

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -987,6 +987,22 @@ def test_sensenova_resolution_for_snaps_to_buckets():
     assert sensenova_resolution_for(1500, 1000) == (2496, 1664)
 
 
+def test_image_request_allows_sensenova_wide_buckets():
+    # The W/H clamp was raised (2048 -> 4096) so SenseNova's true trained buckets
+    # (up to 3456) survive into the adapter, which snaps by the requested aspect
+    # ratio. Truncating 2720x1536 to 2048x1536 would mis-snap 16:9 to a ~4:3 bucket.
+    request = image_request_from_job({"payload": {"projectId": "p", "width": 2720, "height": 1536}})
+    assert (request.width, request.height) == (2720, 1536)
+    assert sensenova_resolution_for(request.width, request.height) == (2720, 1536)
+    assert sensenova_resolution_for(2048, 1536) != (2720, 1536)
+
+
+def test_image_request_clamps_above_new_ceiling():
+    request = image_request_from_job({"payload": {"projectId": "p", "width": 9000, "height": 9000}})
+    assert request.width == 4096
+    assert request.height == 4096
+
+
 def test_create_image_adapter_routes_sensenova_u1_fast():
     adapter = create_image_adapter({"payload": {"model": "sensenova_u1_8b_fast"}})
     assert adapter.__class__.__name__ == "SenseNovaU1Adapter"


### PR DESCRIPTION
## Summary

Second slice of epic [#1571](https://app.shortcut.com/trefry/epic/1571). Lets users generate **SenseNova-U1 at its non-1:1 trained buckets** (16:9 → 2720×1536, 4:3 → 2368×1760, 3:2 → 2496×1664, plus portraits), not just 2048². Story: [sc-1573](https://app.shortcut.com/trefry/story/1573). (sc-1572 already merged via #142.)

The adapter already snaps any request to the nearest bucket by aspect ratio; the blocker was the model-agnostic ≤2048 W/H cap, which truncated wide-bucket dims and mis-snapped the aspect.

## What changed
- **`apps/rust-api/src/lib.rs`** — new `MAX_IMAGE_DIMENSION = 4096` const replaces the `2048` literal at the four **image-path** `validate_dimension` sites (recipe preset, recipe-defaults validation, image gen, character image). Video's `1920` cap is untouched.
- **`apps/worker/scene_worker/image_adapters.py`** — `image_request_from_job` clamp raised 2048 → 4096 so true bucket dims (e.g. 2720) reach the adapter and snap to the correct aspect instead of being truncated.
- **`apps/web/src/screens/ImageStudio.jsx`** — the Aspect picker (previously a hardcoded 4-option list) now reads the selected model's `limits.resolutions` (fallback to the prior list for models without it), and resets to the model default when switching to a model whose buckets exclude the current value.
- **`config/manifests/builtin.models.jsonc`** + **`apps/web/src/constants.js`** — SenseNova `limits.resolutions` now list the true trained buckets.

## Notes for reviewers
- **Why raising the cap is safe.** The picker is model-scoped, so Z-Image/Qwen/Lens never request >2048 via the UI; the cap is a backstop. Z-Image/Qwen options are byte-for-byte unchanged. Side effect: image-model `limits.resolutions` were defined in the manifest but previously **ignored** by the picker — this makes them load-bearing, so Lens-Turbo now also exposes its real buckets.
- **No real-MPS run needed for this AC** — output size is deterministic from the bucket. Selecting 16:9 sends 2720×1536; truncation to 2048 (the old behavior) would mis-snap 16:9 to a ~4:3 bucket (covered by a new test).

## Verification
- web vitest **92**, worker pytest **188**, rust fmt + clippy `-D warnings` + test **52**, scaffold ✓
- New tests: worker clamp allows >2048 / would mis-snap if truncated; rust dimension-cap boundary; web picker reflects the model's buckets + default snapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)