### PR TITLE
fix(ui): wrap Document Studio in the main-surface card [sc-1607]

### DIFF
--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -76,7 +76,7 @@ export function DocumentStudio({
   }
 
   return (
-    <div className="studio document-studio">
+    <section className="main-surface document-studio">
       <form className="studio-form" onSubmit={submit}>
         {interleaveModels.length ? null : (
           <p className="empty-panel compact-panel">
@@ -156,6 +156,6 @@ export function DocumentStudio({
           <p className="empty-panel">Your generated document will appear here.</p>
         )}
       </section>
-    </div>
+    </section>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1321,18 +1321,13 @@ label {
   }
 }
 
-/* Document Studio (interleaved text-image) — sc-1607/1608. The screen reuses the
-   generic .field / .studio-results class names, which only carry layout inside
-   preset/ImageStudio scopes, so give them rhythm here. */
-.document-studio {
-  display: grid;
-  gap: var(--gap-5);
-}
-
+/* Document Studio (interleaved text-image) — sc-1607/1608. The screen wraps in
+   .main-surface (edge margin + padded card, like Video/Image Studio); these rules
+   give the form/fields rhythm since the generic .field / .field-row class names
+   only carry layout inside preset/ImageStudio scopes. */
 .document-studio .studio-form {
   display: grid;
   gap: var(--gap-4);
-  max-width: 760px;
 }
 
 .document-studio .field {


### PR DESCRIPTION
## Summary
Follow-up to the first spacing pass (#160). That added field rhythm but left the screen edge-to-edge; this matches Video/Image Studio's contained layout.

The screen now wraps in `<section className="main-surface document-studio">`, so it inherits the shared surface treatment — **edge margin (`0 22px`), padded card (`20px`), border, and `16px` radius** — exactly like Video Studio. Dropped the now-redundant `.document-studio` grid rule and the 760px form cap so the form fills the padded card (as Video does); kept the horizontal Model/Max images/GPU field row and the single-column results override.

## Verification
- [x] Web vitest — 96 passed
- [x] `node scripts/check-scaffold.mjs` — passed
- [x] Computed-style check in the dev preview: an injected `main-surface document-studio` section as a direct child of `.workspace` resolves to `margin: 0 22px 30px`, `padding: 20px`, `1px` border, `16px` radius — matching Video Studio's surface; form gap 20px; field row flex-wrap 14px; results single column.
- CSS + one wrapper element; no logic/test-behavior changes. Live render still needs a workspace + backend (offline preview is workspace-gated), so verified via computed styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)