### PR TITLE
fix(worker): remove sourceImagePath arbitrary read; unify guarded HF cache resolution (sc-1638, sc-1649)

### DIFF
--- a/apps/worker/scene_worker/hf_cache.py
+++ b/apps/worker/scene_worker/hf_cache.py
@@ -1,0 +1,92 @@
+"""Single source of truth for resolving Hugging Face cache paths.
+
+This consolidates what were three near-identical copies in the image, lora, and
+video adapters. The lora copy skipped the ``resolve()`` + ``relative_to()``
+traversal guard and consulted a different cache-root order, so a repo cached
+under one root was "found here but not there". Everything now flows through one
+guarded primitive (:func:`huggingface_repo_cache_path_for_root`) and one ordered,
+de-duplicated list of roots (:func:`huggingface_cache_roots`).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def safe_repo_dir_name(repo: str) -> str | None:
+    """The ``models--<repo>`` directory stem HF uses, unsafe chars folded to ``--``."""
+
+    name = "".join(char if char.isalnum() or char in "._-" else "--" for char in repo).strip("-")
+    return name or None
+
+
+def huggingface_cache_root() -> Path:
+    """The primary HF hub cache root from the environment (falls back to ~/.cache)."""
+
+    default_home = Path.home() / ".cache" / "huggingface"
+    hf_home = Path(os.getenv("HF_HOME") or default_home)
+    return Path(os.getenv("HF_HUB_CACHE") or os.getenv("HUGGINGFACE_HUB_CACHE") or hf_home / "hub")
+
+
+def huggingface_cache_roots(settings: Any | None = None) -> list[Path]:
+    """All HF hub cache roots to consult, in priority order, de-duplicated.
+
+    Order: explicit ``HF_HUB_CACHE`` / ``HUGGINGFACE_HUB_CACHE``, then ``HF_HOME/hub``,
+    then the app data dir's cache (``settings.data_dir`` if given, else
+    ``$SCENEWORKS_DATA_DIR``), then ``huggingface_cache_root()`` (env-or-~/.cache).
+    """
+
+    roots: list[Path] = []
+    for value in (os.getenv("HF_HUB_CACHE"), os.getenv("HUGGINGFACE_HUB_CACHE")):
+        if value:
+            roots.append(Path(value).expanduser())
+    hf_home = os.getenv("HF_HOME", "").strip()
+    if hf_home:
+        roots.append(Path(hf_home).expanduser() / "hub")
+    data_dir = getattr(settings, "data_dir", None)
+    if data_dir is None:
+        data_dir = Path(os.getenv("SCENEWORKS_DATA_DIR", "data")).expanduser()
+    roots.append(Path(data_dir) / "cache" / "huggingface" / "hub")
+    roots.append(huggingface_cache_root())
+    unique: list[Path] = []
+    for root in roots:
+        if root not in unique:
+            unique.append(root)
+    return unique
+
+
+def huggingface_repo_cache_path_for_root(cache_root: Path, repo: str) -> Path | None:
+    """``<cache_root>/models--<repo>``, guarded so it can never escape ``cache_root``."""
+
+    safe_repo = safe_repo_dir_name(repo)
+    if not safe_repo:
+        return None
+    try:
+        root = cache_root.resolve()
+        repo_cache = (root / f"models--{safe_repo}").resolve()
+        repo_cache.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return repo_cache
+
+
+def huggingface_repo_cache_path(repo: str, settings: Any | None = None) -> Path | None:
+    """The cached ``models--<repo>`` directory.
+
+    Returns the first known root where it actually exists; if it exists nowhere,
+    returns the guarded path under the primary root (for callers asking "where
+    would it go"). Returns ``None`` only when ``repo`` has no safe directory name.
+    """
+
+    fallback: Path | None = None
+    for root in huggingface_cache_roots(settings):
+        repo_cache = huggingface_repo_cache_path_for_root(root, repo)
+        if repo_cache is None:
+            continue
+        if fallback is None:
+            fallback = repo_cache
+        if repo_cache.exists():
+            return repo_cache
+    return fallback

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -31,6 +31,7 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import cancel_step_callback, filter_call_kwargs
+from .hf_cache import huggingface_repo_cache_path
 from .lora_adapters import (
     LoraPipelineState,
     apply_loras_to_pipeline,
@@ -63,22 +64,6 @@ def huggingface_repo_cache_exists(repo: str) -> bool:
     if repo_cache is None:
         return False
     return (repo_cache / "snapshots").is_dir() or (repo_cache / "blobs").is_dir()
-
-
-def huggingface_repo_cache_path(repo: str) -> Path | None:
-    default_home = Path.home() / ".cache" / "huggingface"
-    hf_home = Path(os.getenv("HF_HOME") or default_home)
-    cache_root = Path(os.getenv("HF_HUB_CACHE") or os.getenv("HUGGINGFACE_HUB_CACHE") or hf_home / "hub")
-    safe_repo = "".join(char if char.isalnum() or char in "._-" else "--" for char in repo).strip("-")
-    if not safe_repo:
-        return None
-    try:
-        root = cache_root.resolve()
-        repo_cache = (root / f"models--{safe_repo}").resolve()
-        repo_cache.relative_to(root)
-    except (OSError, ValueError):
-        return None
-    return repo_cache
 
 
 def emit_worker_event(event: str, **payload: Any) -> None:
@@ -1859,7 +1844,7 @@ class SenseNovaU1Adapter:
         model, tokenizer = self._load_model(torch, repo, device, dtype, distill_lora=None, job_id=job["id"])
         self._loaded_model = model_id
 
-        source_path = self._resolve_source_path(settings, project_id, source_asset_id, advanced.get("sourceImagePath"))
+        source_path = self._resolve_source_path(settings, project_id, source_asset_id)
         try:
             image = Image.open(source_path).convert("RGB")
         except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
@@ -1898,10 +1883,11 @@ class SenseNovaU1Adapter:
         settings: WorkerSettings,
         project_id: str,
         source_asset_id: str | None,
-        source_image_path: str | None,
     ) -> str:
-        if source_image_path:
-            return str(source_image_path)
+        # Resolve only through the project sidecar/DB (find_asset_media_path constrains
+        # the result to the project root). There is deliberately no client-supplied path
+        # escape hatch: an arbitrary sourceImagePath would let a job read any file the
+        # worker can open and, for VQA, return its contents to the caller.
         if not source_asset_id:
             raise RuntimeError("Visual question answering requires a source image asset.")
         project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", project_id)
@@ -2457,12 +2443,13 @@ def select_torch_dtype(torch: Any, device: str, requested: Any) -> Any:
 
 
 def load_source_image(settings: WorkerSettings, request: ImageRequest) -> Image.Image:
-    source_path = request.advanced.get("sourceImagePath")
-    if not source_path and request.source_asset_id:
-        project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
-        source_path = find_asset_media_path(project_path, request.source_asset_id)
-    if not source_path:
+    # Resolve only through the project sidecar/DB (find_asset_media_path constrains the
+    # result to the project root). No client-supplied path escape hatch: an arbitrary
+    # sourceImagePath would let an edit job read any file the worker can open.
+    if not request.source_asset_id:
         raise RuntimeError("Image edit jobs require a source image asset.")
+    project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
+    source_path = find_asset_media_path(project_path, request.source_asset_id)
     try:
         image = Image.open(source_path).convert("RGB")
     except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
-import os
 import re
 from pathlib import Path
 from typing import Any
+
+from .hf_cache import huggingface_repo_cache_path
 
 
 # Keep in sync with packages/schemas/recipe-preset.schema.json and the Rust
@@ -267,25 +268,6 @@ def huggingface_cached_lora_path(lora: dict[str, Any]) -> Path | None:
         if safetensors_path is not None:
             return safetensors_path
     return first_safetensors_path(root)
-
-
-def huggingface_repo_cache_path(repo: str) -> Path | None:
-    safe_repo = "".join(character if character.isalnum() or character in "._-" else "--" for character in repo).strip("-")
-    if not safe_repo:
-        return None
-    return huggingface_hub_cache_dir() / f"models--{safe_repo}"
-
-
-def huggingface_hub_cache_dir() -> Path:
-    for key in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"):
-        value = os.getenv(key, "").strip()
-        if value:
-            return Path(value).expanduser()
-    hf_home = os.getenv("HF_HOME", "").strip()
-    if hf_home:
-        return Path(hf_home).expanduser() / "hub"
-    data_dir = Path(os.getenv("SCENEWORKS_DATA_DIR", "data")).expanduser()
-    return data_dir / "cache" / "huggingface" / "hub"
 
 
 def huggingface_snapshot_dirs(repo_root: Path) -> list[Path]:

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -31,6 +31,7 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import cancel_step_callback, filter_call_kwargs
+from .hf_cache import huggingface_cache_root, huggingface_cache_roots, huggingface_repo_cache_path_for_root
 from .image_adapters import emit_worker_event, empty_torch_cache, gpu_memory_snapshot, require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
 from .lora_adapters import (
     LoraPipelineState,
@@ -2664,42 +2665,6 @@ def resolve_manifest_path(settings: WorkerSettings, value: Any) -> Path:
         raw_path = raw_path.replace("${HF_CACHE}", str(huggingface_cache_root()))
     path = Path(raw_path)
     return path if path.is_absolute() else settings.data_dir / path
-
-
-def huggingface_cache_root() -> Path:
-    default_home = Path.home() / ".cache" / "huggingface"
-    hf_home = Path(os.getenv("HF_HOME") or default_home)
-    return Path(os.getenv("HF_HUB_CACHE") or os.getenv("HUGGINGFACE_HUB_CACHE") or hf_home / "hub")
-
-
-def huggingface_cache_roots(settings: WorkerSettings | None = None) -> list[Path]:
-    roots: list[Path] = []
-    for value in (os.getenv("HF_HUB_CACHE"), os.getenv("HUGGINGFACE_HUB_CACHE")):
-        if value:
-            roots.append(Path(value))
-    if os.getenv("HF_HOME"):
-        roots.append(Path(os.getenv("HF_HOME", "")) / "hub")
-    if settings is not None:
-        roots.append(settings.data_dir / "cache" / "huggingface" / "hub")
-    roots.append(huggingface_cache_root())
-    unique: list[Path] = []
-    for root in roots:
-        if root not in unique:
-            unique.append(root)
-    return unique
-
-
-def huggingface_repo_cache_path_for_root(cache_root: Path, repo: str) -> Path | None:
-    safe_repo = "".join(char if char.isalnum() or char in "._-" else "--" for char in repo).strip("-")
-    if not safe_repo:
-        return None
-    try:
-        root = cache_root.resolve()
-        repo_cache = (root / f"models--{safe_repo}").resolve()
-        repo_cache.relative_to(root)
-    except (OSError, ValueError):
-        return None
-    return repo_cache
 
 
 def huggingface_cached_snapshot_dir(settings: WorkerSettings, repo: str) -> Path | None:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1210,6 +1210,23 @@ def test_huggingface_repo_cache_path_stays_under_cache_root(monkeypatch, tmp_pat
     assert path.name.startswith("models--")
 
 
+def test_repo_cache_path_is_a_single_guarded_helper(monkeypatch, tmp_path):
+    # The lora adapter previously had its own unguarded copy with a different
+    # cache-root order. Every adapter must now resolve through the one guarded
+    # helper, so a traversal repo id can't escape the cache root from any entry point.
+    from scene_worker.hf_cache import huggingface_repo_cache_path as shared
+    from scene_worker.lora_adapters import huggingface_repo_cache_path as lora_entry
+
+    assert huggingface_repo_cache_path is shared
+    assert lora_entry is shared
+
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(tmp_path / "hub"))
+    path = lora_entry(r"..\..\outside/model")
+    assert path is not None
+    path.relative_to((tmp_path / "hub").resolve())
+    assert path.name.startswith("models--")
+
+
 def test_image_asset_writer_reports_partial_result_assets(tmp_path):
     data_dir = tmp_path / "data"
     project_path = tmp_path / "project"


### PR DESCRIPTION
## Summary
Python path-safety cluster from the 2026-05-24 full-repo review (epic [1628](https://app.shortcut.com/trefry/epic/1628)).

- **sc-1638 (High):** VQA (`SenseNovaU1Adapter._resolve_source_path`) and image-edit (`load_source_image`) took a client-supplied `advanced.sourceImagePath` and passed it straight to `Image.open` with no containment check — an arbitrary-file-read primitive (and, for VQA, an exfiltration primitive, since the file's contents are summarized back to the caller). Nothing in the API/UI ever sends `sourceImagePath` (verified repo-wide), so the escape hatch is **removed**: both paths now resolve only through the project sidecar via `find_asset_media_path` (project-root constrained) and require `sourceAssetId`.
- **sc-1649 (Medium):** three near-identical "HF repo id → `models--<safe>` cache dir" copies disagreed — the `lora_adapters` copy skipped the `resolve()`+`relative_to()` traversal guard and used a different cache-root order, producing "found here but not there" bugs. Consolidated into one guarded module `scene_worker/hf_cache.py` with a single ordered, de-duplicated root list (the **union** of all roots the three copies consulted, so nothing is lost). `image`/`lora`/`video`/`training` adapters now delegate to it; the lora/training entry point gains the guard.

Deployment note: the desktop sets `HF_HOME` for the sidecars, under which all three former copies already resolved to `HF_HOME/hub`; the root-order divergence only bit unconfigured dev environments.

## Test plan
- [x] `tests/test_worker_runtime.py` — 217 passed, 7 skipped (ephemeral pytest+pillow+httpx venv; torch lazy-imported)
- [x] `tests/test_person_adapters.py` + `tests/test_worker_gpu.py` — 31 passed
- [x] New `test_repo_cache_path_is_a_single_guarded_helper` pins that image/lora share the one guarded resolver and that traversal repo ids stay under the cache root
- [x] `py_compile` clean across all four edited modules + new `hf_cache.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)