### PR TITLE
[codex] Move dataset management into Library

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -458,6 +458,10 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
             get(list_training_datasets).post(create_training_dataset),
         )
         .route(
+            "/api/v1/projects/:project_id/training/uploads",
+            post(upload_training_dataset_item),
+        )
+        .route(
             "/api/v1/projects/:project_id/training/datasets/:dataset_id",
             get(get_training_dataset)
                 .patch(update_training_dataset)

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1080,6 +1080,96 @@ async fn training_dataset_routes_persist_and_validate_project_assets() {
 }
 
 #[tokio::test]
+async fn training_dataset_uploads_are_dataset_owned_not_assets() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let app = create_app(settings).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Dataset Upload Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(project["path"].as_str().unwrap());
+
+    let (status, upload) = request_multipart_upload(
+        app.clone(),
+        &format!("/api/v1/projects/{project_id}/training/uploads"),
+        "DatasetOnly.PNG",
+        "image/png",
+        b"dataset-only-png",
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(upload["datasetOnly"], true);
+    let staged_path = upload["file"]["path"]
+        .as_str()
+        .expect("staged path")
+        .to_owned();
+    assert!(staged_path.starts_with("training/uploads/"));
+
+    let (status, listed_assets) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/assets"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(listed_assets.as_array().expect("asset list").len(), 0);
+
+    let (status, dataset) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/projects/{project_id}/training/datasets"),
+        json!({
+            "name": "Dataset-owned import",
+            "items": [{
+                "path": staged_path,
+                "displayName": "DatasetOnly.PNG",
+                "caption": { "text": "dataset only portrait" }
+            }]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert!(dataset["items"][0]["assetId"].is_null());
+    assert_eq!(dataset["items"][0]["path"], "images/item_0001.png");
+    let dataset_id = dataset["id"].as_str().expect("dataset id");
+    assert_eq!(
+        std::fs::read(
+            project_path
+                .join("training")
+                .join("datasets")
+                .join(dataset_id)
+                .join("images")
+                .join("item_0001.png")
+        )
+        .expect("dataset-owned image copied"),
+        b"dataset-only-png"
+    );
+
+    let (status, listed_assets_after_dataset) = request(
+        app,
+        "GET",
+        &format!("/api/v1/projects/{project_id}/assets"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        listed_assets_after_dataset
+            .as_array()
+            .expect("asset list after dataset")
+            .len(),
+        0
+    );
+}
+
+#[tokio::test]
 async fn create_training_job_resolves_plan_and_queues_lora_train() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -33,6 +33,40 @@ pub(crate) async fn create_training_dataset(
     Ok((StatusCode::CREATED, Json(dataset)))
 }
 
+pub(crate) async fn upload_training_dataset_item(
+    State(state): State<AppState>,
+    Path(project_id): Path<String>,
+    mut multipart: Multipart,
+) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|error| ApiError::bad_request(error.to_string()))?
+    {
+        if field.name() != Some("file") {
+            continue;
+        }
+        let filename = field.file_name().unwrap_or("dataset-upload").to_owned();
+        let content_type = field.content_type().map(str::to_owned);
+        let temp_path = write_upload_field_to_temp_file(&state, field).await?;
+        let source_path = temp_path.clone();
+        let upload = sceneworks_core::project_store::TrainingDatasetUpload {
+            filename,
+            content_type,
+            source_path,
+        };
+        let item = project_call(state, move |store| {
+            store.upload_training_dataset_item(&project_id, upload)
+        })
+        .await
+        .inspect_err(|_| {
+            let _ = std::fs::remove_file(&temp_path);
+        })?;
+        return Ok((StatusCode::CREATED, Json(item)));
+    }
+    Err(ApiError::bad_request("Upload file field is required"))
+}
+
 pub(crate) async fn get_training_dataset(
     State(state): State<AppState>,
     Path((project_id, dataset_id)): Path<(String, String)>,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -10,7 +10,7 @@ import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { DocumentStudio } from "./screens/DocumentStudio.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
-import { TrainingStudio } from "./screens/TrainingStudio.jsx";
+import { TrainingDataSetsLibrary, TrainingStudio } from "./screens/TrainingStudio.jsx";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { EditorScreen } from "./screens/EditorScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
@@ -120,6 +120,7 @@ const navSections = [
     label: "Library",
     items: [
       { id: "Library", label: "Assets", icon: Icon.Library },
+      { id: "LibraryDataSets", label: "Data Sets", icon: Icon.Train },
       { id: "Characters", icon: Icon.Character },
       { id: "Presets", icon: Icon.Preset },
       { id: "Models", icon: Icon.Model },
@@ -136,6 +137,7 @@ const navSections = [
 
 const viewTitles = {
   Library: { title: "Assets", blurb: "Browse stills and clips across all your projects." },
+  LibraryDataSets: { title: "Data Sets", blurb: "Create and caption training datasets." },
   Image: { title: "Image Studio", blurb: "Describe what you want — we'll render variations side by side." },
   Video: { title: "Video Studio", blurb: "Bring stills to life, or render new clips from scratch." },
   Document: { title: "Document Studio", blurb: "Generate interleaved text-image documents — guides, storyboards, tutorials." },
@@ -421,6 +423,7 @@ export function App() {
     refreshTrainingDatasets,
     loadTrainingDataset,
     createTrainingDataset,
+    uploadTrainingDatasetItem,
     updateTrainingDataset,
     batchRenameTrainingDataset,
     writeTrainingDatasetCaptionSidecars,
@@ -1308,6 +1311,7 @@ export function App() {
     refreshTrainingDatasets,
     loadTrainingDataset,
     createTrainingDataset,
+    uploadTrainingDatasetItem,
     updateTrainingDataset,
     batchRenameTrainingDataset,
     writeTrainingDatasetCaptionSidecars,
@@ -1459,6 +1463,10 @@ export function App() {
           <>
         {activeView === "Library" ? (
           <LibraryScreen />
+        ) : null}
+
+        {activeView === "LibraryDataSets" ? (
+          <TrainingDataSetsLibrary />
         ) : null}
 
         {activeView === "Image" ? (

--- a/apps/web/src/hooks/useTraining.js
+++ b/apps/web/src/hooks/useTraining.js
@@ -60,6 +60,18 @@ export function useTraining({ token, activeProject, setError, setJobs }) {
     return created;
   }
 
+  async function uploadTrainingDatasetItem(file, projectId = activeProject?.id) {
+    if (!projectId) {
+      throw new Error("Create or open a project first.");
+    }
+    const form = new FormData();
+    form.append("file", file);
+    return apiFetch(`/api/v1/projects/${projectId}/training/uploads`, token, {
+      method: "POST",
+      body: form,
+    });
+  }
+
   async function updateTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
     if (!projectId || !datasetId) {
       throw new Error("Select a training dataset first.");
@@ -145,6 +157,7 @@ export function useTraining({ token, activeProject, setError, setJobs }) {
     refreshTrainingDatasets,
     loadTrainingDataset,
     createTrainingDataset,
+    uploadTrainingDatasetItem,
     updateTrainingDataset,
     batchRenameTrainingDataset,
     writeTrainingDatasetCaptionSidecars,

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -16,7 +16,7 @@ import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { ReplacePersonPanel } from "./screens/ReplacePersonPanel.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
-import { TrainingStudio } from "./screens/TrainingStudio.jsx";
+import { TrainingDataSetsLibrary, TrainingStudio } from "./screens/TrainingStudio.jsx";
 import { AppContext } from "./context/AppContext.js";
 import { qualityChoices, GPU_REQUIRED_JOB_TYPES, errorStatuses } from "./jobTypes.js";
 
@@ -107,6 +107,7 @@ function withTrainingStudioContext(p) {
       refreshTrainingDatasets: p.onRefreshDatasets ? () => p.onRefreshDatasets() : () => {},
       loadTrainingDataset: p.loadDataset,
       createTrainingDataset: p.createDataset,
+      uploadTrainingDatasetItem: p.uploadDatasetItem,
       updateTrainingDataset: p.updateDataset,
       batchRenameTrainingDataset: p.batchRenameDataset,
       writeTrainingDatasetCaptionSidecars: p.writeCaptionSidecars,
@@ -118,6 +119,39 @@ function withTrainingStudioContext(p) {
       trainingTargetsError: p.trainingTargetsError,
     },
     <TrainingStudio />,
+  );
+}
+
+function withTrainingDataSetsLibraryContext(p) {
+  return withAppContext(
+    {
+      activeProject: p.activeProject,
+      authenticated: p.authenticated,
+      assets: p.assets,
+      gpuOptions: p.gpuOptions,
+      jobs: p.jobs,
+      setPreviewAsset: p.onPreview ?? (() => {}),
+      importAsset: p.importAsset,
+      trainingDatasets: p.datasets,
+      trainingDatasetsProjectId: p.activeProject?.id,
+      trainingDatasetsError: p.datasetsError,
+      loadingTrainingDatasets: p.loadingDatasets,
+      refreshTrainingDatasets: p.onRefreshDatasets ? () => p.onRefreshDatasets() : () => {},
+      loadTrainingDataset: p.loadDataset,
+      createTrainingDataset: p.createDataset,
+      uploadTrainingDatasetItem: p.uploadDatasetItem,
+      updateTrainingDataset: p.updateDataset,
+      batchRenameTrainingDataset: p.batchRenameDataset,
+      writeTrainingDatasetCaptionSidecars: p.writeCaptionSidecars,
+      createTrainingDatasetCaptionJob: p.createCaptionJob,
+      createTrainingJob: p.createTrainingJob,
+      trainingPresets: { presets: p.trainingPresets },
+      trainingPresetsError: p.trainingPresetsError,
+      trainingTargets: { targets: p.trainingTargets },
+      trainingTargetsError: p.trainingTargetsError,
+      setActiveView: p.setActiveView,
+    },
+    <TrainingDataSetsLibrary />,
   );
 }
 
@@ -599,12 +633,13 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     expect(container.textContent).toContain("Training Studio");
-    expect(container.textContent).toContain("Portrait Set");
     expect(container.textContent).toContain("Configure Job");
+    expect(container.textContent).toContain("Data Sets");
+    expect(container.textContent).not.toContain("Rename & Caption");
     expect([...container.querySelectorAll("button")].some((button) => /queue training/i.test(button.textContent))).toBe(false);
   });
 
-  it("supports keyboard navigation across Training Studio tabs", async () => {
+  it("keeps Training Studio focused on selecting existing datasets", async () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
@@ -616,21 +651,11 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    const datasetTab = container.querySelector("#training-tab-dataset");
-    datasetTab.focus();
-
-    await act(async () => {
-      datasetTab.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
-    });
-
-    expect(container.querySelector("#training-tab-rename-caption").getAttribute("aria-selected")).toBe("true");
-
-    await act(async () => {
-      container.querySelector("#training-tab-rename-caption").dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
-    });
-
     expect(container.querySelector("#training-tab-configure").getAttribute("aria-selected")).toBe("true");
     expect(container.textContent).toContain("A dry run validates the Rust-resolved training plan");
+    expect(container.querySelector("#training-tab-dataset")).toBeNull();
+    expect(container.querySelector("#training-tab-rename-caption")).toBeNull();
+    expect(container.textContent).not.toContain("Import images & captions");
   });
 
   it("creates a training dataset from selected image assets", async () => {
@@ -644,7 +669,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
           createDataset,
@@ -678,17 +703,22 @@ describe("SceneWorks app shell", () => {
       version: 1,
       items: payload.items,
     }));
-    const importAsset = vi.fn(async (file) => ({ id: "asset-mira", displayName: file.name }));
+    const uploadDatasetItem = vi.fn(async (file) => ({
+      id: "dataset-upload-mira",
+      datasetOnly: true,
+      displayName: file.name,
+      file: { path: "training/uploads/mira.png", mimeType: "image/png" },
+    }));
 
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [{ id: "asset-mira", type: "image", displayName: "mira.png", file: { path: "assets/images/mira.png", mimeType: "image/png" } }],
           createDataset,
           datasets: [],
-          importAsset,
+          uploadDatasetItem,
         }),
       );
     });
@@ -702,8 +732,8 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    // Only the image is uploaded as an asset; the .txt is parsed locally.
-    expect(importAsset).toHaveBeenCalledTimes(1);
+    // Only the image is uploaded to dataset-owned staging; the .txt is parsed locally.
+    expect(uploadDatasetItem).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Imported 1 image with 1 caption");
 
     await changeField(field(container, "Dataset name"), "Mira Set");
@@ -716,7 +746,7 @@ describe("SceneWorks app shell", () => {
         name: "Mira Set",
         items: [
           expect.objectContaining({
-            assetId: "asset-mira",
+            path: "training/uploads/mira.png",
             caption: expect.objectContaining({ text: "a portrait of mira", source: "imported" }),
           }),
         ],
@@ -745,7 +775,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets,
           datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
@@ -802,7 +832,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
           datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 2 }],
@@ -847,7 +877,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
           datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
@@ -915,7 +945,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
           batchRenameDataset,
@@ -931,9 +961,6 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
-    await act(async () => {
-      container.querySelector("#training-tab-rename-caption").click();
-    });
     await changeField(field(container, "Item ID"), "item_0007");
     await changeField(field(container, "File stem"), "mira_0007");
     await changeField(field(container, "Display name"), "mira_0007.png");
@@ -995,7 +1022,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
           createCaptionJob,
@@ -1010,9 +1037,6 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
-    await act(async () => {
-      container.querySelector("#training-tab-rename-caption").click();
-    });
     expect(field(container, "Caption prompt").value).toContain("Write a long detailed description for this image.");
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Captions").click();
@@ -1072,7 +1096,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [
             {
@@ -1094,9 +1118,6 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
-    await act(async () => {
-      container.querySelector("#training-tab-rename-caption").click();
-    });
     await changeField(field(container, "Method"), "metadata");
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Captions").click();
@@ -1148,7 +1169,7 @@ describe("SceneWorks app shell", () => {
     root = createRoot(container);
     await act(async () => {
       root.render(
-        withTrainingStudioContext({
+        withTrainingDataSetsLibraryContext({
           activeProject: { id: "project-a", name: "Project A" },
           assets: [
             { id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } },
@@ -1165,9 +1186,6 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
-    await act(async () => {
-      container.querySelector("#training-tab-rename-caption").click();
-    });
     expect(field(container, "Trigger words").value).toBe("Portrait Set");
     expect(field(container, "Character Name").value).toBe("Portrait Set");
     await changeField(field(container, "Trigger words"), "miraStyle, portraitSet");
@@ -1184,7 +1202,7 @@ describe("SceneWorks app shell", () => {
     });
   });
 
-  it("defaults the training trigger phrase from sidebar trigger words until edited", async () => {
+  it("defaults the training trigger phrase from the selected dataset name until edited", async () => {
     const loadDataset = vi.fn(async () => ({
       id: "dataset-a",
       name: "Portrait Set",
@@ -1213,33 +1231,12 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
-    });
+    await changeField(field(container, "Dataset"), "dataset-a");
     await settle();
-    await act(async () => {
-      container.querySelector("#training-tab-configure").click();
-    });
     expect(field(container, "Trigger phrase").value).toBe("Portrait Set");
 
-    await act(async () => {
-      container.querySelector("#training-tab-rename-caption").click();
-    });
-    await changeField(field(container, "Trigger words"), "miraStyle, portraitSet");
-    await act(async () => {
-      container.querySelector("#training-tab-configure").click();
-    });
-    expect(field(container, "Trigger phrase").value).toBe("miraStyle, portraitSet");
-
     await changeField(field(container, "Trigger phrase"), "manualTrigger");
-    await act(async () => {
-      container.querySelector("#training-tab-rename-caption").click();
-    });
-    await changeField(field(container, "Trigger words"), "otherTrigger");
-    await act(async () => {
-      container.querySelector("#training-tab-configure").click();
-    });
-
+    expect(container.querySelector("#training-tab-rename-caption")).toBeNull();
     expect(field(container, "Trigger phrase").value).toBe("manualTrigger");
   });
 

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -7,9 +7,7 @@ import { useLiveJobElapsedSeconds } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
 import { formatSeconds, percent } from "../formatting.js";
 
-const tabs = [
-  { id: "dataset", label: "Dataset", title: "Dataset intake", status: "Rust dataset store" },
-  { id: "rename-caption", label: "Rename & Caption", title: "Rename and caption pass", status: "Needs valid dataset" },
+const trainingTabs = [
   { id: "configure", label: "Configure Job", title: "Configure training job", status: "Queue dry run" },
 ];
 const defaultGpuOptions = ["auto"];
@@ -332,7 +330,7 @@ function renameCaptionDrafts(dataset) {
     displayName: item.displayName ?? imageAssetName(item),
     captionText: item.caption?.text ?? "",
     captionSource: item.caption?.source ?? "manual",
-    assetId: item.assetId ?? "",
+    assetId: datasetItemSelectionKey(dataset, item, index),
     path: item.path ?? "",
   }));
 }
@@ -352,8 +350,58 @@ function renameFieldsDirty(drafts, dataset) {
   });
 }
 
-function normalizeDatasetAssetIds(dataset) {
-  return (dataset?.items ?? []).map((item) => item.assetId).filter(Boolean);
+function datasetItemSelectionKey(dataset, item, index = 0) {
+  return item?.assetId || `dataset-item:${dataset?.id ?? "draft"}:${item?.id ?? index}`;
+}
+
+function datasetItemProjectPath(dataset, item) {
+  const path = String(item?.path ?? "").replaceAll("\\", "/");
+  if (!dataset?.id || !path) {
+    return "";
+  }
+  return `training/datasets/${dataset.id}/${path}`;
+}
+
+function datasetOwnedAssets(dataset, projectId, catalogAssets = []) {
+  const catalogIds = new Set(catalogAssets.map((asset) => asset.id));
+  return (dataset?.items ?? [])
+    .map((item, index) => {
+      if (item.assetId && catalogIds.has(item.assetId)) {
+        return null;
+      }
+      const path = datasetItemProjectPath(dataset, item);
+      if (!path) {
+        return null;
+      }
+      const id = datasetItemSelectionKey(dataset, item, index);
+      return {
+        id,
+        assetId: item.assetId ?? null,
+        datasetOwned: true,
+        projectId,
+        type: "image",
+        displayName: item.displayName ?? imageAssetName(item),
+        file: {
+          path,
+          mimeType: `image/${String(path).split(".").pop() || "png"}`,
+          width: item.width ?? null,
+          height: item.height ?? null,
+        },
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizeDatasetAssetIds(dataset, catalogAssets = []) {
+  const catalogIds = new Set(catalogAssets.map((asset) => asset.id));
+  return (dataset?.items ?? [])
+    .map((item, index) => {
+      if (item.assetId && catalogIds.has(item.assetId)) {
+        return item.assetId;
+      }
+      return datasetItemSelectionKey(dataset, item, index);
+    })
+    .filter(Boolean);
 }
 
 function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) {
@@ -363,7 +411,9 @@ function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) {
   const disabledItems = selectedAssets.filter((asset) => asset.status?.rejected || asset.status?.trashed).length + missingAssets;
   const names = selectedAssets.map((asset) => imageAssetName(asset).toLowerCase());
   const duplicateFilenames = names.filter((name, index) => names.indexOf(name) !== index).length;
-  const captionsByAssetId = new Map((activeDataset?.items ?? []).map((item) => [item.assetId, captionText(item)]));
+  const captionsByAssetId = new Map(
+    (activeDataset?.items ?? []).map((item, index) => [datasetItemSelectionKey(activeDataset, item, index), captionText(item)]),
+  );
   const missingCaptions = selectedAssetIds.filter((id) => !captionsByAssetId.get(id)).length;
   const valid = selectedAssetIds.length > 0 && disabledItems === 0;
 
@@ -377,18 +427,20 @@ function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) {
 }
 
 function datasetPayload({ activeDataset, assetsById, importedCaptions = {}, name, selectedAssetIds }) {
-  const itemsByAssetId = new Map((activeDataset?.items ?? []).map((item) => [item.assetId, item]));
+  const itemsByAssetId = new Map(
+    (activeDataset?.items ?? []).map((item, index) => [datasetItemSelectionKey(activeDataset, item, index), item]),
+  );
   return {
     name: name.trim(),
     modality: "image",
     items: selectedAssetIds
-      .map((assetId) => {
-        const asset = assetsById.get(assetId);
+      .map((selectionId) => {
+        const asset = assetsById.get(selectionId);
         if (!asset) {
           return null;
         }
-        const previous = itemsByAssetId.get(assetId);
-        const imported = importedCaptions[assetId];
+        const previous = itemsByAssetId.get(selectionId);
+        const imported = importedCaptions[selectionId];
         let caption;
         if (imported) {
           // An imported .txt sidecar takes precedence over a carried-forward
@@ -405,8 +457,9 @@ function datasetPayload({ activeDataset, assetsById, importedCaptions = {}, name
             triggerWords: previous.caption.triggerWords ?? [],
           };
         }
+        const source = asset.datasetOwned || asset.datasetOnly ? { path: asset.file?.path } : { assetId: asset.id };
         return {
-          assetId,
+          ...source,
           displayName: asset.displayName ?? imageAssetName(asset),
           caption,
         };
@@ -781,7 +834,12 @@ function TrainingLiveProgress({ jobs, projectId }) {
   );
 }
 
-export function TrainingStudio() {
+export function TrainingDataSetsLibrary() {
+  return <TrainingStudio mode="datasets" />;
+}
+
+export function TrainingStudio({ mode = "training" } = {}) {
+  const datasetLibraryMode = mode === "datasets";
   const {
     activeProject,
     authenticated = true,
@@ -797,6 +855,7 @@ export function TrainingStudio() {
     refreshTrainingDatasets,
     loadTrainingDataset,
     createTrainingDataset,
+    uploadTrainingDatasetItem,
     updateTrainingDataset,
     batchRenameTrainingDataset,
     writeTrainingDatasetCaptionSidecars,
@@ -806,13 +865,14 @@ export function TrainingStudio() {
     trainingPresetsError = "",
     trainingTargets: trainingTargetsCatalog,
     trainingTargetsError = "",
+    setActiveView,
   } = useAppContext();
   const datasets = trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [];
   const datasetsError = trainingDatasetsError;
   const loadingDatasets = loadingTrainingDatasets;
   const onPreview = setPreviewAsset;
   const onRefreshDatasets = () => refreshTrainingDatasets(activeProject?.id);
-  const importAsset = (file) => importAssetRaw(file, { throwOnError: true });
+  const uploadDatasetItem = uploadTrainingDatasetItem ?? ((file) => importAssetRaw(file, { throwOnError: true }));
   const loadDataset = loadTrainingDataset;
   const createDataset = createTrainingDataset;
   const updateDataset = updateTrainingDataset;
@@ -821,13 +881,15 @@ export function TrainingStudio() {
   const createCaptionJob = createTrainingDatasetCaptionJob;
   const trainingPresets = trainingPresetsCatalog?.presets ?? [];
   const trainingTargets = trainingTargetsCatalog?.targets ?? [];
-  const [activeTab, setActiveTab] = useState("dataset");
+  const workflowTabs = datasetLibraryMode ? [] : trainingTabs;
+  const [activeTab, setActiveTab] = useState(datasetLibraryMode ? "dataset" : "configure");
   const [activeDataset, setActiveDataset] = useState(null);
   const [datasetError, setDatasetError] = useState("");
   const [datasetMessage, setDatasetMessage] = useState("");
   const [draftName, setDraftName] = useState("");
   const [busyDatasetId, setBusyDatasetId] = useState("");
   const [importingAssets, setImportingAssets] = useState(false);
+  const [uploadedDatasetAssets, setUploadedDatasetAssets] = useState([]);
   const [savingDataset, setSavingDataset] = useState(false);
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
   // Captions parsed from .txt sidecars during import, keyed by imported asset id.
@@ -855,10 +917,28 @@ export function TrainingStudio() {
   const configBasisRef = useRef("");
   const tabRefs = useRef({});
 
-  const activeIndex = tabs.findIndex((tab) => tab.id === activeTab);
-  const active = tabs[activeIndex] ?? tabs[0];
+  const activeIndex = workflowTabs.findIndex((tab) => tab.id === activeTab);
+  const active = workflowTabs[activeIndex] ?? { id: activeTab, title: datasetLibraryMode ? "Dataset management" : "Configure training job" };
   const datasetSummary = useMemo(() => summarizeDatasets(datasets), [datasets]);
-  const imageAssets = useMemo(() => assets.filter((asset) => assetCanRenderAsImage(asset)), [assets]);
+  const datasetAssets = useMemo(
+    () => datasetOwnedAssets(activeDataset, activeProject?.id, assets),
+    [activeDataset, activeProject?.id, assets],
+  );
+  const imageAssets = useMemo(() => {
+    const merged = [
+      ...assets.filter((asset) => assetCanRenderAsImage(asset)),
+      ...uploadedDatasetAssets,
+      ...datasetAssets,
+    ];
+    const seen = new Set();
+    return merged.filter((asset) => {
+      if (!asset?.id || seen.has(asset.id)) {
+        return false;
+      }
+      seen.add(asset.id);
+      return true;
+    });
+  }, [assets, datasetAssets, uploadedDatasetAssets]);
   const assetsById = useMemo(() => new Map(imageAssets.map((asset) => [asset.id, asset])), [imageAssets]);
   const unavailableAssetIds = useMemo(
     () => selectedAssetIds.filter((assetId) => !assetsById.has(assetId)),
@@ -868,7 +948,7 @@ export function TrainingStudio() {
     () => datasetHealth({ activeDataset, imageAssets, selectedAssetIds }),
     [activeDataset, imageAssets, selectedAssetIds],
   );
-  const originalAssetIds = useMemo(() => normalizeDatasetAssetIds(activeDataset), [activeDataset]);
+  const originalAssetIds = useMemo(() => normalizeDatasetAssetIds(activeDataset, assets), [activeDataset, assets]);
   const dirty =
     Boolean(activeDataset) &&
     (draftName.trim() !== activeDataset.name ||
@@ -949,6 +1029,7 @@ export function TrainingStudio() {
     setDatasetMessage("");
     setDraftName("");
     setSelectedAssetIds([]);
+    setUploadedDatasetAssets([]);
     setSelectedDatasetId("");
     setRenamePrefix("");
     setCaptionTriggerWords("");
@@ -963,6 +1044,10 @@ export function TrainingStudio() {
     setConfigTriggerFollowsCaptions(true);
     configBasisRef.current = "";
   }, [activeProject?.id]);
+
+  useEffect(() => {
+    setActiveTab(datasetLibraryMode ? "dataset" : "configure");
+  }, [datasetLibraryMode]);
 
   useEffect(() => {
     const datasetTriggerPhrase = triggerPhraseFromText(activeDataset?.name);
@@ -1034,7 +1119,10 @@ export function TrainingStudio() {
   }, [gpuOptionsKey]);
 
   function focusTab(index) {
-    const next = tabs[(index + tabs.length) % tabs.length];
+    if (!workflowTabs.length) {
+      return;
+    }
+    const next = workflowTabs[(index + workflowTabs.length) % workflowTabs.length];
     setActiveTab(next.id);
     window.requestAnimationFrame(() => tabRefs.current[next.id]?.focus());
   }
@@ -1073,7 +1161,7 @@ export function TrainingStudio() {
       const dataset = await loadDataset(datasetId);
       setActiveDataset(dataset);
       setDraftName(dataset?.name ?? "");
-      setSelectedAssetIds(normalizeDatasetAssetIds(dataset));
+      setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
       setSelectedDatasetId(dataset?.id ?? datasetId);
     } catch (err) {
       setDatasetError(err.message);
@@ -1100,6 +1188,7 @@ export function TrainingStudio() {
     setDatasetMessage("");
     setDraftName("");
     setSelectedAssetIds([]);
+    setUploadedDatasetAssets([]);
     setSelectedDatasetId("");
   }
 
@@ -1236,9 +1325,11 @@ export function TrainingStudio() {
       const imported = [];
       const captionsByAssetId = {};
       for (const file of imageFiles) {
-        const asset = await importAsset(file);
+        const asset = await uploadDatasetItem(file);
         if (asset?.id) {
+          asset.datasetOnly = true;
           imported.push(asset.id);
+          setUploadedDatasetAssets((current) => [asset, ...current.filter((item) => item.id !== asset.id)]);
           const caption = captionByStem.get(uploadFileStem(file.name));
           if (caption) {
             captionsByAssetId[asset.id] = { source: "imported", text: caption };
@@ -1286,7 +1377,8 @@ export function TrainingStudio() {
         : await createDataset(payload);
       setActiveDataset(dataset);
       setDraftName(dataset?.name ?? draftName.trim());
-      setSelectedAssetIds(normalizeDatasetAssetIds(dataset));
+      setUploadedDatasetAssets([]);
+      setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
       setSelectedDatasetId(dataset?.id ?? "");
       setDatasetMessage(activeDataset ? "Dataset changes saved" : "Dataset created");
     } catch (err) {
@@ -1336,7 +1428,7 @@ export function TrainingStudio() {
       const nextDataset = result?.dataset ?? dataset;
       setActiveDataset(nextDataset);
       setDraftName(nextDataset?.name ?? draftName);
-      setSelectedAssetIds(normalizeDatasetAssetIds(nextDataset));
+      setSelectedAssetIds(normalizeDatasetAssetIds(nextDataset, assets));
       setSelectedDatasetId(nextDataset?.id ?? activeDataset.id);
       if (useJoyCaption && (captionSettings.recaption || missingDraftCaptions > 0)) {
         const job = await createCaptionJob(activeDataset.id, trainingCaptionJobPayload(captionSettings));
@@ -1386,10 +1478,12 @@ export function TrainingStudio() {
       <div className="training-studio-shell">
         <div className="training-summary-band">
           <div className="section-heading">
-            <p className="eyebrow">Training Studio</p>
-            <h2>Native LoRA training workflow</h2>
+            <p className="eyebrow">{datasetLibraryMode ? "Library" : "Training Studio"}</p>
+            <h2>{datasetLibraryMode ? "Data Sets" : "Native LoRA training workflow"}</h2>
             <p className="view-copy">
-              Build datasets, normalize captions, and prepare a Rust-owned training plan before any ML runtime work begins.
+              {datasetLibraryMode
+                ? "Create training datasets, manage imported dataset images, and normalize captions in one place."
+                : "Select an existing dataset and prepare a Rust-owned training plan before any ML runtime work begins."}
             </p>
           </div>
           <div className="training-metrics" aria-label="Training workspace summary">
@@ -1407,14 +1501,14 @@ export function TrainingStudio() {
             </div>
           </div>
         </div>
-        <TrainingLiveProgress jobs={activeTrainingJobs} projectId={activeProject?.id} />
+        {datasetLibraryMode ? null : <TrainingLiveProgress jobs={activeTrainingJobs} projectId={activeProject?.id} />}
 
         {!authenticated ? (
           <div className="training-empty-state" role="status">
             <Icon.Train size={24} />
             <div>
               <strong>Pairing required</strong>
-              <span>Unlock SceneWorks to load project training datasets.</span>
+              <span>Unlock SceneWorks to load project datasets.</span>
             </div>
           </div>
         ) : !activeProject ? (
@@ -1427,8 +1521,9 @@ export function TrainingStudio() {
           </div>
         ) : (
           <>
+            {workflowTabs.length ? (
             <div className="training-tabs" role="tablist" aria-label="Training workflow">
-              {tabs.map((tab) => (
+              {workflowTabs.map((tab) => (
                 <button
                   aria-controls={activeTab === tab.id ? `training-panel-${tab.id}` : undefined}
                   aria-selected={activeTab === tab.id}
@@ -1449,14 +1544,15 @@ export function TrainingStudio() {
                 </button>
               ))}
             </div>
+            ) : null}
 
             <section
-              aria-labelledby={`training-tab-${active.id}`}
+              aria-labelledby={workflowTabs.length ? `training-tab-${active.id}` : undefined}
               className="training-panel"
               id={`training-panel-${active.id}`}
               role="tabpanel"
             >
-              {activeTab === "dataset" ? (
+              {datasetLibraryMode || activeTab === "dataset" ? (
                 <>
                   <div className="training-panel-head">
                     <div>
@@ -1587,7 +1683,7 @@ export function TrainingStudio() {
                 </>
               ) : null}
 
-              {activeTab === "rename-caption" ? (
+              {datasetLibraryMode || activeTab === "rename-caption" ? (
                 <>
                   <div className="training-panel-head">
                     <div>
@@ -1868,7 +1964,13 @@ export function TrainingStudio() {
                       <p className="eyebrow">Configure Job</p>
                       <h3>{active.title}</h3>
                     </div>
-                    <span className="training-status-pill">{configReady ? "Ready" : "Needs input"}</span>
+                    <div className="training-head-actions">
+                      <button className="secondary-action" onClick={() => setActiveView?.("LibraryDataSets")} type="button">
+                        <Icon.Library size={14} />
+                        Data Sets
+                      </button>
+                      <span className="training-status-pill">{configReady ? "Ready" : "Needs input"}</span>
+                    </div>
                   </div>
                   {trainingTargetsError ? <p className="inline-warning">{trainingTargetsError}</p> : null}
                   {trainingPresetsError ? <p className="inline-warning">{trainingPresetsError}</p> : null}

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -47,6 +47,7 @@ pub const PROJECT_FOLDERS: &[&str] = &[
     "recipes",
     "timelines",
     "training/datasets",
+    "training/uploads",
     "trash",
     "cache",
 ];
@@ -190,6 +191,13 @@ pub struct ProjectStore {
     lock: Mutex<()>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrainingDatasetUpload {
+    pub filename: String,
+    pub content_type: Option<String>,
+    pub source_path: PathBuf,
+}
+
 impl ProjectStore {
     pub fn new(data_dir: impl Into<PathBuf>, app_version: impl Into<String>) -> Self {
         Self {
@@ -294,6 +302,67 @@ impl ProjectStore {
     ) -> ProjectStoreResult<TrainingDataset> {
         let (project_path, _project_guard) = self.lock_project(project_id)?;
         TrainingDatasetStore::new(project_path).create_dataset(project_id, input)
+    }
+
+    pub fn upload_training_dataset_item(
+        &self,
+        project_id: &str,
+        upload: TrainingDatasetUpload,
+    ) -> ProjectStoreResult<Value> {
+        if fs::metadata(&upload.source_path)?.len() == 0 {
+            return Err(ProjectStoreError::BadRequest(
+                "Uploaded file is empty".to_owned(),
+            ));
+        }
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
+        let upload_dir = project_path.join("training").join("uploads");
+        fs::create_dir_all(&upload_dir)?;
+
+        let guessed_mime = guess_mime_from_filename(&upload.filename);
+        let content_type = upload
+            .content_type
+            .as_deref()
+            .filter(|value| !value.is_empty() && *value != "application/octet-stream")
+            .map(str::to_owned)
+            .or(guessed_mime)
+            .unwrap_or_else(|| "application/octet-stream".to_owned());
+        if !content_type.starts_with("image/") {
+            return Err(ProjectStoreError::BadRequest(
+                "Only image dataset uploads are supported".to_owned(),
+            ));
+        }
+
+        let upload_id = format!("dataset_upload_{}", random_hex(16)?);
+        let extension = upload_extension(&upload.filename, &content_type);
+        let suffix = &upload_id[upload_id.len().saturating_sub(8)..];
+        let filename = format!(
+            "{}-{suffix}{extension}",
+            safe_filename(&upload.filename, &upload_id)
+        );
+        let media_path = upload_dir.join(filename);
+        move_or_copy_file(&upload.source_path, &media_path)?;
+        let media_rel = relative_string(&project_path, &media_path)?;
+        let display_name = Path::new(&upload.filename)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .filter(|value| !value.is_empty())
+            .unwrap_or("dataset-upload")
+            .to_owned();
+
+        Ok(json!({
+            "id": upload_id,
+            "projectId": project_id,
+            "datasetOnly": true,
+            "type": "image",
+            "displayName": display_name,
+            "file": {
+                "path": media_rel,
+                "mimeType": content_type,
+                "width": Value::Null,
+                "height": Value::Null
+            },
+            "url": format!("/api/v1/projects/{project_id}/files/{media_rel}")
+        }))
     }
 
     pub fn get_training_dataset(


### PR DESCRIPTION
## Summary
- add Library > Data Sets navigation and reuse the dataset management surface there
- move dataset create/edit plus rename/caption workflows out of Training into the Library Data Sets surface
- limit Training Studio to configuring jobs from existing datasets, with a shortcut back to Data Sets
- add dataset-only upload staging under `training/uploads` so new dataset imports do not become general Asset records

## Validation
- npm --prefix apps/web run test
- npm --prefix apps/web run build
- cargo test -p sceneworks-rust-api
- cargo test -p sceneworks-core
- browser smoke check against the refreshed Vite dev build