### PR TITLE
fix(interleave): stop max_images shadowing the caller's value [sc-1606]

### DIFF
--- a/apps/worker/scene_worker/_vendor/README.md
+++ b/apps/worker/scene_worker/_vendor/README.md
@@ -44,9 +44,24 @@ torch SDPA when `flash_attn` is absent, so it runs on CUDA and MPS unchanged.
   `transformers>=4.57,<4.58`, accelerate, sentencepiece, safetensors) match the
   worker stack. Pip-install is not viable — upstream `pyproject` requires
   Python <3.12 (the worker is 3.12) and pins a cu128 torch.
-- Only the T2I path is wired today (`model.t2i_generate`); the `gguf` /
-  `--vram_mode` offload paths are unused (the offload path is the only place
-  upstream hard-excludes MPS).
+- Wired paths: `t2i_generate` (text-to-image), `it2i_generate` (instruction
+  editing), `chat` (VQA), and `interleave_gen` (interleaved text-image
+  documents). The `gguf` / `--vram_mode` offload paths are unused (the offload
+  path is the only place upstream hard-excludes MPS).
+
+### Local patches (re-apply on re-vendoring)
+
+SceneWorks-local edits to `sensenova_u1/models/neo_unify/modeling_neo_chat.py`:
+
+1. **`chat()` think flag (sc-1575):** added a `think` parameter; when `False` it
+   primes `<think>\n\n</think>` so VQA returns the answer instead of the model's
+   chain-of-thought. `SenseNovaU1Adapter.answer_question` passes `think=False`.
+2. **`interleave_gen()` max_images fix (sc-1606):** removed a hardcoded
+   `max_images = 10` that shadowed the caller's value (which had already sized
+   `image_size_list`), leaving the per-image guard at 10 regardless — so any
+   caller passing `max_images < 10` hit an `IndexError` once the model emitted
+   more images than its cap. Control-flow bug, not numerics; affects all
+   platforms.
 
 To update: re-copy `src/sensenova_u1/` from the upstream repo at the desired
-commit and update the commit hash above.
+commit, update the commit hash above, and re-apply the local patches.

--- a/apps/worker/scene_worker/_vendor/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/apps/worker/scene_worker/_vendor/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -1096,7 +1096,12 @@ class NEOChatModel(PreTrainedModel):
 
         generated_text = ""
         generated_images =[]
-        max_images = 10
+        # SceneWorks vendored patch (re-apply on re-vendoring upstream 238d6cf; sc-1606):
+        # upstream hardcoded ``max_images = 10`` here, shadowing the caller's value that
+        # already sized ``image_size_list`` above. The img_count guard below would then run
+        # to 10 regardless, so any caller passing max_images < 10 IndexErrors once the model
+        # emits more images than its cap. Dropping the line lets the parameter govern both
+        # the list size and the guard (a cross-platform fix; our callers cap maxImages 1-10).
         img_count = 0
 
         next_token = torch.argmax(outputs_cond.logits[:, -1, :], dim=-1)


### PR DESCRIPTION
## Summary
Fixes the Non-Think interleave crash root-caused during MPS validation. In the vendored `modeling_neo_chat.py::interleave_gen`, a hardcoded `max_images = 10` (line ~1099) overwrote the caller's value **after** `image_size_list` had already been sized from it (line ~1014). The per-image guard (`if img_count >= max_images`) then compared against 10, so any caller passing `max_images < 10` hit `IndexError` on `image_size_list[img_count]` once the model emitted more images than its cap.

- **Latent on every platform**, not a CUDA-numerics issue — the Mac runs only passed because they happened to stay within the cap. With the production default `maxImages=6`, any prompt the model answers with 7+ images would crash on Mac too.
- **Fix:** drop the hardcoded line so the parameter governs both the list size and the guard. The model now stops cleanly at the caller's cap instead of crashing. Our callers already validate `maxImages` to 1–10 (`validate_interleave_job` + worker `safe_int`), so no in-model bound is lost, and runs that currently work are unchanged.
- Marked as a **SceneWorks vendored patch** (with the existing `chat()` think-flag patch) and documented under "Local patches" in `_vendor/README.md` so a re-vendor at upstream `238d6cf` re-applies it.

## Verification
- [x] Vendored file parses; worker pytest 218 passed / 6 skipped; scaffold green.
- [ ] **Non-Think interleave re-run on CUDA** (no crash, coherent output) is owned by the rescue agent / Michael — I can't run CUDA or the 35GB model. The fix itself is a one-line control-flow correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)