### PR TITLE
Pin repo->dir slug functions across languages (sc-1667, reframed)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -7398,7 +7398,12 @@ fn huggingface_hub_cache_dir(data_dir: &FsPath) -> PathBuf {
     data_dir.join("cache").join("huggingface").join("hub")
 }
 
-fn huggingface_repo_cache_path(data_dir: &FsPath, repo: &str) -> Option<PathBuf> {
+/// The `<X>` in Hugging Face hub's `models--<X>` cache directory name: every
+/// character outside `[A-Za-z0-9._-]` becomes `--`, then surrounding `-` are
+/// trimmed. `None` when nothing survives. Kept byte-identical to the Python
+/// worker (`hf_cache.safe_repo_dir_name`) and the Rust CPU worker — pinned by
+/// the `repo_slugs.json` cross-language contract (story 1667).
+fn safe_repo_dir_name(repo: &str) -> Option<String> {
     let safe_repo = repo
         .chars()
         .map(|character| {
@@ -7412,8 +7417,14 @@ fn huggingface_repo_cache_path(data_dir: &FsPath, repo: &str) -> Option<PathBuf>
         .trim_matches('-')
         .to_owned();
     if safe_repo.is_empty() {
-        return None;
+        None
+    } else {
+        Some(safe_repo)
     }
+}
+
+fn huggingface_repo_cache_path(data_dir: &FsPath, repo: &str) -> Option<PathBuf> {
+    let safe_repo = safe_repo_dir_name(repo)?;
     Some(huggingface_hub_cache_dir(data_dir).join(format!("models--{safe_repo}")))
 }
 
@@ -8257,10 +8268,10 @@ mod tests {
     use super::{
         create_app, huggingface_repo_cache_path, inprocess_worker_gpu_id, insufficient_disk_space,
         lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
-        person_readiness_from_workers, requires_token, strip_jsonc_comments,
-        sweep_stale_lora_uploads_before, EventHub, EventMessage, Settings, WorkerCapability,
-        WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
-        HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+        person_readiness_from_workers, requires_token, safe_download_dir, safe_repo_dir_name,
+        strip_jsonc_comments, sweep_stale_lora_uploads_before, EventHub, EventMessage, Settings,
+        WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
+        EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
     };
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
@@ -8365,6 +8376,33 @@ mod tests {
         let user = json!({"id": "ltx_2_3", "name": "user"});
         assert_eq!(merge_model_manifest_entry(None, Some(user.clone())), user);
         assert_eq!(merge_model_manifest_entry(None, None), json!({}));
+    }
+
+    #[test]
+    fn repo_slug_functions_match_cross_language_contract() {
+        // story 1667: these repo->dir slug ops are duplicated in the Python
+        // worker and the Rust CPU worker; repo_slugs.json is the shared contract
+        // pinning them byte-for-byte across languages.
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/rust_migration_contracts/repo_slugs.json");
+        let contract: Value =
+            serde_json::from_str(&std::fs::read_to_string(&fixture).expect("read repo_slugs.json"))
+                .expect("parse repo_slugs.json");
+        let cases = contract["cases"].as_array().expect("cases array");
+        assert!(!cases.is_empty(), "repo_slugs fixture has no cases");
+        for case in cases {
+            let repo = case["repo"].as_str().expect("repo string");
+            assert_eq!(
+                safe_download_dir(repo),
+                case["safeDownloadDir"].as_str().expect("safeDownloadDir"),
+                "safe_download_dir drift for {repo:?}"
+            );
+            assert_eq!(
+                safe_repo_dir_name(repo).as_deref(),
+                case["safeRepoDirName"].as_str(),
+                "safe_repo_dir_name drift for {repo:?}"
+            );
+        }
     }
 
     fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -3548,8 +3548,12 @@ fn huggingface_hub_cache_dir(data_dir: &Path) -> PathBuf {
     data_dir.join("cache").join("huggingface").join("hub")
 }
 
-fn huggingface_repo_cache_path(data_dir: &Path, repo: &str) -> Option<PathBuf> {
-    let cache_dir = huggingface_hub_cache_dir(data_dir);
+/// The `<X>` in Hugging Face hub's `models--<X>` cache directory name: every
+/// character outside `[A-Za-z0-9._-]` becomes `--`, then surrounding `-` are
+/// trimmed. `None` when nothing survives. Kept byte-identical to the Python
+/// worker (`hf_cache.safe_repo_dir_name`) and the Rust API — pinned by the
+/// `repo_slugs.json` cross-language contract (story 1667).
+fn safe_repo_dir_name(repo: &str) -> Option<String> {
     let safe_repo = repo
         .chars()
         .map(|character| {
@@ -3563,9 +3567,15 @@ fn huggingface_repo_cache_path(data_dir: &Path, repo: &str) -> Option<PathBuf> {
         .trim_matches('-')
         .to_owned();
     if safe_repo.is_empty() {
-        return None;
+        None
+    } else {
+        Some(safe_repo)
     }
-    Some(cache_dir.join(format!("models--{safe_repo}")))
+}
+
+fn huggingface_repo_cache_path(data_dir: &Path, repo: &str) -> Option<PathBuf> {
+    let safe_repo = safe_repo_dir_name(repo)?;
+    Some(huggingface_hub_cache_dir(data_dir).join(format!("models--{safe_repo}")))
 }
 
 async fn directory_size(path: &Path) -> u64 {
@@ -4869,6 +4879,33 @@ mod tests {
             path.file_name().and_then(|name| name.to_str()),
             Some("models--owner--model-name")
         );
+    }
+
+    #[test]
+    fn repo_slug_functions_match_cross_language_contract() {
+        // story 1667: these repo->dir slug ops are duplicated in the Python
+        // worker and the Rust API; repo_slugs.json is the shared contract that
+        // pins them byte-for-byte across languages.
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/rust_migration_contracts/repo_slugs.json");
+        let contract: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&fixture).expect("read repo_slugs.json"))
+                .expect("parse repo_slugs.json");
+        let cases = contract["cases"].as_array().expect("cases array");
+        assert!(!cases.is_empty(), "repo_slugs fixture has no cases");
+        for case in cases {
+            let repo = case["repo"].as_str().expect("repo string");
+            assert_eq!(
+                super::safe_download_dir(repo),
+                case["safeDownloadDir"].as_str().expect("safeDownloadDir"),
+                "safe_download_dir drift for {repo:?}"
+            );
+            assert_eq!(
+                super::safe_repo_dir_name(repo).as_deref(),
+                case["safeRepoDirName"].as_str(),
+                "safe_repo_dir_name drift for {repo:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/fixtures/rust_migration_contracts/repo_slugs.json
+++ b/tests/fixtures/rust_migration_contracts/repo_slugs.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "comment": "Cross-language drift guard (sc-1667) for the pure repo->directory slug string ops shared by the Rust API, the Rust CPU worker, and the Python GPU worker. These are the only genuinely de-duplicable part of the HF path math; runtime cache/snapshot resolution must stay in the worker (snapshot dirs only exist post-download and depend on the worker filesystem). safeDownloadDir = managed models dir name (data_dir/models/<X>): runs of unsafe chars collapse to a single '__', trim '_', empty -> 'download'. safeRepoDirName = the '<X>' in the HF hub cache dir 'models--<X>': every unsafe char -> '--', trim '-', empty -> null. Unsafe = anything not [A-Za-z0-9._-]. Repo ids are ASCII (Python uses Unicode isalnum, Rust uses is_ascii_alphanumeric; they only diverge on non-ASCII, which HF repo ids never contain), so cases stay ASCII.",
+  "cases": [
+    {
+      "repo": "Lightricks/LTX-2.3",
+      "safeDownloadDir": "Lightricks__LTX-2.3",
+      "safeRepoDirName": "Lightricks--LTX-2.3"
+    },
+    {
+      "repo": "google/gemma-3-12b-it-qat-q4_0-unquantized",
+      "safeDownloadDir": "google__gemma-3-12b-it-qat-q4_0-unquantized",
+      "safeRepoDirName": "google--gemma-3-12b-it-qat-q4_0-unquantized"
+    },
+    {
+      "repo": "owner/model-name",
+      "safeDownloadDir": "owner__model-name",
+      "safeRepoDirName": "owner--model-name"
+    },
+    {
+      "repo": "owner//repo",
+      "safeDownloadDir": "owner__repo",
+      "safeRepoDirName": "owner----repo"
+    },
+    {
+      "repo": "/leading/trailing/",
+      "safeDownloadDir": "leading__trailing",
+      "safeRepoDirName": "leading--trailing"
+    },
+    {
+      "repo": "///",
+      "safeDownloadDir": "download",
+      "safeRepoDirName": null
+    }
+  ]
+}

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -14,6 +14,7 @@ from PIL import Image
 import pytest
 
 from scene_worker.adapter_utils import cancel_step_callback, filter_call_kwargs
+from scene_worker.hf_cache import safe_repo_dir_name
 from scene_worker.caption_adapters import (
     JOY_CAPTION_RESAMPLE,
     JoyCaptionOptions,
@@ -5375,3 +5376,18 @@ def test_worker_settings_force_cancel_seconds_env_override(monkeypatch):
     from scene_worker.settings import WorkerSettings
 
     assert WorkerSettings().force_cancel_seconds == 5
+
+
+def test_repo_slug_functions_match_cross_language_contract():
+    # sc-1667: the repo->directory slug string ops are duplicated in the Rust
+    # API, the Rust CPU worker, and here. They must stay byte-identical so a
+    # repo resolves to the same managed dir / HF cache dir in every language.
+    # This fixture is the shared contract; matching Rust tests live in
+    # apps/rust-api and crates/sceneworks-worker.
+    fixture_path = Path(__file__).resolve().parent / "fixtures" / "rust_migration_contracts" / "repo_slugs.json"
+    cases = json.loads(fixture_path.read_text(encoding="utf-8"))["cases"]
+    assert cases, "repo_slugs fixture has no cases"
+    for case in cases:
+        repo = case["repo"]
+        assert safe_download_dir(repo) == case["safeDownloadDir"], f"safe_download_dir drift for {repo!r}"
+        assert safe_repo_dir_name(repo) == case["safeRepoDirName"], f"safe_repo_dir_name drift for {repo!r}"


### PR DESCRIPTION
## Summary
Epic 1628, Python→Rust migration #3 (F-035). **Reframed** from the original story after validation.

The original ask — have Rust report resolved HF cache paths in the job payload so the Python worker stops re-deriving them — isn't a viable dedup:
- The worker's HF cache resolution is **runtime / filesystem-state dependent**: `newest_huggingface_snapshot` scans `models--<repo>/snapshots/*` and picks the newest by mtime; snapshot dirs are content hashes that only exist *after download*.
- **Video jobs are routinely queued before the model is downloaded** (the queue has an explicit model-download dependency wait), so the API can't resolve a snapshot path at create time, and the worker must keep its own resolution regardless (also for any worker whose cache ≠ the API's). Injecting paths would add a fragile optional hint *without removing the duplication*. The story itself flagged this as low priority ("HF-hub also resolves these at load time").

The genuinely de-duplicable part is the **pure repo→directory slug string ops**, duplicated across the Rust API, the Rust CPU worker, and the Python worker. This PR pins them with a shared cross-language contract instead.

- New fixture `tests/fixtures/rust_migration_contracts/repo_slugs.json` (`repo → {safeDownloadDir, safeRepoDirName}`), asserted by a Python test (`safe_download_dir` + `hf_cache.safe_repo_dir_name`) and unit tests in **both** Rust crates — so the two slug schemes can't drift across languages.
  - `safeDownloadDir` (managed models dir): runs of unsafe chars collapse to a single `__`.
  - `safeRepoDirName` (the `<X>` in HF's `models--<X>`): every unsafe char → `--`.
- Extracted a named `safe_repo_dir_name` in `apps/rust-api` and `crates/sceneworks-worker` (was inlined in `huggingface_repo_cache_path`) — removes that inline dup and makes it testable. **Worker runtime cache resolution is unchanged.**

(Latent edge noted in the fixture: Python uses Unicode `isalnum()` vs Rust `is_ascii_alphanumeric()`; they only diverge on non-ASCII, which HF repo ids never contain, so cases stay ASCII.)

The Shortcut story description + a comment record this reframe and the rationale.

## Test plan
- [x] `cargo test -p sceneworks-rust-api -p sceneworks-worker` (new slug tests + existing cache-layout test green)
- [x] `cargo clippy ... -D warnings` + `cargo fmt --check` (both crates)
- [x] `pytest tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` (249 passed, 6 skipped)
- [x] `pytest -m e2e` (1) and `pytest -m parity` (12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)