### PR TITLE
feat(interleave): reopen documents from the Library [sc-1608]

### DIFF
--- a/apps/web/src/components/DocumentView.jsx
+++ b/apps/web/src/components/DocumentView.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { assetUrl } from "./assetMedia.jsx";
+
+// Renders an interleaved document: ordered text runs + generated images.
+// Image segments resolve through the asset catalog when available (so they pick up
+// the normalized `url`), falling back to building the file URL from projectId + path
+// (used by the Library reader, which only has the document asset itself).
+export function DocumentView({ segments, assets = [], projectId }) {
+  if (!Array.isArray(segments) || !segments.length) {
+    return <p className="empty-panel">This document has no content.</p>;
+  }
+  return (
+    <article className="document-view" aria-label="Generated document">
+      {segments.map((segment, index) => {
+        if (segment.type === "text") {
+          return (
+            <p className="document-text" key={`segment-${index}`}>
+              {segment.text}
+            </p>
+          );
+        }
+        const asset = assets.find((item) => item.id === segment.assetId);
+        const src = assetUrl(asset ?? { projectId, file: { path: segment.path } });
+        return src ? <img alt="" className="document-image" key={`segment-${index}`} src={src} /> : null;
+      })}
+    </article>
+  );
+}

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -1,6 +1,53 @@
 import React from "react";
