### PR TITLE
[codex] Add upscale request threading for image jobs

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -366,6 +366,8 @@ pub(crate) struct ImageJobRequest {
     pub(crate) source_asset_id: Option<String>,
     #[serde(default = "default_requested_gpu")]
     pub(crate) requested_gpu: String,
+    #[serde(default, skip_serializing_if = "ImageUpscaleRequest::is_disabled")]
+    pub(crate) upscale: ImageUpscaleRequest,
     #[serde(default)]
     pub(crate) advanced: JsonObject,
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -20,9 +20,9 @@ use axum::{Json, Router};
 use futures_util::future::join_all;
 use parking_lot::Mutex;
 use sceneworks_core::contracts::{
-    ClaimRequest, ClaimResponse, ContractNumber, DuplicateJobRequest, JobCreateRequest,
-    JobSnapshot, JobStatus, JobType, JsonObject, ProgressRequest, QueueSummary, WorkerCapability,
-    WorkerHeartbeatRequest, WorkerRegisterRequest, WorkerSnapshot, WorkerStatus,
+    ClaimRequest, ClaimResponse, ContractNumber, DuplicateJobRequest, ImageUpscaleRequest,
+    JobCreateRequest, JobSnapshot, JobStatus, JobType, JsonObject, ProgressRequest, QueueSummary,
+    WorkerCapability, WorkerHeartbeatRequest, WorkerRegisterRequest, WorkerSnapshot, WorkerStatus,
 };
 use sceneworks_core::jobs_store::{
     CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker,
@@ -1643,6 +1643,14 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
     }
     validate_dimension(payload.width, "width", MAX_IMAGE_DIMENSION)?;
     validate_dimension(payload.height, "height", MAX_IMAGE_DIMENSION)?;
+    if payload.upscale.enabled {
+        if ![2, 4].contains(&payload.upscale.factor) {
+            return Err(ApiError::bad_request("upscale.factor must be 2 or 4"));
+        }
+        if payload.upscale.engine.trim().is_empty() {
+            return Err(ApiError::bad_request("upscale.engine is required"));
+        }
+    }
     Ok(())
 }
 

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2203,6 +2203,63 @@ async fn timeline_routes_persist_and_create_worker_jobs() {
 }
 
 #[tokio::test]
