### PR TITLE
feat(sc-1784): Flux generation-side LoRA compatibility

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -428,9 +428,8 @@
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
-        // Flipped to ["flux"] in sc-1784 once generation-side LoRA lands.
-        "families": [],
-        "types": []
+        "families": ["flux"],
+        "types": ["style", "enhance", "character"]
       },
       "ui": {
         "label": "FLUX.1 [schnell]",
@@ -477,9 +476,8 @@
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
-        // Flipped to ["flux"] in sc-1784 once generation-side LoRA lands.
-        "families": [],
-        "types": []
+        "families": ["flux"],
+        "types": ["style", "enhance", "character"]
       },
       "ui": {
         "label": "FLUX.1 [dev]",

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -355,6 +355,24 @@ const SIGNATURES: &[BucketSignature] = &[
         ],
     },
     BucketSignature {
+        bucket: Bucket::Flux,
+        // XLabs / x-flux Flux LoRAs adapt only the double-stream blocks through an
+        // attention-processor layout (`double_blocks.<n>.processor.{qkv,proj}_lora{1,2}`)
+        // and ship no single-stream keys, so the primary Flux signature (which
+        // requires a single-block marker) misses them. `double_blocks.` is unique to
+        // Flux among the architectures we detect; pairing it with the x-flux
+        // processor/lora naming keeps this tight. Disqualified whenever single-block
+        // keys are present so it never co-scores with the primary Flux signature
+        // (two same-bucket scores could otherwise trip the runner-up margin and
+        // return ambiguous).
+        require_all_of: &[
+            &["double_blocks."],
+            &["qkv_lora", "proj_lora", "processor."],
+        ],
+        disqualifiers: &["single_transformer_blocks.", "single_blocks_"],
+        markers: &["double_blocks.", "processor.", "qkv_lora", "proj_lora"],
+    },
+    BucketSignature {
         bucket: Bucket::WanVideo,
         // Wan transformers expose their blocks under `transformer.blocks.<n>.`
         // (not `transformer.transformer_blocks.`) and use `self_attn`/`cross_attn`/`ffn`
@@ -742,6 +760,31 @@ mod tests {
         });
 
         assert_eq!(detect_lora_family(&header).as_deref(), Some("flux"));
+    }
+
+    #[test]
+    fn detects_xflux_double_blocks_only() {
+        // XLabs / x-flux realism-style LoRAs adapt only the double-stream blocks
+        // (no single blocks, no metadata) via the attention-processor layout.
+        let mut keys = Vec::new();
+        for block in 0..19 {
+            for module in ["qkv_lora1", "qkv_lora2", "proj_lora1", "proj_lora2"] {
+                keys.push(format!("double_blocks.{block}.processor.{module}.down.weight"));
+                keys.push(format!("double_blocks.{block}.processor.{module}.up.weight"));
+            }
+        }
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("flux"));
+    }
+
+    #[test]
+    fn flux_family_maps_to_flux_diffusers_adapter_and_image_capabilities() {
+        assert_eq!(model_adapter_for_family("flux"), Some("flux_diffusers"));
+        assert_eq!(
+            model_capabilities_for_type_and_family("image", "flux"),
+            vec!["text_to_image", "style_variations"],
+        );
     }
 
     #[test]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1057,6 +1057,51 @@ def test_flux_rejects_image_edit():
         raise AssertionError("FLUX.1 is text-to-image only and must reject edit_image.")
 
 
+def test_flux_adapter_applies_flux_lora(tmp_path):
+    lora = tmp_path / "flux_style.safetensors"
+    lora.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    adapter = FluxDiffusersAdapter()
+    request = SimpleNamespace(
+        model="flux_schnell",
+        loras=[
+            {
+                "id": "flux_style",
+                "installedPath": str(lora),
+                "weight": 0.7,
+                "compatibility": {"families": ["flux"]},
+            }
+        ],
+    )
+    adapter._apply_loras(pipe, request)
+    state = adapter._loaded_lora_states["text"]
+    assert [path for path, _name in pipe.loaded] == [str(lora)]
+    assert pipe.set_calls == [(list(state.adapter_names), [0.7])]
+
+
+def test_flux_adapter_rejects_incompatible_lora_family(tmp_path):
+    lora = tmp_path / "qwen_style.safetensors"
+    lora.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    adapter = FluxDiffusersAdapter()
+    request = SimpleNamespace(
+        model="flux_dev",
+        loras=[
+            {
+                "id": "qwen_style",
+                "installedPath": str(lora),
+                "compatibility": {"families": ["qwen-image"]},
+            }
+        ],
+    )
+    try:
+        adapter._apply_loras(pipe, request)
+    except RuntimeError as exc:
+        assert "not compatible with model family flux" in str(exc)
+    else:
+        raise AssertionError("FLUX.1 must reject a LoRA whose family is not flux.")
+
+
 def test_create_image_adapter_routes_sensenova_u1():
     adapter = create_image_adapter({"payload": {"model": "sensenova_u1_8b"}})
     assert adapter.__class__.__name__ == "SenseNovaU1Adapter"


### PR DESCRIPTION
Part 3 of epic [1780](https://app.shortcut.com/trefry/epic/1780). Enables Flux LoRAs for FLUX.1 and detects imported Flux LoRAs. Story: sc-1784.

## Changes
- Manifest: flip `loraCompatibility.families` `[]` → `["flux"]` (types style/enhance/character) on both variants. The adapter already applies LoRAs via the shared `apply_loras_to_pipeline` helper (family/adapter-agnostic) — no adapter change.
- Detector: add a second, tightly-scoped `Bucket::Flux` signature for **XLabs / x-flux** LoRAs that adapt only the double-stream blocks (`double_blocks.<n>.processor.{qkv,proj}_lora*`, no single-block keys, no metadata) — the spike found these slipped past the single-block-requiring primary signature. Disqualified on single-block keys so the two Flux signatures are mutually exclusive and never trip the runner-up margin.
- Tests: `lora_family` x-flux detection + `flux` → `flux_diffusers` adapter/capabilities mapping; worker pytest for the Flux LoRA apply/reject path.

## Verification
- `rust:check` ✅ · worker pytest **272 passed / 2 skipped** ✅
- On RTX PRO 6000, a public Flux LoRA (XLabs RealismLora) applied through the real `FluxDiffusersAdapter._apply_loras` visibly changes the 1024² output at a fixed seed/prompt.

E2E (sc-1785) validated the full pipeline on this stack: both variants complete real jobs (33.8 GiB, schnell 22.6 s / dev 33.3 s) writing PNG + sidecar, and mid-generation cancel → canceled.

> Stacked on #250 (sc-1782) and the sc-1783 PR. Review/merge those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)