### PR TITLE
feat(sc-1837): add Kolors as a selectable Image Studio model (T2I)

### DIFF
--- a/apps/web/public/prompt-guides/kolors.md
+++ b/apps/web/public/prompt-guides/kolors.md
@@ -1,0 +1,87 @@
+# Kolors Prompt Guide
+
+## Best For
+
+Photorealistic text-to-image with strong prompt following in **both English and Chinese**, and notably accurate text rendering — including Chinese characters. Kolors (Kwai-Kolors) is Apache-2.0 and commercial-safe, built on a ChatGLM3 text encoder with an SDXL-style UNet.
+
+## Prompt Shape
+
+Unlike guidance-distilled models, Kolors uses **real classifier-free guidance**, so it has both a positive *and* a negative prompt:
+
+`subject + setting + visual details + style + composition + lighting + any text`
+
+Write the positive prompt as a fluent description of the finished image, and use the negative prompt to push away unwanted qualities. Recommended defaults: **~25 steps at guidance 5.0** (the model card also suggests 5.0–6.5).
+
+## Build The Prompt
+
+### Subject
+
+Describe the subject as if captioning a finished photo — type, action, position, distinguishing features.
+
+Good: `a young chef plating a dessert in a bright modern kitchen`
+
+### Details
+
+Add material, texture, and atmosphere:
+
+- `glossy chocolate ganache`
+- `steam rising from fresh espresso`
+- `soft natural window light`
+- `intricate porcelain pattern`
+
+### Style
+
+- `editorial food photography`
+- `cinematic film still, 35mm`
+- `flat vector illustration`
+- `traditional ink wash painting`
+
+### Camera And Composition
+
+- `low-angle hero shot`
+- `extreme close-up macro`
+- `wide establishing shot`
+- `centered product shot, studio backdrop`
+
+### Lighting
+
+- `golden hour backlight`
+- `soft diffused studio light`
+- `neon-lit night scene`
+- `dramatic rim lighting`
+
+### Text In Images
+
+Kolors renders text well in both scripts — quote the exact words and describe the medium:
+
+`a wooden cafe sign reading "晨光咖啡" in warm hand-painted brush lettering`
+
+`a vintage enamel poster reading "MORNING LIGHT" in cream serif letters`
+
+## Negative Prompts
+
+Keep negatives short and targeted. Common starting points:
+
+`blurry, lowres, deformed, extra fingers, watermark, text artifacts, oversaturated`
+
+## Chinese Prompting
+
+Kolors understands Chinese natively — you can write the whole prompt in Chinese, mix Chinese and English, or request Chinese text rendering directly. Chinese prompts often produce stronger results for culturally specific subjects.
+
+## Tips
+
+- ~25 steps at guidance 5.0 is the sweet spot; raise guidance toward 6.5 for stronger prompt adherence.
+- Use the negative prompt — it is active, unlike distilled models.
+- 1024×1024 is the native sweet spot; portrait/landscape buckets work well too.
+
+## Example Prompts
+
+`A cozy independent bookstore storefront at dusk, warm interior glow spilling onto a rain-slick cobblestone street, a hand-painted sign reading "PAGE & QUILL" in gold script, reflections in the wet pavement, cinematic shallow depth of field.`
+
+`一只橘猫坐在窗台上，窗外是黄昏的城市天际线，柔和的逆光，电影感，高质量，细节丰富.`
+
+## Sources
+
+- [Kolors model card](https://huggingface.co/Kwai-Kolors/Kolors)
+- [Kolors diffusers checkpoint](https://huggingface.co/Kwai-Kolors/Kolors-diffusers)
+- [Diffusers Kolors pipeline docs](https://huggingface.co/docs/diffusers/main/en/api/pipelines/kolors)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -130,6 +130,16 @@ export const fallbackModels = [
     },
   },
   {
+    id: "kolors",
+    name: "Kolors",
+    type: "image",
+    capabilities: ["text_to_image", "style_variations"],
+    ui: {
+      description: "Kwai-Kolors Kolors — photorealistic text-to-image with strong Chinese + English prompting and text rendering. Apache-2.0 (commercial-safe). ChatGLM3-6B + SDXL-style UNet; ~16.5GB, real CFG + negative prompt, ~25 steps at guidance 5.0.",
+      promptGuide: { title: "Kolors Prompt Guide", path: "/prompt-guides/kolors.md" },
+    },
+  },
+  {
     id: "ltx_2_3",
     name: "LTX-2.3",
     type: "video",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -494,6 +494,58 @@
       }
     },
     {
+      "id": "kolors",
+      "name": "Kolors",
+      "family": "kolors",
+      "type": "image",
+      "adapter": "kolors_diffusers",
+      "capabilities": ["text_to_image", "style_variations"],
+      "downloads": [
+        {
+          // Self-contained diffusers checkpoint: bundles the ChatGLM3-6B text
+          // encoder + SDXL-style UNet + VAE. Whole-repo download (~16.5 GiB, approx).
+          "provider": "huggingface",
+          "repo": "Kwai-Kolors/Kolors-diffusers",
+          "files": [],
+          "estimatedSizeBytes": 17716740096
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/Kwai-Kolors/Kolors-diffusers"
+      },
+      "defaults": {
+        // Model card: DPMSolverMultistep (Karras) / Euler; guidance ~5.0, ~25 steps.
+        "resolution": "1024x1024",
+        "steps": 25,
+        "guidanceScale": 5.0,
+        "count": 4
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        // Kolors uses an SDXL-style UNet; generation-side Kolors LoRA is not wired
+        // yet, so advertise no compatible families until that lands.
+        "families": [],
+        "types": ["style", "enhance", "character"]
+      },
+      "ui": {
+        "label": "Kolors",
+        "description": "Kwai-Kolors Kolors — photorealistic text-to-image with strong Chinese + English prompting and text rendering (Midjourney-v6-level human eval). Apache-2.0 (commercial-safe). ChatGLM3-6B text encoder + SDXL-style UNet; ~16.5GB checkpoint, real CFG + negative prompt. Recommended ~25 steps at guidance 5.0.",
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "promptGuide": {
+          "title": "Kolors Prompt Guide",
+          "path": "/prompt-guides/kolors.md",
+          "sources": [
+            { "label": "Kolors model card", "url": "https://huggingface.co/Kwai-Kolors/Kolors" },
+            { "label": "Kolors diffusers checkpoint", "url": "https://huggingface.co/Kwai-Kolors/Kolors-diffusers" },
+            { "label": "Diffusers Kolors pipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/kolors" }
+          ]
+        }
+      }
+    },
+    {
       "id": "ltx_2_3",
       "name": "LTX-2.3",
       "family": "ltx-video",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -139,6 +139,7 @@ string_enum! {
         LensTurbo => "lens_turbo",
         SenseNovaU1 => "sensenova_u1",
         FluxDiffusers => "flux_diffusers",
+        KolorsDiffusers => "kolors_diffusers",
         ProceduralVideo => "procedural_video",
         ProceduralPersonTracking => "procedural_person_tracking",
         FfmpegFrameExtract => "ffmpeg-frame-extract",

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -218,6 +218,7 @@ pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
         "lens" => Some("lens_turbo"),
         "sensenova-u1" => Some("sensenova_u1"),
         "flux" => Some("flux_diffusers"),
+        "kolors" => Some("kolors_diffusers"),
         "ltx-video" => Some("ltx_video"),
         "wan-video" => Some("wan_video"),
         _ => None,
@@ -234,6 +235,7 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         ("image", "lens") => vec!["text_to_image", "style_variations"],
         ("image", "sensenova-u1") => vec!["text_to_image", "edit_image", "vqa", "interleave"],
         ("image", "flux") => vec!["text_to_image", "style_variations"],
+        ("image", "kolors") => vec!["text_to_image", "style_variations"],
         ("video", "ltx-video") => vec![
             "image_to_video",
             "text_to_video",
@@ -281,6 +283,7 @@ pub fn diffusers_class_name_to_family(class_name: &str) -> Option<String> {
         }
         "lenspipeline" => Some("lens".to_owned()),
         "fluxpipeline" | "fluximg2imgpipeline" | "fluxinpaintpipeline" => Some("flux".to_owned()),
+        "kolorspipeline" | "kolorsimg2imgpipeline" => Some("kolors".to_owned()),
         "wanpipeline" | "wani2vpipeline" | "wantext2videopipeline" => Some("wan-video".to_owned()),
         "ltxpipeline" | "ltxvideopipeline" | "ltximagetovideopipeline" => {
             Some("ltx-video".to_owned())
@@ -788,6 +791,15 @@ mod tests {
     }
 
     #[test]
+    fn kolors_family_maps_to_kolors_diffusers_adapter_and_image_capabilities() {
+        assert_eq!(model_adapter_for_family("kolors"), Some("kolors_diffusers"));
+        assert_eq!(
+            model_capabilities_for_type_and_family("image", "kolors"),
+            vec!["text_to_image", "style_variations"],
+        );
+    }
+
+    #[test]
     fn detects_ltx_video() {
         let mut keys = Vec::new();
         for block in 0..28 {
@@ -909,6 +921,10 @@ mod tests {
         assert_eq!(
             diffusers_class_name_to_family("FluxPipeline").as_deref(),
             Some("flux")
+        );
+        assert_eq!(
+            diffusers_class_name_to_family("KolorsPipeline").as_deref(),
+            Some("kolors")
         );
         assert_eq!(
             diffusers_class_name_to_family("StableDiffusionXLPipeline").as_deref(),


### PR DESCRIPTION
## Summary
Wires **Kwai-Kolors Kolors** in as a selectable text-to-image model, mirroring the FLUX sc-1782 contract/manifest/web pattern. **No inference yet** — the `KolorsDiffusersAdapter` worker implementation lands in sc-1838, so selecting Kolors is end-to-end selectable but will not run until that ships (same staging FLUX used).

- `crates/sceneworks-core/src/contracts.rs`: `RecipeAdapter::KolorsDiffusers => "kolors_diffusers"`
- `crates/sceneworks-core/src/lora_family.rs`: `"kolors"` family → `kolors_diffusers` adapter + `("image","kolors")` capabilities + `KolorsPipeline`/`KolorsImg2ImgPipeline` class-name detection, with unit tests
- `config/manifests/builtin.models.jsonc`: `kolors` T2I entry — self-contained Kolors-diffusers checkpoint (~16.5 GiB; ChatGLM3-6B text encoder + SDXL-style UNet + VAE), guidance 5.0 / 25-step defaults, `loraCompatibility.families: []` until generation-side Kolors LoRA lands
- `apps/web/src/constants.js`: Kolors web fallback entry
- `apps/web/public/prompt-guides/kolors.md`: prompt guide (English **and** Chinese; real CFG + negative prompt, unlike FLUX). sc-1845 will expand it with img2img/reference notes.

Licensing: Apache-2.0, commercial-safe and OSS-compatible — no commercial registration required for SceneWorks. `supportsEdit` stays `false` (img2img is sc-1839).

## Test plan
- [x] `npm run rust:check` (fmt / clippy `-D warnings` / full `cargo test` / build)
- [x] `cargo build -p sceneworks-rust-api --features embed-web`
- [x] web vitest (115 pass) + web build
- [ ] CI `Check` + `Desktop (Windows)` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)