### PR TITLE
test(worker): fix worker suite broken by sc-1670/sc-1677 (restore main CI)

### DIFF
--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -630,10 +630,11 @@ def test_mlx_adapter_rejects_incompatible_lora_family(tmp_path):
 
 
 def test_mlx_condition_image_resolves_source_asset_from_file_path(tmp_path):
-    # Regression: MLX image_to_video / first_last_frame jobs failed with
-    # "Image-to-video mode requires a source image asset." because the adapter
-    # read a non-existent top-level `mediaPath` sidecar key instead of the real
-    # nested `file.path`, so the source image never resolved.
+    # Regression: MLX image_to_video jobs failed with "Image-to-video mode
+    # requires a source image asset." because the adapter read a non-existent
+    # top-level `mediaPath` sidecar key instead of the real nested `file.path`,
+    # so the source image never resolved. (MLX supports only text/image-to-video;
+    # first_last_frame is rejected in ensure_models, so there's no _last frame.)
     project_path = tmp_path / "project"
     (project_path / "assets" / "images").mkdir(parents=True)
     image_rel = "assets/images/source.png"
@@ -660,20 +661,6 @@ def test_mlx_condition_image_resolves_source_asset_from_file_path(tmp_path):
     assert first_image.mode == "RGB"
     # Validation now passes instead of raising the source-image error.
     adapter._validate_inputs(project_path, i2v_request, first_image, None)
-
-    flf_request = video_request_from_job(
-        {
-            "id": "job-flf",
-            "payload": {
-                "projectId": "project-1",
-                "model": "ltx_2_3",
-                "mode": "first_last_frame",
-                "sourceAssetId": "asset-source",
-                "lastFrameAssetId": "asset-source",
-            },
-        }
-    )
-    assert adapter._last_condition_image(project_path, flf_request) is not None
 
 
 def test_mlx_wan_user_loras_resolved_to_path_strength_tuples(tmp_path):
@@ -3176,7 +3163,7 @@ def test_video_job_reports_dynamic_loaded_models_on_progress_and_keepalive(monke
         def cleanup(self, _job_id):
             raise AssertionError("cleanup should not be called")
 
-    def run_immediately(_api, _settings, _job_id, _status, callback, *, loaded_models):
+    def run_immediately(_api, _settings, _job_id, _status, callback, *, loaded_models, on_force_terminate=None):
         blocking_models.append(loaded_models())
         result = callback(lambda: False)
         blocking_models.append(loaded_models())


### PR DESCRIPTION
## Why
After #178 and #179 merged, `main`'s `parity` CI job went red at the **Run worker test suite** step (`tests/test_worker_runtime.py`). That suite needs only light deps (`pytest`/`httpx`/`pillow`/`numpy`, no torch) and isn't covered by `py_compile`, so the breakage wasn't caught before merge. Both failures are test-side; the merged production changes are correct.

## Fixes
- **`test_mlx_condition_image_resolves_source_asset_from_file_path`** — called `MlxVideoAdapter._last_condition_image`, which sc-1670 (#178) deleted. `MlxVideoAdapter._supported_modes = {text_to_video, image_to_video}` and `ensure_models` rejects anything else, so `first_last_frame` (and thus `_last_condition_image`) is unreachable in production. Dropped the `first_last_frame` block; the `image_to_video` half still covers the `file.path` resolution regression the test guards.
- **`test_video_job_reports_dynamic_loaded_models_on_progress_and_keepalive`** — its `run_blocking_job_step` stub (`run_immediately`) has an explicit signature that didn't accept the `on_force_terminate` kwarg sc-1677 (#179) added, so `run_video_job` raised `TypeError` → job failed → `cleanup()` fired its "should not be called" assertion. Added `on_force_terminate=None` to the stub. (The other three `run_video_job` stubs already use `**kwargs`, which is why only this one broke.)

## Verification
```
python -m pytest -q tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py
# 250 passed, 6 skipped
```
Run in a venv matching `.github/workflows/check.yml` (`pytest==9.0.2 httpx==0.28.1 pillow numpy`).

## Process note
Going forward I'll run this worker suite locally before pushing any `apps/worker` change — it's runnable without the heavy torch venv, and `py_compile` alone doesn't catch behavioral/signature breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)