### PR TITLE
Rust writes video assets on completion; worker ships facts (sc-1656 slice 3)

### DIFF
--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -425,50 +425,24 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         temp_path.replace(media_path)
 
         sidecar_path = media_path.with_suffix(".sceneworks.json")
-        generation_set = {
-            "schemaVersion": 1,
-            "id": generation_set_id,
-            "projectId": request.project_id,
-            "jobId": job["id"],
-            "mode": request.mode,
-            "model": request.model,
-            "prompt": request.prompt,
-            "negativePrompt": request.negative_prompt,
-            "count": 1,
-            "createdAt": created_at,
-        }
-        asset = build_video_asset_sidecar(
-            asset_id=asset_id,
-            project_id=request.project_id,
-            generation_set_id=generation_set_id,
-            request=request,
-            job_id=job["id"],
-            media_rel=media_rel,
-            created_at=created_at,
-            seed=seed,
-            target=target,
-            adapter_id=self.id,
-            mime_type="image/webp",
-            raw_settings=raw_settings,
-        )
-
         progress("saving", "saving", 0.9, "Saving video asset and recipe.")
         if cancel_requested():
             media_path.unlink(missing_ok=True)
             raise InterruptedError("Video generation canceled before asset promotion.")
 
-        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
-        write_json(sidecar_path, asset)
-        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
-        index_asset(project_path, asset)
-        return {
-            "generationSetId": generation_set_id,
-            "assetIds": [asset_id],
-            "assets": [asset],
-            "adapter": self.id,
-            "model": request.model,
-            "requirements": self.estimate_requirements(request),
-        }
+        return video_generation_result(
+            request=request,
+            target=target,
+            adapter_id=self.id,
+            asset_id=asset_id,
+            generation_set_id=generation_set_id,
+            media_rel=media_rel,
+            seed=seed,
+            created_at=created_at,
+            mime_type="image/webp",
+            raw_settings=raw_settings,
+            extra={"requirements": self.estimate_requirements(request)},
+        )
 
     def cancel(self, job_id: str) -> None:
         self.cleanup(job_id)
@@ -822,46 +796,21 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
                 "correctionCount": replacement_control.correction_count,
             }
 
