### PR TITLE
fix(worker): reap force-cancel temp leaks for MLX/Diffusers video + Lens/training scratch dirs (sc-1719)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1115,6 +1115,23 @@ class LensTurboAdapter:
 
     id = "lens_turbo"
 
+    def __init__(self) -> None:
+        # Sidecar scratch dir for the in-flight job, reaped by discard_temp_outputs
+        # on force-cancel (os._exit skips the finally in generate). One job runs at
+        # a time (sc-1719).
+        self._scratch_dir: Path | None = None
+
+    def discard_temp_outputs(self, job_id: str | None = None) -> None:
+        """Reap the in-flight sidecar scratch dir only — filesystem-only.
+
+        Called from generate's finally and from the force-cancel monitor thread
+        right before os._exit, so it must stay filesystem-only (no torch/GPU; the
+        main thread may be wedged in a native call)."""
+        work_dir = self._scratch_dir
+        if work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+            self._scratch_dir = None
+
     def loaded_models(self) -> list[str]:
         # The sidecar process loads and frees the model per job; nothing stays
         # resident in this (main-venv) process.
@@ -1177,6 +1194,7 @@ class LensTurboAdapter:
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']} (sidecar venv).")
         work_dir = Path(tempfile.mkdtemp(prefix="lens_sidecar_"))
+        self._scratch_dir = work_dir
         try:
             images = self._run_sidecar(
                 job_id=job["id"],
@@ -1237,8 +1255,9 @@ class LensTurboAdapter:
             )
         finally:
             # The writer has read every PNG into the project by now; drop the
