### PR TITLE
refactor(web): convert VideoStudio to AppContext (sc-1651 Phase B)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1255,6 +1255,18 @@ export function App() {
     setProjectFilter,
     projects,
     visibleWorkers,
+    // Generation studios (sc-1651 Phase B batch 3)
+    createVideoJob,
+    latestVideoAssets,
+    videoLocalJobs,
+    studioLaunch,
+    rememberLocalGenerationJob,
+    // Person tracks (Video Studio + Replace Person)
+    personTracks,
+    personReadiness,
+    createPersonDetectionJob,
+    createPersonTrackJob,
+    saveTrackCorrections,
     // Models / GPU
     imageModels,
     videoModels,
@@ -1439,42 +1451,7 @@ export function App() {
         ) : null}
 
         {activeView === "Video" ? (
-          <VideoStudio
-            activeProject={activeProject}
-            assets={assets}
-            characters={characters}
-            createPersonDetectionJob={createPersonDetectionJob}
-            createPersonTrackJob={createPersonTrackJob}
-            createVideoJob={createVideoJob}
-            deleteAsset={deleteAsset}
-            purgeAsset={purgeAsset}
-            gpuOptions={gpuOptions}
-            latestAssets={latestVideoAssets}
-            launchRequest={studioLaunch}
-            loras={loras}
-            jobs={jobs}
-            localJobs={videoLocalJobs}
-            onCancelJob={(job) => jobAction(job, "cancel")}
-            onLocalJobCreated={(job) => rememberLocalGenerationJob("video", job)}
-            onOpenPresets={() => setActiveView("Presets")}
-            onOpenQueue={() => setActiveView("Queue")}
-            onPreview={setPreviewAsset}
-            onSendToEditor={(asset) => {
-              if (asset?.id) {
-                setSelectedAssetId(asset.id);
-              }
-              setActiveView("Editor");
-            }}
-            personTracks={personTracks}
-            personReadiness={personReadiness}
-            presets={presets}
-            requestedGpu={requestedGpu}
-            saveTrackCorrections={saveTrackCorrections}
-            selectedAsset={selectedAsset}
-            setRequestedGpu={setRequestedGpu}
-            updateAssetStatus={updateAssetStatus}
-            videoModels={videoModels}
-          />
+          <VideoStudio />
         ) : null}
 
         {activeView === "Document" ? (

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4757,21 +4757,22 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <VideoStudio
-          activeProject={{ id: "project-1", name: "Noir" }}
-          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
-          characters={[]}
-          createPersonDetectionJob={() => {}}
-          createPersonTrackJob={() => {}}
-          createVideoJob={createVideoJob}
-          deleteAsset={() => {}}
-          gpuOptions={["auto"]}
-          latestAssets={[]}
-          loras={[{ id: "wan_motion", name: "Wan Motion", family: "wan-video", scope: "builtin", presetManaged: true }]}
-          onPreview={() => {}}
-          personTracks={[]}
-          purgeAsset={() => {}}
-          presets={[
+        withAppContext(
+          {
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [{ id: "image-1", type: "image", displayName: "Frame One" }],
+          characters: [],
+          createPersonDetectionJob: () => {},
+          createPersonTrackJob: () => {},
+          createVideoJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          latestVideoAssets: [],
+          loras: [{ id: "wan_motion", name: "Wan Motion", family: "wan-video", scope: "builtin", presetManaged: true }],
+          setPreviewAsset: () => {},
+          personTracks: [],
+          purgeAsset: () => {},
+          presets: [
             {
               id: "dream_motion",
               name: "Dream Motion",
@@ -4779,12 +4780,12 @@ describe("SceneWorks app shell", () => {
               model: "ltx_2_3",
               builtInLoras: [{ id: "wan_motion" }],
             },
-          ]}
-          requestedGpu="auto"
-          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
-          setRequestedGpu={() => {}}
-          updateAssetStatus={() => {}}
-          videoModels={[
+          ],
+          requestedGpu: "auto",
+          selectedAsset: { id: "image-1", type: "image", displayName: "Frame One" },
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+          videoModels: [
             {
               id: "ltx_2_3",
               name: "LTX",
@@ -4794,8 +4795,10 @@ describe("SceneWorks app shell", () => {
               defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
               loraCompatibility: { families: ["ltx-video"] },
             },
-          ]}
-        />,
+          ],
+          },
+          <VideoStudio />,
+        ),
       );
     });
 
@@ -5017,21 +5020,23 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <VideoStudio
-          activeProject={{ id: "project-1", name: "Noir" }}
-          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
-          characters={[]}
-          createPersonDetectionJob={() => {}}
-          createPersonTrackJob={() => {}}
-          createVideoJob={createVideoJob}
-          deleteAsset={() => {}}
-          gpuOptions={["auto"]}
-          latestAssets={[]}
-          loras={[{ id: "video_motion", name: "Video Motion" }]}
-          onPreview={() => {}}
-          personTracks={[]}
-          purgeAsset={() => {}}
-          presets={[
+        withAppContext(
+          {
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [{ id: "image-1", type: "image", displayName: "Frame One" }],
+          characters: [],
+          createPersonDetectionJob: () => {},
+          createPersonTrackJob: () => {},
+          createVideoJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          latestVideoAssets: [],
+          loras: [{ id: "video_motion", name: "Video Motion" }],
+          setPreviewAsset: () => {},
+          rememberLocalGenerationJob: () => {},
+          personTracks: [],
+          purgeAsset: () => {},
+          presets: [
             {
               id: "dream_motion",
               name: "Dream Motion",
@@ -5042,12 +5047,12 @@ describe("SceneWorks app shell", () => {
               builtInLoras: [{ id: "video_motion" }],
               ui: { description: "Soft camera motion." },
             },
-          ]}
-          requestedGpu="auto"
-          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
-          setRequestedGpu={() => {}}
-          updateAssetStatus={() => {}}
-          videoModels={[
+          ],
+          requestedGpu: "auto",
+          selectedAsset: { id: "image-1", type: "image", displayName: "Frame One" },
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+          videoModels: [
             {
               id: "ltx_2_3",
               name: "LTX",
@@ -5056,8 +5061,10 @@ describe("SceneWorks app shell", () => {
               defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
               limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
             },
-          ]}
-        />,
+          ],
+          },
+          <VideoStudio />,
+        ),
       );
     });
     await settle();
@@ -5094,30 +5101,31 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <VideoStudio
-          activeProject={{ id: "project-1", name: "Noir" }}
-          assets={[{ id: "image-1", type: "image", displayName: "Frame One" }]}
-          characters={[]}
-          createPersonDetectionJob={() => {}}
-          createPersonTrackJob={() => {}}
-          createVideoJob={() => {}}
-          deleteAsset={() => {}}
-          gpuOptions={["auto"]}
-          latestAssets={[]}
-          loras={[]}
-          onPreview={() => {}}
-          personTracks={[]}
-          purgeAsset={() => {}}
-          presets={[
+        withAppContext(
+          {
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [{ id: "image-1", type: "image", displayName: "Frame One" }],
+          characters: [],
+          createPersonDetectionJob: () => {},
+          createPersonTrackJob: () => {},
+          createVideoJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          latestVideoAssets: [],
+          loras: [],
+          setPreviewAsset: () => {},
+          personTracks: [],
+          purgeAsset: () => {},
+          presets: [
             { id: "ltx_motion", name: "LTX Motion", workflow: "image_to_video", model: "ltx_2_3" },
             { id: "ltx_story", name: "LTX Story", workflow: "text_to_video", model: "ltx_2_3" },
             { id: "wan_motion", name: "Wan Motion", workflow: "image_to_video", model: "wan_2_2" },
-          ]}
-          requestedGpu="auto"
-          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
-          setRequestedGpu={() => {}}
-          updateAssetStatus={() => {}}
-          videoModels={[
+          ],
+          requestedGpu: "auto",
+          selectedAsset: { id: "image-1", type: "image", displayName: "Frame One" },
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+          videoModels: [
             {
               id: "ltx_2_3",
               name: "LTX",
@@ -5134,8 +5142,10 @@ describe("SceneWorks app shell", () => {
               defaults: { duration: 5, fps: 24, resolution: "1280x720", quality: "balanced" },
               limits: { durations: [4, 5], fps: [24], resolutions: ["1280x720"] },
             },
-          ]}
-        />,
+          ],
+          },
+          <VideoStudio />,
+        ),
       );
     });
     await settle();
@@ -5165,24 +5175,25 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <VideoStudio
-          activeProject={{ id: "project-1", name: "Noir" }}
-          assets={[
+        withAppContext(
+          {
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [
             { id: "image-1", type: "image", displayName: "Frame One" },
             { id: "image-2", type: "image", displayName: "Frame Two" },
-          ]}
-          characters={[]}
-          createPersonDetectionJob={() => {}}
-          createPersonTrackJob={() => {}}
-          createVideoJob={() => {}}
-          deleteAsset={() => {}}
-          gpuOptions={["auto"]}
-          latestAssets={[]}
-          loras={[]}
-          onPreview={() => {}}
-          personTracks={[]}
-          purgeAsset={() => {}}
-          presets={[
+          ],
+          characters: [],
+          createPersonDetectionJob: () => {},
+          createPersonTrackJob: () => {},
+          createVideoJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          latestVideoAssets: [],
+          loras: [],
+          setPreviewAsset: () => {},
+          personTracks: [],
+          purgeAsset: () => {},
+          presets: [
             {
               id: "camera_bridge",
               name: "Camera Bridge",
@@ -5197,12 +5208,12 @@ describe("SceneWorks app shell", () => {
               modes: ["image_to_video"],
               model: "ltx_2_3",
             },
-          ]}
-          requestedGpu="auto"
-          selectedAsset={{ id: "image-1", type: "image", displayName: "Frame One" }}
-          setRequestedGpu={() => {}}
-          updateAssetStatus={() => {}}
-          videoModels={[
+          ],
+          requestedGpu: "auto",
+          selectedAsset: { id: "image-1", type: "image", displayName: "Frame One" },
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+          videoModels: [
             {
               id: "ltx_2_3",
               name: "LTX",
@@ -5211,8 +5222,10 @@ describe("SceneWorks app shell", () => {
               defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
               limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
             },
-          ]}
-        />,
+          ],
+          },
+          <VideoStudio />,
+        ),
       );
     });
     await settle();

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -49,41 +49,56 @@ import {
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
+import { useAppContext } from "../context/AppContext.js";
 
 const ltxVideoModelId = "ltx_2_3";
 const ltxIcLoraRequiredModes = new Set(["extend_clip", "video_bridge"]);
 
-export function VideoStudio({
-  activeProject,
-  assets,
-  characters,
-  createPersonDetectionJob,
-  createPersonTrackJob,
-  createVideoJob,
-  deleteAsset,
-  purgeAsset,
-  gpuOptions,
-  latestAssets,
-  launchRequest,
-  loras = [],
-  jobs = [],
-  localJobs: trackedLocalJobs = [],
-  onCancelJob,
-  onLocalJobCreated,
-  onOpenPresets,
-  onOpenQueue,
-  onPreview,
-  onSendToEditor,
-  personTracks = [],
-  personReadiness = {},
-  presets = [],
-  requestedGpu,
-  saveTrackCorrections,
-  selectedAsset,
-  setRequestedGpu,
-  updateAssetStatus,
-  videoModels,
-}) {
+export function VideoStudio() {
+  const {
+    activeProject,
+    assets,
+    characters,
+    createPersonDetectionJob,
+    createPersonTrackJob,
+    createVideoJob,
+    deleteAsset,
+    purgeAsset,
+    gpuOptions,
+    latestVideoAssets,
+    studioLaunch,
+    loras = [],
+    jobs = [],
+    videoLocalJobs = [],
+    jobAction,
+    rememberLocalGenerationJob,
+    setActiveView,
+    setSelectedAssetId,
+    setPreviewAsset,
+    personTracks = [],
+    personReadiness = {},
+    presets = [],
+    requestedGpu,
+    saveTrackCorrections,
+    selectedAsset,
+    setRequestedGpu,
+    updateAssetStatus,
+    videoModels,
+  } = useAppContext();
+  const latestAssets = latestVideoAssets;
+  const launchRequest = studioLaunch;
+  const trackedLocalJobs = videoLocalJobs;
+  const onCancelJob = (job) => jobAction(job, "cancel");
+  const onLocalJobCreated = (job) => rememberLocalGenerationJob("video", job);
+  const onOpenPresets = () => setActiveView("Presets");
+  const onOpenQueue = () => setActiveView("Queue");
+  const onPreview = setPreviewAsset;
+  const onSendToEditor = (asset) => {
+    if (asset?.id) {
+      setSelectedAssetId(asset.id);
+    }
+    setActiveView("Editor");
+  };
   const [motion, setMotion] = useState("slow push-in");
   const imageAssets = assets.filter((asset) => asset.type === "image" || asset.type === "frame");
   const videoAssets = assets.filter((asset) => asset.type === "video");


### PR DESCRIPTION
## Summary
- sc-1651 Phase B slice 4: convert **VideoStudio** (4 tests, ~30 props) from prop drilling to `useAppContext()`.
- Grow `appContextValue` with `createVideoJob`, the person-track domain (`personTracks`/`personReadiness` + `createPersonDetectionJob`/`createPersonTrackJob`/`saveTrackCorrections`), `latestVideoAssets`, `studioLaunch`, `videoLocalJobs`, and `rememberLocalGenerationJob`.
- VideoStudio is now propless in App's render and derives its `launchRequest`, `trackedLocalJobs`, and `onCancelJob`/`onLocalJobCreated`/`onOpenPresets`/`onOpenQueue`/`onPreview`/`onSendToEditor` callbacks locally.
- **ReplacePersonPanel stays prop-driven** — its props are mostly VideoStudio-local state (detection results, setters, derived values); only 4 come from App, which VideoStudio sources from context and passes down. That's legitimate parent→child composition, not the god-module drilling Phase B targets.
- Tests wrap each VideoStudio render in the `withAppContext()` helper.

## Test plan
- [x] `npm --prefix apps/web run test -- --run` — 107/107 pass (no unhandled errors)
- [x] `npm --prefix apps/web run build` — clean
- [x] Browser smoke against real Rust API: Video Studio renders all modes/controls via context; switching to **Replace person** renders ReplacePersonPanel correctly (real-tracking status, Analyze Source, track/mode controls). Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)