### PR TITLE
feat: verify downloaded model family against the catalog (sc-1663)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3391,6 +3391,15 @@ async fn create_model_download_job(
     );
     job_payload.insert("repo".to_owned(), Value::String(repo.clone()));
     job_payload.insert("files".to_owned(), json!(files));
+    // Forward the catalog-declared family so the worker can re-verify the downloaded
+    // weights match it (parity with model import). The catalog is project-curated, but
+    // a mis-declared family would otherwise silently mismatch downstream adapter
+    // selection; the worker reconciles and fails on a confident conflict (sc-1663).
+    if let Some(family) = model.get("family").and_then(Value::as_str) {
+        if !family.trim().is_empty() {
+            job_payload.insert("family".to_owned(), Value::String(family.to_owned()));
+        }
+    }
     job_payload.insert(
         "targetDir".to_owned(),
         Value::String(
@@ -11883,6 +11892,71 @@ mod tests {
         assert!(models[0]["installedPath"]
             .as_str()
             .is_some_and(|value| value.contains("models--owner--model")));
+    }
+
+    #[tokio::test]
+    async fn model_download_job_forwards_catalog_family_for_worker_reconciliation() {
+        // sc-1663: the download job must carry the catalog-declared family so the
+        // worker can re-verify the downloaded weights match it (parity with import).
+        std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let config_dir = temp_dir.path().join("config/manifests");
+        std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+        std::fs::write(
+            config_dir.join("builtin.models.jsonc"),
+            r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "base_model",
+                "name": "Base Model",
+                "type": "image",
+                "family": "z-image",
+                "downloads": [{ "provider": "huggingface", "repo": "owner/model" }]
+              }]
+            }
+            "#,
+        )
+        .expect("builtin models writes");
+        std::fs::write(
+            config_dir.join("user.models.jsonc"),
+            r#"{ "schemaVersion": 1, "models": [] }"#,
+        )
+        .expect("user models writes");
+        std::fs::write(
+            config_dir.join("builtin.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("builtin loras writes");
+        std::fs::write(
+            config_dir.join("user.loras.jsonc"),
+            r#"{ "schemaVersion": 1, "loras": [] }"#,
+        )
+        .expect("user loras writes");
+        std::fs::write(
+            config_dir.join("builtin.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("builtin presets writes");
+        std::fs::write(
+            config_dir.join("user.recipe-presets.jsonc"),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("user presets writes");
+
+        let app = create_app(test_settings(&temp_dir)).expect("app creates");
+        let (status, job) = request(
+            app,
+            "POST",
+            "/api/v1/models/base_model/download",
+            json!({ "requestedGpu": "auto" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(job["type"], "model_download");
+        assert_eq!(job["payload"]["modelId"], "base_model");
+        assert_eq!(job["payload"]["family"], "z-image");
     }
 
     #[tokio::test]

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -14,7 +14,7 @@ use sceneworks_core::contracts::{
 };
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
-    read_safetensors_header, reconcile_detected_family, SafetensorsHeaderError,
+    read_safetensors_header, reconcile_detected_family, FamilyMismatch, SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{
     lora_source_url_file_name, lora_source_url_file_stem, parse_lora_source_url_with_private,
@@ -1043,6 +1043,9 @@ async fn run_model_download_job(
     if let Some(cache_path) =
         download_model_with_hf_cli(api, settings, job, repo, revision, &files, &target_dir).await?
     {
+        if !reconcile_downloaded_model_family(api, job, &cache_path).await? {
+            return Ok(());
+        }
         let mut result = JsonObject::new();
         result.insert(
             "modelId".to_owned(),
@@ -1114,6 +1117,10 @@ async fn run_model_download_job(
     )
     .await?;
     write_model_install_marker(&target_dir, &job.payload, repo, &job.id).await?;
+
+    if !reconcile_downloaded_model_family(api, job, &target_dir).await? {
+        return Ok(());
+    }
 
     let mut result = JsonObject::new();
     result.insert(
@@ -1702,6 +1709,79 @@ fn model_family_detection_error(error: SafetensorsHeaderError) -> String {
         }
         SafetensorsHeaderError::InvalidHeader => {
             "Imported model file has an invalid safetensors header.".to_owned()
+        }
+    }
+}
+
+/// Outcome of re-checking a downloaded model's architecture family against the
+/// catalog-declared family (sc-1663). Kept pure (no API I/O) so the decision is
+/// unit-testable; [`reconcile_downloaded_model_family`] maps it to a job failure.
+#[derive(Debug)]
+enum DownloadFamilyCheck {
+    /// Detection agrees, is inconclusive, or no family was declared — proceed.
+    Proceed,
+    /// The catalog declared one family but the weights are confidently another.
+    Mismatch(FamilyMismatch),
+    /// A safetensors file was found but its header could not be read.
+    DetectionFailed(SafetensorsHeaderError),
+}
+
+/// Re-detect the architecture family of the downloaded weights and reconcile it
+/// against the catalog-declared `supplied` family. A missing declaration or an
+/// inconclusive detector result proceeds — the curated catalog is trusted when there
+/// is no confident contradicting signal — so this never blocks a legitimate
+/// download; only a confident conflict is a mismatch.
+fn check_downloaded_model_family(
+    supplied: Option<String>,
+    model_dir: &Path,
+) -> DownloadFamilyCheck {
+    let detected = match detect_model_family(model_dir) {
+        Ok(detected) => detected,
+        Err(error) => return DownloadFamilyCheck::DetectionFailed(error),
+    };
+    match reconcile_detected_family(supplied, detected) {
+        Ok(_) => DownloadFamilyCheck::Proceed,
+        Err(mismatch) => DownloadFamilyCheck::Mismatch(mismatch),
+    }
+}
+
+/// Enforce family parity with model import on a completed download: verify the
+/// downloaded weights match the catalog-declared family and fail the job on a
+/// confident mismatch (or an unreadable header). Returns `Ok(true)` when the
+/// download may complete, `Ok(false)` when the job was already failed and the
+/// caller should return.
+async fn reconcile_downloaded_model_family(
+    api: &ApiClient,
+    job: &JobSnapshot,
+    model_dir: &Path,
+) -> WorkerResult<bool> {
+    let supplied = optional_payload_string(&job.payload, "family").map(str::to_owned);
+    match check_downloaded_model_family(supplied, model_dir) {
+        DownloadFamilyCheck::Proceed => Ok(true),
+        DownloadFamilyCheck::DetectionFailed(error) => {
+            let detail = match error {
+                SafetensorsHeaderError::Io(io_error) => {
+                    format!("Unable to inspect downloaded model file: {io_error}")
+                }
+                SafetensorsHeaderError::InvalidHeader => {
+                    "Downloaded model file has an invalid safetensors header.".to_owned()
+                }
+            };
+            fail_job(api, &job.id, "Model download failed.", Some(detail)).await?;
+            Ok(false)
+        }
+        DownloadFamilyCheck::Mismatch(mismatch) => {
+            fail_job(
+                api,
+                &job.id,
+                "Model download failed.",
+                Some(format!(
+                    "Downloaded model files appear to be {}, but the catalog declared family {}. Fix the catalog entry to family {} or correct the download source.",
+                    mismatch.detected, mismatch.supplied, mismatch.detected
+                )),
+            )
+            .await?;
+            Ok(false)
         }
     }
 }
@@ -4789,18 +4869,94 @@ mod tests {
 
     use super::{
         allow_pattern_matches, auto_worker_specs, bounded_tail, candidate_people,
-        child_environment, cleanup_uploaded_import_source, concat_file_contents, copy_lora_source,
-        cpu_gpu, cpu_worker_id, crossfade_duration, download_lora_source_url,
-        download_progress_payload, download_snapshot, fallback_gpu, finalize_converted_dir,
-        fresh_asset_id, gpu_worker_id, import_lora_source_path, now_rfc3339, output_dimensions,
-        parse_nvidia_smi_gpus, resolve_model_convert_output, resolve_model_import_target,
-        restart_exited_children_with_spawner, run_ffmpeg, safe_download_dir, safe_project_path,
-        utility_worker_specs, value_f64, visible_gpu_ids, worker_capabilities_with_utility,
-        write_model_install_marker, ApiClient, DownloadContext, DownloadProgress,
-        HuggingFaceSnapshot, JsonObject, Settings, SnapshotFile, SupervisedChild, WorkerError,
-        WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
-        DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+        check_downloaded_model_family, child_environment, cleanup_uploaded_import_source,
+        concat_file_contents, copy_lora_source, cpu_gpu, cpu_worker_id, crossfade_duration,
+        download_lora_source_url, download_progress_payload, download_snapshot, fallback_gpu,
+        finalize_converted_dir, fresh_asset_id, gpu_worker_id, import_lora_source_path,
+        now_rfc3339, output_dimensions, parse_nvidia_smi_gpus, resolve_model_convert_output,
+        resolve_model_import_target, restart_exited_children_with_spawner, run_ffmpeg,
+        safe_download_dir, safe_project_path, utility_worker_specs, value_f64, visible_gpu_ids,
+        worker_capabilities_with_utility, write_model_install_marker, ApiClient, DownloadContext,
+        DownloadFamilyCheck, DownloadProgress, HuggingFaceSnapshot, JsonObject, Settings,
+        SnapshotFile, SupervisedChild, WorkerError, WorkerSpec, DEFAULT_MAX_LORA_URL_BYTES,
+        DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
     };
+
+    fn write_safetensors_with_keys(path: &std::path::Path, keys: &[String]) {
+        // Minimal valid safetensors: 8-byte little-endian header length + JSON header.
+        // The family detector only reads the header, so empty tensor slices are fine.
+        let mut header = serde_json::Map::new();
+        header.insert("__metadata__".to_owned(), json!({"format": "pt"}));
+        for key in keys {
+            header.insert(
+                key.clone(),
+                json!({"dtype": "F16", "shape": [1], "data_offsets": [0, 0]}),
+            );
+        }
+        let header_bytes = serde_json::to_vec(&Value::Object(header)).expect("serialize header");
+        let mut buffer = (header_bytes.len() as u64).to_le_bytes().to_vec();
+        buffer.extend_from_slice(&header_bytes);
+        std::fs::write(path, buffer).expect("write safetensors");
+    }
+
+    fn wan_video_safetensors_keys() -> Vec<String> {
+        // Mirrors the Wan2.2 architecture signature the family detector keys on.
+        let mut keys = Vec::new();
+        for block in 0..30 {
+            for module in ["self_attn.q", "self_attn.k", "cross_attn.q", "ffn.0"] {
+                keys.push(format!("transformer.blocks.{block}.{module}.lora_A.weight"));
+                keys.push(format!("transformer.blocks.{block}.{module}.lora_B.weight"));
+            }
+        }
+        keys
+    }
+
+    #[test]
+    fn download_family_check_proceeds_when_no_weights_to_detect() {
+        // A curated catalog download with no detectable signal (no safetensors yet, or
+        // an inconclusive header) is trusted — the guard must never block a legitimate
+        // download, whether or not a family was declared.
+        let dir = tempdir().expect("tempdir creates");
+        assert!(matches!(
+            check_downloaded_model_family(Some("z-image".to_owned()), dir.path()),
+            DownloadFamilyCheck::Proceed
+        ));
+        assert!(matches!(
+            check_downloaded_model_family(None, dir.path()),
+            DownloadFamilyCheck::Proceed
+        ));
+    }
+
+    #[test]
+    fn download_family_check_flags_confident_mismatch() {
+        // Weights that confidently detect as one family while the catalog declared
+        // another are rejected (parity with model import).
+        let dir = tempdir().expect("tempdir creates");
+        write_safetensors_with_keys(
+            &dir.path().join("model.safetensors"),
+            &wan_video_safetensors_keys(),
+        );
+        match check_downloaded_model_family(Some("z-image".to_owned()), dir.path()) {
+            DownloadFamilyCheck::Mismatch(mismatch) => {
+                assert_eq!(mismatch.supplied, "z-image");
+                assert_eq!(mismatch.detected, "wan-video");
+            }
+            other => panic!("expected a family mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn download_family_check_proceeds_when_detection_matches_catalog() {
+        let dir = tempdir().expect("tempdir creates");
+        write_safetensors_with_keys(
+            &dir.path().join("model.safetensors"),
+            &wan_video_safetensors_keys(),
+        );
+        assert!(matches!(
+            check_downloaded_model_family(Some("wan-video".to_owned()), dir.path()),
+            DownloadFamilyCheck::Proceed
+        ));
+    }
 
     #[tokio::test]
     async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1886,6 +1886,7 @@
     "lastHeartbeatAt": null,
     "message": "Waiting for an available worker.",
     "payload": {
+      "family": "z-image",
       "files": [
         "*.safetensors"
       ],


### PR DESCRIPTION
## Summary
Closes an undocumented asymmetry flagged in the 2026-05-24 review (F-031): `run_model_import_job` re-detects the architecture family from the staged weights and reconciles it against the declared family (hard-failing on a mismatch), but `run_model_download_job` did **no** detection — so a mis-declared catalog entry would silently mismatch downstream adapter selection.

Brings download to parity (the "enforce" option):
- **API** (`create_model_download_job`): forwards the catalog-declared `family` into the download job payload.
- **Worker** (`run_model_download_job`): after the transfer, re-detects the family from the downloaded weights and reconciles against the declared family in **both** completion paths (the HF-cache path and the snapshot-to-`targetDir` path), failing the job on a confident mismatch.

The curated catalog is still trusted when there's no contradicting signal: `reconcile_detected_family` only rejects a *conclusive* conflict, so a missing declaration or an inconclusive detector result proceeds — a legitimate download is never blocked. Factored the decision into a pure `check_downloaded_model_family` (unit-testable) + an async wrapper that maps the outcome to `fail_job`.

## Test plan
- [x] `cargo fmt -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean (rust-api, core, worker)
- [x] `cargo test` (worker/core/rust-api) — 191 pass, incl. 3 new worker guard tests (proceed on no-signal w/ and w/o declared family; reject a wan-video fixture declared z-image; proceed when detection matches) + 1 new API test (download payload carries `family`)
- [x] e2e (1) + parity (12) — `model_download` contract snapshot updated to carry `family`

🤖 Generated with [Claude Code](https://claude.com/claude-code)