### PR TITLE
fix(image): reset model when the mode switch filters it out [sc-1574]

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4707,6 +4707,9 @@ describe("SceneWorks app shell", () => {
     expect(modelValues).toContain("sensenova_u1_8b");
     // The text-to-image-only model is filtered out of the edit-mode picker.
     expect(modelValues).not.toContain("z_image_turbo");
+    // The selected model resets to an edit-capable one, so Generate doesn't submit
+    // the (filtered-out) text default and get rejected by the worker.
+    expect(field(container, "Model").value).toBe("sensenova_u1_8b");
   });
 
   it("uses preset modes as the Image Studio picker surface", async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -223,13 +223,25 @@ export function ImageStudio({
     }
   }, [characters, characterId]);
 
-  const availableModels = imageModels.filter((item) => {
-    const caps = item.capabilities ?? [];
-    if (mode === "edit_image") {
-      return caps.includes("edit_image") || caps.includes("image_edit");
+  const availableModels = useMemo(
+    () =>
+      imageModels.filter((item) => {
+        const caps = item.capabilities ?? [];
+        if (mode === "edit_image") {
+          return caps.includes("edit_image") || caps.includes("image_edit");
+        }
+        return item.type === "image";
+      }),
+    [imageModels, mode],
+  );
+  // When the mode change filters out the current model (e.g. Lens-Turbo is the
+  // text default but isn't edit-capable), snap to the first available model so
+  // the dropdown's displayed option matches the value actually submitted.
+  useEffect(() => {
+    if (availableModels.length && !availableModels.some((item) => item.id === model)) {
+      setModel(availableModels[0].id);
     }
-    return item.type === "image";
-  });
+  }, [availableModels, model]);
   const selectedModel = imageModels.find((item) => item.id === model);
   const resolutionOptions = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Bug fix found while testing SenseNova-U1 editing ([sc-1574](https://app.shortcut.com/trefry/story/1574) / #145, now merged).

**Symptom:** with Lens-Turbo as the text-mode default, switching to **Edit** mode and clicking Generate fails with `lens_turbo does not support image editing`.

**Cause:** Edit mode filters the model picker to edit-capable models, but the selected `model` state wasn't re-synced. The `<select>` *displayed* the first edit-capable model (SenseNova) while the underlying state stayed `lens_turbo`, so Generate submitted `lens_turbo` with `edit_image` and the worker rejected it. Pre-existing (the model-reset effect only checked membership in the full model list, not the mode-filtered list), but surfaced now that SenseNova makes Edit mode broadly useful.

## Fix
`apps/web/src/screens/ImageStudio.jsx` — memoize the mode-filtered `availableModels` and add an effect that snaps `model` to the first available choice when the current one isn't valid for the mode. The displayed option now always matches the value submitted.

## Verification
- web vitest **93** ✓ (the edit-mode test now also asserts the model *value* resets to the edit-capable model, not just the option list — this assertion fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)