### PR TITLE
fix(web): single source of truth for job-type/status/quality enums (sc-1657)

### DIFF
--- a/apps/web/src/components/JobProgress.jsx
+++ b/apps/web/src/components/JobProgress.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { terminalStatuses } from "../constants.js";
+import { errorStatuses } from "../jobTypes.js";
 import { formatSeconds, liveElapsedSeconds, percent } from "../formatting.js";
-
-const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
 
 function formatJobType(type) {
   const label = String(type ?? "job").replaceAll("_", " ");
@@ -45,7 +44,7 @@ export function useLiveJobElapsedSeconds(job) {
 }
 
 export function JobProgressCard({ job, label, onOpenQueue, onCancel }) {
-  const isError = localErrorStatuses.has(job.status);
+  const isError = errorStatuses.has(job.status);
   const canCancel = !terminalStatuses.has(job.status);
   const progressLabel = percent(job.progress);
   const message = jobMessage(job);

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -1,5 +1,7 @@
-export const terminalStatuses = new Set(["completed", "failed", "canceled", "interrupted"]);
-export const actionStatuses = new Set(["failed", "canceled", "interrupted", "completed"]);
+// Job-status/job-type/quality enums live in jobTypes.js (single source of truth,
+// sc-1657). Re-exported here so existing `from "./constants.js"` importers are
+// unaffected.
+export { terminalStatuses, actionStatuses } from "./jobTypes.js";
 
 // SenseNova-U1 interleave resolution buckets (distinct from plain text-to-image).
 // Mirrors the worker's interleave_resolution_for / upstream examples/interleave.

--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -1,0 +1,43 @@
+// Single source of truth for job-type, job-status, and generation-quality enums
+// shared across the web UI (sc-1657). Previously these literals were re-declared
+// — and drifted — across QueueScreen, PresetManagerScreen, VideoStudio,
+// ImageStudio, JobProgress, and constants.js.
+
+// Job types that require a GPU worker. Keep in sync with the backend:
+//   crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu
+//   apps/worker/scene_worker/runtime.py (SUPPORTED_JOB_TYPES + TRAINING_JOB_TYPES + CAPTION_JOB_TYPES)
+export const GPU_REQUIRED_JOB_TYPES = new Set([
+  "image_generate",
+  "image_edit",
+  "image_vqa",
+  "image_interleave",
+  "video_generate",
+  "video_extend",
+  "video_bridge",
+  "person_replace",
+  "lora_train",
+  "training_caption",
+]);
+
+// Utility job types that run on any worker (no GPU required).
+export const NON_GPU_JOB_TYPES = new Set(["model_download", "model_import", "model_convert", "lora_import"]);
+
+// Terminal job statuses (no further progress expected).
+export const terminalStatuses = new Set(["completed", "failed", "canceled", "interrupted"]);
+
+// Statuses that surface job actions (retry/repeat/cancel) in the queue.
+export const actionStatuses = new Set(["failed", "canceled", "interrupted", "completed"]);
+
+// Terminal statuses that represent an error/abnormal end (terminal minus completed).
+export const errorStatuses = new Set(["failed", "canceled", "interrupted"]);
+
+// Generation quality enum. The VALUES are what the worker honors
+// (apps/worker/scene_worker/video_adapters.py step maps: fast | balanced | best;
+// unknown values fall through to balanced). Labels are the user-facing names.
+// Shared by Video Studio and the Preset Manager so a saved preset's quality
+// always matches the studio control.
+export const qualityChoices = [
+  ["fast", "Draft"],
+  ["balanced", "Balanced"],
+  ["best", "Final"],
+];

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -18,6 +18,7 @@ import { ReplacePersonPanel } from "./screens/ReplacePersonPanel.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
 import { TrainingStudio } from "./screens/TrainingStudio.jsx";
 import { AppContext } from "./context/AppContext.js";
+import { qualityChoices, GPU_REQUIRED_JOB_TYPES, errorStatuses } from "./jobTypes.js";
 
 // sc-1651 Phase B: screens converted to useAppContext() read their data from the
 // provider instead of props. Tests wrap the screen in a provider carrying only the
@@ -3696,6 +3697,23 @@ describe("SceneWorks app shell", () => {
 
   it("adds the SSE ticket as a query parameter", () => {
     expect(eventUrl("/api/v1/jobs/events", "stream-ticket")).toContain("ticket=stream-ticket");
+  });
+
+  it("uses one worker-canonical quality enum across studios (no draft/final drift)", () => {
+    // sc-1657: PresetManager previously used draft/balanced/final while VideoStudio
+    // and the worker (video_adapters.py step maps) use fast/balanced/best, so saved
+    // presets didn't match the studio control. Pin the shared values.
+    expect(qualityChoices.map(([value]) => value)).toEqual(["fast", "balanced", "best"]);
+    expect(qualityChoices.map(([, label]) => label)).toEqual(["Draft", "Balanced", "Final"]);
+  });
+
+  it("keeps the centralized job-type/status enums consistent", () => {
+    // GPU-required job types must stay aligned with the Rust dispatch gate
+    // (jobs_store.rs::job_requires_gpu); errorStatuses is terminal minus completed.
+    expect(GPU_REQUIRED_JOB_TYPES.has("video_generate")).toBe(true);
+    expect(GPU_REQUIRED_JOB_TYPES.has("model_download")).toBe(false);
+    expect([...errorStatuses].sort()).toEqual(["canceled", "failed", "interrupted"]);
+    expect(errorStatuses.has("completed")).toBe(false);
   });
 
   it("filters stale and placeholder-only GPU workers from the queue view", async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -42,6 +42,7 @@ import {
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { errorStatuses } from "../jobTypes.js";
 
 // Used only for models that don't declare limits.resolutions (e.g. user-imported).
 const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x1280"];
@@ -51,7 +52,6 @@ function formatResolutionLabel(value) {
   return height ? `${width} × ${height}` : value;
 }
 
-const localErrorStatuses = new Set(["failed", "canceled", "interrupted"]);
 const localErrorLabels = {
   failed: "Failed",
   canceled: "Canceled",
@@ -108,7 +108,7 @@ function assetBatchIndex(asset) {
 }
 
 function jobPendingSlotLabel(job, index) {
-  if (localErrorStatuses.has(job.status)) {
+  if (errorStatuses.has(job.status)) {
     return `${localErrorLabels[job.status] ?? "Failed"} #${index + 1}`;
   }
   return `Pending #${index + 1}`;
@@ -396,7 +396,7 @@ export function ImageStudio() {
           type: "placeholder",
           id: `${job.id}:slot-${index}`,
           label: jobPendingSlotLabel(job, index),
-          isError: localErrorStatuses.has(job.status),
+          isError: errorStatuses.has(job.status),
         };
       });
     });

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -11,6 +11,7 @@ import {
   workflowModes,
 } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
+import { qualityChoices } from "../jobTypes.js";
 
 const workflowOptions = [
   ["text_to_image", "Text to Image"],
@@ -26,12 +27,6 @@ const workflowCards = [
   { id: "image_to_video", label: "Image → Video", desc: "Animate a starting frame.", outputs: "Video", icon: "Video" },
   { id: "text_to_video", label: "Text → Video", desc: "Generate a clip from prose.", outputs: "Video", icon: "Sparkle" },
   { id: "first_last_frame", label: "First/Last Frame", desc: "Render the in-betweens of two frames.", outputs: "Video", icon: "ArrowRight" },
-];
-
-const qualityChoices = [
-  ["draft", "Draft"],
-  ["balanced", "Balanced"],
-  ["final", "Final"],
 ];
 
 const imageAspectChoices = ["1024x1024", "1536x1024", "1024x1536", "2048x1152"];

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -1,26 +1,9 @@
 import React, { useMemo } from "react";
 import { useLiveJobElapsedSeconds } from "../components/JobProgress.jsx";
 import { actionStatuses, terminalStatuses } from "../constants.js";
+import { GPU_REQUIRED_JOB_TYPES, NON_GPU_JOB_TYPES } from "../jobTypes.js";
 import { formatSeconds, percent } from "../formatting.js";
 import { useAppContext } from "../context/AppContext.js";
-
-const nonGpuJobTypes = new Set(["model_download", "model_import", "model_convert", "lora_import"]);
-// Keep GPU-required job types in sync with
-// crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
-// apps/worker/scene_worker/runtime.py (SUPPORTED_JOB_TYPES + TRAINING_JOB_TYPES + CAPTION_JOB_TYPES).
-const gpuRequiredJobTypes = new Set([
-  "image_generate",
-  "image_edit",
-  "image_vqa",
-  "image_interleave",
-  "video_generate",
-  "video_extend",
-  "video_bridge",
-  "person_replace",
-  "lora_train",
-  "training_caption",
-]);
-const terminalStatusesForBlocking = new Set(["completed", "failed", "canceled", "interrupted"]);
 
 function formatJobType(type) {
   return String(type ?? "job").replaceAll("_", " ");
@@ -34,10 +17,10 @@ function workerCanClaim(job, worker) {
   if (!workerSupports(worker, job.type)) {
     return false;
   }
-  if (nonGpuJobTypes.has(job.type)) {
+  if (NON_GPU_JOB_TYPES.has(job.type)) {
     return true;
   }
-  if (gpuRequiredJobTypes.has(job.type) && worker.gpuId === "cpu") {
+  if (GPU_REQUIRED_JOB_TYPES.has(job.type) && worker.gpuId === "cpu") {
     return false;
   }
   return job.requestedGpu === "auto" || job.requestedGpu === worker.gpuId;
@@ -68,7 +51,7 @@ function activeModelDownloadFor(job, jobs) {
   return jobs.find(
     (candidate) =>
       candidate.type === "model_download" &&
-      !terminalStatusesForBlocking.has(candidate.status) &&
+      !terminalStatuses.has(candidate.status) &&
       (keys.has(candidate.payload?.modelId) || keys.has(candidate.payload?.repo)),
   );
 }
@@ -83,7 +66,7 @@ function activeDependencyFor(job, jobs) {
     return null;
   }
   const dependency = jobs.find((candidate) => candidate.id === id);
-  return dependency && !terminalStatusesForBlocking.has(dependency.status) ? dependency : null;
+  return dependency && !terminalStatuses.has(dependency.status) ? dependency : null;
 }
 
 function jobWaitingMessage(job, workers, jobs) {
@@ -112,7 +95,7 @@ function jobWaitingMessage(job, workers, jobs) {
   if (job.requestedGpu && job.requestedGpu !== "auto") {
     return `Waiting for GPU ${job.requestedGpu} to claim the job.`;
   }
-  return nonGpuJobTypes.has(job.type) ? "Waiting for a utility worker." : "Waiting for an available GPU worker.";
+  return NON_GPU_JOB_TYPES.has(job.type) ? "Waiting for a utility worker." : "Waiting for an available GPU worker.";
 }
 
 function workerStatusLine(worker) {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -50,6 +50,7 @@ import {
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { qualityChoices } from "../jobTypes.js";
 
 const ltxVideoModelId = "ltx_2_3";
 const ltxIcLoraRequiredModes = new Set(["extend_clip", "video_bridge"]);
@@ -713,11 +714,7 @@ export function VideoStudio() {
               <label>
                 Quality
                 <div className="quality-segment" role="radiogroup" aria-label="Quality">
-                  {[
-                    ["fast", "Draft"],
-                    ["balanced", "Balanced"],
-                    ["best", "Final"],
-                  ].map(([value, label]) => (
+                  {qualityChoices.map(([value, label]) => (
                     <button
                       aria-checked={quality === value}
                       className={quality === value ? "active" : ""}


### PR DESCRIPTION
## Summary
Fixes the cross-language enum drift flagged in F-023 (sc-1657). The **real bug**: PresetManagerScreen used quality `draft/balanced/final` while VideoStudio and the Python worker (`video_adapters.py` step maps) use `fast/balanced/best`. A preset saved with quality `draft`/`final` left VideoStudio's segmented control unselected and the value silently fell through to the worker's `balanced` default.

- **New `apps/web/src/jobTypes.js`** — single source of truth for:
  - `GPU_REQUIRED_JOB_TYPES` / `NON_GPU_JOB_TYPES` (verified the GPU list matches Rust `jobs_store.rs::job_requires_gpu`; cross-language "keep in sync" note preserved)
  - `terminalStatuses` / `actionStatuses` (re-exported via `constants.js` so the 7 existing importers are untouched) + `errorStatuses` (replaces the `localErrorStatuses` duplicated in JobProgress + ImageStudio)
  - `qualityChoices` — **worker-canonical `fast/balanced/best`** values with `Draft/Balanced/Final` labels
- **Consumers wired:** QueueScreen (job-type sets + dropped its duplicate `terminalStatusesForBlocking`), JobProgress + ImageStudio (errorStatuses), PresetManagerScreen + VideoStudio (shared `qualityChoices` — fixes the mismatch).
- Out of scope: the story's "ideally expose via a backend capabilities endpoint" (larger cross-language effort); `qualityPreset` in training.rs is a separate training concept.

## Test plan
- [x] `npm --prefix apps/web run test -- --run` — 109/109 pass (added 2 regression tests pinning the quality enum + centralized job-type/status sets)
- [x] `npm --prefix apps/web run build` — clean
- [x] Browser smoke against real Rust API: VideoStudio quality control renders Draft/Balanced/Final and selecting **Final** (value `best`) works; console clean. The shared module + unit tests guarantee PresetManager emits the identical values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)