### PR TITLE
feat(sc-1782): FLUX.1 [schnell] + [dev] selectable Image Studio models

### DIFF
--- a/apps/web/public/prompt-guides/flux-dev.md
+++ b/apps/web/public/prompt-guides/flux-dev.md
@@ -1,0 +1,80 @@
+# FLUX.1 [dev] Prompt Guide
+
+## Best For
+
+Highest-quality FLUX text-to-image: detailed photography, illustration, concept art, and crisp, legible text. [dev] is the guided ~28-step variant — slower than [schnell] but with finer detail and guidance control.
+
+> **License:** FLUX.1 [dev] is distributed under the FLUX.1 [dev] Non-Commercial License — generations are for non-commercial use only. It is a gated Hugging Face download (accept the license and configure an HF token first). For commercial use, choose FLUX.1 [schnell] (Apache-2.0).
+
+## Prompt Shape
+
+FLUX was trained on rich natural-language captions, so write a fluent sentence (or two) describing the finished image rather than a list of tags:
+
+`subject + setting + visual details + style + composition + lighting + any text`
+
+[dev] uses an embedded **guidance** value (default ~3.5): higher values follow the prompt more literally, lower values are more creative. There is no separate negative prompt — keep everything in the positive prompt.
+
+## Build The Prompt
+
+### Subject
+
+Describe the subject as if captioning a finished photo. Include type, action, position, and distinguishing features.
+
+Good: `a botanist examining a glowing bioluminescent orchid in a misty greenhouse`
+
+### Details
+
+Add material, texture, and atmosphere:
+
+- `brushed titanium`
+- `dew on spider silk`
+- `volumetric haze`
+- `ornate art-nouveau scrollwork`
+
+### Style
+
+Use photographic or art-direction terms:
+
+- `National Geographic wildlife photography`
+- `cinematic film still, anamorphic lens`
+- `detailed digital matte painting`
+- `loose watercolor on cold-press paper`
+
+### Camera And Composition
+
+FLUX handles many aspect ratios — pair composition with the selected size:
+
+- `overhead flat-lay`
+- `telephoto compression`
+- `Dutch angle`
+- `symmetrical centered composition`
+
+### Lighting
+
+- `golden hour`
+- `soft chiaroscuro`
+- `bioluminescent glow`
+- `hard noon sunlight with sharp shadows`
+
+### Text In Images
+
+FLUX renders text well — quote the exact words and describe the medium:
+
+`a letterpress poster reading "NORTHERN LIGHTS FESTIVAL" in condensed sans-serif, layered ink texture`
+
+## Tips
+
+- Start at guidance ~3.5; raise toward 5 for stricter prompt adherence, lower toward 2 for more variation.
+- ~28 steps balances quality and speed; more steps add marginal detail.
+- No negative prompt — describe what you *want*, in detail.
+
+## Example Prompts
+
+`A grand library reading room at golden hour, sun shafts through tall arched windows, dust motes in the air, a brass plaque reading "QUIET STUDY" on a carved oak desk, leather-bound books, intricate coffered ceiling, cinematic depth.`
+
+`An ultra-detailed macro photograph of a dew-covered jumping spider on a fern frond at dawn, iridescent eyes, soft bokeh background, National Geographic wildlife photography, razor-sharp focus.`
+
+## Sources
+
+- [FLUX.1 [dev] model card](https://huggingface.co/black-forest-labs/FLUX.1-dev)
+- [Diffusers Flux pipeline docs](https://huggingface.co/docs/diffusers/main/en/api/pipelines/flux)

--- a/apps/web/public/prompt-guides/flux-schnell.md
+++ b/apps/web/public/prompt-guides/flux-schnell.md
@@ -1,0 +1,76 @@
+# FLUX.1 [schnell] Prompt Guide
+
+## Best For
+
+Fast, high-quality text-to-image generations: photography, illustration, concept art, and notably strong, legible text rendering. [schnell] is the distilled, ~4-step variant — Apache-2.0 and commercial-safe — so it favors speed while keeping FLUX's excellent prompt following.
+
+## Prompt Shape
+
+FLUX was trained on rich natural-language captions, so write a fluent sentence (or two) describing the finished image rather than a list of tags:
+
+`subject + setting + visual details + style + composition + lighting + any text`
+
+FLUX is guidance-distilled, so it does **not** use a CFG / negative prompt — put everything you want into the positive prompt and leave guidance at 0.
+
+## Build The Prompt
+
+### Subject
+
+Describe the subject as if captioning a finished photo. Include type, action, position, and distinguishing features.
+
+Good: `a weathered fisherman mending a net on a wooden dock at dawn`
+
+### Details
+
+Add material, texture, and atmosphere:
+
+- `hand-stitched leather`
+- `condensation on cold glass`
+- `drifting morning fog`
+- `intricate filigree pattern`
+
+### Style
+
+Use photographic or art-direction terms:
+
+- `editorial fashion photography`
+- `cinematic film still, 35mm`
+- `flat vector illustration`
+- `soft gouache painting`
+
+### Camera And Composition
+
+- `low-angle hero shot`
+- `extreme close-up macro`
+- `wide establishing shot`
+- `centered product shot, studio backdrop`
+
+### Lighting
+
+- `golden hour backlight`
+- `soft window light`
+- `neon-lit night scene`
+- `dramatic rim lighting`
+
+### Text In Images
+
+FLUX renders text well — quote the exact words and describe the medium:
+
+`a vintage enamel sign reading "HARBOR CAFE" in cream serif letters`
+
+## Tips
+
+- Keep the prompt descriptive and positive; there is no negative prompt.
+- ~4 steps is the sweet spot — more steps rarely help [schnell].
+- For maximum quality (more steps, guidance control), use FLUX.1 [dev].
+
+## Example Prompts
+
+`A cozy independent bookstore storefront at dusk, warm interior glow spilling onto a rain-slick cobblestone street, a hand-painted sign reading "PAGE & QUILL" in gold script, reflections in the wet pavement, cinematic shallow depth of field.`
+
+`A studio product shot of a matte-black ceramic pour-over coffee set on a pale oak table, soft diffused side light, subtle steam rising, minimalist composition, high detail.`
+
+## Sources
+
+- [FLUX.1 [schnell] model card](https://huggingface.co/black-forest-labs/FLUX.1-schnell)
+- [Diffusers Flux pipeline docs](https://huggingface.co/docs/diffusers/main/en/api/pipelines/flux)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -110,6 +110,26 @@ export const fallbackModels = [
     },
   },
   {
+    id: "flux_schnell",
+    name: "FLUX.1 [schnell]",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    ui: {
+      description: "FLUX.1 [schnell] — fast ~4-step distilled text-to-image, Apache-2.0 (commercial-safe). ~34GB bf16, large-VRAM GPU.",
+      promptGuide: { title: "FLUX.1 [schnell] Prompt Guide", path: "/prompt-guides/flux-schnell.md" },
+    },
+  },
+  {
+    id: "flux_dev",
+    name: "FLUX.1 [dev]",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    ui: {
+      description: "FLUX.1 [dev] — higher-quality ~28-step text-to-image under the FLUX.1 [dev] Non-Commercial License (non-commercial only); gated download needs an HF token + license acceptance. ~34GB bf16, large-VRAM GPU.",
+      promptGuide: { title: "FLUX.1 [dev] Prompt Guide", path: "/prompt-guides/flux-dev.md" },
+    },
+  },
+  {
     id: "ltx_2_3",
     name: "LTX-2.3",
     type: "video",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -397,6 +397,105 @@
       }
     },
     {
+      "id": "flux_schnell",
+      "name": "FLUX.1 [schnell]",
+      "family": "flux",
+      "type": "image",
+      "adapter": "flux_diffusers",
+      "capabilities": ["text_to_image", "style_variations"],
+      "downloads": [
+        {
+          // Whole-repo download (~53.9 GiB: bundles the original single-file
+          // checkpoint AND the diffusers folders FluxPipeline loads).
+          "provider": "huggingface",
+          "repo": "black-forest-labs/FLUX.1-schnell",
+          "files": [],
+          "estimatedSizeBytes": 57845743616
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/black-forest-labs/FLUX.1-schnell"
+      },
+      "defaults": {
+        // Guidance-distilled: ignores CFG (guidance 0), ~4 steps.
+        "resolution": "1024x1024",
+        "steps": 4,
+        "guidanceScale": 0,
+        "count": 4
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        // Flipped to ["flux"] in sc-1784 once generation-side LoRA lands.
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "FLUX.1 [schnell]",
+        "description": "Black Forest Labs FLUX.1 [schnell] — fast ~4-step distilled text-to-image, Apache-2.0 (commercial-safe). 12B transformer + T5-XXL text encoder; ~34GB bf16 VRAM, needs a large-VRAM GPU.",
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "FLUX.1 [schnell] Prompt Guide",
+          "path": "/prompt-guides/flux-schnell.md",
+          "sources": [
+            { "label": "FLUX.1 [schnell] model card", "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell" },
+            { "label": "Diffusers Flux pipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/flux" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "flux_dev",
+      "name": "FLUX.1 [dev]",
+      "family": "flux",
+      "type": "image",
+      "adapter": "flux_diffusers",
+      "capabilities": ["text_to_image", "style_variations"],
+      "downloads": [
+        {
+          // Gated repo (Non-Commercial License). Whole-repo download (~53.9 GiB).
+          "provider": "huggingface",
+          "repo": "black-forest-labs/FLUX.1-dev",
+          "files": [],
+          "estimatedSizeBytes": 57886638080
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/black-forest-labs/FLUX.1-dev"
+      },
+      "defaults": {
+        // Guided: guidance ~3.5, ~28 steps (higher quality than schnell).
+        "resolution": "1024x1024",
+        "steps": 28,
+        "guidanceScale": 3.5,
+        "count": 1
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        // Flipped to ["flux"] in sc-1784 once generation-side LoRA lands.
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "FLUX.1 [dev]",
+        "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and configure an HF token before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU.",
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "FLUX.1 [dev] Prompt Guide",
+          "path": "/prompt-guides/flux-dev.md",
+          "sources": [
+            { "label": "FLUX.1 [dev] model card", "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev" },
+            { "label": "Diffusers Flux pipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/flux" }
+          ]
+        }
+      }
+    },
+    {
       "id": "ltx_2_3",
       "name": "LTX-2.3",
       "family": "ltx-video",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -138,6 +138,7 @@ string_enum! {
         QwenImage => "qwen_image",
         LensTurbo => "lens_turbo",
         SenseNovaU1 => "sensenova_u1",
+        FluxDiffusers => "flux_diffusers",
         ProceduralVideo => "procedural_video",
         ProceduralPersonTracking => "procedural_person_tracking",
         FfmpegFrameExtract => "ffmpeg-frame-extract",

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -217,6 +217,7 @@ pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
         "qwen-image" => Some("qwen_image"),
         "lens" => Some("lens_turbo"),
         "sensenova-u1" => Some("sensenova_u1"),
+        "flux" => Some("flux_diffusers"),
         "ltx-video" => Some("ltx_video"),
         "wan-video" => Some("wan_video"),
         _ => None,
@@ -232,6 +233,7 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         ("image", "qwen-image") => vec!["text_to_image", "style_variations"],
         ("image", "lens") => vec!["text_to_image", "style_variations"],
         ("image", "sensenova-u1") => vec!["text_to_image", "edit_image", "vqa", "interleave"],
+        ("image", "flux") => vec!["text_to_image", "style_variations"],
         ("video", "ltx-video") => vec![
             "image_to_video",
             "text_to_video",


### PR DESCRIPTION
Part 1 of epic [1780 — FLUX.1 Image Studio Integration](https://app.shortcut.com/trefry/epic/1780). Wires FLUX.1 in as a **selectable** text-to-image model (no inference yet). Story: sc-1782.

## Changes
- `RecipeAdapter::FluxDiffusers => "flux_diffusers"` (`contracts.rs`)
- `model_adapter_for_family` `flux` arm + `("image","flux")` capabilities arm (`lora_family.rs`; the `Bucket::Flux` detector already existed)
- `flux_schnell` + `flux_dev` builtin manifest entries — whole-repo downloads (~53.9 GiB each, size from the real download), per-variant step/guidance defaults, **dev Non-Commercial License notice** in `ui.description`, `loraCompatibility.families: []` (flipped to `["flux"]` in sc-1784)
- web `fallbackModels` entries + `flux-schnell` / `flux-dev` prompt guides

## Verification
- `rust:check` (fmt · clippy · full `cargo test` · build) ✅
- web vitest **112 passed** + build ✅
- Live: `/api/v1/models` from the real manifest serves both variants with `adapter=flux_diffusers`, capabilities `[text_to_image, style_variations]`, sizes ~57.8 GB.

Spike (sc-1781) confirmed FLUX.1 runs in the **main worker venv** (transformers 4.57 + diffusers) — no sidecar.

> Stacked: this is the base of a 3-PR stack (sc-1782 → sc-1783 → sc-1784).

🤖 Generated with [Claude Code](https://claude.com/claude-code)