### PR TITLE
refactor(web): consolidate LoRA-family extraction into one helper (sc-1668)

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5,6 +5,7 @@ import { App, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
 import { AssetDetail, FullscreenPreview } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
+import { extractFamilies } from "./presetUtils.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { DocumentStudio } from "./screens/DocumentStudio.jsx";
@@ -5660,5 +5661,42 @@ describe("SceneWorks app shell", () => {
     expect(image.getAttribute("src")).toContain("assets/images/a.png");
     // The document JSON was fetched from its file path.
     expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("assets/documents/doc_1.json"));
+  });
+});
+
+describe("extractFamilies", () => {
+  it("reads the supported shapes in precedence order", () => {
+    expect(extractFamilies({ families: ["a"], compatibleFamilies: ["b"] })).toEqual(["a"]);
+    expect(extractFamilies({ compatibleFamilies: ["b"], modelFamilies: ["c"] })).toEqual(["b"]);
+    expect(extractFamilies({ modelFamilies: ["c"] })).toEqual(["c"]);
+    expect(extractFamilies({ compatibility: { families: ["d"] } })).toEqual(["d"]);
+    expect(extractFamilies({ family: "e" })).toEqual(["e"]);
+  });
+
+  it("returns an empty array when nothing is set", () => {
+    expect(extractFamilies(undefined)).toEqual([]);
+    expect(extractFamilies({})).toEqual([]);
+  });
+
+  it("returns raw values without normalizing casing or separators", () => {
+    expect(extractFamilies({ families: ["Z_Image", "Qwen-Image"] })).toEqual(["Z_Image", "Qwen-Image"]);
+  });
+
+  it("ignores manifest metadata unless includeManifest is set", () => {
+    const job = { payload: { manifestEntry: { families: ["z-image"] }, family: "qwen-image" } };
+    expect(extractFamilies(job)).toEqual([]);
+    expect(extractFamilies(job, { includeManifest: true })).toEqual(["z-image"]);
+  });
+
+  it("falls back through manifest fields then payload.family", () => {
+    expect(extractFamilies({ payload: { family: "qwen-image" } }, { includeManifest: true })).toEqual(["qwen-image"]);
+    expect(
+      extractFamilies({ payload: { manifestEntry: { compatibility: { families: ["z-image"] } } } }, { includeManifest: true }),
+    ).toEqual(["z-image"]);
+  });
+
+  it("prefers top-level fields over manifest even with includeManifest", () => {
+    const job = { families: ["top"], payload: { manifestEntry: { families: ["manifest"] } } };
+    expect(extractFamilies(job, { includeManifest: true })).toEqual(["top"]);
   });
 });

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -50,15 +50,36 @@ export function compactModeList(workflow) {
   return workflowModes(workflow).map((mode) => modeLabels[mode] ?? mode).join(", ");
 }
 
