### PR TITLE
Rust writes interleaved-document assets; worker ships facts (sc-1656 slice 4)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -472,94 +472,6 @@ class ImageAssetWriter:
             "assetWrites": asset_writes,
         }
 
-    def persist_images_directly(
-        self,
-        *,
-        settings: WorkerSettings,
-        job: dict[str, Any],
-        images: list[Image.Image],
-        adapter_id: str,
-        raw_settings: dict[str, Any],
-        cancel_requested: CancelCallback = lambda: False,
-    ) -> dict[str, Any]:
-        """Build + write the sidecar/generation-set/recipe and index project.db for
-        a fixed set of images, returning the built asset records.
-
-        Story 1656 moves the main image-generate path to the Rust project-store
-        writer (``write_incremental_outputs`` now ships flat facts). The
-        interleave/document path still needs the built image assets synchronously
-        (to compose the document segments + sidecar) and is migrated in a later
-        slice, so it keeps writing its embedded images here for now. This mirrors
-        the pre-migration ``write_incremental_outputs`` behavior."""
-        request = image_request_from_job(job)
-        project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
-        for folder in ("assets/images", "generation-sets", "recipes"):
-            (project_path / folder).mkdir(parents=True, exist_ok=True)
-
-        created_at = utc_now()
-        generation_set_id = f"genset_{uuid4().hex}"
-        model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
-        prompt_slug = slugify(request.prompt, fallback="image", max_length=42)
-        date_slug = created_at[:10]
-        images_dir = project_path / "assets" / "images" / generation_set_id
-        images_dir.mkdir(parents=True, exist_ok=True)
-        image_count = len(images)
-        assets = []
-
-        generation_set = {
-            "schemaVersion": 1,
-            "id": generation_set_id,
-            "projectId": request.project_id,
-            "jobId": job["id"],
-            "mode": request.mode,
-            "model": request.model,
-            "prompt": request.prompt,
-            "negativePrompt": request.negative_prompt,
-            "count": image_count,
-            "createdAt": created_at,
-        }
-        write_json(project_path / "generation-sets" / f"{generation_set_id}.json", generation_set)
-
-        for index, image in enumerate(images):
-            if cancel_requested():
-                raise InterruptedError("Image generation canceled by user.")
-            asset_id = f"asset_{uuid4().hex}"
-            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
-            filename = f"{date_slug}_{request.model}_{prompt_slug}_{index + 1:04d}.png"
-            media_rel = f"assets/images/{generation_set_id}/{filename}"
-            media_path = project_path / media_rel
-            sidecar_path = media_path.with_suffix(".sceneworks.json")
-            image.save(media_path, "PNG")
-            asset = build_asset_sidecar(
-                asset_id=asset_id,
-                project_id=request.project_id,
-                generation_set_id=generation_set_id,
-                request=request,
-                job_id=job["id"],
-                media_rel=media_rel,
-                created_at=created_at,
-                seed=seed,
-                index=index,
-                width=image.width,
-                height=image.height,
-                model_target=model_target,
-                adapter_id=adapter_id,
-                raw_settings=raw_settings,
-            )
-            write_json(sidecar_path, asset)
-            write_json(project_path / "recipes" / f"{asset_id}.recipe.json", asset["recipe"])
-            index_asset(project_path, asset, sidecar_path)
-            assets.append(asset)
-
-        return {
-            "generationSetId": generation_set_id,
-            "assetIds": [asset["id"] for asset in assets],
-            "assets": assets,
-            "expectedCount": image_count,
-            "adapter": adapter_id,
-            "model": request.model,
-        }
-
 
 class ZImageDiffusersAdapter:
     id = "z_image_diffusers"
