### PR TITLE
feat(image): SenseNova-U1 instruction editing (it2i) [sc-1574]

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -41,9 +41,9 @@ export const fallbackModels = [
     id: "sensenova_u1_8b",
     name: "SenseNova-U1 8B",
     type: "image",
-    capabilities: ["text_to_image"],
+    capabilities: ["text_to_image", "edit_image"],
     limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
-    ui: { description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image with strong text rendering and infographics. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon." },
+    ui: { description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon." },
   },
   {
     id: "sensenova_u1_8b_fast",

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4662,6 +4662,53 @@ describe("SceneWorks app shell", () => {
     expect(createImageJob).toHaveBeenCalledWith(expect.objectContaining({ model: "qwen_image", recipePresetId: "qwen_detail" }));
   });
 
+  it("offers SenseNova-U1 in edit mode via its edit_image capability", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ImageStudio
+          activeProject={{ id: "project-1", name: "Noir" }}
+          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
+          characters={[]}
+          createImageJob={() => {}}
+          deleteAsset={() => {}}
+          gpuOptions={["auto"]}
+          imageModels={[
+            { id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image", capabilities: ["text_to_image"] },
+            {
+              id: "sensenova_u1_8b",
+              name: "SenseNova-U1 8B",
+              type: "image",
+              family: "sensenova-u1",
+              capabilities: ["text_to_image", "edit_image"],
+              limits: { resolutions: ["2048x2048"] },
+            },
+          ]}
+          latestAssets={[]}
+          loras={[]}
+          onPreview={() => {}}
+          purgeAsset={() => {}}
+          presets={[]}
+          requestedGpu="auto"
+          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
+          setRequestedGpu={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "Edit").click();
+    });
+    await settle();
+
+    const modelValues = [...field(container, "Model").querySelectorAll("option")].map((option) => option.value);
+    expect(modelValues).toContain("sensenova_u1_8b");
+    // The text-to-image-only model is filtered out of the edit-mode picker.
+    expect(modelValues).not.toContain("z_image_turbo");
+  });
+
   it("uses preset modes as the Image Studio picker surface", async () => {
     root = createRoot(container);
     await act(async () => {

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -244,7 +244,8 @@ MODEL_TARGETS = {
     "sensenova_u1_8b": {
         "label": "SenseNova-U1 8B",
         "family": "sensenova-u1",
-        "supportsEdit": False,
+        # Unified model: same weights do text-to-image and instruction editing (it2i).
+        "supportsEdit": True,
         # Base 8B-MoT uses ~50 steps; an 8-step distill LoRA exists (cfg 1.0).
         "steps": 50,
         "repo": "sensenova/SenseNova-U1-8B-MoT",
@@ -1308,10 +1309,10 @@ class SenseNovaU1Adapter:
     type, so ``AutoModel.from_pretrained`` resolves it with no trust_remote_code.
     Attention uses torch SDPA (flash-attn optional), so it runs on CUDA and MPS.
 
-    Text-to-image only for now — no edit/img2img, VQA, or interleaved. The
-    ``sensenova_u1_8b_fast`` variant merges the upstream 8-step distill LoRA at
-    load (see ``distillLora`` in MODEL_TARGETS); user-supplied LoRAs are still
-    rejected.
+    Supports text-to-image and instruction-based editing (it2i); VQA and
+    interleaved generation are not wired yet. The ``sensenova_u1_8b_fast``
+    variant merges the upstream 8-step distill LoRA at load (see ``distillLora``
+    in MODEL_TARGETS); user-supplied LoRAs are still rejected.
     """
 
     id = "sensenova_u1"
@@ -1351,6 +1352,14 @@ class SenseNovaU1Adapter:
         except (TypeError, ValueError):
             return default
 
+    @staticmethod
+    def _image_guidance_scale(request: ImageRequest) -> float:
+        # Image-conditioning guidance for editing (it2i); upstream default is 1.0.
+        try:
+            return float(request.advanced.get("imageGuidanceScale", 1.0))
+        except (TypeError, ValueError):
+            return 1.0
+
     def generate(
         self,
         *,
@@ -1360,12 +1369,13 @@ class SenseNovaU1Adapter:
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
         request = image_request_from_job(job)
-        if request.mode == "edit_image":
-            raise RuntimeError(f"{request.model} does not support image editing.")
         reject_loras_if_unsupported(request.loras, self.id)
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["sensenova_u1_8b"])
         if model_target.get("adapter") != self.id:
             raise RuntimeError(f"{request.model} is not a SenseNova-U1 target.")
+        is_edit = request.mode == "edit_image"
+        if is_edit and not model_supports_edit(request.model):
+            raise RuntimeError(f"{request.model} does not support image editing.")
 
         torch = importlib.import_module("torch")
         require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
@@ -1377,7 +1387,9 @@ class SenseNovaU1Adapter:
         steps = self._num_inference_steps(request, model_target)
         guidance_scale = self._guidance_scale(request, model_target)
         timestep_shift = float(request.advanced.get("timestepShift", 3.0) or 3.0)
+        img_guidance_scale = self._image_guidance_scale(request)
         width, height = sensenova_resolution_for(request.width, request.height)
+        source_image = load_source_image(settings, request) if is_edit else None
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
         model, tokenizer = self._load_model(torch, repo, device, dtype, distill_lora=distill_lora, job_id=job["id"])
@@ -1404,10 +1416,16 @@ class SenseNovaU1Adapter:
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                image = self._run_inference(
-                    torch, model, tokenizer, request.prompt,
-                    width, height, steps, guidance_scale, timestep_shift, seed,
-                )
+                if is_edit:
+                    image = self._run_edit_inference(
+                        torch, model, tokenizer, request.prompt, source_image,
+                        width, height, steps, guidance_scale, img_guidance_scale, timestep_shift, seed,
+                    )
+                else:
+                    image = self._run_inference(
+                        torch, model, tokenizer, request.prompt,
+                        width, height, steps, guidance_scale, timestep_shift, seed,
+                    )
             except Exception as exc:
                 emit_worker_event(
                     "image_inference_failed",
@@ -1440,6 +1458,7 @@ class SenseNovaU1Adapter:
                 "repo": repo,
                 "numInferenceSteps": steps,
                 "guidanceScale": guidance_scale,
+                **({"imageGuidanceScale": img_guidance_scale} if is_edit else {}),
                 "timestepShift": timestep_shift,
                 "resolution": f"{width}x{height}",
                 "realModelInference": True,
@@ -1563,6 +1582,42 @@ class SenseNovaU1Adapter:
                 prompt,
                 image_size=(width, height),
                 cfg_scale=guidance_scale,
+                cfg_norm="none",
+                timestep_shift=timestep_shift,
+                cfg_interval=(0.0, 1.0),
+                num_steps=steps,
+                batch_size=1,
+                seed=seed,
+                think_mode=False,
+            )
+        return self._to_pil(torch, tensor)[0]
+
+    def _run_edit_inference(
+        self,
+        torch: Any,
+        model: Any,
+        tokenizer: Any,
+        prompt: str,
+        source_image: Image.Image,
+        width: int,
+        height: int,
+        steps: int,
+        guidance_scale: float,
+        img_guidance_scale: float,
+        timestep_shift: float,
+        seed: int,
+    ) -> Image.Image:
+        # Instruction-based editing (it2i): the source image is the conditioning
+        # input; `image_size` is the output bucket. Defaults mirror the upstream
+        # editing example (cfg 4.0 text / 1.0 image, 50 steps, shift 3.0).
+        with torch.inference_mode():
+            tensor = model.it2i_generate(
+                tokenizer,
+                prompt,
+                [source_image],
+                image_size=(width, height),
+                cfg_scale=guidance_scale,
+                img_cfg_scale=img_guidance_scale,
                 cfg_norm="none",
                 timestep_shift=timestep_shift,
                 cfg_interval=(0.0, 1.0),

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -202,7 +202,7 @@
       "family": "sensenova-u1",
       "type": "image",
       "adapter": "sensenova_u1",
-      "capabilities": ["text_to_image"],
+      "capabilities": ["text_to_image", "edit_image"],
       "downloads": [
         {
           "provider": "huggingface",
@@ -235,8 +235,8 @@
       },
       "ui": {
         "label": "SenseNova-U1 8B",
-        "description": "Unified multimodal model (NEO-unify, ~16B). Native text-to-image with strong prompt following, dense text, and infographics. Heavy: ~42GB bf16, ~50 steps; runs on large-VRAM GPUs and 96GB+ Apple Silicon (MPS). Edit/VQA/interleaved not wired yet.",
-        "recommendedFor": ["text_to_image"]
+        "description": "Unified multimodal model (NEO-unify, ~16B). Native text-to-image and instruction-based editing with strong prompt following, dense text, and infographics. Heavy: ~42GB bf16, ~50 steps; runs on large-VRAM GPUs and 96GB+ Apple Silicon (MPS). VQA/interleaved not wired yet.",
+        "recommendedFor": ["text_to_image", "edit_image"]
       }
     },
     {

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -231,7 +231,7 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         ("image", "z-image") => vec!["text_to_image", "character_image", "style_variations"],
         ("image", "qwen-image") => vec!["text_to_image", "style_variations"],
         ("image", "lens") => vec!["text_to_image", "style_variations"],
-        ("image", "sensenova-u1") => vec!["text_to_image"],
+        ("image", "sensenova-u1") => vec!["text_to_image", "edit_image"],
         ("video", "ltx-video") => vec![
             "image_to_video",
             "text_to_video",
@@ -961,5 +961,12 @@ mod tests {
         .expect("write index");
         let family = detect_model_family(temp.path()).expect("detect");
         assert!(family.is_none());
+    }
+
+    #[test]
+    fn sensenova_u1_image_family_supports_text_to_image_and_edit() {
+        let caps = model_capabilities_for_type_and_family("image", "sensenova-u1");
+        assert!(caps.contains(&"text_to_image"));
+        assert!(caps.contains(&"edit_image"));
     }
 }

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -34,6 +34,7 @@ from scene_worker.image_adapters import (
     image_batch_progress,
     image_request_from_job,
     lens_resolution_for,
+    model_supports_edit,
     pipeline_component_devices,
     require_inference_backend_for_gpu_worker,
     resolve_seed,
@@ -954,17 +955,26 @@ def test_sensenova_u1_model_target_defaults():
     assert target["adapter"] == "sensenova_u1"
     assert target["family"] == "sensenova-u1"
     assert target["steps"] == 50
-    assert target["supportsEdit"] is False
+    # Unified model: the base entry supports instruction editing (it2i).
+    assert target["supportsEdit"] is True
     assert target["repo"] == "sensenova/SenseNova-U1-8B-MoT"
 
 
-def test_sensenova_u1_rejects_image_edit():
+def test_sensenova_u1_edit_support():
+    # The base unified model edits; the distill (fast) variant is text-to-image only.
+    assert model_supports_edit("sensenova_u1_8b") is True
+    assert model_supports_edit("sensenova_u1_8b_fast") is False
+
+
+def test_sensenova_u1_fast_rejects_image_edit():
+    # The worker guard backstops the capability list: the fast variant must reject
+    # edit jobs before any model load (it doesn't advertise edit_image).
     job = {
-        "id": "job_sensenova_edit",
+        "id": "job_sensenova_fast_edit",
         "payload": {
             "projectId": "project_x",
             "mode": "edit_image",
-            "model": "sensenova_u1_8b",
+            "model": "sensenova_u1_8b_fast",
             "prompt": "a cat",
         },
     }
@@ -974,7 +984,7 @@ def test_sensenova_u1_rejects_image_edit():
     except RuntimeError as exc:
         assert "does not support image editing" in str(exc)
     else:
-        raise AssertionError("SenseNova-U1 is text-to-image only and must reject edit_image.")
+        raise AssertionError("The SenseNova-U1 fast variant must reject edit_image.")
 
 
 def test_sensenova_resolution_for_snaps_to_buckets():


### PR DESCRIPTION
## Summary

Third slice of epic [#1571](https://app.shortcut.com/trefry/epic/1571). Enables the **`edit_image` mode for SenseNova-U1 8B** (instruction-based editing) via the vendored `it2i_generate`. Story: [sc-1574](https://app.shortcut.com/trefry/story/1574). (sc-1572/sc-1573 already merged.)

SenseNova-U1 is a unified model — the same weights do text-to-image and editing — so this advertises the capability on the **existing** model entry rather than adding a separate `_edit` model (no extra 35 GB download). The UI's Edit mode already filters models by the `edit_image` capability, so no UI plumbing is needed.

## What changed
- **`apps/worker/scene_worker/image_adapters.py`** — `SenseNovaU1Adapter` drops the T2I-only edit rejection and adds the it2i path: load the source asset via `load_source_image`, call `model.it2i_generate([source], image_size=<snapped bucket>, …)`. Defaults mirror the upstream `examples/editing/inference.py`: `cfg_scale=4.0` (text), `img_cfg_scale=1.0` (image, tunable via `advanced.imageGuidanceScale`), `num_steps=50`, `timestep_shift=3.0`, `cfg_norm="none"`. `supportsEdit:true` on the base MODEL_TARGETS entry.
- **`config/manifests/builtin.models.jsonc`** + **`apps/web/src/constants.js`** — `edit_image` added to `sensenova_u1_8b` capabilities; description updated.
- **`crates/sceneworks-core/src/lora_family.rs`** — the `("image","sensenova-u1")` family capability map now includes `edit_image`.
- The fast distill variant (`sensenova_u1_8b_fast`) stays text-to-image only; the worker guard backstops the capability list and rejects edit jobs for it.

## Notes for reviewers
- Output sizing reuses `load_source_image` (resize to the requested resolution), consistent with how Z-Image/Qwen editing already behaves; with sc-1573 the requested resolution is a true SenseNova bucket, so the source isn't distorted when the user picks the matching aspect.
- The "coherent edited image" AC needs a real MPS/CUDA run; cfg defaults are the upstream editing values and are tunable.

## Verification
- web vitest **93**, worker pytest **189**, rust fmt + clippy `-D warnings` + test (workspace), scaffold ✓
- New tests: base supports edit / fast variant rejects it (worker); family capability map includes `edit_image` (rust); SenseNova surfaces in the edit-mode model picker (web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)