### PR TITLE
refactor(rust): migration gating, query dedup, supervision fix, capability doc (sc-1645/1662/1671/1672)

### DIFF
--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -280,6 +280,10 @@ string_enum! {
         // and apps/worker/scene_worker/runtime.py.
         PersonDetectPreview => "person_detect_preview",
         PersonTrackPreview => "person_track_preview",
+        // Real person segmentation (SAM2), advertised only by the Python GPU worker
+        // (runtime.py, gated on segmenter_backend_available) and consumed by
+        // replace-person readiness; the Rust worker never emits it. Not dead — see
+        // the API "segment" capability mapping.
         PersonSegment => "person_segment",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use parking_lot::Mutex;
-use rusqlite::{params, params_from_iter, Connection, OptionalExtension, Row};
+use rusqlite::{params, params_from_iter, Connection, OptionalExtension, Row, ToSql};
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Number, Value};
 
@@ -302,38 +302,26 @@ impl JobsStore {
         let _guard = self.lock.lock();
         let connection = self.connect()?;
         let limit = limit.clamp(1, 500);
-        let jobs = match (project_id, status) {
-            (Some(project_id), Some(status)) => {
-                let mut statement = connection.prepare(
-                    "select * from jobs where project_id = ?1 and status = ?2 order by created_at desc limit ?3",
-                )?;
-                let jobs = collect_jobs(
-                    statement.query_map(params![project_id, status, limit], row_to_job)?,
-                )?;
-                jobs
-            }
-            (Some(project_id), None) => {
-                let mut statement = connection.prepare(
-                    "select * from jobs where project_id = ?1 order by created_at desc limit ?2",
-                )?;
-                let jobs =
-                    collect_jobs(statement.query_map(params![project_id, limit], row_to_job)?)?;
-                jobs
-            }
-            (None, Some(status)) => {
-                let mut statement = connection.prepare(
-                    "select * from jobs where status = ?1 order by created_at desc limit ?2",
-                )?;
-                let jobs = collect_jobs(statement.query_map(params![status, limit], row_to_job)?)?;
-                jobs
-            }
-            (None, None) => {
-                let mut statement =
-                    connection.prepare("select * from jobs order by created_at desc limit ?1")?;
-                let jobs = collect_jobs(statement.query_map(params![limit], row_to_job)?)?;
-                jobs
-            }
-        };
+        let mut conditions: Vec<&str> = Vec::new();
+        let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
+        if let Some(project_id) = project_id {
+            conditions.push("project_id = ?");
+            bindings.push(Box::new(project_id.to_owned()));
+        }
+        if let Some(status) = status {
+            conditions.push("status = ?");
+            bindings.push(Box::new(status.to_owned()));
+        }
+        let mut sql = String::from("select * from jobs");
+        if !conditions.is_empty() {
+            sql.push_str(" where ");
+            sql.push_str(&conditions.join(" and "));
+        }
+        sql.push_str(" order by created_at desc limit ?");
+        bindings.push(Box::new(limit));
+        let mut statement = connection.prepare(&sql)?;
+        let jobs =
+            collect_jobs(statement.query_map(params_from_iter(bindings.iter()), row_to_job)?)?;
         Ok(jobs)
     }
 

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1270,7 +1270,19 @@ struct ReindexCounts {
     timelines: u32,
 }
 
