### PR TITLE
refactor(web): introduce AppContext + convert EditorScreen (sc-1651 Phase B, slice 1)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -24,6 +24,7 @@ import { useTraining } from "./hooks/useTraining.js";
 import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
+import { AppContext } from "./context/AppContext.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
 // web/Docker keep the existing first-run project gate. Tauri commands persist the
@@ -1212,7 +1213,29 @@ export function App() {
   const setupGateLoading = isDesktopShell && setupCompleted === null;
   const showSetupWizard = isDesktopShell && setupCompleted === false && authenticated;
 
+  // sc-1651 Phase B: shared primitives screens read via useAppContext() instead of
+  // drilled props. Screens build any screen-specific wrappers from these (e.g. a
+  // send-to-studio action with a mode). Grown one screen at a time as screens convert.
+  const appContextValue = {
+    activeProject,
+    mediaAssets,
+    setPreviewAsset,
+    sendAssetToImage,
+    sendAssetToVideo,
+    activeTimeline,
+    timelines,
+    selectedTimelineId,
+    setSelectedTimelineId,
+    setActiveTimeline,
+    createTimeline,
+    saveTimeline,
+    exportTimeline,
+    extractTimelineFrame,
+    queueTimelineVideoJob,
+  };
+
   return (
+    <AppContext.Provider value={appContextValue}>
     <main className="app">
       <aside className="sidebar" aria-label="Primary">
         <div className="brand">
@@ -1513,24 +1536,7 @@ export function App() {
         ) : null}
 
         {activeView === "Editor" ? (
-          <EditorScreen
-            activeProject={activeProject}
-            activeTimeline={activeTimeline}
-            assets={mediaAssets}
-            createTimeline={createTimeline}
-            extractTimelineFrame={extractTimelineFrame}
-            exportTimeline={exportTimeline}
-            onPreview={setPreviewAsset}
-            onSendImage={(asset) => sendAssetToImage(asset, "edit_image")}
-            onSendVideo={(asset) => sendAssetToVideo(asset, asset?.type === "video" ? "extend_clip" : "image_to_video")}
-            queueTimelineVideoJob={queueTimelineVideoJob}
-            refreshAssets={refreshAssets}
-            saveTimeline={saveTimeline}
-            selectedTimelineId={selectedTimelineId}
-            setActiveTimeline={setActiveTimeline}
-            setSelectedTimelineId={setSelectedTimelineId}
-            timelines={timelines}
-          />
+          <EditorScreen />
         ) : null}
 
         {activeView === "Characters" ? (
@@ -1586,5 +1592,6 @@ export function App() {
         />
       ) : null}
     </main>
+    </AppContext.Provider>
   );
 }

--- a/apps/web/src/context/AppContext.js
+++ b/apps/web/src/context/AppContext.js
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+
+// Shared app data/actions provider (sc-1651 Phase B). App composes the per-domain
+// hooks (Phase A) and exposes the primitives here so screens read what they need via
+// useAppContext() instead of receiving dozens of drilled props. Screens build any
+// screen-specific wrappers (e.g. send-to-studio with a mode) from these primitives.
+export const AppContext = createContext(null);
+
+export function useAppContext() {
+  const value = useContext(AppContext);
+  if (value === null) {
+    throw new Error("useAppContext must be used within an <AppContext.Provider>");
+  }
+  return value;
+}

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -11,24 +11,31 @@ import {
   trackItems,
   transitionOptions,
 } from "../timeline.js";
+import { useAppContext } from "../context/AppContext.js";
 
-export function EditorScreen({
-  activeProject,
-  activeTimeline,
-  assets,
-  createTimeline,
-  extractTimelineFrame,
-  exportTimeline,
-  onPreview,
-  onSendImage,
-  onSendVideo,
-  queueTimelineVideoJob,
-  saveTimeline,
-  selectedTimelineId,
-  setActiveTimeline,
-  setSelectedTimelineId,
-  timelines,
-}) {
+export function EditorScreen() {
+  const {
+    activeProject,
+    activeTimeline,
+    mediaAssets,
+    setPreviewAsset,
+    sendAssetToImage,
+    sendAssetToVideo,
+    createTimeline,
+    extractTimelineFrame,
+    exportTimeline,
+    queueTimelineVideoJob,
+    saveTimeline,
+    selectedTimelineId,
+    setActiveTimeline,
+    setSelectedTimelineId,
+    timelines,
+  } = useAppContext();
+  const assets = mediaAssets;
+  const onPreview = setPreviewAsset;
+  const onSendImage = (asset) => sendAssetToImage(asset, "edit_image");
+  const onSendVideo = (asset) => sendAssetToVideo(asset, asset?.type === "video" ? "extend_clip" : "image_to_video");
+
   const [newTimelineName, setNewTimelineName] = useState("Main timeline");
   const [newAspectRatio, setNewAspectRatio] = useState("16:9");
   const [selectedItemId, setSelectedItemId] = useState(null);


### PR DESCRIPTION
## Summary
**Phase B** of the `App.jsx` decomposition (epic [1628](https://app.shortcut.com/trefry/epic/1628), sc-1651) — removing the per-screen prop drilling that remained after Phase A extracted the domain logic into hooks (#185–#190, all merged). Single-context approach (agreed): a new `context/AppContext.js` exposes shared primitives via `useAppContext()`; `App` wraps its tree in `<AppContext.Provider>` and screens read what they need instead of receiving dozens of drilled props.

**Key design point:** prop names collide across screens — App passed `assets={mediaAssets}` to the editor but `assets={assets}` to the studios, and `onSendImage`/`onSendVideo` are different wrappers per screen. So the context exposes the **primitives** (`mediaAssets`, `assets`, `sendAssetToImage`, `sendAssetToVideo`, `setPreviewAsset`, the timeline actions, …) and each screen derives its own view (e.g. `const onSendImage = (a) => sendAssetToImage(a, "edit_image")`).

**EditorScreen** is the proof of concept — it has **zero dedicated tests** (only exercised via `<App/>`), so this conversion has no test churn. It now takes **no props** and pulls everything from `useAppContext()`. Removed its 16 drilled props from App's render (including an unused `refreshAssets`). The context value grows one screen at a time as later slices convert the studios.

## Test plan
- [x] `npm --prefix apps/web run test -- --run` → **107 passed**
- [x] `npm --prefix apps/web run build` → clean
- [x] Browser smoke (Rust API on a temp data dir): navigated to the Editor (now context-backed), created a timeline through the context (`createTimeline` → `activeTimeline` renders, select shows "Main timeline") with **no console errors**

## Remaining Phase B
Convert the other screens to `useAppContext()` in ascending test-churn order — Settings(0)/Character(1)/Document(1)/Library(1)/Presets(2)/ReplacePerson(2)/Queue(3)/Video(4)/ModelManager(15)/Image(18)/Training(20), updating each screen's dedicated tests to wrap in the provider — then drop the now-dead prop-passing from App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)