### PR TITLE
refactor(web): convert Library/Document/Character screens to AppContext (sc-1651 Phase B)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1232,6 +1232,45 @@ export function App() {
     exportTimeline,
     extractTimelineFrame,
     queueTimelineVideoJob,
+    // Assets / library (sc-1651 Phase B batch 1)
+    assets,
+    selectedAsset,
+    setSelectedAssetId,
+    deleteAsset,
+    purgeAsset,
+    importAsset,
+    updateAssetStatus,
+    latestImageAssets,
+    // Jobs / queue
+    jobs,
+    jobAction,
+    createVqaJob,
+    createInterleaveJob,
+    // Models / GPU
+    imageModels,
+    loras,
+    gpuOptions,
+    requestedGpu,
+    setRequestedGpu,
+    // Navigation
+    setActiveView,
+    // Characters
+    characters,
+    createCharacter,
+    updateCharacter,
+    archiveCharacter,
+    addCharacterReference,
+    updateCharacterReference,
+    removeCharacterReference,
+    createCharacterLook,
+    updateCharacterLook,
+    deleteCharacterLook,
+    attachCharacterLora,
+    updateCharacterLora,
+    detachCharacterLora,
+    createCharacterTestJob,
+    sendCharacterToImage,
+    sendCharacterToVideo,
   };
 
   return (
@@ -1353,26 +1392,7 @@ export function App() {
         ) : (
           <>
         {activeView === "Library" ? (
-          <LibraryScreen
-            activeProject={activeProject}
-            assets={assets}
-            jobs={jobs}
-            imageModels={imageModels}
-            createVqaJob={createVqaJob}
-            deleteAsset={deleteAsset}
-            purgeAsset={purgeAsset}
-            importAsset={importAsset}
-            onPreview={setPreviewAsset}
-            onSendImage={(asset) => sendAssetToImage(asset)}
-            selectedAsset={selectedAsset}
-            setSelectedAssetId={setSelectedAssetId}
-            onSendVideo={(asset) => sendAssetToVideo(asset)}
-            onSendEditor={(asset) => {
-              setSelectedAssetId(asset.id);
-              setActiveView("Editor");
-            }}
-            updateAssetStatus={updateAssetStatus}
-          />
+          <LibraryScreen />
         ) : null}
 
         {activeView === "Image" ? (
@@ -1442,18 +1462,7 @@ export function App() {
         ) : null}
 
         {activeView === "Document" ? (
-          <DocumentStudio
-            activeProject={activeProject}
-            assets={assets}
-            createInterleaveJob={createInterleaveJob}
-            gpuOptions={gpuOptions}
-            imageModels={imageModels}
-            jobs={jobs}
-            onCancelJob={(job) => jobAction(job, "cancel")}
-            onOpenQueue={() => setActiveView("Queue")}
-            requestedGpu={requestedGpu}
-            setRequestedGpu={setRequestedGpu}
-          />
+          <DocumentStudio />
         ) : null}
 
         {activeView === "Train" ? (
@@ -1540,33 +1549,7 @@ export function App() {
         ) : null}
 
         {activeView === "Characters" ? (
-          <CharacterStudio
-            activeProject={activeProject}
-            addCharacterReference={addCharacterReference}
-            archiveCharacter={archiveCharacter}
-            assets={assets}
-            attachCharacterLora={attachCharacterLora}
-            characters={characters}
-            createCharacter={createCharacter}
-            createCharacterLook={createCharacterLook}
-            createCharacterTestJob={createCharacterTestJob}
-            deleteAsset={deleteAsset}
-            deleteCharacterLook={deleteCharacterLook}
-            detachCharacterLora={detachCharacterLora}
-            imageModels={imageModels}
-            latestAssets={latestImageAssets}
-            loras={loras}
-            onPreview={setPreviewAsset}
-            onSendImage={sendCharacterToImage}
-            onSendVideo={sendCharacterToVideo}
-            purgeAsset={purgeAsset}
-            removeCharacterReference={removeCharacterReference}
-            updateAssetStatus={updateAssetStatus}
-            updateCharacter={updateCharacter}
-            updateCharacterLook={updateCharacterLook}
-            updateCharacterLora={updateCharacterLora}
-            updateCharacterReference={updateCharacterReference}
-          />
+          <CharacterStudio />
         ) : null}
         {activeView === "Settings" ? <SettingsScreen /> : null}
           </>

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -17,6 +17,14 @@ import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { ReplacePersonPanel } from "./screens/ReplacePersonPanel.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
 import { TrainingStudio } from "./screens/TrainingStudio.jsx";
+import { AppContext } from "./context/AppContext.js";
+
+// sc-1651 Phase B: screens converted to useAppContext() read their data from the
+// provider instead of props. Tests wrap the screen in a provider carrying only the
+// values that screen reads.
+function withAppContext(value, ui) {
+  return <AppContext.Provider value={value}>{ui}</AppContext.Provider>;
+}
 
 // jsdom 27 omits Blob.text(); all real browsers implement it. Polyfill so the
 // dataset import flow (which reads .txt caption sidecars) is exercisable here.
@@ -1851,33 +1859,36 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <CharacterStudio
-          activeProject={{ id: "project-1", name: "Noir" }}
-          addCharacterReference={addCharacterReference}
-          archiveCharacter={() => {}}
-          assets={assets}
-          attachCharacterLora={() => {}}
-          characters={[{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }]}
-          createCharacter={() => {}}
-          createCharacterLook={() => {}}
-          createCharacterTestJob={() => {}}
-          deleteAsset={() => {}}
-          deleteCharacterLook={() => {}}
-          detachCharacterLora={() => {}}
-          imageModels={[]}
-          latestAssets={[]}
-          loras={[]}
-          onPreview={() => {}}
-          onSendImage={() => {}}
-          onSendVideo={() => {}}
-          purgeAsset={() => {}}
-          removeCharacterReference={() => {}}
-          updateAssetStatus={() => {}}
-          updateCharacter={() => {}}
-          updateCharacterLook={() => {}}
-          updateCharacterLora={() => {}}
-          updateCharacterReference={() => {}}
-        />,
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference,
+            archiveCharacter: () => {},
+            assets,
+            attachCharacterLora: () => {},
+            characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: [],
+            loras: [],
+            setPreviewAsset: () => {},
+            sendCharacterToImage: () => {},
+            sendCharacterToVideo: () => {},
+            purgeAsset: () => {},
+            removeCharacterReference: () => {},
+            updateAssetStatus: () => {},
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
       );
     });
 
@@ -5478,31 +5489,34 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <LibraryScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          assets={[asset]}
-          jobs={[
-            {
-              id: "job-vqa-1",
-              type: "image_vqa",
-              status: "completed",
-              payload: { sourceAssetId: "asset-1", question: "What time of day is it?" },
-              result: { question: "What time of day is it?", answer: "It appears to be nighttime." },
-            },
-          ]}
-          imageModels={[{ id: "sensenova_u1_8b", name: "SenseNova-U1 8B", type: "image", capabilities: ["text_to_image", "vqa"] }]}
-          createVqaJob={createVqaJob}
-          deleteAsset={() => {}}
-          purgeAsset={() => {}}
-          importAsset={() => {}}
-          onPreview={() => {}}
-          onSendImage={() => {}}
-          onSendVideo={() => {}}
-          onSendEditor={() => {}}
-          selectedAsset={asset}
-          setSelectedAssetId={() => {}}
-          updateAssetStatus={() => {}}
-        />,
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [asset],
+            jobs: [
+              {
+                id: "job-vqa-1",
+                type: "image_vqa",
+                status: "completed",
+                payload: { sourceAssetId: "asset-1", question: "What time of day is it?" },
+                result: { question: "What time of day is it?", answer: "It appears to be nighttime." },
+              },
+            ],
+            imageModels: [{ id: "sensenova_u1_8b", name: "SenseNova-U1 8B", type: "image", capabilities: ["text_to_image", "vqa"] }],
+            createVqaJob,
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: asset,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+          },
+          <LibraryScreen />,
+        ),
       );
     });
     await settle();
