### PR TITLE
ci: add web tests + production build to main CI (sc-1631)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,22 @@ on:
       - "codex/**"
 
 jobs:
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/web/package-lock.json
+      - name: Install web dependencies
+        run: npm ci --prefix apps/web
+      - name: Run web test suite
+        run: npm --prefix apps/web run test
+      - name: Build web production bundle
+        run: npm --prefix apps/web run build
+
   parity:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds a dedicated `web` job to `.github/workflows/check.yml` that runs the React web test suite and Vite production build on every PR / `main` push.
- The job installs `apps/web` deps with `npm ci` (npm cache keyed on `apps/web/package-lock.json`), runs `npm run test` (vitest), then `npm run build`.
- Runs in parallel with the existing `parity` job; no changes to existing steps.

## Why
The main Check workflow ran scaffold, Rust, worker, parity/e2e, and Docker checks but never exercised the React app. React regressions, syntax issues, and bundle failures could merge outside the desktop-specific (Windows) workflow. Closes [sc-1631](https://app.shortcut.com/trefry/story/1631).

## Test plan
- [x] `npm ci --prefix apps/web` → clean install
- [x] `npm --prefix apps/web run test` → 109 tests pass
- [x] `npm --prefix apps/web run build` → clean production build (60 modules)
- [ ] CI: new `web` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)