### PR TITLE
refactor(web): extract useTimelines hook from App.jsx (sc-1651, slice 6 — last Phase A)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -18,12 +18,12 @@ import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { SettingsScreen } from "./screens/SettingsScreen.jsx";
 import { SetupWizard } from "./screens/SetupWizard.jsx";
 import { sortNewest, sortWorkers } from "./sorters.js";
-import { ensureItemVersionFields } from "./timeline.js";
 import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
 import { useTraining } from "./hooks/useTraining.js";
 import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
+import { useTimelines } from "./hooks/useTimelines.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
 // web/Docker keep the existing first-run project gate. Tauri commands persist the
@@ -366,10 +366,6 @@ export function App() {
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
   const [trainingPresetsError, setTrainingPresetsError] = useState("");
   const [assets, setAssets] = useState([]);
-  const [timelines, setTimelines] = useState([]);
-  const [timelinesProjectId, setTimelinesProjectId] = useState(null);
-  const [selectedTimelineId, setSelectedTimelineId] = useState(null);
-  const [activeTimeline, setActiveTimeline] = useState(null);
   const [selectedAssetId, setSelectedAssetId] = useState(null);
   const [projectFilter, setProjectFilter] = useState("all");
   const [requestedGpu, setRequestedGpu] = useState("auto");
@@ -382,8 +378,6 @@ export function App() {
   const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
-  const selectedTimelineIdRef = useRef(null);
-  const timelineApplyQueueRef = useRef(Promise.resolve());
   const generatedAssetRefreshesRef = useRef(new Map());
 
   const {
@@ -463,6 +457,32 @@ export function App() {
     createPersonTrackJob,
     saveTrackCorrections,
   } = usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView, refreshData });
+
+  const {
+    timelines,
+    setTimelines,
+    setTimelinesProjectId,
+    selectedTimelineId,
+    setSelectedTimelineId,
+    activeTimeline,
+    setActiveTimeline,
+    refreshTimelines,
+    createTimeline,
+    saveTimeline,
+    exportTimeline,
+    extractTimelineFrame,
+    queueTimelineVideoJob,
+    enqueueTimelineGenerationApply,
+  } = useTimelines({
+    token,
+    activeProject,
+    activeProjectRef,
+    setError,
+    requestedGpu,
+    setActiveView,
+    refreshData,
+    createVideoJob,
+  });
 
   const authenticated = useMemo(() => !access.authRequired || token.length > 0, [access, token]);
   const imageModels = useMemo(() => {
@@ -589,10 +609,6 @@ export function App() {
   }, [localGenerationJobIds]);
 
   useEffect(() => {
-    selectedTimelineIdRef.current = selectedTimelineId;
-  }, [selectedTimelineId]);
-
-  useEffect(() => {
     if (typeof document === "undefined") {
       return;
     }
@@ -660,13 +676,6 @@ export function App() {
     refreshTimelines(activeProject.id, { signal });
     return () => controller.abort();
   }, [activeProject?.id, authenticated, token]);
-
-  useEffect(() => {
-    if (!activeProject || !selectedTimelineId || timelinesProjectId !== activeProject.id) {
-      return;
-    }
-    loadTimeline(activeProject.id, selectedTimelineId);
-  }, [activeProject?.id, selectedTimelineId, timelinesProjectId]);
 
   useEffect(() => {
     if (!authenticated) {
@@ -881,103 +890,6 @@ export function App() {
       .catch(() => {});
   }
 
-
-  async function refreshTimelines(projectId = activeProject?.id, { signal } = {}) {
-    if (!projectId) {
-      return;
-    }
-    try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token, { signal });
-      if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
-        return;
-      }
-      setTimelines(items);
-      setTimelinesProjectId(projectId);
-      setSelectedTimelineId((current) => (items.some((item) => item.id === current) ? current : items[0]?.id ?? null));
-      if (!items.length) {
-        setActiveTimeline(null);
-      }
-      setError("");
-    } catch (err) {
-      if (isAbortError(err)) return;
-      setError(err.message);
-    }
-  }
-
-  async function loadTimeline(projectId, timelineId) {
-    try {
-      const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
-      if (activeProjectRef.current?.id !== projectId || selectedTimelineIdRef.current !== timelineId) {
-        return;
-      }
-      setActiveTimeline(timeline);
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
-
-  async function createTimeline(payload) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const created = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      setTimelines((items) => [created, ...items.filter((item) => item.id !== created.id)]);
-      setTimelinesProjectId(activeProject.id);
-      setSelectedTimelineId(created.id);
-      setActiveTimeline(created);
-      setError("");
-      return created;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function saveTimeline(timeline) {
-    if (!activeProject || !timeline) {
-      return null;
-    }
-    try {
-      const saved = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}`, token, {
-        method: "PUT",
-        body: JSON.stringify({ timeline }),
-      });
-      setActiveTimeline(saved);
-      refreshTimelines(activeProject.id);
-      setError("");
-      return saved;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function exportTimeline(timeline, options) {
-    if (!activeProject || !timeline) {
-      return;
-    }
-    const saved = await saveTimeline(timeline);
-    if (!saved) {
-      return;
-    }
-    try {
-      await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${saved.id}/exports`, token, {
-        method: "POST",
-        body: JSON.stringify({ ...options, requestedGpu }),
-      });
-      setActiveView("Queue");
-      setError("");
-      refreshData();
-    } catch (err) {
-      setError(err.message);
-    }
-  }
 
   function saveToken(event) {
     event.preventDefault();
@@ -1206,148 +1118,6 @@ export function App() {
     }
     setStudioLaunch({ id: crypto.randomUUID(), view: "Video", characterId: character.id, lookId, mode: "text_to_video" });
     setActiveView("Video");
-  }
-
-  async function extractTimelineFrame({ timeline, item, playheadSeconds, intendedUse }) {
-    if (!activeProject || !timeline || !item) {
-      return null;
-    }
-    try {
-      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}/items/${item.id}/frames`, token, {
-        method: "POST",
-        body: JSON.stringify({ playheadSeconds, intendedUse, requestedGpu }),
-      });
-      setError("");
-      refreshData();
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function queueTimelineVideoJob(payload) {
-    return createVideoJob(payload, { navigateToQueue: false });
-  }
-
-  function applyTimelineGenerationResult(timeline, job) {
-    const payload = job.payload ?? {};
-    const action = payload.advanced?.timelineAction;
-    const context = payload.advanced?.timelineContext ?? {};
-    const assetId = job.result?.assetIds?.[0];
-    if (!action || !assetId || context.timelineId !== timeline.id) {
-      return timeline;
-    }
-    const resultAsset = job.result?.assets?.[0];
-    const displayName = resultAsset?.displayName ?? "Generated clip";
-    const createdAt = resultAsset?.createdAt ?? new Date().toISOString();
-    const tracks = timeline.tracks.map((track) => {
-      if (track.id !== context.trackId) {
-        return track;
-      }
-      if (action === "bridge") {
-        const bridgeItem = ensureItemVersionFields({
-          id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
-          trackId: track.id,
-          assetId,
-          type: "video",
-          displayName,
-          sourceIn: 0,
-          sourceOut: Number(payload.duration) || Math.max(0.1, Number(context.timelineEnd) - Number(context.timelineStart)),
-          timelineStart: Number(context.timelineStart),
-          timelineEnd: Number(context.timelineEnd),
-          speed: 1,
-          fit: "fit",
-          volume: 1,
-          versionAssetIds: [assetId],
-          currentVersionAssetId: assetId,
-          versionHistory: [{ assetId, createdAt, source: "bridge", jobId: job.id, note: "Generated bridge clip" }],
-          transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
-          transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
-        });
-        return { ...track, items: [...track.items, bridgeItem] };
-      }
-      if (action === "extend") {
-        const start = Number(context.timelineStart);
-        const duration = Number(payload.duration) || 4;
-        const extensionItem = ensureItemVersionFields({
-          id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
-          trackId: track.id,
-          assetId,
-          type: "video",
-          displayName,
-          sourceIn: 0,
-          sourceOut: duration,
-          timelineStart: start,
-          timelineEnd: start + duration,
-          speed: 1,
-          fit: "fit",
-          volume: 1,
-          versionAssetIds: [assetId],
-          currentVersionAssetId: assetId,
-          versionHistory: [{ assetId, createdAt, source: "extension", jobId: job.id, note: "Generated extension" }],
-          transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
-          transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
-        });
-        return { ...track, items: [...track.items, extensionItem] };
-      }
-      if (action === "replace") {
-        return {
-          ...track,
-          items: track.items.map((item) => {
-            if (item.id !== context.itemId) {
-              return item;
-            }
-            const current = ensureItemVersionFields(item);
-            return {
-              ...current,
-              assetId,
-              currentVersionAssetId: assetId,
-              type: "video",
-              displayName,
-              versionAssetIds: Array.from(new Set([...current.versionAssetIds, assetId])),
-              versionHistory: [
-                ...current.versionHistory,
-                { assetId, createdAt, source: "replacement", jobId: job.id, note: "Generated replacement" },
-              ],
-            };
-          }),
-        };
-      }
-      return track;
-    });
-    return { ...timeline, tracks };
-  }
-
-  function enqueueTimelineGenerationApply(job) {
-    timelineApplyQueueRef.current = timelineApplyQueueRef.current
-      .then(() => applyCompletedTimelineGeneration(job))
-      .catch((err) => setError(err.message));
-  }
-
-  async function applyCompletedTimelineGeneration(job) {
-    const timelineId = job.payload?.advanced?.timelineContext?.timelineId;
-    const projectId = job.projectId;
-    if (!projectId || !timelineId || !job.result?.assetIds?.length) {
-      return;
-    }
-    try {
-      const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
-      const updated = applyTimelineGenerationResult(timeline, job);
-      if (updated === timeline) {
-        return;
-      }
-      const saved = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token, {
-        method: "PUT",
-        body: JSON.stringify({ timeline: updated }),
-      });
-      if (selectedTimelineIdRef.current === timelineId) {
-        setActiveTimeline(saved);
-      }
-      refreshTimelines(projectId);
-    } catch (err) {
-      setError(err.message);
-    }
   }
 
   async function updateAssetStatus(asset, changes) {

--- a/apps/web/src/hooks/useTimelines.js
+++ b/apps/web/src/hooks/useTimelines.js
@@ -1,0 +1,299 @@
+import { useEffect, useRef, useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+import { ensureItemVersionFields } from "../timeline.js";
+
+// Owns the editor's timeline state (list, selection, the loaded timeline) plus every
+// timeline mutation, frame extraction, and the SSE-driven "apply generated clip to the
+// timeline" pipeline. Extracted from App.jsx (sc-1651) — the largest, most coupled
+// slice. App keeps the SSE job.updated handler and calls the returned
+// enqueueTimelineGenerationApply; the bulk reset/project-load effects use the returned
+// setters/refreshTimelines. createVideoJob (App-owned) is injected for the timeline's
+// generate-clip action. The two timeline-specific effects (selectedTimelineId ref sync,
+// then the load-on-selection effect) live here, in that order, matching App's prior
+// behavior.
+export function useTimelines({
+  token,
+  activeProject,
+  activeProjectRef,
+  setError,
+  requestedGpu,
+  setActiveView,
+  refreshData,
+  createVideoJob,
+}) {
+  const [timelines, setTimelines] = useState([]);
+  const [timelinesProjectId, setTimelinesProjectId] = useState(null);
+  const [selectedTimelineId, setSelectedTimelineId] = useState(null);
+  const [activeTimeline, setActiveTimeline] = useState(null);
+  const selectedTimelineIdRef = useRef(null);
+  const timelineApplyQueueRef = useRef(Promise.resolve());
+
+  useEffect(() => {
+    selectedTimelineIdRef.current = selectedTimelineId;
+  }, [selectedTimelineId]);
+
+  useEffect(() => {
+    if (!activeProject || !selectedTimelineId || timelinesProjectId !== activeProject.id) {
+      return;
+    }
+    loadTimeline(activeProject.id, selectedTimelineId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeProject?.id, selectedTimelineId, timelinesProjectId]);
+
+  async function refreshTimelines(projectId = activeProject?.id, { signal } = {}) {
+    if (!projectId) {
+      return;
+    }
+    try {
+      const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token, { signal });
+      if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
+        return;
+      }
+      setTimelines(items);
+      setTimelinesProjectId(projectId);
+      setSelectedTimelineId((current) => (items.some((item) => item.id === current) ? current : items[0]?.id ?? null));
+      if (!items.length) {
+        setActiveTimeline(null);
+      }
+      setError("");
+    } catch (err) {
+      if (isAbortError(err)) return;
+      setError(err.message);
+    }
+  }
+
+  async function loadTimeline(projectId, timelineId) {
+    try {
+      const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
+      if (activeProjectRef.current?.id !== projectId || selectedTimelineIdRef.current !== timelineId) {
+        return;
+      }
+      setActiveTimeline(timeline);
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function createTimeline(payload) {
+    if (!activeProject) {
+      setError("Create or open a project first.");
+      return null;
+    }
+    try {
+      const created = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines`, token, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      setTimelines((items) => [created, ...items.filter((item) => item.id !== created.id)]);
+      setTimelinesProjectId(activeProject.id);
+      setSelectedTimelineId(created.id);
+      setActiveTimeline(created);
+      setError("");
+      return created;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function saveTimeline(timeline) {
+    if (!activeProject || !timeline) {
+      return null;
+    }
+    try {
+      const saved = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}`, token, {
+        method: "PUT",
+        body: JSON.stringify({ timeline }),
+      });
+      setActiveTimeline(saved);
+      refreshTimelines(activeProject.id);
+      setError("");
+      return saved;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function exportTimeline(timeline, options) {
+    if (!activeProject || !timeline) {
+      return;
+    }
+    const saved = await saveTimeline(timeline);
+    if (!saved) {
+      return;
+    }
+    try {
+      await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${saved.id}/exports`, token, {
+        method: "POST",
+        body: JSON.stringify({ ...options, requestedGpu }),
+      });
+      setActiveView("Queue");
+      setError("");
+      refreshData();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function extractTimelineFrame({ timeline, item, playheadSeconds, intendedUse }) {
+    if (!activeProject || !timeline || !item) {
+      return null;
+    }
+    try {
+      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}/items/${item.id}/frames`, token, {
+        method: "POST",
+        body: JSON.stringify({ playheadSeconds, intendedUse, requestedGpu }),
+      });
+      setError("");
+      refreshData();
+      return job;
+    } catch (err) {
+      setError(err.message);
+      return null;
+    }
+  }
+
+  async function queueTimelineVideoJob(payload) {
+    return createVideoJob(payload, { navigateToQueue: false });
+  }
+
+  function applyTimelineGenerationResult(timeline, job) {
+    const payload = job.payload ?? {};
+    const action = payload.advanced?.timelineAction;
+    const context = payload.advanced?.timelineContext ?? {};
+    const assetId = job.result?.assetIds?.[0];
+    if (!action || !assetId || context.timelineId !== timeline.id) {
+      return timeline;
+    }
+    const resultAsset = job.result?.assets?.[0];
+    const displayName = resultAsset?.displayName ?? "Generated clip";
+    const createdAt = resultAsset?.createdAt ?? new Date().toISOString();
+    const tracks = timeline.tracks.map((track) => {
+      if (track.id !== context.trackId) {
+        return track;
+      }
+      if (action === "bridge") {
+        const bridgeItem = ensureItemVersionFields({
+          id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
+          trackId: track.id,
+          assetId,
+          type: "video",
+          displayName,
+          sourceIn: 0,
+          sourceOut: Number(payload.duration) || Math.max(0.1, Number(context.timelineEnd) - Number(context.timelineStart)),
+          timelineStart: Number(context.timelineStart),
+          timelineEnd: Number(context.timelineEnd),
+          speed: 1,
+          fit: "fit",
+          volume: 1,
+          versionAssetIds: [assetId],
+          currentVersionAssetId: assetId,
+          versionHistory: [{ assetId, createdAt, source: "bridge", jobId: job.id, note: "Generated bridge clip" }],
+          transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+          transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+        });
+        return { ...track, items: [...track.items, bridgeItem] };
+      }
+      if (action === "extend") {
+        const start = Number(context.timelineStart);
+        const duration = Number(payload.duration) || 4;
+        const extensionItem = ensureItemVersionFields({
+          id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
+          trackId: track.id,
+          assetId,
+          type: "video",
+          displayName,
+          sourceIn: 0,
+          sourceOut: duration,
+          timelineStart: start,
+          timelineEnd: start + duration,
+          speed: 1,
+          fit: "fit",
+          volume: 1,
+          versionAssetIds: [assetId],
+          currentVersionAssetId: assetId,
+          versionHistory: [{ assetId, createdAt, source: "extension", jobId: job.id, note: "Generated extension" }],
+          transitionIn: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+          transitionOut: { id: `transition_${crypto.randomUUID().replaceAll("-", "")}`, type: "cut", duration: 0 },
+        });
+        return { ...track, items: [...track.items, extensionItem] };
+      }
+      if (action === "replace") {
+        return {
+          ...track,
+          items: track.items.map((item) => {
+            if (item.id !== context.itemId) {
+              return item;
+            }
+            const current = ensureItemVersionFields(item);
+            return {
+              ...current,
+              assetId,
+              currentVersionAssetId: assetId,
+              type: "video",
+              displayName,
+              versionAssetIds: Array.from(new Set([...current.versionAssetIds, assetId])),
+              versionHistory: [
+                ...current.versionHistory,
+                { assetId, createdAt, source: "replacement", jobId: job.id, note: "Generated replacement" },
+              ],
+            };
+          }),
+        };
+      }
+      return track;
+    });
+    return { ...timeline, tracks };
+  }
+
+  function enqueueTimelineGenerationApply(job) {
+    timelineApplyQueueRef.current = timelineApplyQueueRef.current
+      .then(() => applyCompletedTimelineGeneration(job))
+      .catch((err) => setError(err.message));
+  }
+
+  async function applyCompletedTimelineGeneration(job) {
+    const timelineId = job.payload?.advanced?.timelineContext?.timelineId;
+    const projectId = job.projectId;
+    if (!projectId || !timelineId || !job.result?.assetIds?.length) {
+      return;
+    }
+    try {
+      const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
+      const updated = applyTimelineGenerationResult(timeline, job);
+      if (updated === timeline) {
+        return;
+      }
+      const saved = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token, {
+        method: "PUT",
+        body: JSON.stringify({ timeline: updated }),
+      });
+      if (selectedTimelineIdRef.current === timelineId) {
+        setActiveTimeline(saved);
+      }
+      refreshTimelines(projectId);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return {
+    timelines,
+    setTimelines,
+    timelinesProjectId,
+    setTimelinesProjectId,
+    selectedTimelineId,
+    setSelectedTimelineId,
+    activeTimeline,
+    setActiveTimeline,
+    refreshTimelines,
+    createTimeline,
+    saveTimeline,
+    exportTimeline,
+    extractTimelineFrame,
+    queueTimelineVideoJob,
+    enqueueTimelineGenerationApply,
+  };
+}


### PR DESCRIPTION
## Summary
Sixth and **final Phase-A slice** of the `App.jsx` god-module decomposition (epic [1628](https://app.shortcut.com/trefry/epic/1628), sc-1651). Follows merged #185–#189. The most coupled domain — extracted with the same behavior-preserving, no-prop-signature-change approach.

`apps/web/src/hooks/useTimelines.js` now owns:
- **state**: `timelines`, `timelinesProjectId`, `selectedTimelineId`, `activeTimeline`
- **refs**: `selectedTimelineIdRef`, `timelineApplyQueueRef`
- **10 functions**: `refreshTimelines`, `loadTimeline`, `createTimeline`, `saveTimeline`, `exportTimeline`, `extractTimelineFrame`, `queueTimelineVideoJob`, `applyTimelineGenerationResult`, `enqueueTimelineGenerationApply`, `applyCompletedTimelineGeneration`
- **two timeline-specific effects** (selectedTimelineId ref-sync, then load-on-selection — in that order, matching App's prior behavior)

`App` keeps the cross-cutting pieces and wires them in:
- the **SSE `job.updated` handler** stays in App and calls the returned `enqueueTimelineGenerationApply`
- the bulk **reset / project-load effects** use the returned setters / `refreshTimelines`
- `createVideoJob` (App-owned) is injected for the timeline generate-clip action; `ensureItemVersionFields` moved with `applyTimelineGenerationResult`

`EditorScreen` prop signatures unchanged.

`App.jsx`: **1820 → 1590 lines** (god module **2334 → 1590, −744 across six slices**).

## Test plan
- [x] `npm --prefix apps/web run test -- --run` → **107 passed**
- [x] `npm --prefix apps/web run build` → clean
- [x] Browser smoke (Rust API on a temp data dir): created a timeline (`createTimeline` → `activeTimeline` renders in the Editor); after a **reload**, the project-load `refreshTimelines` → ref-sync → load-on-selection effect chain **auto-loaded the timeline** (select shows it, editor renders it) with **no console errors** — exercising the moved effects + the SSE-adjacent apply pipeline's wiring

## Note
This completes **Phase A** (per-domain hooks). Phase B (ApiContext/JobsContext/AssetsContext to remove the remaining prop drilling) is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)