### PR TITLE
feat(sc-1783): FluxDiffusersAdapter — FLUX.1 [schnell]/[dev] worker T2I

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -287,6 +287,28 @@ MODEL_TARGETS = {
             "file": "SenseNova-U1-8B-MoT-LoRA-8step-V1.0.safetensors",
         },
     },
+    "flux_schnell": {
+        "label": "FLUX.1 [schnell]",
+        "family": "flux",
+        "supportsEdit": False,
+        # Guidance-distilled: ignores CFG (guidance 0), ~4 steps; T5 max_seq_len 256.
+        "steps": 4,
+        "guidanceScale": 0.0,
+        "maxSequenceLength": 256,
+        "repo": "black-forest-labs/FLUX.1-schnell",
+        "adapter": "flux_diffusers",
+    },
+    "flux_dev": {
+        "label": "FLUX.1 [dev]",
+        "family": "flux",
+        "supportsEdit": False,
+        # Guided: guidance ~3.5, ~28 steps; T5 max_seq_len 512. Gated (non-commercial).
+        "steps": 28,
+        "guidanceScale": 3.5,
+        "maxSequenceLength": 512,
+        "repo": "black-forest-labs/FLUX.1-dev",
+        "adapter": "flux_diffusers",
+    },
 }
 
 
@@ -1047,6 +1069,296 @@ class QwenImageAdapter:
             return float(request.advanced.get("guidanceScale", 4.0))
         except (TypeError, ValueError):
             return 4.0