@@ -5557,20 +5571,24 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <DocumentStudio
-          activeProject={{ id: "project-1", name: "Noir" }}
-          assets={[imageAsset]}
-          createInterleaveJob={createInterleaveJob}
-          gpuOptions={["auto"]}
-          imageModels={[
-            { id: "sensenova_u1_8b", name: "SenseNova-U1 8B", type: "image", capabilities: ["text_to_image", "interleave"] },
-            { id: "z_image_turbo", name: "Z-Image Turbo", type: "image", capabilities: ["text_to_image"] },
-          ]}
-          jobs={[completedJob]}
-          onOpenQueue={() => {}}
-          requestedGpu="auto"
-          setRequestedGpu={() => {}}
-        />,
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [imageAsset],
+            createInterleaveJob,
+            gpuOptions: ["auto"],
+            imageModels: [
+              { id: "sensenova_u1_8b", name: "SenseNova-U1 8B", type: "image", capabilities: ["text_to_image", "interleave"] },
+              { id: "z_image_turbo", name: "Z-Image Turbo", type: "image", capabilities: ["text_to_image"] },
+            ],
+            jobs: [completedJob],
+            jobAction: () => {},
+            setActiveView: () => {},
+            requestedGpu: "auto",
+            setRequestedGpu: () => {},
+          },
+          <DocumentStudio />,
+        ),
       );
     });
     await settle();

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -7,6 +7,7 @@ import {
   editableLora,
 } from "./characterPanels.jsx";
 import { extractFamilies } from "../presetUtils.js";
