### PR TITLE
style: rustfmt the xflux LoRA-detection test (fix main fmt gate)

### DIFF
--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -769,8 +769,12 @@ mod tests {
         let mut keys = Vec::new();
         for block in 0..19 {
             for module in ["qkv_lora1", "qkv_lora2", "proj_lora1", "proj_lora2"] {
-                keys.push(format!("double_blocks.{block}.processor.{module}.down.weight"));
-                keys.push(format!("double_blocks.{block}.processor.{module}.up.weight"));
+                keys.push(format!(
+                    "double_blocks.{block}.processor.{module}.down.weight"
+                ));
+                keys.push(format!(
+                    "double_blocks.{block}.processor.{module}.up.weight"
+                ));
             }
         }
         let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());


### PR DESCRIPTION
## Summary
Fixes the `Check` CI job on `main`, which is currently red on formatting.

`cargo fmt --all -- --check` (run inside `npm run rust:check`) reports a single diff: the `detects_xflux_double_blocks_only` test in `crates/sceneworks-core/src/lora_family.rs` has two long `format!(...)` calls on single lines that current stable rustfmt reflows onto multiple lines. This code landed via PR #256 (FLUX `sc-1783`/`sc-1784` worker adapter) and the fmt nit rode along with it.

This applies the rustfmt normalization. No logic change — purely whitespace.

## Why a standalone PR
The toolchain is unpinned `stable` and CI uses `dtolnay/rust-toolchain@stable`, so any branch's `rust:check` inherits this failure. Fixing it on its own keeps the attribution with the FLUX code and unblocks CI for every in-flight branch.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [ ] CI `Check` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)