### PR TITLE
refactor(web): convert ModelManagerScreen to AppContext (sc-1651 Phase B)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1270,7 +1270,14 @@ export function App() {
     // Models / GPU
     imageModels,
     videoModels,
+    models,
     loras,
+    deleteLora,
+    deleteModel,
+    createModelDownloadJob,
+    createModelConvertJob,
+    createLoraImportJob,
+    createModelImportJob,
     gpuOptions,
     requestedGpu,
     setRequestedGpu,
@@ -1494,21 +1501,7 @@ export function App() {
         ) : null}
 
         {activeView === "Models" ? (
-          <ModelManagerScreen
-            activeProject={activeProject}
-            jobs={jobs}
-            loras={loras}
-            models={models}
-            onDeleteLora={deleteLora}
-            onDeleteModel={deleteModel}
-            onDownloadModel={createModelDownloadJob}
-            onConvertModel={createModelConvertJob}
-            onCancelJob={(job) => jobAction(job, "cancel")}
-            onImportLora={createLoraImportJob}
-            onImportModel={createModelImportJob}
-            onOpenQueue={() => setActiveView("Queue")}
-            recipePresets={presets}
-          />
+          <ModelManagerScreen />
         ) : null}
 
         {activeView === "Editor" ? (

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -26,6 +26,31 @@ function withAppContext(value, ui) {
   return <AppContext.Provider value={value}>{ui}</AppContext.Provider>;
 }
 
+// ModelManagerScreen (sc-1651 Phase B) reads primitives from context and derives
+// its own on* callbacks. This adapter lets the existing tests keep their old
+// prop-shaped objects (and their assertions on those fns) while feeding the
+// screen via the provider.
+function withModelManagerContext(p) {
+  return withAppContext(
+    {
+      activeProject: p.activeProject,
+      jobs: p.jobs,
+      loras: p.loras,
+      models: p.models,
+      presets: p.recipePresets,
+      jobAction: p.onCancelJob ? (job) => p.onCancelJob(job) : () => {},
+      setActiveView: p.onOpenQueue ? () => p.onOpenQueue() : () => {},
+      deleteLora: p.onDeleteLora,
+      deleteModel: p.onDeleteModel,
+      createModelDownloadJob: p.onDownloadModel,
+      createModelConvertJob: p.onConvertModel,
+      createLoraImportJob: p.onImportLora,
+      createModelImportJob: p.onImportModel,
+    },
+    <ModelManagerScreen />,
+  );
+}
+
 // jsdom 27 omits Blob.text(); all real browsers implement it. Polyfill so the
 // dataset import flow (which reads .txt caption sidecars) is exercisable here.
 if (typeof Blob !== "undefined" && typeof Blob.prototype.text !== "function") {
@@ -3028,15 +3053,15 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[]}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={onImportLora}
-          onOpenQueue={() => {}}
-        />,
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora,
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3063,18 +3088,18 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[]}
-          loras={[]}
-          models={[
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [],
+          loras: [],
+          models: [
             { id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" },
             { id: "qwen_image", name: "Qwen Image", type: "image", family: "qwen-image" },
-          ]}
-          onDownloadModel={() => {}}
-          onImportLora={onImportLora}
-          onOpenQueue={() => {}}
-        />,
+          ],
+          onDownloadModel: () => {},
+          onImportLora,
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3105,15 +3130,15 @@ describe("SceneWorks app shell", () => {
     const onImportLora = vi.fn(async (payload) => ({ payload: { ...payload, loraId: "detail_lora" } }));
     const renderScreen = (models) =>
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[]}
-          loras={[]}
-          models={models}
-          onDownloadModel={() => {}}
-          onImportLora={onImportLora}
-          onOpenQueue={() => {}}
-        />,
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [],
+          loras: [],
+          models,
+          onDownloadModel: () => {},
+          onImportLora,
+          onOpenQueue: () => {},
+        }),
       );
 
     root = createRoot(container);
