### PR TITLE
fix(web): component hygiene — shared Modal, stable listener, list key (sc-1673/1674/1679)

### DIFF
--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { AssetThumbnail, assetCanRenderAsImage, assetCanRenderAsVideo } from "./assetMedia.jsx";
+import { Modal } from "./Modal.jsx";
 
 const categoryOptions = [
   ["all", "All"],
@@ -184,15 +185,10 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
   const [category, setCategory] = useState("all");
   const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
-  const dialogRef = useRef(null);
 
   useEffect(() => {
     setSelectedIds((ids) => normalizeSelection(ids, assets, multiple));
   }, [assets, multiple]);
-
-  useEffect(() => {
-    dialogRef.current?.focus();
-  }, []);
 
   const categoryCounts = useMemo(() => {
     return Object.fromEntries(categoryOptions.map(([key]) => [key, assets.filter((asset) => categoryMatches(asset, key)).length]));
@@ -215,22 +211,7 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
   }
 
   return (
-    <div className="modal-backdrop" onMouseDown={(event) => event.target === event.currentTarget && onCancel()}>
-      <section
-        aria-labelledby="asset-picker-title"
-        aria-modal="true"
-        className="asset-picker-modal"
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            event.preventDefault();
-            onCancel();
-          }
-        }}
-        onMouseDown={(event) => event.stopPropagation()}
-        ref={dialogRef}
-        role="dialog"
-        tabIndex={-1}
-      >
+    <Modal className="asset-picker-modal" labelledBy="asset-picker-title" onClose={onCancel}>
         <header className="asset-picker-modal-head">
           <div>
             <p className="eyebrow">Library</p>
@@ -299,7 +280,6 @@ export function AssetPickerModal({ assets, initialSelectedIds, multiple = false,
             </button>
           </div>
         </footer>
-      </section>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/Modal.jsx
+++ b/apps/web/src/components/Modal.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from "react";
+
+// Shared modal primitive: a backdrop that closes on outside mousedown, a
+// role="dialog" container that closes on Escape, and focus moved into the
+// dialog on mount. Extracted so every overlay behaves consistently for
+// keyboard and pointer users.
+export function Modal({ children, onClose, className, labelledBy, label }) {
+  const dialogRef = useRef(null);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="modal-backdrop"
+      onMouseDown={(event) => event.target === event.currentTarget && onClose()}
+    >
+      <div
+        aria-label={label}
+        aria-labelledby={labelledBy}
+        aria-modal="true"
+        className={className}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onClose();
+          }
+        }}
+        onMouseDown={(event) => event.stopPropagation()}
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { AssetMedia, assetUrl } from "./assetMedia.jsx";
 import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
+import { Modal } from "./Modal.jsx";
 
 // Reopens a saved interleaved document: the asset's file points to the segments
 // JSON in assets/documents/, fetched here (served like any project file).
