### PR TITLE
fix(core): include model_convert in non-GPU dispatch filters (sc-1629)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use parking_lot::Mutex;
 use rusqlite::{params, params_from_iter, Connection, OptionalExtension, Row, ToSql};
@@ -40,6 +41,23 @@ pub const NON_GPU_JOB_TYPES: &[&str] = &[
     "lora_import",
 ];
 pub const MAX_JOB_ATTEMPTS: u32 = 5;
+
+/// The non-GPU job types as a quoted SQL list for `type in (...)` / `type not in
+/// (...)` dispatch filters, derived once from [`NON_GPU_JOB_TYPES`]. This keeps
+/// the SQL from drifting away from the declared contract — the drift this fixes
+/// was `model_convert` living in the const but missing from the hard-coded SQL
+/// lists (sc-1629). Values are crate constants, never user input, so direct
+/// interpolation is safe.
+fn non_gpu_job_types_sql() -> &'static str {
+    static SQL: OnceLock<String> = OnceLock::new();
+    SQL.get_or_init(|| {
+        NON_GPU_JOB_TYPES
+            .iter()
+            .map(|job_type| format!("'{job_type}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    })
+}
 const DISPATCH_MEMORY_NOT_WORSE_TOLERANCE_MB: f64 = 512.0;
 const DISPATCH_MEMORY_RELIEF_THRESHOLD_MB: f64 = 1024.0;
 const DISPATCH_LOW_MEMORY_THRESHOLD_MB: f64 = 2048.0;
@@ -618,28 +636,32 @@ impl JobsStore {
         let worker = self.get_worker_on_connection(&transaction, worker_id)?;
         let has_active_gpu_job = transaction
             .query_row(
-                "
+                &format!(
+                    "
                 select id from jobs
                  where assigned_gpu = ?1
                    and status in ('preparing', 'downloading', 'loading_model', 'running', 'saving')
-                   and type not in ('model_download', 'model_import', 'lora_import')
+                   and type not in ({})
                  limit 1
                 ",
+                    non_gpu_job_types_sql()
+                ),
                 params![worker.gpu_id],
                 |_row| Ok(()),
             )
             .optional()?
             .is_some();
 
-        let mut statement = transaction.prepare(
+        let mut statement = transaction.prepare(&format!(
             "
             select * from jobs
              where status = 'queued'
-               and (type in ('model_download', 'model_import', 'lora_import') or requested_gpu = 'auto' or requested_gpu = ?1)
-               and (?2 = 0 or type in ('model_download', 'model_import', 'lora_import'))
+               and (type in ({list}) or requested_gpu = 'auto' or requested_gpu = ?1)
+               and (?2 = 0 or type in ({list}))
              order by created_at asc
             ",
-        )?;
+            list = non_gpu_job_types_sql()
+        ))?;
         let queued_rows = collect_jobs(statement.query_map(
             params![worker.gpu_id, i64::from(has_active_gpu_job)],
             row_to_job,
@@ -1203,13 +1225,16 @@ fn should_defer_auto_gpu_claim(
 fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResult<bool> {
     Ok(connection
         .query_row(
-            "
+            &format!(
+                "
             select id from jobs
              where assigned_gpu = ?1
                and status in ('preparing', 'downloading', 'loading_model', 'running', 'saving')
-               and type not in ('model_download', 'model_import', 'lora_import')
+               and type not in ({})
              limit 1
             ",
+                non_gpu_job_types_sql()
+            ),
             params![gpu_id],
             |_row| Ok(()),
         )

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -143,6 +143,62 @@ fn non_gpu_jobs_can_claim_while_gpu_is_busy() {
 }
 
 #[test]
+fn model_convert_can_claim_while_gpu_is_busy() {
+    // sc-1629: model_convert is declared non-GPU (NON_GPU_JOB_TYPES) and the
+    // worker/UI treat it that way, but the dispatch SQL used to omit it from its
+    // non-GPU lists — so a queued model_convert would be gated behind GPU work.
+    // It must claim on the CPU lane even while a GPU job is active on the worker.
+    let store = store("model-convert-claim");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "worker-1".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            gpu_name: None,
+            capabilities: vec![
+                WorkerCapability::ImageGenerate,
+                WorkerCapability::ModelConvert,
+            ],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("worker registers");
+
+    let gpu_job = store
+        .create_job(image_job(Map::new()))
+        .expect("gpu job creates");
+    let convert_job = store
+        .create_job(CreateJob {
+            job_type: JobType::ModelConvert,
+            project_id: None,
+            project_name: None,
+            payload: object(json!({ "model": "owner/model" })),
+            requested_gpu: "auto".to_owned(),
+            source_job_id: None,
+            duplicate_of_job_id: None,
+            attempts: 1,
+        })
+        .expect("convert job creates");
+
+    // First claim takes the GPU job; it is now active on gpu-0.
+    assert_eq!(
+        store
+            .claim_next_job("worker-1")
+            .expect("first claim succeeds")
+            .expect("first job")
+            .id,
+        gpu_job.id
+    );
+    // With a GPU job active only non-GPU work is claimable; model_convert must
+    // still claim and land on the CPU lane.
+    let second = store
+        .claim_next_job("worker-1")
+        .expect("second claim succeeds")
+        .expect("second job");
+    assert_eq!(second.id, convert_job.id);
+    assert_eq!(second.assigned_gpu.as_deref(), Some("cpu"));
+}
+
+#[test]
 fn claim_skips_jobs_not_supported_by_worker_capabilities() {
     let store = store("capabilities");
     store


### PR DESCRIPTION
## Summary
`model_convert` is declared non-GPU in `NON_GPU_JOB_TYPES` (and `job_requires_gpu`, the worker, and `QueueScreen.jsx` all treat it that way), but the SQL dispatch filters in `jobs_store.rs` hard-coded only `('model_download','model_import','lora_import')` — omitting `model_convert` from all four branches:
- `claim_next_job`: the has-active-gpu-job probe (`type not in (...)`) and the queued-rows gpu-lane / gpu-busy gates (`type in (...)` ×2)
- `active_gpu_job_exists`: `type not in (...)`

Net effect: a queued `model_convert` job was scheduled as if it required a GPU, so CPU-utility conversion work could be serialized behind GPU work and disagree with the worker/UI contract.

## Fix
Centralized the filter (the story's preferred option): a `non_gpu_job_types_sql()` helper derives the quoted SQL IN-list **once** from `NON_GPU_JOB_TYPES` (crate constants, never user input — safe to interpolate) and is used at all four sites. This removes the exact drift that caused this bug: the list now has a single source.

## Out of scope
`run_model_convert_job`'s `outputDir` path-traversal (sc-1655) and `model_download`'s `targetDir` (sc-1637) are separate stories — not touched here.

## Test plan
- [x] New `cargo test -p sceneworks-core` integration test `model_convert_can_claim_while_gpu_is_busy` — registers a worker with an active GPU job, then asserts a queued `model_convert` still claims on the CPU lane (would return `None`/panic without the fix)
- [x] jobs_store integration suite 28 pass; `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean (core + rust-api + worker)
- [x] `cargo test` rust-api (62) + worker (30) pass
- [x] `pytest -m e2e` (1) and `pytest -m parity` (12) pass against the rebuilt API

🤖 Generated with [Claude Code](https://claude.com/claude-code)