@@ -3139,11 +3164,11 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[]}
-          loras={[]}
-          models={[
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [],
+          loras: [],
+          models: [
             {
               id: "z_image_turbo",
               name: "Z-Image Turbo",
@@ -3175,11 +3200,11 @@ describe("SceneWorks app shell", () => {
               downloadSizeEstimated: false,
               downloads: [{ provider: "huggingface", repo: "owner/exact" }],
             },
-          ]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onOpenQueue={() => {}}
-        />,
+          ],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3196,18 +3221,18 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[]}
-          loras={[
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [],
+          loras: [
             { id: "ready_style", name: "Ready Style", family: "z-image", scope: "global", installState: "installed" },
             { id: "broken_style", name: "Broken Style", family: "z-image", scope: "global", installState: "missing" },
-          ]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image", installState: "installed" }]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onOpenQueue={() => {}}
-        />,
+          ],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image", installState: "installed" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3229,18 +3254,18 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[]}
-          loras={[{ id: "ready_style", name: "Ready Style", family: "z-image", scope: "global", installState: "installed", removable: true }]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image", installState: "installed", removable: true }]}
-          onDeleteLora={onDeleteLora}
-          onDeleteModel={onDeleteModel}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onOpenQueue={() => {}}
-          recipePresets={[{ id: "moody", name: "Moody", model: "z_image_turbo", loras: [{ id: "ready_style" }] }]}
-        />,
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [],
+          loras: [{ id: "ready_style", name: "Ready Style", family: "z-image", scope: "global", installState: "installed", removable: true }],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image", installState: "installed", removable: true }],
+          onDeleteLora,
+          onDeleteModel,
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onOpenQueue: () => {},
+          recipePresets: [{ id: "moody", name: "Moody", model: "z_image_turbo", loras: [{ id: "ready_style" }] }],
+        }),
       );
     });
 
@@ -3289,17 +3314,15 @@ describe("SceneWorks app shell", () => {
         setJobs((items) => [job, ...items]);
         return job;
       }
-      return (
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={jobs}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={importLora}
-          onOpenQueue={() => {}}
-        />
-      );
+      return withModelManagerContext({
+        activeProject: { id: "project-1", name: "Noir" },
+        jobs,
+        loras: [],
+        models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+        onDownloadModel: () => {},
+        onImportLora: importLora,
+        onOpenQueue: () => {},
+      });
     }
 
     root = createRoot(container);