-        generation_set = {
-            "schemaVersion": 1,
-            "id": generation_set_id,
-            "projectId": request.project_id,
-            "jobId": job["id"],
-            "mode": request.mode,
-            "model": request.model,
-            "prompt": request.prompt,
-            "negativePrompt": request.negative_prompt,
-            "count": 1,
-            "createdAt": created_at,
-        }
-        asset = build_video_asset_sidecar(
-            asset_id=asset_id,
-            project_id=request.project_id,
-            generation_set_id=generation_set_id,
+        self._loaded_models.update({request.model, self._pipeline_module(request), str(resources.checkpoint_path)})
+        return video_generation_result(
             request=request,
-            job_id=job["id"],
-            media_rel=media_rel,
-            created_at=created_at,
-            seed=seed,
             target=target,
             adapter_id=self.id,
+            asset_id=asset_id,
+            generation_set_id=generation_set_id,
+            media_rel=media_rel,
+            seed=seed,
+            created_at=created_at,
             mime_type="video/mp4",
             raw_settings=self.map_settings(request, target),
             replacement_status=replacement_status,
+            extra={"requirements": self.estimate_requirements(request)},
         )
-        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
-        write_json(media_path.with_suffix(".sceneworks.json"), asset)
-        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
-        index_asset(project_path, asset)
-        self._loaded_models.update({request.model, self._pipeline_module(request), str(resources.checkpoint_path)})
-        return {
-            "generationSetId": generation_set_id,
-            "assetIds": [asset_id],
-            "assets": [asset],
-            "adapter": self.id,
-            "model": request.model,
-            "requirements": self.estimate_requirements(request),
-        }
 
     def _ltx_conditioning_images(self, project_path: Path, request: VideoRequest, num_frames: int) -> list[Any]:
         if request.mode in {"text_to_video", "extend_clip", "video_bridge"}:
@@ -1800,47 +1749,20 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         temp_path.replace(media_path)
         write_poster_frame(media_path)
 
-        generation_set = {
-            "schemaVersion": 1,
-            "id": generation_set_id,
-            "projectId": request.project_id,
-            "jobId": job["id"],
-            "mode": request.mode,
-            "model": request.model,
-            "prompt": request.prompt,
-            "negativePrompt": request.negative_prompt,
-            "count": 1,
-            "createdAt": created_at,
-        }
-        asset = build_video_asset_sidecar(
-            asset_id=asset_id,
-            project_id=request.project_id,
-            generation_set_id=generation_set_id,
+        progress("saving", "saved", 0.95, "Asset saved.")
+        return video_generation_result(
             request=request,
-            job_id=job["id"],
-            media_rel=media_rel,
-            created_at=created_at,
-            seed=seed,
             target=target,
             adapter_id=self.id,
+            asset_id=asset_id,
+            generation_set_id=generation_set_id,
+            media_rel=media_rel,
+            seed=seed,
+            created_at=created_at,
             mime_type="video/mp4",
             raw_settings=raw_settings,
+            extra={"requirements": self.estimate_requirements(request)},
         )
-
-        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
-        write_json(media_path.with_suffix(".sceneworks.json"), asset)
-        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
-        index_asset(project_path, asset)
-
-        progress("saving", "saved", 0.95, "Asset saved.")
-        return {
-            "generationSetId": generation_set_id,
-            "assetIds": [asset_id],
-            "assets": [asset],
-            "adapter": self.id,
-            "model": request.model,
-            "requirements": self.estimate_requirements(request),
-        }
 
     def _apply_ltx_loras(self, request: VideoRequest, progress: ProgressCallback):
         """Stage user LoRAs for the next LTX generation. Returns a ContextVar token
@@ -2027,44 +1949,19 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         write_poster_frame(media_path)
 
         progress("saving", "saving", 0.9, "Saving video asset and recipe.")
-        generation_set = {
-            "schemaVersion": 1,
-            "id": generation_set_id,
-            "projectId": request.project_id,
-            "jobId": job["id"],
-            "mode": request.mode,
-            "model": request.model,
-            "prompt": request.prompt,
-            "negativePrompt": request.negative_prompt,
-            "count": 1,
-            "createdAt": created_at,
-        }
-        asset = build_video_asset_sidecar(
-            asset_id=asset_id,
-            project_id=request.project_id,
-            generation_set_id=generation_set_id,
+        return video_generation_result(
             request=request,
-            job_id=job["id"],
-            media_rel=media_rel,
-            created_at=created_at,
-            seed=seed,
             target=target,
             adapter_id=self.id,
+            asset_id=asset_id,
+            generation_set_id=generation_set_id,
+            media_rel=media_rel,
+            seed=seed,
+            created_at=created_at,
             mime_type="video/mp4",
             raw_settings=raw_settings,
+            extra={"requirements": self.estimate_requirements(request)},
         )
-        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
-        write_json(media_path.with_suffix(".sceneworks.json"), asset)
-        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
-        index_asset(project_path, asset)
-        return {
-            "generationSetId": generation_set_id,
-            "assetIds": [asset_id],
-            "assets": [asset],
-            "adapter": self.id,
-            "model": request.model,
-            "requirements": self.estimate_requirements(request),
-        }
 
 
 class DiffusersVideoAdapter(VideoGenerationAdapter):
@@ -2181,45 +2078,19 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         temp_path.replace(media_path)
         write_poster_frame(media_path)
 
-        generation_set = {
-            "schemaVersion": 1,
-            "id": generation_set_id,
-            "projectId": request.project_id,
-            "jobId": job["id"],
-            "mode": request.mode,
-            "model": request.model,
-            "prompt": request.prompt,
-            "negativePrompt": request.negative_prompt,
-            "count": 1,
-            "createdAt": created_at,
-        }
-        asset = build_video_asset_sidecar(
-            asset_id=asset_id,
-            project_id=request.project_id,
-            generation_set_id=generation_set_id,
+        return video_generation_result(
             request=request,
-            job_id=job["id"],
-            media_rel=media_rel,
-            created_at=created_at,
-            seed=seed,
             target=target,
             adapter_id=target["adapter"],
+            asset_id=asset_id,
+            generation_set_id=generation_set_id,
+            media_rel=media_rel,
+            seed=seed,
+            created_at=created_at,
             mime_type="video/mp4",
             raw_settings=raw_settings,
+            extra={"requirements": self.estimate_requirements(request)},
         )
-
-        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
-        write_json(media_path.with_suffix(".sceneworks.json"), asset)
-        write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
-        index_asset(project_path, asset)
-        return {
-            "generationSetId": generation_set_id,
-            "assetIds": [asset_id],
-            "assets": [asset],
-            "adapter": target["adapter"],
-            "model": request.model,
-            "requirements": self.estimate_requirements(request),
-        }
 
     def cancel(self, _job_id: str) -> None:
         return
@@ -3110,40 +2981,51 @@ def default_negative_prompt(target: dict[str, Any]) -> str:
     return "worst quality, inconsistent motion, blurry, jittery, distorted"
 
 
-def build_video_asset_sidecar(
+def video_generation_result(
     *,
-    asset_id: str,
-    project_id: str,
-    generation_set_id: str,
     request: VideoRequest,
-    job_id: str,
-    media_rel: str,
-    created_at: str,
-    seed: int,
     target: dict[str, Any],
-    raw_settings: dict[str, Any],
     adapter_id: str,
+    asset_id: str,
+    generation_set_id: str,
+    media_rel: str,
+    seed: int,
+    created_at: str,
     mime_type: str,
+    raw_settings: dict[str, Any],
     replacement_status: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    parents = [
-        asset_id
-        for asset_id in [
-            request.source_asset_id,
-            request.last_frame_asset_id,
-            request.source_clip_asset_id,
-            request.bridge_right_clip_asset_id,
-        ]
-        if asset_id
-    ]
-    timeline_context = request.advanced.get("timelineContext", {})
-    normalized_settings = {
-        "duration": request.duration,
-        "fps": request.fps,
+    """Worker->API result for a generated video asset (story 1656).
+
+    The worker saves the media bytes (and runs faststart/poster — those stay
+    worker-side, sc-1654) but no longer builds/writes the sidecar/generation-set/
+    recipe or indexes project.db. It ships flat per-asset facts (``assetWrites``)
+    + generation-set facts; the Rust API builds the sidecar
+    (``project_store::build_generated_asset_sidecar`` video branch), writes it +
+    the recipe + generation-set, indexes project.db, and re-injects the built
+    sidecar into ``result.assets``."""
+    fact = {
+        "type": "video",
+        "assetId": asset_id,
+        "mediaPath": media_rel,
+        "mimeType": mime_type,
         "width": request.width,
         "height": request.height,
+        "duration": request.duration,
+        "fps": request.fps,
         "quality": request.quality,
         "family": target["family"],
+        "seed": seed,
+        "displayName": request.prompt[:56] or "Generated video",
+        "createdAt": created_at,
+        "mode": request.mode,
+        "model": request.model,
+        "adapter": adapter_id,
+        "prompt": request.prompt,
+        "negativePrompt": request.negative_prompt,
+        "loras": request.loras,
+        "rawAdapterSettings": raw_settings,
         "sourceAssetId": request.source_asset_id,
         "lastFrameAssetId": request.last_frame_asset_id,
         "sourceClipAssetId": request.source_clip_asset_id,
@@ -3152,66 +3034,27 @@ def build_video_asset_sidecar(
         "characterLookId": request.character_look_id,
         "personTrackId": request.person_track_id,
         "replacementMode": request.replacement_mode,
-        "timelineContextRef": "lineage.timeline",
+        "timelineContext": request.advanced.get("timelineContext", {}),
     }
-    if request.mode == "replace_person":
-        # Honest defaults: a replacement asset only claims active detection/
-        # tracking/replacement when the adapter actually ran a real masked-control
-        # path and reported it via replacement_status (sc-1483/sc-1487). Adapters
-        # that did not (mocked previews, not-yet-upgraded paths) leave these false.
-        replacement_settings = {
-            "personDetectionActive": False,
-            "personTrackingActive": False,
-            "replacementActive": False,
-        }
-        if replacement_status:
-            replacement_settings.update(replacement_status)
-        normalized_settings.update(replacement_settings)
-    return {
-        "schemaVersion": 1,
-        "id": asset_id,
-        "projectId": project_id,
-        "generationSetId": generation_set_id,
-        "type": "video",
-        "displayName": f"{request.prompt[:56] or 'Generated video'}",
+    if replacement_status is not None:
+        fact["replacementStatus"] = replacement_status
+    generation_set = {
+        "id": generation_set_id,
+        "mode": request.mode,
+        "model": request.model,
+        "prompt": request.prompt,
+        "negativePrompt": request.negative_prompt,
+        "count": 1,
         "createdAt": created_at,
-        "file": {
-            "path": media_rel,
-            "mimeType": mime_type,
-            "width": request.width,
-            "height": request.height,
-            "duration": request.duration,
-            "fps": request.fps,
-        },
-        "status": {
-            "favorite": False,
-            "rating": 0,
-            "rejected": False,
-            "trashed": False,
-        },
-        "recipe": {
-            "mode": request.mode,
-            "model": request.model,
-            "adapter": adapter_id,
-            "prompt": request.prompt,
-            "negativePrompt": request.negative_prompt,
-            "seed": seed,
-            "loras": request.loras,
-            "normalizedSettings": normalized_settings,
-            "rawAdapterSettings": raw_settings,
-        },
-        "lineage": {
-            "parents": parents,
-            "sourceAssetId": request.source_asset_id,
-            "lastFrameAssetId": request.last_frame_asset_id,
-            "sourceClipAssetId": request.source_clip_asset_id,
-            "bridgeRightClipAssetId": request.bridge_right_clip_asset_id,
-            "personTrackId": request.person_track_id,
-            "characterId": request.character_id,
-            "characterLookId": request.character_look_id,
-            "replacementMode": request.replacement_mode,
-            "sourceTimestamp": None,
-            "timeline": timeline_context,
-            "jobId": job_id,
-        },
     }
+    result = {
+        "generationSetId": generation_set_id,
+        "expectedCount": 1,
+        "adapter": adapter_id,
+        "model": request.model,
+        "generationSet": generation_set,
+        "assetWrites": [fact],
+    }
+    if extra:
+        result.update(extra)
+    return result

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -2072,18 +2072,28 @@ fn build_generated_asset_sidecar(
     fact: &Value,
 ) -> Value {
     let get = |key: &str| fact.get(key).cloned().unwrap_or(Value::Null);
+    // The worker sends an explicit `type` (a procedural video preview is a .webp,
+    // so mime alone can't classify it); fall back to mime for image facts that
+    // predate it.
     let mime = fact
         .get("mimeType")
         .and_then(Value::as_str)
         .unwrap_or("image/png");
-    let media_type = if mime.starts_with("video/") {
-        "video"
+    let media_type = fact
+        .get("type")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            if mime.starts_with("video/") {
+                "video".to_owned()
+            } else {
+                "image".to_owned()
+            }
+        });
+    let (file, recipe, lineage) = if media_type == "video" {
+        build_video_sidecar_parts(job_id, fact)
     } else {
-        "image"
-    };
-    let parents = match fact.get("sourceAssetId").and_then(Value::as_str) {
-        Some(source) => vec![Value::String(source.to_owned())],
-        None => Vec::new(),
+        build_image_sidecar_parts(job_id, fact)
     };
     json!({
         "schemaVersion": 1,
@@ -2093,43 +2103,140 @@ fn build_generated_asset_sidecar(
         "type": media_type,
         "displayName": get("displayName"),
         "createdAt": get("createdAt"),
-        "file": {
-            "path": get("mediaPath"),
-            "mimeType": mime,
-            "width": get("width"),
-            "height": get("height"),
-            "duration": get("duration"),
-            "fps": get("fps"),
-        },
+        "file": file,
         "status": { "favorite": false, "rating": 0, "rejected": false, "trashed": false },
-        "recipe": {
-            "mode": get("mode"),
-            "model": get("model"),
-            "adapter": get("adapter"),
-            "prompt": get("prompt"),
-            "negativePrompt": get("negativePrompt"),
-            "seed": get("seed"),
-            "loras": fact.get("loras").cloned().unwrap_or_else(|| json!([])),
-            "stylePreset": get("stylePreset"),
-            "normalizedSettings": {
-                "width": get("normalizedWidth"),
-                "height": get("normalizedHeight"),
-                "count": get("count"),
-                "family": get("family"),
-                "characterId": get("characterId"),
-                "characterLookId": get("characterLookId"),
-                "characterConditioningActive": false,
-                "characterConditioningNote": "Character metadata is recorded, but adapter-level character conditioning is not active in this build.",
-            },
-            "rawAdapterSettings": fact.get("rawAdapterSettings").cloned().unwrap_or_else(|| json!({})),
-        },
-        "lineage": {
-            "parents": parents,
-            "sourceAssetId": get("sourceAssetId"),
-            "sourceTimestamp": Value::Null,
-            "jobId": job_id,
-        },
+        "recipe": recipe,
+        "lineage": lineage,
     })
+}
+
+/// `(file, recipe, lineage)` for a generated image asset, matching the worker's
+/// former `build_asset_sidecar` (story 1656).
+fn build_image_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value) {
+    let get = |key: &str| fact.get(key).cloned().unwrap_or(Value::Null);
+    let parents = match fact.get("sourceAssetId").and_then(Value::as_str) {
+        Some(source) => vec![Value::String(source.to_owned())],
+        None => Vec::new(),
+    };
+    let file = json!({
+        "path": get("mediaPath"),
+        "mimeType": get("mimeType"),
+        "width": get("width"),
+        "height": get("height"),
+        "duration": Value::Null,
+        "fps": Value::Null,
+    });
+    let recipe = json!({
+        "mode": get("mode"),
+        "model": get("model"),
+        "adapter": get("adapter"),
+        "prompt": get("prompt"),
+        "negativePrompt": get("negativePrompt"),
+        "seed": get("seed"),
+        "loras": fact.get("loras").cloned().unwrap_or_else(|| json!([])),
+        "stylePreset": get("stylePreset"),
+        "normalizedSettings": {
+            "width": get("normalizedWidth"),
+            "height": get("normalizedHeight"),
+            "count": get("count"),
+            "family": get("family"),
+            "characterId": get("characterId"),
+            "characterLookId": get("characterLookId"),
+            "characterConditioningActive": false,
+            "characterConditioningNote": "Character metadata is recorded, but adapter-level character conditioning is not active in this build.",
+        },
+        "rawAdapterSettings": fact.get("rawAdapterSettings").cloned().unwrap_or_else(|| json!({})),
+    });
+    let lineage = json!({
+        "parents": parents,
+        "sourceAssetId": get("sourceAssetId"),
+        "sourceTimestamp": Value::Null,
+        "jobId": job_id,
+    });
+    (file, recipe, lineage)
+}
+
+/// `(file, recipe, lineage)` for a generated video asset, matching the worker's
+/// former `build_video_asset_sidecar` (story 1656): video file carries
+/// duration/fps, the recipe has no `stylePreset`, normalizedSettings are
+/// video-shaped (and fold in the honest `replacement_status` for replace_person),
+/// and lineage tracks the four source clip/frame ids + the timeline context.
+fn build_video_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value) {
+    let get = |key: &str| fact.get(key).cloned().unwrap_or(Value::Null);
+    let source_keys = [
+        "sourceAssetId",
+        "lastFrameAssetId",
+        "sourceClipAssetId",
+        "bridgeRightClipAssetId",
+    ];
+    let parents: Vec<Value> = source_keys
+        .iter()
+        .filter_map(|key| fact.get(*key).and_then(Value::as_str))
+        .map(|id| Value::String(id.to_owned()))
+        .collect();
+    let file = json!({
+        "path": get("mediaPath"),
+        "mimeType": get("mimeType"),
+        "width": get("width"),
+        "height": get("height"),
+        "duration": get("duration"),
+        "fps": get("fps"),
+    });
+    let mut normalized = json!({
+        "duration": get("duration"),
+        "fps": get("fps"),
+        "width": get("width"),
+        "height": get("height"),
+        "quality": get("quality"),
+        "family": get("family"),
+        "sourceAssetId": get("sourceAssetId"),
+        "lastFrameAssetId": get("lastFrameAssetId"),
+        "sourceClipAssetId": get("sourceClipAssetId"),
+        "bridgeRightClipAssetId": get("bridgeRightClipAssetId"),
+        "characterId": get("characterId"),
+        "characterLookId": get("characterLookId"),
+        "personTrackId": get("personTrackId"),
+        "replacementMode": get("replacementMode"),
+        "timelineContextRef": "lineage.timeline",
+    });
+    if fact.get("mode").and_then(Value::as_str) == Some("replace_person") {
+        if let Some(object) = normalized.as_object_mut() {
+            object.insert("personDetectionActive".to_owned(), Value::Bool(false));
+            object.insert("personTrackingActive".to_owned(), Value::Bool(false));
+            object.insert("replacementActive".to_owned(), Value::Bool(false));
+            if let Some(status) = fact.get("replacementStatus").and_then(Value::as_object) {
+                for (key, value) in status {
+                    object.insert(key.clone(), value.clone());
+                }
+            }
+        }
+    }
+    let recipe = json!({
+        "mode": get("mode"),
+        "model": get("model"),
+        "adapter": get("adapter"),
+        "prompt": get("prompt"),
+        "negativePrompt": get("negativePrompt"),
+        "seed": get("seed"),
+        "loras": fact.get("loras").cloned().unwrap_or_else(|| json!([])),
+        "normalizedSettings": normalized,
+        "rawAdapterSettings": fact.get("rawAdapterSettings").cloned().unwrap_or_else(|| json!({})),
+    });
+    let lineage = json!({
+        "parents": parents,
+        "sourceAssetId": get("sourceAssetId"),
+        "lastFrameAssetId": get("lastFrameAssetId"),
+        "sourceClipAssetId": get("sourceClipAssetId"),
+        "bridgeRightClipAssetId": get("bridgeRightClipAssetId"),
+        "personTrackId": get("personTrackId"),
+        "characterId": get("characterId"),
+        "characterLookId": get("characterLookId"),
+        "replacementMode": get("replacementMode"),
+        "sourceTimestamp": Value::Null,
+        "timeline": fact.get("timelineContext").cloned().unwrap_or_else(|| json!({})),
+        "jobId": job_id,
+    });
+    (file, recipe, lineage)
 }
 
 fn index_asset(
@@ -2530,6 +2637,65 @@ mod tests {
         let asset = build_generated_asset_sidecar("project-1", "job-1", "genset_y", &fact);
         assert_eq!(asset["type"], json!("video"));
         assert_eq!(asset["file"]["mimeType"], json!("video/mp4"));
+    }
+
+    #[test]
+    fn build_generated_asset_sidecar_assembles_video_replace_person() {
+        // sc-1656 slice 3: the video branch carries duration/fps, has no
+        // stylePreset, builds video-shaped normalizedSettings + lineage, and fills
+        // the honest replace_person defaults when no replacementStatus is reported.
+        let fact = json!({
+            "type": "video",
+            "assetId": "asset-output",
+            "mediaPath": "assets/videos/replacement.mp4",
+            "mimeType": "video/mp4",
+            "width": 1280, "height": 720, "duration": 6.0, "fps": 25,
+            "quality": "balanced", "family": "ltx-video",
+            "seed": 44, "displayName": "Replace the hero",
+            "createdAt": "2026-05-17T00:00:00Z",
+            "mode": "replace_person", "model": "wan_2_2", "adapter": "wan_video",
+            "prompt": "Replace the hero", "negativePrompt": "", "loras": [],
+            "rawAdapterSettings": {},
+            "sourceClipAssetId": "asset-video",
+            "personTrackId": "track-1",
+            "replacementMode": "full_person_keep_outfit",
+            "characterId": "character-1", "characterLookId": "look-1",
+            "timelineContext": {},
+        });
+        let asset = build_generated_asset_sidecar("project-1", "job-1", "genset-1", &fact);
+        assert_eq!(asset["type"], json!("video"));
+        assert_eq!(asset["file"]["duration"], json!(6.0));
+        assert_eq!(asset["file"]["fps"], json!(25));
+        assert!(asset["recipe"].get("stylePreset").is_none());
+        let normalized = &asset["recipe"]["normalizedSettings"];
+        assert_eq!(normalized["personTrackId"], json!("track-1"));
+        assert_eq!(
+            normalized["replacementMode"],
+            json!("full_person_keep_outfit")
+        );
+        assert_eq!(normalized["timelineContextRef"], json!("lineage.timeline"));
+        assert_eq!(normalized["personDetectionActive"], json!(false));
+        assert_eq!(normalized["replacementActive"], json!(false));
+        assert_eq!(asset["lineage"]["sourceClipAssetId"], json!("asset-video"));
+        assert_eq!(asset["lineage"]["characterId"], json!("character-1"));
+        assert_eq!(asset["lineage"]["parents"], json!(["asset-video"]));
+    }
+
+    #[test]
+    fn build_generated_asset_sidecar_merges_replacement_status() {
+        let fact = json!({
+            "type": "video",
+            "assetId": "a",
+            "mediaPath": "assets/videos/x.mp4",
+            "mimeType": "video/mp4",
+            "mode": "replace_person",
+            "replacementStatus": {"replacementActive": true, "maskMode": "segmentation"},
+        });
+        let asset = build_generated_asset_sidecar("p", "j", "g", &fact);
+        let normalized = &asset["recipe"]["normalizedSettings"];
+        assert_eq!(normalized["replacementActive"], json!(true));
+        assert_eq!(normalized["maskMode"], json!("segmentation"));
+        assert_eq!(normalized["personDetectionActive"], json!(false));
     }
 
     #[test]

--- a/tests/test_person_adapters.py
+++ b/tests/test_person_adapters.py
@@ -29,8 +29,8 @@ from scene_worker.person_adapters import (
 from scene_worker.video_adapters import (
     LtxPipelinesResources,
     LtxPipelinesVideoAdapter,
-    build_video_asset_sidecar,
     person_track_masks,
+    video_generation_result,
     video_request_from_job,
 )
 
@@ -597,24 +597,25 @@ def test_person_track_masks_prefers_stored_segmentation(tmp_path):
     assert nonzero < (bbox[2] - bbox[0]) * (bbox[3] - bbox[1]) * 0.95
 
 
-def test_build_sidecar_marks_replacement_inactive_without_status(tmp_path):
+def test_replace_person_result_omits_replacement_status_without_real_run(tmp_path):
+    # sc-1656 slice 3: when no real masked-control path ran, the worker emits no
+    # replacementStatus fact; the Rust builder then fills replacementActive=False
+    # (the honest defaults moved to project_store::build_generated_asset_sidecar).
     settings = _seed_replacement_project(tmp_path)
     request = video_request_from_job(_replacement_job(settings))
-    asset = build_video_asset_sidecar(
-        asset_id="asset_x",
-        project_id="proj_1",
-        generation_set_id="gen_x",
+    result = video_generation_result(
         request=request,
-        job_id="job_replace_1",
-        media_rel="assets/videos/out.mp4",
-        created_at="2026-05-21T00:00:00Z",
-        seed=1,
         target={"family": "ltx-video"},
-        raw_settings={},
         adapter_id="ltx_pipelines",
+        asset_id="asset_x",
+        generation_set_id="gen_x",
+        media_rel="assets/videos/out.mp4",
+        seed=1,
+        created_at="2026-05-21T00:00:00Z",
         mime_type="video/mp4",
+        raw_settings={},
     )
-    assert asset["recipe"]["normalizedSettings"]["replacementActive"] is False
+    assert "replacementStatus" not in result["assetWrites"][0]
 
 
 def test_ltx_replacement_control_builds_segmentation_package(tmp_path):
@@ -709,11 +710,13 @@ def test_ltx_replace_person_active_run_marks_replacement_active(tmp_path, monkey
         progress=lambda *_a, **_k: None,
         cancel_requested=lambda: False,
     )
-    normalized = result["assets"][0]["recipe"]["normalizedSettings"]
-    assert normalized["replacementActive"] is True
-    assert normalized["maskMode"] == "segmentation"
-    assert normalized["replacementAdapter"] == "ltx_pipelines"
-    assert normalized["personTrackId"] == "track_repl"
+    # The worker reports the honest replacement_status as a fact; the Rust builder
+    # folds it into the sidecar's normalizedSettings (sc-1656 slice 3).
+    replacement_status = result["assetWrites"][0]["replacementStatus"]
+    assert replacement_status["replacementActive"] is True
+    assert replacement_status["maskMode"] == "segmentation"
+    assert replacement_status["replacementAdapter"] == "ltx_pipelines"
+    assert replacement_status["personTrackId"] == "track_repl"
     # Prove the masked control clip is injected into the native LTX path as
     # video_conditioning (sc-1486), not just that the flag flipped.
     video_conditioning = captured.get("video_conditioning")
@@ -734,8 +737,9 @@ def test_ltx_replace_person_mock_run_stays_inactive(tmp_path, monkeypatch):
         progress=lambda *_a, **_k: None,
         cancel_requested=lambda: False,
     )
-    asset = result["assets"][0]
-    assert asset["recipe"]["normalizedSettings"]["replacementActive"] is False
+    # No real masked-control run -> the worker reports no replacementStatus fact;
+    # the Rust builder then fills replacementActive=False.
+    assert "replacementStatus" not in result["assetWrites"][0]
 
 
 def test_ensure_models_replace_person_requires_track_and_character(tmp_path):

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -107,7 +107,6 @@ from scene_worker.video_adapters import (
     MlxVideoAdapter,
     VIDEO_MODEL_TARGETS,
     _PENDING_LTX_LORAS,
-    build_video_asset_sidecar,
     character_reference_images,
     create_video_adapter,
     evenly_spaced_indices,
@@ -118,6 +117,7 @@ from scene_worker.video_adapters import (
     load_seekable_image_frame,
     person_track_masks,
     safe_download_dir,
+    video_generation_result,
     video_request_from_job,
 )
 
@@ -3973,13 +3973,13 @@ def test_native_ltx_mocked_run_writes_scene_video_asset(monkeypatch, tmp_path):
         cancel_requested=lambda: False,
     )
 
-    asset = result["assets"][0]
-    media_path = project_path / asset["file"]["path"]
+    asset = result["assetWrites"][0]
+    media_path = project_path / asset["mediaPath"]
     assert media_path.exists()
     assert result["adapter"] == "ltx_pipelines"
-    assert asset["recipe"]["adapter"] == "ltx_pipelines"
-    assert asset["recipe"]["rawAdapterSettings"]["pipeline"] == "ltx_pipelines.ti2vid_two_stages"
-    assert asset["recipe"]["rawAdapterSettings"]["mockedNativeInference"] is True
+    assert asset["adapter"] == "ltx_pipelines"
+    assert asset["rawAdapterSettings"]["pipeline"] == "ltx_pipelines.ti2vid_two_stages"
+    assert asset["rawAdapterSettings"]["mockedNativeInference"] is True
     assert adapter.loaded_models() == ["ltx_2_3", "ltx_pipelines.ti2vid_two_stages"]
 
 
@@ -4077,8 +4077,8 @@ def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, 
         cancel_requested=lambda: False,
     )
 
-    asset = result["assets"][0]
-    media_path = project_path / asset["file"]["path"]
+    asset = result["assetWrites"][0]
+    media_path = project_path / asset["mediaPath"]
     assert media_path.read_bytes() == b"mp4"
     assert calls["init"]["checkpoint_path"] == str(checkpoint)
     assert calls["init"]["distilled_lora"] == [(str(lora), 0.6, {"rename": "map"})]
@@ -4093,9 +4093,9 @@ def test_native_ltx_text_to_video_uses_ltx_pipeline_and_writes_mp4(monkeypatch, 
     assert calls["encode"]["video"] == ["video-chunk"]
     assert calls["encode"]["audio"] == "audio-track"
     assert calls["encode"]["video_chunks_number"] == 2
-    assert asset["file"]["mimeType"] == "video/mp4"
-    assert asset["recipe"]["rawAdapterSettings"]["realModelInference"] is True
-    assert asset["recipe"]["rawAdapterSettings"]["mockedNativeInference"] is False
+    assert asset["mimeType"] == "video/mp4"
+    assert asset["rawAdapterSettings"]["realModelInference"] is True
+    assert asset["rawAdapterSettings"]["mockedNativeInference"] is False
     assert result["requirements"]["mockedInference"] is False
 
 
@@ -4267,8 +4267,8 @@ def test_native_ltx_image_to_video_passes_source_image_conditioning(monkeypatch,
     assert image_condition.path == str(project_path / image_rel)
     assert image_condition.frame_idx == 0
     assert image_condition.strength == 0.7
-    assert result["assets"][0]["lineage"]["sourceAssetId"] == "asset-source"
-    assert result["assets"][0]["recipe"]["rawAdapterSettings"]["realModelInference"] is True
+    assert result["assetWrites"][0]["sourceAssetId"] == "asset-source"
+    assert result["assetWrites"][0]["rawAdapterSettings"]["realModelInference"] is True
 
 
 def test_native_ltx_image_to_video_falls_back_without_ic_lora(monkeypatch, tmp_path):
@@ -4512,7 +4512,7 @@ def test_native_ltx_extend_clip_uses_ic_lora_video_conditioning(monkeypatch, tmp
     assert calls["run"]["video_conditioning"] == [(str(project_path / video_rel), 0.85)]
     assert calls["run"]["conditioning_attention_strength"] == 0.9
     assert result["requirements"]["pipeline"] == "ltx_pipelines.ic_lora"
-    assert result["assets"][0]["lineage"]["sourceClipAssetId"] == "asset-source-video"
+    assert result["assetWrites"][0]["sourceClipAssetId"] == "asset-source-video"
 
 
 def test_native_ltx_cleanup_deletes_temp_output_and_evicts_pipeline(monkeypatch, tmp_path):
@@ -4801,7 +4801,11 @@ def test_character_image_recipe_marks_conditioning_inactive():
     assert normalized["characterConditioningActive"] is False
 
 
-def test_replace_person_video_sidecar_preserves_lineage():
+def test_replace_person_video_result_carries_lineage_facts():
+    # sc-1656 slice 3: the worker reports flat video facts and the Rust API builds
+    # the sidecar. Pin the facts the worker emits for a replace_person job — the
+    # honest personDetection/replacement defaults now live in the Rust builder
+    # (project_store::build_generated_asset_sidecar), tested Rust-side.
     job = {
         "id": "job-1",
         "payload": {
@@ -4819,30 +4823,29 @@ def test_replace_person_video_sidecar_preserves_lineage():
     }
     request = video_request_from_job(job)
 
-    asset = build_video_asset_sidecar(
-        asset_id="asset-output",
-        project_id="project-1",
-        generation_set_id="genset-1",
+    result = video_generation_result(
         request=request,
-        job_id="job-1",
-        media_rel="assets/videos/replacement.webp",
-        created_at="2026-05-17T00:00:00Z",
-        seed=44,
         target=VIDEO_MODEL_TARGETS["wan_2_2"],
         adapter_id="wan_video",
+        asset_id="asset-output",
+        generation_set_id="genset-1",
+        media_rel="assets/videos/replacement.mp4",
+        seed=44,
+        created_at="2026-05-17T00:00:00Z",
         mime_type="video/mp4",
         raw_settings={},
     )
-
-    assert asset["recipe"]["mode"] == "replace_person"
-    assert asset["file"]["mimeType"] == "video/mp4"
-    assert asset["recipe"]["normalizedSettings"]["personTrackId"] == "track-1"
-    assert asset["recipe"]["normalizedSettings"]["replacementMode"] == "full_person_keep_outfit"
-    assert asset["recipe"]["normalizedSettings"]["personDetectionActive"] is False
-    assert asset["recipe"]["normalizedSettings"]["personTrackingActive"] is False
-    assert asset["recipe"]["normalizedSettings"]["replacementActive"] is False
-    assert asset["lineage"]["sourceClipAssetId"] == "asset-video"
-    assert asset["lineage"]["characterId"] == "character-1"
+    fact = result["assetWrites"][0]
+    assert fact["type"] == "video"
+    assert fact["mode"] == "replace_person"
+    assert fact["mimeType"] == "video/mp4"
+    assert fact["personTrackId"] == "track-1"
+    assert fact["replacementMode"] == "full_person_keep_outfit"
+    assert fact["sourceClipAssetId"] == "asset-video"
+    assert fact["characterId"] == "character-1"
+    # No real masked-control path ran here, so the worker reports no
+    # replacementStatus; the Rust builder fills the honest false defaults.
+    assert "replacementStatus" not in fact
 
 
 def test_build_sidecar_outputs_match_cross_language_schema_contract():
@@ -4884,33 +4887,11 @@ def test_build_sidecar_outputs_match_cross_language_schema_contract():
         adapter_id="procedural_preview",
         raw_settings={},
     )
-    video_asset = build_video_asset_sidecar(
-        asset_id="asset-video",
-        project_id="project-1",
-        generation_set_id="genset-1",
-        request=video_request_from_job(
-            {
-                "id": "job-1",
-                "payload": {
-                    "projectId": "project-1",
-                    "mode": "text_to_video",
-                    "prompt": "city",
-                    "model": "wan_2_2",
-                    "advanced": {},
-                },
-            }
-        ),
-        job_id="job-1",
-        media_rel="assets/videos/city.mp4",
-        created_at="2026-05-17T00:00:00Z",
-        seed=7,
-        target=VIDEO_MODEL_TARGETS["wan_2_2"],
-        adapter_id="wan_video",
-        mime_type="video/mp4",
-        raw_settings={},
-    )
 
-    for fixture_name, asset in (("imageAsset", image_asset), ("videoAsset", video_asset)):
+    # The video sidecar schema moved to Rust in slice 3 (build_video_sidecar_parts);
+    # it is pinned by contract_roundtrip.rs + the Rust builder unit tests. The image
+    # builder is still used by the interleave path (persist_images_directly).
+    for fixture_name, asset in (("imageAsset", image_asset),):
         missing = [key for key in required[fixture_name] if key not in asset]
         assert not missing, f"{fixture_name} is missing contract keys: {missing}"
         recipe_missing = [key for key in required["recipe"] if key not in asset["recipe"]]


### PR DESCRIPTION
## Summary
Third slice of **sc-1656** (Rust as the single `project.db`/sidecar writer) — applies the slice-2 pattern to video.

The five Python video write blocks (procedural webp, native LTX, LTX-MLX, Wan-MLX, Diffusers) stop building/writing the sidecar/generation-set/recipe and calling `index_asset`. Each saves the MP4 bytes, runs faststart + poster (**those stay worker-side** — sc-1654), and emits flat per-asset facts via a shared `video_generation_result()`. The Rust API's `persist_reported_assets` (from slice 2) builds + writes + indexes them — no rust-api change needed.

- `project_store::build_generated_asset_sidecar` gains a **video branch** (`build_video_sidecar_parts`): `file.duration/fps`, no recipe `stylePreset`, video-shaped `normalizedSettings` (incl. the honest `replace_person` defaults + `replacement_status` merge), and video `lineage` with the four source clip/frame ids + timeline context. An explicit `type` fact classifies the `.webp` procedural preview as video.
- **Deleted** the Python `build_video_asset_sidecar` (the duplicate builder); its `replace_person` honesty + lineage coverage moved to Rust unit tests. Migrated its 3 test consumers to assert the worker's facts.

faststart/poster stay in the worker by design (the poster is convention-based — `assetMedia.jsx` swaps the extension — not a sidecar field; the API has no ffmpeg). **sc-1654 stays open** (recorded on that story).

## Test plan
- [x] `pytest tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` (250 passed, 6 skipped)
- [x] `pytest -m e2e` (1) and `pytest -m parity` (12)
- [x] `cargo test -p sceneworks-core build_generated_asset_sidecar` (4 incl. new video/replace_person) + `clippy -D warnings` + `fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)