### PR TITLE
[codex] Add model prompt guides

### DIFF
--- a/apps/web/public/prompt-guides/generic-image.md
+++ b/apps/web/public/prompt-guides/generic-image.md
@@ -1,0 +1,19 @@
+# Image Prompt Guide
+
+## Prompt Shape
+
+`subject + details + setting + style + camera/composition + lighting`
+
+## Quick Checklist
+
+- Name the main subject first.
+- Add visible details: color, material, pose, expression, props.
+- Describe the setting and background.
+- Pick a visual style.
+- Specify camera angle, shot size, and composition.
+- Describe lighting and mood through visible cues.
+- Quote exact text if the image should contain words.
+
+## Example
+
+`A glass teapot filled with amber tea on a walnut table, steam rising, scattered jasmine flowers, soft morning window light from the left, close-up product photograph, shallow depth of field, calm warm atmosphere.`

--- a/apps/web/public/prompt-guides/generic-video.md
+++ b/apps/web/public/prompt-guides/generic-video.md
@@ -1,0 +1,19 @@
+# Video Prompt Guide
+
+## Prompt Shape
+
+`subject + scene + motion + camera movement + lighting/atmosphere + optional audio`
+
+## Quick Checklist
+
+- Describe the subject with visible traits.
+- Set the scene with location, time, weather, and props.
+- Write motion as a simple sequence from beginning to end.
+- Say how the camera moves: fixed, push in, pan, track, pull back.
+- Keep short clips focused on one main action.
+- Use present tense.
+- If dialogue is supported, put spoken words in quotes.
+
+## Example
+
+`A medium shot shows a baker opening a small oven in a quiet kitchen at dawn. Warm light spills onto the counter as steam rolls out and flour drifts in the air. The camera slowly pushes in while the baker lifts a golden loaf and smiles. Soft room tone and a faint oven hum.`