+import { useAppContext } from "../context/AppContext.js";
 
 const characterTypes = [
   ["person", "Person"],
@@ -18,33 +19,38 @@ function typeLabel(value) {
   return characterTypes.find(([id]) => id === value)?.[1] ?? "Person";
 }
 
-export function CharacterStudio({
-  activeProject,
-  assets,
-  characters,
-  createCharacter,
-  updateCharacter,
-  archiveCharacter,
-  addCharacterReference,
-  updateCharacterReference,
-  removeCharacterReference,
-  createCharacterLook,
-  updateCharacterLook,
-  deleteCharacterLook,
-  attachCharacterLora,
-  updateCharacterLora,
-  detachCharacterLora,
-  createCharacterTestJob,
-  deleteAsset,
-  purgeAsset,
-  imageModels,
-  latestAssets,
-  loras,
-  onPreview,
-  onSendImage,
-  onSendVideo,
-  updateAssetStatus,
-}) {
+export function CharacterStudio() {
+  const {
+    activeProject,
+    assets,
+    characters,
+    createCharacter,
+    updateCharacter,
+    archiveCharacter,
+    addCharacterReference,
+    updateCharacterReference,
+    removeCharacterReference,
+    createCharacterLook,
+    updateCharacterLook,
+    deleteCharacterLook,
+    attachCharacterLora,
+    updateCharacterLora,
+    detachCharacterLora,
+    createCharacterTestJob,
+    deleteAsset,
+    purgeAsset,
+    imageModels,
+    latestImageAssets,
+    loras,
+    setPreviewAsset,
+    sendCharacterToImage,
+    sendCharacterToVideo,
+    updateAssetStatus,
+  } = useAppContext();
+  const latestAssets = latestImageAssets;
+  const onPreview = setPreviewAsset;
+  const onSendImage = sendCharacterToImage;
+  const onSendVideo = sendCharacterToVideo;
   const [selectedCharacterId, setSelectedCharacterId] = useState(characters[0]?.id ?? "");
   const [draft, setDraft] = useState({ name: "", type: "person", description: "" });
   const [newCharacter, setNewCharacter] = useState({ name: "", type: "person", description: "" });

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_INTERLEAVE_SYSTEM_MESSAGE,
   INTERLEAVE_RESOLUTION_OPTIONS,
 } from "../constants.js";
+import { useAppContext } from "../context/AppContext.js";
 
 const MAX_IMAGES_DEFAULT = 6;
 const MAX_IMAGES_LIMIT = 10;
@@ -28,18 +29,21 @@ function DocumentResult({ job, assets, projectId, onCancel, onOpenQueue }) {
   return <DocumentView assets={assets} projectId={projectId} segments={segments} />;
 }
 
-export function DocumentStudio({
-  activeProject,
-  assets,
-  createInterleaveJob,
-  gpuOptions,
-  imageModels,
-  jobs,
-  onCancelJob,
-  onOpenQueue,
-  requestedGpu,
-  setRequestedGpu,
-}) {
+export function DocumentStudio() {
+  const {
+    activeProject,
+    assets,
+    createInterleaveJob,
+    gpuOptions,
+    imageModels,
+    jobs,
+    jobAction,
+    setActiveView,
+    requestedGpu,
+    setRequestedGpu,
+  } = useAppContext();
+  const onCancelJob = (job) => jobAction(job, "cancel");
+  const onOpenQueue = () => setActiveView("Queue");
   const interleaveModels = useMemo(
     () => (imageModels ?? []).filter(modelSupportsInterleave),
     [imageModels],

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -1,24 +1,33 @@
 import React, { useState } from "react";
 import { AssetDetail, AssetGrid } from "../components/assetPanels.jsx";
 import { terminalStatuses } from "../constants.js";
+import { useAppContext } from "../context/AppContext.js";
 
-export function LibraryScreen({
-  activeProject,
-  assets,
-  jobs = [],
-  imageModels = [],
-  createVqaJob,
-  deleteAsset,
-  purgeAsset,
-  importAsset,
-  onPreview,
-  onSendImage,
-  onSendVideo,
-  onSendEditor,
-  selectedAsset,
-  setSelectedAssetId,
-  updateAssetStatus,
-}) {
+export function LibraryScreen() {
+  const {
+    activeProject,
+    assets,
+    jobs = [],
+    imageModels = [],
+    createVqaJob,
+    deleteAsset,
+    purgeAsset,
+    importAsset,
+    setPreviewAsset,
+    sendAssetToImage,
+    sendAssetToVideo,
+    selectedAsset,
+    setSelectedAssetId,
+    setActiveView,
+    updateAssetStatus,
+  } = useAppContext();
+  const onPreview = setPreviewAsset;
+  const onSendImage = (asset) => sendAssetToImage(asset);
+  const onSendVideo = (asset) => sendAssetToVideo(asset);
+  const onSendEditor = (asset) => {
+    setSelectedAssetId(asset.id);
+    setActiveView("Editor");
+  };
   const vqaEnabled = Boolean(createVqaJob) && imageModels.some((model) => (model.capabilities ?? []).includes("vqa"));
   const assetVqaJobs = selectedAsset
     ? jobs.filter((job) => job.type === "image_vqa" && job.payload?.sourceAssetId === selectedAsset.id)


### PR DESCRIPTION
## Summary
- sc-1651 Phase B batch: convert the three single-test screens (**LibraryScreen**, **DocumentStudio**, **CharacterStudio**) from prop drilling to `useAppContext()`.
- Grow `appContextValue` in `App.jsx` with the primitives these screens need (assets/jobs/models/GPU/navigation + the full character mutation set). Each screen derives its own screen-shaped callbacks locally (`onSendImage`, `onCancelJob`, `onSendEditor`, …) per the established "context exposes primitives, not screen-views" pattern.
- App's render for these three screens is now propless (`<LibraryScreen />`, `<DocumentStudio />`, `<CharacterStudio />`).
- Tests wrap each screen in a provider via a new `withAppContext()` helper in `main.test.jsx`.

## Test plan
- [x] `npm --prefix apps/web run test -- --run` — 107/107 pass
- [x] `npm --prefix apps/web run build` — clean
- [x] Browser smoke against real Rust API: Library (default), Document, and Characters all render via context; created a character end-to-end (context→useCharacters→API→refresh); zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)