### PR TITLE
refactor(rust-api): extract auth/access middleware into auth.rs (sc-1636)

### DIFF
--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+pub(crate) async fn access_control(
+    State(state): State<AppState>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    if request.method() == Method::OPTIONS
+        || !requires_token(request.uri().path())
+        || is_authorized(request.headers(), &state.settings)
+    {
+        return next.run(request).await;
+    }
+
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "detail": "SceneWorks access token required",
+            "authRequired": true
+        })),
+    )
+        .into_response()
+}
+
+pub(crate) fn cors_layer(settings: &Settings) -> CorsLayer {
+    let origins = settings
+        .cors_origins
+        .iter()
+        .filter_map(|origin| HeaderValue::from_str(origin).ok())
+        .collect::<Vec<_>>();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            header::AUTHORIZATION,
+            header::CONTENT_TYPE,
+            HeaderName::from_static("x-sceneworks-token"),
+        ])
+}
+
+/// Whether a path is gated by the access token. Only `/api/*` routes are
+/// protected (minus the explicitly public ones); everything else is the
+/// embedded web bundle / SPA fallback, which a browser must be able to load
+/// before it can attach the token header.
+pub(crate) fn requires_token(path: &str) -> bool {
+    path.starts_with("/api/") && !PUBLIC_PATHS.contains(&path)
+}
+
+pub(crate) fn is_authorized(headers: &HeaderMap, settings: &Settings) -> bool {
+    if settings.access_token.is_empty() {
+        return true;
+    }
+    constant_time_eq(
+        token_from_headers(headers).as_bytes(),
+        settings.access_token.as_bytes(),
+    )
+}
+
+fn token_from_headers(headers: &HeaderMap) -> String {
+    if let Some(token) = headers
+        .get("x-sceneworks-token")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return token.to_owned();
+    }
+    headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_owned()
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right.iter())
+        .fold(0, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -62,6 +62,9 @@ use tokio_util::io::ReaderStream;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use uuid::Uuid;
 
+mod auth;
+use auth::{access_control, cors_layer, is_authorized};
+
 const PUBLIC_PATHS: &[&str] = &[
     "/api/v1/health",
     "/api/v1/access",
@@ -5107,99 +5110,6 @@ fn sse_message_event(message: EventMessage) -> Event {
 
 fn heartbeat_event() -> Event {
     Event::default().event("heartbeat").data(HEARTBEAT_SSE_DATA)
-}
-
-async fn access_control(
-    State(state): State<AppState>,
-    request: Request<axum::body::Body>,
-    next: Next,
-) -> Response {
-    if request.method() == Method::OPTIONS
-        || !requires_token(request.uri().path())
-        || is_authorized(request.headers(), &state.settings)
-    {
-        return next.run(request).await;
-    }
-
-    (
-        StatusCode::UNAUTHORIZED,
-        Json(json!({
-            "detail": "SceneWorks access token required",
-            "authRequired": true
-        })),
-    )
-        .into_response()
-}
-
-fn cors_layer(settings: &Settings) -> CorsLayer {
-    let origins = settings
-        .cors_origins
-        .iter()
-        .filter_map(|origin| HeaderValue::from_str(origin).ok())
-        .collect::<Vec<_>>();
-
-    CorsLayer::new()
-        .allow_origin(AllowOrigin::list(origins))
-        .allow_methods([
-            Method::GET,
-            Method::POST,
-            Method::PUT,
-            Method::PATCH,
-            Method::DELETE,
-            Method::OPTIONS,
-        ])
-        .allow_headers([
-            header::AUTHORIZATION,
-            header::CONTENT_TYPE,
-            HeaderName::from_static("x-sceneworks-token"),
-        ])
-}
-
-/// Whether a path is gated by the access token. Only `/api/*` routes are
-/// protected (minus the explicitly public ones); everything else is the
-/// embedded web bundle / SPA fallback, which a browser must be able to load
-/// before it can attach the token header.
-fn requires_token(path: &str) -> bool {
-    path.starts_with("/api/") && !PUBLIC_PATHS.contains(&path)
-}
-
-fn is_authorized(headers: &HeaderMap, settings: &Settings) -> bool {
-    if settings.access_token.is_empty() {
-        return true;
-    }
-    constant_time_eq(
-        token_from_headers(headers).as_bytes(),
-        settings.access_token.as_bytes(),
-    )
-}
-
-fn token_from_headers(headers: &HeaderMap) -> String {
-    if let Some(token) = headers
-        .get("x-sceneworks-token")
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        return token.to_owned();
-    }
-    headers
-        .get("authorization")
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .and_then(|value| value.strip_prefix("Bearer "))
-        .map(str::trim)
-        .unwrap_or_default()
-        .to_owned()
-}
-
-fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
-    if left.len() != right.len() {
-        return false;
-    }
-    left.iter()
-        .zip(right.iter())
-        .fold(0, |difference, (left, right)| difference | (left ^ right))
-        == 0
 }
 
 async fn store_call<T, F>(state: AppState, operation: F) -> Result<T, ApiError>

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1,9 +1,10 @@
+use super::auth::requires_token;
 use super::{
     create_app, huggingface_repo_cache_path, inprocess_worker_gpu_id, insufficient_disk_space,
     lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
-    person_readiness_from_workers, requires_token, safe_download_dir, safe_repo_dir_name,
-    strip_jsonc_comments, sweep_stale_lora_uploads_before, EventHub, EventMessage, Settings,
-    WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
+    person_readiness_from_workers, safe_download_dir, safe_repo_dir_name, strip_jsonc_comments,
+    sweep_stale_lora_uploads_before, EventHub, EventMessage, Settings, WorkerCapability,
+    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
     HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};


### PR DESCRIPTION
## Summary
First **production-seam** split of the API `lib.rs` for [sc-1636](https://app.shortcut.com/trefry/story/1636) (follows the test-module extraction in #216). Establishes the pattern the remaining domain modules will follow.

- Moves the access-token middleware cluster — `access_control`, `cors_layer`, `requires_token`, `is_authorized`, `token_from_headers`, `constant_time_eq` — into a dedicated `apps/rust-api/src/auth.rs`.
- **Pattern:** `auth.rs` starts with `use super::*;` so it sees the crate root's items (`AppState`, `Settings`, `PUBLIC_PATHS`, the axum/tower imports) exactly as before. The three fns referenced from outside the module (`access_control` + `cors_layer` by `create_app`, `is_authorized` by `verify_access`) are `pub(crate)` and re-imported at the root, so every call site stays unqualified. `tests.rs`'s `requires_token` import is repointed to `super::auth`.
- Behavior-preserving; no logic changes.

## Test plan
- [x] `cargo test -p sceneworks-rust-api` — 62 tests pass (same set)
- [x] `npm run rust:check` green — fmt, clippy `-D warnings`, all-crate tests, build
- [x] Diff is move + minimal wiring (`mod auth;`, one `use`, one repointed test import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)