@@ -285,12 +286,11 @@ export function FullscreenPreview({
   updateAssetStatus,
 }) {
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true">
-      <div className="preview-modal">
-        <button className="modal-close" onClick={onClose} type="button">
-          Close
-        </button>
-        <div className="preview-modal-stage">
+    <Modal className="preview-modal" label="Asset preview" onClose={onClose}>
+      <button className="modal-close" onClick={onClose} type="button">
+        Close
+      </button>
+      <div className="preview-modal-stage">
           <button
             aria-label="Previous asset"
             className="preview-nav-button previous"
@@ -334,7 +334,6 @@ export function FullscreenPreview({
             )}
           </div>
         </footer>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
-import { AssetDetail } from "./components/assetPanels.jsx";
+import { AssetDetail, FullscreenPreview } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
@@ -1728,6 +1728,46 @@ describe("SceneWorks app shell", () => {
     });
 
     expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("dismisses FullscreenPreview via Escape and backdrop click", async () => {
+    const onClose = vi.fn();
+    const noop = () => {};
+    const asset = {
+      id: "asset-a",
+      displayName: "Plate",
+      type: "image",
+      status: {},
+      file: { path: "assets/images/plate.png" },
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={asset}
+          deleteAsset={noop}
+          nextAsset={null}
+          onClose={onClose}
+          onPreviewAsset={noop}
+          previousAsset={null}
+          purgeAsset={noop}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+
+    await act(async () => {
+      container.querySelector('[role="dialog"]').dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      container.querySelector(".modal-backdrop").dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(2);
   });
 
   it("keeps in-progress picker selection across parent rerenders", async () => {

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -82,6 +82,12 @@ export function EditorScreen({
     video.pause();
   }, [isPlaying, selectedAsset?.id]);
 
+  // Keep the global keydown listener mounted once and read live editor state
+  // through a ref, so undo/redo/delete don't re-bind window on every history
+  // or selection change.
+  const shortcutStateRef = useRef({ undo, redo, removeSelectedItem, selectedItemId });
+  shortcutStateRef.current = { undo, redo, removeSelectedItem, selectedItemId };
+
   useEffect(() => {
     function onKeyDown(event) {
       const target = event.target;
@@ -89,6 +95,7 @@ export function EditorScreen({
       if (isTyping) {
         return;
       }
+      const { undo, redo, removeSelectedItem, selectedItemId } = shortcutStateRef.current;
       if (event.code === "Space") {
         event.preventDefault();
         setIsPlaying((value) => !value);
@@ -114,7 +121,7 @@ export function EditorScreen({
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activeTimeline, history, future, selectedItemId]);
+  }, []);
 
   async function submitNewTimeline(event) {
     event.preventDefault();

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -134,8 +134,8 @@ export function SettingsScreen() {
         <h3>Detected GPU</h3>
         {gpu?.devices?.length ? (
           <ul className="settings-list">
-            {gpu.devices.map((device, index) => (
-              <li key={index}>{device}</li>
+            {gpu.devices.map((device) => (
+              <li key={device}>{device}</li>
             ))}
           </ul>
         ) : (


### PR DESCRIPTION
## Summary

Fourth cluster from epic [1628](https://app.shortcut.com/trefry/epic/1628) — low-risk web component hygiene (a11y, effect churn, list keys). Independent of the other PRs.

- **sc-1673** (a11y): `FullscreenPreview` was a `role="dialog"` overlay with **no Escape, no backdrop click-to-close, and no focus-on-open** — unlike `AssetPickerModal`, which had all three. Extracted a shared `<Modal>` primitive (backdrop mousedown-close, Escape-to-close, focus on mount, `role="dialog"`/`aria-modal`) and reused it in both modals. FullscreenPreview is now keyboard-dismissable and consistent. Added a test covering its Escape + backdrop paths.
- **sc-1674** (bad-pattern): the `EditorScreen` global keydown listener depended on `[activeTimeline, history, future, selectedItemId]`, so it re-bound `window` on every history/selection change. Now reads live editor state through a ref and mounts once (behavior unchanged — undo/redo/delete/space all still work).
- **sc-1679** (bad-pattern): `SettingsScreen` GPU device list used `key={index}`; switched to `key={device}`.

## Notes
- **Deferred sc-1668** (consolidate LoRA-family extraction) to its own PR: the family-extraction helpers have **no direct unit tests** and unify raw-vs-normalized arrays, so collapsing them could shift cross-screen LoRA family matching (Models / Character / Studios). It needs added coverage first — out of scope for a hygiene PR.
- The shared `Modal` renders a `<div role="dialog">` (AssetPickerModal previously used `<section>`); tests query by `[role="dialog"]`/`.modal-backdrop`, not by tag, so this is transparent.

## Test plan
- [x] `npm --prefix apps/web run test -- --run` — 101 vitest tests pass (the existing AssetPicker modal tests still hold via the shared Modal; new FullscreenPreview Escape/backdrop test added)
- [x] `npm --prefix apps/web run build` — clean, no broken imports
- [ ] Live browser not exercised — FullscreenPreview needs the full backend with project assets to open; behavior is covered by the jsdom component tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)