### PR TITLE
[codex] Disable Vite dev response caching

### DIFF
--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  },
+});


### PR DESCRIPTION
﻿## Summary
- Add a Vite dev-server config that sends `Cache-Control: no-store`.

## Context
The app worked in Incognito but the regular Chrome profile hit React's `Cannot read properties of null (reading 'useState')`, which is consistent with a stale cached Vite optimized React dependency graph. I also restarted the local dev server with `--force`, which re-optimized dependencies and produced fresh React dependency URLs.

## Validation
- `npm --prefix apps/web run test`
- `npm --prefix apps/web run build`
- Browser smoke check at `http://127.0.0.1:5173`: populated root with fresh React dependency URLs.
