### PR TITLE
refactor(worker): extract the API HTTP client into api_client.rs (sc-1636)

### DIFF
--- a/crates/sceneworks-worker/src/api_client.rs
+++ b/crates/sceneworks-worker/src/api_client.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[derive(Clone)]
+pub(crate) struct ApiClient {
+    client: reqwest::Client,
+    api_url: String,
+    access_token: Option<String>,
+}
+
+impl ApiClient {
+    pub(crate) fn new(settings: &Settings) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_url: settings.api_url.trim_end_matches('/').to_owned(),
+            access_token: settings.access_token.clone(),
+        }
+    }
+
+    pub(crate) async fn get_json<T>(&self, path: &str) -> WorkerResult<T>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let response = self
+            .with_auth(self.client.get(self.url(path)))
+            .send()
+            .await?;
+        decode_api_response(response).await
+    }
+
+    pub(crate) async fn post_json<T, U>(&self, path: &str, payload: &T) -> WorkerResult<U>
+    where
+        T: serde::Serialize + ?Sized,
+        U: for<'de> Deserialize<'de>,
+    {
+        let response = self
+            .with_auth(self.client.post(self.url(path)).json(payload))
+            .send()
+            .await?;
+        decode_api_response(response).await
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn with_auth(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.access_token {
+            Some(token) => request.header("X-SceneWorks-Token", token),
+            None => request,
+        }
+    }
+}
+
+async fn decode_api_response<T>(response: reqwest::Response) -> WorkerResult<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let status = response.status();
+    if !status.is_success() {
+        let detail = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "request failed".to_owned());
+        return Err(WorkerError::Api { status, detail });
+    }
+    Ok(response.json::<T>().await?)
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -31,6 +31,8 @@ use tokio::process::{Child, Command};
 use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
 
+mod api_client;
+use api_client::*;
 mod gpu;
 use gpu::*;
 mod supervisor;
@@ -176,72 +178,6 @@ impl From<ProjectStoreError> for WorkerError {
 }
 
 pub type WorkerResult<T> = Result<T, WorkerError>;
-
-#[derive(Clone)]
-struct ApiClient {
-    client: reqwest::Client,
-    api_url: String,
-    access_token: Option<String>,
-}
-
-impl ApiClient {
-    fn new(settings: &Settings) -> Self {
-        Self {
-            client: reqwest::Client::new(),
-            api_url: settings.api_url.trim_end_matches('/').to_owned(),
-            access_token: settings.access_token.clone(),
-        }
-    }
-
-    async fn get_json<T>(&self, path: &str) -> WorkerResult<T>
-    where
-        T: for<'de> Deserialize<'de>,
-    {
-        let response = self
-            .with_auth(self.client.get(self.url(path)))
-            .send()
-            .await?;
-        decode_api_response(response).await
-    }
-
-    async fn post_json<T, U>(&self, path: &str, payload: &T) -> WorkerResult<U>
-    where
-        T: serde::Serialize + ?Sized,
-        U: for<'de> Deserialize<'de>,
-    {
-        let response = self
-            .with_auth(self.client.post(self.url(path)).json(payload))
-            .send()
-            .await?;
-        decode_api_response(response).await
-    }
-
-    fn url(&self, path: &str) -> String {
-        format!("{}{}", self.api_url, path)
-    }
-
-    fn with_auth(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        match &self.access_token {
-            Some(token) => request.header("X-SceneWorks-Token", token),
-            None => request,
-        }
-    }
-}
-
-async fn decode_api_response<T>(response: reqwest::Response) -> WorkerResult<T>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let status = response.status();
-    if !status.is_success() {
-        let detail = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "request failed".to_owned());
-        return Err(WorkerError::Api { status, detail });
-    }
-    Ok(response.json::<T>().await?)
-}
 
 #[derive(Debug, Clone, PartialEq)]
 struct DiscoveredGpu {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -13,6 +13,7 @@ use sceneworks_core::contracts::WorkerUtilizationSnapshot;
 use serde_json::{json, Value};
 use tempfile::tempdir;
 
+use super::api_client::ApiClient;
 use super::gpu::{
     cpu_gpu, cpu_worker_id, fallback_gpu, gpu_worker_id, parse_nvidia_smi_gpus, visible_gpu_ids,
     worker_capabilities_with_utility,
@@ -27,10 +28,10 @@ use super::{
     download_lora_source_url, download_progress_payload, download_snapshot, finalize_converted_dir,
     fresh_asset_id, import_lora_source_path, now_rfc3339, output_dimensions,
     resolve_model_convert_output, resolve_model_import_target, run_ffmpeg, safe_download_dir,
-    safe_project_path, value_f64, write_model_install_marker, ApiClient, DownloadContext,
-    DownloadFamilyCheck, DownloadProgress, HuggingFaceSnapshot, JsonObject, Settings, SnapshotFile,
-    WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
-    DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+    safe_project_path, value_f64, write_model_install_marker, DownloadContext, DownloadFamilyCheck,
+    DownloadProgress, HuggingFaceSnapshot, JsonObject, Settings, SnapshotFile, WorkerError,
+    DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
+    INSTALL_MARKER,
 };
 
 fn write_safetensors_with_keys(path: &std::path::Path, keys: &[String]) {


### PR DESCRIPTION
## Summary
Next worker seam for [sc-1636](https://app.shortcut.com/trefry/story/1636) (follows the supervisor split in #230).

- Moves the `ApiClient` struct/impl and the `decode_api_response` helper into `crates/sceneworks-worker/src/api_client.rs`.
- `Settings`/`WorkerError`/`WorkerResult` stay at the root as shared core types (resolved in the module via `use super::*`).
- `pub(crate)` on `ApiClient` + `new`/`get_json`/`post_json` (used by the run loop and job handlers); `url`/`with_auth`/`decode_api_response` stay private. Worker `tests.rs` `ApiClient` import repointed to `super::api_client`.
- Behavior-preserving; worker `lib.rs` **4,415 → 4,350 lines**.

## Test plan
- [x] `cargo test -p sceneworks-worker` — 30 tests pass (same set)
- [x] `npm run rust:check` green — fmt, clippy `-D warnings`, all-crate tests, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)