### PR TITLE
[codex] Show fallback for render crashes

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -15,7 +15,12 @@
     <script src="/theme-init.js"></script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main class="app-boot-fallback" role="status">
+        <strong>SceneWorks is starting</strong>
+        <span>If this stays here, refresh the page or check the browser console.</span>
+      </main>
+    </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/apps/web/src/components/ErrorBoundary.jsx
+++ b/apps/web/src/components/ErrorBoundary.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("SceneWorks render failed", error, info);
+  }
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    const message = this.state.error?.message ?? "Unknown render error";
+    return (
+      <main className="app-fallback" role="alert">
+        <section className="empty-panel app-fallback-panel">
+          <p className="eyebrow">SceneWorks</p>
+          <h1>Something went wrong</h1>
+          <p className="view-copy">{message}</p>
+          <div className="toolbar">
+            <button className="secondary-action" onClick={() => this.setState({ error: null })} type="button">
+              Try again
+            </button>
+            <button className="primary-action" onClick={() => window.location.reload()} type="button">
+              Reload
+            </button>
+          </div>
+        </section>
+      </main>
+    );
+  }
+}

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.jsx";
+import { ErrorBoundary } from "./components/ErrorBoundary.jsx";
 import "./styles.css";
 
 const rootElement = typeof document === "undefined" ? null : document.getElementById("root");
 if (rootElement) {
-  createRoot(rootElement).render(<App />);
+  createRoot(rootElement).render(
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>,
+  );
 }
 
 export { App } from "./App.jsx";
+export { ErrorBoundary } from "./components/ErrorBoundary.jsx";
 export { eventUrl } from "./api.js";

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1,7 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { App, eventUrl } from "./main.jsx";
+import { App, ErrorBoundary, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
 import { AssetDetail, FullscreenPreview } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
@@ -391,6 +391,31 @@ describe("SceneWorks app shell", () => {
     });
     container.remove();
     vi.restoreAllMocks();
+  });
+
+  it("shows a fallback instead of a blank screen when rendering fails", async () => {
+    function BrokenScreen() {
+      throw new Error("Render smoke signal");
+    }
+
+    const preventExpectedError = (event) => event.preventDefault();
+    window.addEventListener("error", preventExpectedError);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <ErrorBoundary>
+            <BrokenScreen />
+          </ErrorBoundary>,
+        );
+      });
+    } finally {
+      window.removeEventListener("error", preventExpectedError);
+    }
+
+    expect(container.textContent).toContain("Something went wrong");
+    expect(container.textContent).toContain("Render smoke signal");
   });
 
   const wizardModels = [

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5479,6 +5479,40 @@ label {
   border-style: dashed;
 }
 
+.app-fallback {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--bg);
+}
+
+.app-boot-fallback {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 8px;
+  padding: 24px;
+  color: var(--text);
+  background: var(--bg);
+  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
+  text-align: center;
+}
+
+.app-boot-fallback span {
+  max-width: 420px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.app-fallback-panel {
+  width: min(100%, 520px);
+  display: grid;
+  gap: 14px;
+  color: var(--text);
+}
+
 .job-row {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
﻿## Summary
- Wrap the SceneWorks React root in an ErrorBoundary so render crashes show a visible fallback instead of a blank screen.
- Add a static boot fallback inside `#root` so module-loader/cache stalls show a message instead of an empty dark page.
- Add fallback styling using the existing panel/button vocabulary.
- Add a regression test that forces a render error and verifies the fallback message is shown.

## Context
I could not reproduce the blank screen locally after the Library Data Sets merge: localhost rendered normally and the browser console had no warnings or errors. The report that the app works in Incognito points to stale browser/Vite cache or persisted browser state. This PR makes both app-render failures and pre-mount startup stalls visible.

## Validation
- `npm --prefix apps/web run test`
- `npm --prefix apps/web run build`
- Browser smoke check at `http://localhost:5173`: populated root, no warning/error console messages.