@@ -2210,19 +2122,21 @@ class SenseNovaU1Adapter:
     @staticmethod
     def _build_interleaved_segments(
         generated_text: str,
-        image_assets: list[dict[str, Any]],
+        image_writes: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
         """Split the model output on its inline ``<image>`` markers and slot the
-        generated image assets in order: text[0], image[0], text[1], image[1], …."""
+        generated image assets in order: text[0], image[0], text[1], image[1], ….
+        Reads the worker-reported image facts (assetId + mediaPath); Rust builds
+        the image sidecars from the same facts (story 1656)."""
         parts = (generated_text or "").split("<image>")
         segments: list[dict[str, Any]] = []
         for index, part in enumerate(parts):
             text = part.strip()
             if text:
                 segments.append({"type": "text", "text": text})
-            if index < len(image_assets):
-                asset = image_assets[index]
-                segments.append({"type": "image", "assetId": asset["id"], "path": asset["file"]["path"]})
+            if index < len(image_writes):
+                write = image_writes[index]
+                segments.append({"type": "image", "assetId": write["assetId"], "path": write["mediaPath"]})
         return segments
 
     def _write_interleaved_document(
@@ -2243,106 +2157,80 @@ class SenseNovaU1Adapter:
         project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", project_id)
         (project_path / "assets" / "documents").mkdir(parents=True, exist_ok=True)
 
-        # Generated images persist as ordinary image assets (individually browsable);
-        # the document references them in order.
-        image_assets: list[dict[str, Any]] = []
-        generation_set_id: str | None = None
-        image_asset_ids: list[str] = []
-        if images:
-            image_result = ImageAssetWriter().persist_images_directly(
-                settings=settings,
-                job=job,
-                images=images,
-                adapter_id=self.id,
-                cancel_requested=cancel_requested,
-                raw_settings={**raw_settings, "interleaved": True},
-            )
-            image_assets = image_result.get("assets", [])
-            generation_set_id = image_result.get("generationSetId")
-            image_asset_ids = list(image_result.get("assetIds", []))
+        # Generated images persist as ordinary image assets — the worker saves the
+        # PNG bytes + reports facts, and the Rust API builds + indexes their
+        # sidecars (story 1656). The document references them in order.
+        image_result = ImageAssetWriter().write_outputs(
+            settings=settings,
+            job=job,
+            images=images,
+            adapter_id=self.id,
+            progress=lambda *_args, **_kwargs: None,
+            cancel_requested=cancel_requested,
+            raw_settings={**raw_settings, "interleaved": True},
+        )
+        image_writes = image_result.get("assetWrites", [])
+        generation_set_id = image_result.get("generationSetId")
+        generation_set = image_result.get("generationSet")
+        image_asset_ids = [write["assetId"] for write in image_writes]
 
-        segments = self._build_interleaved_segments(generated_text, image_assets)
+        segments = self._build_interleaved_segments(generated_text, image_writes)
 
         created_at = utc_now()
         document_id = f"doc_{uuid4().hex}"
         media_rel = f"assets/documents/{document_id}.json"
-        document = {
-            "schemaVersion": 1,
-            "id": document_id,
-            "projectId": project_id,
-            "jobId": job["id"],
-            "model": model_id,
-            "prompt": prompt,
-            "createdAt": created_at,
-            "segments": segments,
-        }
-        write_json(project_path / media_rel, document)
-
-        asset_id = f"asset_{uuid4().hex}"
-        sidecar = {
-            "schemaVersion": 1,
-            "id": asset_id,
-            "projectId": project_id,
-            "generationSetId": generation_set_id,
-            "type": "document",
-            "displayName": prompt[:56] or "Interleaved document",
-            "createdAt": created_at,
-            "file": {
-                "path": media_rel,
-                "mimeType": "application/json",
-                "width": None,
-                "height": None,
-                "duration": None,
-                "fps": None,
-            },
-            "status": {"favorite": False, "rating": 0, "rejected": False, "trashed": False},
-            "recipe": {
-                "mode": "interleave",
-                "model": model_id,
-                "adapter": self.id,
-                "prompt": prompt,
-                "negativePrompt": "",
-                "seed": int(seed),
-                "loras": [],
-                "normalizedSettings": {
-                    "maxImages": raw_settings.get("maxImages"),
-                    "resolution": raw_settings.get("resolution"),
-                    "imageCount": len(image_assets),
-                },
-                "rawAdapterSettings": raw_settings,
-            },
-            "lineage": {
-                "parents": list(image_asset_ids),
-                "sourceAssetId": None,
-                "sourceTimestamp": None,
-                "jobId": job["id"],
-            },
-        }
-        sidecar_path = (project_path / media_rel).with_suffix(".sceneworks.json")
-        write_json(sidecar_path, sidecar)
-        index_asset(project_path, sidecar, sidecar_path)
-
-        progress(
-            "saving",
-            "saving",
-            1.0,
-            "Interleaved document saved.",
+        # The worker saves the document body (the "media"); the Rust API builds the
+        # document sidecar + indexes project.db from the document fact below.
+        write_json(
+            project_path / media_rel,
             {
-                "documentId": document_id,
-                "documentAssetId": asset_id,
-                "assetIds": [asset_id, *image_asset_ids],
-                "imageAssetIds": image_asset_ids,
+                "schemaVersion": 1,
+                "id": document_id,
+                "projectId": project_id,
+                "jobId": job["id"],
+                "model": model_id,
+                "prompt": prompt,
+                "createdAt": created_at,
                 "segments": segments,
             },
         )
-        return {
+
+        asset_id = f"asset_{uuid4().hex}"
+        document_write = {
+            "type": "document",
+            "assetId": asset_id,
+            "mediaPath": media_rel,
+            "mimeType": "application/json",
+            "displayName": prompt[:56] or "Interleaved document",
+            "createdAt": created_at,
+            "mode": "interleave",
+            "model": model_id,
+            "adapter": self.id,
+            "prompt": prompt,
+            "negativePrompt": "",
+            "seed": int(seed),
+            "loras": [],
+            "rawAdapterSettings": raw_settings,
+            "maxImages": raw_settings.get("maxImages"),
+            "resolution": raw_settings.get("resolution"),
+            "imageCount": len(image_asset_ids),
+            "parents": list(image_asset_ids),
+        }
+        asset_writes = [*image_writes, document_write]
+        result = {
             "documentId": document_id,
             "documentAssetId": asset_id,
             "imageAssetIds": image_asset_ids,
             "segments": segments,
             "model": model_id,
             "realModelInference": True,
+            "generationSetId": generation_set_id,
+            "expectedCount": len(asset_writes),
+            "generationSet": generation_set,
+            "assetWrites": asset_writes,
         }
+        progress("saving", "saving", 1.0, "Interleaved document saved.", result)
+        return result
 
 
 def create_image_adapter(

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -2090,10 +2090,10 @@ fn build_generated_asset_sidecar(
                 "image".to_owned()
             }
         });
-    let (file, recipe, lineage) = if media_type == "video" {
-        build_video_sidecar_parts(job_id, fact)
-    } else {
-        build_image_sidecar_parts(job_id, fact)
+    let (file, recipe, lineage) = match media_type.as_str() {
+        "video" => build_video_sidecar_parts(job_id, fact),
+        "document" => build_document_sidecar_parts(job_id, fact),
+        _ => build_image_sidecar_parts(job_id, fact),
     };
     json!({
         "schemaVersion": 1,
@@ -2234,6 +2234,44 @@ fn build_video_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value
         "replacementMode": get("replacementMode"),
         "sourceTimestamp": Value::Null,
         "timeline": fact.get("timelineContext").cloned().unwrap_or_else(|| json!({})),
+        "jobId": job_id,
+    });
+    (file, recipe, lineage)
+}
+
+/// `(file, recipe, lineage)` for an interleaved document asset (story 1656,
+/// slice 4). The worker writes the document body JSON (the "media"); Rust builds
+/// this sidecar from the document fact. The recipe mode is `interleave` and
+/// lineage parents are the embedded image asset ids.
+fn build_document_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value) {
+    let get = |key: &str| fact.get(key).cloned().unwrap_or(Value::Null);
+    let file = json!({
+        "path": get("mediaPath"),
+        "mimeType": get("mimeType"),
+        "width": Value::Null,
+        "height": Value::Null,
+        "duration": Value::Null,
+        "fps": Value::Null,
+    });
+    let recipe = json!({
+        "mode": get("mode"),
+        "model": get("model"),
+        "adapter": get("adapter"),
+        "prompt": get("prompt"),
+        "negativePrompt": get("negativePrompt"),
+        "seed": get("seed"),
+        "loras": fact.get("loras").cloned().unwrap_or_else(|| json!([])),
+        "normalizedSettings": {
+            "maxImages": get("maxImages"),
+            "resolution": get("resolution"),
+            "imageCount": get("imageCount"),
+        },
+        "rawAdapterSettings": fact.get("rawAdapterSettings").cloned().unwrap_or_else(|| json!({})),
+    });
+    let lineage = json!({
+        "parents": fact.get("parents").cloned().unwrap_or_else(|| json!([])),
+        "sourceAssetId": Value::Null,
+        "sourceTimestamp": Value::Null,
         "jobId": job_id,
     });
     (file, recipe, lineage)
@@ -2696,6 +2734,51 @@ mod tests {
         assert_eq!(normalized["replacementActive"], json!(true));
         assert_eq!(normalized["maskMode"], json!("segmentation"));
         assert_eq!(normalized["personDetectionActive"], json!(false));
+    }
+
+    #[test]
+    fn build_generated_asset_sidecar_assembles_document() {
+        // sc-1656 slice 4: interleaved document asset. The worker writes the body
+        // JSON; Rust builds this sidecar — type document, mimeType
+        // application/json, recipe.mode interleave, lineage.parents = image ids.
+        let fact = json!({
+            "type": "document",
+            "assetId": "asset-doc",
+            "mediaPath": "assets/documents/doc_1.json",
+            "mimeType": "application/json",
+            "displayName": "An illustrated guide",
+            "createdAt": "2026-05-17T00:00:00Z",
+            "mode": "interleave",
+            "model": "sensenova_u1_8b",
+            "adapter": "sensenova_u1",
+            "prompt": "An illustrated guide",
+            "negativePrompt": "",
+            "seed": 7,
+            "loras": [],
+            "rawAdapterSettings": {"maxImages": 6},
+            "maxImages": 6,
+            "resolution": "2048x1152",
+            "imageCount": 2,
+            "parents": ["asset-img-1", "asset-img-2"],
+        });
+        let asset = build_generated_asset_sidecar("project-1", "job-1", "genset-1", &fact);
+        assert_eq!(asset["type"], json!("document"));
+        assert_eq!(asset["file"]["mimeType"], json!("application/json"));
+        assert_eq!(asset["file"]["path"], json!("assets/documents/doc_1.json"));
+        assert_eq!(asset["recipe"]["mode"], json!("interleave"));
+        assert_eq!(
+            asset["recipe"]["normalizedSettings"]["imageCount"],
+            json!(2)
+        );
+        assert_eq!(
+            asset["recipe"]["normalizedSettings"]["resolution"],
+            json!("2048x1152")
+        );
+        assert_eq!(
+            asset["lineage"]["parents"],
+            json!(["asset-img-1", "asset-img-2"])
+        );
+        assert_eq!(asset["generationSetId"], json!("genset-1"));
     }
 
     #[test]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1036,8 +1036,8 @@ def test_generate_interleaved_rejects_non_sensenova_model():
 
 def test_interleave_segments_interleave_text_and_images():
     assets = [
-        {"id": "asset_a", "file": {"path": "assets/images/a.png"}},
-        {"id": "asset_b", "file": {"path": "assets/images/b.png"}},
+        {"assetId": "asset_a", "mediaPath": "assets/images/a.png"},
+        {"assetId": "asset_b", "mediaPath": "assets/images/b.png"},
     ]
     text = "Boil the water.<image>Steep the leaves.<image>Pour and enjoy."
     segments = SenseNovaU1Adapter._build_interleaved_segments(text, assets)
@@ -1051,7 +1051,7 @@ def test_interleave_segments_interleave_text_and_images():
 
 
 def test_interleave_segments_handles_leading_image_and_blank_text():
-    assets = [{"id": "asset_a", "file": {"path": "assets/images/a.png"}}]
+    assets = [{"assetId": "asset_a", "mediaPath": "assets/images/a.png"}]
     segments = SenseNovaU1Adapter._build_interleaved_segments("<image>Only a caption.", assets)
     assert segments == [
         {"type": "image", "assetId": "asset_a", "path": "assets/images/a.png"},
@@ -1061,7 +1061,7 @@ def test_interleave_segments_handles_leading_image_and_blank_text():
 
 def test_interleave_segments_caps_images_to_available_assets():
     # More <image> markers than generated images: extra markers emit no image segment.
-    assets = [{"id": "asset_a", "file": {"path": "assets/images/a.png"}}]
+    assets = [{"assetId": "asset_a", "mediaPath": "assets/images/a.png"}]
     segments = SenseNovaU1Adapter._build_interleaved_segments("A<image>B<image>C", assets)
     assert segments == [
         {"type": "text", "text": "A"},
@@ -1103,28 +1103,38 @@ def test_write_interleaved_document_persists_document_and_image_assets(tmp_path)
 
     document_dir = project_path / "assets" / "documents"
     doc_jsons = [p for p in document_dir.glob("*.json") if not p.name.endswith(".sceneworks.json")]
-    sidecars = list(document_dir.glob("*.sceneworks.json"))
+    # The worker writes the document body; the Rust API builds the sidecar from
+    # the document fact (story 1656 slice 4), so no sidecar lands here.
     assert len(doc_jsons) == 1
-    assert len(sidecars) == 1
+    assert not list(document_dir.glob("*.sceneworks.json"))
 
     document = json.loads(doc_jsons[0].read_text(encoding="utf-8"))
     assert [segment["type"] for segment in document["segments"]] == ["text", "image", "text", "image", "text"]
     assert document["model"] == "sensenova_u1_8b"
     assert document["jobId"] == "job-1"
 
-    sidecar = json.loads(sidecars[0].read_text(encoding="utf-8"))
-    assert sidecar["type"] == "document"
-    assert sidecar["file"]["mimeType"] == "application/json"
-    assert sidecar["file"]["path"] == f"assets/documents/{document['id']}.json"
-    assert sidecar["recipe"]["mode"] == "interleave"
-
-    # The two generated images persist as ordinary image assets.
-    # rglob: the writer nests each generation set in its own subfolder.
+    # The two generated images persist as ordinary image assets (Rust writes their
+    # sidecars from facts); the worker still saves their PNG bytes, nested in the
+    # generation-set subfolder.
     assert len(list((project_path / "assets" / "images").rglob("*.png"))) == 2
     assert len(result["imageAssetIds"]) == 2
     assert result["documentId"] == document["id"]
     assert result["segments"] == document["segments"]
     assert progress_results and progress_results[-1]["documentId"] == document["id"]
+
+    # The worker emits flat facts: two image facts + one document fact; the Rust
+    # API builds + indexes all three sidecars on completion.
+    asset_writes = result["assetWrites"]
+    assert len(asset_writes) == 3
+    assert all(write["mimeType"] == "image/png" for write in asset_writes[:2])
+    document_write = asset_writes[-1]
+    assert document_write["type"] == "document"
+    assert document_write["assetId"] == result["documentAssetId"]
+    assert document_write["mediaPath"] == f"assets/documents/{document['id']}.json"
+    assert document_write["mimeType"] == "application/json"
+    assert document_write["mode"] == "interleave"
+    assert document_write["imageCount"] == 2
+    assert document_write["parents"] == result["imageAssetIds"]
 
 
 def test_sensenova_resolution_for_snaps_to_buckets():
@@ -4888,9 +4898,11 @@ def test_build_sidecar_outputs_match_cross_language_schema_contract():
         raw_settings={},
     )
 
-    # The video sidecar schema moved to Rust in slice 3 (build_video_sidecar_parts);
-    # it is pinned by contract_roundtrip.rs + the Rust builder unit tests. The image
-    # builder is still used by the interleave path (persist_images_directly).
+    # The video + document sidecar schemas are Rust-owned now
+    # (build_video_sidecar_parts / build_document_sidecar_parts), pinned by
+    # contract_roundtrip.rs + the Rust builder unit tests. build_asset_sidecar is
+    # retained as a tested utility; the production image path ships facts and the
+    # Rust API builds the sidecar.
     for fixture_name, asset in (("imageAsset", image_asset),):
         missing = [key for key in required[fixture_name] if key not in asset]
         assert not missing, f"{fixture_name} is missing contract keys: {missing}"


### PR DESCRIPTION
## Summary
**Final slice of sc-1656** (Rust as the single `project.db`/sidecar writer). The interleave/document path (`SenseNovaU1Adapter._write_interleaved_document`) stops writing the document sidecar + calling `index_asset`, and its embedded images stop using the retained direct-writer. It now:
- persists embedded images via `ImageAssetWriter.write_outputs` (facts) — the Rust API builds + indexes their sidecars (slices 2/3),
- writes the document **body** JSON (the "media"),
- emits a `document` fact in `assetWrites`; the Rust API builds the document sidecar via a new `project_store::build_document_sidecar_parts` branch (type `document`, `application/json`, `recipe.mode` `interleave`, `lineage.parents` = embedded image ids).

- `build_generated_asset_sidecar` now dispatches image / video / **document**.
- `_build_interleaved_segments` reads the image facts (`assetId`/`mediaPath`).
- **Deleted** the temporary `ImageAssetWriter.persist_images_directly` (added in slice 2 to keep the document path working during the migration).

With this, **no Python adapter writes `project.db` or sidecars** — Rust is the single project-store writer, completing sc-1656.

Follow-up: `build_asset_sidecar` (Python image builder) is now used only by tests; it can be removed in a small separate cleanup.

## Test plan
- [x] `pytest tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` (250 passed, 6 skipped)
- [x] `pytest -m e2e` (1) and `pytest -m parity` (12)
- [x] `cargo test -p sceneworks-core build_generated_asset_sidecar` (5, incl. new document) + `clippy -D warnings` + `fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)