### PR TITLE
refactor(web): extract usePersonTracks hook from App.jsx (sc-1651, slice 5)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -23,6 +23,7 @@ import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
 import { useTraining } from "./hooks/useTraining.js";
 import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
+import { usePersonTracks } from "./hooks/usePersonTracks.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
 // web/Docker keep the existing first-run project gate. Tauri commands persist the
@@ -365,7 +366,6 @@ export function App() {
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
   const [trainingPresetsError, setTrainingPresetsError] = useState("");
   const [assets, setAssets] = useState([]);
-  const [personTracks, setPersonTracks] = useState([]);
   const [timelines, setTimelines] = useState([]);
   const [timelinesProjectId, setTimelinesProjectId] = useState(null);
   const [selectedTimelineId, setSelectedTimelineId] = useState(null);
@@ -454,6 +454,15 @@ export function App() {
     refreshData,
     refreshDataWithLoraOverlay,
   });
+
+  const {
+    personTracks,
+    setPersonTracks,
+    refreshPersonTracks,
+    createPersonDetectionJob,
+    createPersonTrackJob,
+    saveTrackCorrections,
+  } = usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView, refreshData });
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
@@ -872,19 +881,6 @@ export function App() {
       .catch(() => {});
   }
 
-  async function refreshPersonTracks(projectId = activeProject?.id, { signal } = {}) {
-    if (!projectId) {
-      return;
-    }
-    try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token, { signal });
-      setPersonTracks(items);
-      setError("");
-    } catch (err) {
-      if (isAbortError(err)) return;
-      setError(err.message);
-    }
-  }
 
   async function refreshTimelines(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
@@ -1194,75 +1190,6 @@ export function App() {
       setStudioLaunch({ id: crypto.randomUUID(), view: "Video", assetId: asset.id, mode });
     }
     setActiveView("Video");
-  }
-
-  async function createPersonDetectionJob(payload, options = {}) {
-    const { navigateToQueue = false } = options;
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/detections`, token, {
-        method: "POST",
-        body: JSON.stringify({ ...payload, requestedGpu }),
-      });
-      if (navigateToQueue) {
-        setActiveView("Queue");
-      }
-      setError("");
-      refreshData();
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function createPersonTrackJob(payload, options = {}) {
-    const { navigateToQueue = false } = options;
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/jobs`, token, {
-        method: "POST",
-        body: JSON.stringify({ ...payload, requestedGpu }),
-      });
-      if (navigateToQueue) {
-        setActiveView("Queue");
-      }
-      setError("");
-      refreshData();
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function saveTrackCorrections(trackId, corrections) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const track = await apiFetch(
-        `/api/v1/projects/${activeProject.id}/person-tracks/${trackId}/corrections`,
-        token,
-        {
-          method: "POST",
-          body: JSON.stringify({ corrections }),
-        },
-      );
-      setPersonTracks((items) => items.map((item) => (item.id === track.id ? track : item)));
-      setError("");
-      return track;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
   }
 
   function sendCharacterToImage(character, lookId = null) {

--- a/apps/web/src/hooks/usePersonTracks.js
+++ b/apps/web/src/hooks/usePersonTracks.js
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+
+// Owns the project's person-track state plus detection/track job creation and manual
+// track corrections. Extracted from App.jsx (sc-1651). personTracks is project-scoped
+// (loaded by the project-load effect, not the bulk refreshData), so the hook just
+// takes the shared concerns it needs; detection/track jobs refresh via refreshData.
+export function usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView, refreshData }) {
+  const [personTracks, setPersonTracks] = useState([]);
+
+  async function refreshPersonTracks(projectId = activeProject?.id, { signal } = {}) {
+    if (!projectId) {
+      return;
+    }
+    try {
+      const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token, { signal });
+      setPersonTracks(items);
+      setError("");
+    } catch (err) {
+      if (isAbortError(err)) return;
+      setError(err.message);
+    }
+  }
+
+  async function createPersonDetectionJob(payload, options = {}) {
+    const { navigateToQueue = false } = options;
+    if (!activeProject) {
+      setError("Create or open a project first.");
+      return null;
+    }
+    try {
+      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/detections`, token, {
+        method: "POST",
+        body: JSON.stringify({ ...payload, requestedGpu }),
+      });
+      if (navigateToQueue) {
+        setActiveView("Queue");
+      }
+      setError("");
+      refreshData();
+      return job;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function createPersonTrackJob(payload, options = {}) {
+    const { navigateToQueue = false } = options;
+    if (!activeProject) {
+      setError("Create or open a project first.");
+      return null;
+    }
+    try {
+      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/jobs`, token, {
+        method: "POST",
+        body: JSON.stringify({ ...payload, requestedGpu }),
+      });
+      if (navigateToQueue) {
+        setActiveView("Queue");
+      }
+      setError("");
+      refreshData();
+      return job;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function saveTrackCorrections(trackId, corrections) {
+    if (!activeProject) {
+      setError("Create or open a project first.");
+      return null;
+    }
+    try {
+      const track = await apiFetch(
+        `/api/v1/projects/${activeProject.id}/person-tracks/${trackId}/corrections`,
+        token,
+        {
+          method: "POST",
+          body: JSON.stringify({ corrections }),
+        },
+      );
+      setPersonTracks((items) => items.map((item) => (item.id === track.id ? track : item)));
+      setError("");
+      return track;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  return {
+    personTracks,
+    setPersonTracks,
+    refreshPersonTracks,
+    createPersonDetectionJob,
+    createPersonTrackJob,
+    saveTrackCorrections,
+  };
+}


### PR DESCRIPTION
## Summary
Fifth Phase-A slice of the `App.jsx` god-module decomposition (epic [1628](https://app.shortcut.com/trefry/epic/1628), sc-1651). Follows merged #185–#188. Same approach: behavior-preserving, self-contained per-domain hook composed by `App` — **no screen prop-signature changes**.

Moves the person-track domain into `apps/web/src/hooks/usePersonTracks.js`:
- `personTracks` state
- `refreshPersonTracks`, `createPersonDetectionJob`, `createPersonTrackJob`, `saveTrackCorrections`

`personTracks` is project-scoped (loaded by the project-load effect, not the bulk `refreshData`), so the hook is self-contained like `useCharacters`. Detection/track jobs refresh via the injected `refreshData`. `App` calls `usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView, refreshData })` and forwards the values down unchanged, so `VideoStudio` is untouched. `personReadiness` (derived from `workers`) stays in App.

`App.jsx`: **1893 → 1820 lines** (god module **2334 → 1820**, −514 across five slices).

## Test plan
- [x] `npm --prefix apps/web run test -- --run` → **107 passed**
- [x] `npm --prefix apps/web run build` → clean
- [x] Browser smoke (Rust API on a temp data dir): VideoStudio renders with all person-track props wired; the **Replace-person panel renders** with **no console errors**. (Detection/track mutations need a GPU worker, so the App→hook wiring is verified by render — consistent with the prior slices' smoke approach.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)