### PR TITLE
fix(api,desktop): reduce health disclosure; restore desktop webview CSP (sc-1632, sc-1634)

### DIFF
--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
     }
   },
   "bundle": {

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -813,7 +813,10 @@ struct HealthResponse {
     runtime: String,
     version: String,
     auth_required: bool,
-    directories: DirectoriesResponse,
+    // Absolute host paths are withheld from the public health endpoint when a token is
+    // configured, so a LAN client can't map the host filesystem despite auth being on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    directories: Option<DirectoriesResponse>,
     interrupted_jobs_on_startup: usize,
 }
 
@@ -1296,17 +1299,24 @@ struct LoraImportRequest {
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
+    let token_configured = !state.settings.access_token.is_empty();
     Json(HealthResponse {
         status: "ok",
         service: "sceneworks-api",
         runtime: "rust".to_owned(),
         version: state.settings.app_version.clone(),
-        auth_required: !state.settings.access_token.is_empty(),
-        directories: DirectoriesResponse {
-            data: state.settings.data_dir.display().to_string(),
-            config: state.settings.config_dir.display().to_string(),
-            projects: state.settings.projects_dir().display().to_string(),
-            jobs_db: state.settings.jobs_db_path.display().to_string(),
+        auth_required: token_configured,
+        // When a token is configured the endpoint is public but the deployment expects
+        // auth, so don't leak absolute host paths to unauthenticated LAN callers.
+        directories: if token_configured {
+            None
+        } else {
+            Some(DirectoriesResponse {
+                data: state.settings.data_dir.display().to_string(),
+                config: state.settings.config_dir.display().to_string(),
+                projects: state.settings.projects_dir().display().to_string(),
+                jobs_db: state.settings.jobs_db_path.display().to_string(),
+            })
         },
         interrupted_jobs_on_startup: state.interrupted_jobs_on_startup,
     })
@@ -3228,6 +3238,24 @@ mod web_assets {
     #[folder = "../web/dist"]
     struct WebAssets;
 
+    // The desktop shell navigates its privileged webview to this server, so the embedded
+    // UI runs from this origin and its CSP must come from here (tauri.conf.json only
+    // governs the bundled setup screen). Kept narrow: scripts only from this origin (the
+    // theme bootstrap was moved to /theme-init.js so no inline script is needed), Google
+    // Fonts allowed, images/media as self/data/blob, IPC for the Tauri webview. Same-origin
+    // API + SSE are covered by connect-src 'self'.
+    pub(super) const CONTENT_SECURITY_POLICY: &str = "default-src 'self'; \
+script-src 'self'; \
+style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
+font-src 'self' https://fonts.gstatic.com data:; \
+img-src 'self' data: blob:; \
+media-src 'self' data: blob:; \
+connect-src 'self' ipc: http://ipc.localhost; \
+object-src 'none'; \
+base-uri 'self'; \
+frame-ancestors 'none'; \
+form-action 'self'";
+
     pub(super) async fn serve(uri: Uri) -> Response {
         let requested = uri.path().trim_start_matches('/');
         let requested = if requested.is_empty() {
@@ -3238,7 +3266,10 @@ mod web_assets {
         if let Some(file) = WebAssets::get(requested) {
             let mime = mime_guess::from_path(requested).first_or_octet_stream();
             return (
-                [(header::CONTENT_TYPE, mime.as_ref())],
+                [
+                    (header::CONTENT_TYPE, mime.as_ref()),
+                    (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
+                ],
                 file.data.into_owned(),
             )
                 .into_response();
@@ -3247,7 +3278,10 @@ mod web_assets {
         // client-side deep links (e.g. project routes) load correctly.
         match WebAssets::get("index.html") {
             Some(index) => (
-                [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+                [
+                    (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+                    (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
+                ],
                 index.data.into_owned(),
             )
                 .into_response(),
@@ -13356,6 +13390,29 @@ mod tests {
         assert_eq!(jobs, json!([]));
     }
 
+    #[tokio::test]
+    async fn public_health_withholds_host_paths_when_a_token_is_configured() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+
+        // No token: single-user/local, directories stay for diagnostics.
+        let open_app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, health) = request(open_app, "GET", "/api/v1/health", Value::Null).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(health["status"], "ok");
+        assert_eq!(health["authRequired"], false);
+        assert!(health.get("directories").is_some());
+
+        // Token configured but /health is public: don't leak absolute host paths.
+        let mut settings = test_settings(&temp_dir);
+        settings.access_token = "secret-token".to_owned();
+        let guarded_app = create_app(settings).expect("app creates");
+        let (status, health) = request(guarded_app, "GET", "/api/v1/health", Value::Null).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(health["status"], "ok");
+        assert_eq!(health["authRequired"], true);
+        assert!(health.get("directories").is_none());
+    }
+
     #[test]
     fn requires_token_only_gates_api_paths() {
         // Non-API paths (embedded UI / SPA fallback) must never require a token,
@@ -13386,6 +13443,26 @@ mod tests {
         // API routes stay protected.
         let (status, _) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[cfg(feature = "embed-web")]
+    #[test]
+    fn embedded_ui_csp_locks_down_scripts_but_allows_app_resources() {
+        let csp = super::web_assets::CONTENT_SECURITY_POLICY;
+        // The whole point: scripts only from this origin, no inline/eval escape hatch.
+        assert!(csp.contains("script-src 'self'"));
+        assert!(!csp.contains("script-src 'self' 'unsafe-inline'"));
+        assert!(!csp.contains("unsafe-eval"));
+        // Resources the app genuinely needs.
+        assert!(csp.contains("default-src 'self'"));
+        assert!(csp.contains("font-src 'self' https://fonts.gstatic.com data:"));
+        assert!(csp.contains("https://fonts.googleapis.com"));
+        assert!(csp.contains("img-src 'self' data: blob:"));
+        // Tauri IPC for the navigated desktop webview.
+        assert!(csp.contains("ipc:"));
+        // Hardening directives.
+        assert!(csp.contains("object-src 'none'"));
+        assert!(csp.contains("frame-ancestors 'none'"));
     }
 
     #[test]

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,17 +12,7 @@
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script>
-      // Apply persisted theme before paint to avoid a flash.
-      try {
-        const saved = window.localStorage.getItem("sceneworks-theme");
-        if (saved === "dark" || saved === "light") {
-          document.documentElement.setAttribute("data-theme", saved);
-        }
-      } catch (_) {
-        // ignore (private mode etc.)
-      }
-    </script>
+    <script src="/theme-init.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/public/theme-init.js
+++ b/apps/web/public/theme-init.js
@@ -1,0 +1,10 @@
+// Apply the persisted theme before first paint to avoid a flash. Kept as an
+// external script (not inline) so the served CSP can use a strict script-src 'self'.
+try {
+  const saved = window.localStorage.getItem("sceneworks-theme");
+  if (saved === "dark" || saved === "light") {
+    document.documentElement.setAttribute("data-theme", saved);
+  }
+} catch (_) {
+  // ignore (private mode etc.)
+}


### PR DESCRIPTION
## Summary
API/desktop hardening cluster from the 2026-05-24 full-repo review (epic [1628](https://app.shortcut.com/trefry/epic/1628)).

- **sc-1632 (Medium):** `/api/v1/health` is public but returned absolute host paths (`data`/`config`/`projects`/`jobsDb`), letting a LAN client map the host filesystem even with token auth on. The `directories` block is now **omitted whenever an access token is configured**; with no token (local single-user) it stays for diagnostics. Verified no consumer breaks: the web UI only reads `health.status`, and the desktop readiness check only inspects `service`/`runtime`.
- **sc-1634 (Low/Medium):** the desktop disabled CSP (`csp: null`). Because the shell **navigates its privileged webview to the local API origin** (`apps/desktop/src/setup.rs` → `window.navigate("http://127.0.0.1:{port}")`), the live app's CSP must come from HTTP headers, not just `tauri.conf.json`:
  - The **Rust API now sends a narrow `Content-Security-Policy`** on its embedded-UI responses (`web_assets::serve`): `script-src 'self'` (no inline — the theme bootstrap moved to `/theme-init.js`), Google Fonts allowed, `img`/`media` `self`/`data`/`blob`, `ipc:` for the Tauri webview, plus `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`.
  - **`tauri.conf.json`** gets a matching CSP for the bundled setup screen (`apps/desktop/ui/`); Tauri augments it with that screen's inline-script/style hashes automatically.

## ⚠️ Needs a build smoke-test before merge
I could not run the Tauri webview or the Vite build in this environment. Please smoke-test a desktop build (and a `npm --prefix apps/web run build` + served bundle) to confirm:
- No CSP console violations; the SPA renders (fonts, images, video previews).
- Tauri IPC still works from the navigated page (Settings/Model manager invoke `window.__TAURI__`). If Tauri's injected IPC bootstrap needs it, we may have to add a nonce/hash or `'wasm-unsafe-eval'` to `script-src`.

## Test plan
- [x] `cargo test -p sceneworks-rust-api` — new `public_health_withholds_host_paths_when_a_token_is_configured` passes (directories present w/o token, absent w/ token)
- [x] `cargo test -p sceneworks-rust-api --features embed-web` — new `embedded_ui_csp_locks_down_scripts_but_allows_app_resources` passes (verified via a throwaway dist; not committed)
- [x] `cargo clippy` clean on both default and `embed-web`
- [ ] Desktop + browser build smoke-test (see above) — **pre-merge gate**

> Note: CI `cargo fmt --check` is currently red on a pre-existing `parent_death` test formatting issue in `apps/rust-api/src/lib.rs` (documented in the epic), unrelated to this PR. Raising separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)