### PR TITLE
perf: resolve ImageRequest + project path once per image job (sc-1678)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -339,8 +339,8 @@ class ImageAssetWriter:
     def write_outputs(
         self,
         *,
-        settings: WorkerSettings,
-        job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         images: list[Image.Image],
         adapter_id: str,
         progress: ProgressCallback,
@@ -348,8 +348,8 @@ class ImageAssetWriter:
         raw_settings: dict[str, Any],
     ) -> dict[str, Any]:
         return self.write_incremental_outputs(
-            settings=settings,
-            job=job,
+            request=request,
+            project_path=project_path,
             image_count=len(images),
             image_at_index=lambda index: images[index],
             adapter_id=adapter_id,
@@ -361,8 +361,8 @@ class ImageAssetWriter:
     def write_incremental_outputs(
         self,
         *,
-        settings: WorkerSettings,
-        job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         image_count: int,
         image_at_index: Callable[[int], Image.Image],
         adapter_id: str,
@@ -370,9 +370,6 @@ class ImageAssetWriter:
         cancel_requested: CancelCallback,
         raw_settings: dict[str, Any],
     ) -> dict[str, Any]:
-        request = image_request_from_job(job)
-        project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
-
         created_at = utc_now()
         generation_set_id = f"genset_{uuid4().hex}"
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
@@ -499,10 +496,11 @@ class ZImageDiffusersAdapter:
         *,
         settings: WorkerSettings,
         job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
-        request = image_request_from_job(job)
         if request.mode == "edit_image" and not model_supports_edit(request.model):
             raise RuntimeError(f"{request.model} does not support image editing.")
 
@@ -565,8 +563,8 @@ class ZImageDiffusersAdapter:
             return image
 
         return ImageAssetWriter().write_incremental_outputs(
-            settings=settings,
-            job=job,
+            request=request,
+            project_path=project_path,
             image_count=total,
             image_at_index=image_at_index,
             adapter_id=self.id,
@@ -732,7 +730,7 @@ class ZImageDiffusersAdapter:
         if request.negative_prompt:
             kwargs["negative_prompt"] = request.negative_prompt
         if request.mode == "edit_image":
-            kwargs["image"] = load_source_image(settings, request)
+            kwargs["image"] = load_source_image(project_path, request)
             kwargs["strength"] = float(request.advanced.get("strength", 0.6))
         step_callback = cancel_step_callback(pipe, cancel_requested)
         if step_callback is not None:
@@ -800,10 +798,11 @@ class QwenImageAdapter:
         *,
         settings: WorkerSettings,
         job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
-        request = image_request_from_job(job)
         model_target = MODEL_TARGETS.get(request.model, {})
         if model_target.get("adapter") != self.id:
             raise RuntimeError(f"{request.model} is not a Qwen Image target.")
@@ -864,8 +863,8 @@ class QwenImageAdapter:
             return image
 
         return ImageAssetWriter().write_incremental_outputs(
-            settings=settings,
-            job=job,
+            request=request,
+            project_path=project_path,
             image_count=request.count,
             image_at_index=image_at_index,
             adapter_id=self.id,
@@ -1012,7 +1011,7 @@ class QwenImageAdapter:
         if request.negative_prompt:
             kwargs["negative_prompt"] = request.negative_prompt
         if request.mode == "edit_image":
-            kwargs["image"] = load_source_image(settings, request)
+            kwargs["image"] = load_source_image(project_path, request)
             kwargs["strength"] = float(request.advanced.get("strength", 0.6))
             kwargs["true_cfg_scale"] = float(request.advanced.get("trueCfgScale", 4.0))
         step_callback = cancel_step_callback(pipe, cancel_requested)
@@ -1137,10 +1136,11 @@ class LensTurboAdapter:
         *,
         settings: WorkerSettings,
         job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
-        request = image_request_from_job(job)
         if request.mode == "edit_image":
             raise RuntimeError(f"{request.model} does not support image editing.")
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["lens_turbo"])
@@ -1216,8 +1216,8 @@ class LensTurboAdapter:
                     return handle.convert("RGB")
 
             return ImageAssetWriter().write_incremental_outputs(
-                settings=settings,
-                job=job,
+                request=request,
+                project_path=project_path,
                 image_count=total,
                 image_at_index=image_at_index,
                 adapter_id=self.id,
@@ -1345,10 +1345,11 @@ class ProceduralImageAdapter:
         *,
         settings: WorkerSettings,
         job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
-        request = image_request_from_job(job)
         reject_loras_if_unsupported(request.loras, self.id)
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
         if request.mode == "edit_image" and not model_supports_edit(request.model):
@@ -1365,8 +1366,8 @@ class ProceduralImageAdapter:
             return render_preview_image(request, model_target, seed, index)
 
         return ImageAssetWriter().write_incremental_outputs(
-            settings=settings,
-            job=job,
+            request=request,
+            project_path=project_path,
             image_count=request.count,
             image_at_index=image_at_index,
             adapter_id=self.id,
@@ -1529,10 +1530,11 @@ class SenseNovaU1Adapter:
         *,
         settings: WorkerSettings,
         job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
-        request = image_request_from_job(job)
         reject_loras_if_unsupported(request.loras, self.id)
         model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["sensenova_u1_8b"])
         if model_target.get("adapter") != self.id:
@@ -1553,7 +1555,7 @@ class SenseNovaU1Adapter:
         timestep_shift = float(request.advanced.get("timestepShift", 3.0) or 3.0)
         img_guidance_scale = self._image_guidance_scale(request)
         width, height = sensenova_resolution_for(request.width, request.height)
-        source_image = load_source_image(settings, request) if is_edit else None
+        source_image = load_source_image(project_path, request) if is_edit else None
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
         model, tokenizer = self._load_model(torch, repo, device, dtype, distill_lora=distill_lora, job_id=job["id"])
@@ -1610,8 +1612,8 @@ class SenseNovaU1Adapter:
             return image
 
         return ImageAssetWriter().write_incremental_outputs(
-            settings=settings,
-            job=job,
+            request=request,
+            project_path=project_path,
             image_count=request.count,
             image_at_index=image_at_index,
             adapter_id=self.id,
@@ -1951,6 +1953,8 @@ class SenseNovaU1Adapter:
         *,
         settings: WorkerSettings,
         job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
@@ -2000,7 +2004,7 @@ class SenseNovaU1Adapter:
         model, tokenizer = self._load_model(torch, repo, device, dtype, distill_lora=None, job_id=job["id"])
         self._loaded_model = model_id
 
-        input_images = self._load_input_images(settings, project_id, source_asset_ids)
+        input_images = self._load_input_images(project_path, source_asset_ids)
 
         if cancel_requested():
             raise InterruptedError("Interleaved generation canceled by user.")
@@ -2032,7 +2036,8 @@ class SenseNovaU1Adapter:
         )
 
         return self._write_interleaved_document(
-            settings=settings,
+            project_path=project_path,
+            request=request,
             job=job,
             project_id=project_id,
             model_id=model_id,
@@ -2059,13 +2064,11 @@ class SenseNovaU1Adapter:
 
     def _load_input_images(
         self,
-        settings: WorkerSettings,
-        project_id: str,
+        project_path: Path,
         source_asset_ids: list[str],
     ) -> list[Image.Image]:
         if not source_asset_ids:
             return []
-        project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", project_id)
         images: list[Image.Image] = []
         for asset_id in source_asset_ids:
             path = find_asset_media_path(project_path, asset_id)
@@ -2142,7 +2145,8 @@ class SenseNovaU1Adapter:
     def _write_interleaved_document(
         self,
         *,
-        settings: WorkerSettings,
+        project_path: Path,
+        request: ImageRequest,
         job: dict[str, Any],
         project_id: str,
         model_id: str,
@@ -2154,15 +2158,14 @@ class SenseNovaU1Adapter:
         progress: ProgressCallback,
         raw_settings: dict[str, Any],
     ) -> dict[str, Any]:
-        project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", project_id)
         (project_path / "assets" / "documents").mkdir(parents=True, exist_ok=True)
 
         # Generated images persist as ordinary image assets — the worker saves the
         # PNG bytes + reports facts, and the Rust API builds + indexes their
         # sidecars (story 1656). The document references them in order.
         image_result = ImageAssetWriter().write_outputs(
-            settings=settings,
-            job=job,
+            request=request,
+            project_path=project_path,
             images=images,
             adapter_id=self.id,
             progress=lambda *_args, **_kwargs: None,
@@ -2431,13 +2434,12 @@ def select_torch_dtype(torch: Any, device: str, requested: Any) -> Any:
     return torch.bfloat16
 
 
-def load_source_image(settings: WorkerSettings, request: ImageRequest) -> Image.Image:
+def load_source_image(project_path: Path, request: ImageRequest) -> Image.Image:
     # Resolve only through the project sidecar/DB (find_asset_media_path constrains the
     # result to the project root). No client-supplied path escape hatch: an arbitrary
     # sourceImagePath would let an edit job read any file the worker can open.
     if not request.source_asset_id:
         raise RuntimeError("Image edit jobs require a source image asset.")
-    project_path = shared_find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
     source_path = find_asset_media_path(project_path, request.source_asset_id)
     try:
         image = Image.open(source_path).convert("RGB")

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 import httpx
 
-from sceneworks_shared import utc_now
+from sceneworks_shared import find_project_path, utc_now
 
 from .caption_adapters import run_training_caption_job
 from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_utilization, gpu_worker_id
@@ -24,6 +24,7 @@ from .image_adapters import (
     ZImageDiffusersAdapter,
     create_image_adapter,
     evict_other_image_adapters,
+    image_request_from_job,
     release_image_worker_memory,
     torch_inference_backend_available,
 )
@@ -646,6 +647,11 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
     try:
         progress("preparing", "preparing", 0.08, "Preparing Image Studio request.")
         progress("loading_model", "loading_model", 0.16, "Resolving image adapter target.")
+        # Resolve the request + project path once per job (sc-1678); the adapter, the
+        # asset writer, and source-image loading reuse these instead of each re-parsing
+        # the job and re-scanning recent-projects.json.
+        request = image_request_from_job(job)
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
         result = run_blocking_job_step(
             api,
             settings,
@@ -654,6 +660,8 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
             lambda cancel: adapter.generate(
                 settings=settings,
                 job=job,
+                request=request,
+                project_path=project_path,
                 progress=progress,
                 cancel_requested=cancel,
             ),
@@ -787,6 +795,11 @@ def run_interleave_job(api: ApiClient, settings: WorkerSettings, job: dict, imag
 
     try:
         progress("preparing", "preparing", 0.08, "Preparing interleaved document.")
+        # Resolve the request + project path once per job (sc-1678); generate_interleaved
+        # threads them into input-image loading, the asset writer, and the document write
+        # instead of re-scanning recent-projects.json at each step.
+        request = image_request_from_job(job)
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
         result = run_blocking_job_step(
             api,
             settings,
@@ -795,6 +808,8 @@ def run_interleave_job(api: ApiClient, settings: WorkerSettings, job: dict, imag
             lambda cancel: adapter.generate_interleaved(
                 settings=settings,
                 job=job,
+                request=request,
+                project_path=project_path,
                 progress=progress,
                 cancel_requested=cancel,
             ),

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -911,7 +911,10 @@ def test_lens_turbo_rejects_image_edit(tmp_path):
     }
     noop = lambda *args, **kwargs: None  # noqa: E731
     try:
-        LensTurboAdapter().generate(settings=None, job=job, progress=noop, cancel_requested=lambda: False)
+        LensTurboAdapter().generate(
+            settings=None, job=job, request=image_request_from_job(job), project_path=None,
+            progress=noop, cancel_requested=lambda: False,
+        )
     except RuntimeError as exc:
         assert "does not support image editing" in str(exc)
     else:
@@ -934,7 +937,10 @@ def test_lens_turbo_requires_sidecar_when_missing(monkeypatch):
     }
     noop = lambda *args, **kwargs: None  # noqa: E731
     try:
-        LensTurboAdapter().generate(settings=None, job=job, progress=noop, cancel_requested=lambda: False)
+        LensTurboAdapter().generate(
+            settings=None, job=job, request=image_request_from_job(job), project_path=None,
+            progress=noop, cancel_requested=lambda: False,
+        )
     except RuntimeError as exc:
         assert "sidecar" in str(exc).lower()
     else:
@@ -1022,7 +1028,10 @@ def test_generate_interleaved_requires_prompt():
     job = {"id": "job_il", "payload": {"projectId": "p", "prompt": "   "}}
     noop = lambda *args, **kwargs: None  # noqa: E731
     with pytest.raises(RuntimeError, match="requires a prompt"):
-        adapter.generate_interleaved(settings=None, job=job, progress=noop, cancel_requested=lambda: False)
+        adapter.generate_interleaved(
+            settings=None, job=job, request=image_request_from_job(job), project_path=None,
+            progress=noop, cancel_requested=lambda: False,
+        )
 
 
 def test_generate_interleaved_rejects_non_sensenova_model():
@@ -1030,7 +1039,10 @@ def test_generate_interleaved_rejects_non_sensenova_model():
     job = {"id": "job_il", "payload": {"projectId": "p", "prompt": "guide", "model": "z_image_turbo"}}
     noop = lambda *args, **kwargs: None  # noqa: E731
     with pytest.raises(RuntimeError, match="not a SenseNova-U1 target"):
-        adapter.generate_interleaved(settings=None, job=job, progress=noop, cancel_requested=lambda: False)
+        adapter.generate_interleaved(
+            settings=None, job=job, request=image_request_from_job(job), project_path=None,
+            progress=noop, cancel_requested=lambda: False,
+        )
 
 
 def test_interleave_segments_interleave_text_and_images():
@@ -1087,7 +1099,8 @@ def test_write_interleaved_document_persists_document_and_image_assets(tmp_path)
             progress_results.append(result)
 
     result = SenseNovaU1Adapter()._write_interleaved_document(
-        settings=SimpleNamespace(data_dir=data_dir),
+        project_path=project_path,
+        request=image_request_from_job(job),
         job=job,
         project_id="project-1",
         model_id="sensenova_u1_8b",
@@ -1258,8 +1271,8 @@ def test_image_asset_writer_reports_partial_result_assets(tmp_path):
         )
 
     result = ImageAssetWriter().write_outputs(
-        settings=SimpleNamespace(data_dir=data_dir),
-        job=job,
+        request=image_request_from_job(job),
+        project_path=project_path,
         images=[
             Image.new("RGB", (16, 16), (255, 0, 0)),
             Image.new("RGB", (16, 16), (0, 255, 0)),
@@ -1316,8 +1329,8 @@ def test_image_asset_writer_persists_each_image_before_requesting_next(tmp_path)
         return Image.new("RGB", (16, 16), (255, 0, 0) if index == 0 else (0, 255, 0))
 
     result = ImageAssetWriter().write_incremental_outputs(
-        settings=SimpleNamespace(data_dir=data_dir),
-        job=job,
+        request=image_request_from_job(job),
+        project_path=project_path,
         image_count=2,
         image_at_index=image_at_index,
         adapter_id="z_image_diffusers",
@@ -1357,8 +1370,8 @@ def test_image_asset_writer_does_not_clobber_identical_jobs(tmp_path):
 
     def run(color):
         return ImageAssetWriter().write_incremental_outputs(
-            settings=SimpleNamespace(data_dir=data_dir),
-            job=job,
+            request=image_request_from_job(job),
+            project_path=project_path,
             image_count=1,
             image_at_index=lambda _index: Image.new("RGB", (16, 16), color),
             adapter_id="sensenova_u1",
@@ -1416,8 +1429,8 @@ def test_image_asset_writer_records_actual_output_dimensions(tmp_path):
     }
 
     result = ImageAssetWriter().write_incremental_outputs(
-        settings=SimpleNamespace(data_dir=data_dir),
-        job=job,
+        request=image_request_from_job(job),
+        project_path=project_path,
         image_count=1,
         image_at_index=lambda _index: Image.new("RGB", (2720, 1536), "navy"),
         adapter_id="sensenova_u1",
@@ -1461,8 +1474,8 @@ def test_image_asset_writer_batch_progress_is_monotonic(tmp_path):
         return Image.new("RGB", (16, 16), (255, 0, 0))
 
     ImageAssetWriter().write_incremental_outputs(
-        settings=SimpleNamespace(data_dir=data_dir),
-        job=job,
+        request=image_request_from_job(job),
+        project_path=project_path,
         image_count=4,
         image_at_index=image_at_index,
         adapter_id="z_image_diffusers",
@@ -5091,6 +5104,8 @@ def test_z_image_adapter_emits_phase_diagnostics_and_running_message(tmp_path, m
     adapter.generate(
         settings=SimpleNamespace(data_dir=data_dir, gpu_id="0"),
         job=job,
+        request=image_request_from_job(job),
+        project_path=project_path,
         progress=progress,
         cancel_requested=lambda: False,
     )
@@ -5202,6 +5217,8 @@ def test_z_image_adapter_fails_fast_when_pipeline_stays_on_cpu_with_offload_fall
         adapter.generate(
             settings=SimpleNamespace(data_dir=data_dir, gpu_id="0"),
             job=job,
+            request=image_request_from_job(job),
+            project_path=project_path,
             progress=lambda *_args, **_kwargs: None,
             cancel_requested=lambda: False,
         )


### PR DESCRIPTION
## Summary
Closes the last clean thread in the Py→Rust boundary cluster (epic 1628). The image worker resolved `ImageRequest` and the project path repeatedly per job — each adapter parsed the job, and the asset writer parsed it a *second* time and re-scanned `recent-projects.json`; edit/img2img added another scan via `load_source_image`, and interleave added two more.

Now the dispatchers resolve once and thread down (the approach the story prescribes):
- `run_image_job` / `run_interleave_job` resolve `request = image_request_from_job(job)` + `project_path = find_project_path(...)` once (inside the existing try/except, so a missing-project error still surfaces as a clean job failure).
- All 5 image adapters' `generate(...)` and `generate_interleaved(...)` take `request` + `project_path` and stop re-parsing.
- `ImageAssetWriter.write_outputs/write_incremental_outputs` take `request` + `project_path` and no longer re-derive them (dropped `settings`/`job`).
- `load_source_image`, `_load_input_images`, `_write_interleaved_document` take `project_path` directly.

Net effect: removes the duplicate `find_project_path` IO (recent-projects.json read + linear scan) — 2× on edit/img2img jobs, up to 3× on interleave jobs — and the redundant `image_request_from_job` re-parse. No wire-contract or Rust changes; the reported `assetWrites`/`generationSet` facts are unchanged.

## Test plan
- [x] Worker suite: `tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` — 248 passed, 6 skipped
- [x] e2e (`-m e2e`) — 1 passed (procedural image job runs end-to-end through `run_image_job` → adapter → writer)
- [x] parity (`-m parity`) — 12 passed
- [x] No Rust changes (Rust API still builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)