### PR TITLE
refactor(web): extract useTraining hook from App.jsx (sc-1651, slice 3)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -21,6 +21,7 @@ import { sortNewest, sortWorkers } from "./sorters.js";
 import { ensureItemVersionFields } from "./timeline.js";
 import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
+import { useTraining } from "./hooks/useTraining.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
 // web/Docker keep the existing first-run project gate. Tauri commands persist the
@@ -371,10 +372,6 @@ export function App() {
   const [trainingPresets, setTrainingPresets] = useState({ schemaVersion: 1, presets: [] });
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
   const [trainingPresetsError, setTrainingPresetsError] = useState("");
-  const [trainingDatasets, setTrainingDatasets] = useState([]);
-  const [trainingDatasetsProjectId, setTrainingDatasetsProjectId] = useState(null);
-  const [loadingTrainingDatasets, setLoadingTrainingDatasets] = useState(false);
-  const [trainingDatasetsError, setTrainingDatasetsError] = useState("");
   const [assets, setAssets] = useState([]);
   const [personTracks, setPersonTracks] = useState([]);
   const [timelines, setTimelines] = useState([]);
@@ -425,6 +422,24 @@ export function App() {
     duplicatePreset,
     deletePreset,
   } = usePresets({ token, activeProject, setError });
+
+  const {
+    trainingDatasets,
+    setTrainingDatasets,
+    trainingDatasetsProjectId,
+    setTrainingDatasetsProjectId,
+    loadingTrainingDatasets,
+    trainingDatasetsError,
+    setTrainingDatasetsError,
+    refreshTrainingDatasets,
+    loadTrainingDataset,
+    createTrainingDataset,
+    updateTrainingDataset,
+    batchRenameTrainingDataset,
+    writeTrainingDatasetCaptionSidecars,
+    createTrainingDatasetCaptionJob,
+    createTrainingJob,
+  } = useTraining({ token, activeProject, setError, setJobs });
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
@@ -853,127 +868,6 @@ export function App() {
         }
       })
       .catch(() => {});
