### PR TITLE
fix(worker): reap tracked video temp files on force-cancel hard stop (sc-1677)

### DIFF
--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -381,11 +381,15 @@ class JobCancelMonitor:
         *,
         poll_interval: float = 1.0,
         force_cancel_seconds: float | None = None,
+        on_force_terminate: Callable[[], None] | None = None,
     ) -> None:
         self._api = api
         self._settings = settings
         self._job_id = job_id
         self._poll_interval = max(0.05, poll_interval)
+        # Best-effort hook run just before os._exit (which skips adapter cleanup).
+        # Must be filesystem-only — see _force_terminate.
+        self._on_force_terminate = on_force_terminate
         deadline = (
             force_cancel_seconds
             if force_cancel_seconds is not None
@@ -467,6 +471,24 @@ class JobCancelMonitor:
                     "reportedAt": now(),
                 }
             )
+        # os._exit skips the cooperative adapter.cancel()/cleanup() path, so a
+        # force-killed job would otherwise orphan its temp files. Give the caller
+        # one best-effort hook to reap them first. It must be filesystem-only: the
+        # main thread is wedged in a native call, so touching torch/GPU here is
+        # unsafe (the hook removes tracked temp files, not the resident pipeline,
+        # which os._exit frees anyway).
+        if self._on_force_terminate is not None:
+            try:
+                self._on_force_terminate()
+            except Exception as exc:  # noqa: BLE001 - never block the hard stop
+                emit(
+                    {
+                        "event": "cancel_force_kill_cleanup_failed",
+                        "jobId": self._job_id,
+                        "error": str(exc),
+                        "reportedAt": now(),
+                    }
+                )
         # The main thread is wedged in a native call we cannot interrupt from
         # Python, so os._exit is the only way to stop it now. It skips interpreter
         # cleanup by design — the supervisor restarts a fresh worker.
@@ -474,9 +496,15 @@ class JobCancelMonitor:
 
 
 @contextmanager
-def job_cancel_monitor(api: ApiClient, settings: WorkerSettings, job_id: str):
+def job_cancel_monitor(
+    api: ApiClient,
+    settings: WorkerSettings,
+    job_id: str,
+    *,
+    on_force_terminate: Callable[[], None] | None = None,
+):
     """Run a JobCancelMonitor for the duration of a job's blocking work."""
-    monitor = JobCancelMonitor(api, settings, job_id)
+    monitor = JobCancelMonitor(api, settings, job_id, on_force_terminate=on_force_terminate)
     monitor.start()
     try:
         yield monitor
