### PR TITLE
feat(worker): force-stop unacknowledged job cancellations [sc-1598]

### DIFF
--- a/apps/worker/scene_worker/_vendor/lens/pipeline.py
+++ b/apps/worker/scene_worker/_vendor/lens/pipeline.py
@@ -485,6 +485,9 @@ class LensPipeline(DiffusionPipeline):
         self.scheduler.set_timesteps(sigmas=sigmas, device=device, mu=mu)
 
         # 7. Denoising loop.
+        # Reset the interrupt flag so a callback_on_step_end can stop this run
+        # (used for cancellation) without leaking state into the next call.
+        self._interrupt = False
         img_shapes = [(1, latent_h, latent_w)]
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(self.scheduler.timesteps):
@@ -522,6 +525,10 @@ class LensPipeline(DiffusionPipeline):
                     negative_prompt_embeds = cb_out.pop(
                         "negative_prompt_embeds", negative_prompt_embeds
                     )
+
+                # Stop early if a callback requested interruption (cancellation).
+                if getattr(self, "_interrupt", False):
+                    break
 
                 progress_bar.update()
 

--- a/apps/worker/scene_worker/adapter_utils.py
+++ b/apps/worker/scene_worker/adapter_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any
+from typing import Any, Callable
 
 
 def accepted_call_parameters(callable_owner: Any) -> set[str]:
