### PR TITLE
refactor(web): abort stale project-scoped loads with AbortController (sc-1676)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { apiFetch, eventUrl } from "./api.js";
+import { apiFetch, eventUrl, isAbortError } from "./api.js";
 import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
@@ -580,13 +580,18 @@ export function App() {
       setActiveTimeline(null);
       return;
     }
-    refreshAssets(activeProject.id);
-    refreshCharacters(activeProject.id);
-    refreshLoras(activeProject.id);
-    refreshPresets(activeProject.id);
-    refreshTrainingDatasets(activeProject.id);
-    refreshPersonTracks(activeProject.id);
-    refreshTimelines(activeProject.id);
+    // Switching projects (or unmounting) aborts the previous project's in-flight
+    // loads so a slow response can't overwrite the newly-selected project's data.
+    const controller = new AbortController();
+    const { signal } = controller;
+    refreshAssets(activeProject.id, { signal });
+    refreshCharacters(activeProject.id, { signal });
+    refreshLoras(activeProject.id, { signal });
+    refreshPresets(activeProject.id, { signal });
+    refreshTrainingDatasets(activeProject.id, { signal });
+    refreshPersonTracks(activeProject.id, { signal });
+    refreshTimelines(activeProject.id, { signal });
+    return () => controller.abort();
   }, [activeProject?.id, authenticated, token]);
 
   useEffect(() => {
@@ -783,41 +788,44 @@ export function App() {
     );
   }
 
-  async function refreshAssets(projectId = activeProject?.id) {
+  async function refreshAssets(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
       return;
     }
     try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token);
+      const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token, { signal });
       setAssets(items);
       const defaultAsset = items.find((asset) => !asset.status?.trashed && !asset.status?.rejected) ?? items[0] ?? null;
       setSelectedAssetId((current) => current ?? defaultAsset?.id ?? null);
       setError("");
     } catch (err) {
+      if (isAbortError(err)) return;
       setError(err.message);
     }
   }
 