-import { AssetMedia } from "./assetMedia.jsx";
+import { AssetMedia, assetUrl } from "./assetMedia.jsx";
+import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
+
+// Reopens a saved interleaved document: the asset's file points to the segments
+// JSON in assets/documents/, fetched here (served like any project file).
+function DocumentReader({ asset }) {
+  const url = assetUrl(asset);
+  const [segments, setSegments] = React.useState(null);
+  const [error, setError] = React.useState("");
+
+  React.useEffect(() => {
+    if (!url) {
+      setError("Document file is unavailable.");
+      return undefined;
+    }
+    let cancelled = false;
+    setSegments(null);
+    setError("");
+    fetch(url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Request failed (${response.status})`);
+        }
+        return response.json();
+      })
+      .then((document) => {
+        if (!cancelled) {
+          setSegments(Array.isArray(document?.segments) ? document.segments : []);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(String(err?.message ?? err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error) {
+    return <p className="empty-panel error-text">Couldn't load document: {error}</p>;
+  }
+  if (segments === null) {
+    return <p className="empty-panel">Loading document…</p>;
+  }
+  return <DocumentView projectId={asset.projectId} segments={segments} />;
+}
 
 function RatingControl({ asset, updateAssetStatus }) {
   const currentRating = Number(asset.status?.rating) || 0;
@@ -134,9 +181,13 @@ export function AssetDetail({
 
   return (
     <aside className="asset-detail">
-      <button className="preview-button" onClick={() => onPreview(asset)} type="button">
-        <AssetMedia asset={asset} />
-      </button>
+      {asset.type === "document" ? (
+        <DocumentReader asset={asset} />
+      ) : (
+        <button className="preview-button" onClick={() => onPreview(asset)} type="button">
+          <AssetMedia asset={asset} />
+        </button>
+      )}
       <h3>{asset.displayName}</h3>
       <p>{asset.recipe?.prompt ?? "No prompt"}</p>
       <RatingControl asset={asset} updateAssetStatus={updateAssetStatus} />

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
+import { AssetDetail } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
@@ -5382,5 +5383,57 @@ describe("SceneWorks app shell", () => {
     expect(payload.prompt).toBe("An illustrated guide to brewing tea");
     expect(payload.model).toBe("sensenova_u1_8b");
     expect(payload.maxImages).toBe(6);
+  });
+
+  it("AssetDetail reopens a saved document from the Library", async () => {
+    global.fetch.mockImplementation((url) => {
+      if (String(url).includes("assets/documents")) {
+        return Promise.resolve(
+          response({
+            schemaVersion: 1,
+            id: "doc_1",
+            segments: [
+              { type: "text", text: "Boil the water." },
+              { type: "image", assetId: "img-1", path: "assets/images/a.png" },
+              { type: "text", text: "Steep three minutes." },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(response([]));
+    });
+    const documentAsset = {
+      id: "doc_1",
+      type: "document",
+      projectId: "project-1",
+      displayName: "Tea guide",
+      file: { path: "assets/documents/doc_1.json", mimeType: "application/json" },
+      url: "/api/v1/projects/project-1/files/assets/documents/doc_1.json",
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <AssetDetail
+          asset={documentAsset}
+          deleteAsset={() => {}}
+          purgeAsset={() => {}}
+          onPreview={() => {}}
+          onSendImage={() => {}}
+          onSendVideo={() => {}}
+          onSendEditor={() => {}}
+          updateAssetStatus={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    // The saved document's text + image segments render in order.
+    expect(container.textContent).toContain("Boil the water.");
+    expect(container.textContent).toContain("Steep three minutes.");
+    const image = container.querySelector("img.document-image");
+    expect(image).not.toBeNull();
+    expect(image.getAttribute("src")).toContain("assets/images/a.png");
+    // The document JSON was fetched from its file path.
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("assets/documents/doc_1.json"));
   });
 });

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
-import { assetUrl } from "../components/assetMedia.jsx";
+import { DocumentView } from "../components/DocumentView.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 
 const MAX_IMAGES_DEFAULT = 6;
@@ -15,22 +15,7 @@ function DocumentResult({ job, assets, projectId, onOpenQueue }) {
   if (job.status !== "completed" || !Array.isArray(segments) || !segments.length) {
     return <JobProgressCard job={job} label="Interleaved document" onOpenQueue={onOpenQueue} />;
   }
-  return (
-    <article className="document-view" aria-label="Generated document">
-      {segments.map((segment, index) => {
-        if (segment.type === "text") {
-          return (
-            <p className="document-text" key={`segment-${index}`}>
-              {segment.text}
-            </p>
-          );
-        }
-        const asset = assets.find((item) => item.id === segment.assetId);
-        const src = assetUrl(asset ?? { projectId, file: { path: segment.path } });
-        return src ? <img alt="" className="document-image" key={`segment-${index}`} src={src} /> : null;
-      })}
-    </article>
-  );
+  return <DocumentView assets={assets} projectId={projectId} segments={segments} />;
 }
 
 export function DocumentStudio({


### PR DESCRIPTION
## Summary
Final slice of [sc-1576](https://app.shortcut.com/trefry/story/1576). A saved interleaved **document** can now be reopened and read from the Library. With this, the interleaved text-image feature is complete end to end (contract → worker → asset type → Document Studio → Library reader).

- **Shared `DocumentView`** (`components/DocumentView.jsx`): the ordered text + image segment renderer, extracted from DocumentStudio's inline rendering (DocumentStudio now reuses it). Image segments resolve via the asset catalog when available, else from `projectId` + segment `path`.
- **`DocumentReader`** (in `assetPanels.jsx`): fetches the companion `assets/documents/<id>.json` (segments live there, not in the sidecar — served like any project file) and renders it via `DocumentView`, with loading/error states. `AssetDetail` shows the reader for `type === "document"` instead of the media placeholder.
- **main.test.jsx**: `AssetDetail` reopens a saved document (mocked fetch) and renders its ordered text + image segments; asserts the JSON was fetched from the file path.

## Verification
- [x] Web vitest — 96 passed (1 new Library-reader test; the DocumentStudio test still passes via the extracted `DocumentView`)
- [x] `node scripts/check-scaffold.mjs` — passed
- [x] Web-only change — rust/parity unaffected
- [ ] **In-browser real-document read is Michael's MPS validation** (needs a real generated document); vitest exercises the reader with mocked segment data.

## Epic status
This closes the build work for sc-1576. Remaining: Michael's MPS validation of the real-model interleave generation (sc-1606/1607) and reading it back (sc-1608).

🤖 Generated with [Claude Code](https://claude.com/claude-code)