### PR TITLE
fix(worker): quick bugs — VRAM gate clamp, snapshot integrity, dead code, lora cache (sc-1659/1646/1675/1670)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -310,14 +310,6 @@ class ImageRequest:
     advanced: dict[str, Any]
 
 
-def load_registry(data_dir: Path) -> list[dict[str, Any]]:
-    registry_path = data_dir / "recent-projects.json"
-    if not registry_path.exists():
-        return []
-    with registry_path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
 def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
     payload = job["payload"]
     return ImageRequest(

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -576,15 +576,31 @@ def should_skip_claim_low_vram(settings: WorkerSettings) -> bool:
     if threshold <= 0 or settings.gpu_id in ("cpu", "mps"):
         return False
     utilization = gpu_utilization(settings.gpu_id)
-    free_mb = utilization.get("memoryFreeMb") if utilization else None
-    if free_mb is None or free_mb >= threshold:
+    if not utilization:
+        return False
+    free_mb = utilization.get("memoryFreeMb")
+    if free_mb is None:
+        return False
+    # The configured gate (24 GB default) is NVIDIA-tuned for large cards. On a
+    # smaller card an absolute MB threshold can exceed what the card could ever
+    # report free, deferring every claim forever with no obvious signal. Clamp it
+    # to a high fraction of this card's capacity so a small idle card still
+    # claims, while keeping the "defer when another tool is hogging the card"
+    # intent on cards big enough to satisfy the configured value.
+    total_mb = utilization.get("memoryTotalMb")
+    effective = threshold
+    if isinstance(total_mb, int) and total_mb > 0:
+        effective = min(threshold, int(total_mb * 0.9))
+    if free_mb >= effective:
         return False
     emit(
         {
             "event": "claim_skipped_low_vram",
             "gpuId": settings.gpu_id,
             "memoryFreeMb": free_mb,
-            "thresholdMb": threshold,
+            "memoryTotalMb": total_mb,
+            "thresholdMb": effective,
+            "configuredThresholdMb": threshold,
             "reportedAt": now(),
         }
     )

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -24,7 +24,9 @@ class WorkerSettings:
         self.force_cancel_seconds = int(os.getenv("SCENEWORKS_WORKER_FORCE_CANCEL_SECONDS", "30"))
         # A GPU worker won't claim a job when its GPU has less free VRAM than this
         # (MB), so jobs flow to a free card when another tool (e.g. ComfyUI) is using
-        # one. 0 disables the gate. CPU workers are never gated.
+        # one. The 24 GB default is NVIDIA-tuned; at claim time it's clamped to a high
+        # fraction of the card's own capacity so a smaller card isn't blocked forever
+        # (see should_skip_claim_low_vram). 0 disables the gate. CPU/MPS are never gated.
         self.min_free_vram_mb = int(os.getenv("SCENEWORKS_MIN_FREE_VRAM_MB", "24000"))
 
     def for_worker(self, *, worker_id: str, gpu_id: str) -> "WorkerSettings":

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -503,7 +503,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         self._loaded_models: set[str] = set()
         self._settings: WorkerSettings | None = None
         self._resources_by_model: dict[str, LtxPipelinesResources] = {}
-        self._lora_specs_by_request_id: dict[int, list[LoraSpec]] = {}
+        self._lora_specs: list[LoraSpec] | None = None
         self._pipeline: Any | None = None
         self._pipeline_key_value: str | None = None
 
@@ -512,7 +512,7 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
 
     def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
         self._settings = settings
-        self._lora_specs_by_request_id.clear()
+        self._lora_specs = None
         return video_request_from_job(job)
 
     def ensure_models(self, request: VideoRequest) -> None:
@@ -1187,12 +1187,12 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         )
 
     def _ltx_lora_specs(self, request: VideoRequest) -> list[LoraSpec]:
-        cache_key = id(request)
-        specs = self._lora_specs_by_request_id.get(cache_key)
-        if specs is None:
-            specs = normalize_lora_specs(request.loras)
-            self._lora_specs_by_request_id[cache_key] = specs
-        return specs
+        # Memoize the normalized specs for the current job (one job at a time;
+        # reset in prepare()). A single slot avoids the id(request)-keyed dict
+        # whose keys could be reused after a frozen VideoRequest is collected.
+        if self._lora_specs is None:
+            self._lora_specs = normalize_lora_specs(request.loras)
+        return self._lora_specs
 
     def _ltx_loras(self, loader: Any, request: VideoRequest) -> tuple[Any, ...]:
         specs = self._ltx_lora_specs(request)
@@ -1848,9 +1848,6 @@ class MlxVideoAdapter(VideoGenerationAdapter):
 
     def _first_condition_image(self, project_path: Path, request: VideoRequest) -> Any:
         return self._condition_image(project_path, request.source_asset_id)
-
-    def _last_condition_image(self, project_path: Path, request: VideoRequest) -> Any:
-        return self._condition_image(project_path, request.last_frame_asset_id)
 
     def _condition_image(self, project_path: Path, asset_id: str | None) -> Any:
         # Resolve via the shared helper: asset sidecars store the media path at

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -3035,6 +3035,23 @@ async fn download_snapshot(
             }
         }
         output.flush().await?;
+        // A truncated transfer (e.g. the server closes the stream at what looks
+        // like a clean EOF) would otherwise be treated as success: the install
+        // marker gets written over a corrupt dir and the bad shard only surfaces
+        // as an opaque load failure later. When the expected size is known,
+        // verify it and remove the partial so the next attempt re-downloads.
+        if let Some(expected) = file.size {
+            let written = tokio::fs::metadata(&target_path).await?.len();
+            if written != expected {
+                let _ = tokio::fs::remove_file(&target_path).await;
+                return Err(WorkerError::InvalidPayload(format!(
+                    "{} download ended at {} but expected {}",
+                    file.path,
+                    format_bytes(written),
+                    format_bytes(expected)
+                )));
+            }
+        }
     }
     Ok(())
 }
