### PR TITLE
[codex] Add library asset tags and trashcan

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -108,6 +108,19 @@ pub(crate) async fn update_asset_status(
     ))
 }
 
+pub(crate) async fn update_asset_tags(
+    State(state): State<AppState>,
+    Path((project_id, asset_id)): Path<(String, String)>,
+    ApiJson(payload): ApiJson<AssetTagsPatch>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    Ok(Json(
+        project_call(state, move |store| {
+            store.update_asset_tags(&project_id, &asset_id, payload)
+        })
+        .await?,
+    ))
+}
+
 pub(crate) async fn delete_asset(
     State(state): State<AppState>,
     Path((project_id, asset_id)): Path<(String, String)>,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -34,10 +34,10 @@ use sceneworks_core::lora_family::{
 };
 use sceneworks_core::lora_url::{lora_source_url_file_stem, parse_lora_source_url, LoraUrlError};
 use sceneworks_core::project_store::{
-    AssetStatusPatch, CharacterCreateInput, CharacterLookInput, CharacterLookUpdateInput,
-    CharacterLoraInput, CharacterLoraUpdateInput, CharacterReferenceInput,
-    CharacterReferenceUpdateInput, CharacterUpdateInput, ProjectStore, ProjectStoreError,
-    UploadAsset,
+    AssetStatusPatch, AssetTagsPatch, CharacterCreateInput, CharacterLookInput,
+    CharacterLookUpdateInput, CharacterLoraInput, CharacterLoraUpdateInput,
+    CharacterReferenceInput, CharacterReferenceUpdateInput, CharacterUpdateInput, ProjectStore,
+    ProjectStoreError, UploadAsset,
 };
 use sceneworks_core::time::{format_unix_seconds, now_unix_seconds};
 use sceneworks_core::training::{
@@ -448,6 +448,10 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id/status",
             patch(update_asset_status),
+        )
+        .route(
+            "/api/v1/projects/:project_id/assets/:asset_id/tags",
+            patch(update_asset_tags),
         )
         .route(
             "/api/v1/projects/:project_id/training/datasets",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -667,6 +667,16 @@ async fn project_and_asset_routes_persist_contract_state() {
     assert_eq!(updated["status"]["rating"], 4);
     assert_eq!(updated["status"]["rejected"], true);
 
+    let (status, tagged) = request(
+        app.clone(),
+        "PATCH",
+        &format!("/api/v1/projects/{project_id}/assets/{asset_id}/tags"),
+        json!({ "tags": [" Portrait ", "portrait", "Reference"] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(tagged["tags"], json!(["portrait", "reference"]));
+
     let (status, deleted) = request(
         app.clone(),
         "DELETE",

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -109,7 +109,6 @@ const navSections = [
   {
     label: "Workspace",
     items: [
-      { id: "Library", icon: Icon.Library },
       { id: "Image", icon: Icon.Image },
       { id: "Video", icon: Icon.Video },
       { id: "Document", icon: Icon.Wand },
@@ -120,6 +119,7 @@ const navSections = [
   {
     label: "Library",
     items: [
+      { id: "Library", label: "Assets", icon: Icon.Library },
       { id: "Characters", icon: Icon.Character },
       { id: "Presets", icon: Icon.Preset },
       { id: "Models", icon: Icon.Model },
@@ -135,7 +135,7 @@ const navSections = [
 ];
 
 const viewTitles = {
-  Library: { title: "Library", blurb: "Browse stills and clips across all your projects." },
+  Library: { title: "Assets", blurb: "Browse stills and clips across all your projects." },
   Image: { title: "Image Studio", blurb: "Describe what you want — we'll render variations side by side." },
   Video: { title: "Video Studio", blurb: "Bring stills to life, or render new clips from scratch." },
   Document: { title: "Document Studio", blurb: "Generate interleaved text-image documents — guides, storyboards, tutorials." },
@@ -1128,11 +1128,27 @@ export function App() {
     }
   }
 
+  async function updateAssetTags(asset, tags) {
+    try {
+      const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/tags`, token, {
+        method: "PATCH",
+        body: JSON.stringify({ tags }),
+      });
+      setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+      setError("");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
   async function deleteAsset(asset) {
     try {
       await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}`, token, { method: "DELETE" });
-      setAssets((items) => items.filter((item) => item.id !== asset.id));
-      setSelectedAssetId((current) => (current === asset.id ? null : current));
+      setAssets((items) =>
+        items.map((item) =>
+          item.id === asset.id ? { ...item, status: { ...item.status, trashed: true } } : item,
+        ),
+      );
       setError("");
     } catch (err) {
       setError(err.message);
@@ -1233,6 +1249,7 @@ export function App() {
     purgeAsset,
     importAsset,
     updateAssetStatus,
+    updateAssetTags,
     latestImageAssets,
     // Jobs / queue
     jobs,
@@ -1350,16 +1367,17 @@ export function App() {
               {section.items.map((item) => {
                 const IconComponent = item.icon;
                 const active = activeIndicators[item.id];
+                const label = item.label ?? item.id;
                 return (
                   <button
                     className={activeView === item.id ? "nav-item active" : "nav-item"}
                     key={item.id}
                     onClick={() => setActiveView(item.id)}
-                    title={item.id}
+                    title={label}
                     type="button"
                   >
                     <IconComponent />
-                    <span className="nav-label">{item.id}</span>
+                    <span className="nav-label">{label}</span>
                     {active ? <span aria-hidden="true" className="nav-pulse" /> : null}
                   </button>
                 );

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -74,6 +74,61 @@ function RatingControl({ asset, updateAssetStatus }) {
   );
 }
 
+function normalizeTagInput(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function AssetTags({ asset, availableTags = [], updateAssetTags = () => {} }) {
+  const [draft, setDraft] = React.useState("");
+  const tags = Array.isArray(asset.tags) ? asset.tags : [];
+  const suggestions = availableTags.filter((tag) => !tags.includes(tag));
+
+  function submit(event) {
+    event.preventDefault();
+    const tag = normalizeTagInput(draft);
+    if (!tag || tags.includes(tag)) {
+      setDraft("");
+      return;
+    }
+    updateAssetTags(asset, [...tags, tag]);
+    setDraft("");
+  }
+
+  return (
+    <div className="asset-tags">
+      <div className="asset-tag-list" aria-label="Asset tags">
+        {tags.length ? (
+          tags.map((tag) => (
+            <span className="asset-tag" key={tag}>
+              {tag}
+              <button aria-label={`Remove ${tag} tag`} onClick={() => updateAssetTags(asset, tags.filter((item) => item !== tag))} type="button">
+                Remove
+              </button>
+            </span>
+          ))
+        ) : (
+          <span className="asset-tag-empty">No tags</span>
+        )}
+      </div>
+      <form className="asset-tag-form" onSubmit={submit}>
+        <input
+          aria-label="Add asset tag"
+          list="asset-tag-suggestions"
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Add tag"
+          value={draft}
+        />
+        <datalist id="asset-tag-suggestions">
+          {suggestions.map((tag) => (
+            <option key={tag} value={tag} />
+          ))}
+        </datalist>
+        <button type="submit">Add</button>
+      </form>
+    </div>
+  );
+}
+
 export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
   if (!assets.length) {
     return <div className="empty-panel">No assets in this view</div>;
@@ -91,6 +146,15 @@ export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId
         >
           <AssetMedia asset={asset} />
           <strong>{asset.displayName}</strong>
+          {Array.isArray(asset.tags) && asset.tags.length ? (
+            <div className="asset-tile-tags">
+              {asset.tags.map((tag) => (
+                <span className="asset-tag compact" key={tag}>
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </button>
       ))}
     </div>
@@ -167,6 +231,8 @@ export function AssetDetail({
   onSendVideo,
   onSendEditor,
   updateAssetStatus,
+  updateAssetTags,
+  availableTags,
   vqaEnabled = false,
   vqaEntries = [],
   vqaPending = false,
@@ -187,6 +253,7 @@ export function AssetDetail({
       )}
       <h3>{asset.displayName}</h3>
       <p>{asset.recipe?.prompt ?? "No prompt"}</p>
+      <AssetTags asset={asset} availableTags={availableTags} updateAssetTags={updateAssetTags} />
       <RatingControl asset={asset} updateAssetStatus={updateAssetStatus} />
       <div className="detail-actions">
         <button onClick={() => updateAssetStatus(asset, { favorite: !asset.status?.favorite })} type="button">
@@ -211,9 +278,14 @@ export function AssetDetail({
           </button>
         ) : null}
         {asset.status?.trashed ? (
-          <button onClick={() => purgeAsset(asset)} type="button">
-            Purge
-          </button>
+          <>
+            <button onClick={() => updateAssetStatus(asset, { trashed: false })} type="button">
+              Restore
+            </button>
+            <button onClick={() => purgeAsset(asset)} type="button">
+              Purge
+            </button>
+          </>
         ) : (
           <button onClick={() => deleteAsset(asset)} type="button">
             Discard
@@ -258,9 +330,14 @@ export function AssetCard({ asset, deleteAsset, purgeAsset, onPreview, updateAss
           {asset.status?.rejected ? "Restore" : "Reject"}
         </button>
         {asset.status?.trashed ? (
-          <button onClick={() => purgeAsset(asset)} type="button">
-            Purge
-          </button>
+          <>
+            <button onClick={() => updateAssetStatus(asset, { trashed: false })} type="button">
+              Restore
+            </button>
+            <button onClick={() => purgeAsset(asset)} type="button">
+              Purge
+            </button>
+          </>
         ) : (
           <button onClick={() => deleteAsset(asset)} type="button">
             Discard
@@ -320,9 +397,14 @@ export function FullscreenPreview({
               {asset.status?.rejected ? "Restore" : "Reject"}
             </button>
             {asset.status?.trashed ? (
-              <button className="danger-action" onClick={() => purgeAsset(asset)} type="button">
-                Purge
-              </button>
+              <>
+                <button onClick={() => updateAssetStatus(asset, { trashed: false })} type="button">
+                  Restore
+                </button>
+                <button className="danger-action" onClick={() => purgeAsset(asset)} type="button">
+                  Purge
+                </button>
+              </>
             ) : (
               <button className="danger-action" onClick={() => deleteAsset(asset)} type="button">
                 Discard

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -190,6 +190,13 @@ function buttonInside(scope, label) {
   return [...scope.querySelectorAll("button")].find((button) => button.textContent === label);
 }
 
+function navLabels(container, sectionLabel) {
+  const section = [...container.querySelectorAll(".sidebar-section")].find(
+    (item) => item.querySelector(".sidebar-section-title")?.textContent === sectionLabel,
+  );
+  return [...(section?.querySelectorAll(".nav-label") ?? [])].map((item) => item.textContent);
+}
+
 const zImageTrainingTarget = {
   id: "z_image_turbo_lora",
   name: "Z-Image-Turbo LoRA",
@@ -512,7 +519,9 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    expect(container.textContent).toContain("Library");
+    expect(container.textContent).toContain("Assets");
+    expect(navLabels(container, "Workspace")).not.toContain("Library");
+    expect(navLabels(container, "Library")).toContain("Assets");
     expect(container.textContent).toContain("Train");
     expect(container.textContent).toContain("Queue");
   });
@@ -2038,6 +2047,7 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     expect(container.textContent).toContain("Library");
+    expect(container.textContent).toContain("Assets");
     expect(container.textContent).toContain("Project One");
     expect(container.textContent).not.toContain("Not Found");
   });
@@ -2351,7 +2361,7 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Jobs and GPUs");
 
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Library").click();
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Assets").click();
     });
     await settle();
     await act(async () => {
@@ -2682,7 +2692,7 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Jobs and GPUs");
 
     await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Library").click();
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Assets").click();
     });
     await settle();
     await act(async () => {
@@ -5679,6 +5689,137 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Ask").click();
     });
     expect(createVqaJob).toHaveBeenLastCalledWith(asset, "Write a detailed critique of this image.", 512);
+  });
+
+  it("filters library assets by tag and edits selected asset tags", async () => {
+    const updateAssetTags = vi.fn();
+    const portrait = {
+      id: "asset-portrait",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Portrait One",
+      tags: ["portrait"],
+      recipe: { prompt: "studio portrait" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const landscape = {
+      id: "asset-landscape",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Wide Hill",
+      tags: ["landscape"],
+      recipe: { prompt: "wide hill" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Tagged" },
+            assets: [portrait, landscape],
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: portrait,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+            updateAssetTags,
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    await changeField(container.querySelector('select[aria-label="Asset tag"]'), "landscape");
+    const filteredTiles = [...container.querySelectorAll(".asset-tile")];
+    expect(filteredTiles).toHaveLength(1);
+    expect(filteredTiles[0].textContent).toContain("Wide Hill");
+
+    await changeField(container.querySelector('input[aria-label="Add asset tag"]'), "  Moody  ");
+    await act(async () => {
+      [...container.querySelectorAll(".asset-tag-form button")].find((button) => button.textContent === "Add").click();
+    });
+    expect(updateAssetTags).toHaveBeenCalledWith(portrait, ["portrait", "moody"]);
+
+    await act(async () => {
+      container.querySelector('button[aria-label="Remove portrait tag"]').click();
+    });
+    expect(updateAssetTags).toHaveBeenLastCalledWith(portrait, []);
+  });
+
+  it("shows discarded assets in Trashcan and exposes restore and purge actions", async () => {
+    const updateAssetStatus = vi.fn();
+    const purgeAsset = vi.fn();
+    const active = {
+      id: "asset-active",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Active Frame",
+      recipe: { prompt: "active" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const trashed = {
+      id: "asset-trash",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Discarded Frame",
+      recipe: { prompt: "discarded" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: true },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Trash" },
+            assets: [active, trashed],
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset,
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: trashed,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus,
+            updateAssetTags: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    expect([...container.querySelectorAll(".asset-tile")].map((tile) => tile.textContent).join(" ")).toContain("Active Frame");
+    expect([...container.querySelectorAll(".asset-tile")].map((tile) => tile.textContent).join(" ")).not.toContain("Discarded Frame");
+
+    await act(async () => {
+      [...container.querySelectorAll('button')].find((button) => button.textContent === "Trashcan").click();
+    });
+    expect([...container.querySelectorAll(".asset-tile")].map((tile) => tile.textContent).join(" ")).toContain("Discarded Frame");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Restore").click();
+    });
+    expect(updateAssetStatus).toHaveBeenCalledWith(trashed, { trashed: false });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Purge").click();
+    });
+    expect(purgeAsset).toHaveBeenCalledWith(trashed);
   });
 
   it("DocumentStudio renders an interleaved document and submits a compose job", async () => {

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -20,6 +20,7 @@ export function LibraryScreen() {
     setSelectedAssetId,
     setActiveView,
     updateAssetStatus,
+    updateAssetTags,
   } = useAppContext();
   const onPreview = setPreviewAsset;
   const onSendImage = (asset) => sendAssetToImage(asset);
@@ -41,8 +42,9 @@ export function LibraryScreen() {
     }));
   const vqaPending = assetVqaJobs.some((job) => !terminalStatuses.has(job.status));
   const [typeFilter, setTypeFilter] = useState("all");
+  const [tagFilter, setTagFilter] = useState("all");
   const [showRejected, setShowRejected] = useState(false);
-  const [showTrashed, setShowTrashed] = useState(false);
+  const [assetMode, setAssetMode] = useState("assets");
   const [isImporting, setIsImporting] = useState(false);
   const visibleAssets = assets.filter((asset) => {
     if (typeFilter !== "all" && asset.type !== typeFilter) {
@@ -51,7 +53,13 @@ export function LibraryScreen() {
     if (!showRejected && asset.status?.rejected) {
       return false;
     }
-    if (!showTrashed && asset.status?.trashed) {
+    if (assetMode === "trashcan" && !asset.status?.trashed) {
+      return false;
+    }
+    if (assetMode === "assets" && asset.status?.trashed) {
+      return false;
+    }
+    if (tagFilter !== "all" && !(asset.tags ?? []).includes(tagFilter)) {
       return false;
     }
     return true;
@@ -71,13 +79,14 @@ export function LibraryScreen() {
   const imageCount = assets.filter((asset) => asset.type === "image").length;
   const videoCount = assets.filter((asset) => asset.type === "video").length;
   const uploadCount = assets.filter((asset) => asset.type === "upload").length;
+  const availableTags = [...new Set(assets.flatMap((asset) => (Array.isArray(asset.tags) ? asset.tags : [])))].sort();
 
   return (
     <section className="main-surface library-surface">
       <div className="surface-header hero">
         <div className="section-heading">
           <p className="eyebrow">Project assets</p>
-          <h2>Library</h2>
+          <h2>Assets</h2>
           <p className="hero-blurb">
             Browse stills and clips across {activeProject?.name ?? "your project"} — pick a recent render to drop into the editor, or send one back to a studio for another pass.
           </p>
@@ -94,14 +103,26 @@ export function LibraryScreen() {
             <option value="upload">Uploads</option>
             <option value="render">Renders</option>
           </select>
+          <select aria-label="Asset tag" onChange={(event) => setTagFilter(event.target.value)} value={tagFilter}>
+            <option value="all">All tags</option>
+            {availableTags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option>
+            ))}
+          </select>
           <label className="checkline">
             <input checked={showRejected} onChange={(event) => setShowRejected(event.target.checked)} type="checkbox" />
             Rejected
           </label>
-          <label className="checkline">
-            <input checked={showTrashed} onChange={(event) => setShowTrashed(event.target.checked)} type="checkbox" />
-            Trash
-          </label>
+          <div className="segmented-control" role="group" aria-label="Asset collection">
+            <button className={assetMode === "assets" ? "active" : ""} onClick={() => setAssetMode("assets")} type="button">
+              Assets
+            </button>
+            <button className={assetMode === "trashcan" ? "active" : ""} onClick={() => setAssetMode("trashcan")} type="button">
+              Trashcan
+            </button>
+          </div>
         </div>
         <div className="hero-stats">
           <div className="hero-stat">
@@ -139,6 +160,8 @@ export function LibraryScreen() {
           onSendVideo={onSendVideo}
           onSendEditor={onSendEditor}
           updateAssetStatus={updateAssetStatus}
+          updateAssetTags={updateAssetTags}
+          availableTags={availableTags}
           vqaEnabled={vqaEnabled}
           vqaEntries={vqaEntries}
           vqaPending={vqaPending}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -812,6 +812,7 @@ label {
 .bin-actions button,
 .advanced-toggle,
 .detail-actions button,
+.asset-tag-form button,
 .review-actions button,
 .preview-actions button,
 .preview-nav-button,
@@ -855,6 +856,7 @@ label {
 .bin-actions button:hover:not(:disabled),
 .advanced-toggle:hover:not(:disabled),
 .detail-actions button:hover:not(:disabled),
+.asset-tag-form button:hover:not(:disabled),
 .review-actions button:hover:not(:disabled),
 .preview-actions button:hover:not(:disabled),
 .preview-nav-button:hover:not(:disabled),
@@ -2805,6 +2807,74 @@ label {
   font-family: var(--font-mono);
   font-size: 12px;
   overflow-wrap: anywhere;
+}
+
+.asset-tags {
+  display: grid;
+  gap: 8px;
+}
+
+.asset-tag-list,
+.asset-tile-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.asset-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 26px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.asset-tag.compact {
+  min-height: 22px;
+  padding: 2px 6px;
+  font-size: 11px;
+}
+
+.asset-tag button {
+  min-height: 20px;
+  padding: 0 5px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-faint);
+  font-size: 11px;
+}
+
+.asset-tag button:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.asset-tag-empty {
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+.asset-tag-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.asset-tag-form input {
+  min-width: 0;
+}
+
+.asset-tag-form button {
+  min-height: 34px;
+  padding: 0 12px;
 }
 
 .vqa-panel {

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -150,6 +151,12 @@ pub struct AssetStatusPatch {
     pub rating: Option<u8>,
     pub rejected: Option<bool>,
     pub trashed: Option<bool>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetTagsPatch {
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1139,6 +1146,28 @@ impl ProjectStore {
         if let Some(value) = patch.trashed {
             status.insert("trashed".to_owned(), Value::Bool(value));
         }
+        write_json(&sidecar_path, &asset)?;
+        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        normalize_asset(project_id, &project_path, &sidecar_path)
+    }
+
+    pub fn update_asset_tags(
+        &self,
+        project_id: &str,
+        asset_id: &str,
+        patch: AssetTagsPatch,
+    ) -> ProjectStoreResult<Value> {
+        let tags = normalize_asset_tags(&patch.tags)?;
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
+        let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
+        let mut asset = read_json(&sidecar_path)?;
+        let object = asset.as_object_mut().ok_or_else(|| {
+            ProjectStoreError::BadRequest("Asset sidecar must be an object".to_owned())
+        })?;
+        object.insert(
+            "tags".to_owned(),
+            Value::Array(tags.into_iter().map(Value::String).collect()),
+        );
         write_json(&sidecar_path, &asset)?;
         index_asset(&project_path, &asset, Some(&sidecar_path))?;
         normalize_asset(project_id, &project_path, &sidecar_path)
@@ -2517,6 +2546,31 @@ fn required_str<'a>(payload: &'a Value, key: &str) -> ProjectStoreResult<&'a str
         .ok_or_else(|| ProjectStoreError::BadRequest(format!("Missing required field: {key}")))
 }
 
+fn normalize_asset_tags(tags: &[String]) -> ProjectStoreResult<Vec<String>> {
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::new();
+    for tag in tags {
+        let value = tag.trim().to_ascii_lowercase();
+        if value.is_empty() {
+            continue;
+        }
+        if value.len() > 40 {
+            return Err(ProjectStoreError::BadRequest(
+                "Asset tags must be 40 characters or fewer".to_owned(),
+            ));
+        }
+        if seen.insert(value.clone()) {
+            normalized.push(value);
+        }
+    }
+    if normalized.len() > 24 {
+        return Err(ProjectStoreError::BadRequest(
+            "Assets can have at most 24 tags".to_owned(),
+        ));
+    }
+    Ok(normalized)
+}
+
 fn safe_filename(value: &str, fallback: &str) -> String {
     let name = value.replace('\\', "/");
     let stem = Path::new(name.rsplit('/').next().unwrap_or_default())
@@ -2592,10 +2646,24 @@ fn move_or_copy_file(source: &Path, destination: &Path) -> ProjectStoreResult<()
 mod tests {
     use super::{
         build_generated_asset_sidecar, guess_mime_from_filename, is_safe_relative_path,
-        CharacterCreateInput, CharacterLookInput, ProjectStore, PROJECT_FOLDERS,
+        normalize_asset_tags, CharacterCreateInput, CharacterLookInput, ProjectStore,
+        PROJECT_FOLDERS,
     };
     use serde_json::{json, Value};
     use std::sync::Arc;
+
+    #[test]
+    fn normalize_asset_tags_trims_lowercases_and_deduplicates() {
+        let tags = normalize_asset_tags(&[
+            " Portrait ".to_owned(),
+            "portrait".to_owned(),
+            "Reference".to_owned(),
+            "".to_owned(),
+        ])
+        .expect("normalized tags");
+
+        assert_eq!(tags, vec!["portrait", "reference"]);
+    }
 
     #[test]
     fn build_generated_asset_sidecar_assembles_the_contract_schema() {

--- a/packages/schemas/asset.schema.json
+++ b/packages/schemas/asset.schema.json
@@ -11,6 +11,11 @@
     "generationSetId": { "type": ["string", "null"] },
     "type": { "enum": ["image", "video", "upload", "frame", "render"] },
     "displayName": { "type": "string", "minLength": 1 },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
     "createdAt": { "type": "string", "format": "date-time" },
     "file": {
       "type": "object",

--- a/tests/fixtures/rust_migration_contracts/api_surface.json
+++ b/tests/fixtures/rust_migration_contracts/api_surface.json
@@ -45,6 +45,7 @@
     { "family": "assets", "path": "/api/v1/projects/{project_id}/assets/{asset_id}", "methods": ["DELETE"], "usedBy": ["web"] },
     { "family": "assets", "path": "/api/v1/projects/{project_id}/assets/{asset_id}/purge", "methods": ["DELETE"], "usedBy": ["web"] },
     { "family": "assets", "path": "/api/v1/projects/{project_id}/assets/{asset_id}/status", "methods": ["PATCH"], "usedBy": ["web"] },
+    { "family": "assets", "path": "/api/v1/projects/{project_id}/assets/{asset_id}/tags", "methods": ["PATCH"], "usedBy": ["web"] },
     { "family": "characters", "path": "/api/v1/projects/{project_id}/characters", "methods": ["GET", "POST"], "usedBy": ["web"] },
     { "family": "characters", "path": "/api/v1/projects/{project_id}/characters/{character_id}", "methods": ["DELETE", "GET", "PATCH"], "usedBy": ["web"] },
     { "family": "characters", "path": "/api/v1/projects/{project_id}/characters/{character_id}/archive", "methods": ["POST"], "usedBy": ["web"] },


### PR DESCRIPTION
## Summary

- Move the existing asset library entry under the Library section as Assets.
- Add persistent free-form asset tags with normalization, editing, suggestions, and tag filtering.
- Add Assets/Trashcan mode so discarded assets can be restored or permanently purged.

## Impact

Library > Assets is now the source of truth for reusable project assets. Normal asset browsing excludes trashed assets, while Trashcan exposes restore and purge actions.

## Verification

- npm --prefix apps/web run build
- npm --prefix apps/web run test
- cargo test -p sceneworks-core normalize_asset_tags_trims_lowercases_and_deduplicates
- cargo test -p sceneworks-rust-api project_and_asset_routes_persist_contract_state
- cargo test -p sceneworks-rust-api
- Browser smoke check at http://127.0.0.1:5173/

## Notes

`python -m pytest tests/test_rust_api_contract_snapshots.py` still has two unrelated existing snapshot mismatches around model/download payload fields (`modelManifestEntry` and `family`).