### PR TITLE
fix(core): harden project/character/training file writes against concurrent mutations (sc-1633)

### DIFF
--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -9,7 +9,8 @@ use serde_json::{json, Map, Value};
 use crate::asset_index::{asset_sidecars, normalize_asset, row_to_asset_record, upsert_asset_row};
 use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
-    optional_bool, optional_f64, optional_str, random_hex, read_json, relative_string, write_json,
+    atomic_write, optional_bool, optional_f64, optional_str, random_hex, read_json,
+    relative_string, write_json,
 };
 use crate::time::utc_now;
 
@@ -1292,21 +1293,10 @@ fn prepend_array_field(payload: &mut Value, field: &str, item: Value) -> Project
 }
 
 fn write_character_json(path: &Path, payload: &Value) -> ProjectStoreResult<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
     let mut output = String::new();
     write_character_value(payload, 0, None, &mut output)?;
     output.push('\n');
-    let tmp_path = path.with_extension(format!(
-        "{}.tmp",
-        path.extension()
-            .and_then(|extension| extension.to_str())
-            .unwrap_or("json")
-    ));
-    fs::write(&tmp_path, output)?;
-    fs::rename(tmp_path, path)?;
-    Ok(())
+    atomic_write(path, output.as_bytes())
 }
 
 fn write_character_value(

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, ReentrantMutexGuard};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -20,8 +20,8 @@ pub use crate::character_store::{
 };
 use crate::slug::slugify;
 use crate::store_util::{
-    is_safe_relative_path, optional_f64, optional_str, optional_u64, random_hex, read_json,
-    relative_string, write_json,
+    is_safe_relative_path, lock_project_files, optional_f64, optional_str, optional_u64,
+    random_hex, read_json, relative_string, write_json,
 };
 use crate::time::utc_now;
 use crate::training::TrainingDataset;
@@ -285,7 +285,7 @@ impl ProjectStore {
         project_id: &str,
         input: TrainingDatasetCreateInput,
     ) -> ProjectStoreResult<TrainingDataset> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         TrainingDatasetStore::new(project_path).create_dataset(project_id, input)
     }
 
@@ -325,7 +325,7 @@ impl ProjectStore {
         dataset_id: &str,
         input: TrainingDatasetUpdateInput,
     ) -> ProjectStoreResult<TrainingDataset> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         TrainingDatasetStore::new(project_path).update_dataset(project_id, dataset_id, input)
     }
 
@@ -335,7 +335,7 @@ impl ProjectStore {
         dataset_id: &str,
         input: TrainingDatasetBatchRenameInput,
     ) -> ProjectStoreResult<TrainingDataset> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         TrainingDatasetStore::new(project_path)
             .batch_rename_dataset_items(project_id, dataset_id, input)
     }
@@ -346,7 +346,7 @@ impl ProjectStore {
         dataset_id: &str,
         input: TrainingDatasetCaptionSidecarsInput,
     ) -> ProjectStoreResult<TrainingCaptionSidecarsResult> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         TrainingDatasetStore::new(project_path)
             .write_caption_sidecars(project_id, dataset_id, input)
     }
@@ -356,7 +356,7 @@ impl ProjectStore {
         project_id: &str,
         dataset_id: &str,
     ) -> ProjectStoreResult<TrainingDatasetMutationResult> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         TrainingDatasetStore::new(project_path).delete_dataset(project_id, dataset_id)
     }
 
@@ -370,7 +370,7 @@ impl ProjectStore {
     }
 
     pub fn reindex_project(&self, project_id: &str) -> ProjectStoreResult<ReindexResult> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let counts = reindex_project_path(&project_path)?;
         Ok(ReindexResult {
             project_id: project_id.to_owned(),
@@ -463,7 +463,7 @@ impl ProjectStore {
         project_id: &str,
         mut timeline: Value,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let timeline_id = required_str(&timeline, "id")?.to_owned();
         let timeline_project_id = required_str(&timeline, "projectId")?;
         if timeline_project_id != project_id {
@@ -628,7 +628,7 @@ impl ProjectStore {
         project_id: &str,
         input: CharacterCreateInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).create_character(project_id, input)
     }
 
@@ -643,7 +643,7 @@ impl ProjectStore {
         character_id: &str,
         input: CharacterUpdateInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).update_character(
             project_id,
             character_id,
@@ -656,7 +656,7 @@ impl ProjectStore {
         project_id: &str,
         character_id: &str,
     ) -> ProjectStoreResult<CharacterMutationResult> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).archive_character(character_id)
     }
 
@@ -665,7 +665,7 @@ impl ProjectStore {
         project_id: &str,
         character_id: &str,
     ) -> ProjectStoreResult<CharacterMutationResult> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).purge_character(character_id)
     }
 
