### PR TITLE
refactor(web): extract useModelsAndLoras hook from App.jsx (sc-1651, slice 4)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -22,6 +22,7 @@ import { ensureItemVersionFields } from "./timeline.js";
 import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
 import { useTraining } from "./hooks/useTraining.js";
+import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
 // web/Docker keep the existing first-run project gate. Tauri commands persist the
@@ -101,8 +102,6 @@ function generatedResultAssetCount(job) {
 // Studios show only the most recent run's progress card; starting a new run
 // replaces the previous one rather than stacking cards.
 const localJobStackLimit = 1;
-const maxLoraUploadBytes = 2 * 1024 * 1024 * 1024;
-const maxModelUploadBytes = 256 * 1024 * 1024 * 1024;
 
 const navSections = [
   {
@@ -346,11 +345,6 @@ function FirstRunProjectGate({ onCreate, disabled }) {
   );
 }
 
-function uploadLimitLabel(bytes) {
-  const gib = bytes / (1024 * 1024 * 1024);
-  return Number.isInteger(gib) ? `${gib}GB` : `${gib.toFixed(1)}GB`;
-}
-
 export function App() {
   const [health, setHealth] = useState(null);
   const [access, setAccess] = useState({ authRequired: false });
@@ -366,8 +360,6 @@ export function App() {
   const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [] });
   const [workers, setWorkers] = useState([]);
   const [queueSummary, setQueueSummary] = useState(null);
-  const [models, setModels] = useState([]);
-  const [loras, setLoras] = useState([]);
   const [trainingTargets, setTrainingTargets] = useState({ schemaVersion: 1, targets: [] });
   const [trainingPresets, setTrainingPresets] = useState({ schemaVersion: 1, presets: [] });
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
@@ -440,6 +432,28 @@ export function App() {
     createTrainingDatasetCaptionJob,
     createTrainingJob,
   } = useTraining({ token, activeProject, setError, setJobs });
+
+  const {
+    models,
+    setModels,
+    loras,
+    setLoras,
+    refreshLoras,
+    deleteModel,
+    deleteLora,
+    createModelImportJob,
+    createLoraImportJob,
+    createModelDownloadJob,
+    createModelConvertJob,
+  } = useModelsAndLoras({
+    token,
+    activeProject,
+    setError,
+    setJobs,
+    setActiveView,
+    refreshData,
+    refreshDataWithLoraOverlay,
+  });
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
@@ -848,18 +862,6 @@ export function App() {
     }
   }
 
-  async function refreshLoras(projectId = activeProject?.id, { signal } = {}) {
-    try {
-      const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-      const items = await apiFetch(`/api/v1/loras${query}`, token, { signal });
-      setLoras(items);
-      setError("");
-    } catch (err) {
-      if (isAbortError(err)) return;
-      setError(err.message);
-    }
-  }
-
   function refreshDataWithLoraOverlay(projectId = activeProjectRef.current?.id) {
     refreshData()
       .then(() => {
@@ -868,109 +870,6 @@ export function App() {
         }
       })
       .catch(() => {});
-  }
-
-  async function deleteModel(model) {
-    const result = await apiFetch(`/api/v1/models/${encodeURIComponent(model.id)}`, token, {
-      method: "DELETE",
-    });
-    if (result.removedManifestEntry) {
-      setModels((items) => items.filter((item) => item.id !== model.id));
-    }
-    setError("");
-    await refreshData();
-    return result;
-  }
-
-  async function deleteLora(lora) {
-    const params = new URLSearchParams();
-    if (lora.scope) {
-      params.set("scope", lora.scope);
-    }
-    if (lora.scope === "project" && activeProject?.id) {
-      params.set("projectId", activeProject.id);
-    }
-    const query = params.toString() ? `?${params.toString()}` : "";
-    const result = await apiFetch(`/api/v1/loras/${encodeURIComponent(lora.id)}${query}`, token, {
-      method: "DELETE",
-    });
-    if (result.removedManifestEntry) {
-      setLoras((items) => items.filter((item) => item.id !== lora.id || item.scope !== lora.scope));
-    }
-    setError("");
-    await refreshDataWithLoraOverlay(activeProject?.id);
-    return result;
-  }
-
-  async function createModelImportJob(payload, options = {}) {
-    const { file, ...metadata } = payload;
-    if (file?.size > maxModelUploadBytes) {
-      throw new Error(`Uploaded model file exceeds the ${uploadLimitLabel(maxModelUploadBytes)} limit`);
-    }
-    let body;
-    if (file) {
-      body = new FormData();
-      Object.entries(metadata).forEach(([key, value]) => {
-        if (value != null && value !== "") {
-          body.append(key, value);
-        }
-      });
-      body.append("file", file);
-    } else {
-      body = JSON.stringify(metadata);
-    }
-    const job = await apiFetch("/api/v1/models/import", token, {
-      method: "POST",
-      body,
-    });
-    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-    if (options.navigateToQueue ?? false) {
-      setActiveView("Queue");
-    }
-    setError("");
-    refreshData();
-    return job;
-  }
-
-  async function createLoraImportJob(payload, options = {}) {
-    if (payload.scope === "project" && !activeProject) {
-      throw new Error("Create or open a project first.");
-    }
-    const { file, ...metadata } = payload;
-    if (file?.size > maxLoraUploadBytes) {
-      throw new Error("Uploaded LoRA file exceeds the 2GB limit");
-    }
-    let body;
-    if (file) {
-      body = new FormData();
-      Object.entries({
-        ...metadata,
-        projectId: metadata.scope === "project" ? activeProject.id : null,
-        projectName: metadata.scope === "project" ? activeProject.name : null,
-      }).forEach(([key, value]) => {
-        if (value != null && value !== "") {
-          body.append(key, value);
-        }
-      });
-      body.append("file", file);
-    } else {
-      body = JSON.stringify({
-        ...metadata,
-        projectId: metadata.scope === "project" ? activeProject.id : null,
-        projectName: metadata.scope === "project" ? activeProject.name : null,
-      });
-    }
-    const job = await apiFetch("/api/v1/loras/import", token, {
-      method: "POST",
-      body,
-    });
-    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-    if (options.navigateToQueue ?? false) {
-      setActiveView("Queue");
-    }
-    setError("");
-    refreshDataWithLoraOverlay(activeProject?.id);
-    return job;
   }
 
   async function refreshPersonTracks(projectId = activeProject?.id, { signal } = {}) {
@@ -1583,38 +1482,6 @@ export function App() {
       if (options.throwOnError) {
         throw err;
       }
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function createModelDownloadJob(model) {
-    try {
-      const job = await apiFetch(`/api/v1/models/${model.id}/download`, token, {
-        method: "POST",
-        body: JSON.stringify({ requestedGpu: "auto" }),
-      });
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      refreshData();
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function createModelConvertJob(model) {
-    try {
-      const job = await apiFetch(`/api/v1/models/${model.id}/convert`, token, {
-        method: "POST",
-        body: JSON.stringify({ requestedGpu: "auto" }),
-      });
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      refreshData();
-      return job;
-    } catch (err) {
       setError(err.message);
       return null;
     }

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -1,0 +1,191 @@
+import { useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+import { sortNewest } from "../sorters.js";
+
+const maxLoraUploadBytes = 2 * 1024 * 1024 * 1024;
+const maxModelUploadBytes = 256 * 1024 * 1024 * 1024;
+
+function uploadLimitLabel(bytes) {
+  const gib = bytes / (1024 * 1024 * 1024);
+  return Number.isInteger(gib) ? `${gib}GB` : `${gib.toFixed(1)}GB`;
+}
+
+// Owns the model + LoRA catalogs and their import/download/convert/delete actions.
+// Extracted from App.jsx (sc-1651). Models and LoRAs are coupled (a LoRA delete/
+// import re-pulls both via the lora overlay), so they share one hook. App keeps the
+// cross-cutting orchestrators — refreshData (bulk loader; seeds models+loras through
+// the returned setters) and refreshDataWithLoraOverlay (refreshData + refreshLoras,
+// also called by the SSE handler) — and passes them in.
+export function useModelsAndLoras({
+  token,
+  activeProject,
+  setError,
+  setJobs,
+  setActiveView,
+  refreshData,
+  refreshDataWithLoraOverlay,
+}) {
+  const [models, setModels] = useState([]);
+  const [loras, setLoras] = useState([]);
+
+  async function refreshLoras(projectId = activeProject?.id, { signal } = {}) {
+    try {
+      const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+      const items = await apiFetch(`/api/v1/loras${query}`, token, { signal });
+      setLoras(items);
+      setError("");
+    } catch (err) {
+      if (isAbortError(err)) return;
+      setError(err.message);
+    }
+  }
+
+  async function deleteModel(model) {
+    const result = await apiFetch(`/api/v1/models/${encodeURIComponent(model.id)}`, token, {
+      method: "DELETE",
+    });
+    if (result.removedManifestEntry) {
+      setModels((items) => items.filter((item) => item.id !== model.id));
+    }
+    setError("");
+    await refreshData();
+    return result;
+  }
+
+  async function deleteLora(lora) {
+    const params = new URLSearchParams();
+    if (lora.scope) {
+      params.set("scope", lora.scope);
+    }
+    if (lora.scope === "project" && activeProject?.id) {
+      params.set("projectId", activeProject.id);
+    }
+    const query = params.toString() ? `?${params.toString()}` : "";
+    const result = await apiFetch(`/api/v1/loras/${encodeURIComponent(lora.id)}${query}`, token, {
+      method: "DELETE",
+    });
+    if (result.removedManifestEntry) {
+      setLoras((items) => items.filter((item) => item.id !== lora.id || item.scope !== lora.scope));
+    }
+    setError("");
+    await refreshDataWithLoraOverlay(activeProject?.id);
+    return result;
+  }
+
+  async function createModelImportJob(payload, options = {}) {
+    const { file, ...metadata } = payload;
+    if (file?.size > maxModelUploadBytes) {
+      throw new Error(`Uploaded model file exceeds the ${uploadLimitLabel(maxModelUploadBytes)} limit`);
+    }
+    let body;
+    if (file) {
+      body = new FormData();
+      Object.entries(metadata).forEach(([key, value]) => {
+        if (value != null && value !== "") {
+          body.append(key, value);
+        }
+      });
+      body.append("file", file);
+    } else {
+      body = JSON.stringify(metadata);
+    }
+    const job = await apiFetch("/api/v1/models/import", token, {
+      method: "POST",
+      body,
+    });
+    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    if (options.navigateToQueue ?? false) {
+      setActiveView("Queue");
+    }
+    setError("");
+    refreshData();
+    return job;
+  }
+
+  async function createLoraImportJob(payload, options = {}) {
+    if (payload.scope === "project" && !activeProject) {
+      throw new Error("Create or open a project first.");
+    }
+    const { file, ...metadata } = payload;
+    if (file?.size > maxLoraUploadBytes) {
+      throw new Error("Uploaded LoRA file exceeds the 2GB limit");
+    }
+    let body;
+    if (file) {
+      body = new FormData();
+      Object.entries({
+        ...metadata,
+        projectId: metadata.scope === "project" ? activeProject.id : null,
+        projectName: metadata.scope === "project" ? activeProject.name : null,
+      }).forEach(([key, value]) => {
+        if (value != null && value !== "") {
+          body.append(key, value);
+        }
+      });
+      body.append("file", file);
+    } else {
+      body = JSON.stringify({
+        ...metadata,
+        projectId: metadata.scope === "project" ? activeProject.id : null,
+        projectName: metadata.scope === "project" ? activeProject.name : null,
+      });
+    }
+    const job = await apiFetch("/api/v1/loras/import", token, {
+      method: "POST",
+      body,
+    });
+    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+    if (options.navigateToQueue ?? false) {
+      setActiveView("Queue");
+    }
+    setError("");
+    refreshDataWithLoraOverlay(activeProject?.id);
+    return job;
+  }
+
+  async function createModelDownloadJob(model) {
+    try {
+      const job = await apiFetch(`/api/v1/models/${model.id}/download`, token, {
+        method: "POST",
+        body: JSON.stringify({ requestedGpu: "auto" }),
+      });
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+      setError("");
+      refreshData();
+      return job;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function createModelConvertJob(model) {
+    try {
+      const job = await apiFetch(`/api/v1/models/${model.id}/convert`, token, {
+        method: "POST",
+        body: JSON.stringify({ requestedGpu: "auto" }),
+      });
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+      setError("");
+      refreshData();
+      return job;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  return {
+    models,
+    setModels,
+    loras,
+    setLoras,
+    refreshLoras,
+    deleteModel,
+    deleteLora,
+    createModelImportJob,
+    createLoraImportJob,
+    createModelDownloadJob,
+    createModelConvertJob,
+  };
+}


### PR DESCRIPTION
## Summary
Fourth Phase-A slice of the `App.jsx` god-module decomposition (epic [1628](https://app.shortcut.com/trefry/epic/1628), sc-1651). Follows merged #185 (useCharacters), #186 (usePresets), #187 (useTraining). Same approach: behavior-preserving, self-contained per-domain hook composed by `App` — **no screen prop-signature changes**.

Models and LoRAs share one hook (`apps/web/src/hooks/useModelsAndLoras.js`) because they're coupled — a LoRA import/delete re-pulls both via the lora overlay. It owns:
- `models` + `loras` state
- `refreshLoras`, `deleteModel`, `deleteLora`, `createModelImportJob`, `createLoraImportJob`, `createModelDownloadJob`, `createModelConvertJob`
- the upload-size constants (`maxLoraUploadBytes`/`maxModelUploadBytes`/`uploadLimitLabel`) that only those functions used

`App` keeps the **cross-cutting orchestrators** and passes them in:
- `refreshData` (bulk loader) seeds `models`+`loras` via the hook's returned setters (same setter identity)
- `refreshDataWithLoraOverlay` (`refreshData` + `refreshLoras`, also invoked by the SSE `job.updated` handler) stays in App and calls the hook's `refreshLoras`

`imageModels`/`videoModels` useMemos stay in App, deriving from the hook's `models`.

`App.jsx`: **2026 → 1893 lines** (god module **2334 → 1893**, −441 across four slices).

## Test plan
- [x] `npm --prefix apps/web run test -- --run` → **107 passed**
- [x] `npm --prefix apps/web run build` → clean
- [x] Browser smoke (Rust API on a temp data dir): the **model catalog (12) + LoRA-family filter render** (proves `refreshData` → hook `setModels`/`setLoras`), and clicking a model **Download** created a queued `model_download` job through the hook (optimistic `setJobs` → **Queue 1** → `refreshData`) with **no console errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)