### PR TITLE
fix(worker): report VQA and interleave job types in --check output (sc-1635)

### DIFF
--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -81,6 +81,20 @@ VQA_JOB_TYPES = ("image_vqa",)
 # replaced. Keep in sync with contracts.rs::JobType/WorkerCapability,
 # jobs_store::job_requires_gpu, and QueueScreen gpuRequiredJobTypes.
 INTERLEAVE_JOB_TYPES = ("image_interleave",)
+# Every runtime-dispatchable job-type group, in a stable order, for the
+# ``--check`` diagnostic. Derived from the groups above so run_check can't drift
+# out of sync and underreport readiness (sc-1635: VQA + interleave were
+# advertised and dispatched but missing from the check output).
+# ``lora_train_execute`` is a capability flag, not a dispatchable job type, so it
+# is intentionally absent here (it still appears in the ``capabilities`` field).
+ALL_JOB_TYPES = (
+    SUPPORTED_JOB_TYPES
+    + PERSON_JOB_TYPES
+    + TRAINING_JOB_TYPES
+    + CAPTION_JOB_TYPES
+    + VQA_JOB_TYPES
+    + INTERLEAVE_JOB_TYPES
+)
 
 
 def emit(payload: dict) -> None:
@@ -1388,11 +1402,9 @@ def run_check(settings: WorkerSettings) -> None:
             "gpu": gpu,
             "capabilities": capabilities,
             "jobTypes": [
-                job_type
-                for job_type in SUPPORTED_JOB_TYPES + PERSON_JOB_TYPES + TRAINING_JOB_TYPES + CAPTION_JOB_TYPES
-                if job_type in capabilities
+                job_type for job_type in ALL_JOB_TYPES if job_type in capabilities
             ],
-            "supportedJobTypes": list(SUPPORTED_JOB_TYPES + PERSON_JOB_TYPES + TRAINING_JOB_TYPES + CAPTION_JOB_TYPES),
+            "supportedJobTypes": list(ALL_JOB_TYPES),
             "reportedAt": utc_now(),
         }
     )

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1659,6 +1659,10 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         "person_track",
         "lora_train",
         "training_caption",
+        # sc-1635: VQA + interleave are advertised and dispatched, so the check
+        # must report them too.
+        "image_vqa",
+        "image_interleave",
     ]
     assert events[0]["supportedJobTypes"] == events[0]["jobTypes"]
 


### PR DESCRIPTION
## Summary
`run_check` built its `jobTypes` / `supportedJobTypes` from only `SUPPORTED + PERSON + TRAINING + CAPTION` groups, omitting VQA (`image_vqa`) and interleave (`image_interleave`) — even though the runtime advertises both as capabilities (`worker_capabilities`) and dispatches them (the runtime job loop). So `python -m scene_worker --check` underreported runtime readiness, which could mislead setup verification / debugging.

## Fix
Introduced an `ALL_JOB_TYPES` aggregate derived **once** from the group constants (now including VQA + interleave) and used it for both check lists, so the diagnostic can't drift from the advertised/dispatched set again. `lora_train_execute` stays out of the job-type lists — it's a capability flag, not a dispatchable job type, and still appears in the `capabilities` field.

## Test plan
- [x] Updated the existing diagnostic-contract test `test_worker_check_reports_inference_sidecar_capabilities` to pin the corrected list (now includes `image_vqa`, `image_interleave`)
- [x] Light-dep worker suite green: `tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` → 259 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)