### PR TITLE
Add the worker upscaler engine foundation for SC-1793

### DIFF
--- a/apps/worker/scene_worker/upscalers.py
+++ b/apps/worker/scene_worker/upscalers.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+from PIL import Image
+
+
+@dataclass(frozen=True)
+class UpscaleJob:
+    factor: int
+    weights_path: Path
+    engine: str = "real_esrgan"
+    tile_size: int = 512
+    tile_pad: int = 16
+
+
+class UpscalerEngine(Protocol):
+    id: str
+
+    def upscale(
+        self,
+        image: Image.Image,
+        *,
+        job: UpscaleJob,
+        settings: Any,
+    ) -> Image.Image: ...
+
+
+@dataclass(frozen=True)
+class TileSlice:
+    x0: int
+    y0: int
+    x1: int
+    y1: int
+
+
+def tile_slices(width: int, height: int, tile_size: int) -> list[TileSlice]:
+    if width <= 0 or height <= 0:
+        raise ValueError("Image dimensions must be positive.")
+    if tile_size <= 0 or tile_size >= max(width, height):
+        return [TileSlice(0, 0, width, height)]
+
+    tiles: list[TileSlice] = []
+    for y0 in range(0, height, tile_size):
+        for x0 in range(0, width, tile_size):
+            tiles.append(TileSlice(x0, y0, min(x0 + tile_size, width), min(y0 + tile_size, height)))
+    return tiles
+
+
+def create_upscaler_engine(engine: str | None = None) -> UpscalerEngine:
+    engine_id = (engine or "real_esrgan").strip().lower().replace("-", "_")
+    if engine_id in {"real_esrgan", "realesrgan"}:
+        return RealESRGANUpscaler()
+    raise RuntimeError(f"Unsupported upscaler engine: {engine}.")
+
+
+class RealESRGANUpscaler:
+    id = "real_esrgan"
+
+    def upscale(
+        self,
+        image: Image.Image,
+        *,
+        job: UpscaleJob,
+        settings: Any,
+    ) -> Image.Image:
+        if job.factor not in {2, 4}:
+            raise RuntimeError("Real-ESRGAN upscaling supports only 2x and 4x factors.")
+        if not job.weights_path.exists():
+            raise RuntimeError(f"Real-ESRGAN weights are missing: {job.weights_path}")
+
+        torch = importlib.import_module("torch")
+        from .image_adapters import activate_torch_device, select_torch_device, select_torch_dtype
+
+        device = select_torch_device(torch, getattr(settings, "gpu_id", None))
+        activate_torch_device(torch, device)
+        dtype = select_torch_dtype(torch, device, None)
+        model = self._load_model(torch, job.weights_path, factor=job.factor, device=device, dtype=dtype)
+        return self._upscale_with_model(
+            torch,
+            model,
+            image.convert("RGB"),
+            factor=job.factor,
+            device=device,
+            dtype=dtype,
+            tile_size=job.tile_size,
+            tile_pad=job.tile_pad,
+        )
+
+    def _load_model(
+        self,
+        torch: Any,
+        weights_path: Path,
+        *,
+        factor: int,
+        device: str,
+        dtype: Any,
+    ) -> Any:
+        state = _load_state_dict(torch, weights_path)
+        num_blocks = _infer_rrdb_blocks(state)
+        RRDBNet = _rrdbnet_class(torch)
+        model = RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=num_blocks, num_grow_ch=32, scale=factor)
+        missing, unexpected = model.load_state_dict(state, strict=False)
+        if missing:
+            raise RuntimeError(f"Real-ESRGAN weights are missing {len(missing)} network tensors.")
+        if unexpected:
+            raise RuntimeError(f"Real-ESRGAN weights contain {len(unexpected)} unexpected tensors.")
+        model.eval()
+        return model.to(device=device, dtype=dtype)
+
+    def _upscale_with_model(
+        self,
+        torch: Any,
+        model: Any,
+        image: Image.Image,
+        *,
+        factor: int,
+        device: str,
+        dtype: Any,
+        tile_size: int,
+        tile_pad: int,
+    ) -> Image.Image:
+        return _run_tiled(torch, model, image, factor=factor, device=device, dtype=dtype, tile_size=tile_size, tile_pad=tile_pad)
+
+
+def _load_state_dict(torch: Any, weights_path: Path) -> dict[str, Any]:
+    if weights_path.suffix.lower() == ".safetensors":
+        safetensors_torch = importlib.import_module("safetensors.torch")
+        checkpoint = safetensors_torch.load_file(str(weights_path), device="cpu")
+    else:
+        try:
+            checkpoint = torch.load(str(weights_path), map_location="cpu", weights_only=True)
+        except TypeError:
+            checkpoint = torch.load(str(weights_path), map_location="cpu")
+
+    state = checkpoint
+    if isinstance(checkpoint, dict):
+        for key in ("params_ema", "params", "state_dict"):
+            candidate = checkpoint.get(key)
+            if isinstance(candidate, dict):
+                state = candidate
+                break
+    if not isinstance(state, dict):
+        raise RuntimeError("Real-ESRGAN weights did not contain a state dict.")
+    return {str(key).removeprefix("module."): value for key, value in state.items()}
+
+
+def _infer_rrdb_blocks(state: dict[str, Any]) -> int:
+    block_indexes = []
+    for key in state:
+        match = re.match(r"body\.(\d+)\.", key)
+        if match:
+            block_indexes.append(int(match.group(1)))
+    return max(block_indexes) + 1 if block_indexes else 23
+
+
+def _rrdbnet_class(torch: Any) -> type:
+    nn = torch.nn
+    F = torch.nn.functional
+
+    class ResidualDenseBlock(nn.Module):
+        def __init__(self, num_feat: int = 64, num_grow_ch: int = 32) -> None:
+            super().__init__()
+            self.conv1 = nn.Conv2d(num_feat, num_grow_ch, 3, 1, 1)
+            self.conv2 = nn.Conv2d(num_feat + num_grow_ch, num_grow_ch, 3, 1, 1)
+            self.conv3 = nn.Conv2d(num_feat + 2 * num_grow_ch, num_grow_ch, 3, 1, 1)
+            self.conv4 = nn.Conv2d(num_feat + 3 * num_grow_ch, num_grow_ch, 3, 1, 1)
+            self.conv5 = nn.Conv2d(num_feat + 4 * num_grow_ch, num_feat, 3, 1, 1)
+            self.lrelu = nn.LeakyReLU(negative_slope=0.2, inplace=True)
+
+        def forward(self, x: Any) -> Any:
+            x1 = self.lrelu(self.conv1(x))
+            x2 = self.lrelu(self.conv2(torch.cat((x, x1), 1)))
+            x3 = self.lrelu(self.conv3(torch.cat((x, x1, x2), 1)))
+            x4 = self.lrelu(self.conv4(torch.cat((x, x1, x2, x3), 1)))
+            x5 = self.conv5(torch.cat((x, x1, x2, x3, x4), 1))
+            return x5 * 0.2 + x
+
+    class RRDB(nn.Module):
+        def __init__(self, num_feat: int, num_grow_ch: int = 32) -> None:
+            super().__init__()
+            self.rdb1 = ResidualDenseBlock(num_feat, num_grow_ch)
+            self.rdb2 = ResidualDenseBlock(num_feat, num_grow_ch)
+            self.rdb3 = ResidualDenseBlock(num_feat, num_grow_ch)
+
+        def forward(self, x: Any) -> Any:
+            out = self.rdb1(x)
+            out = self.rdb2(out)
+            out = self.rdb3(out)
+            return out * 0.2 + x
+
+    class RRDBNet(nn.Module):
+        def __init__(
+            self,
+            *,
+            num_in_ch: int,
+            num_out_ch: int,
+            scale: int,
+            num_feat: int = 64,
+            num_block: int = 23,
+            num_grow_ch: int = 32,
+        ) -> None:
+            super().__init__()
+            self.scale = scale
+            if scale == 2:
+                num_in_ch *= 4
+            elif scale == 1:
+                num_in_ch *= 16
+            self.conv_first = nn.Conv2d(num_in_ch, num_feat, 3, 1, 1)
+            self.body = nn.Sequential(*[RRDB(num_feat, num_grow_ch) for _ in range(num_block)])
+            self.conv_body = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+            self.conv_up1 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+            self.conv_up2 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+            self.conv_hr = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+            self.conv_last = nn.Conv2d(num_feat, num_out_ch, 3, 1, 1)
+            self.lrelu = nn.LeakyReLU(negative_slope=0.2, inplace=True)
+
+        def forward(self, x: Any) -> Any:
+            if self.scale == 2:
+                feat = F.pixel_unshuffle(x, 2)
+            elif self.scale == 1:
+                feat = F.pixel_unshuffle(x, 4)
+            else:
+                feat = x
+            feat = self.conv_first(feat)
+            body_feat = self.conv_body(self.body(feat))
+            feat = feat + body_feat
+            feat = self.lrelu(self.conv_up1(F.interpolate(feat, scale_factor=2, mode="nearest")))
+            feat = self.lrelu(self.conv_up2(F.interpolate(feat, scale_factor=2, mode="nearest")))
+            return self.conv_last(self.lrelu(self.conv_hr(feat)))
+
+    return RRDBNet
+
+
+def _run_tiled(
+    torch: Any,
+    model: Any,
+    image: Image.Image,
+    *,
+    factor: int,
+    device: str,
+    dtype: Any,
+    tile_size: int,
+    tile_pad: int,
+) -> Image.Image:
+    width, height = image.size
+    output = torch.empty((1, 3, height * factor, width * factor), dtype=torch.float32, device="cpu")
+    context = getattr(torch, "inference_mode", None) or getattr(torch, "no_grad")
+    with context():
+        for tile in tile_slices(width, height, tile_size):
+            crop_x0 = max(0, tile.x0 - tile_pad)
+            crop_y0 = max(0, tile.y0 - tile_pad)
+            crop_x1 = min(width, tile.x1 + tile_pad)
+            crop_y1 = min(height, tile.y1 + tile_pad)
+            tile_image = image.crop((crop_x0, crop_y0, crop_x1, crop_y1))
+            tile_tensor = _image_to_tensor(torch, tile_image, device=device, dtype=dtype)
+            tile_output = model(tile_tensor)
+
+            inner_x0 = (tile.x0 - crop_x0) * factor
+            inner_y0 = (tile.y0 - crop_y0) * factor
+            inner_x1 = inner_x0 + (tile.x1 - tile.x0) * factor
+            inner_y1 = inner_y0 + (tile.y1 - tile.y0) * factor
+            output[
+                ...,
+                tile.y0 * factor : tile.y1 * factor,
+                tile.x0 * factor : tile.x1 * factor,
+            ] = tile_output[..., inner_y0:inner_y1, inner_x0:inner_x1].detach().float().cpu()
+    return _tensor_to_image(torch, output)
+
+
+def _image_to_tensor(torch: Any, image: Image.Image, *, device: str, dtype: Any) -> Any:
+    np = importlib.import_module("numpy")
+    array = np.asarray(image, dtype=np.float32) / 255.0
+    return torch.from_numpy(array).permute(2, 0, 1).unsqueeze(0).to(device=device, dtype=dtype)
+
+
+def _tensor_to_image(torch: Any, tensor: Any) -> Image.Image:
+    np = importlib.import_module("numpy")
+    array = (
+        torch.clamp(tensor.squeeze(0), 0.0, 1.0)
+        .permute(1, 2, 0)
+        .mul(255.0)
+        .round()
+        .byte()
+        .cpu()
+        .numpy()
+    )
+    return Image.fromarray(array.astype(np.uint8), "RGB")

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 from types import ModuleType, SimpleNamespace
 
 from PIL import Image