-  async function refreshCharacters(projectId = activeProject?.id) {
+  async function refreshCharacters(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
       return;
     }
     try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/characters`, token);
+      const items = await apiFetch(`/api/v1/projects/${projectId}/characters`, token, { signal });
       setCharacters(items);
       setError("");
     } catch (err) {
+      if (isAbortError(err)) return;
       setError(err.message);
     }
   }
 
-  async function refreshLoras(projectId = activeProject?.id) {
+  async function refreshLoras(projectId = activeProject?.id, { signal } = {}) {
     try {
       const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-      const items = await apiFetch(`/api/v1/loras${query}`, token);
+      const items = await apiFetch(`/api/v1/loras${query}`, token, { signal });
       setLoras(items);
       setError("");
     } catch (err) {
+      if (isAbortError(err)) return;
       setError(err.message);
     }
   }
@@ -832,20 +840,21 @@ export function App() {
       .catch(() => {});
   }
 
-  async function refreshPresets(projectId = activeProject?.id) {
+  async function refreshPresets(projectId = activeProject?.id, { signal } = {}) {
     try {
       const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-      const items = await apiFetch(`/api/v1/recipe-presets${query}`, token);
+      const items = await apiFetch(`/api/v1/recipe-presets${query}`, token, { signal });
       setPresets(items);
       setError("");
       return items;
     } catch (err) {
+      if (isAbortError(err)) return [];
       setError(err.message);
       return [];
     }
   }
 
-  async function refreshTrainingDatasets(projectId = activeProject?.id) {
+  async function refreshTrainingDatasets(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
       setTrainingDatasets([]);
       setTrainingDatasetsProjectId(null);
@@ -854,18 +863,22 @@ export function App() {
     }
     setLoadingTrainingDatasets(true);
     try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token);
+      const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, { signal });
       setTrainingDatasets(items);
       setTrainingDatasetsProjectId(projectId);
       setTrainingDatasetsError("");
       return items;
     } catch (err) {
+      if (isAbortError(err)) return [];
       setTrainingDatasets([]);
       setTrainingDatasetsProjectId(projectId);
       setTrainingDatasetsError(err.message);
       return [];
     } finally {
-      setLoadingTrainingDatasets(false);
+      // A superseded load must not clear the loading flag the new load just set.
+      if (!signal?.aborted) {
+        setLoadingTrainingDatasets(false);
+      }
     }
   }
 
@@ -1115,25 +1128,26 @@ export function App() {
     return job;
   }
 
-  async function refreshPersonTracks(projectId = activeProject?.id) {
+  async function refreshPersonTracks(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
       return;
     }
     try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token);
+      const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token, { signal });
       setPersonTracks(items);
       setError("");
     } catch (err) {
+      if (isAbortError(err)) return;
       setError(err.message);
     }
   }
 
-  async function refreshTimelines(projectId = activeProject?.id) {
+  async function refreshTimelines(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
       return;
     }
     try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token);
+      const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token, { signal });
       if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
         return;
       }
@@ -1145,6 +1159,7 @@ export function App() {
       }
       setError("");
     } catch (err) {
+      if (isAbortError(err)) return;
       setError(err.message);
     }
   }

--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -11,6 +11,14 @@ export const API_BASE_URL =
       ? window.location.origin
       : configuredApiBaseUrl;
 
+// True for the DOMException fetch raises when an AbortController aborts a
+// request. Callers treat this as "request superseded", not a real error.
+export function isAbortError(err) {
+  return err?.name === "AbortError";
+}
+
+// `options` is forwarded to fetch, so callers can pass an AbortController
+// `signal` to cancel a request (e.g. a stale project-scoped load).
 export async function apiFetch(path, token, options = {}) {
   const headers = new Headers(options.headers ?? {});
   const isFormData = options.body instanceof FormData;

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { isAbortError } from "../api.js";
 import { AssetMedia, assetUrl } from "./assetMedia.jsx";
 import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
@@ -16,10 +17,10 @@ function DocumentReader({ asset }) {
       setError("Document file is unavailable.");
       return undefined;
     }
-    let cancelled = false;
+    const controller = new AbortController();
     setSegments(null);
     setError("");
-    fetch(url)
+    fetch(url, { signal: controller.signal })
       .then((response) => {
         if (!response.ok) {
           throw new Error(`Request failed (${response.status})`);
@@ -27,18 +28,13 @@ function DocumentReader({ asset }) {
         return response.json();
       })
       .then((document) => {
-        if (!cancelled) {
-          setSegments(Array.isArray(document?.segments) ? document.segments : []);
-        }
+        setSegments(Array.isArray(document?.segments) ? document.segments : []);
       })
       .catch((err) => {
-        if (!cancelled) {
-          setError(String(err?.message ?? err));
-        }
+        if (isAbortError(err)) return;
+        setError(String(err?.message ?? err));
       });
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, [url]);
 
   if (error) {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5659,8 +5659,11 @@ describe("SceneWorks app shell", () => {
     const image = container.querySelector("img.document-image");
     expect(image).not.toBeNull();
     expect(image.getAttribute("src")).toContain("assets/images/a.png");
-    // The document JSON was fetched from its file path.
-    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("assets/documents/doc_1.json"));
+    // The document JSON was fetched from its file path (with an abort signal).
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("assets/documents/doc_1.json"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });
 


### PR DESCRIPTION
Part of [epic 1628](https://app.shortcut.com/trefry/epic/1628) (full-repo review 2026-05-24). Web cluster.

## Problem
`apiFetch` accepted no abort signal in practice, so rapid project switching fired overlapping project-scoped loads that all completed — a slow response for the *previous* project could overwrite the newly-selected project's state. Stale writes were guarded ad hoc (`activeProjectRef` equality checks, `cancelled` flags), and that guard pattern was duplicated.

## Change
- **`api.js`**: add `isAbortError()` and document that `apiFetch` forwards `options.signal` to `fetch` (it already did via the options spread — this makes it explicit and actually used).
- **`App.jsx`**: the project-scoped data effect now creates an `AbortController`, threads its `signal` through the seven `refresh*` loaders, and aborts on project switch / unmount. Each loader returns early on `AbortError` instead of surfacing it as an error. `refreshTrainingDatasets` skips clearing its loading flag when aborted, so a superseded load can't clear the flag the new load just set.
- **`assetPanels.jsx` `DocumentReader`**: replace its `cancelled`-flag fetch with an `AbortController` so a stale document fetch is actually cancelled (not just ignored).

## Out of scope (deliberately)
`ModelManagerScreen`'s `cancelled` flag (review pointed near it) guards a **Tauri `invoke("get_gpu_info")`**, which isn't an abortable `fetch` — the flag is the right pattern there, so it's left as-is.

## Test plan
- [x] `npm --prefix apps/web run test` → 107 pass (updated the `DocumentReader` assertion to expect the new `{ signal }` fetch arg)
- [x] `npm --prefix apps/web run build` → clean
- [x] Browser smoke: bundle loads, no console errors. The abort itself is only observable with a live backend + switching between projects, which the static preview (API offline) can't exercise; the loader call-shape is covered by the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)