### PR TITLE
chore(api): fix pre-existing rustfmt failure in parent_death test

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -13534,15 +13534,15 @@ mod tests {
             .expect("spawn dummy parent");
         let pid = parent.id() as i32;
 
-        assert!(super::pid_alive(pid), "freshly spawned parent reads as dead");
+        assert!(
+            super::pid_alive(pid),
+            "freshly spawned parent reads as dead"
+        );
         // Still alive -> the watchdog must not resolve within a poll cycle.
         assert!(
-            tokio::time::timeout(
-                Duration::from_millis(200),
-                super::parent_death(Some(pid)),
-            )
-            .await
-            .is_err(),
+            tokio::time::timeout(Duration::from_millis(200), super::parent_death(Some(pid)),)
+                .await
+                .is_err(),
             "watchdog resolved while the parent was still alive"
         );
 


### PR DESCRIPTION
## Summary
`cargo fmt --check` was failing on the `parent_death` watchdog test in `apps/rust-api/src/lib.rs` — a pre-existing issue (documented in epic [1628](https://app.shortcut.com/trefry/epic/1628)). Since it's the first step of `npm run rust:check`, it short-circuits lint/test/build and reddens CI for every Rust PR in the epic.

Formatting-only change (applied `cargo fmt`); no behavior change. Merging this first unblocks CI for the security-cluster PRs and all subsequent Rust work.

## Test plan
- [x] `cargo fmt --all -- --check` now clean across the workspace