@@ -675,7 +675,7 @@ impl ProjectStore {
         character_id: &str,
         input: CharacterReferenceInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).add_reference(
             project_id,
             character_id,
@@ -690,7 +690,7 @@ impl ProjectStore {
         asset_id: &str,
         input: CharacterReferenceUpdateInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).update_reference(
             project_id,
             character_id,
@@ -705,7 +705,7 @@ impl ProjectStore {
         character_id: &str,
         asset_id: &str,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).remove_reference(
             project_id,
             character_id,
@@ -719,7 +719,7 @@ impl ProjectStore {
         character_id: &str,
         input: CharacterLookInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).create_look(
             project_id,
             character_id,
@@ -734,7 +734,7 @@ impl ProjectStore {
         look_id: &str,
         input: CharacterLookUpdateInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).update_look(
             project_id,
             character_id,
@@ -749,7 +749,7 @@ impl ProjectStore {
         character_id: &str,
         look_id: &str,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).delete_look(
             project_id,
             character_id,
@@ -763,7 +763,7 @@ impl ProjectStore {
         character_id: &str,
         input: CharacterLoraInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).attach_lora(
             project_id,
             character_id,
@@ -778,7 +778,7 @@ impl ProjectStore {
         link_id: &str,
         input: CharacterLoraUpdateInput,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).update_lora_link(
             project_id,
             character_id,
@@ -793,7 +793,7 @@ impl ProjectStore {
         character_id: &str,
         link_id: &str,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         CharacterStore::new(&self.data_dir, project_path).detach_lora(
             project_id,
             character_id,
@@ -878,7 +878,7 @@ impl ProjectStore {
                 "Invalid person track ID".to_owned(),
             ));
         }
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let tracks_dir = project_path.join("person-tracks");
         let track_path = tracks_dir.join(format!("{track_id}.sceneworks.person-track.json"));
         if !track_path.exists() {
@@ -942,7 +942,7 @@ impl ProjectStore {
                 "Uploaded file is empty".to_owned(),
             ));
         }
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let upload_dir = project_path.join("assets").join("uploads");
         fs::create_dir_all(&upload_dir)?;
 
@@ -1042,7 +1042,7 @@ impl ProjectStore {
         generation_set_id: &str,
         fact: &Value,
     ) -> ProjectStoreResult<Value> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let media_rel = fact
             .get("mediaPath")
             .and_then(Value::as_str)
@@ -1077,7 +1077,7 @@ impl ProjectStore {
         job_id: &str,
         generation_set: &Value,
     ) -> ProjectStoreResult<()> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let id = generation_set
             .get("id")
             .and_then(Value::as_str)
@@ -1114,7 +1114,7 @@ impl ProjectStore {
                 "Rating must be between 0 and 5".to_owned(),
             ));
         }
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
         let mut asset = read_json(&sidecar_path)?;
         let status = asset
@@ -1155,7 +1155,7 @@ impl ProjectStore {
         project_id: &str,
         sidecar_path: &Path,
     ) -> ProjectStoreResult<()> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let asset = read_json(sidecar_path)?;
         index_asset(&project_path, &asset, Some(sidecar_path))
     }
@@ -1165,7 +1165,7 @@ impl ProjectStore {
         project_id: &str,
         asset_id: &str,
     ) -> ProjectStoreResult<AssetMutationResult> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
         let mut asset = read_json(&sidecar_path)?;
         let media_rel = asset
@@ -1219,7 +1219,7 @@ impl ProjectStore {
         project_id: &str,
         asset_id: &str,
     ) -> ProjectStoreResult<AssetMutationResult> {
-        let project_path = self.find_project_path(project_id)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
         let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
         let asset = read_json(&sidecar_path)?;
         let media_path = project_path.join(
@@ -1303,10 +1303,22 @@ impl ProjectStore {
 
     fn save_registry(&self, projects: &[RegistryItem]) -> ProjectStoreResult<()> {
         fs::create_dir_all(&self.data_dir)?;
-        let tmp_path = self.registry_path().with_extension("json.tmp");
-        write_json(&tmp_path, &serde_json::to_value(projects)?)?;
-        fs::rename(tmp_path, self.registry_path())?;
-        Ok(())
+        // `write_json` stages to a unique temp and renames atomically (sc-1633),
+        // so the registry write no longer needs its own intermediate temp file.
+        write_json(&self.registry_path(), &serde_json::to_value(projects)?)
+    }
+
+    /// Resolves the project path and acquires the per-project file lock, so the
+    /// caller's read-modify-write of that project's JSON/sidecar files is
+    /// serialized against other threads mutating the same project (sc-1633).
+    /// Read-only paths keep using [`find_project_path`] and don't take the lock.
+    fn lock_project(
+        &self,
+        project_id: &str,
+    ) -> ProjectStoreResult<(PathBuf, ReentrantMutexGuard<'static, ()>)> {
+        let project_path = self.find_project_path(project_id)?;
+        let guard = lock_project_files(&project_path);
+        Ok((project_path, guard))
     }
 
     fn find_project_path(&self, project_id: &str) -> ProjectStoreResult<PathBuf> {
@@ -2580,9 +2592,10 @@ fn move_or_copy_file(source: &Path, destination: &Path) -> ProjectStoreResult<()
 mod tests {
     use super::{
         build_generated_asset_sidecar, guess_mime_from_filename, is_safe_relative_path,
-        ProjectStore, PROJECT_FOLDERS,
+        CharacterCreateInput, CharacterLookInput, ProjectStore, PROJECT_FOLDERS,
     };
     use serde_json::{json, Value};
+    use std::sync::Arc;
 
     #[test]
     fn build_generated_asset_sidecar_assembles_the_contract_schema() {
@@ -3068,5 +3081,70 @@ mod tests {
             guess_mime_from_filename("reference.avif").as_deref(),
             Some("image/avif")
         );
+    }
+
+    #[test]
+    fn concurrent_look_adds_do_not_lose_updates() {
+        // sc-1633: create_character_look does a read-modify-write of the character
+        // sidecar (read looks -> prepend -> write). The per-project file lock makes
+        // overlapping calls serialize, so concurrent threads can't clobber each
+        // other's appended look. Without the lock this race drops updates and the
+        // final count comes up short. Asserts the lock is wired into the mutation.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = Arc::new(ProjectStore::new(
+            temp_dir.path().join("data"),
+            "test-version",
+        ));
+        let project = store.create_project("Race").expect("project creates");
+        let character = store
+            .create_character(
+                &project.id,
+                CharacterCreateInput {
+                    name: "Hero".to_owned(),
+                    character_type: "person".to_owned(),
+                    description: String::new(),
+                },
+            )
+            .expect("character creates");
+        let character_id = character
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("character id")
+            .to_owned();
+
+        let threads = 4;
+        let per_thread = 12;
+        std::thread::scope(|scope| {
+            for worker in 0..threads {
+                let store = Arc::clone(&store);
+                let project_id = project.id.clone();
+                let character_id = character_id.clone();
+                scope.spawn(move || {
+                    for index in 0..per_thread {
+                        store
+                            .create_character_look(
+                                &project_id,
+                                &character_id,
+                                CharacterLookInput {
+                                    name: format!("look-{worker}-{index}"),
+                                    description: String::new(),
+                                    approved_reference_ids: Vec::new(),
+                                    recipe_settings: serde_json::Map::new(),
+                                },
+                            )
+                            .expect("look adds");
+                    }
+                });
+            }
+        });
+
+        let character = store
+            .get_character(&project.id, &character_id)
+            .expect("character reads");
+        let looks = character
+            .get("looks")
+            .and_then(Value::as_array)
+            .expect("looks array");
+        assert_eq!(looks.len(), threads * per_thread);
     }
 }

--- a/crates/sceneworks-core/src/store_util.rs
+++ b/crates/sceneworks-core/src/store_util.rs
@@ -1,6 +1,10 @@
+use std::collections::hash_map::DefaultHasher;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::Path;
+use std::sync::OnceLock;
 
+use parking_lot::{ReentrantMutex, ReentrantMutexGuard};
 use rusqlite::Connection;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -13,21 +17,66 @@ pub(crate) fn read_json(path: &Path) -> ProjectStoreResult<Value> {
     Ok(serde_json::from_str(&payload)?)
 }
 
-pub(crate) fn write_json<T: Serialize>(path: &Path, payload: &T) -> ProjectStoreResult<()> {
+/// Atomically writes `contents` to `path`: stage into a uniquely-named temp file
+/// in the same directory, then rename it into place.
+///
+/// The temp suffix carries random bytes so two threads writing the *same* target
+/// never collide on the temp path. Previously the temp name was deterministic
+/// (`foo.json` -> `foo.json.tmp`), so overlapping writers interleaved their bytes
+/// into one temp file and the second `rename` failed once the first had already
+/// renamed the temp away (sc-1633). Pair with [`lock_project_files`] when the
+/// caller does a read-modify-write so concurrent updates don't clobber each other.
+pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> ProjectStoreResult<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or("json");
+    let token = random_hex(8)?;
+    let tmp_path = path.with_extension(format!("{extension}.{token}.tmp"));
+    fs::write(&tmp_path, contents)?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+pub(crate) fn write_json<T: Serialize>(path: &Path, payload: &T) -> ProjectStoreResult<()> {
     let mut output = serde_json::to_string_pretty(payload)?;
     output.push('\n');
-    let tmp_path = path.with_extension(format!(
-        "{}.tmp",
-        path.extension()
-            .and_then(|extension| extension.to_str())
-            .unwrap_or("json")
-    ));
-    fs::write(&tmp_path, output)?;
-    fs::rename(tmp_path, path)?;
-    Ok(())
+    atomic_write(path, output.as_bytes())
+}
+
+const PROJECT_LOCK_STRIPES: usize = 256;
+
+/// Process-wide striped locks that serialize file read-modify-write within a
+/// single project. A store resolves the project path, then holds this guard
+/// across its read -> mutate -> write so concurrent API/worker mutations to the
+/// same project can't lose each other's sidecar/JSON updates (sc-1633).
+///
+/// Striping (rather than a per-path map) keeps this allocation-free with no
+/// unbounded growth; distinct projects only contend on the rare hash collision.
+/// The lock is *reentrant* so a mutating method that calls another mutating
+/// method on the same project (e.g. `create_timeline` -> `save_timeline`) does
+/// not self-deadlock on the single blocking thread that runs the call chain.
+///
+/// Scope: this guards mutations that flow through `ProjectStore` within one
+/// process. It does not coordinate separate OS processes writing the same
+/// project directory; that is out of scope for the single-API desktop model.
+fn project_locks() -> &'static [ReentrantMutex<()>] {
+    static LOCKS: OnceLock<Vec<ReentrantMutex<()>>> = OnceLock::new();
+    LOCKS.get_or_init(|| {
+        (0..PROJECT_LOCK_STRIPES)
+            .map(|_| ReentrantMutex::new(()))
+            .collect()
+    })
+}
+
+pub(crate) fn lock_project_files(project_path: &Path) -> ReentrantMutexGuard<'static, ()> {
+    let mut hasher = DefaultHasher::new();
+    project_path.hash(&mut hasher);
+    let index = (hasher.finish() as usize) % PROJECT_LOCK_STRIPES;
+    project_locks()[index].lock()
 }
 
 pub(crate) fn relative_string(root: &Path, path: &Path) -> ProjectStoreResult<String> {
@@ -84,4 +133,78 @@ where
 {
     serde_json::from_value(Value::String(value.to_owned()))
         .expect("string enum deserialization is infallible")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{atomic_write, lock_project_files};
+
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers_to_same_path() {
+        // sc-1633: the temp file is uniquely named, so overlapping writers to the
+        // same target never collide. With the old deterministic `*.tmp` name they
+        // interleaved bytes and the second `rename` failed (the temp was already
+        // renamed away) — which would surface here as an Err from `atomic_write`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("doc.json");
+        std::thread::scope(|scope| {
+            for writer in 0..8 {
+                let path = path.clone();
+                scope.spawn(move || {
+                    for _ in 0..50 {
+                        atomic_write(&path, format!("{{\"writer\":{writer}}}").as_bytes())
+                            .expect("atomic_write never collides on its temp file");
+                    }
+                });
+            }
+        });
+        // The final file is exactly one writer's complete value, never torn.
+        let contents = std::fs::read_to_string(&path).expect("file reads");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&contents).expect("final contents are valid json");
+        assert!(parsed
+            .get("writer")
+            .and_then(|value| value.as_i64())
+            .is_some());
+    }
+
+    #[test]
+    fn lock_project_files_serializes_read_modify_write() {
+        // sc-1633: holding the per-project lock across read -> mutate -> write makes
+        // overlapping increments serialize. Without it the read/write window races
+        // and the total comes up short of the expected count.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).expect("project dir");
+        let counter = project.join("counter.json");
+        std::fs::write(&counter, "0").expect("counter seed");
+
+        let threads = 8;
+        let per_thread = 50;
+        std::thread::scope(|scope| {
+            for _ in 0..threads {
+                let project = project.clone();
+                let counter = counter.clone();
+                scope.spawn(move || {
+                    for _ in 0..per_thread {
+                        let _guard = lock_project_files(&project);
+                        let current: i64 = std::fs::read_to_string(&counter)
+                            .expect("counter reads")
+                            .trim()
+                            .parse()
+                            .expect("counter parses");
+                        atomic_write(&counter, (current + 1).to_string().as_bytes())
+                            .expect("counter writes");
+                    }
+                });
+            }
+        });
+
+        let total: i64 = std::fs::read_to_string(&counter)
+            .expect("counter reads")
+            .trim()
+            .parse()
+            .expect("counter parses");
+        assert_eq!(total, (threads * per_thread) as i64);
+    }
 }

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 
 use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
-    is_safe_id, is_safe_relative_path, parse_string_enum, random_hex, read_json, relative_string,
-    write_json,
+    atomic_write, is_safe_id, is_safe_relative_path, parse_string_enum, random_hex, read_json,
+    relative_string, write_json,
 };
 use crate::time::utc_now;
 use crate::training::{
@@ -1077,13 +1077,7 @@ fn read_dataset(path: &Path) -> ProjectStoreResult<TrainingDataset> {
 }
 
 fn write_text(path: &Path, payload: &str) -> ProjectStoreResult<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let tmp_path = path.with_extension("txt.tmp");
-    fs::write(&tmp_path, payload)?;
-    fs::rename(tmp_path, path)?;
-    Ok(())
+    atomic_write(path, payload.as_bytes())
 }
 
 fn dataset_item_path(


### PR DESCRIPTION
## Summary
Fixes two races on per-project JSON/sidecar files (sc-1633), both in `sceneworks-core`:

1. **Deterministic temp paths → torn writes + rename failures.** `write_json`, `write_character_json`, and `write_text` all staged to `<name>.<ext>.tmp`, so two threads writing the *same* target collided on one temp file and the second `fs::rename` failed once the first had renamed it away. All three now route through a shared `store_util::atomic_write` that stages to a **uniquely-named** temp (`random_hex` suffix) before the atomic rename. `save_registry`'s now-redundant manual temp+rename is dropped.

2. **No lock around read-modify-write → lost updates.** The only app-level lock guarded the recent-project registry; per-project sidecar/JSON mutations ran concurrently through the API's `spawn_blocking` pool, so overlapping read → mutate → write could clobber each other. Added a process-global **striped `ReentrantMutex`** registry keyed by project path (`store_util::lock_project_files`) plus a `ProjectStore::lock_project` helper. Every mutating `ProjectStore` entry point (28 methods: training, character, timeline-writer, person-track corrections, asset import/persist/status/delete/purge/index, reindex) now resolves the path and holds the lock across its write. Read-only paths keep using `find_project_path` and take no lock.

### Why this design
- **ReentrantMutex**: wrapper → writer chains on one thread (e.g. `create_timeline` → `save_timeline`) re-enter safely; the whole call chain runs on a single `spawn_blocking` thread.
- **Striped, not a per-path map**: allocation-free, no unbounded growth; distinct projects only contend on a rare hash collision.
- **Single layer (`ProjectStore`)**: the API never constructs the leaf `CharacterStore`/`TrainingDatasetStore` directly, so locking at the `ProjectStore` boundary is the one chokepoint and keeps leaf stores lock-free. Each method touches one project → no lock-ordering hazard.

### Scope / limits
In-process only. This guards mutations flowing through `ProjectStore` within one process (the single-API desktop model); it does not coordinate separate OS processes writing the same project dir.

## Test plan
- [x] `cargo test -p sceneworks-core` — 3 new tests: `atomic_write_tolerates_concurrent_writers_to_same_path`, `lock_project_files_serializes_read_modify_write`, and a wiring regression `concurrent_look_adds_do_not_lose_updates` (4 threads × `create_character_look`, asserts no looks lost)
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean (core + rust-api + worker)
- [x] `cargo test` rust-api (62) + worker (30) pass
- [x] `pytest -m e2e` (1) and `pytest -m parity` (12) pass against the built API

🤖 Generated with [Claude Code](https://claude.com/claude-code)