-  }
-
-  async function refreshTrainingDatasets(projectId = activeProject?.id, { signal } = {}) {
-    if (!projectId) {
-      setTrainingDatasets([]);
-      setTrainingDatasetsProjectId(null);
-      setTrainingDatasetsError("");
-      return [];
-    }
-    setLoadingTrainingDatasets(true);
-    try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, { signal });
-      setTrainingDatasets(items);
-      setTrainingDatasetsProjectId(projectId);
-      setTrainingDatasetsError("");
-      return items;
-    } catch (err) {
-      if (isAbortError(err)) return [];
-      setTrainingDatasets([]);
-      setTrainingDatasetsProjectId(projectId);
-      setTrainingDatasetsError(err.message);
-      return [];
-    } finally {
-      // A superseded load must not clear the loading flag the new load just set.
-      if (!signal?.aborted) {
-        setLoadingTrainingDatasets(false);
-      }
-    }
-  }
-
-  async function loadTrainingDataset(datasetId, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      return null;
-    }
-    return apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token);
-  }
-
-  async function createTrainingDataset(payload, projectId = activeProject?.id) {
-    if (!projectId) {
-      throw new Error("Create or open a project first.");
-    }
-    const created = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    await refreshTrainingDatasets(projectId);
-    return created;
-  }
-
-  async function updateTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const updated = await apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token, {
-      method: "PATCH",
-      body: JSON.stringify(payload),
-    });
-    await refreshTrainingDatasets(projectId);
-    return updated;
-  }
-
-  async function batchRenameTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const updated = await apiFetch(
-      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/batch-rename`,
-      token,
-      {
-        method: "POST",
-        body: JSON.stringify(payload),
-      },
-    );
-    await refreshTrainingDatasets(projectId);
-    return updated;
-  }
-
-  async function writeTrainingDatasetCaptionSidecars(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const result = await apiFetch(
-      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-sidecars`,
-      token,
-      {
-        method: "POST",
-        body: JSON.stringify(payload),
-      },
-    );
-    await refreshTrainingDatasets(projectId);
-    return result;
-  }
-
-  async function createTrainingDatasetCaptionJob(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const job = await apiFetch(
-      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-jobs`,
-      token,
-      {
-        method: "POST",
-        body: JSON.stringify(payload),
-      },
-    );
-    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-    setError("");
-    return job;
-  }
-
-  async function createTrainingJob(request, projectId = activeProject?.id) {
-    if (!projectId) {
-      throw new Error("Select a workspace before creating a training job.");
-    }
-    const job = await apiFetch(`/api/v1/projects/${projectId}/training/jobs`, token, {
-      method: "POST",
-      body: JSON.stringify(request),
-    });
-    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-    setError("");
-    return job;
   }
 
   async function deleteModel(model) {

--- a/apps/web/src/hooks/useTraining.js
+++ b/apps/web/src/hooks/useTraining.js
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+import { sortNewest } from "../sorters.js";
+
+// Owns the project's training-dataset state plus dataset CRUD, caption sidecar/job,
+// and training-job creation. Extracted from App.jsx (sc-1651). The training target/
+// preset catalogs stay in App (bulk-loaded by refreshData) — only the project-scoped
+// dataset workflow lives here. Shared concerns (token, activeProject, error, jobs) are
+// passed in; caption/training jobs push onto the shared jobs list via setJobs.
+export function useTraining({ token, activeProject, setError, setJobs }) {
+  const [trainingDatasets, setTrainingDatasets] = useState([]);
+  const [trainingDatasetsProjectId, setTrainingDatasetsProjectId] = useState(null);
+  const [loadingTrainingDatasets, setLoadingTrainingDatasets] = useState(false);
+  const [trainingDatasetsError, setTrainingDatasetsError] = useState("");
+
+  async function refreshTrainingDatasets(projectId = activeProject?.id, { signal } = {}) {
+    if (!projectId) {
+      setTrainingDatasets([]);
+      setTrainingDatasetsProjectId(null);
+      setTrainingDatasetsError("");
+      return [];
+    }
+    setLoadingTrainingDatasets(true);
+    try {
+      const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, { signal });
+      setTrainingDatasets(items);
+      setTrainingDatasetsProjectId(projectId);
+      setTrainingDatasetsError("");
+      return items;
+    } catch (err) {
+      if (isAbortError(err)) return [];
+      setTrainingDatasets([]);
+      setTrainingDatasetsProjectId(projectId);
+      setTrainingDatasetsError(err.message);
+      return [];
+    } finally {
+      // A superseded load must not clear the loading flag the new load just set.
+      if (!signal?.aborted) {
+        setLoadingTrainingDatasets(false);
+      }
+    }
+  }
+
+  async function loadTrainingDataset(datasetId, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      return null;
+    }
+    return apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token);
+  }
+
+  async function createTrainingDataset(payload, projectId = activeProject?.id) {
+    if (!projectId) {
+      throw new Error("Create or open a project first.");
+    }
+    const created = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    await refreshTrainingDatasets(projectId);
+    return created;
+  }
+
+  async function updateTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      throw new Error("Select a training dataset first.");
+    }
+    const updated = await apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token, {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    });
+    await refreshTrainingDatasets(projectId);
+    return updated;
+  }
+
+  async function batchRenameTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      throw new Error("Select a training dataset first.");
+    }
+    const updated = await apiFetch(
+      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/batch-rename`,
+      token,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    await refreshTrainingDatasets(projectId);
+    return updated;
+  }
+
+  async function writeTrainingDatasetCaptionSidecars(datasetId, payload, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      throw new Error("Select a training dataset first.");
+    }
+    const result = await apiFetch(
+      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-sidecars`,
+      token,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    await refreshTrainingDatasets(projectId);
+    return result;
+  }
+
+  async function createTrainingDatasetCaptionJob(datasetId, payload, projectId = activeProject?.id) {
+    if (!projectId || !datasetId) {
+      throw new Error("Select a training dataset first.");
+    }
+    const job = await apiFetch(
+      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-jobs`,
+      token,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    setError("");
+    return job;
+  }
+
+  async function createTrainingJob(request, projectId = activeProject?.id) {
+    if (!projectId) {
+      throw new Error("Select a workspace before creating a training job.");
+    }
+    const job = await apiFetch(`/api/v1/projects/${projectId}/training/jobs`, token, {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    setError("");
+    return job;
+  }
+
+  return {
+    trainingDatasets,
+    setTrainingDatasets,
+    trainingDatasetsProjectId,
+    setTrainingDatasetsProjectId,
+    loadingTrainingDatasets,
+    trainingDatasetsError,
+    setTrainingDatasetsError,
+    refreshTrainingDatasets,
+    loadTrainingDataset,
+    createTrainingDataset,
+    updateTrainingDataset,
+    batchRenameTrainingDataset,
+    writeTrainingDatasetCaptionSidecars,
+    createTrainingDatasetCaptionJob,
+    createTrainingJob,
+  };
+}


### PR DESCRIPTION
## Summary
Third Phase-A slice of the `App.jsx` god-module decomposition (epic [1628](https://app.shortcut.com/trefry/epic/1628), sc-1651). Follows merged [#185](https://github.com/michaeltrefry/SceneWorks/pull/185) (useCharacters) and [#186](https://github.com/michaeltrefry/SceneWorks/pull/186) (usePresets). Same approach: behavior-preserving, extract a self-contained per-domain hook that `App` still composes — **no screen prop-signature changes**.

Moves the project's training-dataset domain into `apps/web/src/hooks/useTraining.js`:
- state: `trainingDatasets`, `trainingDatasetsProjectId`, `loadingTrainingDatasets`, `trainingDatasetsError`
- functions: `refreshTrainingDatasets`, `loadTrainingDataset`, `createTrainingDataset`, `updateTrainingDataset`, `batchRenameTrainingDataset`, `writeTrainingDatasetCaptionSidecars`, `createTrainingDatasetCaptionJob`, `createTrainingJob`

`App` calls `useTraining({ token, activeProject, setError, setJobs })` and forwards the returned values down unchanged, so `TrainingStudio` is untouched. The training **target/preset catalogs** (bulk-loaded by `refreshData`) stay in `App`; caption/training jobs still push onto the shared jobs list via the injected `setJobs`.

`App.jsx`: **2132 → 2026 lines** (god module **2334 → 2026**, −308 across three slices).

## Test plan
- [x] `npm --prefix apps/web run test -- --run` → **107 passed**
- [x] `npm --prefix apps/web run build` → clean
- [x] Browser smoke (Rust API on a temp data dir): Training Studio renders with all hook props wired (0 datasets = clean empty `refreshTrainingDatasets` load); after seeding a dataset via the API, a reload showed it through the hook (**0 → 1 dataset**) with **no console errors**. (The create-dataset *form* needs project assets — a real form requirement — so the dataset was seeded via the API, same as the preset slice.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)