@@ -3335,9 +3358,9 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [
             {
               id: "lora-import-job-1",
               type: "lora_import",
@@ -3346,13 +3369,13 @@ describe("SceneWorks app shell", () => {
               progress: 0.3,
               payload: { loraId: "existing_import" },
             },
-          ]}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={onImportLora}
-          onOpenQueue={() => {}}
-        />,
+          ],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora,
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3381,9 +3404,9 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [
             {
               id: "lora-import-job-1",
               type: "lora_import",
@@ -3393,13 +3416,13 @@ describe("SceneWorks app shell", () => {
               error: "Adapter crashed",
               payload: { loraId: "broken_detail", family: "z-image" },
             },
-          ]}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onOpenQueue={() => {}}
-        />,
+          ],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3413,9 +3436,9 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [
             {
               id: "lora-import-job-2",
               type: "lora_import",
@@ -3435,13 +3458,13 @@ describe("SceneWorks app shell", () => {
               error: "LoRA manifestPath must target the global user manifest or the selected project's LoRA manifest",
               payload: { loraId: "detail_lora", family: "z-image" },
             },
-          ]}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onOpenQueue={() => {}}
-        />,
+          ],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3457,15 +3480,15 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={{ id: "project-1", name: "Noir" }}
-          jobs={[]}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={onImportLora}
-          onOpenQueue={() => {}}
-        />,
+        withModelManagerContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora,
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3486,16 +3509,16 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={null}
-          jobs={[]}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onImportModel={onImportModel}
-          onOpenQueue={() => {}}
-        />,
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel,
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3525,16 +3548,16 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={null}
-          jobs={[]}
-          loras={[]}
-          models={[{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onImportModel={onImportModel}
-          onOpenQueue={() => {}}
-        />,
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel,
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3554,16 +3577,16 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={null}
-          jobs={[]}
-          loras={[]}
-          models={[{ id: "imported_custom", name: "Imported Custom", type: "image" }]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onImportModel={() => {}}
-          onOpenQueue={() => {}}
-        />,
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [{ id: "imported_custom", name: "Imported Custom", type: "image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel: () => {},
+          onOpenQueue: () => {},
+        }),
       );
     });
 
@@ -3575,9 +3598,9 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        <ModelManagerScreen
-          activeProject={null}
-          jobs={[
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [
             {
               id: "model-import-job-1",
               type: "model_import",
@@ -3586,14 +3609,14 @@ describe("SceneWorks app shell", () => {
               progress: 0.42,
               payload: { modelId: "custom_model", name: "Custom Model" },
             },
-          ]}
-          loras={[]}
-          models={[]}
-          onDownloadModel={() => {}}
-          onImportLora={() => {}}
-          onImportModel={() => {}}
-          onOpenQueue={() => {}}
-        />,
+          ],
+          loras: [],
+          models: [],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel: () => {},
+          onOpenQueue: () => {},
+        }),
       );
     });
 

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
 import { extractFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
+import { useAppContext } from "../context/AppContext.js";
 
 function matchesFamily(item, familyFilter) {
   if (familyFilter === "all") {
@@ -109,21 +110,30 @@ function deleteResultText(result, name) {
   return `${removed} for ${name}.${warnings}`;
 }
 
-export function ModelManagerScreen({
-  activeProject,
-  jobs,
-  loras,
-  models,
-  onCancelJob,
-  onConvertModel,
-  onDeleteLora,
-  onDeleteModel,
-  onDownloadModel,
-  onImportLora,
-  onImportModel,
-  onOpenQueue,
-  recipePresets = [],
-}) {
+export function ModelManagerScreen() {
+  const {
+    activeProject,
+    jobs,
+    loras,
+    models,
+    jobAction,
+    setActiveView,
+    deleteLora: deleteLoraAction,
+    deleteModel: deleteModelAction,
+    createModelDownloadJob,
+    createModelConvertJob,
+    createLoraImportJob,
+    createModelImportJob,
+    presets: recipePresets = [],
+  } = useAppContext();
+  const onCancelJob = (job) => jobAction(job, "cancel");
+  const onConvertModel = createModelConvertJob;
+  const onDeleteLora = deleteLoraAction;
+  const onDeleteModel = deleteModelAction;
+  const onDownloadModel = createModelDownloadJob;
+  const onImportLora = createLoraImportJob;
+  const onImportModel = createModelImportJob;
+  const onOpenQueue = () => setActiveView("Queue");
   const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
   const familiesKey = families.join("|");
   const [familyFilter, setFamilyFilter] = useState("all");


### PR DESCRIPTION
## Summary
- sc-1651 Phase B slice 5: convert **ModelManagerScreen** (15 test renders) from prop drilling to `useAppContext()`.
- Grow `appContextValue` with `models` + the model/LoRA CRUD primitives (`deleteLora`/`deleteModel`, `createModelDownloadJob`/`createModelConvertJob`/`createLoraImportJob`/`createModelImportJob`).
- ModelManagerScreen is now propless in App's render. It derives its `on*` callbacks locally; the context `deleteLora`/`deleteModel` are aliased on destructure to avoid clashing with the screen's internal handler functions of the same name.
- Tests use a new `withModelManagerContext()` adapter that maps the existing prop-shaped fixtures (and their `expect(onImportLora)` etc. assertions) onto the provider.

## Test plan
- [x] `npm --prefix apps/web run test -- --run` — 107/107 pass
- [x] `npm --prefix apps/web run build` — clean
- [x] Browser smoke against real Rust API: Models screen renders the full catalog + LoRA-family filter via context; clicking **Download** dispatched a model_download job end-to-end (Queue 0 → 1). Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)