@@ -16,3 +16,38 @@ def filter_call_kwargs(callable_owner: Any, kwargs: dict[str, Any]) -> dict[str,
     if not accepted:
         return kwargs
     return {key: value for key, value in kwargs.items() if key in accepted}
+
+
+def cancel_step_callback(
+    pipe: Any,
+    cancel_requested: Callable[[], bool] | None,
+) -> Callable[[Any, int, Any, dict[str, Any]], dict[str, Any]] | None:
+    """Build a diffusers ``callback_on_step_end`` that interrupts the denoise
+    loop the moment a job is canceled.
+
+    The callback flips ``pipe._interrupt`` — diffusers and the vendored Lens
+    pipeline check that flag at the top of each step and break cleanly, so a
+    cancel lands at the next step boundary instead of after the whole run.
+    Returns ``None`` when there's nothing to wire (no cancel predicate, or the
+    pipe's ``__call__`` doesn't accept ``callback_on_step_end``); the caller then
+    just runs the pipe normally and relies on the worker's cancel watchdog.
+
+    Note: pipelines that *accept* the callback but ignore ``_interrupt`` will run
+    to completion anyway, so callers MUST re-check cancellation after the pipe
+    returns and discard the (possibly partial) result."""
+    if cancel_requested is None:
+        return None
+    if "callback_on_step_end" not in accepted_call_parameters(pipe):
+        return None
+
+    def _on_step_end(
+        active_pipe: Any,
+        step: int,
+        timestep: Any,
+        callback_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        if cancel_requested():
+            active_pipe._interrupt = True
+        return callback_kwargs
+
+    return _on_step_end

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -29,7 +29,7 @@ from sceneworks_shared import (
     write_json,
 )
 
-from .adapter_utils import filter_call_kwargs
+from .adapter_utils import cancel_step_callback, filter_call_kwargs
 from .lora_adapters import (
     LoraPipelineState,
     apply_loras_to_pipeline,
@@ -535,7 +535,7 @@ class ZImageDiffusersAdapter:
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                image = self._run_pipeline(settings, pipe, request, seed)
+                image = self._run_pipeline(settings, pipe, request, seed, cancel_requested=cancel_requested)
             except Exception as exc:
                 emit_worker_event(
                     "image_inference_failed",
@@ -696,7 +696,14 @@ class ZImageDiffusersAdapter:
     def _empty_cuda_cache(self, torch: Any) -> None:
         empty_torch_cache(torch)
 
-    def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
+    def _run_pipeline(
+        self,
+        settings: WorkerSettings,
+        pipe: Any,
+        request: ImageRequest,
+        seed: int,
+        cancel_requested: CancelCallback | None = None,
+    ) -> Image.Image:
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
@@ -715,7 +722,12 @@ class ZImageDiffusersAdapter:
         if request.mode == "edit_image":
             kwargs["image"] = load_source_image(settings, request)
             kwargs["strength"] = float(request.advanced.get("strength", 0.6))
+        step_callback = cancel_step_callback(pipe, cancel_requested)
+        if step_callback is not None:
+            kwargs["callback_on_step_end"] = step_callback
         output = pipe(**kwargs)
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
         image = output.images[0]
         return image.convert("RGB")
 
@@ -805,7 +817,7 @@ class QwenImageAdapter:
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                image = self._run_pipeline(settings, pipe, request, seed)
+                image = self._run_pipeline(settings, pipe, request, seed, cancel_requested=cancel_requested)
             except Exception as exc:
                 emit_worker_event(
                     "image_inference_failed",
@@ -949,7 +961,14 @@ class QwenImageAdapter:
     def _empty_cuda_cache(self, torch: Any) -> None:
         empty_torch_cache(torch)
 
-    def _run_pipeline(self, settings: WorkerSettings, pipe: Any, request: ImageRequest, seed: int) -> Image.Image:
+    def _run_pipeline(
+        self,
+        settings: WorkerSettings,
+        pipe: Any,
+        request: ImageRequest,
+        seed: int,
+        cancel_requested: CancelCallback | None = None,
+    ) -> Image.Image:
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
@@ -968,7 +987,12 @@ class QwenImageAdapter:
             kwargs["image"] = load_source_image(settings, request)
             kwargs["strength"] = float(request.advanced.get("strength", 0.6))
             kwargs["true_cfg_scale"] = float(request.advanced.get("trueCfgScale", 4.0))
+        step_callback = cancel_step_callback(pipe, cancel_requested)
+        if step_callback is not None:
+            kwargs["callback_on_step_end"] = step_callback
         output = pipe(**filter_call_kwargs(pipe, kwargs))
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
         return output.images[0].convert("RGB")
 
     def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import UTC, datetime
 import importlib
 import json
@@ -41,6 +42,8 @@ from .video_adapters import create_video_adapter
 
 
 LoadedModelsSource = Callable[[], list[str]] | None
+# Predicate adapters call to learn whether the running job has been canceled.
+CancelCallback = Callable[[], bool]
 IMAGE_JOB_TYPES = ("image_generate", "image_edit")
 VIDEO_JOB_TYPES = ("video_generate", "video_extend", "video_bridge", "person_replace")
 # Real person detection/tracking run in the Python GPU worker (YOLO/ByteTrack/SAM2),
@@ -350,6 +353,135 @@ def job_cancel_requested(api: ApiClient, job_id: str) -> bool:
     return bool(api.get(f"/api/v1/jobs/{job_id}")["cancelRequested"])
 
 
+class JobCancelMonitor:
+    """Watches a running job's cancel flag on a background thread.
+
+    Two responsibilities:
+
+    1. Cache the cancel state so hot paths (per-step pipe callbacks, tight
+       per-frame loops) can ask "was this canceled?" without an HTTP round-trip
+       on every check. ``requested`` returns the most recently polled value.
+    2. Enforce the hard-stop backstop: if the cancel flag stays set for longer
+       than ``settings.force_cancel_seconds`` while the job is still running, the
+       cooperative path failed to interrupt a wedged native call in time — so we
+       mark the job canceled and force-terminate the worker process. Its
+       supervisor (Tauri on desktop, the child supervisor / Docker on the web
+       build) respawns a clean worker. The worker runs one job at a time, so
+       killing the process cancels exactly the stuck job (at the cost of the
+       loaded model, which must reload on the next job).
+    """
+
+    def __init__(
+        self,
+        api: ApiClient,
+        settings: WorkerSettings,
+        job_id: str,
+        *,
+        poll_interval: float = 1.0,
+        force_cancel_seconds: float | None = None,
+    ) -> None:
+        self._api = api
+        self._settings = settings
+        self._job_id = job_id
+        self._poll_interval = max(0.05, poll_interval)
+        deadline = (
+            force_cancel_seconds
+            if force_cancel_seconds is not None
+            else getattr(settings, "force_cancel_seconds", 0)
+        )
+        self._deadline = max(0, deadline)
+        self._requested = False
+        self._requested_monotonic: float | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def requested(self) -> bool:
+        """The most recently polled cancel state (cheap; no HTTP)."""
+        return self._requested
+
+    def start(self) -> "JobCancelMonitor":
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"cancel-monitor-{self._job_id}",
+            daemon=True,
+        )
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1)
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._poll_interval):
+            try:
+                requested = job_cancel_requested(self._api, self._job_id)
+            except httpx.HTTPError as exc:
+                emit({"event": "cancel_poll_failed", "jobId": self._job_id, "error": str(exc), "reportedAt": now()})
+                continue
+            if not requested:
+                continue
+            self._requested = True
+            if self._requested_monotonic is None:
+                self._requested_monotonic = time.monotonic()
+                continue
+            if self._deadline and (time.monotonic() - self._requested_monotonic) >= self._deadline:
+                self._force_terminate()
+                return
+
+    def _force_terminate(self) -> None:
+        # Lost the race with a clean finish? Don't kill a process that's done.
+        if self._stop.is_set():
+            return
+        emit(
+            {
+                "event": "cancel_force_kill",
+                "jobId": self._job_id,
+                "workerId": getattr(self._settings, "worker_id", None),
+                "afterSeconds": self._deadline,
+                "reportedAt": now(),
+            }
+        )
+        # Mark the job canceled *before* exiting so the UI resolves immediately
+        # instead of waiting for a stale-worker reaper to notice the dead worker.
+        try:
+            update_job(
+                self._api,
+                self._job_id,
+                {
+                    "status": "canceled",
+                    "stage": "canceled",
+                    "progress": 1,
+                    "message": f"Force-stopped: cancellation was not acknowledged within {self._deadline}s.",
+                },
+            )
+        except httpx.HTTPError as exc:
+            emit(
+                {
+                    "event": "cancel_force_kill_finalize_failed",
+                    "jobId": self._job_id,
+                    "error": str(exc),
+                    "reportedAt": now(),
+                }
+            )
+        # The main thread is wedged in a native call we cannot interrupt from
+        # Python, so os._exit is the only way to stop it now. It skips interpreter
+        # cleanup by design — the supervisor restarts a fresh worker.
+        os._exit(FORCED_CANCEL_EXIT_CODE)
+
+
+@contextmanager
+def job_cancel_monitor(api: ApiClient, settings: WorkerSettings, job_id: str):
+    """Run a JobCancelMonitor for the duration of a job's blocking work."""
+    monitor = JobCancelMonitor(api, settings, job_id)
+    monitor.start()
+    try:
+        yield monitor
+    finally:
+        monitor.stop()
+
+
 def keep_job_alive(
     api: ApiClient,
     settings: WorkerSettings,
@@ -371,10 +503,16 @@ def run_blocking_job_step(
     settings: WorkerSettings,
     job_id: str,
     status: str,
-    callback: Any,
+    callback: Callable[[CancelCallback], Any],
     *,
     loaded_models: LoadedModelsSource,
 ) -> Any:
+    """Run a job's blocking work while keeping it alive and cancelable.
+
+    Spawns a heartbeat thread and a JobCancelMonitor for the duration of the
+    work, then invokes ``callback`` with a cached cancel predicate so adapters
+    can poll cancellation cheaply (and so the monitor can force-stop the worker
+    if a cancel goes unacknowledged past the deadline)."""
     stop_event = threading.Event()
     thread = threading.Thread(
         target=keep_job_alive,
@@ -383,7 +521,8 @@ def run_blocking_job_step(
     )
     thread.start()
     try:
-        return callback()
+        with job_cancel_monitor(api, settings, job_id) as monitor:
+            return callback(monitor.requested)
     finally:
         stop_event.set()
         thread.join(timeout=1)
@@ -400,6 +539,11 @@ def is_cuda_oom(exc: BaseException) -> bool:
 # Exit code used when a worker child restarts itself after a CUDA OOM so the
 # supervisor respawns it with a fresh (non-poisoned) CUDA context.
 OOM_RESTART_EXIT_CODE = 75
+
+# Exit code used when the worker force-terminates itself because a cancellation
+# went unacknowledged past force_cancel_seconds (the hard-stop backstop). The
+# supervisor respawns a clean worker.
+FORCED_CANCEL_EXIT_CODE = 76
 
 
 def restart_worker_after_oom(settings: WorkerSettings, job_id: str) -> None:
@@ -469,11 +613,11 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
             settings,
             job_id,
             "busy",
-            lambda: adapter.generate(
+            lambda cancel: adapter.generate(
                 settings=settings,
                 job=job,
                 progress=progress,
-                cancel_requested=lambda: job_cancel_requested(api, job_id),
+                cancel_requested=cancel,
             ),
             loaded_models=adapter_loaded_models,
         )
@@ -541,11 +685,11 @@ def run_vqa_job(api: ApiClient, settings: WorkerSettings, job: dict, image_adapt
             settings,
             job_id,
             "busy",
-            lambda: adapter.answer_question(
+            lambda cancel: adapter.answer_question(
                 settings=settings,
                 job=job,
                 progress=progress,
-                cancel_requested=lambda: job_cancel_requested(api, job_id),
+                cancel_requested=cancel,
             ),
             loaded_models=adapter_loaded_models,
         )
@@ -598,11 +742,11 @@ def run_interleave_job(api: ApiClient, settings: WorkerSettings, job: dict, imag
             settings,
             job_id,
             "busy",
-            lambda: adapter.generate_interleaved(
+            lambda cancel: adapter.generate_interleaved(
                 settings=settings,
                 job=job,
                 progress=progress,
-                cancel_requested=lambda: job_cancel_requested(api, job_id),
+                cancel_requested=cancel,
             ),
             loaded_models=adapter_loaded_models,
         )
@@ -683,12 +827,12 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             settings,
             job_id,
             "busy",
-            lambda: adapter.run(
+            lambda cancel: adapter.run(
                 settings=settings,
                 job=job,
                 request=request,
                 progress=progress,
-                cancel_requested=lambda: job_cancel_requested(api, job_id),
+                cancel_requested=cancel,
             ),
             loaded_models=adapter_loaded_models,
         )
@@ -774,11 +918,11 @@ def run_person_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             settings,
             job_id,
             "busy",
-            lambda: runner(
+            lambda cancel: runner(
                 settings,
                 job,
                 progress=progress,
-                cancel_requested=lambda: job_cancel_requested(api, job_id),
+                cancel_requested=cancel,
             ),
             loaded_models=lambda: [],
         )
@@ -898,11 +1042,11 @@ def _run_lora_train_execution(api: ApiClient, settings: WorkerSettings, job: dic
             settings,
             job_id,
             "busy",
-            lambda: trainer.train(
+            lambda cancel: trainer.train(
                 settings=settings,
                 plan=plan,
                 progress=progress,
-                cancel_requested=lambda: job_cancel_requested(api, job_id),
+                cancel_requested=cancel,
             ),
             loaded_models=trainer_loaded_models,
         )
@@ -965,12 +1109,12 @@ def run_training_caption_worker_job(api: ApiClient, settings: WorkerSettings, jo
             settings,
             job_id,
             "busy",
-            lambda: run_training_caption_job(
+            lambda cancel: run_training_caption_job(
                 api=api,
                 settings=settings,
                 job=job,
                 progress=progress,
-                cancel_requested=lambda: job_cancel_requested(api, job_id),
+                cancel_requested=cancel,
             ),
             loaded_models=lambda: [],
         )

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -17,6 +17,11 @@ class WorkerSettings:
         self.access_token = os.getenv("SCENEWORKS_ACCESS_TOKEN", "").strip()
         self.heartbeat_seconds = int(os.getenv("SCENEWORKS_WORKER_HEARTBEAT_SECONDS", "30"))
         self.poll_seconds = int(os.getenv("SCENEWORKS_WORKER_POLL_SECONDS", "3"))
+        # Hard-stop backstop: if a running job's cancellation isn't honored
+        # cooperatively within this many seconds, the worker force-terminates
+        # itself so its supervisor respawns it (releasing the wedged job/model).
+        # 0 disables the backstop, leaving cancellation cooperative-only.
+        self.force_cancel_seconds = int(os.getenv("SCENEWORKS_WORKER_FORCE_CANCEL_SECONDS", "30"))
         # A GPU worker won't claim a job when its GPU has less free VRAM than this
         # (MB), so jobs flow to a free card when another tool (e.g. ComfyUI) is using
         # one. 0 disables the gate. CPU workers are never gated.
@@ -33,4 +38,5 @@ class WorkerSettings:
         settings.heartbeat_seconds = self.heartbeat_seconds
         settings.poll_seconds = self.poll_seconds
         settings.min_free_vram_mb = self.min_free_vram_mb
+        settings.force_cancel_seconds = self.force_cancel_seconds
         return settings

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -30,7 +30,7 @@ from sceneworks_shared import (
     utc_now,
 )
 
-from .adapter_utils import filter_call_kwargs
+from .adapter_utils import cancel_step_callback, filter_call_kwargs
 from .image_adapters import emit_worker_event, empty_torch_cache, gpu_memory_snapshot, require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
 from .lora_adapters import (
     LoraPipelineState,
@@ -2165,6 +2165,9 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             num_frames=num_frames,
         )
         progress("running", "generating", 0.32, f"Running {target['label']} inference.")
+        step_callback = cancel_step_callback(pipe, cancel_requested)
+        if step_callback is not None:
+            kwargs["callback_on_step_end"] = step_callback
         torch = importlib.import_module("torch")
         with torch.inference_mode():
             output = pipe(**kwargs)

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -4,6 +4,8 @@ import importlib
 import json
 import os
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import NamedTuple
 from types import ModuleType, SimpleNamespace
@@ -11,7 +13,7 @@ from types import ModuleType, SimpleNamespace
 from PIL import Image
 import pytest
 
-from scene_worker.adapter_utils import filter_call_kwargs
+from scene_worker.adapter_utils import cancel_step_callback, filter_call_kwargs
 from scene_worker.caption_adapters import (
     JOY_CAPTION_RESAMPLE,
     JoyCaptionOptions,
@@ -55,6 +57,8 @@ from scene_worker.lora_adapters import (
     validate_lora_compatibility,
 )
 from scene_worker.runtime import (
+    FORCED_CANCEL_EXIT_CODE,
+    JobCancelMonitor,
     child_environment,
     friendly_failure,
     heartbeat,
@@ -2869,7 +2873,7 @@ def test_run_lora_train_job_executes_real_run(monkeypatch, tmp_path):
     monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda api, settings, job_id, status, callback, *, loaded_models: callback(),
+        lambda api, settings, job_id, status, callback, *, loaded_models: callback(lambda: False),
     )
     backend = FakeTrainingBackend()
     trainer = ZImageLoraTrainer(backend=backend)
@@ -2894,7 +2898,7 @@ def test_run_lora_train_job_marks_canceled(monkeypatch, tmp_path):
     monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda api, settings, job_id, status, callback, *, loaded_models: callback(),
+        lambda api, settings, job_id, status, callback, *, loaded_models: callback(lambda: False),
     )
 
     class CancelingTrainer:
@@ -2927,7 +2931,7 @@ def test_run_lora_train_job_reports_friendly_failure(monkeypatch, tmp_path):
     monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda api, settings, job_id, status, callback, *, loaded_models: callback(),
+        lambda api, settings, job_id, status, callback, *, loaded_models: callback(lambda: False),
     )
 
     class FailingTrainer:
@@ -3157,7 +3161,7 @@ def test_video_job_reports_dynamic_loaded_models_on_progress_and_keepalive(monke
 
     def run_immediately(_api, _settings, _job_id, _status, callback, *, loaded_models):
         blocking_models.append(loaded_models())
-        result = callback()
+        result = callback(lambda: False)
         blocking_models.append(loaded_models())
         return result
 
@@ -3217,7 +3221,7 @@ def test_video_job_estimate_progress_accepts_non_preview_frame_requirements(monk
     monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda _job=None: VideoAdapter())
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda *_args, **_kwargs: _args[4](),
+        lambda *_args, **_kwargs: _args[4](lambda: False),
     )
 
     run_video_job(
@@ -3266,7 +3270,7 @@ def test_video_job_failure_runs_cleanup_to_free_gpu(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda _job=None: VideoAdapter())
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda *_args, **_kwargs: _args[4](),
+        lambda *_args, **_kwargs: _args[4](lambda: False),
     )
 
     # A CUDA OOM cleans up, marks the job failed, then exits (SystemExit) so the
@@ -3320,7 +3324,7 @@ def test_video_job_nonoom_failure_does_not_restart(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.create_video_adapter", lambda _job=None: VideoAdapter())
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda *_args, **_kwargs: _args[4](),
+        lambda *_args, **_kwargs: _args[4](lambda: False),
     )
 
     # A non-OOM failure cleans up and marks failed but returns normally (no restart).
@@ -5275,3 +5279,157 @@ def test_z_image_adapter_fails_fast_when_pipeline_stays_on_cpu_with_offload_fall
             progress=lambda *_args, **_kwargs: None,
             cancel_requested=lambda: False,
         )
+
+
+# --- Cancellation: JobCancelMonitor watchdog + per-step interrupt ---------------
+
+
+class _CancelPollApi:
+    """Fake API for JobCancelMonitor tests: GET reports a (mutable) cancel flag;
+    POST /progress records the payload so the test can assert the final status."""
+
+    def __init__(self, cancel_requested=False):
+        self.cancel_requested = cancel_requested
+        self.progress = []
+
+    def get(self, _path):
+        return {"cancelRequested": self.cancel_requested}
+
+    def post(self, path, payload):
+        if path.endswith("/heartbeat"):
+            return {}
+        if path.endswith("/progress"):
+            self.progress.append(payload)
+            return {"status": payload["status"], "stage": payload["stage"]}
+        raise AssertionError(path)
+
+
+def _wait_until(predicate, timeout=2.0, interval=0.02):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+def test_cancel_monitor_caches_cancel_state(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    api = _CancelPollApi(cancel_requested=True)
+    settings = SimpleNamespace(worker_id="worker-1", force_cancel_seconds=0)
+    monitor = JobCancelMonitor(api, settings, "job-1", poll_interval=0.05, force_cancel_seconds=0)
+    monitor.start()
+    try:
+        assert _wait_until(monitor.requested)
+    finally:
+        monitor.stop()
+
+
+def test_cancel_monitor_does_not_escalate_without_cancel(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    exits = []
+    monkeypatch.setattr("scene_worker.runtime.os._exit", lambda code: exits.append(code))
+    api = _CancelPollApi(cancel_requested=False)
+    settings = SimpleNamespace(worker_id="worker-1", force_cancel_seconds=0.1)
+    monitor = JobCancelMonitor(api, settings, "job-1", poll_interval=0.02, force_cancel_seconds=0.1)
+    monitor.start()
+    try:
+        time.sleep(0.3)
+        assert exits == []
+        assert monitor.requested() is False
+    finally:
+        monitor.stop()
+
+
+def test_cancel_monitor_force_terminates_after_deadline(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    exited = threading.Event()
+    exits = []
+
+    def fake_exit(code):
+        exits.append(code)
+        exited.set()
+
+    monkeypatch.setattr("scene_worker.runtime.os._exit", fake_exit)
+    api = _CancelPollApi(cancel_requested=True)
+    settings = SimpleNamespace(worker_id="worker-1", force_cancel_seconds=0.15)
+    monitor = JobCancelMonitor(api, settings, "job-9", poll_interval=0.02, force_cancel_seconds=0.15)
+    monitor.start()
+    try:
+        assert exited.wait(timeout=2.0)
+    finally:
+        monitor.stop()
+    assert exits == [FORCED_CANCEL_EXIT_CODE]
+    # The job was marked canceled before the (mocked) process exit, so the UI
+    # resolves immediately instead of waiting for a stale-worker reaper.
+    terminal = api.progress[-1]
+    assert terminal["status"] == "canceled"
+    assert terminal["stage"] == "canceled"
+    assert "force-stopped" in terminal["message"].lower()
+
+
+def test_cancel_monitor_skips_escalation_when_stopped(monkeypatch):
+    # A cooperative cancel that finishes before the deadline must not force-kill.
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    exits = []
+    monkeypatch.setattr("scene_worker.runtime.os._exit", lambda code: exits.append(code))
+    api = _CancelPollApi(cancel_requested=True)
+    settings = SimpleNamespace(worker_id="worker-1", force_cancel_seconds=5)
+    monitor = JobCancelMonitor(api, settings, "job-2", poll_interval=0.02, force_cancel_seconds=5)
+    monitor.start()
+    assert _wait_until(monitor.requested)  # cancel observed
+    monitor.stop()  # cooperative path finished the job before the deadline
+    time.sleep(0.1)
+    assert exits == []
+
+
+class _FakeStepPipe:
+    def __init__(self):
+        self._interrupt = False
+
+    def __call__(self, *, prompt=None, callback_on_step_end=None):
+        return None
+
+
+class _NoCallbackPipe:
+    def __call__(self, *, prompt=None):
+        return None
+
+
+def test_cancel_step_callback_sets_interrupt_when_canceled():
+    pipe = _FakeStepPipe()
+    callback = cancel_step_callback(pipe, lambda: True)
+    assert callback is not None
+    returned = callback(pipe, 0, None, {"latents": "x"})
+    assert returned == {"latents": "x"}  # callback must pass kwargs through
+    assert pipe._interrupt is True
+
+
+def test_cancel_step_callback_leaves_interrupt_when_not_canceled():
+    pipe = _FakeStepPipe()
+    callback = cancel_step_callback(pipe, lambda: False)
+    assert callback is not None
+    callback(pipe, 0, None, {})
+    assert pipe._interrupt is False
+
+
+def test_cancel_step_callback_none_without_predicate():
+    assert cancel_step_callback(_FakeStepPipe(), None) is None
+
+
+def test_cancel_step_callback_none_when_pipe_lacks_support():
+    assert cancel_step_callback(_NoCallbackPipe(), lambda: True) is None
+
+
+def test_worker_settings_force_cancel_seconds_default(monkeypatch):
+    monkeypatch.delenv("SCENEWORKS_WORKER_FORCE_CANCEL_SECONDS", raising=False)
+    from scene_worker.settings import WorkerSettings
+
+    assert WorkerSettings().force_cancel_seconds == 30
+
+
+def test_worker_settings_force_cancel_seconds_env_override(monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_WORKER_FORCE_CANCEL_SECONDS", "5")
+    from scene_worker.settings import WorkerSettings
+
+    assert WorkerSettings().force_cancel_seconds == 5


### PR DESCRIPTION
## Summary
Canceling a *running* job used to sit on "Cancellation requested. Waiting for worker acknowledgement." for minutes, because cancellation was cooperative and only checked at coarse checkpoints (between images / between stages) — never mid-inference. This adds two layers so cancellation lands fast and is bounded:

- **Per-step cooperative interrupt (fast path):** `adapter_utils.cancel_step_callback` builds a diffusers `callback_on_step_end` that flips `pipe._interrupt` mid-denoise. Wired into the Z-Image / Qwen / diffusers-video pipe calls, and the vendored Lens pipeline now honors `_interrupt`. After the pipe returns, cancellation is re-checked and the partial result is discarded. A canceled generation breaks at the next step boundary instead of after the whole run.
- **30s hard-stop watchdog (the guarantee):** `runtime.JobCancelMonitor` polls the job's cancel flag on a background thread and caches it (so per-step checks need no HTTP). If a cancel stays unacknowledged past `force_cancel_seconds` (default **30**), it marks the job `canceled` via the API and then `os._exit`s the worker; the supervisor (Tauri on desktop / child supervisor / Docker on web) respawns a clean worker. `run_blocking_job_step` owns the monitor, so **every** job type — image, video, person, training, caption, VQA, interleave — is covered uniformly, including non-diffusers paths (ltx-core video, MLX) that the per-step interrupt can't reach.

Follow-on to sc-1370 (PR #50), which fixed the *queued*-job case and explicitly left the running-job force-cancel path for later.

### Design notes
- Self-watchdog (worker exits itself) rather than a supervisor-driven kill: no PID is stored in the jobs/workers tables, and the Python worker runs one job per process — so `os._exit` after marking the job canceled stops exactly the stuck job, and the existing restart-on-exit supervision respawns it. Mirrors the existing OOM-restart pattern (exit code 75; this uses 76).
- Configurable via `SCENEWORKS_WORKER_FORCE_CANCEL_SECONDS` (`0` disables the hard stop, leaving cancellation cooperative-only).

### Known limitations (tracked on sc-1598)
- The Rust worker (model download, MLX convert, timeline export) is not covered; it has its own cooperative `check_cancel` and would need a separate Rust-side watchdog.
- `os._exit` can orphan worker-spawned subprocesses (e.g. `lens_runner`) — follow-up: kill the worker's process group on force-stop.

## Test plan
- [x] `pytest tests/test_worker_runtime.py` → 217 passed, 7 skipped (incl. new monitor/interrupt/settings tests)
- [x] `pytest tests/test_person_adapters.py tests/test_worker_gpu.py` → 31 passed
- [x] All changed files `py_compile` clean; rebased onto current `origin/main` (735c490), conflict-free
- [ ] Manual: cancel an in-flight image/video generation on Mac/MPS and confirm it stops within ~1 step (fast path) and, for a wedged job, within 30s (watchdog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)