### PR TITLE
Run Lens LoRA training on Apple Silicon (MPS) [sc-1602]

### DIFF
--- a/apps/worker/scene_worker/lens_train_runner.py
+++ b/apps/worker/scene_worker/lens_train_runner.py
@@ -172,19 +172,38 @@ def _build_lr_scheduler(torch: Any, optimizer: Any, name: str, total_updates: in
     return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
+def _seeded_sample(torch: Any, fn: Any, shape: Any, *, generator: Any, device: str, dtype: Any) -> Any:
+    """Draw seeded random values, MPS-safe.
+
+    ``torch.Generator`` only lives on cpu/cuda, so on Apple Silicon a seeded run
+    pairs a cpu generator with tensors on ``mps``. ``torch.randn``/``torch.rand``
+    reject a cpu generator alongside a non-cpu ``device=`` argument, so when the
+    generator's device differs from the target we draw on the generator's device
+    and move — mirroring diffusers' ``randn_tensor`` and the main worker's
+    ``training_adapters.seeded_sample``. ``fn`` is ``torch.randn`` or ``torch.rand``.
+    """
+    if generator is not None and generator.device.type != torch.device(device).type:
+        return fn(shape, generator=generator, device=generator.device, dtype=dtype).to(device)
+    return fn(shape, generator=generator, device=device, dtype=dtype)
+
+
 def _sample_timestep(torch: Any, generator: Any, device: str, dtype: Any, ts_type: str, ts_bias: str) -> Any:
     """Sample a normalized flow-matching timestep (the noise fraction) in [0, 1],
     matching training_adapters.sample_training_timestep."""
 
     normalized_type = (ts_type or "sigmoid").strip().lower().replace("-", "_")
     if normalized_type in {"linear", "uniform"}:
-        t = torch.rand(1, generator=generator, device=device, dtype=dtype)
+        t = _seeded_sample(torch, torch.rand, 1, generator=generator, device=device, dtype=dtype)
     elif normalized_type == "weighted":
-        base = torch.rand(1, generator=generator, device=device, dtype=dtype)
-        center = torch.sigmoid(torch.randn(1, generator=generator, device=device, dtype=dtype))
+        base = _seeded_sample(torch, torch.rand, 1, generator=generator, device=device, dtype=dtype)
+        center = torch.sigmoid(
+            _seeded_sample(torch, torch.randn, 1, generator=generator, device=device, dtype=dtype)
+        )
         t = (base + center) / 2.0
     else:
-        t = torch.sigmoid(torch.randn(1, generator=generator, device=device, dtype=dtype))
+        t = torch.sigmoid(
+            _seeded_sample(torch, torch.randn, 1, generator=generator, device=device, dtype=dtype)
+        )
 
     normalized_bias = (ts_bias or "balanced").strip().lower().replace("-", "_").replace(" ", "_")
     if normalized_bias in {"high", "high_noise", "favor_high_noise"}:
@@ -375,6 +394,10 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
             progress.emit(event="cache", done=index + 1, total=len(items))
     if device.startswith("cuda"):
         torch.cuda.empty_cache()
+    elif device == "mps" and getattr(torch, "mps", None) is not None:
+        # Release the caching-phase allocator cache; the Lens stack peaks near
+        # ~90 GB on Apple Silicon, so reclaiming here eases the train-loop ceiling.
+        torch.mps.empty_cache()
 
     # ---- Attach the trainable LoRA -----------------------------------------
     progress.emit(event="stage", stage="loading_model", message="Attaching LoRA adapter to the transformer.")
@@ -437,7 +460,9 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
         features = [feat.to(device=device, dtype=dtype) for feat in entry["features"]]
         mask = entry["mask"].to(device)
 
-        noise = torch.randn(latents.shape, generator=train_generator, device=device, dtype=dtype)
+        noise = _seeded_sample(
+            torch, torch.randn, latents.shape, generator=train_generator, device=device, dtype=dtype
+        )
         t = _sample_timestep(torch, train_generator, device, dtype, ts_type, ts_bias)
         noisy = (1.0 - t) * latents + t * noise
         # Lens feeds the transformer output to FlowMatchEulerDiscreteScheduler.step

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -2114,9 +2114,24 @@ class LensLoraTrainer:
 
     @staticmethod
     def _device_hint(settings: WorkerSettings) -> str:
+        """Resolve the device the sidecar should train on, mirroring the Lens
+        inference adapter (``LensTurboAdapter.generate``): ``select_torch_device``
+        picks ``mps`` on Apple Silicon, ``cuda``/``cuda:N`` on NVIDIA, and ``cpu``
+        when ``SCENEWORKS_GPU_ID=cpu`` is set. The driver runs in the main worker
+        venv (which has torch); if torch is somehow unimportable here we fall back
+        to a platform heuristic so the hint is still sane (the sidecar re-resolves
+        and fails fast on a real mismatch)."""
         gpu_id = getattr(settings, "gpu_id", None)
-        token = str(gpu_id).strip() if gpu_id is not None else ""
-        return f"cuda:{token}" if token.isdigit() else "cuda"
+        try:
+            torch = importlib.import_module("torch")
+            return select_torch_device(torch, gpu_id)
+        except ImportError:
+            token = str(gpu_id or "").strip()
+            if token.lower() == "cpu":
+                return "cpu"
+            if sys.platform == "darwin" and platform.machine() == "arm64":
+                return "mps"
+            return f"cuda:{token}" if token.isdigit() else "cuda"
 
     def train(
         self,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2277,6 +2277,82 @@ def test_lens_trainer_requires_sidecar(tmp_path, monkeypatch):
         )
 
 
+def test_lens_device_hint_delegates_to_select_torch_device(monkeypatch):
+    # On a real worker the driver has torch in the main venv, so the sidecar
+    # device hint must come from select_torch_device — picking "mps" on Apple
+    # Silicon exactly like the Lens inference adapter, not a hardcoded "cuda".
+    captured = {}
+
+    def _fake_import(name):
+        captured["imported"] = name
+        return SimpleNamespace(__name__="torch")
+
+    def _fake_select(torch, gpu_id):
+        captured["gpu_id"] = gpu_id
+        return "mps"
+
+    monkeypatch.setattr("scene_worker.training_adapters.importlib.import_module", _fake_import)
+    monkeypatch.setattr("scene_worker.training_adapters.select_torch_device", _fake_select)
+
+    device = LensLoraTrainer._device_hint(SimpleNamespace(gpu_id="0"))
+    assert device == "mps"
+    assert captured["imported"] == "torch"
+    assert captured["gpu_id"] == "0"
+
+
+def test_lens_device_hint_falls_back_to_mps_without_torch(monkeypatch):
+    # If torch is somehow unimportable in the main venv, the hint still resolves
+    # sensibly from the platform: Apple Silicon -> "mps", explicit cpu -> "cpu".
+    def _no_torch(name):
+        raise ImportError("no torch in this venv")
+
+    monkeypatch.setattr("scene_worker.training_adapters.importlib.import_module", _no_torch)
+    monkeypatch.setattr("scene_worker.training_adapters.sys.platform", "darwin")
+    monkeypatch.setattr("scene_worker.training_adapters.platform.machine", lambda: "arm64")
+
+    assert LensLoraTrainer._device_hint(SimpleNamespace(gpu_id="0")) == "mps"
+    assert LensLoraTrainer._device_hint(SimpleNamespace(gpu_id="cpu")) == "cpu"
+
+
+def test_lens_device_hint_falls_back_to_cuda_off_apple_silicon(monkeypatch):
+    def _no_torch(name):
+        raise ImportError("no torch in this venv")
+
+    monkeypatch.setattr("scene_worker.training_adapters.importlib.import_module", _no_torch)
+    monkeypatch.setattr("scene_worker.training_adapters.sys.platform", "linux")
+    monkeypatch.setattr("scene_worker.training_adapters.platform.machine", lambda: "x86_64")
+
+    assert LensLoraTrainer._device_hint(SimpleNamespace(gpu_id="1")) == "cuda:1"
+    assert LensLoraTrainer._device_hint(SimpleNamespace(gpu_id=None)) == "cuda"
+
+
+def test_lens_trainer_passes_resolved_device_to_sidecar(tmp_path, monkeypatch):
+    # The device the driver resolves must reach the sidecar spec verbatim, so a
+    # Mac run actually trains on "mps" instead of erroring on a "cuda" hint.
+    import subprocess as _subprocess
+
+    captured = {}
+
+    class _RecordingPopen(_FakeLensSidecarPopen):
+        def __init__(self, cmd, env=None, stdout=None, stderr=None):
+            spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+            captured["device"] = spec["device"]
+            super().__init__(cmd, env=env, stdout=stdout, stderr=stderr)
+
+    plan = _lens_train_plan(tmp_path, steps=2)
+    monkeypatch.setattr(LensLoraTrainer, "_sidecar_available", lambda self: True)
+    monkeypatch.setattr(LensLoraTrainer, "_device_hint", staticmethod(lambda settings: "mps"))
+    monkeypatch.setattr(_subprocess, "Popen", _RecordingPopen)
+
+    LensLoraTrainer().train(
+        settings=SimpleNamespace(worker_id="worker-1", gpu_id="0"),
+        plan=plan,
+        progress=lambda *args, **kwargs: None,
+        cancel_requested=lambda: False,
+    )
+    assert captured["device"] == "mps"
+
+
 def test_resolve_pretrained_source_prefers_loadable_model_dir(tmp_path):
     model_dir = tmp_path / "models" / "z_image"
     model_dir.mkdir(parents=True)


### PR DESCRIPTION
Extends the Lens / Lens-Turbo LoRA training kernel — built CUDA-only in #152 (epic [sc-1583](https://app.shortcut.com/trefry/epic/1583)) — to Apple Silicon (MPS), mirroring how Lens-Turbo *inference* was ported to Mac in #136. Tracked by [sc-1602](https://app.shortcut.com/trefry/story/1602).

## Why this is small
Most of the Mac plumbing the trainer needs already exists:
- The desktop bootstrap provisions the dedicated **lens venv on macOS** (PyPI/MPS torch, mxfp4 dequantized) and sets `SCENEWORKS_LENS_PYTHON` unconditionally (sc-1558, extended in #136).
- `apps/desktop/scripts/stage-python.mjs` copies the whole `scene_worker/` package, so `lens_train_runner.py` is **bundled automatically** — no packaging change.
- The Rust `lens_turbo_lora` target is **device-agnostic** (no `appleSiliconOnly`/`requiresBackend` gate, unlike `ltx_video_lora`), so a Mac MPS worker already offers it; routing is by job-type only. **No Rust change.**
- The sidecar runner already set `PYTORCH_ENABLE_MPS_FALLBACK=1`, forced bf16 on non-CPU (fp16 NaNs on MPS), and forced `disableMxfp4` on non-CUDA.

## The two real gaps fixed here
1. **Driver hardcoded a CUDA device hint.** `LensLoraTrainer._device_hint` returned `cuda`/`cuda:N` from `gpu_id` only, so on a Mac the sidecar got `device="cuda"` and raised (`torch.cuda.is_available()` is False in the lens venv). Now resolves via `select_torch_device` (→ `mps` on Apple Silicon, `cuda[:N]` on NVIDIA, `cpu` for `SCENEWORKS_GPU_ID=cpu`), mirroring `LensTurboAdapter.generate`, with a platform-heuristic fallback if torch is unimportable in the main venv.
2. **MPS-unsafe seeded RNG.** The runner drew `torch.randn/rand(generator=cpu_gen, device="mps")`, which torch rejects (a cpu `Generator` can't drive an mps draw — the exact trap already fixed for the Z-Image trainer via `seeded_sample`). Added a `_seeded_sample` helper (draw on the generator's device, then `.to(device)`) and routed the timestep + training-loop noise through it.

Also added `torch.mps.empty_cache()` after the latent-caching phase to ease the ~90 GB Lens peak on Apple Silicon.

## Verified
- Full `apps/worker` pytest in a torch-less env: **198 passed, 7 skipped** (torch/MLX-gated).
- 4 new tests: `_device_hint` delegates to `select_torch_device`; MPS/cpu/cuda fallback branches; the resolved device reaches the sidecar spec verbatim.
- `py_compile` on both edited modules.

## NOT verified — hardware-gated
The Mac analogue of sc-1588's in-container CUDA validation. Needs a **96 GB+ Apple Silicon Mac** with the lens venv to confirm:
1. it runs end-to-end on MPS with no RNG/device errors and produces a `lens`-family adapter;
2. the trained adapter measurably changes Lens-Turbo output at inference (save/load key-prefix pairing holds on MPS);
3. memory stays within the documented ~90 GB peak (so realistically 96 GB+; 64 GB likely needs offload or is out of scope).

## Test plan
- [ ] On a 96 GB+ Apple Silicon Mac, run a short Lens LoRA training job and confirm it completes on MPS with no errors.
- [ ] Apply the trained `lens` LoRA to Lens-Turbo at generation time and confirm visible effect.
- [ ] Confirm peak memory stays within ~90 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)