### PR TITLE
perf(web): stop refetching the whole workspace after job mutations (sc-1658)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -398,7 +398,7 @@ export function App() {
     updateCharacterLora,
     detachCharacterLora,
     createCharacterTestJob,
-  } = useCharacters({ token, activeProject, setError, requestedGpu, setActiveView, refreshData });
+  } = useCharacters({ token, activeProject, setError, requestedGpu, setActiveView });
 
   const {
     presets,
@@ -457,7 +457,7 @@ export function App() {
     createPersonDetectionJob,
     createPersonTrackJob,
     saveTrackCorrections,
-  } = usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView, refreshData });
+  } = usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView });
 
   const {
     timelines,
@@ -481,7 +481,6 @@ export function App() {
     setError,
     requestedGpu,
     setActiveView,
-    refreshData,
     createVideoJob,
   });
 
@@ -948,7 +947,6 @@ export function App() {
       });
       setActiveView("Queue");
       setError("");
-      refreshData();
     } catch (err) {
       setError(err.message);
     }
@@ -971,7 +969,6 @@ export function App() {
       });
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);
@@ -998,7 +995,6 @@ export function App() {
       });
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);
@@ -1023,7 +1019,6 @@ export function App() {
       });
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);
@@ -1075,7 +1070,6 @@ export function App() {
       }
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);
@@ -1192,7 +1186,6 @@ export function App() {
       const updatedJob = await apiFetch(path, token, { method: "POST", body: JSON.stringify(body) });
       setJobs((items) => [updatedJob, ...items.filter((item) => item.id !== updatedJob.id)].sort(sortNewest));
       setError("");
-      await refreshData();
     } catch (err) {
       setError(err.message);
     }

--- a/apps/web/src/hooks/useCharacters.js
+++ b/apps/web/src/hooks/useCharacters.js
@@ -3,9 +3,10 @@ import { apiFetch, isAbortError } from "../api.js";
 
 // Owns the project's character roster plus every character CRUD/reference/look/LoRA
 // mutation. Extracted from App.jsx (sc-1651) to shrink the god module; behavior is
-// unchanged — shared concerns (token, active project, error/navigation, refreshData)
-// are passed in so the hook stays a thin data layer.
-export function useCharacters({ token, activeProject, setError, requestedGpu, setActiveView, refreshData }) {
+// unchanged — shared concerns (token, active project, error/navigation) are passed in
+// so the hook stays a thin data layer. Character test jobs surface live via the SSE
+// job stream (the create endpoint publishes job.updated), so no post-create refetch.
+export function useCharacters({ token, activeProject, setError, requestedGpu, setActiveView }) {
   const [characters, setCharacters] = useState([]);
 
   async function refreshCharacters(projectId = activeProject?.id, { signal } = {}) {
@@ -170,7 +171,6 @@ export function useCharacters({ token, activeProject, setError, requestedGpu, se
         body: JSON.stringify({ ...payload, requestedGpu }),
       });
       setActiveView("Queue");
-      refreshData();
       return { id: characterId, status: "queued" };
     });
   }

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -98,7 +98,6 @@ export function useModelsAndLoras({
       setActiveView("Queue");
     }
     setError("");
-    refreshData();
     return job;
   }
 
@@ -139,7 +138,6 @@ export function useModelsAndLoras({
       setActiveView("Queue");
     }
     setError("");
-    refreshDataWithLoraOverlay(activeProject?.id);
     return job;
   }
 
@@ -151,7 +149,6 @@ export function useModelsAndLoras({
       });
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);
@@ -167,7 +164,6 @@ export function useModelsAndLoras({
       });
       setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);

--- a/apps/web/src/hooks/usePersonTracks.js
+++ b/apps/web/src/hooks/usePersonTracks.js
@@ -4,8 +4,9 @@ import { apiFetch, isAbortError } from "../api.js";
 // Owns the project's person-track state plus detection/track job creation and manual
 // track corrections. Extracted from App.jsx (sc-1651). personTracks is project-scoped
 // (loaded by the project-load effect, not the bulk refreshData), so the hook just
-// takes the shared concerns it needs; detection/track jobs refresh via refreshData.
-export function usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView, refreshData }) {
+// takes the shared concerns it needs; detection/track jobs surface live via the SSE
+// job stream (the create endpoints publish job.updated), so no post-create refetch.
+export function usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView }) {
   const [personTracks, setPersonTracks] = useState([]);
 
   async function refreshPersonTracks(projectId = activeProject?.id, { signal } = {}) {
@@ -37,7 +38,6 @@ export function usePersonTracks({ token, activeProject, setError, requestedGpu, 
         setActiveView("Queue");
       }
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);
@@ -60,7 +60,6 @@ export function usePersonTracks({ token, activeProject, setError, requestedGpu, 
         setActiveView("Queue");
       }
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);

--- a/apps/web/src/hooks/useTimelines.js
+++ b/apps/web/src/hooks/useTimelines.js
@@ -18,7 +18,6 @@ export function useTimelines({
   setError,
   requestedGpu,
   setActiveView,
-  refreshData,
   createVideoJob,
 }) {
   const [timelines, setTimelines] = useState([]);
@@ -131,7 +130,6 @@ export function useTimelines({
       });
       setActiveView("Queue");
       setError("");
-      refreshData();
     } catch (err) {
       setError(err.message);
     }
@@ -147,7 +145,6 @@ export function useTimelines({
         body: JSON.stringify({ playheadSeconds, intendedUse, requestedGpu }),
       });
       setError("");
-      refreshData();
       return job;
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
`refreshData()` pulled **all 8** workspace collections (projects, jobs, workers, models, loras, presets, training targets/presets) after nearly every create/cancel/duplicate/retry — even on every "Generate" click — despite the SSE stream already pushing the relevant updates and the create paths already updating `jobs` optimistically.

Re-validated against the current code (post the sc-1651 App.jsx context refactor): every job-creation endpoint routes through `create_generation_job`, which `publish("job.updated")` + `publish_queue()` on creation, and `cancel/retry/duplicate/update_progress` publish too. So a created/changed job (and the queue/worker state) always arrives live via SSE.

Dropped `refreshData()` from every job-mutation path:
- App.jsx: `createImageJob`, `createVqaJob`, `createInterleaveJob`, `createVideoJob`, `createPlaceholderJob`, `jobAction` (cancel/retry/duplicate)
- `useModelsAndLoras`: `createModelImportJob`, `createLoraImportJob`, `createModelDownloadJob`, `createModelConvertJob`
- `usePersonTracks`: detect + track jobs
- `useTimelines`: timeline export + frame extraction
- `useCharacters`: character test job

Kept full `refreshData()` only for **genuine catalog changes** — model/LoRA import+download **completion** (SSE handler) and model/LoRA **delete** — plus the initial authenticated load. Removed the now-unused `refreshData` prop from `usePersonTracks`, `useTimelines`, and `useCharacters`.

Net: catalog data still reconciles where it actually changes; job/worker/queue state rides the SSE stream + optimistic updates instead of triggering an 8-collection refetch per click.

## Test plan
- [x] `vitest run` (jsdom) — 109 passed
- [x] `vite build` — clean
- [ ] Manual browser smoke recommended (web isn't in CI): Generate an image/video, cancel/duplicate a job, run person-detect, export a timeline → confirm each appears in the Queue live via SSE without the full refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)