@@ -4764,14 +4781,15 @@ mod tests {
         allow_pattern_matches, auto_worker_specs, bounded_tail, candidate_people,
         child_environment, cleanup_uploaded_import_source, concat_file_contents, copy_lora_source,
         cpu_gpu, cpu_worker_id, crossfade_duration, download_lora_source_url,
-        download_progress_payload, fallback_gpu, finalize_converted_dir, fresh_asset_id,
-        gpu_worker_id, import_lora_source_path, now_rfc3339, output_dimensions,
+        download_progress_payload, download_snapshot, fallback_gpu, finalize_converted_dir,
+        fresh_asset_id, gpu_worker_id, import_lora_source_path, now_rfc3339, output_dimensions,
         parse_nvidia_smi_gpus, resolve_model_convert_output, resolve_model_import_target,
         restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
         utility_worker_specs, value_f64, visible_gpu_ids, worker_capabilities_with_utility,
-        write_model_install_marker, ApiClient, DownloadContext, HuggingFaceSnapshot, JsonObject,
-        Settings, SupervisedChild, WorkerError, WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES,
-        DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+        write_model_install_marker, ApiClient, DownloadContext, DownloadProgress,
+        HuggingFaceSnapshot, JsonObject, Settings, SnapshotFile, SupervisedChild, WorkerError,
+        WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
+        DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
     };
 
     #[tokio::test]
@@ -5223,6 +5241,52 @@ mod tests {
                 .unwrap(),
             b"old-lora"
         );
+    }
+
+    #[tokio::test]
+    async fn download_snapshot_rejects_truncated_file() {
+        let temp = tempdir().expect("tempdir creates");
+        // The stub serves 4 bytes, but the snapshot claims the shard is 64 —
+        // a truncated transfer that must not be accepted as complete.
+        let base_url = spawn_binary_stub(b"trun".to_vec()).await;
+        let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+        settings.api_url = base_url.clone();
+        let api = ApiClient::new(&settings);
+        let client = reqwest::Client::new();
+        let target_dir = temp.path().join("model");
+
+        let snapshot = HuggingFaceSnapshot {
+            files: vec![SnapshotFile {
+                path: "shard.safetensors".to_owned(),
+                size: Some(64),
+                download_url: format!("{base_url}/owner/model/resolve/main/shard.safetensors"),
+            }],
+        };
+        let mut progress = DownloadProgress::new(
+            "owner/model",
+            0,
+            snapshot.total_bytes(),
+            Duration::from_secs(3600),
+        );
+
+        let error = download_snapshot(
+            &DownloadContext {
+                api: &api,
+                client: &client,
+                settings: &settings,
+                job_id: "job-1",
+                cancel_message: "canceled",
+            },
+            &target_dir,
+            &snapshot,
+            &mut progress,
+        )
+        .await
+        .expect_err("truncated shard is rejected");
+
+        assert!(error.to_string().contains("expected"));
+        // The partial file is removed so a retry re-downloads from scratch.
+        assert!(!target_dir.join("shard.safetensors").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Part of [epic 1628](https://app.shortcut.com/trefry/epic/1628) (full-repo review 2026-05-24). Worker quick-bugs cluster, grouped into one PR.

## Summary
- **sc-1659** (Medium bug): the `min_free_vram_mb` default of 24000 is NVIDIA-tuned; on a sub-24GB card it deferred *every* GPU claim indefinitely with no obvious signal (the worker just never claimed). `should_skip_claim_low_vram` now clamps the gate to 90% of the card's detected `memoryTotalMb` so a small idle card still claims, while preserving the "defer when another tool is hogging the card" intent on cards large enough to satisfy the configured value. The skip event now reports `memoryTotalMb`, the effective `thresholdMb`, and the `configuredThresholdMb` for diagnosability.
- **sc-1646** (Medium, data integrity): `download_snapshot` wrote each HF file but never compared the received length to `file.size` — a truncated transfer was treated as success, resume-skipped next time, and an install marker was written over a corrupt dir (later load failed opaquely). It now verifies the on-disk length against `file.size` when known, removes the partial, and fails loudly, mirroring `download_source_url`. Added a `download_snapshot_rejects_truncated_file` test.
- **sc-1675** (Low, bad pattern): the LoRA-spec cache keyed on `id(request)`; a frozen `VideoRequest`'s `id()` can be reused after GC, returning stale specs. Replaced with a single per-job slot reset in `prepare()` (the adapter runs one job at a time).
- **sc-1670** (Low, dead code): deleted `image_adapters.load_registry` (a no-caller duplicate of `sceneworks_shared.load_registry`) and the never-called `MlxVideoAdapter._last_condition_image`.

## Stale-premise note
The review's line numbers for sc-1670 were stale: `_last_condition_image` now has two definitions and a live caller. Verified the live one belongs to `DiffusersVideoAdapter` (kept) and only the `MlxVideoAdapter` copy is dead (removed).

## Test plan
- [x] `npm run rust:check` (fmt + clippy `-D warnings` + test + build) — green; new truncation test passes
- [x] `python -m py_compile` on all changed worker modules
- [ ] No worker pytest harness in repo (modules require the heavy torch venv); Python changes are dead-code removal + localized logic, validated by inspection + py_compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)