### PR TITLE
feat(vqa): Ask-control response length + sidebar scroll fix [sc-1575]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1072,6 +1072,8 @@ struct VqaJobRequest {
     question: String,
     #[serde(default = "default_vqa_model")]
     model: String,
+    #[serde(default = "default_vqa_max_new_tokens")]
+    max_new_tokens: u32,
     #[serde(default = "default_requested_gpu")]
     requested_gpu: String,
     #[serde(default)]
@@ -1080,6 +1082,10 @@ struct VqaJobRequest {
 
 fn default_vqa_model() -> String {
     "sensenova_u1_8b".to_owned()
+}
+
+fn default_vqa_max_new_tokens() -> u32 {
+    256
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2866,6 +2872,11 @@ fn validate_vqa_job(payload: &VqaJobRequest) -> Result<(), ApiError> {
     if question.is_empty() || question.chars().count() > 4000 {
         return Err(ApiError::bad_request(
             "question must be between 1 and 4000 characters",
+        ));
+    }
+    if !(16..=2048).contains(&payload.max_new_tokens) {
+        return Err(ApiError::bad_request(
+            "maxNewTokens must be between 16 and 2048",
         ));
     }
     Ok(())
@@ -12710,10 +12721,18 @@ mod tests {
             source_asset_id: "asset_1".to_owned(),
             question: "What is in this image?".to_owned(),
             model: "sensenova_u1_8b".to_owned(),
+            max_new_tokens: 256,
             requested_gpu: "auto".to_owned(),
             advanced: serde_json::Map::new(),
         };
         assert!(super::validate_vqa_job(&base).is_ok());
+
+        // The UI's length presets are all valid.
+        for tokens in [256u32, 512, 1024] {
+            let mut request = base.clone();
+            request.max_new_tokens = tokens;
+            assert!(super::validate_vqa_job(&request).is_ok());
+        }
 
         let mut blank_question = base.clone();
         blank_question.question = "   ".to_owned();
@@ -12726,6 +12745,10 @@ mod tests {
         let mut missing_project = base.clone();
         missing_project.project_id = String::new();
         assert!(super::validate_vqa_job(&missing_project).is_err());
+
+        let mut too_many_tokens = base.clone();
+        too_many_tokens.max_new_tokens = 4096;
+        assert!(super::validate_vqa_job(&too_many_tokens).is_err());
     }
 
     #[tokio::test]

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1306,7 +1306,7 @@ export function App() {
     }
   }
 
-  async function createVqaJob(asset, question) {
+  async function createVqaJob(asset, question, maxNewTokens) {
     if (!activeProject) {
       setError("Create or open a project first.");
       return null;
@@ -1319,6 +1319,7 @@ export function App() {
           projectName: activeProject.name,
           sourceAssetId: asset.id,
           question,
+          maxNewTokens,
           requestedGpu,
         }),
       });

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -53,14 +53,21 @@ export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId
   );
 }
 
+const VQA_LENGTHS = [
+  { value: 256, label: "Short (256)" },
+  { value: 512, label: "Medium (512)" },
+  { value: 1024, label: "Long (1024)" },
+];
+
 function VqaPanel({ asset, entries, pending, onAsk }) {
   const [question, setQuestion] = React.useState("");
+  const [maxNewTokens, setMaxNewTokens] = React.useState(256);
   const trimmed = question.trim();
   const submit = () => {
     if (!trimmed) {
       return;
     }
-    onAsk(asset, trimmed);
+    onAsk(asset, trimmed, maxNewTokens);
     setQuestion("");
   };
 
@@ -76,9 +83,23 @@ function VqaPanel({ asset, entries, pending, onAsk }) {
           value={question}
         />
       </label>
-      <button disabled={!trimmed || pending} onClick={submit} type="button">
-        {pending ? "Asking…" : "Ask"}
-      </button>
+      <div className="vqa-controls">
+        <label className="vqa-length">
+          Response length
+          <select
+            aria-label="Response length"
+            onChange={(event) => setMaxNewTokens(Number(event.target.value))}
+            value={maxNewTokens}
+          >
+            {VQA_LENGTHS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
+        <button disabled={!trimmed || pending} onClick={submit} type="button">
+          {pending ? "Asking…" : "Ask"}
+        </button>
+      </div>
       {entries.length ? (
         <ul className="vqa-history">
           {entries.map((entry) => (

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5299,6 +5299,15 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       askButton.click();
     });
-    expect(createVqaJob).toHaveBeenCalledWith(asset, "What is the person wearing?");
+    // Defaults to the short (256-token) response length.
+    expect(createVqaJob).toHaveBeenCalledWith(asset, "What is the person wearing?", 256);
+
+    // Choosing a longer response length is passed through to the job.
+    await changeField(container.querySelector('select[aria-label="Response length"]'), "512");
+    await changeField(input, "Write a detailed critique of this image.");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Ask").click();
+    });
+    expect(createVqaJob).toHaveBeenLastCalledWith(asset, "Write a detailed critique of this image.", 512);
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2694,6 +2694,11 @@ label {
 .asset-detail {
   position: sticky;
   top: 86px;
+  /* Cap to the viewport and scroll internally so a tall panel (e.g. the VQA Ask
+     box + Q&A history) stays fully reachable instead of pinning off-screen. */
+  max-height: calc(100vh - 102px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   display: grid;
   gap: 12px;
   padding: 16px;
@@ -5494,6 +5499,8 @@ label {
 
   .asset-detail {
     position: static;
+    max-height: none;
+    overflow: visible;
   }
 
   .timeline-panel,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2737,6 +2737,31 @@ label {
   overflow-wrap: anywhere;
 }
 
+.vqa-panel {
+  display: grid;
+  gap: 8px;
+}
+
+.vqa-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.vqa-controls .vqa-length {
+  flex: 1;
+  min-width: 0;
+}
+
+.vqa-history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
 /* ---------- Model + LoRA panels ---------- */
 .model-grid {
   display: grid;


### PR DESCRIPTION
## Summary

Two VQA-Ask UX improvements found while using VQA in the Library (both on the asset-detail panel):

### 1. Response-length control
VQA is useful well beyond "describe this image" (e.g. image critiques), and 256 tokens is too short for those. Adds a **"Response length"** dropdown to the Ask control — **Short (256, default) / Medium (512) / Long (1024)** — forwarded as `maxNewTokens`.
- Rust: `VqaJobRequest` gains `maxNewTokens` (default 256), validated `16..=2048`. The worker already reads `payload.maxNewTokens`, so no worker change.
- Web: `createVqaJob` forwards the choice; the Ask panel exposes the select.
- The three presets cover the common cases; the API accepts any value in range, so a free-text control is trivial to add later.

### 2. Sidebar scroll fix
The sticky asset-detail sidebar had no height cap, so once it held the Ask box + Q&A history, the **"Ask" button pinned off-screen** and was only reachable by scrolling the whole library to the end. Capped it to the viewport with internal scroll, mirroring the LoRA Training caption sidebar (`max-height: calc(100vh - 102px)` + `overflow-y: auto` + overscroll containment; reset to static on mobile).

## Verification
- web vitest **94** (Ask sends 256 by default, 512 when the length is changed)
- rust fmt + clippy `-D warnings` + rust-api tests **53** (length presets valid; out-of-range rejected)
- Sidebar fix is CSS-only, mirroring an already-working pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)