### PR TITLE
fix(ui): Document Studio spacing [sc-1607]

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1321,6 +1321,71 @@ label {
   }
 }
 
+/* Document Studio (interleaved text-image) — sc-1607/1608. The screen reuses the
+   generic .field / .studio-results class names, which only carry layout inside
+   preset/ImageStudio scopes, so give them rhythm here. */
+.document-studio {
+  display: grid;
+  gap: var(--gap-5);
+}
+
+.document-studio .studio-form {
+  display: grid;
+  gap: var(--gap-4);
+  max-width: 760px;
+}
+
+.document-studio .field {
+  display: grid;
+  gap: var(--gap-1);
+}
+
+.document-studio .field > span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.document-studio .field-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-3);
+}
+
+.document-studio .field-row > .field {
+  flex: 1 1 180px;
+}
+
+.document-studio .studio-form > .primary-action {
+  justify-self: start;
+}
+
+/* The document reader is single-column — override ImageStudio's results+rail grid. */
+.document-studio .studio-results {
+  grid-template-columns: 1fr;
+}
+
+/* Generated/reopened interleaved document: ordered text runs + images. */
+.document-view {
+  display: grid;
+  gap: var(--gap-3);
+  max-width: 720px;
+}
+
+.document-text {
+  margin: 0;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.document-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: var(--r-sm);
+}
+
 .studio-source-band {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary
Polish follow-up to [sc-1607](https://app.shortcut.com/trefry/story/1607) — the Document Studio form was cramped (no vertical rhythm; the Model/Max images/GPU controls stacked instead of sitting in a row; the result area inherited ImageStudio's 2-column results+rail grid, squishing the document).

Root cause: the screen reuses the generic `.field` / `.studio-form` / `.field-row` / `.studio-results` class names, but those only carry layout inside preset/ImageStudio scopes — so unscoped they had no spacing.

Adds `.document-studio`-scoped CSS (using the app's `--gap-*` / `--r-sm` / `--text-muted` tokens):
- `.studio-form` → grid with `--gap-4` (20px) rhythm, capped at 760px.
- `.field` → label-over-control grid; `.field-row` → flex-wrap row (`--gap-3`) so Model/Max images/GPU sit side by side.
- `.studio-results` → single column (overrides the inherited 2-col grid).
- New `.document-view` / `.document-text` / `.document-image` styles for the interleaved document reader (used by both Document Studio and the Library reader).

## Verification
- [x] `node scripts/check-scaffold.mjs` — passed
- [x] Computed-style check in the dev preview confirms each rule resolves (form gap 20px / max-width 760px; field-row flex+wrap 14px; results single-column; document-view grid 720px; image rounded). The live form is gated behind a workspace + backend in the offline preview, so it's verified via injected DOM + computed styles rather than a full render.
- CSS-only; no JS/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)