### PR TITLE
refactor(web): convert PresetManager/Queue screens to AppContext (sc-1651 Phase B)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1246,12 +1246,28 @@ export function App() {
     jobAction,
     createVqaJob,
     createInterleaveJob,
+    // Queue screen (sc-1651 Phase B batch 2)
+    createPlaceholderJob,
+    filteredJobs,
+    jobPrompt,
+    setJobPrompt,
+    projectFilter,
+    setProjectFilter,
+    projects,
+    visibleWorkers,
     // Models / GPU
     imageModels,
+    videoModels,
     loras,
     gpuOptions,
     requestedGpu,
     setRequestedGpu,
+    // Presets
+    presets,
+    createPreset,
+    updatePreset,
+    deletePreset,
+    duplicatePreset,
     // Navigation
     setActiveView,
     // Characters
@@ -1493,37 +1509,11 @@ export function App() {
         ) : null}
 
         {activeView === "Presets" ? (
-          <PresetManagerScreen
-            activeProject={activeProject}
-            createPreset={createPreset}
-            deletePreset={deletePreset}
-            duplicatePreset={duplicatePreset}
-            imageModels={imageModels}
-            loras={loras}
-            onOpenModels={() => setActiveView("Models")}
-            presets={presets}
-            updatePreset={updatePreset}
-            videoModels={videoModels}
-          />
+          <PresetManagerScreen />
         ) : null}
 
         {activeView === "Queue" ? (
-          <QueueScreen
-            activeProject={activeProject}
-            createJob={createPlaceholderJob}
-            filteredJobs={filteredJobs}
-            gpuOptions={gpuOptions}
-            jobAction={jobAction}
-            jobs={jobs}
-            jobPrompt={jobPrompt}
-            projectFilter={projectFilter}
-            projects={projects}
-            requestedGpu={requestedGpu}
-            setJobPrompt={setJobPrompt}
-            setProjectFilter={setProjectFilter}
-            setRequestedGpu={setRequestedGpu}
-            workers={visibleWorkers}
-          />
+          <QueueScreen />
         ) : null}
 
         {activeView === "Models" ? (

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -3841,10 +3841,11 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <QueueScreen
-          activeProject={{ id: "project-1", name: "Project 1" }}
-          createJob={(event) => event.preventDefault()}
-          filteredJobs={[
+        withAppContext(
+          {
+          activeProject: { id: "project-1", name: "Project 1" },
+          createPlaceholderJob: (event) => event.preventDefault(),
+          filteredJobs: [
             {
               id: "job-waiting",
               type: "image_generate",
@@ -3923,17 +3924,17 @@ describe("SceneWorks app shell", () => {
               payload: { prompt: "dependent", dependsOnJobId: "job-dependency" },
               attempts: 1,
             },
-          ]}
-          gpuOptions={["auto", "0"]}
-          jobAction={() => {}}
-          jobPrompt="Placeholder generation"
-          projectFilter="all"
-          projects={[{ id: "project-1", name: "Project 1" }]}
-          requestedGpu="auto"
-          setJobPrompt={() => {}}
-          setProjectFilter={() => {}}
-          setRequestedGpu={() => {}}
-          workers={[
+          ],
+          gpuOptions: ["auto", "0"],
+          jobAction: () => {},
+          jobPrompt: "Placeholder generation",
+          projectFilter: "all",
+          projects: [{ id: "project-1", name: "Project 1" }],
+          requestedGpu: "auto",
+          setJobPrompt: () => {},
+          setProjectFilter: () => {},
+          setRequestedGpu: () => {},
+          visibleWorkers: [
             {
               id: "misregistered-cpu",
               gpuId: "cpu",
@@ -3952,8 +3953,10 @@ describe("SceneWorks app shell", () => {
               capabilities: ["placeholder", "gpu", "image_generate"],
               loadedModels: ["z_image_turbo"],
             },
-          ]}
-        />,
+          ],
+          },
+          <QueueScreen />,
+        ),
       );
     });
 
@@ -3967,7 +3970,7 @@ describe("SceneWorks app shell", () => {
   it("updates Queue GPU utilization when worker props change", async () => {
     const queueProps = {
       activeProject: { id: "project-1", name: "Project 1" },
-      createJob: (event) => event.preventDefault(),
+      createPlaceholderJob: (event) => event.preventDefault(),
       filteredJobs: [],
       gpuOptions: ["auto", "0"],
       jobAction: () => {},
@@ -3991,7 +3994,7 @@ describe("SceneWorks app shell", () => {
 
     root = createRoot(container);
     await act(async () => {
-      root.render(<QueueScreen {...queueProps} workers={[worker]} />);
+      root.render(withAppContext({ ...queueProps, visibleWorkers: [worker] }, <QueueScreen />));
     });
 
     expect(container.textContent).toContain("20.0 GB");
@@ -3999,15 +4002,18 @@ describe("SceneWorks app shell", () => {
 
     await act(async () => {
       root.render(
-        <QueueScreen
-          {...queueProps}
-          workers={[
-            {
-              ...worker,
-              utilization: { memoryTotalMb: 24576, memoryUsedMb: 12288, memoryFreeMb: 12288, gpuLoadPercent: 67 },
-            },
-          ]}
-        />,
+        withAppContext(
+          {
+            ...queueProps,
+            visibleWorkers: [
+              {
+                ...worker,
+                utilization: { memoryTotalMb: 24576, memoryUsedMb: 12288, memoryFreeMb: 12288, gpuLoadPercent: 67 },
+              },
+            ],
+          },
+          <QueueScreen />,
+        ),
       );
     });
 
@@ -5231,18 +5237,19 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <PresetManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          createPreset={createPreset}
-          deletePreset={deletePreset}
-          duplicatePreset={duplicatePreset}
-          imageModels={[{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]}
-          loras={[
+        withAppContext(
+          {
+          activeProject: { id: "project-1", name: "Noir" },
+          createPreset,
+          deletePreset,
+          duplicatePreset,
+          imageModels: [{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }],
+          loras: [
             { id: "cinematic_detail", name: "Cinematic Detail", family: "z-image", scope: "builtin", defaultWeight: 0.55 },
             { id: "global_detail", name: "Global Detail", family: "z-image", scope: "global", defaultWeight: 0.7 },
             { id: "qwen_only", name: "Qwen Only", family: "qwen-image", scope: "global" },
-          ]}
-          presets={[
+          ],
+          presets: [
             {
               id: "cinematic",
               name: "Cinematic",
@@ -5260,10 +5267,13 @@ describe("SceneWorks app shell", () => {
               model: "z_image_turbo",
               ui: { description: "Low key color." },
             },
-          ]}
-          updatePreset={updatePreset}
-          videoModels={[{ id: "ltx_2_3", name: "LTX", type: "video" }]}
-        />,
+          ],
+          updatePreset,
+          videoModels: [{ id: "ltx_2_3", name: "LTX", type: "video" }],
+          setActiveView: () => {},
+          },
+          <PresetManagerScreen />,
+        ),
       );
     });
 
@@ -5352,14 +5362,15 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <PresetManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          createPreset={() => {}}
-          deletePreset={() => {}}
-          duplicatePreset={() => {}}
-          imageModels={[]}
-          loras={[{ id: "pending_style", name: "Pending Style", family: "z-image", scope: "global", installState: "missing" }]}
-          presets={[
+        withAppContext(
+          {
+          activeProject: { id: "project-1", name: "Noir" },
+          createPreset: () => {},
+          deletePreset: () => {},
+          duplicatePreset: () => {},
+          imageModels: [],
+          loras: [{ id: "pending_style", name: "Pending Style", family: "z-image", scope: "global", installState: "missing" }],
+          presets: [
             {
               id: "blocked",
               name: "Blocked",
@@ -5368,10 +5379,13 @@ describe("SceneWorks app shell", () => {
               model: "z_image_turbo",
               loras: [{ id: "pending_style" }],
             },
-          ]}
-          updatePreset={updatePreset}
-          videoModels={[]}
-        />,
+          ],
+          updatePreset,
+          videoModels: [],
+          setActiveView: () => {},
+          },
+          <PresetManagerScreen />,
+        ),
       );
     });
 

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -10,6 +10,7 @@ import {
   workflowModelType,
   workflowModes,
 } from "../presetUtils.js";
+import { useAppContext } from "../context/AppContext.js";
 
 const workflowOptions = [
   ["text_to_image", "Text to Image"],
@@ -119,18 +120,20 @@ function presetStatusLabel(status) {
   return `Remove ${status.incompatible.join(", ")}`;
 }
 
-export function PresetManagerScreen({
-  activeProject,
-  createPreset,
-  deletePreset,
-  duplicatePreset,
-  imageModels,
-  loras = [],
-  onOpenModels,
-  presets = [],
-  updatePreset,
-  videoModels,
-}) {
+export function PresetManagerScreen() {
+  const {
+    activeProject,
+    createPreset,
+    deletePreset,
+    duplicatePreset,
+    imageModels,
+    loras = [],
+    presets = [],
+    updatePreset,
+    videoModels,
+    setActiveView,
+  } = useAppContext();
+  const onOpenModels = () => setActiveView("Models");
   const models = useMemo(() => [...imageModels, ...videoModels], [imageModels, videoModels]);
   const [selectedPresetId, setSelectedPresetId] = useState(presets.find((preset) => preset.scope !== "builtin")?.id ?? "");
   const selectedPreset = presets.find((preset) => preset.id === selectedPresetId) ?? null;

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { useLiveJobElapsedSeconds } from "../components/JobProgress.jsx";
 import { actionStatuses, terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
+import { useAppContext } from "../context/AppContext.js";
 
 const nonGpuJobTypes = new Set(["model_download", "model_import", "model_convert", "lora_import"]);
 // Keep GPU-required job types in sync with
@@ -198,22 +199,25 @@ function WorkerCard({ worker }) {
   );
 }
 
-export function QueueScreen({
-  activeProject,
-  createJob,
-  filteredJobs,
-  gpuOptions,
-  jobAction,
-  jobs = filteredJobs,
-  jobPrompt,
-  projectFilter,
-  projects,
-  requestedGpu,
-  setJobPrompt,
-  setProjectFilter,
-  setRequestedGpu,
-  workers,
-}) {
+export function QueueScreen() {
+  const {
+    activeProject,
+    createPlaceholderJob,
+    filteredJobs,
+    gpuOptions,
+    jobAction,
+    jobs = filteredJobs,
+    jobPrompt,
+    projectFilter,
+    projects,
+    requestedGpu,
+    setJobPrompt,
+    setProjectFilter,
+    setRequestedGpu,
+    visibleWorkers,
+  } = useAppContext();
+  const createJob = createPlaceholderJob;
+  const workers = visibleWorkers;
   const workersById = useMemo(() => new Map(workers.map((worker) => [worker.id, worker])), [workers]);
   const gpuWorkers = useMemo(() => workers.filter(isGpuWorker), [workers]);
   return (


### PR DESCRIPTION
## Summary
- sc-1651 Phase B slice 3: convert **PresetManagerScreen** (2 tests) and **QueueScreen** (3 tests) from prop drilling to `useAppContext()`.
- Grow `appContextValue` with the preset mutations (`createPreset`/`updatePreset`/`deletePreset`/`duplicatePreset` + `presets` + `videoModels`), placeholder-job creation (`createPlaceholderJob`), and the queue's own primitives (`filteredJobs`, `jobPrompt`/`setJobPrompt`, `projectFilter`/`setProjectFilter`, `projects`, `visibleWorkers`).
- Both screens are now propless in App's render. PresetManagerScreen derives `onOpenModels` locally; QueueScreen maps `createPlaceholderJob`→`createJob` and `visibleWorkers`→`workers` locally (preserving its `jobs = filteredJobs` default).
- Tests wrap each screen in the `withAppContext()` provider helper.

## Test plan
- [x] `npm --prefix apps/web run test -- --run` — 107/107 pass
- [x] `npm --prefix apps/web run build` — clean
- [x] Browser smoke against real Rust API: Presets renders the preset list + editor via context; Queue renders prompt/GPU/project filters and worker/job empty states, and **Add job** created a placeholder job end-to-end (Queue 0 → Queue 1, job list populated). Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)