-            # sidecar's scratch dir regardless of success/failure.
-            shutil.rmtree(work_dir, ignore_errors=True)
+            # sidecar's scratch dir regardless of success/failure (also clears the
+            # force-cancel registry).
+            self.discard_temp_outputs(job["id"])
 
     def _run_sidecar(
         self,

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -652,6 +652,10 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
         # the job and re-scanning recent-projects.json.
         request = image_request_from_job(job)
         project_path = find_project_path(settings.data_dir / "recent-projects.json", request.project_id)
+        # Some adapters (e.g. the Lens sidecar) hold a filesystem scratch dir to reap
+        # if the cancel backstop force-kills the worker — os._exit skips the adapter's
+        # own finally (sc-1719). Filesystem-only; no-op for adapters without one.
+        discard_scratch = getattr(adapter, "discard_temp_outputs", None)
         result = run_blocking_job_step(
             api,
             settings,
@@ -666,6 +670,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
                 cancel_requested=cancel,
             ),
             loaded_models=adapter_loaded_models,
+            on_force_terminate=(lambda: discard_scratch(job_id)) if callable(discard_scratch) else None,
         )
         update_job(
             api,
@@ -1109,6 +1114,10 @@ def _run_lora_train_execution(api: ApiClient, settings: WorkerSettings, job: dic
         kernel_id = (plan.get("target") or {}).get("kernel")
         trainer = create_training_kernel(kernel_id)
         trainer_holder["trainer"] = trainer
+        # The Lens trainer holds a sidecar scratch dir to reap if the cancel backstop
+        # force-kills the worker (os._exit skips train()'s finally) — sc-1719.
+        # Filesystem-only; no-op for kernels without a scratch dir.
+        discard_scratch = getattr(trainer, "discard_temp_outputs", None)
         result = run_blocking_job_step(
             api,
             settings,
@@ -1121,6 +1130,7 @@ def _run_lora_train_execution(api: ApiClient, settings: WorkerSettings, job: dic
                 cancel_requested=cancel,
             ),
             loaded_models=trainer_loaded_models,
+            on_force_terminate=(lambda: discard_scratch(job_id)) if callable(discard_scratch) else None,
         )
         update_job(
             api,

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -2097,6 +2097,18 @@ class LensLoraTrainer:
         # The sidecar loads and frees the base model per job; nothing resident here.
         return []
 
+    def discard_temp_outputs(self, job_id: str | None = None) -> None:
+        """Reap the in-flight training scratch dir only — filesystem-only.
+
+        Called from train's finally and from the force-cancel monitor thread right
+        before os._exit, so it must stay filesystem-only (no torch/GPU; the main
+        thread may be wedged in a native call). A trainer is created per job and
+        the worker runs one job at a time, so a single scratch dir suffices (sc-1719)."""
+        work_dir = getattr(self, "_scratch_dir", None)
+        if work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+            self._scratch_dir = None
+
     @staticmethod
     def _lens_python() -> str:
         return os.getenv("SCENEWORKS_LENS_PYTHON", "/opt/lens-venv/bin/python")
@@ -2160,6 +2172,7 @@ class LensLoraTrainer:
         progress("preparing", "preparing", 0.04, "Preparing Lens LoRA training run.")
 
         work_dir = Path(tempfile.mkdtemp(prefix="lens_train_"))
+        self._scratch_dir = work_dir
         progress_path = work_dir / "progress.jsonl"
         progress_path.write_text("", encoding="utf-8")
         result_path = work_dir / "result.json"
@@ -2246,7 +2259,7 @@ class LensLoraTrainer:
                 plan=plan, config=config, result=result, total_steps=total_steps, items=items
             )
         finally:
-            shutil.rmtree(work_dir, ignore_errors=True)
+            self.discard_temp_outputs()
 
     @staticmethod
     def _drain_progress(

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -378,6 +378,15 @@ def install_ltx_pipelines_multigpu_compat() -> None:
 class VideoGenerationAdapter(ABC):
     id: str
 
+    def __init__(self) -> None:
+        # job_id -> temp files to reap if the job is force-canceled. The cancel
+        # backstop's os._exit skips cooperative cleanup, so the monitor's
+        # filesystem-only on_force_terminate hook calls discard_temp_outputs to
+        # remove these. Adapters that write temp files register them via
+        # track_temp_output (sc-1719). Subclasses with their own __init__ must
+        # call super().__init__().
+        self._temporary_outputs: dict[str, list[Path]] = {}
+
     @abstractmethod
     def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
         raise NotImplementedError
@@ -410,21 +419,22 @@ class VideoGenerationAdapter(ABC):
     def cleanup(self, job_id: str) -> None:
         raise NotImplementedError
 
+    def track_temp_output(self, job_id: str, path: Path) -> None:
+        """Register a temp file to reap if the job is force-canceled (filesystem-only)."""
+        self._temporary_outputs.setdefault(job_id, []).append(path)
+
     def discard_temp_outputs(self, job_id: str) -> None:
-        """Reap the job's temp files only — no model/pipeline teardown.
+        """Reap the job's tracked temp files only — no model/pipeline teardown.
 
         The force-cancel backstop calls this from the monitor thread right before
         os._exit, so it must stay filesystem-only: the main thread may be wedged
-        in a native call and touching torch/GPU from here would be unsafe.
-        Adapters that track temp files override this; the default is a no-op."""
-        return
+        in a native call and touching torch/GPU from here would be unsafe."""
+        for path in self._temporary_outputs.pop(job_id, []):
+            path.unlink(missing_ok=True)
 
 
 class ProceduralVideoAdapter(VideoGenerationAdapter):
     id = "procedural_video"
-
-    def __init__(self) -> None:
-        self._temporary_outputs: dict[str, list[Path]] = {}
 
     def prepare(self, *, settings: WorkerSettings, job: dict[str, Any]) -> VideoRequest:
         return video_request_from_job(job)
@@ -471,7 +481,7 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         media_rel = f"assets/videos/{filename_base}.webp"
         media_path = project_path / media_rel
         temp_path = media_path.with_suffix(".tmp.webp")
-        self._temporary_outputs.setdefault(job["id"], []).append(temp_path)
+        self.track_temp_output(job["id"], temp_path)
 
         first_image = load_source_image(project_path, request.source_asset_id, request.width, request.height)
         last_image = load_source_image(project_path, request.last_frame_asset_id, request.width, request.height)
@@ -518,10 +528,6 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
 
     def cleanup(self, job_id: str) -> None:
         self.discard_temp_outputs(job_id)
-
-    def discard_temp_outputs(self, job_id: str) -> None:
-        for path in self._temporary_outputs.pop(job_id, []):
-            path.unlink(missing_ok=True)
 
     def map_settings(self, request: VideoRequest, target: dict[str, Any]) -> dict[str, Any]:
         steps = target["steps"].get(request.quality, target["steps"]["balanced"])
@@ -783,14 +789,14 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         media_rel = f"assets/videos/{filename_base}.mp4"
         media_path = project_path / media_rel
         temp_path = media_path.with_suffix(".tmp.mp4")
-        self._temporary_outputs.setdefault(job["id"], []).append(temp_path)
+        self.track_temp_output(job["id"], temp_path)
 
         progress("preparing", "validating_inputs", 0.2, "Validating native LTX-2.3 inputs.")
         replacement_control: LtxReplacementControl | None = None
         replacement_status: dict[str, Any] | None = None
         if request.mode == "replace_person":
             control_clip = media_path.with_suffix(".control.mp4")
-            self._temporary_outputs.setdefault(job["id"], []).append(control_clip)
+            self.track_temp_output(job["id"], control_clip)
             progress("preparing", "building_control", 0.24, "Building masked control clip from person track.")
             replacement_control = self._ltx_replacement_control(project_path, request, num_frames, control_clip)
             conditioning_images = []
@@ -1651,6 +1657,7 @@ class MlxVideoAdapter(VideoGenerationAdapter):
     _supported_modes = {"text_to_video", "image_to_video"}
 
     def __init__(self) -> None:
+        super().__init__()
         self._pipeline: Any | None = None
         self._pipeline_key_value: str | None = None
         self._loaded_models: set[str] = set()
@@ -1724,13 +1731,16 @@ class MlxVideoAdapter(VideoGenerationAdapter):
             return self._run_wan_mlx(settings, job, request, progress, cancel_requested)
         raise RuntimeError(f"MLX adapter does not support {target['label']}.")
 
-    def cancel(self, _job_id: str) -> None:
-        return
+    def cancel(self, job_id: str) -> None:
+        # Reap tracked temp files but keep the resident pipeline loaded for reuse
+        # (filesystem-only; safe on the cooperative-cancel path).
+        self.discard_temp_outputs(job_id)
 
-    def cleanup(self, _job_id: str) -> None:
+    def cleanup(self, job_id: str) -> None:
         self._loaded_models.clear()
         self._pipeline = None
         self._pipeline_key_value = None
+        self.discard_temp_outputs(job_id)
 
     def map_settings(self, request: VideoRequest, target: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -1793,6 +1803,7 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         media_rel = f"assets/videos/{filename_base}.mp4"
         media_path = project_path / media_rel
         temp_path = media_path.with_suffix(".tmp.mp4")
+        self.track_temp_output(job["id"], temp_path)
 
         lora_token = self._apply_ltx_loras(request, progress)
         progress("running", "generating", 0.3, f"Generating {num_frames} frames with LTX-2.3 (MLX).")
@@ -1990,6 +2001,7 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         media_rel = f"assets/videos/{filename_base}.mp4"
         media_path = project_path / media_rel
         temp_path = media_path.with_suffix(".tmp.mp4")
+        self.track_temp_output(job["id"], temp_path)
 
         progress("running", "generating", 0.3, f"Generating {num_frames} frames with {target['label']} (MLX).")
         self._loaded_models.update({request.model, str(spec["model_dir"])})
@@ -2050,6 +2062,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
     id = "diffusers_video"
 
     def __init__(self) -> None:
+        super().__init__()
         self._pipeline: Any | None = None
         self._pipeline_key_value: str | None = None
         self._loaded_models: set[str] = set()
@@ -2152,6 +2165,7 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         media_rel = f"assets/videos/{filename_base}.mp4"
         media_path = project_path / media_rel
         temp_path = media_path.with_suffix(".tmp.mp4")
+        self.track_temp_output(job["id"], temp_path)
 
         progress("saving", "saving", 0.9, "Saving generated MP4 asset and recipe.")
         diffusers_utils = importlib.import_module("diffusers.utils")
@@ -2174,11 +2188,11 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
             extra={"requirements": self.estimate_requirements(request)},
         )
 
-    def cancel(self, _job_id: str) -> None:
-        return
+    def cancel(self, job_id: str) -> None:
+        self.discard_temp_outputs(job_id)
 
-    def cleanup(self, _job_id: str) -> None:
-        return
+    def cleanup(self, job_id: str) -> None:
+        self.discard_temp_outputs(job_id)
 
     def map_settings(self, request: VideoRequest, target: dict[str, Any]) -> dict[str, Any]:
         return {

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2910,7 +2910,7 @@ def test_run_lora_train_job_executes_real_run(monkeypatch, tmp_path):
     monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda api, settings, job_id, status, callback, *, loaded_models: callback(lambda: False),
+        lambda api, settings, job_id, status, callback, *, loaded_models, on_force_terminate=None: callback(lambda: False),
     )
     backend = FakeTrainingBackend()
     trainer = ZImageLoraTrainer(backend=backend)
@@ -2935,7 +2935,7 @@ def test_run_lora_train_job_marks_canceled(monkeypatch, tmp_path):
     monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda api, settings, job_id, status, callback, *, loaded_models: callback(lambda: False),
+        lambda api, settings, job_id, status, callback, *, loaded_models, on_force_terminate=None: callback(lambda: False),
     )
 
     class CancelingTrainer:
@@ -2968,7 +2968,7 @@ def test_run_lora_train_job_reports_friendly_failure(monkeypatch, tmp_path):
     monkeypatch.setattr("scene_worker.runtime.gpu_utilization", lambda _gpu_id: None)
     monkeypatch.setattr(
         "scene_worker.runtime.run_blocking_job_step",
-        lambda api, settings, job_id, status, callback, *, loaded_models: callback(lambda: False),
+        lambda api, settings, job_id, status, callback, *, loaded_models, on_force_terminate=None: callback(lambda: False),
     )
 
     class FailingTrainer:
@@ -3537,6 +3537,93 @@ def test_require_patch_target_raises_when_required_callable_is_not_callable():
 def test_require_patch_target_allows_non_callable_when_not_required():
     owner = SimpleNamespace(some_attr=123)
     assert _require_patch_target(owner, "some_attr", pin="some-dep==1.0", patch="example patch") == 123
+
+
+def test_video_adapter_tracks_and_discards_temp_outputs(tmp_path):
+    # The temp registry now lives on the base VideoGenerationAdapter, so the MLX and
+    # Diffusers adapters (which extend the base directly) get force-cancel reaping too
+    # via the already-wired on_force_terminate hook (sc-1719).
+    adapter = MlxVideoAdapter()
+    first = tmp_path / "a.tmp.mp4"
+    second = tmp_path / "b.control.mp4"
+    first.write_bytes(b"x")
+    second.write_bytes(b"y")
+    adapter.track_temp_output("job-1", first)
+    adapter.track_temp_output("job-1", second)
+
+    adapter.discard_temp_outputs("job-1")
+
+    assert not first.exists()
+    assert not second.exists()
+    # Idempotent: the entry is popped, so a later cleanup after the force-cancel hook
+    # is a harmless no-op.
+    adapter.discard_temp_outputs("job-1")
+
+
+def test_mlx_cancel_reaps_temp_but_keeps_pipeline(tmp_path):
+    adapter = MlxVideoAdapter()
+    adapter._pipeline = object()
+    temp = tmp_path / "clip.tmp.mp4"
+    temp.write_bytes(b"x")
+    adapter.track_temp_output("job-2", temp)
+
+    adapter.cancel("job-2")
+
+    assert not temp.exists()  # temp reaped on cooperative cancel
+    assert adapter._pipeline is not None  # ...but the resident pipeline stays loaded
+
+
+def test_mlx_cleanup_reaps_temp_and_evicts_pipeline(tmp_path):
+    adapter = MlxVideoAdapter()
+    adapter._pipeline = object()
+    temp = tmp_path / "clip.tmp.mp4"
+    temp.write_bytes(b"x")
+    adapter.track_temp_output("job-3", temp)
+
+    adapter.cleanup("job-3")
+
+    assert not temp.exists()
+    assert adapter._pipeline is None
+
+
+def test_diffusers_cleanup_reaps_temp_outputs(tmp_path):
+    adapter = DiffusersVideoAdapter()
+    temp = tmp_path / "clip.tmp.mp4"
+    temp.write_bytes(b"x")
+    adapter.track_temp_output("job-4", temp)
+
+    adapter.cleanup("job-4")
+
+    assert not temp.exists()
+
+
+def test_lens_adapter_discards_sidecar_scratch_dir(tmp_path):
+    adapter = LensTurboAdapter()
+    scratch = tmp_path / "lens_sidecar_abc"
+    scratch.mkdir()
+    (scratch / "spec.json").write_text("{}", encoding="utf-8")
+    adapter._scratch_dir = scratch
+
+    adapter.discard_temp_outputs("job-5")
+
+    assert not scratch.exists()
+    assert adapter._scratch_dir is None
+    # No scratch dir registered -> no-op.
+    adapter.discard_temp_outputs("job-5")
+
+
+def test_lens_trainer_discards_scratch_dir(tmp_path):
+    trainer = LensLoraTrainer()
+    scratch = tmp_path / "lens_train_abc"
+    scratch.mkdir()
+    (scratch / "spec.json").write_text("{}", encoding="utf-8")
+    trainer._scratch_dir = scratch
+
+    trainer.discard_temp_outputs()
+
+    assert not scratch.exists()
+    # Lazily-set attr cleared; a second call is a harmless no-op.
+    trainer.discard_temp_outputs()
 
 
 class _FakeQuantizationPolicy:
@@ -5344,6 +5431,39 @@ def test_cancel_monitor_force_terminates_after_deadline(monkeypatch):
     assert terminal["status"] == "canceled"
     assert terminal["stage"] == "canceled"
     assert "force-stopped" in terminal["message"].lower()
+
+
+def test_cancel_monitor_runs_on_force_terminate_hook_before_exit(monkeypatch):
+    # The force-cancel backstop reaps tracked temp files via on_force_terminate
+    # before the hard os._exit (which skips cooperative adapter cleanup) — the
+    # image/training runners rely on this to drop their scratch dirs (sc-1719).
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    events: list[tuple[str, object]] = []
+    exited = threading.Event()
+
+    def fake_exit(code):
+        events.append(("exit", code))
+        exited.set()
+
+    monkeypatch.setattr("scene_worker.runtime.os._exit", fake_exit)
+    api = _CancelPollApi(cancel_requested=True)
+    settings = SimpleNamespace(worker_id="worker-1", force_cancel_seconds=0.1)
+    monitor = JobCancelMonitor(
+        api,
+        settings,
+        "job-hook",
+        poll_interval=0.02,
+        force_cancel_seconds=0.1,
+        on_force_terminate=lambda: events.append(("hook", None)),
+    )
+    monitor.start()
+    try:
+        assert exited.wait(timeout=2.0)
+    finally:
+        monitor.stop()
+    assert ("hook", None) in events
+    # The reap must run before the process exits.
+    assert events.index(("hook", None)) < events.index(("exit", FORCED_CANCEL_EXIT_CODE))
 
 
 def test_cancel_monitor_skips_escalation_when_stopped(monkeypatch):


### PR DESCRIPTION
## Summary
Follow-up to sc-1677 / PR #179. The cancel backstop's `on_force_terminate` hook reaps tracked temp files before its hard `os._exit` (which skips cooperative adapter cleanup), but it only covered `ProceduralVideoAdapter`. Three leak paths were still bypassed on force-cancel:

- **MLX / Diffusers video** wrote `<media>.tmp.mp4` without registering it, so the (already-wired) video force-cancel hook had nothing to reap.
- **Lens image sidecar** (`mkdtemp lens_sidecar_`) and **Lens training sidecar** (`mkdtemp lens_train_`) scratch dirs were only removed in a method-local `finally` — which `os._exit` skips — and their runners passed no hook at all.

### Changes
- Promote the `_temporary_outputs` registry (`track_temp_output` + concrete `discard_temp_outputs`) from `ProceduralVideoAdapter` onto the base `VideoGenerationAdapter`, so `MlxVideoAdapter`/`DiffusersVideoAdapter` (which extend the base) inherit it. Register their `.tmp.mp4` outputs; the video runner's existing hook now reaps them. Their `cancel`/`cleanup` route through `discard_temp_outputs` — `cancel` keeps the resident pipeline loaded (only `cleanup` evicts it).
- Add a thread-safe, filesystem-only `discard_temp_outputs` to the Lens image adapter and the Lens training kernel (scratch dir reaped on force-cancel; the normal `finally` routes through the same method), and wire `on_force_terminate` into `run_image_job` + `run_lora_train_job`, guarded by `getattr` so it's a no-op for adapters without a scratch dir.
- Hooks stay strictly filesystem-only (no torch/GPU) — the main thread may be wedged in a native call during force-terminate.

**Out of scope:** this is the force-cancel (`os._exit`) backstop path only — a rare event. Normal finish/cancel/failure cleanup is unchanged.

## Test plan
- [x] Light-dep worker suite: **259 passed / 6 skipped** (`tests/test_worker_runtime.py`, `test_worker_gpu.py`, `test_person_adapters.py`).
- [x] 7 new tests: base `track_temp_output`/`discard_temp_outputs`; MLX `cancel` reaps temp but keeps the pipeline vs `cleanup` reaps + evicts; Diffusers `cleanup` reap; Lens image + Lens trainer scratch-dir reap; a `JobCancelMonitor` test asserting `on_force_terminate` runs **before** `os._exit`.
- [x] Updated 3 `lora_train` test stubs to accept the now-passed `on_force_terminate` kwarg (the real `run_blocking_job_step` already accepts it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)