--- a/apps/web/public/prompt-guides/lens-turbo.md
+++ b/apps/web/public/prompt-guides/lens-turbo.md
@@ -1,0 +1,70 @@
+# Lens-Turbo Prompt Guide
+
+## Best For
+
+Fast Lens generations, visual brainstorming, text rendering tests, and high-detail image prompts where speed matters more than maximum refinement.
+
+## Prompt Shape
+
+Use the same dense caption style as Lens:
+
+`subject + setting + visual details + style + composition + lighting + text if needed`
+
+Lens-Turbo is distilled for 4-step generation, so keep prompts clear and avoid overloading the scene.
+
+## Build The Prompt
+
+### Subject
+
+Lead with one clear subject or a simple scene. If there are multiple subjects, state the count and placement.
+
+Good: `three glass perfume bottles arranged in a triangle on a black acrylic surface`
+
+### Details
+
+Add the few details that matter most: material, color, texture, and background. Turbo can follow rich prompts, but crowded prompts can become visually noisy.
+
+### Style
+
+Use direct style labels: `editorial product photo`, `travel poster`, `macro photography`, `oil painting portrait`, `concept art`.
+
+### Camera And Composition
+
+Use concrete camera words:
+
+- `top-down`
+- `close-up`
+- `wide angle`
+- `telephoto`
+- `centered composition`
+- `panoramic landscape`
+
+### Lighting
+
+Describe the primary light and any accent light:
+
+- `large softbox reflection`
+- `warm window light`
+- `cool rim light`
+- `golden sunset backlight`
+
+### Text In Images
+
+Lens-Turbo can handle text better when the wording, font style, size, and location are explicit.
+
+Example: `the label reads "NORTH STAR" in tall condensed white letters, centered on the bottle`.
+
+### Negative Prompt
+
+Use concise negatives: `blurred lettering, extra objects, low contrast, warped label`.
+
+## Example Prompts
+
+`A clean travel poster for a mountain railway. Large headline at the top reads "ALPINE LINE" in cream block letters. A red train curves across a snowy bridge below, pine forest and blue mountains in the background, flat vintage poster style, balanced composition, crisp readable typography.`
+
+`A close-up editorial photograph of a black ceramic espresso cup on a marble counter, thin steam rising, amber cafe light, shallow depth of field, tiny sugar crystals scattered near the saucer, realistic texture, calm morning mood.`
+
+## Sources
+
+- [Microsoft Lens-Turbo model card](https://huggingface.co/microsoft/Lens-Turbo)
+- [Microsoft Lens model card](https://huggingface.co/microsoft/Lens)

--- a/apps/web/public/prompt-guides/lens.md
+++ b/apps/web/public/prompt-guides/lens.md
@@ -1,0 +1,79 @@
+# Lens Prompt Guide
+
+## Best For
+
+High-quality text-to-image generations with strong prompt following, detailed photography, art styles, and readable text in signs, labels, and documents.
+
+## Prompt Shape
+
+Lens was trained with dense captions, so write a descriptive image caption:
+
+`subject + setting + visual details + style + composition + lighting + text if needed`
+
+The base Lens model is slower than Lens-Turbo but favors quality.
+
+## Build The Prompt
+
+### Subject
+
+Describe the subject like a caption for a finished image. Include type, position, action, and important distinguishing features.
+
+Good: `a ruby-throated hummingbird hovering in front of a red heliconia flower`
+
+### Details
+
+Lens examples often include rich material, surface, location, and atmosphere details. Add texture and context:
+
+- `hand-carved letters`
+- `aged brass compass`
+- `water droplets suspended around the subject`
+- `ornate tile border`
+
+### Style
+
+Use photographic or art direction terms:
+
+- `National Geographic wildlife photography`
+- `warm still life photography`
+- `high fantasy digital art`
+- `loose watercolor on visible paper grain`
+
+### Camera And Composition
+
+Lens supports many aspect ratios, so pair composition with the selected size:
+
+- `overhead shot`
+- `aerial drone photography`
+- `extreme macro`
+- `telephoto wildlife photography`
+- `centered product shot`
+
+### Lighting
+
+Be specific about light and reflections:
+
+- `golden hour`
+- `warm desk lamp lighting`
+- `dramatic backlit scene`
+- `soft chiaroscuro lighting`
+
+### Text In Images
+
+Quote exact text and describe the physical medium:
+
+`a ceramic tile sign reading "GRAND CENTRAL" in white mosaic letters`
+
+### Negative Prompt
+
+Use short negatives for unwanted artifacts: `blurry text, malformed hands, distorted lettering, low detail, busy background`.
+
+## Example Prompts
+
+`A rustic wooden sign at a fishing village dock reading "FRESH CATCH" in hand-carved blue letters, thick hemp rope border, fishing nets and lobster traps stacked behind it, seaside morning atmosphere, warm low sunlight, shallow depth of field.`
+
+`An artisan honey jar with a vintage botanical label reading "CLOVER HONEY" in brown serif letterpress typography, ink drawings of clover and bees, clear glass jar, kraft paper texture, soft studio product lighting, centered composition.`
+
+## Sources
+
+- [Microsoft Lens model card](https://huggingface.co/microsoft/Lens)
+- [Microsoft Lens-Turbo model card](https://huggingface.co/microsoft/Lens-Turbo)

--- a/apps/web/public/prompt-guides/ltx-2-3.md
+++ b/apps/web/public/prompt-guides/ltx-2-3.md
@@ -1,0 +1,71 @@
+# LTX-2.3 Prompt Guide
+
+## Best For
+
+Short cinematic clips, image-to-video, text-to-video, first/last-frame transitions, clip extension, and scenes with clear camera movement or dialogue.
+
+## Prompt Shape
+
+Write a single flowing paragraph:
+
+`shot + scene + action over time + character details + camera movement + lighting/atmosphere + audio or dialogue`
+
+Aim for 4 to 8 descriptive sentences. Use present tense verbs.
+
+## Build The Prompt
+
+### Subject
+
+Define the character or object with visible details: age, clothing, hair, posture, facial cues, and distinguishing features.
+
+Use physical cues instead of internal labels. Prefer `her shoulders tense and her eyes glance toward the door` over `she is nervous`.
+
+### Scene Details
+
+Describe surfaces, colors, weather, time of day, props, and background activity.
+
+### Style
+
+Use cinematic categories and visual style markers:
+
+- `documentary`
+- `film noir`
+- `modern romance`
+- `stop-motion`
+- `hand-drawn animation`
+- `fashion editorial`
+
+### Camera Angle And Movement
+
+Be explicit about camera behavior:
+
+- `slow dolly in`
+- `handheld tracking shot`
+- `camera pans right`
+- `over-the-shoulder shot`
+- `static frame`
+
+Describe what the subject looks like after the movement so the motion has a destination.
+
+### Motion
+
+Write action as a sequence from beginning to end. Avoid too many simultaneous actions. Keep chaotic physics simple.
+
+### Audio And Dialogue
+
+If the workflow supports audio/dialogue, put spoken words in quotes. Add delivery details: language, accent, volume, and tone.
+
+### What To Avoid
+
+Avoid overloaded scenes, conflicting lighting, too many characters, complex physics, and relying on readable logos or text.
+
+## Example Prompts
+
+`A medium shot opens on a chef standing alone in a quiet restaurant kitchen before dawn, white jacket sleeves rolled up, flour on her hands. Warm light from the prep counter glows against stainless steel while blue morning light enters through a small window. She presses dough flat, pauses, then smiles as it rises under her palms. The camera slowly pushes in from the doorway to a close view of her hands and face. Soft room tone, a low refrigerator hum, and the faint scrape of dough on wood fill the scene.`
+
+`A wide establishing shot shows a cyclist crossing a rain-slick bridge at night, red jacket bright against the dark river. Neon signs reflect in long streaks across the wet pavement. The rider moves from left to right while the camera tracks beside them, then gently pulls back to reveal the city skyline. Fine rain drifts through the light, with realistic motion blur and a calm cinematic mood.`
+
+## Sources
+
+- [LTX official prompting guide](https://docs.ltx.video/api-documentation/guides/prompting-guide)
+- [LTX-2.3 prompt guide blog](https://ltx.io/model/model-blog/ltx-2-3-prompt-guide)

--- a/apps/web/public/prompt-guides/qwen-image-edit.md
+++ b/apps/web/public/prompt-guides/qwen-image-edit.md
@@ -1,0 +1,60 @@
+# Qwen Image Edit Prompt Guide
+
+## Best For
+
+Precise instruction edits, combining reference images, replacing objects or clothing, changing pose/style, and preserving selected parts of the original image.
+
+## Prompt Shape
+
+Use a direct edit instruction:
+
+`source reference + edit action + preserved elements + target details + style/composition constraints`
+
+When multiple images are used, refer to them by order: `Image 1`, `Image 2`, `Image 3`.
+
+## Build The Prompt
+
+### Subject
+
+Identify the source subject clearly. Say what should be preserved: identity, pose, outfit, lighting, background, camera angle, or composition.
+
+Good: `Make the girl from Image 1 wear the black dress from Image 2 and sit in the pose from Image 3.`
+
+### Details
+
+Describe the edit with concrete visual details. For replacement edits, include color, material, shape, scale, and placement.
+
+### Style
+
+If changing style, describe both the desired style and what should stay realistic or unchanged.
+
+Use: `preserve facial identity`, `keep realistic skin texture`, `change only the background to watercolor`.
+
+### Camera And Composition
+
+For controlled edits, ask the model to keep perspective and framing:
+
+- `same camera angle`
+- `same crop`
+- `same lens perspective`
+- `do not move the subject`
+
+### Text And Layout
+
+Quote exact text and specify its location. If editing signs, labels, posters, or UI, describe font style and alignment.
+
+### Negative Prompt
+
+Use a minimal negative prompt for quality issues: `blur, extra fingers, warped text, changed identity, mismatched lighting`.
+
+## Example Prompts
+
+`Keep the person from Image 1 with the same face, hair, and camera angle. Replace the jacket with the leather jacket from Image 2, matching the original lighting and body pose. Preserve the plain gray background and realistic photography style.`
+
+`Edit the cafe sign so it reads "ORCHARD COFFEE" in white hand-painted script. Keep the storefront, awning, window reflections, and morning sunlight unchanged. The new lettering should follow the same perspective on the glass.`
+
+## Sources
+
+- [Qwen Cloud image editing docs](https://docs.qwencloud.com/developer-guides/image-generation/image-editing)
+- [Qwen Cloud image prompt guide](https://docs.qwencloud.com/developer-guides/accuracy-tuning/image-generation)
+- [Qwen Cloud text-to-image docs](https://docs.qwencloud.com/developer-guides/image-generation/text-to-image)

--- a/apps/web/public/prompt-guides/qwen-image.md
+++ b/apps/web/public/prompt-guides/qwen-image.md
@@ -1,0 +1,73 @@
+# Qwen Image Prompt Guide
+
+## Best For
+
+Detailed image composition, posters, illustration, realistic photography, complex layouts, and readable text.
+
+## Prompt Shape
+
+Use the official Qwen-style structure:
+
+`subject + setting + style + camera + atmosphere + detail modifiers`
+
+For quick ideas, the simpler shape also works:
+
+`subject + setting + style`
+
+## Build The Prompt
+
+### Subject
+
+Start with the main subject and include count, age or type, action, pose, clothing, expression, and distinguishing traits.
+
+Good: `a ceramic fox figurine wearing a tiny raincoat, standing beside a puddle`
+
+### Details
+
+Add concrete environmental and object details. Qwen Image benefits from precise layout and text instructions.
+
+For text, quote the exact words and describe typography, size, and placement.
+
+### Style
+
+Name the visual language: `realistic photography`, `watercolor`, `3D cartoon`, `ink painting`, `post-apocalyptic`, `surreal`, `flat editorial poster`.
+
+### Camera And Composition
+
+Use shot size, angle, lens, and layout words:
+
+- `extreme close-up`
+- `medium shot`
+- `long shot`
+- `eye-level perspective`
+- `bird's-eye view`
+- `low angle`
+- `macro lens`
+- `telephoto lens`
+
+### Lighting And Atmosphere
+
+Describe lighting as part of the scene:
+
+- `natural morning light`
+- `soft backlight`
+- `neon light after rain`
+- `ambient lantern glow`
+
+Add mood only when it maps to visible details: `serene`, `dramatic`, `playful`, `lonely`.
+
+### Negative Prompt
+
+Use a short negative prompt for common failures: `low resolution, blurry text, distorted hands, malformed fingers, chaotic composition, warped lettering`.
+
+## Example Prompts
+
+`A hand-drawn poster of three puppies playing with a blue ball on lush green grass. The top headline reads "COME PLAY BALL!" in bold rounded blue letters. A smaller subtitle below reads "Show Off Your Skills" in green. Fresh greens and sky blues, cheerful childlike illustration, centered poster layout, soft sunlight, decorative birds and stars.`
+
+`A macro photograph of cherries in sparkling water, bubbles clinging to the fruit, clean sharp focus, commercial product lighting, cool red and clear glass color palette, shallow depth of field, high-detail realistic texture.`
+
+## Sources
+
+- [Qwen Cloud image prompt guide](https://docs.qwencloud.com/developer-guides/accuracy-tuning/image-generation)
+- [Qwen Cloud text-to-image docs](https://docs.qwencloud.com/developer-guides/image-generation/text-to-image)
+- Supplemental Qwen-style reference: [Qimagine prompt guide](https://www.qwenimagen.com/prompt-guide)

--- a/apps/web/public/prompt-guides/sensenova-u1-8b-fast.md
+++ b/apps/web/public/prompt-guides/sensenova-u1-8b-fast.md
@@ -1,0 +1,63 @@
+# SenseNova-U1 8B Fast Prompt Guide
+
+## Best For
+
+Fast SenseNova-U1 drafts, quick layout exploration, posters, infographics, and image edits where speed matters more than final polish.
+
+## Prompt Shape
+
+Use the same structured brief as the base model:
+
+`purpose + subject/content + layout + visual hierarchy + exact text + style + details`
+
+The fast variant uses fewer steps, so be clear and avoid asking for too many unrelated ideas at once.
+
+## Build The Prompt
+
+### Subject
+
+State the topic or main subject first. If the image is informational, say what the viewer should learn.
+
+### Details
+
+Include only the details that matter most. For graphics, specify sections and labels. For realistic scenes, specify materials, props, and background.
+
+### Style
+
+Use direct style labels:
+
+- `clean infographic`
+- `modern presentation slide`
+- `friendly cartoon explainer`
+- `realistic product photo`
+- `minimal poster design`
+
+### Camera And Composition
+
+For graphics, use layout language. For photos, use camera language.
+
+Good: `three equal cards across the center`, `top-down product flat lay`, `eye-level portrait`.
+
+### Motion
+
+This is an image model, so describe implied motion only as a still frame: `fabric caught mid-sway`, `steam rising`, `water droplets suspended`.
+
+### Text And Typography
+
+Quote all required text. Keep text blocks short when possible. Specify hierarchy: title, subtitle, labels, and captions.
+
+### Editing
+
+Fast editing is useful for drafts. For critical identity preservation or maximum-quality edits, use the base SenseNova-U1 8B model.
+
+## Example Prompts
+
+`A square infographic titled "MORNING ROUTINE". Four rounded panels in a 2x2 grid show: "Hydrate", "Stretch", "Plan", "Focus". Each panel has a simple icon, one short caption, and a warm pastel background. Clean modern vector style, high contrast readable text, generous spacing.`
+
+`Keep the original portrait identity, face shape, and pose. Change the background to a bright studio wall with a soft blue gradient. Add a clean white name badge on the jacket that reads "MIRA". Preserve realistic lighting and skin texture.`
+
+## Sources
+
+- [SenseNova-U1 model card](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT)
+- [SenseNova-U1 prompt enhancement doc](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT/blob/main/docs/prompt_enhancement.md)
+- [SenseNova-U1 Infographic model card](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic)

--- a/apps/web/public/prompt-guides/sensenova-u1-8b.md
+++ b/apps/web/public/prompt-guides/sensenova-u1-8b.md
@@ -1,0 +1,69 @@
+# SenseNova-U1 8B Prompt Guide
+
+## Best For
+
+Dense images, infographics, posters, documents, precise layouts, image editing, and multimodal tasks where text and visual structure both matter.
+
+## Prompt Shape
+
+Use a structured design brief:
+
+`purpose + subject/content + layout + visual hierarchy + exact text + style + camera/composition + details`
+
+Short prompts can under-constrain SenseNova-U1, especially for infographics. Expand simple ideas into a clear layout and content plan.
+
+## Build The Prompt
+
+### Subject
+
+State the topic and main visual subject. For informational images, define the message the viewer should understand.
+
+Good: `an infographic explaining how urban rain gardens reduce street flooding`
+
+### Details
+
+For dense layouts, specify sections, labels, icons, charts, captions, and reading order. Keep every required text string exact and in quotes.
+
+### Style
+
+Name the design language:
+
+- `clean educational infographic`
+- `flat vector poster`
+- `arXiv-style technical page`
+- `presentation slide`
+- `comic explainer`
+
+### Camera And Composition
+
+For generated images, use normal camera terms. For design layouts, use layout terms:
+
+- `two-column layout`
+- `four-card grid`
+- `large title at the top`
+- `central diagram with callout labels`
+- `clear margins and no overlapping text`
+
+### Lighting
+
+For realistic scenes, describe lighting. For graphics, describe color palette and contrast instead.
+
+### Text And Typography
+
+SenseNova-U1 is useful for dense text, but it still needs exact instructions. Include font feel, relative size, alignment, and hierarchy.
+
+### Editing
+
+For edits, say what to preserve first, then what to change. Keep the edit instruction concrete and ordered.
+
+## Example Prompts
+
+`Create a vertical educational infographic titled "RAIN GARDENS AT WORK". Use a clean flat vector style with a blue and green palette. Top section: a city street with rain falling. Middle section: a cutaway soil diagram with arrows labeled "runoff", "plant roots", and "filtered water". Bottom section: three benefit cards reading "Less flooding", "Cleaner rivers", and "More habitat". Large readable sans-serif text, clear margins, no overlapping elements.`
+
+`A realistic product photograph of a transparent smart thermostat on a white wall, showing the screen text "72 F" in crisp blue digits. Soft morning window light from the left, minimal interior background, centered composition, shallow depth of field, polished glass reflections.`
+
+## Sources
+
+- [SenseNova-U1 model card](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT)
+- [SenseNova-U1 prompt enhancement doc](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT/blob/main/docs/prompt_enhancement.md)
+- [SenseNova-U1 Infographic model card](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic)

--- a/apps/web/public/prompt-guides/wan-2-2-i2v-14b.md
+++ b/apps/web/public/prompt-guides/wan-2-2-i2v-14b.md
@@ -1,0 +1,67 @@
+# Wan2.2 14B Image-to-Video Prompt Guide
+
+## Best For
+
+Animating a still image while preserving its subject, setting, and style.
+
+## Prompt Shape
+
+For image-to-video, keep the prompt focused:
+
+`subject motion + environmental motion + camera movement + preservation constraints`
+
+The input image already defines the entity, scene, and visual style. Do not redescribe everything unless you need to override it.
+
+## Build The Prompt
+
+### Subject
+
+Refer to the image subject directly:
+
+- `the person in the image`
+- `the car`
+- `the foreground flowers`
+- `the clouds in the background`
+
+### Details To Preserve
+
+Say what should stay fixed: identity, clothing, composition, background, lighting, or camera angle.
+
+### Style
+
+Usually preserve the source image style. If changing style, state it clearly, but expect stronger results when style remains consistent.
+
+### Camera Angle And Movement
+
+Use simple camera movement:
+
+- `fixed camera`
+- `slow push-in`
+- `gentle pan left`
+- `small handheld drift`
+
+### Motion
+
+Describe motion in layers:
+
+- subject motion: `turns slightly`, `blinks`, `raises one hand`
+- environment motion: `curtains sway`, `rain falls`, `dust drifts`
+- camera motion: `camera slowly pulls back`
+
+For SceneWorks, keep clips at 5 seconds or less and avoid complex action chains.
+
+### Negative Prompt
+
+Use negatives for drift and artifacts: `changed identity, warped face, static frame, blurry details, extra limbs, distorted hands, subtitles`.
+
+## Example Prompts
+
+`Keep the same subject, outfit, and background from the image. The person slowly turns their head toward the window and blinks once while their hair moves gently in a breeze. Dust particles drift through the light. Fixed camera, subtle realistic motion, preserve the original lighting and composition.`
+
+`Animate the landscape with a slow camera push-in. The lake surface ripples gently, fog moves between the trees, and small birds cross the distant sky. Preserve the original colors, mountain shapes, and quiet sunrise mood.`
+
+## Sources
+
+- [Qwen Cloud video prompt guide](https://docs.qwencloud.com/developer-guides/accuracy-tuning/video-generation)
+- [Wan2.2 GitHub repo](https://github.com/Wan-Video/Wan2.2)
+- [Wan2.2 TI2V model card](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers)

--- a/apps/web/public/prompt-guides/wan-2-2-t2v-14b.md
+++ b/apps/web/public/prompt-guides/wan-2-2-t2v-14b.md
@@ -1,0 +1,66 @@
+# Wan2.2 14B Text-to-Video Prompt Guide
+
+## Best For
+
+Higher-fidelity text-to-video clips where the whole scene must be described from scratch.
+
+## Prompt Shape
+
+Use the Wan text-to-video structure:
+
+`entity + scene + motion + aesthetic control + stylization`
+
+Because this variant is text-only, include subject, environment, style, motion, and camera information in the prompt.
+
+## Build The Prompt
+
+### Subject
+
+Describe the main entity with clear visible traits: count, clothing, color, pose, expression, and role in the scene.
+
+### Scene Details
+
+Include location, foreground/background, time of day, weather, props, and light sources.
+
+### Style
+
+Name the target look:
+
+- `cinematic realism`
+- `documentary`
+- `fantasy adventure`
+- `stylized animation`
+- `music video lighting`
+
+### Camera Angle And Movement
+
+Give a clear shot plan:
+
+- `wide shot, then slow push-in`
+- `low-angle tracking shot`
+- `static close-up`
+- `camera pans right to reveal the doorway`
+
+### Motion
+
+Write a simple sequence that fits the duration. For this SceneWorks variant, keep clips at 5 seconds or less and avoid asking for several scene changes.
+
+### Atmosphere And Lighting
+
+Describe lighting and mood through visible conditions: mist, rain, sunset, rim light, lantern glow, dust, particles, reflections.
+
+### Negative Prompt
+
+Use short negatives: `static, blurry, subtitles, overexposed, distorted limbs, crowded background`.
+
+## Example Prompts
+
+`Two anthropomorphic cats in soft boxing gear face each other on a small spotlighted stage. The orange cat bounces lightly on its feet while the gray cat raises bright blue gloves. The camera starts in a wide shot and slowly pushes in as the crowd lights shimmer in the background. Warm theatrical spotlight, playful cinematic style, clear readable action.`
+
+`A lone astronaut walks through a jungle at dusk, white suit marked with scratches and green reflections from wet leaves. Fireflies drift around the helmet as the astronaut brushes aside hanging vines. Low-angle tracking shot, slow forward movement, humid atmosphere, muted teal and amber color palette.`
+
+## Sources
+
+- [Qwen Cloud video prompt guide](https://docs.qwencloud.com/developer-guides/accuracy-tuning/video-generation)
+- [Wan2.2 GitHub repo](https://github.com/Wan-Video/Wan2.2)
+- [Wan2.2 TI2V model card](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers)

--- a/apps/web/public/prompt-guides/wan-2-2.md
+++ b/apps/web/public/prompt-guides/wan-2-2.md
@@ -1,0 +1,74 @@
+# Wan2.2 Prompt Guide
+
+## Best For
+
+Short text-to-video and image-to-video clips with clear subject motion, camera motion, and simple cinematic structure.
+
+## Prompt Shape
+
+For text-to-video:
+
+`entity + scene + motion + aesthetic control + stylization`
+
+For image-to-video:
+
+`motion + camera movement`
+
+If an image already defines the subject, setting, and style, focus the prompt on what moves and how the camera moves.
+
+## Build The Prompt
+
+### Subject
+
+For text-to-video, define the main entity and visible traits. For image-to-video, refer to the source image subject directly.
+
+### Scene Details
+
+Describe background, foreground, lighting, weather, and time of day. Keep the scene focused so motion stays coherent.
+
+### Style
+
+Use concise style labels:
+
+- `cinematic`
+- `cyberpunk`
+- `line art illustration`
+- `wasteland style`
+- `warm commercial video`
+
+### Camera Angle And Movement
+
+Wan benefits from direct camera language:
+
+- `fixed camera`
+- `camera pushes in`
+- `camera moves left`
+- `low angle`
+- `wide shot`
+- `medium close-up`
+
+### Motion
+
+Describe motion amplitude, speed, and effect:
+
+- `slowly turns toward the window`
+- `swaying gently in the wind`
+- `shattering outward in small fragments`
+
+For SceneWorks, keep clips short and write motion that can complete within the selected duration.
+
+### Negative Prompt
+
+Use negatives to reduce common video issues: `static frame, blurry details, subtitles, low quality, distorted hands, crowded background, extra limbs`.
+
+## Example Prompts
+
+`A white cat wearing sunglasses sits on a surfboard at a sunny beach. The cat looks toward the camera with a relaxed expression while small waves move around the board. The camera slowly pushes in from a medium shot to a close-up. Bright summer light, crystal blue water, soft background hills, playful commercial video style.`
+
+`The source image comes alive with a gentle breeze. The woman's hair and scarf move softly, small leaves drift across the foreground, and sunlight flickers through the trees. Fixed camera, subtle natural motion, calm warm atmosphere.`
+
+## Sources
+
+- [Qwen Cloud video prompt guide](https://docs.qwencloud.com/developer-guides/accuracy-tuning/video-generation)
+- [Wan2.2 GitHub repo](https://github.com/Wan-Video/Wan2.2)
+- [Wan2.2 TI2V model card](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers)

--- a/apps/web/public/prompt-guides/z-image-edit.md
+++ b/apps/web/public/prompt-guides/z-image-edit.md
@@ -1,0 +1,63 @@
+# Z-Image-Edit Prompt Guide
+
+## Best For
+
+Instruction-based image edits where the source image should stay recognizable: style changes, object edits, text/layout changes, and creative transformations.
+
+## Prompt Shape
+
+Write an editing instruction plus the visual target:
+
+`preserve what matters + edit action + target details + style + composition/lighting constraints`
+
+Be explicit about what should remain unchanged.
+
+## Build The Prompt
+
+### Subject
+
+Refer to the source image directly: `the person`, `the car`, `the background sign`, `the red chair`. If there are multiple subjects, identify them by position.
+
+Good: `Keep the woman's face, pose, and camera angle unchanged. Replace the blue jacket with a black velvet blazer.`
+
+### Details
+
+Describe the replacement or change in concrete terms: material, color, placement, size, and relationship to existing objects.
+
+If editing text, put exact desired text in quotes and name its location.
+
+### Style
+
+For style transfers, say how strong the change should be:
+
+- `subtle film look while preserving realistic skin texture`
+- `turn the scene into a flat 1960s travel poster`
+- `make the product look like brushed aluminum`
+
+### Camera And Composition
+
+For most edits, preserve the original camera and composition unless you want a transformation. Say that directly.
+
+Use: `keep the same framing`, `same perspective`, `same lighting direction`, `do not crop the subject`.
+
+### Lighting
+
+When changing materials or inserting objects, describe how they should match the existing light:
+
+`The new glass vase should catch the same warm window light from the right.`
+
+### What To Avoid
+
+Avoid vague commands like `make it better`. Avoid stacking unrelated edits in one prompt. For multi-step changes, write them as a short ordered sentence.
+
+## Example Prompts
+
+`Keep the original portrait composition, facial identity, pose, and background unchanged. Replace the gray hoodie with a tailored emerald satin jacket, with realistic folds and highlights matching the existing soft window light. Add a small gold pin on the left lapel shaped like a crescent moon.`
+
+`Preserve the product, camera angle, and white studio background. Change the label text to read "LUMEN TEA" in clean black serif letters, centered on the bottle. Make the cap matte silver and add a faint reflection under the bottle.`
+
+## Sources
+
+- [Z-Image-Turbo model card](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo)
+- [Tongyi-MAI prompting discussion](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo/discussions/8)
+- [Z-Image prompt enhancer template](https://huggingface.co/spaces/Tongyi-MAI/Z-Image-Turbo/blob/main/pe.py)

--- a/apps/web/public/prompt-guides/z-image-turbo.md
+++ b/apps/web/public/prompt-guides/z-image-turbo.md
@@ -1,0 +1,67 @@
+# Z-Image-Turbo Prompt Guide
+
+## Best For
+
+Fast image drafts, photorealistic scenes, bilingual text in images, and prompts that need strong instruction following in a few steps.
+
+## Prompt Shape
+
+Write one detailed visual description:
+
+`subject + action + setting + important details + style + camera/composition + lighting + text requirements`
+
+Z-Image-Turbo responds well to long, specific prompts. If the idea is short, expand it before generating.
+
+## Build The Prompt
+
+### Subject
+
+Name the main subject first. Include count, identity, pose, clothing, expression, and what must not change.
+
+Good: `one ceramic tea cup with a cracked blue glaze, centered on a linen tablecloth`
+
+### Details
+
+Add the details that make the image controllable: materials, colors, props, background objects, layout, and exact relationships between objects.
+
+For text in the image, write the exact text in quotes and say where it appears.
+
+### Style
+
+Use concrete visual styles: `documentary photo`, `product render`, `ink illustration`, `children's book`, `editorial fashion`, `flat poster design`.
+
+Avoid vague praise such as `masterpiece` or `best quality`. The official prompt enhancer avoids generic quality tags and favors concrete visual description.
+
+### Camera And Composition
+
+Specify shot size, angle, lens feel, and framing:
+
+- `close-up product shot`
+- `eye-level portrait`
+- `top-down flat lay`
+- `wide establishing shot`
+- `centered composition with generous negative space`
+
+### Lighting
+
+Describe the light source and mood:
+
+- `soft window light from the left`
+- `neon reflections on wet pavement`
+- `warm backlight with a thin rim light`
+
+### Negative Prompt
+
+Turbo is usually guided by the positive prompt. If your workflow supports negative prompts, keep them short and concrete: `blurry text, extra fingers, distorted logo, crowded background`.
+
+## Example Prompts
+
+`A young woman in a red embroidered hanfu stands in a night market courtyard, holding a round fan painted with cranes. A small neon lightning sign glows above her open left palm. Behind her, a tiered pagoda is softly blurred with colorful lantern bokeh. Eye-level medium portrait, centered composition, warm lantern light mixed with cool blue night light, detailed fabric embroidery, calm expression.`
+
+`A clean bilingual bakery poster. Large headline at the top reads "MOONCAKE MORNING" in bold cream letters. Under it, smaller Chinese text reads "新鲜出炉". Three golden mooncakes sit on a jade plate, with steam rising and osmanthus flowers scattered around. Flat editorial poster style, balanced grid layout, pale green background, crisp readable typography.`
+
+## Sources
+
+- [Z-Image-Turbo model card](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo)
+- [Tongyi-MAI prompting discussion](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo/discussions/8)
+- [Z-Image prompt enhancer template](https://huggingface.co/spaces/Tongyi-MAI/Z-Image-Turbo/blob/main/pe.py)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -32,42 +32,60 @@ export const fallbackModels = [
     name: "Z-Image-Turbo",
     type: "image",
     capabilities: ["text_to_image", "style_variations", "character_image"],
-    ui: { description: "Fast local text-to-image target." },
+    ui: {
+      description: "Fast local text-to-image target.",
+      promptGuide: { title: "Z-Image-Turbo Prompt Guide", path: "/prompt-guides/z-image-turbo.md" },
+    },
   },
   {
     id: "qwen_image",
     name: "Qwen Image",
     type: "image",
     capabilities: ["text_to_image", "style_variations"],
-    ui: { description: "Qwen text-to-image target." },
+    ui: {
+      description: "Qwen text-to-image target.",
+      promptGuide: { title: "Qwen Image Prompt Guide", path: "/prompt-guides/qwen-image.md" },
+    },
   },
   {
     id: "z_image_edit",
     name: "Z-Image-Edit",
     type: "image",
     capabilities: ["edit_image"],
-    ui: { description: "Image edit target." },
+    ui: {
+      description: "Image edit target.",
+      promptGuide: { title: "Z-Image-Edit Prompt Guide", path: "/prompt-guides/z-image-edit.md" },
+    },
   },
   {
     id: "qwen_image_edit",
     name: "Qwen Image Edit",
     type: "image",
     capabilities: ["edit_image"],
-    ui: { description: "Qwen image edit target." },
+    ui: {
+      description: "Qwen image edit target.",
+      promptGuide: { title: "Qwen Image Edit Prompt Guide", path: "/prompt-guides/qwen-image-edit.md" },
+    },
   },
   {
     id: "lens",
     name: "Lens",
     type: "image",
     capabilities: ["text_to_image", "style_variations"],
-    ui: { description: "Microsoft Lens base text-to-image (20-step, CFG 5.0); higher quality than Turbo, also the LoRA training base." },
+    ui: {
+      description: "Microsoft Lens base text-to-image (20-step, CFG 5.0); higher quality than Turbo, also the LoRA training base.",
+      promptGuide: { title: "Lens Prompt Guide", path: "/prompt-guides/lens.md" },
+    },
   },
   {
     id: "lens_turbo",
     name: "Lens-Turbo",
     type: "image",
     capabilities: ["text_to_image", "style_variations"],
-    ui: { description: "Microsoft Lens distilled 4-step text-to-image; strong text rendering, large-VRAM GPU." },
+    ui: {
+      description: "Microsoft Lens distilled 4-step text-to-image; strong text rendering, large-VRAM GPU.",
+      promptGuide: { title: "Lens-Turbo Prompt Guide", path: "/prompt-guides/lens-turbo.md" },
+    },
   },
   {
     id: "sensenova_u1_8b",
@@ -75,7 +93,10 @@ export const fallbackModels = [
     type: "image",
     capabilities: ["text_to_image", "edit_image", "vqa", "interleave"],
     limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
-    ui: { description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon." },
+    ui: {
+      description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
+      promptGuide: { title: "SenseNova-U1 8B Prompt Guide", path: "/prompt-guides/sensenova-u1-8b.md" },
+    },
   },
   {
     id: "sensenova_u1_8b_fast",
@@ -83,7 +104,10 @@ export const fallbackModels = [
     type: "image",
     capabilities: ["text_to_image", "edit_image"],
     limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
-    ui: { description: "8-step distilled SenseNova-U1; ~5-6x faster text-to-image and editing (~50s/image on MPS) at a small quality trade-off. Shares the base 8B weights; a ~0.4GB distill LoRA downloads automatically. Distilled editing is experimental — use the base model for max-quality edits." },
+    ui: {
+      description: "8-step distilled SenseNova-U1; ~5-6x faster text-to-image and editing (~50s/image on MPS) at a small quality trade-off. Shares the base 8B weights; a ~0.4GB distill LoRA downloads automatically. Distilled editing is experimental — use the base model for max-quality edits.",
+      promptGuide: { title: "SenseNova-U1 8B Fast Prompt Guide", path: "/prompt-guides/sensenova-u1-8b-fast.md" },
+    },
   },
   {
     id: "ltx_2_3",
@@ -100,6 +124,7 @@ export const fallbackModels = [
     ui: {
       description: "First-class short-shot video target.",
       durationHint: "Best at 10s or less for the current workflow.",
+      promptGuide: { title: "LTX-2.3 Prompt Guide", path: "/prompt-guides/ltx-2-3.md" },
     },
   },
   {
@@ -117,6 +142,7 @@ export const fallbackModels = [
     ui: {
       description: "Fallback video family.",
       durationHint: "Keep clips short until local looping behavior is validated.",
+      promptGuide: { title: "Wan2.2 Prompt Guide", path: "/prompt-guides/wan-2-2.md" },
     },
   },
   {
@@ -134,6 +160,7 @@ export const fallbackModels = [
     ui: {
       description: "Wan2.2 A14B text-to-video (high/low-noise mixture-of-experts).",
       durationHint: "Heavier than 5B — keep clips at 5s or less. Generates at 16fps.",
+      promptGuide: { title: "Wan2.2 14B Text-to-Video Prompt Guide", path: "/prompt-guides/wan-2-2-t2v-14b.md" },
     },
   },
   {
@@ -151,6 +178,7 @@ export const fallbackModels = [
     ui: {
       description: "Wan2.2 A14B image-to-video (high/low-noise mixture-of-experts).",
       durationHint: "Heavier than 5B — keep clips at 5s or less. Generates at 16fps.",
+      promptGuide: { title: "Wan2.2 14B Image-to-Video Prompt Guide", path: "/prompt-guides/wan-2-2-i2v-14b.md" },
     },
   },
 ];

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -40,7 +40,16 @@
       "ui": {
         "label": "Z-Image-Turbo",
         "description": "Fast first image target for local text-to-image generation.",
-        "recommendedFor": ["text_to_image", "style_variations"]
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "Z-Image-Turbo Prompt Guide",
+          "path": "/prompt-guides/z-image-turbo.md",
+          "sources": [
+            { "label": "Z-Image-Turbo model card", "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo" },
+            { "label": "Tongyi-MAI prompting discussion", "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo/discussions/8" },
+            { "label": "Z-Image prompt enhancer template", "url": "https://huggingface.co/spaces/Tongyi-MAI/Z-Image-Turbo/blob/main/pe.py" }
+          ]
+        }
       }
     },
     {
@@ -78,7 +87,16 @@
       "ui": {
         "label": "Z-Image-Edit",
         "description": "Z-Image edit target using Diffusers ZImageImg2ImgPipeline while the dedicated Edit checkpoint is pending release.",
-        "recommendedFor": ["edit_image"]
+        "recommendedFor": ["edit_image"],
+        "promptGuide": {
+          "title": "Z-Image-Edit Prompt Guide",
+          "path": "/prompt-guides/z-image-edit.md",
+          "sources": [
+            { "label": "Z-Image-Turbo model card", "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo" },
+            { "label": "Tongyi-MAI prompting discussion", "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo/discussions/8" },
+            { "label": "Z-Image prompt enhancer template", "url": "https://huggingface.co/spaces/Tongyi-MAI/Z-Image-Turbo/blob/main/pe.py" }
+          ]
+        }
       }
     },
     {
@@ -115,7 +133,16 @@
       "ui": {
         "label": "Qwen Image",
         "description": "Higher-control Qwen text-to-image target backed by Diffusers.",
-        "recommendedFor": ["text_to_image", "style_variations"]
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "Qwen Image Prompt Guide",
+          "path": "/prompt-guides/qwen-image.md",
+          "sources": [
+            { "label": "Qwen Cloud image prompt guide", "url": "https://docs.qwencloud.com/developer-guides/accuracy-tuning/image-generation" },
+            { "label": "Qwen Cloud text-to-image docs", "url": "https://docs.qwencloud.com/developer-guides/image-generation/text-to-image" },
+            { "label": "Supplemental Qwen-style prompt guide", "url": "https://www.qwenimagen.com/prompt-guide" }
+          ]
+        }
       }
     },
     {
@@ -152,7 +179,16 @@
       "ui": {
         "label": "Qwen Image Edit",
         "description": "Higher-control image edit target kept behind the same adapter contract.",
-        "recommendedFor": ["edit_image"]
+        "recommendedFor": ["edit_image"],
+        "promptGuide": {
+          "title": "Qwen Image Edit Prompt Guide",
+          "path": "/prompt-guides/qwen-image-edit.md",
+          "sources": [
+            { "label": "Qwen Cloud image editing docs", "url": "https://docs.qwencloud.com/developer-guides/image-generation/image-editing" },
+            { "label": "Qwen Cloud image prompt guide", "url": "https://docs.qwencloud.com/developer-guides/accuracy-tuning/image-generation" },
+            { "label": "Qwen Cloud text-to-image docs", "url": "https://docs.qwencloud.com/developer-guides/image-generation/text-to-image" }
+          ]
+        }
       }
     },
     {
@@ -192,7 +228,15 @@
       "ui": {
         "label": "Lens (base)",
         "description": "Microsoft Lens base text-to-image (20-step, CFG 5.0): higher quality than Lens-Turbo, slower. Also the LoRA training base (sc-1583). gpt-oss-20b text encoder + FLUX.2 VAE; needs a large-VRAM GPU (~30GB mxfp4 / ~60GB bf16).",
-        "recommendedFor": ["text_to_image", "style_variations"]
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "Lens Prompt Guide",
+          "path": "/prompt-guides/lens.md",
+          "sources": [
+            { "label": "Microsoft Lens model card", "url": "https://huggingface.co/microsoft/Lens" },
+            { "label": "Microsoft Lens-Turbo model card", "url": "https://huggingface.co/microsoft/Lens-Turbo" }
+          ]
+        }
       }
     },
     {
@@ -235,7 +279,15 @@
       "ui": {
         "label": "Lens-Turbo",
         "description": "Microsoft Lens distilled 4-step text-to-image (gpt-oss-20b text encoder + FLUX.2 VAE). Strong prompt following and text rendering; needs a large-VRAM GPU (~30GB mxfp4 / ~60GB bf16).",
-        "recommendedFor": ["text_to_image", "style_variations"]
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "Lens-Turbo Prompt Guide",
+          "path": "/prompt-guides/lens-turbo.md",
+          "sources": [
+            { "label": "Microsoft Lens-Turbo model card", "url": "https://huggingface.co/microsoft/Lens-Turbo" },
+            { "label": "Microsoft Lens model card", "url": "https://huggingface.co/microsoft/Lens" }
+          ]
+        }
       }
     },
     {
@@ -278,7 +330,16 @@
       "ui": {
         "label": "SenseNova-U1 8B",
         "description": "Unified multimodal model (NEO-unify, ~16B). Native text-to-image and instruction-based editing with strong prompt following, dense text, and infographics. Heavy: ~42GB bf16, ~50 steps; runs on large-VRAM GPUs and 96GB+ Apple Silicon (MPS). VQA/interleaved not wired yet.",
-        "recommendedFor": ["text_to_image", "edit_image"]
+        "recommendedFor": ["text_to_image", "edit_image"],
+        "promptGuide": {
+          "title": "SenseNova-U1 8B Prompt Guide",
+          "path": "/prompt-guides/sensenova-u1-8b.md",
+          "sources": [
+            { "label": "SenseNova-U1 model card", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT" },
+            { "label": "SenseNova-U1 prompt enhancement doc", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT/blob/main/docs/prompt_enhancement.md" },
+            { "label": "SenseNova-U1 Infographic model card", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic" }
+          ]
+        }
       }
     },
     {
@@ -323,7 +384,16 @@
       "ui": {
         "label": "SenseNova-U1 8B Fast",
         "description": "8-step distilled SenseNova-U1 — ~5–6× faster text-to-image and editing (~50s/image on MPS vs ~4.6 min) at a small quality trade-off. Shares the SenseNova-U1 8B base weights (~35GB); a ~0.4GB distill LoRA downloads automatically on first use. Distilled editing is experimental — use the base SenseNova-U1 8B for max-quality edits.",
-        "recommendedFor": ["text_to_image", "edit_image"]
+        "recommendedFor": ["text_to_image", "edit_image"],
+        "promptGuide": {
+          "title": "SenseNova-U1 8B Fast Prompt Guide",
+          "path": "/prompt-guides/sensenova-u1-8b-fast.md",
+          "sources": [
+            { "label": "SenseNova-U1 model card", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT" },
+            { "label": "SenseNova-U1 prompt enhancement doc", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT/blob/main/docs/prompt_enhancement.md" },
+            { "label": "SenseNova-U1 Infographic model card", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic" }
+          ]
+        }
       }
     },
     {
@@ -406,7 +476,15 @@
         "label": "LTX-2.3",
         "description": "First-class short-shot video target for image-to-video and text-to-video.",
         "recommendedFor": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge"],
-        "durationHint": "Best for short clips. Start with 4-8 seconds; 10 seconds is the normal ceiling for the current workflow."
+        "durationHint": "Best for short clips. Start with 4-8 seconds; 10 seconds is the normal ceiling for the current workflow.",
+        "promptGuide": {
+          "title": "LTX-2.3 Prompt Guide",
+          "path": "/prompt-guides/ltx-2-3.md",
+          "sources": [
+            { "label": "LTX official prompting guide", "url": "https://docs.ltx.video/api-documentation/guides/prompting-guide" },
+            { "label": "LTX-2.3 prompt guide blog", "url": "https://ltx.io/model/model-blog/ltx-2-3-prompt-guide" }
+          ]
+        }
       }
     },
     {
@@ -455,7 +533,16 @@
         "label": "Wan2.2",
         "description": "Fallback video family kept behind the adapter contract for future runtime support.",
         "recommendedFor": ["image_to_video", "text_to_video"],
-        "durationHint": "Use shorter clips until local looping behavior is validated."
+        "durationHint": "Use shorter clips until local looping behavior is validated.",
+        "promptGuide": {
+          "title": "Wan2.2 Prompt Guide",
+          "path": "/prompt-guides/wan-2-2.md",
+          "sources": [
+            { "label": "Qwen Cloud video prompt guide", "url": "https://docs.qwencloud.com/developer-guides/accuracy-tuning/video-generation" },
+            { "label": "Wan2.2 GitHub repo", "url": "https://github.com/Wan-Video/Wan2.2" },
+            { "label": "Wan2.2 TI2V model card", "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers" }
+          ]
+        }
       }
     },
     // Wan2.2 A14B is a high/low-noise mixture-of-experts model split into separate
@@ -506,7 +593,16 @@
         "label": "Wan2.2 14B (T2V)",
         "description": "Wan2.2 A14B text-to-video (high/low-noise mixture-of-experts). Higher fidelity than the 5B model; needs ample VRAM for both experts.",
         "recommendedFor": ["text_to_video"],
-        "durationHint": "Heavier than 5B — keep clips at 5s or less. Generates at 16fps."
+        "durationHint": "Heavier than 5B — keep clips at 5s or less. Generates at 16fps.",
+        "promptGuide": {
+          "title": "Wan2.2 14B Text-to-Video Prompt Guide",
+          "path": "/prompt-guides/wan-2-2-t2v-14b.md",
+          "sources": [
+            { "label": "Qwen Cloud video prompt guide", "url": "https://docs.qwencloud.com/developer-guides/accuracy-tuning/video-generation" },
+            { "label": "Wan2.2 GitHub repo", "url": "https://github.com/Wan-Video/Wan2.2" },
+            { "label": "Wan2.2 TI2V model card", "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers" }
+          ]
+        }
       }
     },
     {
@@ -556,7 +652,16 @@
         "label": "Wan2.2 14B (I2V)",
         "description": "Wan2.2 A14B image-to-video (high/low-noise mixture-of-experts). Higher fidelity than the 5B model; needs ample VRAM for both experts.",
         "recommendedFor": ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
-        "durationHint": "Heavier than 5B — keep clips at 5s or less. Generates at 16fps."
+        "durationHint": "Heavier than 5B — keep clips at 5s or less. Generates at 16fps.",
+        "promptGuide": {
+          "title": "Wan2.2 14B Image-to-Video Prompt Guide",
+          "path": "/prompt-guides/wan-2-2-i2v-14b.md",
+          "sources": [
+            { "label": "Qwen Cloud video prompt guide", "url": "https://docs.qwencloud.com/developer-guides/accuracy-tuning/video-generation" },
+            { "label": "Wan2.2 GitHub repo", "url": "https://github.com/Wan-Video/Wan2.2" },
+            { "label": "Wan2.2 TI2V model card", "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers" }
+          ]
+        }
       }
     }
   ]

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -11,6 +11,41 @@
       "items": {
         "type": "object",
         "properties": {
+          "ui": {
+            "type": "object",
+            "description": "Display metadata for model catalog and studio surfaces.",
+            "properties": {
+              "promptGuide": {
+                "type": "object",
+                "description": "Static Markdown prompt guide shown near prompt entry for this model.",
+                "required": ["title", "path"],
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Human-readable guide title."
+                  },
+                  "path": {
+                    "type": "string",
+                    "pattern": "^/prompt-guides/[^?#]+\\.md$",
+                    "description": "Web-public Markdown path, served from apps/web/public."
+                  },
+                  "sources": {
+                    "type": "array",
+                    "description": "Primary or supplemental source links used to write the guide.",
+                    "items": {
+                      "type": "object",
+                      "required": ["label", "url"],
+                      "properties": {
+                        "label": { "type": "string", "minLength": 1 },
+                        "url": { "type": "string", "format": "uri" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "mlx": {
             "type": "object",
             "description": "macOS/Apple-Silicon MLX variant metadata (desktop only). Surfaced by the Model Manager to show MLX availability, conversion status, and the minimum unified-memory tier. Inference repos/paths are owned by the Python MlxVideoAdapter; these mirror them for catalog display.",

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -42,6 +42,67 @@ async function assertContains(relativePath, expected) {
   }
 }
 
+function stripJsoncComments(body) {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    const next = body[index + 1];
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      while (index < body.length && body[index] !== "\n") {
+        index += 1;
+      }
+      result += "\n";
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index < body.length && !(body[index] === "*" && body[index + 1] === "/")) {
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+async function assertBuiltinPromptGuides() {
+  const manifestPath = "config/manifests/builtin.models.jsonc";
+  const manifest = JSON.parse(stripJsoncComments(await readFile(path.join(root, manifestPath), "utf8")));
+  for (const model of manifest.models ?? []) {
+    const guide = model.ui?.promptGuide;
+    if (!guide?.title || !guide?.path) {
+      throw new Error(`${manifestPath} model ${model.id} is missing ui.promptGuide title/path`);
+    }
+    if (!Array.isArray(guide.sources) || guide.sources.length === 0) {
+      throw new Error(`${manifestPath} model ${model.id} promptGuide needs source links`);
+    }
+    if (!guide.path.startsWith("/prompt-guides/") || !guide.path.endsWith(".md")) {
+      throw new Error(`${manifestPath} model ${model.id} promptGuide path is invalid: ${guide.path}`);
+    }
+    await assertReadable(path.join("apps/web/public", guide.path.slice(1)));
+  }
+}
+
 for (const requiredPath of requiredPaths) {
   await assertReadable(requiredPath);
 }
@@ -57,5 +118,6 @@ await assertContains("docker-compose.yml", "/sceneworks/data/cache/jobs.db");
 await assertContains(".env.example", "SCENEWORKS_RUST_WORKER_GPU_ID=cpu");
 await assertContains("docker/rust-api.Dockerfile", "sceneworks-rust-api");
 await assertContains("README.md", "SCENEWORKS_ACCESS_TOKEN");
+await assertBuiltinPromptGuides();
 
 console.log("SceneWorks scaffold check passed.");


### PR DESCRIPTION
## Summary
- Add static Markdown prompt guides for every built-in SceneWorks model plus generic image/video fallbacks.
- Wire each built-in model to `ui.promptGuide` metadata with title, markdown path, and source links.
- Extend manifest schema and scaffold validation so missing guide metadata or dead markdown paths fail early.

## Impact
This prepares the model-specific prompt guide popup work by making the guide content and metadata available through the model catalog. The guides focus on user-facing prompt construction: subject, details, style, camera/composition, video motion, and source provenance.

## Validation
- `npm run check`
- `npm --prefix apps/web run build`
- `git diff --check`
- `cargo test -p sceneworks-core`
- `npm --prefix apps/web test`