+
+
+class FluxDiffusersAdapter:
+    """Black Forest Labs FLUX.1 [schnell] / [dev] text-to-image via diffusers.FluxPipeline.
+
+    Mirrors ZImageDiffusersAdapter / QwenImageAdapter: HF-cache check, device/dtype
+    selection, progress + cancel callbacks, incremental asset writing, and worker
+    events for pipeline load + inference. FLUX.1 runs in the MAIN worker venv
+    (transformers 4.57 + diffusers, confirmed by spike sc-1781) — no sidecar.
+    Text-to-image only; FLUX.1 Kontext editing is a future epic.
+    """
+
+    id = "flux_diffusers"
+
+    def __init__(self) -> None:
+        self._text_pipe: Any | None = None
+        self._text_repo: str | None = None
+        self._loaded_model: str | None = None
+        self._loaded_lora_states: dict[str, LoraPipelineState] = {}
+
+    def loaded_models(self) -> list[str]:
+        return sorted({value for value in (self._text_repo, self._loaded_model) if value})
+
+    def unload(self) -> bool:
+        """Free the resident pipeline so another family can load (cross-adapter
+        eviction). Returns True if it actually freed something."""
+        if self._text_pipe is None:
+            return False
+        self._text_pipe = None
+        self._text_repo = None
+        self._loaded_model = None
+        self._loaded_lora_states.clear()
+        self._empty_cuda_cache(importlib.import_module("torch"))
+        return True
+
+    def generate(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        model_target = MODEL_TARGETS.get(request.model, {})
+        if model_target.get("adapter") != self.id:
+            raise RuntimeError(f"{request.model} is not a FLUX.1 Diffusers target.")
+        if request.mode == "edit_image":
+            raise RuntimeError(f"{request.model} does not support image editing.")
+
+        progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress, job_id=job["id"])
+        emit_worker_event(
+            "image_lora_apply_start",
+            jobId=job["id"],
+            adapter=self.id,
+            loraCount=len(request.loras),
+        )
+        self._apply_loras(pipe, request)
+        emit_worker_event("image_lora_apply_complete", jobId=job["id"], adapter=self.id)
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        label = model_target["label"]
+
+        def image_at_index(index: int) -> Image.Image:
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            progress(
+                "running",
+                "generating",
+                image_batch_progress(index, request.count),
+                format_batch_running_message(label, index, request.count),
+            )
+            emit_worker_event(
+                "image_inference_start",
+                jobId=job["id"],
+                adapter=self.id,
+                model=request.model,
+                imageIndex=index,
+                imageCount=request.count,
+                device=device,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            try:
+                image = self._run_pipeline(settings, pipe, request, seed, cancel_requested=cancel_requested)
+            except Exception as exc:
+                emit_worker_event(
+                    "image_inference_failed",
+                    jobId=job["id"],
+                    adapter=self.id,
+                    imageIndex=index,
+                    error=str(exc),
+                    errorType=exc.__class__.__name__,
+                )
+                raise
+            emit_worker_event(
+                "image_inference_complete",
+                jobId=job["id"],
+                adapter=self.id,
+                imageIndex=index,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return image
+
+        return ImageAssetWriter().write_incremental_outputs(
+            request=request,
+            project_path=project_path,
+            image_count=request.count,
+            image_at_index=image_at_index,
+            adapter_id=self.id,
+            progress=progress,
+            cancel_requested=cancel_requested,
+            raw_settings={
+                **request.advanced,
+                "repo": self._repo_for_request(request, model_target),
+                "numInferenceSteps": self._num_inference_steps(request, model_target),
+                "guidanceScale": self._guidance_scale(request, model_target),
+                "maxSequenceLength": self._max_sequence_length(request, model_target),
+                "realModelInference": True,
+            },
+        )
+
+    def _load_pipeline(
+        self,
+        settings: WorkerSettings,
+        request: ImageRequest,
+        model_target: dict[str, Any],
+        progress: ProgressCallback,
+        *,
+        job_id: str,
+    ) -> Any:
+        torch = importlib.import_module("torch")
+        diffusers = importlib.import_module("diffusers")
+        repo = self._repo_for_request(request, model_target)
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+        cpu_offload = bool(request.advanced.get("cpuOffload", False))
+        if self._text_pipe is not None and self._text_repo == repo:
+            self._loaded_model = request.model
+            progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
+            emit_worker_event(
+                "image_pipeline_cache_hit",
+                jobId=job_id,
+                adapter=self.id,
+                model=request.model,
+                repo=repo,
+                device=device,
+                componentDevices=pipeline_component_devices(self._text_pipe),
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return self._text_pipe
+        if self._text_pipe is not None:
+            self._text_pipe = None
+            self._text_repo = None
+            self._empty_cuda_cache(torch)
+            self._forget_loaded_loras("text")
+
+        pipeline_class = getattr(diffusers, "FluxPipeline", None)
+        if pipeline_class is None:
+            raise RuntimeError(
+                "The installed diffusers package does not expose FluxPipeline. "
+                "Install diffusers >= 0.30 for FLUX.1 support."
+            )
+
+        progress("loading_model", "loading_model", 0.2, f"Loading {model_target['label']} model files.")
+        emit_worker_event(
+            "image_pipeline_load_start",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            device=device,
+            dtype=str(dtype),
+            useImg2img=False,
+            cpuOffload=cpu_offload,
+            cached=huggingface_repo_cache_exists(repo),
+        )
+        pipe = pipeline_class.from_pretrained(repo, torch_dtype=dtype)
+        emit_worker_event(
+            "image_pipeline_load_complete",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            componentDevices=pipeline_component_devices(pipe),
+        )
+        offload_enabled = cpu_offload and hasattr(pipe, "enable_model_cpu_offload")
+        if offload_enabled:
+            pipe.enable_model_cpu_offload()
+        else:
+            pipe.to(device)
+        # VAE tiling keeps high-resolution decodes within memory. Prefer the
+        # current diffusers API (pipe.vae.enable_tiling) and fall back to the
+        # deprecated pipeline-level shim for older builds.
+        vae = getattr(pipe, "vae", None)
+        if vae is not None and hasattr(vae, "enable_tiling"):
+            vae.enable_tiling()
+        elif hasattr(pipe, "enable_vae_tiling"):
+            pipe.enable_vae_tiling()
+        component_devices = verify_pipeline_on_device(
+            pipe,
+            requested_device=device,
+            model_label=model_target["label"],
+            allow_offload=offload_enabled,
+        )
+        emit_worker_event(
+            "image_pipeline_on_device",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            requestedDevice=device,
+            cpuOffload=offload_enabled,
+            componentDevices=component_devices,
+            gpuMemory=gpu_memory_snapshot(torch, device),
+        )
+        self._text_pipe = pipe
+        self._text_repo = repo
+        self._loaded_model = request.model
+        return pipe
+
+    def _empty_cuda_cache(self, torch: Any) -> None:
+        release_inference_memory(torch)
+
+    def _run_pipeline(
+        self,
+        settings: WorkerSettings,
+        pipe: Any,
+        request: ImageRequest,
+        seed: int,
+        cancel_requested: CancelCallback | None = None,
+    ) -> Image.Image:
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
+        model_target = MODEL_TARGETS[request.model]
+        kwargs = {
+            "prompt": request.prompt,
+            "height": request.height,
+            "width": request.width,
+            "num_inference_steps": self._num_inference_steps(request, model_target),
+            # FLUX uses embedded (distilled) guidance: schnell ignores it (0.0),
+            # dev follows it (~3.5). There is no separate negative-prompt CFG path.
+            "guidance_scale": self._guidance_scale(request, model_target),
+            "max_sequence_length": self._max_sequence_length(request, model_target),
+            "generator": generator,
+        }
+        step_callback = cancel_step_callback(pipe, cancel_requested)
+        if step_callback is not None:
+            kwargs["callback_on_step_end"] = step_callback
+        output = pipe(**filter_call_kwargs(pipe, kwargs))
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
+        return output.images[0].convert("RGB")
+
+    def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
+        model_target = MODEL_TARGETS.get(request.model, {})
+        self._loaded_lora_states["text"] = apply_loras_to_pipeline(
+            pipe,
+            request.loras,
+            adapter_id=self.id,
+            model_family=model_target.get("family"),
+            previous_state=self._loaded_lora_states.get("text"),
+        )
+
+    def _forget_loaded_loras(self, key: str) -> None:
+        self._loaded_lora_states.pop(key, None)
+
+    def _repo_for_request(self, request: ImageRequest, model_target: dict[str, Any]) -> str:
+        return request.advanced.get("modelRepo") or model_target["repo"]
+
+    def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        return safe_int(request.advanced.get("steps"), model_target["steps"], 1, 80)
+
+    def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:
+        default = model_target.get("guidanceScale", 0.0)
+        try:
+            return float(request.advanced.get("guidanceScale", default))
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _max_sequence_length(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        return safe_int(
+            request.advanced.get("maxSequenceLength"),
+            model_target.get("maxSequenceLength", 512),
+            1,
+            512,
+        )
 
 
 # Lens trains on two base resolutions crossed with nine aspect ratios and expects
@@ -2258,14 +2570,27 @@ class SenseNovaU1Adapter:
 def create_image_adapter(
     job: dict[str, Any],
     adapters: dict[str, object] | None = None,
-) -> ProceduralImageAdapter | ZImageDiffusersAdapter | QwenImageAdapter | LensTurboAdapter | SenseNovaU1Adapter:
+) -> (
+    ProceduralImageAdapter
+    | ZImageDiffusersAdapter
+    | QwenImageAdapter
+    | LensTurboAdapter
+    | SenseNovaU1Adapter
+    | FluxDiffusersAdapter
+):
     payload = job.get("payload", {})
     requested = os.getenv("SCENEWORKS_IMAGE_ADAPTER", payload.get("adapter", "")).strip()
     if requested == "auto":
         requested = ""
     if requested in {"procedural", "procedural_preview"}:
         return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
-    if requested and requested not in {ZImageDiffusersAdapter.id, QwenImageAdapter.id, LensTurboAdapter.id, SenseNovaU1Adapter.id}:
+    if requested and requested not in {
+        ZImageDiffusersAdapter.id,
+        QwenImageAdapter.id,
+        LensTurboAdapter.id,
+        SenseNovaU1Adapter.id,
+        FluxDiffusersAdapter.id,
+    }:
         raise RuntimeError(f"Unsupported SCENEWORKS_IMAGE_ADAPTER value: {requested}.")
     if requested == ZImageDiffusersAdapter.id:
         return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
@@ -2275,6 +2600,8 @@ def create_image_adapter(
         return adapters.get("lens_turbo") if adapters else LensTurboAdapter()
     if requested == SenseNovaU1Adapter.id:
         return adapters.get("sensenova_u1") if adapters else SenseNovaU1Adapter()
+    if requested == FluxDiffusersAdapter.id:
+        return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
     model_target = MODEL_TARGETS.get(payload.get("model", "z_image_turbo"), {})
     if model_target.get("adapter") == ZImageDiffusersAdapter.id:
         return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
@@ -2284,6 +2611,8 @@ def create_image_adapter(
         return adapters.get("lens_turbo") if adapters else LensTurboAdapter()
     if model_target.get("adapter") == SenseNovaU1Adapter.id:
         return adapters.get("sensenova_u1") if adapters else SenseNovaU1Adapter()
+    if model_target.get("adapter") == FluxDiffusersAdapter.id:
+        return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
     return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
 
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -17,6 +17,7 @@ from sceneworks_shared import find_project_path, utc_now
 from .caption_adapters import run_training_caption_job
 from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_utilization, gpu_worker_id
 from .image_adapters import (
+    FluxDiffusersAdapter,
     LensTurboAdapter,
     ProceduralImageAdapter,
     QwenImageAdapter,
@@ -1250,6 +1251,7 @@ def run_worker_loop(settings: WorkerSettings) -> None:
         "z_image_diffusers": ZImageDiffusersAdapter(),
         "lens_turbo": LensTurboAdapter(),
         "sensenova_u1": SenseNovaU1Adapter(),
+        "flux_diffusers": FluxDiffusersAdapter(),
     }
     max_registration_attempts = 20
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -23,6 +23,7 @@ from scene_worker.caption_adapters import (
     normalize_processor_resample,
 )
 from scene_worker.image_adapters import (
+    FluxDiffusersAdapter,
     ImageAssetWriter,
     LensTurboAdapter,
     MODEL_TARGETS,
@@ -959,6 +960,101 @@ def test_lens_resolution_for_snaps_to_buckets():
     assert lens_resolution_for(720, 1280) == (1024, "9:16")
     assert lens_resolution_for(1152, 864) == (1024, "4:3")
     assert lens_resolution_for(864, 1152) == (1024, "3:4")
+
+
+def test_create_image_adapter_routes_flux_schnell_and_dev():
+    schnell = create_image_adapter({"payload": {"model": "flux_schnell"}})
+    assert schnell.__class__.__name__ == "FluxDiffusersAdapter"
+    assert schnell.id == "flux_diffusers"
+    dev = create_image_adapter({"payload": {"model": "flux_dev"}})
+    assert dev.__class__.__name__ == "FluxDiffusersAdapter"
+
+
+def test_image_adapter_env_override_selects_flux(monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "flux_diffusers")
+    # Env override wins even when the payload names a different family's model.
+    adapter = create_image_adapter({"payload": {"model": "z_image_turbo"}})
+    assert adapter.__class__.__name__ == "FluxDiffusersAdapter"
+
+
+def test_flux_model_target_defaults():
+    schnell = MODEL_TARGETS["flux_schnell"]
+    assert schnell["adapter"] == "flux_diffusers"
+    assert schnell["family"] == "flux"
+    assert schnell["supportsEdit"] is False
+    # Guidance-distilled: 4 steps, guidance 0, T5 max_seq_len 256.
+    assert schnell["steps"] == 4
+    assert schnell["guidanceScale"] == 0.0
+    assert schnell["maxSequenceLength"] == 256
+    assert schnell["repo"] == "black-forest-labs/FLUX.1-schnell"
+
+    dev = MODEL_TARGETS["flux_dev"]
+    assert dev["adapter"] == "flux_diffusers"
+    assert dev["family"] == "flux"
+    assert dev["supportsEdit"] is False
+    # Guided: 28 steps, guidance 3.5, T5 max_seq_len 512.
+    assert dev["steps"] == 28
+    assert dev["guidanceScale"] == 3.5
+    assert dev["maxSequenceLength"] == 512
+    assert dev["repo"] == "black-forest-labs/FLUX.1-dev"
+
+
+def test_flux_guidance_scale_uses_per_model_default_and_override():
+    adapter = FluxDiffusersAdapter()
+    schnell = MODEL_TARGETS["flux_schnell"]
+    dev = MODEL_TARGETS["flux_dev"]
+    # Per-model default applies when the request does not override guidance.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={}), schnell) == 0.0
+    assert adapter._guidance_scale(SimpleNamespace(advanced={}), dev) == 3.5
+    # An explicit request value wins.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={"guidanceScale": 2.0}), dev) == 2.0
+    # Unparseable override falls back to the per-model default.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={"guidanceScale": "x"}), dev) == 3.5
+
+
+def test_flux_num_inference_steps_default_and_override():
+    adapter = FluxDiffusersAdapter()
+    schnell = MODEL_TARGETS["flux_schnell"]
+    dev = MODEL_TARGETS["flux_dev"]
+    # Defaults come straight from the model target (no Z-Image +1 quirk).
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), schnell) == 4
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), dev) == 28
+    # Explicit override is honored and clamped to [1, 80].
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 12}), schnell) == 12
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 999}), dev) == 80
+
+
+def test_flux_max_sequence_length_default_and_override():
+    adapter = FluxDiffusersAdapter()
+    schnell = MODEL_TARGETS["flux_schnell"]
+    dev = MODEL_TARGETS["flux_dev"]
+    assert adapter._max_sequence_length(SimpleNamespace(advanced={}), schnell) == 256
+    assert adapter._max_sequence_length(SimpleNamespace(advanced={}), dev) == 512
+    # Override honored, clamped to the T5 max of 512.
+    assert adapter._max_sequence_length(SimpleNamespace(advanced={"maxSequenceLength": 128}), dev) == 128
+    assert adapter._max_sequence_length(SimpleNamespace(advanced={"maxSequenceLength": 4096}), dev) == 512
+
+
+def test_flux_rejects_image_edit():
+    job = {
+        "id": "job_flux_edit",
+        "payload": {
+            "projectId": "project_x",
+            "mode": "edit_image",
+            "model": "flux_dev",
+            "prompt": "a cat",
+        },
+    }
+    noop = lambda *args, **kwargs: None  # noqa: E731
+    try:
+        FluxDiffusersAdapter().generate(
+            settings=None, job=job, request=image_request_from_job(job), project_path=None,
+            progress=noop, cancel_requested=lambda: False,
+        )
+    except RuntimeError as exc:
+        assert "does not support image editing" in str(exc)
+    else:
+        raise AssertionError("FLUX.1 is text-to-image only and must reject edit_image.")
 
 
 def test_create_image_adapter_routes_sensenova_u1():


