### PR TITLE
chore(worker): version-guard + document the vendored LTX/MLX monkeypatches (sc-1647)

### DIFF
--- a/apps/worker/requirements-ltx.txt
+++ b/apps/worker/requirements-ltx.txt
@@ -8,3 +8,14 @@
 torchaudio>=2.8,<2.9
 ltx-core @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-core
 ltx-pipelines @ git+https://github.com/Lightricks/LTX-2.git@1799988521d5e9725a4fbd4533d0cc12f07c07ed#subdirectory=packages/ltx-pipelines
+#
+# Runtime monkeypatches keyed to the commit pin above (sc-1647), in
+# apps/worker/scene_worker/video_adapters.py — re-validate them when bumping it:
+#   - install_ltx_pipelines_multigpu_compat(): stubs the optional
+#     ltx_pipelines.multigpu.delegating_builder.DelegatingBuilder this commit imports
+#     but does not ship. Self-healing: defers to a real multigpu module if a future
+#     bump ships one (sys.modules early-return + setdefault).
+#   - _neutralize_cuda_sync_for_mps(): no-ops torch.cuda.synchronize/empty_cache off
+#     CUDA because ltx-core's cleanup_memory()/gpu_model call them unguarded. Asserts
+#     the torch.cuda symbols exist before reassigning (raises VendorPatchDriftError on
+#     torch drift instead of silently leaving the unguarded sync in place).

--- a/apps/worker/requirements-mlx.txt
+++ b/apps/worker/requirements-mlx.txt
@@ -17,3 +17,12 @@
 mlx-video-with-audio>=0.1.36,<0.2
 mlx>=0.31,<1
 mlx-vlm>=0.3.6,<0.3.10
+#
+# Runtime monkeypatch keyed to the mlx-video-with-audio pin above (sc-1647), in
+# apps/worker/scene_worker/video_adapters.py — re-validate it when bumping the pin:
+#   - _install_ltx_lora_patch(): wraps mlx_video.models.ltx.ltx.LTXModel.load_weights
+#     to merge user LoRAs after the quantized weights load (the turnkey
+#     generate_video_with_audio API exposes no loras kwarg). The from-imports fail
+#     loudly (ImportError) if apply_loras_to_model / LTXModel move; the patch also
+#     asserts LTXModel.load_weights exists and is callable (VendorPatchDriftError on
+#     a rename instead of a bare AttributeError).

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -90,6 +90,53 @@ def ltx_mps_gating(*, cuda_available: bool, device_str: str) -> dict[str, Any]:
     }
 
 
+class VendorPatchDriftError(RuntimeError):
+    """A pinned-dependency runtime monkeypatch's target symbol drifted away.
+
+    The off-CUDA LTX/MLX patches below reassign or wrap symbols owned by
+    commit-/version-pinned third-party packages (ltx-core / ltx-pipelines and
+    mlx-video-with-audio — see ``requirements-ltx.txt`` / ``requirements-mlx.txt``).
+    Those patches target method/symbol names that only hold at the pinned versions,
+    so a dependency bump can move or rename a target out from under us. We raise this
+    loudly at the patch site rather than letting a bare ``AttributeError`` or a silent
+    no-op mask the drift, pointing the operator at the pin to re-validate (sc-1647).
+    """
+
+
+_PATCH_TARGET_MISSING = object()
+
+
+def _require_patch_target(
+    owner: Any,
+    attr: str,
+    *,
+    pin: str,
+    patch: str,
+    require_callable: bool = False,
+) -> Any:
+    """Return ``owner.attr`` or raise :class:`VendorPatchDriftError` naming the pin.
+
+    Pure helper used by the LTX/MLX runtime monkeypatches so a pinned dependency
+    drifting out from under a patched symbol fails loudly and actionably instead of
+    silently (sc-1647). ``owner`` is the module/class that should expose ``attr``;
+    ``pin`` and ``patch`` are surfaced verbatim in the error so the message points at
+    the requirement to re-validate.
+    """
+    target = getattr(owner, attr, _PATCH_TARGET_MISSING)
+    owner_name = getattr(owner, "__name__", type(owner).__name__)
+    if target is _PATCH_TARGET_MISSING:
+        raise VendorPatchDriftError(
+            f"{patch}: expected symbol '{attr}' on '{owner_name}' is missing. "
+            f"The pinned dependency ({pin}) likely drifted — re-validate this patch against the installed version."
+        )
+    if require_callable and not callable(target):
+        raise VendorPatchDriftError(
+            f"{patch}: symbol '{owner_name}.{attr}' is no longer callable. "
+            f"The pinned dependency ({pin}) likely drifted — re-validate this patch against the installed version."
+        )
+    return target
+
+
 _CUDA_SYNC_NEUTRALIZED = False
 
 
