### PR TITLE
refactor(web): extract usePresets hook from App.jsx (sc-1651, slice 2)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -20,6 +20,7 @@ import { SetupWizard } from "./screens/SetupWizard.jsx";
 import { sortNewest, sortWorkers } from "./sorters.js";
 import { ensureItemVersionFields } from "./timeline.js";
 import { useCharacters } from "./hooks/useCharacters.js";
+import { usePresets } from "./hooks/usePresets.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
 // web/Docker keep the existing first-run project gate. Tauri commands persist the
@@ -366,7 +367,6 @@ export function App() {
   const [queueSummary, setQueueSummary] = useState(null);
   const [models, setModels] = useState([]);
   const [loras, setLoras] = useState([]);
-  const [presets, setPresets] = useState([]);
   const [trainingTargets, setTrainingTargets] = useState({ schemaVersion: 1, targets: [] });
   const [trainingPresets, setTrainingPresets] = useState({ schemaVersion: 1, presets: [] });
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
@@ -415,6 +415,16 @@ export function App() {
     detachCharacterLora,
     createCharacterTestJob,
   } = useCharacters({ token, activeProject, setError, requestedGpu, setActiveView, refreshData });
+
+  const {
+    presets,
+    setPresets,
+    refreshPresets,
+    createPreset,
+    updatePreset,
+    duplicatePreset,
+    deletePreset,
+  } = usePresets({ token, activeProject, setError });
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
@@ -845,20 +855,6 @@ export function App() {
       .catch(() => {});
   }
 
-  async function refreshPresets(projectId = activeProject?.id, { signal } = {}) {
-    try {
-      const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-      const items = await apiFetch(`/api/v1/recipe-presets${query}`, token, { signal });
-      setPresets(items);
-      setError("");
-      return items;
-    } catch (err) {
-      if (isAbortError(err)) return [];
-      setError(err.message);
-      return [];
-    }
-  }
-
   async function refreshTrainingDatasets(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
       setTrainingDatasets([]);
@@ -978,56 +974,6 @@ export function App() {
     setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
     setError("");
     return job;
-  }
-
-  function presetQuery(scope = null) {
-    const params = new URLSearchParams();
-    if (scope) {
-      params.set("scope", scope);
-    }
-    if (scope === "project" && activeProject?.id) {
-      params.set("projectId", activeProject.id);
-    }
-    const value = params.toString();
-    return value ? `?${value}` : "";
-  }
-
-  async function createPreset(payload) {
-    if (payload.scope === "project" && !activeProject) {
-      throw new Error("Create or open a project first.");
-    }
-    const created = await apiFetch(`/api/v1/recipe-presets${presetQuery(payload.scope)}`, token, {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    await refreshPresets(activeProject?.id);
-    return created;
-  }
-
-  async function updatePreset(presetId, payload, scope = payload.scope) {
-    const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
-      method: "PATCH",
-      body: JSON.stringify(payload),
-    });
-    await refreshPresets(activeProject?.id);
-    return updated;
-  }
-
-  async function duplicatePreset(presetId, scope = null) {
-    const duplicated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}/duplicate${presetQuery(scope)}`, token, {
-      method: "POST",
-      body: JSON.stringify({}),
-    });
-    await refreshPresets(activeProject?.id);
-    return duplicated;
-  }
-
-  async function deletePreset(presetId, scope = null) {
-    const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
-      method: "DELETE",
-    });
-    await refreshPresets(activeProject?.id);
-    return archived;
   }
 
   async function deleteModel(model) {

--- a/apps/web/src/hooks/usePresets.js
+++ b/apps/web/src/hooks/usePresets.js
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+
+// Owns the recipe-preset list plus its scoped refresh/create/update/duplicate/delete
+// mutations. Extracted from App.jsx (sc-1651). Behavior unchanged — token, the active
+// project, and error reporting are passed in. App's bulk refreshData still seeds the
+// list via the returned setPresets (same React setter identity), and the project-load
+// effect calls refreshCharacters/refreshPresets exactly as before.
+export function usePresets({ token, activeProject, setError }) {
+  const [presets, setPresets] = useState([]);
+
+  async function refreshPresets(projectId = activeProject?.id, { signal } = {}) {
+    try {
+      const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+      const items = await apiFetch(`/api/v1/recipe-presets${query}`, token, { signal });
+      setPresets(items);
+      setError("");
+      return items;
+    } catch (err) {
+      if (isAbortError(err)) return [];
+      setError(err.message);
+      return [];
+    }
+  }
+
+  function presetQuery(scope = null) {
+    const params = new URLSearchParams();
+    if (scope) {
+      params.set("scope", scope);
+    }
+    if (scope === "project" && activeProject?.id) {
+      params.set("projectId", activeProject.id);
+    }
+    const value = params.toString();
+    return value ? `?${value}` : "";
+  }
+
+  async function createPreset(payload) {
+    if (payload.scope === "project" && !activeProject) {
+      throw new Error("Create or open a project first.");
+    }
+    const created = await apiFetch(`/api/v1/recipe-presets${presetQuery(payload.scope)}`, token, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    await refreshPresets(activeProject?.id);
+    return created;
+  }
+
+  async function updatePreset(presetId, payload, scope = payload.scope) {
+    const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    });
+    await refreshPresets(activeProject?.id);
+    return updated;
+  }
+
+  async function duplicatePreset(presetId, scope = null) {
+    const duplicated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}/duplicate${presetQuery(scope)}`, token, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    await refreshPresets(activeProject?.id);
+    return duplicated;
+  }
+
+  async function deletePreset(presetId, scope = null) {
+    const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
+      method: "DELETE",
+    });
+    await refreshPresets(activeProject?.id);
+    return archived;
+  }
+
+  return {
+    presets,
+    setPresets,
+    refreshPresets,
+    createPreset,
+    updatePreset,
+    duplicatePreset,
+    deletePreset,
+  };
+}


### PR DESCRIPTION
## Summary
Second Phase-A slice of the `App.jsx` god-module decomposition (epic [1628](https://app.shortcut.com/trefry/epic/1628), sc-1651). Follows [PR #185](https://github.com/michaeltrefry/SceneWorks/pull/185) (useCharacters, merged). Same approach: behavior-preserving, extract a self-contained per-domain hook that `App` still composes — **no screen prop-signature changes**.

Moves the recipe-preset domain into `apps/web/src/hooks/usePresets.js`:
- `presets` state
- `refreshPresets`, `createPreset`, `updatePreset`, `duplicatePreset`, `deletePreset`
- `presetQuery` (kept internal — only the preset mutations used it)

`App` calls `usePresets({ token, activeProject, setError })` and forwards the returned values down unchanged, so `PresetManagerScreen`/`ImageStudio`/`VideoStudio` are untouched. App's bulk `refreshData` still seeds the list via the hook's `setPresets` (identical React setter identity), and the reset/project-load effects use the hook's `setPresets`/`refreshPresets` as before.

`App.jsx`: **2186 → 2132 lines** (cumulative since the god module started at 2334).

## Test plan
- [x] `npm --prefix apps/web run test -- --run` → **107 passed**
- [x] `npm --prefix apps/web run build` → clean
- [x] Browser smoke (Rust API on a temp data dir): Preset Manager renders with all hook props wired; after seeding a preset via the API, a reload shows it (`refreshPresets` through the hook); selecting it + **Duplicate** round-tripped through the hook (API → 2 presets → list re-rendered) with **no console errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)