+async fn image_job_route_threads_upscale_contract_when_enabled() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let base_request = json!({
+        "projectId": "project-1",
+        "mode": "text_to_image",
+        "prompt": "mist over hills",
+        "count": 1,
+        "seed": 123
+    });
+    let (status, base_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        base_request.clone(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert!(base_job["payload"].get("upscale").is_none());
+
+    let mut disabled_request = base_request.clone();
+    disabled_request["upscale"] = json!({ "enabled": false, "factor": 4, "engine": "real-esrgan" });
+    let (status, disabled_job) =
+        request(app.clone(), "POST", "/api/v1/image/jobs", disabled_request).await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(disabled_job["payload"], base_job["payload"]);
+
+    let mut enabled_request = base_request;
+    enabled_request["upscale"] = json!({ "enabled": true, "factor": 4, "engine": "real-esrgan" });
+    let (status, enabled_job) =
+        request(app.clone(), "POST", "/api/v1/image/jobs", enabled_request).await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(
+        enabled_job["payload"]["upscale"],
+        json!({ "enabled": true, "factor": 4, "engine": "real-esrgan" })
+    );
+
+    let (status, error) = request(
+        app,
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "count": 1,
+            "seed": 123,
+            "upscale": { "enabled": true, "factor": 3, "engine": "real-esrgan" }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(error["detail"], "upscale.factor must be 2 or 4");
+}
+
+#[tokio::test]
 async fn image_and_video_job_routes_normalize_payloads() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import gc
 import hashlib
 import importlib
@@ -291,6 +291,13 @@ MODEL_TARGETS = {
 
 
 @dataclass(frozen=True)
+class UpscaleRequest:
+    enabled: bool = False
+    factor: int = 2
+    engine: str = "real-esrgan"
+
+
+@dataclass(frozen=True)
 class ImageRequest:
     project_id: str
     mode: str
@@ -308,6 +315,19 @@ class ImageRequest:
     character_look_id: str | None
     source_asset_id: str | None
     advanced: dict[str, Any]
+    upscale: UpscaleRequest = field(default_factory=UpscaleRequest)
+
+
+def upscale_request_from_payload(payload: dict[str, Any]) -> UpscaleRequest:
+    raw = payload.get("upscale")
+    if not isinstance(raw, dict):
+        return UpscaleRequest()
+    enabled = bool(raw.get("enabled", False))
+    factor = safe_int(raw.get("factor"), 2, 2, 4)
+    if factor not in {2, 4}:
+        factor = 2
+    engine = str(raw.get("engine") or "real-esrgan").strip() or "real-esrgan"
+    return UpscaleRequest(enabled=enabled, factor=factor, engine=engine)
 
 
 def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
@@ -331,6 +351,7 @@ def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
         character_id=payload.get("characterId"),
         character_look_id=payload.get("characterLookId"),
         source_asset_id=payload.get("sourceAssetId"),
+        upscale=upscale_request_from_payload(payload),
         advanced=payload.get("advanced", {}),
     )
 
@@ -2509,5 +2530,3 @@ def render_preview_image(request: ImageRequest, model_target: dict[str, Any], se
         draw.text((28, y), line, fill=(255, 255, 255, 242), font=font)
         y += 18
     return image
-
-

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -491,6 +491,44 @@ pub struct JobCreateRequest {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ImageUpscaleRequest {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_image_upscale_factor")]
+    pub factor: u8,
+    #[serde(default = "default_image_upscale_engine")]
+    pub engine: String,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+impl Default for ImageUpscaleRequest {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            factor: default_image_upscale_factor(),
+            engine: default_image_upscale_engine(),
+            extra: ExtraFields::default(),
+        }
+    }
+}
+
+impl ImageUpscaleRequest {
+    pub fn is_disabled(&self) -> bool {
+        !self.enabled
+    }
+}
+
+pub const fn default_image_upscale_factor() -> u8 {
+    2
+}
+
+pub fn default_image_upscale_engine() -> String {
+    "real-esrgan".to_owned()
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WorkerRegisterRequest {
     pub worker_id: String,
     pub gpu_id: String,
@@ -1200,4 +1238,40 @@ pub struct ModelInstallMarker {
     pub completed_at: String,
     #[serde(flatten)]
     pub extra: ExtraFields,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn image_upscale_request_round_trips_when_present() {
+        let value = json!({
+            "enabled": true,
+            "factor": 4,
+            "engine": "real-esrgan"
+        });
+
+        let request: ImageUpscaleRequest =
+            serde_json::from_value(value.clone()).expect("upscale request parses");
+
+        assert!(request.enabled);
+        assert_eq!(request.factor, 4);
+        assert_eq!(request.engine, "real-esrgan");
+        assert_eq!(
+            serde_json::to_value(request).expect("upscale request serializes"),
+            value
+        );
+    }
+
+    #[test]
+    fn image_upscale_request_defaults_to_disabled() {
+        let request: ImageUpscaleRequest =
+            serde_json::from_value(json!({})).expect("empty upscale request parses");
+
+        assert!(request.is_disabled());
+        assert_eq!(request.factor, 2);
+        assert_eq!(request.engine, "real-esrgan");
+    }
 }

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1177,6 +1177,25 @@ def test_image_request_clamps_above_new_ceiling():
     assert request.height == 4096
 
 
+def test_image_request_parses_optional_upscale_contract():
+    default_request = image_request_from_job({"payload": {"projectId": "p"}})
+    assert default_request.upscale.enabled is False
+    assert default_request.upscale.factor == 2
+    assert default_request.upscale.engine == "real-esrgan"
+
+    request = image_request_from_job(
+        {
+            "payload": {
+                "projectId": "p",
+                "upscale": {"enabled": True, "factor": 4, "engine": "real-esrgan"},
+            }
+        }
+    )
+    assert request.upscale.enabled is True
+    assert request.upscale.factor == 4
+    assert request.upscale.engine == "real-esrgan"
+
+
 def test_create_image_adapter_routes_sensenova_u1_fast():
     adapter = create_image_adapter({"payload": {"model": "sensenova_u1_8b_fast"}})
     assert adapter.__class__.__name__ == "SenseNovaU1Adapter"


### PR DESCRIPTION
## Summary
- Add a typed image upscaling request contract with disabled-by-default behavior.
- Thread enabled `upscale` settings through the Rust image job route into the worker payload.
- Parse optional upscaling settings in the Python worker request model.

## Validation
- `cargo test -p sceneworks-core --quiet`
- `cargo test -p sceneworks-rust-api --quiet`
- `python -m pytest tests/test_worker_runtime.py -q`