@@ -102,20 +149,29 @@ def _neutralize_cuda_sync_for_mps() -> None:
     and aborts the run. ``empty_cache()`` is already a safe no-op there but we
     neutralize both for symmetry. Guarded on ``not is_available()`` so it can never
     mask a real CUDA sync, and idempotent so repeated pipeline loads are cheap.
+
+    Drift guard (sc-1647): required by the pinned native LTX path
+    (``requirements-ltx.txt``); targets the stable ``torch.cuda`` surface. We assert
+    both symbols exist before reassigning so a torch bump that removes them fails
+    loudly instead of leaving the unguarded sync silently in place. ``torch`` being
+    unimportable (e.g. light-dep unit tests) stays a no-op.
     """
     global _CUDA_SYNC_NEUTRALIZED
     if _CUDA_SYNC_NEUTRALIZED:
         return
     try:
         import torch
-
-        if torch.cuda.is_available():
-            return
-        torch.cuda.synchronize = lambda *_args, **_kwargs: None  # type: ignore[assignment]
-        torch.cuda.empty_cache = lambda *_args, **_kwargs: None  # type: ignore[assignment]
-        _CUDA_SYNC_NEUTRALIZED = True
     except Exception:
         return
+    if torch.cuda.is_available():
+        return
+    pin = "torch (requirements.txt: torch>=2.8,<2.9)"
+    patch = "off-CUDA cuda-sync neutralize (sc-1647)"
+    _require_patch_target(torch.cuda, "synchronize", pin=pin, patch=patch, require_callable=True)
+    _require_patch_target(torch.cuda, "empty_cache", pin=pin, patch=patch, require_callable=True)
+    torch.cuda.synchronize = lambda *_args, **_kwargs: None  # type: ignore[assignment]
+    torch.cuda.empty_cache = lambda *_args, **_kwargs: None  # type: ignore[assignment]
+    _CUDA_SYNC_NEUTRALIZED = True
 
 
 class _Fp32AudioDecoder:
@@ -288,6 +344,19 @@ class LtxReplacementControl:
 
 
 def install_ltx_pipelines_multigpu_compat() -> None:
+    """Inject a stub ``ltx_pipelines.multigpu.delegating_builder`` so the import resolves.
+
+    The pinned ltx-pipelines (commit ``1799988…`` in ``requirements-ltx.txt``)
+    references an optional ``DelegatingBuilder`` from a ``multigpu`` submodule it does
+    not actually ship; importing the package without it raises ``ModuleNotFoundError``.
+    We register a synthetic module whose ``DelegatingBuilder`` raises only if
+    instantiated (the single-GPU/MPS path never does).
+
+    Drift guard (sc-1647): unlike the other patches there is no upstream symbol to
+    assert — this provides a *fallback*, not a wrapper. The early ``in sys.modules``
+    return and ``setdefault`` mean a future ltx-pipelines bump that ships a real
+    ``multigpu`` module transparently wins. Re-validate against the pin on bump.
+    """
     if "ltx_pipelines.multigpu.delegating_builder" in sys.modules:
         return
 
@@ -1531,14 +1600,27 @@ _ltx_lora_patch_installed = False
 def _install_ltx_lora_patch() -> None:
     """Idempotently wrap LTXModel.load_weights to apply the LoRAs in _PENDING_LTX_LORAS
     after each load. Targets only LTXModel (the text encoder, VAEs, and vocoder are
-    distinct classes), and fires after nn.quantize so the LoRA'd layers are quantized."""
+    distinct classes), and fires after nn.quantize so the LoRA'd layers are quantized.
+
+    Drift guard (sc-1647): targets symbols pinned to mlx-video-with-audio>=0.1.36,<0.2
+    (``requirements-mlx.txt``). The two imports below fail loudly (ImportError) if the
+    package moves ``apply_loras_to_model`` or ``LTXModel``; we additionally assert
+    ``LTXModel.load_weights`` exists and is callable so a rename surfaces as an
+    actionable VendorPatchDriftError instead of a bare AttributeError. Re-validate on
+    any mlx-video-with-audio bump."""
     global _ltx_lora_patch_installed
     if _ltx_lora_patch_installed:
         return
     from mlx_video.lora import apply_loras_to_model
     from mlx_video.models.ltx.ltx import LTXModel
 
-    original_load_weights = LTXModel.load_weights
+    original_load_weights = _require_patch_target(
+        LTXModel,
+        "load_weights",
+        pin="mlx-video-with-audio>=0.1.36,<0.2 (requirements-mlx.txt)",
+        patch="LTX LoRA load_weights wrap (sc-1647)",
+        require_callable=True,
+    )
     if getattr(original_load_weights, "_sw_lora_wrapped", False):  # guard against double-wrap
         _ltx_lora_patch_installed = True
         return

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -105,7 +105,9 @@ from scene_worker.video_adapters import (
     LtxPipelinesVideoAdapter,
     MlxVideoAdapter,
     VIDEO_MODEL_TARGETS,
+    VendorPatchDriftError,
     _PENDING_LTX_LORAS,
+    _require_patch_target,
     character_reference_images,
     create_video_adapter,
     evenly_spaced_indices,
@@ -3502,6 +3504,39 @@ def test_ltx_pipelines_multigpu_compat_installs_missing_type_module(monkeypatch)
     module = importlib.import_module("ltx_pipelines.multigpu.delegating_builder")
     with pytest.raises(RuntimeError, match="optional multigpu DelegatingBuilder"):
         module.DelegatingBuilder()
+
+
+def test_require_patch_target_returns_existing_symbol():
+    owner = SimpleNamespace(load_weights=lambda self: None)
+    target = _require_patch_target(
+        owner, "load_weights", pin="some-dep==1.0", patch="example patch"
+    )
+    assert target is owner.load_weights
+
+
+def test_require_patch_target_raises_naming_pin_on_missing_symbol():
+    owner = SimpleNamespace()
+    with pytest.raises(VendorPatchDriftError) as excinfo:
+        _require_patch_target(
+            owner, "load_weights", pin="mlx-video-with-audio>=0.1.36,<0.2", patch="LTX LoRA wrap (sc-1647)"
+        )
+    message = str(excinfo.value)
+    assert "load_weights" in message
+    assert "mlx-video-with-audio>=0.1.36,<0.2" in message
+    assert "LTX LoRA wrap (sc-1647)" in message
+
+
+def test_require_patch_target_raises_when_required_callable_is_not_callable():
+    owner = SimpleNamespace(load_weights="not-callable")
+    with pytest.raises(VendorPatchDriftError, match="no longer callable"):
+        _require_patch_target(
+            owner, "load_weights", pin="some-dep==1.0", patch="example patch", require_callable=True
+        )
+
+
+def test_require_patch_target_allows_non_callable_when_not_required():
+    owner = SimpleNamespace(some_attr=123)
+    assert _require_patch_target(owner, "some_attr", pin="some-dep==1.0", patch="example patch") == 123
 
 
 class _FakeQuantizationPolicy:


### PR DESCRIPTION
## Summary
The off-CUDA LTX/MLX video path mutates process globals at runtime, all targeting symbols that only hold at the **pinned** dependency versions (ltx-core/ltx-pipelines @ commit `1799988…`, mlx-video-with-audio `0.1.36`). A dependency bump could move a target out from under us, surfacing as a bare `AttributeError` or a silent no-op. This hardens and documents the three patch sites in `apps/worker/scene_worker/video_adapters.py`.

- Add `VendorPatchDriftError` + a pure `_require_patch_target()` helper that hard-fails with an actionable message **naming the pin** when a targeted symbol is missing or no longer callable.
- Wire it in:
  - `_neutralize_cuda_sync_for_mps` — assert `torch.cuda.synchronize`/`empty_cache` exist before reassigning, and narrow the previous bare `except Exception` to the `import torch` only so real drift propagates instead of being swallowed.
  - `_install_ltx_lora_patch` — assert `LTXModel.load_weights` exists and is callable (the `from`-imports already fail loudly if `apply_loras_to_model`/`LTXModel` move).
  - `install_ltx_pipelines_multigpu_compat` — provides a *fallback* (not a wrapper), so there is no upstream symbol to assert; it gets a documenting docstring + the `setdefault` self-healing behavior is called out.
- Document each runtime patch alongside its dependency pin in `requirements-ltx.txt` / `requirements-mlx.txt`, so a bump triggers re-validation. (These are pip-pinned deps, not `_vendor/` copied source, so the pin sites are the correct doc home rather than `_vendor/README.md`.)

**Out of scope:** the story also suggested "upstream the MPS device parameter where possible" — that requires PRs to third-party repos (Lightricks/LTX-2, mlx-video) and is flagged on the story rather than attempted here.

## Test plan
- [x] Light-dep worker suite: **252 passed / 6 skipped** (`tests/test_worker_runtime.py`, `test_worker_gpu.py`, `test_person_adapters.py`) — includes 4 new pure-helper tests covering returns-existing, raises-naming-pin-on-missing, non-callable-when-required, and allows-non-callable-when-not-required.
- [x] Module import + existing `test_ltx_pipelines_multigpu_compat_installs_missing_type_module` unaffected.
- [ ] **Verification limit (honest):** the `torch`/`mlx` runtime sites only execute on the Mac desktop path and are not importable in the light-dep CI env, so they are validated by import + the helper's unit tests, not by exercising the live patch. The guard logic itself is fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)