@@ -45,6 +45,13 @@ from scene_worker.image_adapters import (
     sensenova_resolution_for,
     SenseNovaU1Adapter,
     verify_pipeline_on_device,
+)
+from scene_worker.upscalers import (
+    RealESRGANUpscaler,
+    TileSlice,
+    UpscaleJob,
+    create_upscaler_engine,
+    tile_slices,
 )
 from scene_worker.lora_adapters import (
     apply_loras_to_pipeline,
@@ -4992,6 +4999,93 @@ def test_gpu_memory_snapshot_reports_allocated_and_reserved_bytes():
     snapshot = gpu_memory_snapshot(Torch, "cuda:0")
 
     assert snapshot == {"device": "cuda:0", "allocatedMb": 50.0, "reservedMb": 60.0}
+
+
+def test_upscaler_engine_selection_is_import_safe_without_torch(monkeypatch):
+    imported: list[str] = []
+
+    def fail_torch_import(name):
+        imported.append(name)
+        if name == "torch":
+            raise AssertionError("torch must not be imported while selecting an upscaler")
+        return importlib.import_module(name)
+
+    monkeypatch.setattr("scene_worker.upscalers.importlib.import_module", fail_torch_import)
+
+    engine = create_upscaler_engine("real-esrgan")
+
+    assert isinstance(engine, RealESRGANUpscaler)
+    assert imported == []
+
+
+def test_upscaler_tile_slices_cover_edges_without_overlap_gaps():
+    assert tile_slices(5, 3, 2) == [
+        TileSlice(0, 0, 2, 2),
+        TileSlice(2, 0, 4, 2),
+        TileSlice(4, 0, 5, 2),
+        TileSlice(0, 2, 2, 3),
+        TileSlice(2, 2, 4, 3),
+        TileSlice(4, 2, 5, 3),
+    ]
+    assert tile_slices(5, 3, 0) == [TileSlice(0, 0, 5, 3)]
+
+
+def test_real_esrgan_upscale_lazily_imports_torch_and_reuses_device_helpers(tmp_path, monkeypatch):
+    weights = tmp_path / "realesrgan.pth"
+    weights.write_bytes(b"stub")
+
+    class FakeTorch:
+        float32 = "float32"
+        bfloat16 = "bfloat16"
+        float16 = "float16"
+
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+        class backends:
+            mps = None
+
+    imports: list[str] = []
+
+    def fake_import_module(name):
+        imports.append(name)
+        if name == "torch":
+            return FakeTorch
+        return importlib.import_module(name)
+
+    seen: dict[str, Any] = {}
+
+    def fake_load_model(self, torch, weights_path, *, factor, device, dtype):
+        seen.update({"torch": torch, "weights_path": weights_path, "factor": factor, "device": device, "dtype": dtype})
+        return object()
+
+    def fake_upscale_with_model(self, torch, model, image, *, factor, device, dtype, tile_size, tile_pad):
+        seen.update({"tile_size": tile_size, "tile_pad": tile_pad})
+        return image.resize((image.width * factor, image.height * factor))
+
+    monkeypatch.setattr("scene_worker.upscalers.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(RealESRGANUpscaler, "_load_model", fake_load_model)
+    monkeypatch.setattr(RealESRGANUpscaler, "_upscale_with_model", fake_upscale_with_model)
+
+    result = RealESRGANUpscaler().upscale(
+        Image.new("RGB", (3, 4), "white"),
+        job=UpscaleJob(factor=2, weights_path=weights, tile_size=64, tile_pad=4),
+        settings=SimpleNamespace(gpu_id="cpu"),
+    )
+
+    assert result.size == (6, 8)
+    assert imports == ["torch"]
+    assert seen == {
+        "torch": FakeTorch,
+        "weights_path": weights,
+        "factor": 2,
+        "device": "cpu",
+        "dtype": "float32",
+        "tile_size": 64,
+        "tile_pad": 4,
+    }
 
 
 def test_pipeline_component_devices_inspects_known_submodules():


### PR DESCRIPTION
## Summary
- Added a new worker-side `UpscalerEngine` abstraction with a Real-ESRGAN implementation path.
- Implemented lazy torch import, device/dtype reuse, 2x/4x validation, and tiled inference helpers.
- Added focused runtime tests for engine selection, tile coverage, and lazy import behavior.

## Testing
- `python -m pytest tests/test_worker_runtime.py` passed (230 passed, 7 skipped).
- `python -m pytest tests/test_worker_runtime.py -k "upscaler or gpu_memory_snapshot or pipeline_component_devices or verify_pipeline_on_device"` passed.