+/// Bump whenever the project.db schema changes (new table, column, or index).
+/// `apply_project_migrations` only re-runs its DDL when `PRAGMA user_version`
+/// is behind this; forgetting to bump means an existing DB never gets the change.
+const PROJECT_SCHEMA_VERSION: i64 = 1;
+
+fn project_schema_version(connection: &Connection) -> ProjectStoreResult<i64> {
+    Ok(connection.query_row("pragma user_version", [], |row| row.get(0))?)
+}
+
 pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<()> {
+    if project_schema_version(connection)? >= PROJECT_SCHEMA_VERSION {
+        return Ok(());
+    }
     connection.execute_batch(
         "
         create table if not exists project_metadata (
@@ -1315,6 +1327,8 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
     ensure_column(connection, "assets", "sidecar_path", "text")?;
     apply_character_migrations(connection)?;
     apply_training_dataset_migrations(connection)?;
+    // Pragma assignment cannot be parameterized; the version is a trusted const.
+    connection.execute_batch(&format!("pragma user_version = {PROJECT_SCHEMA_VERSION}"))?;
     Ok(())
 }
 

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -5,7 +5,7 @@ use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::project_store::{ProjectStoreError, ProjectStoreResult};
+use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
     is_safe_id, is_safe_relative_path, parse_string_enum, random_hex, read_json, relative_string,
     write_json,
@@ -907,7 +907,9 @@ fn ensure_dataset_project(project_id: &str, dataset: &TrainingDataset) -> Projec
 
 pub fn ensure_training_dataset_table(project_path: &Path) -> ProjectStoreResult<()> {
     let connection = Connection::open(project_path.join("project.db"))?;
-    apply_training_dataset_migrations(&connection)
+    // Route through the version-gated comprehensive migration so the training
+    // path stops replaying DDL on every call (the table is created either way).
+    apply_project_migrations(&connection)
 }
 
 pub fn apply_training_dataset_migrations(connection: &Connection) -> ProjectStoreResult<()> {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -318,8 +318,10 @@ where
     let mut exited = Vec::new();
     for (worker_id, child) in children.iter_mut() {
         if let Some(status) = child.process.try_wait()? {
-            let restart_attempt = child.restart_attempt.saturating_add(1);
-            let delay = retry_delay(settings.poll_seconds, restart_attempt);
+            // Advance the attempt once here so the logged ETA and the actual
+            // backoff below both read the same stored value.
+            child.restart_attempt = child.restart_attempt.saturating_add(1);
+            let delay = retry_delay(settings.poll_seconds, child.restart_attempt);
             emit_json(json!({
                 "event": "worker_exited",
                 "workerId": worker_id,
@@ -335,7 +337,6 @@ where
         let Some(mut child) = children.remove(&worker_id) else {
             continue;
         };
-        child.restart_attempt = child.restart_attempt.saturating_add(1);
         let delay = retry_delay(settings.poll_seconds, child.restart_attempt);
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(delay)) => {}


### PR DESCRIPTION
## Summary

Third cluster from epic [1628](https://app.shortcut.com/trefry/epic/1628) — small Rust review findings (efficiency / dedup / supervision bug / capability clarity). Independent of the other PRs.

- **sc-1645** (efficiency): every store call was replaying `apply_project_migrations` (a multi-`CREATE TABLE IF NOT EXISTS` batch + `ensure_column` + sub-migrations), defeating WAL. Gated it behind `PRAGMA user_version` via a new `PROJECT_SCHEMA_VERSION` const — the full DDL runs once on a behind DB, then stamps the version; subsequent calls early-return. Routed `ensure_training_dataset_table` through the gated migration too. DDL runs inside the caller's transaction, so a rollback leaves `user_version` untouched and migrations re-run next time. (Bump `PROJECT_SCHEMA_VERSION` on any future schema change — documented at the const.)
- **sc-1662** (redundant): `list_jobs` had four near-identical `(project_id, status)` arms differing only by WHERE clause. Collapsed into one dynamically-built query (`params_from_iter` over `Vec<Box<dyn ToSql>>`), matching the file's existing dynamic-params idiom.
- **sc-1671** (bad-pattern): worker child supervision incremented `restart_attempt` twice — once for the logged ETA, once for the actual backoff. They happened to agree, but a future edit could desync them. Now advanced once at detection; the log and the sleep read the same stored value.
- **sc-1672** (dead-code → doc): the review flagged `person_segment` as advertised by no worker, but that premise is **stale** — the Python worker advertises it (`runtime.py`, gated on `segmenter_backend_available`, SAM2) and the API maps the `"segment"` class to it. It's a live Python-only capability, so I added a clarifying note on the enum variant rather than dropping it.

## Test plan
- [x] `npm run rust:check` — `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build` all pass
- [x] Migration gating exercised by the core suite (fresh-DB → run+stamp, then gate-skip on subsequent ops across project/character/training stores)
- [x] `list_jobs` positional binding preserved by construction (push order matches `?` order); the `(None, None)` path is covered and the filtered API path compiles + runs in the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)