### PR TITLE
refactor(rust-api): extract events/SSE subsystem into events.rs (sc-1636)

### DIFF
--- a/apps/rust-api/src/events.rs
+++ b/apps/rust-api/src/events.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+#[derive(Debug, Clone)]
+pub(crate) struct EventMessage {
+    pub(crate) event: String,
+    pub(crate) data: String,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct EventHub {
+    state: Mutex<EventHubState>,
+}
+
+#[derive(Debug, Default)]
+struct EventHubState {
+    next_subscriber_id: u64,
+    subscribers: HashMap<u64, mpsc::Sender<EventMessage>>,
+}
+
+impl EventHub {
+    pub(crate) fn subscribe(&self) -> ReceiverStream<EventMessage> {
+        let (sender, receiver) = mpsc::channel(EVENT_BUFFER_SIZE);
+        let mut state = self.state.lock();
+        let subscriber_id = state.next_subscriber_id;
+        state.next_subscriber_id = state.next_subscriber_id.wrapping_add(1);
+        state.subscribers.insert(subscriber_id, sender);
+        ReceiverStream::new(receiver)
+    }
+
+    pub(crate) fn publish(&self, message: EventMessage) {
+        let mut state = self.state.lock();
+        state.subscribers.retain(|_, sender| {
+            sender
+                .try_send(message.clone())
+                .map(|_| true)
+                .unwrap_or(false)
+        });
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct EventTicketStore {
+    ttl: Duration,
+    tickets: Mutex<HashMap<String, Instant>>,
+}
+
+impl EventTicketStore {
+    pub(crate) fn new(ttl_seconds: u64) -> Self {
+        Self {
+            ttl: Duration::from_secs(ttl_seconds),
+            tickets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn issue(&self) -> Result<EventTicket, ApiError> {
+        let now = Instant::now();
+        let mut tickets = self.tickets.lock();
+        prune_tickets(&mut tickets, now);
+        let ticket = Uuid::new_v4().simple().to_string();
+        tickets.insert(ticket.clone(), now + self.ttl);
+        Ok(EventTicket {
+            ticket,
+            expires_in_seconds: self.ttl.as_secs(),
+        })
+    }
+
+    fn consume(&self, ticket: &str) -> Result<(), ApiError> {
+        let now = Instant::now();
+        let mut tickets = self.tickets.lock();
+        prune_tickets(&mut tickets, now);
+        match tickets.remove(ticket) {
+            Some(expires_at) if expires_at >= now => Ok(()),
+            _ => Err(ApiError::unauthorized(
+                "Invalid or expired event stream ticket",
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EventTicket {
+    ticket: String,
+    expires_in_seconds: u64,
+}
+
+pub(crate) async fn create_event_ticket(
+    State(state): State<AppState>,
+) -> Result<Json<EventTicket>, ApiError> {
+    Ok(Json(state.event_tickets.issue()?))
+}
+
+pub(crate) async fn job_events(
+    State(state): State<AppState>,
+    Query(query): Query<EventsQuery>,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    if !state.settings.access_token.is_empty() {
+        state
+            .event_tickets
+            .consume(query.ticket.as_deref().unwrap_or_default())?;
+    }
+    Ok(Sse::new(sse_event_stream(state.events.subscribe())))
+}
+
+fn sse_event_stream(
+    messages: ReceiverStream<EventMessage>,
+) -> impl futures_util::Stream<Item = Result<Event, Infallible>> {
+    let mut heartbeat = tokio::time::interval_at(
+        TokioInstant::now() + Duration::from_secs(15),
+        Duration::from_secs(15),
+    );
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    futures_util::stream::unfold(
+        (messages, heartbeat, true),
+        |(mut messages, mut heartbeat, send_ready)| async move {
+            if send_ready {
+                return Some((Ok(ready_event()), (messages, heartbeat, false)));
+            }
+            tokio::select! {
+                message = messages.next() => {
+                    message.map(|message| (Ok(sse_message_event(message)), (messages, heartbeat, false)))
+                }
+                _ = heartbeat.tick() => {
+                    Some((Ok(heartbeat_event()), (messages, heartbeat, false)))
+                }
+            }
+        },
+    )
+}
+
+fn ready_event() -> Event {
+    Event::default()
+        .event("ready")
+        .data(json!({ "status": "connected" }).to_string())
+}
+
+fn sse_message_event(message: EventMessage) -> Event {
+    Event::default().event(message.event).data(message.data)
+}
+
+fn heartbeat_event() -> Event {
+    Event::default().event("heartbeat").data(HEARTBEAT_SSE_DATA)
+}
+
+fn prune_tickets(tickets: &mut HashMap<String, Instant>, now: Instant) {
+    tickets.retain(|_, expires_at| *expires_at >= now);
+}

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -82,6 +82,8 @@ mod jobs;
 use jobs::*;
 mod workers;
 use workers::*;
+mod events;
+use events::*;
 
 const PUBLIC_PATHS: &[&str] = &[
     "/api/v1/health",
@@ -223,90 +225,6 @@ fn json_rejection_response(rejection: JsonRejection) -> Response {
         })),
     )
         .into_response()
-}
-
-#[derive(Debug, Clone)]
-struct EventMessage {
-    event: String,
-    data: String,
-}
-
-#[derive(Debug, Default)]
-struct EventHub {
-    state: Mutex<EventHubState>,
-}
-
-#[derive(Debug, Default)]
-struct EventHubState {
-    next_subscriber_id: u64,
-    subscribers: HashMap<u64, mpsc::Sender<EventMessage>>,
-}
-
-impl EventHub {
-    fn subscribe(&self) -> ReceiverStream<EventMessage> {
-        let (sender, receiver) = mpsc::channel(EVENT_BUFFER_SIZE);
-        let mut state = self.state.lock();
-        let subscriber_id = state.next_subscriber_id;
-        state.next_subscriber_id = state.next_subscriber_id.wrapping_add(1);
-        state.subscribers.insert(subscriber_id, sender);
-        ReceiverStream::new(receiver)
-    }
-
-    fn publish(&self, message: EventMessage) {
-        let mut state = self.state.lock();
-        state.subscribers.retain(|_, sender| {
-            sender
-                .try_send(message.clone())
-                .map(|_| true)
-                .unwrap_or(false)
-        });
-    }
-}
-
-#[derive(Debug)]
-struct EventTicketStore {
-    ttl: Duration,
-    tickets: Mutex<HashMap<String, Instant>>,
-}
-
-impl EventTicketStore {
-    fn new(ttl_seconds: u64) -> Self {
-        Self {
-            ttl: Duration::from_secs(ttl_seconds),
-            tickets: Mutex::new(HashMap::new()),
-        }
-    }
-
-    fn issue(&self) -> Result<EventTicket, ApiError> {
-        let now = Instant::now();
-        let mut tickets = self.tickets.lock();
-        prune_tickets(&mut tickets, now);
-        let ticket = Uuid::new_v4().simple().to_string();
-        tickets.insert(ticket.clone(), now + self.ttl);
-        Ok(EventTicket {
-            ticket,
-            expires_in_seconds: self.ttl.as_secs(),
-        })
-    }
-
-    fn consume(&self, ticket: &str) -> Result<(), ApiError> {
-        let now = Instant::now();
-        let mut tickets = self.tickets.lock();
-        prune_tickets(&mut tickets, now);
-        match tickets.remove(ticket) {
-            Some(expires_at) if expires_at >= now => Ok(()),
-            _ => Err(ApiError::unauthorized(
-                "Invalid or expired event stream ticket",
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct EventTicket {
-    ticket: String,
-    expires_in_seconds: u64,
 }
 
 #[derive(Debug, Default)]
@@ -2807,62 +2725,6 @@ fn max_model_upload_bytes() -> usize {
         }
     }
     MAX_MODEL_UPLOAD_BYTES
-}
-
-async fn create_event_ticket(State(state): State<AppState>) -> Result<Json<EventTicket>, ApiError> {
-    Ok(Json(state.event_tickets.issue()?))
-}
-
-async fn job_events(
-    State(state): State<AppState>,
-    Query(query): Query<EventsQuery>,
-) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, ApiError> {
-    if !state.settings.access_token.is_empty() {
-        state
-            .event_tickets
-            .consume(query.ticket.as_deref().unwrap_or_default())?;
-    }
-    Ok(Sse::new(sse_event_stream(state.events.subscribe())))
-}
-
-fn sse_event_stream(
-    messages: ReceiverStream<EventMessage>,
-) -> impl futures_util::Stream<Item = Result<Event, Infallible>> {
-    let mut heartbeat = tokio::time::interval_at(
-        TokioInstant::now() + Duration::from_secs(15),
-        Duration::from_secs(15),
-    );
-    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    futures_util::stream::unfold(
-        (messages, heartbeat, true),
-        |(mut messages, mut heartbeat, send_ready)| async move {
-            if send_ready {
-                return Some((Ok(ready_event()), (messages, heartbeat, false)));
-            }
-            tokio::select! {
-                message = messages.next() => {
-                    message.map(|message| (Ok(sse_message_event(message)), (messages, heartbeat, false)))
-                }
-                _ = heartbeat.tick() => {
-                    Some((Ok(heartbeat_event()), (messages, heartbeat, false)))
-                }
-            }
-        },
-    )
-}
-
-fn ready_event() -> Event {
-    Event::default()
-        .event("ready")
-        .data(json!({ "status": "connected" }).to_string())
-}
-
-fn sse_message_event(message: EventMessage) -> Event {
-    Event::default().event(message.event).data(message.data)
-}
-
-fn heartbeat_event() -> Event {
-    Event::default().event("heartbeat").data(HEARTBEAT_SSE_DATA)
 }
 
 async fn store_call<T, F>(state: AppState, operation: F) -> Result<T, ApiError>
@@ -5990,10 +5852,6 @@ impl From<ProjectStoreError> for ApiError {
             other => Self::internal(other.to_string()),
         }
     }
-}
-
-fn prune_tickets(tickets: &mut HashMap<String, Instant>, now: Instant) {
-    tickets.retain(|_, expires_at| *expires_at >= now);
 }
 
 impl IntoResponse for ApiError {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1,11 +1,12 @@
 use super::auth::requires_token;
+use super::events::{EventHub, EventMessage};
 use super::training::insufficient_disk_space;
 use super::workers::person_readiness_from_workers;
 use super::{
     create_app, huggingface_repo_cache_path, inprocess_worker_gpu_id, lora_artifact_paths,
     merge_model_manifest_entry, mlx_catalog_status, safe_download_dir, safe_repo_dir_name,
-    strip_jsonc_comments, sweep_stale_lora_uploads_before, EventHub, EventMessage, Settings,
-    WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
+    strip_jsonc_comments, sweep_stale_lora_uploads_before, Settings, WorkerCapability,
+    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
     HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};


### PR DESCRIPTION
## Summary
Next [sc-1636](https://app.shortcut.com/trefry/story/1636) API seam (follows jobs/workers in #225). The events/SSE subsystem — gathered from three scattered regions of `lib.rs`.

- **events.rs** now holds: the `EventMessage`/`EventHub`/`EventHubState`/`EventTicketStore`/`EventTicket` types and impls, the SSE handlers (`create_event_ticket`, `job_events`, `sse_event_stream`, `ready`/`message`/`heartbeat` events), and `prune_tickets`.
- `publish`/`publish_queue` and the `EVENT_*` consts stay at the root (`publish` is called from every route; events.rs sees the consts via `use super::*`).
- `pub(crate)` only on items reached from the root: `EventHub`/`EventTicketStore` (AppState fields + `create_app`), `EventMessage` (root `publish` constructs it), the `publish`/`subscribe`/`new` methods, and the two handlers. `tests.rs`'s `EventHub`/`EventMessage` imports repointed to `super::events`.
- Behavior-preserving; `lib.rs` **6,006 → 5,865 lines** (cumulative API −58% from 13,959).

## Test plan
- [x] `cargo test -p sceneworks-rust-api` — 62 tests pass (same set)
- [x] `npm run rust:check` green — fmt, clippy `-D warnings`, all-crate tests, build
- [x] `cargo build -p sceneworks-rust-api --features embed-web` — compiles (per the #226 lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)