@@ -508,13 +536,15 @@ def run_blocking_job_step(
     callback: Callable[[CancelCallback], Any],
     *,
     loaded_models: LoadedModelsSource,
+    on_force_terminate: Callable[[], None] | None = None,
 ) -> Any:
     """Run a job's blocking work while keeping it alive and cancelable.
 
     Spawns a heartbeat thread and a JobCancelMonitor for the duration of the
     work, then invokes ``callback`` with a cached cancel predicate so adapters
     can poll cancellation cheaply (and so the monitor can force-stop the worker
-    if a cancel goes unacknowledged past the deadline)."""
+    if a cancel goes unacknowledged past the deadline). ``on_force_terminate`` is
+    a best-effort, filesystem-only hook run just before the hard-stop os._exit."""
     stop_event = threading.Event()
     thread = threading.Thread(
         target=keep_job_alive,
@@ -523,7 +553,7 @@ def run_blocking_job_step(
     )
     thread.start()
     try:
-        with job_cancel_monitor(api, settings, job_id) as monitor:
+        with job_cancel_monitor(api, settings, job_id, on_force_terminate=on_force_terminate) as monitor:
             return callback(monitor.requested)
     finally:
         stop_event.set()
@@ -860,6 +890,9 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
                 cancel_requested=cancel,
             ),
             loaded_models=adapter_loaded_models,
+            # Reap the job's partial .tmp.mp4/.control.mp4 outputs if the hard-stop
+            # backstop force-kills the worker (os._exit skips adapter cleanup).
+            on_force_terminate=lambda: adapter.discard_temp_outputs(job_id),
         )
         update_job(
             api,

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -336,6 +336,15 @@ class VideoGenerationAdapter(ABC):
     def cleanup(self, job_id: str) -> None:
         raise NotImplementedError
 
+    def discard_temp_outputs(self, job_id: str) -> None:
+        """Reap the job's temp files only — no model/pipeline teardown.
+
+        The force-cancel backstop calls this from the monitor thread right before
+        os._exit, so it must stay filesystem-only: the main thread may be wedged
+        in a native call and touching torch/GPU from here would be unsafe.
+        Adapters that track temp files override this; the default is a no-op."""
+        return
+
 
 class ProceduralVideoAdapter(VideoGenerationAdapter):
     id = "procedural_video"
@@ -460,6 +469,9 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         self.cleanup(job_id)
 
     def cleanup(self, job_id: str) -> None:
+        self.discard_temp_outputs(job_id)
+
+    def discard_temp_outputs(self, job_id: str) -> None:
         for path in self._temporary_outputs.pop(job_id, []):
             path.unlink(missing_ok=True)
 


### PR DESCRIPTION
Part of [epic 1628](https://app.shortcut.com/trefry/epic/1628) (full-repo review 2026-05-24). Follow-up to the worker quick-bugs PR (#178); split out per discussion because it touches the cancel-monitor machinery rather than being a one-line fix.

## Problem
The hard-stop backstop (`JobCancelMonitor._force_terminate`) calls `os._exit` from the cancel-monitor thread when a cancel goes unacknowledged past `force_cancel_seconds`. `os._exit` bypasses the cooperative `adapter.cancel()`/`cleanup()` path, so a force-killed video job orphaned its partial `.tmp.mp4`/`.control.mp4` outputs. These accumulate over repeated force-cancels.

## Fix
- Thread an optional `on_force_terminate` hook through `run_blocking_job_step` → `job_cancel_monitor` → `JobCancelMonitor`. `_force_terminate` runs it best-effort (wrapped in try/except, emitting `cancel_force_kill_cleanup_failed` on error) right before `os._exit`.
- `run_video_job` passes `adapter.discard_temp_outputs(job_id)`.

## Why not call full `adapter.cleanup(job_id)` (as originally sketched)
`LtxPipelinesVideoAdapter.cleanup` also calls `_evict_pipeline()` (torch/GPU teardown). Running that from the monitor thread while the main thread is wedged in a native call is unsafe (concurrent torch access / freeing a pipeline the wedged thread may hold). So I added a new **filesystem-only** `discard_temp_outputs(job_id)`:
- Base `VideoGenerationAdapter`: concrete no-op (so the hook is callable on any video adapter).
- `ProceduralVideoAdapter`: overrides it to unlink `_temporary_outputs`; `cleanup` now delegates its temp removal to it (behavior identical).

`os._exit` frees the resident GPU pipeline anyway, so the hook only needs to handle the on-disk temps.

## Scope / known gaps
- **Covered:** the tracked `_temporary_outputs` paths — `ProceduralVideoAdapter` and the native LTX `LtxPipelinesVideoAdapter` (the primary video-generation path).
- **Not covered (inherited base no-op):** `MlxVideoAdapter`/`DiffusersVideoAdapter` write their `.tmp.mp4` inline without a tracking registry, and the Lens image-sidecar / training scratch dirs are cleaned in method-local `finally` blocks (also bypassed by `os._exit`). Extending coverage to those needs a shared temp registry — left as a follow-up to keep this change focused and safe.
- Other `run_blocking_job_step` callers keep the default `on_force_terminate=None` (no behavior change).

## Test plan
- [x] `python -m py_compile` on `runtime.py` + `video_adapters.py`
- [ ] No worker pytest harness in this repo (modules require the torch/httpx venv); the change is localized control-flow + a filesystem-only unlink, validated by inspection. The hard-stop path itself (`os._exit`) is not unit-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)