-export function loraFamilies(lora) {
-  const compatibility = lora?.compatibility ?? {};
+// Pull the raw families array out of a LoRA/model entry or a lora_import job
+// snapshot, trying the various shapes producers use. Pass includeManifest for
+// import-job snapshots, whose family metadata lives under payload.manifestEntry.
+// Output is raw (unnormalized) — callers that match should normalizeFamilies().
+export function extractFamilies(item, { includeManifest = false } = {}) {
+  const compatibility = item?.compatibility ?? {};
+  const manifest = item?.payload?.manifestEntry ?? {};
+  const manifestCompatibility = manifest?.compatibility ?? {};
   const values =
-    lora?.families ??
-    lora?.compatibleFamilies ??
-    lora?.modelFamilies ??
+    item?.families ??
+    item?.compatibleFamilies ??
+    item?.modelFamilies ??
     compatibility.families ??
-    (lora?.family ? [lora.family] : []);
-  return normalizeFamilies(values);
+    (includeManifest
+      ? manifest.families ??
+        manifest.compatibleFamilies ??
+        manifest.modelFamilies ??
+        manifestCompatibility.families ??
+        item?.payload?.family ??
+        manifest.family ??
+        item?.family ??
+        []
+      : item?.family
+        ? [item.family]
+        : []);
+  return Array.isArray(values) ? values : [values].filter(Boolean);
+}
+
+export function loraFamilies(lora) {
+  return normalizeFamilies(extractFamilies(lora));
 }
 
 export function modelLoraFamilies(model) {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -4,9 +4,9 @@ import {
   CharacterLooks,
   CharacterReferences,
   CharacterTest,
-  compatibleFamilies,
   editableLora,
 } from "./characterPanels.jsx";
+import { extractFamilies } from "../presetUtils.js";
 
 const characterTypes = [
   ["person", "Person"],
@@ -170,7 +170,7 @@ export function CharacterStudio({
       sourcePath: lora.installedPath ?? lora.source?.path ?? null,
       triggerWords: lora.triggerWords ?? [],
       defaultWeight: lora.defaultWeight ?? 0.8,
-      compatibility: { families: compatibleFamilies(lora) },
+      compatibility: { families: extractFamilies(lora) },
       scope: lora.scope ?? "global",
     });
     setLoraId("");

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,32 +1,15 @@
 import React, { useEffect, useState } from "react";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
-import { presetLoraId, presetLoras } from "../presetUtils.js";
-
-function loraFamilies(item) {
-  // Accept either a LoRA catalog entry or a lora_import job snapshot.
-  const compatibility = item.compatibility ?? {};
-  const values =
-    item.families ??
-    item.compatibleFamilies ??
-    item.modelFamilies ??
-    compatibility.families ??
-    item.payload?.manifestEntry?.families ??
-    item.payload?.manifestEntry?.compatibleFamilies ??
-    item.payload?.manifestEntry?.modelFamilies ??
-    item.payload?.manifestEntry?.compatibility?.families ??
-    item.payload?.family ??
-    item.payload?.manifestEntry?.family ??
-    item.family ??
-    [];
-  return Array.isArray(values) ? values : [values].filter(Boolean);
-}
+import { extractFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
 
 function matchesFamily(item, familyFilter) {
   if (familyFilter === "all") {
     return true;
   }
-  const families = loraFamilies(item);
+  // Accept either a LoRA catalog entry or a lora_import job snapshot (whose
+  // family metadata lives under payload.manifestEntry).
+  const families = extractFamilies(item, { includeManifest: true });
   // Import jobs can briefly lack family metadata; completed catalog entries should not.
   return item.type === "lora_import" && families.length === 0 ? true : families.includes(familyFilter);
 }

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -2,30 +2,20 @@ import React from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
-
-export function compatibleFamilies(item) {
-  const compatibility = item?.compatibility ?? {};
-  const values =
-    item?.families ??
-    item?.compatibleFamilies ??
-    item?.modelFamilies ??
-    compatibility.families ??
-    (item?.family ? [item.family] : []);
-  return Array.isArray(values) ? values : [values].filter(Boolean);
-}
+import { extractFamilies } from "../presetUtils.js";
 
 export function editableLora(link) {
   return {
     name: link?.name ?? "",
     triggerWords: (link?.triggerWords ?? []).join(", "),
     defaultWeight: link?.defaultWeight ?? 0.8,
-    families: compatibleFamilies(link).join(", "),
+    families: extractFamilies(link).join(", "),
     scope: link?.scope ?? "project",
   };
 }
 
 function summarizeCompatibility(item) {
-  const values = compatibleFamilies(item);
+  const values = extractFamilies(item);
   return values.length ? values.join(", ") : "Unspecified";
 }
 


### PR DESCRIPTION
## Summary

Epic [1628](https://app.shortcut.com/trefry/epic/1628), finding #36 (redundant) — and the item I **deferred from PR #176** so it could get proper test coverage.

Three near-identical "pull the families array out of a lora/model/job" implementations drift in which shapes they read:
- `presetUtils.loraFamilies` — normalized, base fields.
- `ModelManagerScreen.loraFamilies` — raw, base fields **+ `payload.manifestEntry.*`** (for lora_import job snapshots).
- `characterPanels.compatibleFamilies` — raw, base fields.

Replaced all three with one `extractFamilies(item, { includeManifest })` in `presetUtils.js`:
- `loraFamilies(lora)` = `normalizeFamilies(extractFamilies(lora))`
- `ModelManagerScreen.matchesFamily` → `extractFamilies(item, { includeManifest: true })`
- `characterPanels` (display) + `CharacterStudio` (storage) → `extractFamilies(item)`

## Why this is behavior-preserving
`extractFamilies` returns **raw** values, with `??` precedence and the empty-array short-circuit **identical** to the three originals (verified field-by-field; `??` is associative, so the grouped manifest chain matches ModelManager's flat one). Normalization stays **opt-in** via `normalizeFamilies` — so the normalized matchers (`loraMatchesModel`) and the raw display/storage paths (character LoRA families string, stored `compatibility.families`) are all unchanged. I deliberately did **not** fold matching normalization into extraction, since that would be a real behavior change to LoRA-family matching and is out of scope for a dedup.

`modelLoraFamilies` reads model-specific fields (`loraCompatibility`, `loraFamilies`) and isn't duplicated, so it's left as-is.

## Test plan
- [x] Added `extractFamilies` unit tests: precedence order, empty fallback, raw (non-normalized) output, `includeManifest` manifest/`payload.family` fallbacks, top-level-wins-over-manifest.
- [x] `npm --prefix apps/web run test -- --run` — 107 vitest tests pass (the existing Models LoRA family-filter tests still hold, confirming `matchesFamily` behavior is unchanged).
- [x] `npm --prefix apps/web run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)