### PR TITLE
refactor(web): extract shared useGenerationStudio hook + preset components (sc-1650)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -33,15 +33,15 @@ import {
   loraWeight,
   clearPresetDefault,
   noPresetId,
-  presetLoraDetails as buildPresetLoraDetails,
-  presetMatchesModel,
-  presetMatchesWorkflow,
-  presetPromptParts as buildPresetPromptParts,
-  presetValidation,
   rememberPresetDefault,
 } from "../presetUtils.js";
+import {
+  onPromptKeyDown,
+  PresetGuidanceStrip,
+  PresetValidationWarnings,
+  useGenerationStudio,
+} from "./generationStudio.jsx";
 
-const completedResultFallbackMs = 30000;
 // Used only for models that don't declare limits.resolutions (e.g. user-imported).
 const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x1280"];
 
@@ -143,7 +143,6 @@ export function ImageStudio({
   const [count, setCount] = useState(4);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(imageModels[0]?.id ?? "z_image_turbo");
-  const [stylePreset, setStylePreset] = useState(null);
   const [seed, setSeed] = useState("");
   const [negativePrompt, setNegativePrompt] = useState("");
   const [resolution, setResolution] = useState("1024x1024");
@@ -153,7 +152,6 @@ export function ImageStudio({
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [resultFallbackTick, setResultFallbackTick] = useState(0);
   const presetDefaultSnapshots = useRef({});
   const editImageAssets = useMemo(
     () => assets.filter((asset) => asset.type === "image" || asset.type === "frame"),
@@ -196,12 +194,6 @@ export function ImageStudio({
   }
 
   useEffect(() => {
-    if (!imageModels.some((item) => item.id === model)) {
-      setModel(imageModels[0]?.id ?? "z_image_turbo");
-    }
-  }, [imageModels, model]);
-
-  useEffect(() => {
     if (mode === "edit_image" && selectedAsset?.id) {
       setSourceAssetId(selectedAsset.id);
     }
@@ -225,13 +217,6 @@ export function ImageStudio({
       setSourceAssetId(selectedAsset.id);
     }
   }, [launchRequest?.id, selectedAsset?.id]);
-
-  useEffect(() => {
-    if (characterId && !characters.some((character) => character.id === characterId)) {
-      setCharacterId("");
-      setCharacterLookId("");
-    }
-  }, [characters, characterId]);
 
   const availableModels = useMemo(
     () =>
@@ -275,15 +260,31 @@ export function ImageStudio({
         : resolutionOptions[0];
     setResolution(preferred);
   }, [resolutionOptions, resolution, selectedModel?.defaults?.resolution]);
-  const availablePresets = useMemo(() => {
-    return presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel));
-  }, [mode, presets, selectedModel?.id]);
-  const selectedPreset =
-    stylePreset === noPresetId
-      ? null
-      : stylePreset
-        ? availablePresets.find((preset) => preset.id === stylePreset) ?? null
-        : availablePresets[0] ?? null;
+  const {
+    availablePresets,
+    selectedPreset,
+    setSelectedPresetId,
+    presetPromptParts,
+    presetLoraDetails,
+    presetValidationResult,
+    localJobs,
+  } = useGenerationStudio({
+    mode,
+    presets,
+    selectedModel,
+    loras,
+    models: imageModels,
+    model,
+    setModel,
+    fallbackModelId: "z_image_turbo",
+    characters,
+    characterId,
+    setCharacterId,
+    setCharacterLookId,
+    assets,
+    latestAssets,
+    trackedLocalJobs,
+  });
   const compatibleLoras = useMemo(() => loras.filter((lora) => {
     if (lora.presetManaged) {
       return false;
@@ -306,12 +307,6 @@ export function ImageStudio({
       ok: incompatible.length === 0,
     };
   }, [selectedLoras, selectedModel]);
-  const presetLoraDetails = buildPresetLoraDetails(selectedPreset, loras);
-  const presetPromptParts = buildPresetPromptParts(selectedPreset);
-  const presetValidationResult = useMemo(
-    () => presetValidation(selectedPreset, loras, selectedModel),
-    [selectedPreset, loras, selectedModel],
-  );
   useEffect(() => {
     if (selectedLoraValidationResult.incompatible.length && !advancedOpen) {
       setAdvancedOpen(true);
@@ -326,15 +321,6 @@ export function ImageStudio({
         ? "No installed LoRAs in the library."
         : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
   const [width, height] = resolution.split("x").map((value) => Number(value));
-
-  useEffect(() => {
-    if (!stylePreset || stylePreset === noPresetId) {
-      return;
-    }
-    if (!selectedPreset) {
-      setStylePreset(availablePresets[0]?.id ?? noPresetId);
-    }
-  }, [availablePresets, selectedPreset, stylePreset]);
 
   useEffect(() => {
     if (!selectedPreset) {
@@ -385,53 +371,6 @@ export function ImageStudio({
     });
   }
 
-  function resultVisible(job) {
-    if (job.result?.generationSetId) {
-      return latestAssets.some((asset) => asset.generationSetId === job.result.generationSetId);
-    }
-    const assetIds = job.result?.assetIds ?? [];
-    return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
-  }
-
-  function completedAnchorMs(job) {
-    return Date.parse(job.completedAt ?? job.updatedAt ?? "");
-  }
-
-  function completedWaitExpired(job, nowMs = Date.now()) {
-    const anchorMs = completedAnchorMs(job);
-    return Number.isFinite(anchorMs) && nowMs - anchorMs > completedResultFallbackMs;
-  }
-
-  useEffect(() => {
-    const nowMs = Date.now();
-    const pendingCompletedJobs = trackedLocalJobs.filter(
-      (job) =>
-        job.status === "completed" &&
-        Number.isFinite(completedAnchorMs(job)) &&
-        !resultVisible(job) &&
-        !completedWaitExpired(job, nowMs),
-    );
-    if (!pendingCompletedJobs.length) {
-      return undefined;
-    }
-    const nextDelay = Math.min(
-      ...pendingCompletedJobs.map((job) => Math.max(0, completedResultFallbackMs - (nowMs - completedAnchorMs(job)))),
-    );
-    const timer = window.setTimeout(() => setResultFallbackTick((value) => value + 1), nextDelay + 50);
-    return () => window.clearTimeout(timer);
-  }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
-
-  const localJobs = useMemo(
-    () =>
-      trackedLocalJobs.filter(
-        (job) =>
-          // Canceled runs produce no output, so drop them instead of leaving a
-          // "Canceled" progress card and empty thumbnail placeholders behind.
-          job.status !== "canceled" &&
-          (job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job))),
-      ),
-    [assets, latestAssets, trackedLocalJobs, resultFallbackTick],
-  );
   const reviewSlots = useMemo(() => {
     if (!localJobs.length) {
       return latestAssets.map((asset) => ({ type: "asset", id: asset.id, asset }));
@@ -493,13 +432,6 @@ export function ImageStudio({
     (mode === "character_image" && !characterId) ||
     !presetValidationResult.ok ||
     !selectedLoraValidationResult.ok;
-
-  function onPromptKeyDown(event) {
-    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-      event.preventDefault();
-      event.currentTarget.form?.requestSubmit();
-    }
-  }
 
   return (
     <section className="main-surface image-studio">
@@ -673,7 +605,7 @@ export function ImageStudio({
               <div className="preset-chips">
                 <button
                   className={!selectedPreset ? "preset-chip active" : "preset-chip"}
-                  onClick={() => setStylePreset(noPresetId)}
+                  onClick={() => setSelectedPresetId(noPresetId)}
                   type="button"
                 >
                   None
@@ -682,7 +614,7 @@ export function ImageStudio({
                   <button
                     className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"}
                     key={preset.id}
-                    onClick={() => setStylePreset(preset.id)}
+                    onClick={() => setSelectedPresetId(preset.id)}
                     type="button"
                   >
                     {preset.name ?? preset.id}
@@ -706,23 +638,12 @@ export function ImageStudio({
               </label>
             </div>
 
-            {selectedPreset ? (
-              <div className="guidance-strip">
-                <strong>{selectedPreset.ui?.description ?? "Preset defaults active"}</strong>
-                <span>
-                  {presetPromptParts.length ? `Adds: ${presetPromptParts.join(", ")}` : "No prompt fragments"}
-                  {presetLoraDetails.length
-                    ? ` | Preset LoRA applied at generation: ${presetLoraDetails.map((lora) => lora.name ?? lora.id).join(", ")}`
-                    : " | No preset LoRAs"}
-                  {presetLoraDetails.some((lora) => lora.missing) ? " | Import still pending" : ""}
-                </span>
-              </div>
-            ) : (
-              <div className="guidance-strip">
-                <strong>No preset selected</strong>
-                <span>Generation uses only the prompt, model, and visible preset settings.</span>
-              </div>
-            )}
+            <PresetGuidanceStrip
+              selectedPreset={selectedPreset}
+              presetPromptParts={presetPromptParts}
+              presetLoraDetails={presetLoraDetails}
+              noPresetHint="Generation uses only the prompt, model, and visible preset settings."
+            />
 
             <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
               <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
@@ -792,16 +713,7 @@ export function ImageStudio({
               </div>
             ) : null}
 
-            {presetValidationResult.missing.length ? (
-              <p className="inline-warning">
-                Preset cannot run until LoRA import finishes: {presetValidationResult.missing.join(", ")}. Wait for the Queue or choose another preset.
-              </p>
-            ) : null}
-            {presetValidationResult.incompatible.length ? (
-              <p className="inline-warning">
-                Preset cannot run with {selectedModel?.name ?? "the selected model"} because these LoRAs are incompatible: {presetValidationResult.incompatible.join(", ")}. Choose another preset or model.
-              </p>
-            ) : null}
+            <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
             {selectedLoraValidationResult.incompatible.length ? (
               <p className="inline-warning">
                 Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
@@ -40,16 +40,16 @@ import {
   clearPresetDefault,
   loraLooksLikeIcLora,
   noPresetId,
-  presetLoraDetails as buildPresetLoraDetails,
-  presetMatchesModel,
-  presetMatchesWorkflow,
-  presetPromptParts as buildPresetPromptParts,
-  presetValidation,
   rememberPresetDefault,
 } from "../presetUtils.js";
+import {
+  onPromptKeyDown,
+  PresetGuidanceStrip,
+  PresetValidationWarnings,
+  useGenerationStudio,
+} from "./generationStudio.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 
-const completedResultFallbackMs = 30000;
 const ltxVideoModelId = "ltx_2_3";
 const ltxIcLoraRequiredModes = new Set(["extend_clip", "video_bridge"]);
 
@@ -95,7 +95,6 @@ export function VideoStudio({
   const [precision, setPrecision] = useState("fp8");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(videoModels[0]?.id ?? ltxVideoModelId);
-  const [selectedPresetId, setSelectedPresetId] = useState(null);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
   const [duration, setDuration] = useState(selectedModel?.defaults?.duration ?? 6);
   const [resolution, setResolution] = useState(selectedModel?.defaults?.resolution ?? "768x512");
@@ -114,7 +113,6 @@ export function VideoStudio({
   const [comparisonMode, setComparisonMode] = useState("side_by_side");
   const [abSide, setAbSide] = useState("replacement");
   const [submitting, setSubmitting] = useState(false);
-  const [resultFallbackTick, setResultFallbackTick] = useState(0);
   const previewVideoRef = useRef(null);
   const [previewPlaying, setPreviewPlaying] = useState(false);
   const [previewTime, setPreviewTime] = useState(0);
@@ -123,29 +121,33 @@ export function VideoStudio({
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
-  const availablePresets = useMemo(() => {
-    return presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel));
-  }, [mode, presets, selectedModel?.id]);
-  const selectedPreset =
-    selectedPresetId === noPresetId
-      ? null
-      : selectedPresetId
-        ? availablePresets.find((preset) => preset.id === selectedPresetId) ?? null
-        : availablePresets[0] ?? null;
-  const presetPromptParts = buildPresetPromptParts(selectedPreset);
-  const presetLoraDetails = buildPresetLoraDetails(selectedPreset, loras);
-  const presetValidationResult = useMemo(
-    () => presetValidation(selectedPreset, loras, selectedModel),
-    [selectedPreset, loras, selectedModel],
-  );
+  const {
+    availablePresets,
+    selectedPreset,
+    setSelectedPresetId,
+    presetPromptParts,
+    presetLoraDetails,
+    presetValidationResult,
+    localJobs,
+  } = useGenerationStudio({
+    mode,
+    presets,
+    selectedModel,
+    loras,
+    models: videoModels,
+    model,
+    setModel,
+    fallbackModelId: ltxVideoModelId,
+    characters,
+    characterId,
+    setCharacterId,
+    setCharacterLookId,
+    assets,
+    latestAssets,
+    trackedLocalJobs,
+  });
   const requiresLtxIcLora = selectedModel?.id === ltxVideoModelId && ltxIcLoraRequiredModes.has(mode);
   const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing && loraLooksLikeIcLora(lora));
-
-  useEffect(() => {
-    if (!videoModels.some((item) => item.id === model)) {
-      setModel(videoModels[0]?.id ?? ltxVideoModelId);
-    }
-  }, [videoModels, model]);
 
   useEffect(() => {
     if (selectedAsset?.type === "image" || selectedAsset?.type === "frame") {
@@ -179,13 +181,6 @@ export function VideoStudio({
   }, [launchRequest?.id, selectedAsset?.id, selectedAsset?.type]);
 
   useEffect(() => {
-    if (characterId && !characters.some((character) => character.id === characterId)) {
-      setCharacterId("");
-      setCharacterLookId("");
-    }
-  }, [characters, characterId]);
-
-  useEffect(() => {
     if (!selectedModel) {
       return;
     }
@@ -212,15 +207,6 @@ export function VideoStudio({
       setModel(replacementModel.id);
     }
   }, [mode, supportsMode, videoModels]);
-
-  useEffect(() => {
-    if (!selectedPresetId || selectedPresetId === noPresetId) {
-      return;
-    }
-    if (!selectedPreset) {
-      setSelectedPresetId(availablePresets[0]?.id ?? noPresetId);
-    }
-  }, [availablePresets, selectedPresetId, selectedPreset]);
 
   useEffect(() => {
     if (!selectedPreset) {
@@ -345,51 +331,6 @@ export function VideoStudio({
     full_person_replace_outfit: "Full Person, Replace Outfit",
   };
 
-  function resultVisible(job) {
-    if (job.result?.generationSetId) {
-      return latestAssets.some((asset) => asset.generationSetId === job.result.generationSetId);
-    }
-    const assetIds = job.result?.assetIds ?? [];
-    return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
-  }
-
-  function completedAnchorMs(job) {
-    return Date.parse(job.completedAt ?? job.updatedAt ?? "");
-  }
-
-  function completedWaitExpired(job, nowMs = Date.now()) {
-    const anchorMs = completedAnchorMs(job);
-    return Number.isFinite(anchorMs) && nowMs - anchorMs > completedResultFallbackMs;
-  }
-
-  useEffect(() => {
-    const nowMs = Date.now();
-    const pendingCompletedJobs = trackedLocalJobs.filter(
-      (job) =>
-        job.status === "completed" &&
-        Number.isFinite(completedAnchorMs(job)) &&
-        !resultVisible(job) &&
-        !completedWaitExpired(job, nowMs),
-    );
-    if (!pendingCompletedJobs.length) {
-      return undefined;
-    }
-    const nextDelay = Math.min(
-      ...pendingCompletedJobs.map((job) => Math.max(0, completedResultFallbackMs - (nowMs - completedAnchorMs(job)))),
-    );
-    const timer = window.setTimeout(() => setResultFallbackTick((value) => value + 1), nextDelay + 50);
-    return () => window.clearTimeout(timer);
-  }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
-
-  const localJobs = trackedLocalJobs.filter(
-    (job) =>
-      // Canceled runs produce no output, so drop them instead of leaving a
-      // "Canceled" progress card behind.
-      job.status !== "canceled" &&
-      (job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job))),
-  );
-  const hasReviewContent = Boolean(localJobs.length || latestAssets.length);
-
   async function submit(event) {
     event.preventDefault();
     if (submitting) {
@@ -459,13 +400,6 @@ export function VideoStudio({
       return;
     }
     video.pause();
-  }
-
-  function onPromptKeyDown(event) {
-    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-      event.preventDefault();
-      event.currentTarget.form?.requestSubmit();
-    }
   }
 
   return (
@@ -715,16 +649,7 @@ export function VideoStudio({
             ) : null}
 
             {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
-            {presetValidationResult.missing.length ? (
-              <p className="inline-warning">
-                Preset cannot run until LoRA import finishes: {presetValidationResult.missing.join(", ")}. Wait for the Queue or choose another preset.
-              </p>
-            ) : null}
-            {presetValidationResult.incompatible.length ? (
-              <p className="inline-warning">
-                Preset cannot run with {selectedModel?.name ?? "the selected model"} because these LoRAs are incompatible: {presetValidationResult.incompatible.join(", ")}. Choose another preset or model.
-              </p>
-            ) : null}
+            <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
           </div>
 
           <div className="video-rail">
@@ -826,23 +751,12 @@ export function VideoStudio({
                 </select>
               </label>
 
-              {selectedPreset ? (
-                <div className="guidance-strip">
-                  <strong>{selectedPreset.ui?.description ?? "Preset defaults active"}</strong>
-                  <span>
-                    {presetPromptParts.length ? `Adds: ${presetPromptParts.join(", ")}` : "No prompt fragments"}
-                    {presetLoraDetails.length
-                      ? ` | Preset LoRA applied at generation: ${presetLoraDetails.map((lora) => lora.name ?? lora.id).join(", ")}`
-                      : " | No preset LoRAs"}
-                    {presetLoraDetails.some((lora) => lora.missing) ? " | Import still pending" : ""}
-                  </span>
-                </div>
-              ) : (
-                <div className="guidance-strip">
-                  <strong>No preset selected</strong>
-                  <span>Generation uses only the prompt, model, and visible render settings.</span>
-                </div>
-              )}
+              <PresetGuidanceStrip
+                selectedPreset={selectedPreset}
+                presetPromptParts={presetPromptParts}
+                presetLoraDetails={presetLoraDetails}
+                noPresetHint="Generation uses only the prompt, model, and visible render settings."
+              />
 
               {durationHint ? <p className="helper-copy">{durationHint}</p> : null}
 

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  noPresetId,
+  presetLoraDetails as buildPresetLoraDetails,
+  presetMatchesModel,
+  presetMatchesWorkflow,
+  presetPromptParts as buildPresetPromptParts,
+  presetValidation,
+} from "../presetUtils.js";
+
+const completedResultFallbackMs = 30000;
+
+// Cmd/Ctrl+Enter submits the studio form from the prompt textarea.
+export function onPromptKeyDown(event) {
+  if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+    event.preventDefault();
+    event.currentTarget.form?.requestSubmit();
+  }
+}
+
+// Shared state/derivations for the Image and Video studios: preset selection and
+// validation, the catalog-driven model/character resets, and the completed-job
+// "keep the progress card until the asset renders" machinery. The studios keep
+// their own divergent pieces (preset-default field application, launch-request
+// handling, submit payloads) and pass the bits this hook needs as arguments.
+export function useGenerationStudio({
+  mode,
+  presets,
+  selectedModel,
+  loras,
+  models,
+  model,
+  setModel,
+  fallbackModelId,
+  characters,
+  characterId,
+  setCharacterId,
+  setCharacterLookId,
+  assets,
+  latestAssets,
+  trackedLocalJobs,
+}) {
+  const [selectedPresetId, setSelectedPresetId] = useState(null);
+  const [resultFallbackTick, setResultFallbackTick] = useState(0);
+
+  // Snap the model back into range when the catalog changes out from under it.
+  useEffect(() => {
+    if (!models.some((item) => item.id === model)) {
+      setModel(models[0]?.id ?? fallbackModelId);
+    }
+  }, [models, model]);
+
+  // Drop a character selection that's no longer in the catalog.
+  useEffect(() => {
+    if (characterId && !characters.some((character) => character.id === characterId)) {
+      setCharacterId("");
+      setCharacterLookId("");
+    }
+  }, [characters, characterId]);
+
+  const availablePresets = useMemo(
+    () => presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel)),
+    [mode, presets, selectedModel?.id],
+  );
+  const selectedPreset =
+    selectedPresetId === noPresetId
+      ? null
+      : selectedPresetId
+        ? availablePresets.find((preset) => preset.id === selectedPresetId) ?? null
+        : availablePresets[0] ?? null;
+  const presetPromptParts = buildPresetPromptParts(selectedPreset);
+  const presetLoraDetails = buildPresetLoraDetails(selectedPreset, loras);
+  const presetValidationResult = useMemo(
+    () => presetValidation(selectedPreset, loras, selectedModel),
+    [selectedPreset, loras, selectedModel],
+  );
+
+  // An explicitly chosen preset that drops out of the available set falls back to
+  // the first available preset (or None) rather than showing stale config.
+  useEffect(() => {
+    if (!selectedPresetId || selectedPresetId === noPresetId) {
+      return;
+    }
+    if (!selectedPreset) {
+      setSelectedPresetId(availablePresets[0]?.id ?? noPresetId);
+    }
+  }, [availablePresets, selectedPresetId, selectedPreset]);
+
+  function resultVisible(job) {
+    if (job.result?.generationSetId) {
+      return latestAssets.some((asset) => asset.generationSetId === job.result.generationSetId);
+    }
+    const assetIds = job.result?.assetIds ?? [];
+    return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
+  }
+
+  function completedAnchorMs(job) {
+    return Date.parse(job.completedAt ?? job.updatedAt ?? "");
+  }
+
+  function completedWaitExpired(job, nowMs = Date.now()) {
+    const anchorMs = completedAnchorMs(job);
+    return Number.isFinite(anchorMs) && nowMs - anchorMs > completedResultFallbackMs;
+  }
+
+  // A completed job's assets can lag its SSE result by a beat; keep the progress
+  // card until the asset renders or the fallback window expires, re-checking on a
+  // timer so a card never lingers forever when the asset never arrives.
+  useEffect(() => {
+    const nowMs = Date.now();
+    const pendingCompletedJobs = trackedLocalJobs.filter(
+      (job) =>
+        job.status === "completed" &&
+        Number.isFinite(completedAnchorMs(job)) &&
+        !resultVisible(job) &&
+        !completedWaitExpired(job, nowMs),
+    );
+    if (!pendingCompletedJobs.length) {
+      return undefined;
+    }
+    const nextDelay = Math.min(
+      ...pendingCompletedJobs.map((job) => Math.max(0, completedResultFallbackMs - (nowMs - completedAnchorMs(job)))),
+    );
+    const timer = window.setTimeout(() => setResultFallbackTick((value) => value + 1), nextDelay + 50);
+    return () => window.clearTimeout(timer);
+  }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
+
+  const localJobs = useMemo(
+    () =>
+      trackedLocalJobs.filter(
+        (job) =>
+          // Canceled runs produce no output, so drop them instead of leaving a
+          // "Canceled" progress card behind.
+          job.status !== "canceled" &&
+          (job.status !== "completed" || (!resultVisible(job) && !completedWaitExpired(job))),
+      ),
+    [assets, latestAssets, trackedLocalJobs, resultFallbackTick],
+  );
+
+  return {
+    availablePresets,
+    selectedPreset,
+    selectedPresetId,
+    setSelectedPresetId,
+    presetPromptParts,
+    presetLoraDetails,
+    presetValidationResult,
+    localJobs,
+  };
+}
+
+// The "what this preset adds" strip shown under the preset picker in both studios.
+export function PresetGuidanceStrip({ selectedPreset, presetPromptParts, presetLoraDetails, noPresetHint }) {
+  if (!selectedPreset) {
+    return (
+      <div className="guidance-strip">
+        <strong>No preset selected</strong>
+        <span>{noPresetHint}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="guidance-strip">
+      <strong>{selectedPreset.ui?.description ?? "Preset defaults active"}</strong>
+      <span>
+        {presetPromptParts.length ? `Adds: ${presetPromptParts.join(", ")}` : "No prompt fragments"}
+        {presetLoraDetails.length
+          ? ` | Preset LoRA applied at generation: ${presetLoraDetails.map((lora) => lora.name ?? lora.id).join(", ")}`
+          : " | No preset LoRAs"}
+        {presetLoraDetails.some((lora) => lora.missing) ? " | Import still pending" : ""}
+      </span>
+    </div>
+  );
+}
+
+// The preset "missing"/"incompatible" inline warnings shared by both studios.
+export function PresetValidationWarnings({ presetValidationResult, selectedModel }) {
+  return (
+    <>
+      {presetValidationResult.missing.length ? (
+        <p className="inline-warning">
+          Preset cannot run until LoRA import finishes: {presetValidationResult.missing.join(", ")}. Wait for the Queue or choose another preset.
+        </p>
+      ) : null}
+      {presetValidationResult.incompatible.length ? (
+        <p className="inline-warning">
+          Preset cannot run with {selectedModel?.name ?? "the selected model"} because these LoRAs are incompatible: {presetValidationResult.incompatible.join(", ")}. Choose another preset or model.
+        </p>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
Part of [epic 1628](https://app.shortcut.com/trefry/epic/1628) (full-repo review 2026-05-24). Web cluster.

## Problem
`ImageStudio.jsx` and `VideoStudio.jsx` carried ~150-200 lines of near-identical preset and result-tracking logic. Bug fixes (e.g. the recent "drop canceled runs" change) had to be applied in both and historically drifted; VideoStudio's `localJobs` wasn't even memoized while ImageStudio's was.

## Change
New `apps/web/src/screens/generationStudio.jsx`:
- **`useGenerationStudio()`** — preset selection + `availablePresets`/`selectedPreset`/`presetPromptParts`/`presetLoraDetails`/`presetValidationResult`, the "snap an explicitly-chosen preset back into range when it drops out" effect, the catalog-driven model-reset and character-reset effects, and the completed-job result-visibility machinery (`resultVisible`/`completedAnchorMs`/`completedWaitExpired` + the fallback-tick timer + `localJobs`). `localJobs` is now memoized in both studios.
- **`onPromptKeyDown`** — shared Cmd/Ctrl+Enter submit handler.
- **`PresetGuidanceStrip`** / **`PresetValidationWarnings`** — the verbatim-duplicated guidance strip and missing/incompatible warning JSX (the no-preset hint text is parameterized: "preset settings" vs "render settings").

Each studio keeps its **divergent** pieces: preset-default field application (image `count`/`resolution`/`negativePrompt` vs video `duration`/`fps`/`quality`/`resolution`/`negativePrompt`), launch-request handling, submit payloads, and Image's extra selected-LoRA validation warning.

## Why it's behavior-preserving
The four effects moved into the hook are all dependency-driven and use deferred `setState` (no synchronous cross-effect ref reads), so the change in declaration order within a render phase doesn't change outcomes — each effect still re-runs on its dependency change on the next render exactly as before.

Net **-174 lines** across the two studios.

## Test plan
- [x] `npm --prefix apps/web run test` → 107 passed (includes the studio-specific tests that render both components: local progress, "keep completed progress until the asset renders", preset application, Replace Person visibility)
- [x] `npm --prefix apps/web run build` → clean (52 modules)
- [x] Browser smoke: app bundle loads with no console errors; nav/shell render. The studios themselves are gated behind workspace creation (needs the backend + a project), so the live studio UI wasn't exercised end-to-end in-browser — but the component tests render both studios directly with realistic props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)