### PR TITLE
fix(core): stop queue-claim starvation behind a large incompatible prefix (sc-1630)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -638,15 +638,19 @@ impl JobsStore {
                and (type in ('model_download', 'model_import', 'lora_import') or requested_gpu = 'auto' or requested_gpu = ?1)
                and (?2 = 0 or type in ('model_download', 'model_import', 'lora_import'))
              order by created_at asc
-             limit 50
             ",
         )?;
         let queued_rows = collect_jobs(statement.query_map(
             params![worker.gpu_id, i64::from(has_active_gpu_job)],
             row_to_job,
         )?)?;
-        // Keep this bounded while the queue is still small; revisit before large multi-tenant
-        // queues so capability-incompatible jobs cannot hide a later compatible job indefinitely.
+        // No row cap (sc-1630): choose_claimable_job must see every gpu/type-gated queued row,
+        // or a capability-incompatible prefix (e.g. 50+ jobs the worker can't run) would hide a
+        // later compatible job and the worker would sit idle. It also needs the whole compatible
+        // set for its priority pass (an explicit-GPU / loaded-model job jumps ahead of an earlier
+        // auto-GPU one), so a bounded scan can't preserve that anyway. The WHERE above already
+        // narrows rows to this worker's gpu/type lane; pushing the capability filter into SQL is
+        // the scale lever if queues ever grow large enough for the full scan to matter.
         let queued = choose_claimable_job(queued_rows, &worker);
         let Some(queued) = queued else {
             return Ok(None);

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -182,6 +182,51 @@ fn claim_skips_jobs_not_supported_by_worker_capabilities() {
 }
 
 #[test]
+fn claim_finds_compatible_job_behind_large_incompatible_prefix() {
+    // sc-1630: a worker must still claim a compatible job even when far more than the
+    // old 50-row query cap of incompatible jobs precede it in the queue — otherwise a
+    // specialized/utility worker sits idle behind a long incompatible prefix.
+    let store = store("starvation");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "downloader".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: None,
+            capabilities: vec![WorkerCapability::ModelDownload],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+
+    // 60 image jobs the worker cannot run (no ImageGenerate capability), enqueued first
+    // so they fill the front of the created_at ordering (well past the old limit 50).
+    for index in 0..60 {
+        let prompt = format!("incompatible {index}");
+        store
+            .create_job(image_job(object(json!({ "prompt": prompt }))))
+            .expect("incompatible job creates");
+    }
+    let download_job = store
+        .create_job(CreateJob {
+            job_type: JobType::ModelDownload,
+            project_id: None,
+            project_name: None,
+            payload: object(json!({ "repo": "owner/model" })),
+            requested_gpu: "auto".to_owned(),
+            source_job_id: None,
+            duplicate_of_job_id: None,
+            attempts: 1,
+        })
+        .expect("download job creates");
+
+    let claimed = store
+        .claim_next_job("downloader")
+        .expect("claim succeeds")
+        .expect("compatible job claimed despite the incompatible prefix");
+    assert_eq!(claimed.id, download_job.id);
+}
+
+#[test]
 fn real_lora_train_requires_execute_capability() {
     let store = store("lora-train-execute-routing");
     // A GPU worker that can validate dry-run plans but lacks the inference backend


### PR DESCRIPTION
## Summary
`claim_next_job` (crates/sceneworks-core/src/jobs_store.rs) selected only the **first 50** queued rows (ordered by `created_at`) before applying worker-capability filtering in Rust. If 50+ incompatible jobs preceded a compatible one, that compatible row was invisible for the claim attempt — so a specialized or CPU/utility worker could sit idle while a job it could run waited behind a long incompatible prefix.

### Fix
- Drop the `limit 50`. The query's `WHERE` already narrows rows to the worker's gpu/type lane, and `choose_claimable_job` needs the **whole** compatible set anyway: its priority pass lets an explicit-GPU / loaded-model job jump ahead of an earlier auto-GPU one, which a bounded or early-stopping scan can't preserve.
- Why not the story's other suggestions: pushing `worker_supports_job`'s capability-list + `dryRun`/`preview` payload logic into SQL would be fragile and risk diverging from the Rust filter, so that's documented at the call site as the future scale lever if queues ever grow large enough for the full scan to matter.

## Test plan
- [x] New regression test `claim_finds_compatible_job_behind_large_incompatible_prefix`: 60 incompatible jobs enqueued before one compatible job; the worker still claims the compatible one.
- [x] `cargo fmt -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean (core/rust-api/worker).
- [x] `cargo test` (core/rust-api/worker) — 192 tests incl. the new one.
- [x] e2e (1) + parity (12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)