### PR DESCRIPTION
Part 2 of epic [1780](https://app.shortcut.com/trefry/epic/1780). Real text-to-image for FLUX.1 through `diffusers.FluxPipeline` in the main worker venv (no sidecar). Story: sc-1783.

## Changes
- `FluxDiffusersAdapter` (id `flux_diffusers`) in `image_adapters.py`, mirroring `ZImageDiffusersAdapter`/`QwenImageAdapter`: HF-cache check, device/dtype (bf16), `FluxPipeline.from_pretrained`, `vae.enable_tiling()` (forward-compatible API), progress + cancel callbacks, pipeline-load/inference worker events, incremental asset writing. **T2I only** (Kontext editing deferred). `guidance_scale` + `max_sequence_length` via `filter_call_kwargs`; per-variant defaults (schnell 4/g=0/seq256, dev 28/g=3.5/seq512).
- `MODEL_TARGETS` `flux_schnell`/`flux_dev`; `create_image_adapter` routing (env override + model-target) + `runtime.py` instantiation.
- Worker pytest: routing, env override, per-variant defaults, edit rejection.

## Verification
- Worker pytest set (`test_worker_runtime` + `worker_gpu` + `person_adapters`) **270 passed / 2 skipped** ✅
- Real-adapter generation on RTX PRO 6000: coherent 1024² for both variants (schnell 3.2 s, dev 14.2 s, **33.8 GiB** peak).

> Stacked on #250 (sc-1782). Review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)