### PR TITLE
feat(sc-1831): ChromaDiffusersAdapter worker text-to-image

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -309,6 +309,40 @@ MODEL_TARGETS = {
         "repo": "black-forest-labs/FLUX.1-dev",
         "adapter": "flux_diffusers",
     },
+    "chroma1_hd": {
+        "label": "Chroma1-HD",
+        "family": "chroma",
+        "supportsEdit": False,
+        # Real CFG with negative prompts (unlike guidance-distilled FLUX.1-schnell):
+        # ~40 steps, guidance 3.0; T5-XXL max_seq_len 512 (no CLIP encoder).
+        "steps": 40,
+        "guidanceScale": 3.0,
+        "maxSequenceLength": 512,
+        "repo": "lodestones/Chroma1-HD",
+        "adapter": "chroma_diffusers",
+    },
+    "chroma1_base": {
+        "label": "Chroma1-Base",
+        "family": "chroma",
+        "supportsEdit": False,
+        # Neutral finetuning foundation; real CFG + negative prompts, ~40 steps, guidance 3.0.
+        "steps": 40,
+        "guidanceScale": 3.0,
+        "maxSequenceLength": 512,
+        "repo": "lodestones/Chroma1-Base",
+        "adapter": "chroma_diffusers",
+    },
+    "chroma1_flash": {
+        "label": "Chroma1-Flash",
+        "family": "chroma",
+        "supportsEdit": False,
+        # CFG baked: ~8 steps, guidance 1.0 (CFG off, negative prompt ignored).
+        "steps": 8,
+        "guidanceScale": 1.0,
+        "maxSequenceLength": 512,
+        "repo": "lodestones/Chroma1-Flash",
+        "adapter": "chroma_diffusers",
+    },
 }
 
 
@@ -1670,6 +1704,307 @@ class FluxDiffusersAdapter:
         )
 
 
+class ChromaDiffusersAdapter:
+    """Lodestones Chroma1-HD / Base / Flash text-to-image via diffusers.ChromaPipeline.
+
+    Near-clone of FluxDiffusersAdapter (Chroma1 is FLUX.1-schnell-derived and runs
+    in the MAIN worker venv — confirmed by spike sc-1829), with two deltas:
+
+    * Text encoder is T5-XXL **only** (no CLIP / no ``prompt_2``), so the single
+      ``prompt`` field is all the pipeline takes.
+    * Chroma exposes **real classifier-free guidance**: HD/Base honor a
+      ``negative_prompt`` at guidance > 1; Flash bakes CFG (guidance 1.0) and
+      ignores the negative prompt. We thread ``request.negative_prompt`` through;
+      ``filter_call_kwargs`` drops it for any pipeline build that does not accept it.
+
+    Text-to-image only (ChromaPipeline ships no img2img/inpaint variant).
+    """
+
+    id = "chroma_diffusers"
+
+    def __init__(self) -> None:
+        self._text_pipe: Any | None = None
+        self._text_repo: str | None = None
+        self._loaded_model: str | None = None
+        self._loaded_lora_states: dict[str, LoraPipelineState] = {}
+
+    def loaded_models(self) -> list[str]:
+        return sorted({value for value in (self._text_repo, self._loaded_model) if value})
+
+    def unload(self) -> bool:
+        """Free the resident pipeline so another family can load (cross-adapter
+        eviction). Returns True if it actually freed something."""
+        if self._text_pipe is None:
+            return False
+        self._text_pipe = None
+        self._text_repo = None
+        self._loaded_model = None
+        self._loaded_lora_states.clear()
+        self._empty_cuda_cache(importlib.import_module("torch"))
+        return True
+
+    def generate(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        model_target = MODEL_TARGETS.get(request.model, {})
+        if model_target.get("adapter") != self.id:
+            raise RuntimeError(f"{request.model} is not a Chroma1 Diffusers target.")
+        if request.mode == "edit_image":
+            raise RuntimeError(f"{request.model} does not support image editing.")
+
+        progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress, job_id=job["id"])
+        emit_worker_event(
+            "image_lora_apply_start",
+            jobId=job["id"],
+            adapter=self.id,
+            loraCount=len(request.loras),
+        )
+        self._apply_loras(pipe, request)
+        emit_worker_event("image_lora_apply_complete", jobId=job["id"], adapter=self.id)
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        label = model_target["label"]
+
+        def image_at_index(index: int) -> Image.Image:
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            progress(
+                "running",
+                "generating",
+                image_batch_progress(index, request.count),
+                format_batch_running_message(label, index, request.count),
+            )
+            emit_worker_event(
+                "image_inference_start",
+                jobId=job["id"],
+                adapter=self.id,
+                model=request.model,
+                imageIndex=index,
+                imageCount=request.count,
+                device=device,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            try:
+                image = self._run_pipeline(settings, pipe, request, seed, cancel_requested=cancel_requested)
+            except Exception as exc:
+                emit_worker_event(
+                    "image_inference_failed",
+                    jobId=job["id"],
+                    adapter=self.id,
+                    imageIndex=index,
+                    error=str(exc),
+                    errorType=exc.__class__.__name__,
+                )
+                raise
+            emit_worker_event(
+                "image_inference_complete",
+                jobId=job["id"],
+                adapter=self.id,
+                imageIndex=index,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return image
+
+        return ImageAssetWriter().write_incremental_outputs(
+            request=request,
+            project_path=project_path,
+            image_count=request.count,
+            image_at_index=image_at_index,
+            adapter_id=self.id,
+            progress=progress,
+            cancel_requested=cancel_requested,
+            raw_settings={
+                **request.advanced,
+                "repo": self._repo_for_request(request, model_target),
+                "numInferenceSteps": self._num_inference_steps(request, model_target),
+                "guidanceScale": self._guidance_scale(request, model_target),
+                "maxSequenceLength": self._max_sequence_length(request, model_target),
+                "negativePrompt": request.negative_prompt,
+                "realModelInference": True,
+            },
+        )
+
+    def _load_pipeline(
+        self,
+        settings: WorkerSettings,
+        request: ImageRequest,
+        model_target: dict[str, Any],
+        progress: ProgressCallback,
+        *,
+        job_id: str,
+    ) -> Any:
+        torch = importlib.import_module("torch")
+        diffusers = importlib.import_module("diffusers")
+        repo = self._repo_for_request(request, model_target)
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+        cpu_offload = bool(request.advanced.get("cpuOffload", False))
+        if self._text_pipe is not None and self._text_repo == repo:
+            self._loaded_model = request.model
+            progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
+            emit_worker_event(
+                "image_pipeline_cache_hit",
+                jobId=job_id,
+                adapter=self.id,
+                model=request.model,
+                repo=repo,
+                device=device,
+                componentDevices=pipeline_component_devices(self._text_pipe),
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return self._text_pipe
+        if self._text_pipe is not None:
+            self._text_pipe = None
+            self._text_repo = None
+            self._empty_cuda_cache(torch)
+            self._forget_loaded_loras("text")
+
+        pipeline_class = getattr(diffusers, "ChromaPipeline", None)
+        if pipeline_class is None:
+            raise RuntimeError(
+                "The installed diffusers package does not expose ChromaPipeline. "
+                "Install/upgrade diffusers (the worker pins diffusers git main) for Chroma1 support."
+            )
+
+        progress("loading_model", "loading_model", 0.2, f"Loading {model_target['label']} model files.")
+        emit_worker_event(
+            "image_pipeline_load_start",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            device=device,
+            dtype=str(dtype),
+            useImg2img=False,
+            cpuOffload=cpu_offload,
+            cached=huggingface_repo_cache_exists(repo),
+        )
+        pipe = pipeline_class.from_pretrained(repo, torch_dtype=dtype)
+        emit_worker_event(
+            "image_pipeline_load_complete",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            componentDevices=pipeline_component_devices(pipe),
+        )
+        offload_enabled = cpu_offload and hasattr(pipe, "enable_model_cpu_offload")
+        if offload_enabled:
+            pipe.enable_model_cpu_offload()
+        else:
+            pipe.to(device)
+        # VAE tiling keeps high-resolution decodes within memory. Prefer the
+        # current diffusers API (pipe.vae.enable_tiling) and fall back to the
+        # deprecated pipeline-level shim for older builds.
+        vae = getattr(pipe, "vae", None)
+        if vae is not None and hasattr(vae, "enable_tiling"):
+            vae.enable_tiling()
+        elif hasattr(pipe, "enable_vae_tiling"):
+            pipe.enable_vae_tiling()
+        component_devices = verify_pipeline_on_device(
+            pipe,
+            requested_device=device,
+            model_label=model_target["label"],
+            allow_offload=offload_enabled,
+        )
+        emit_worker_event(
+            "image_pipeline_on_device",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            requestedDevice=device,
+            cpuOffload=offload_enabled,
+            componentDevices=component_devices,
+            gpuMemory=gpu_memory_snapshot(torch, device),
+        )
+        self._text_pipe = pipe
+        self._text_repo = repo
+        self._loaded_model = request.model
+        return pipe
+
+    def _empty_cuda_cache(self, torch: Any) -> None:
+        release_inference_memory(torch)
+
+    def _run_pipeline(
+        self,
+        settings: WorkerSettings,
+        pipe: Any,
+        request: ImageRequest,
+        seed: int,
+        cancel_requested: CancelCallback | None = None,
+    ) -> Image.Image:
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
+        model_target = MODEL_TARGETS[request.model]
+        kwargs = {
+            "prompt": request.prompt,
+            "height": request.height,
+            "width": request.width,
+            "num_inference_steps": self._num_inference_steps(request, model_target),
+            # Chroma uses real CFG: HD/Base follow guidance (~3.0) and honor a
+            # negative prompt; Flash bakes CFG (guidance 1.0) so the negative
+            # prompt is a no-op. filter_call_kwargs drops negative_prompt for any
+            # pipeline build that does not accept it.
+            "guidance_scale": self._guidance_scale(request, model_target),
+            "max_sequence_length": self._max_sequence_length(request, model_target),
+            "generator": generator,
+        }
+        if request.negative_prompt:
+            kwargs["negative_prompt"] = request.negative_prompt
+        step_callback = cancel_step_callback(pipe, cancel_requested)
+        if step_callback is not None:
+            kwargs["callback_on_step_end"] = step_callback
+        output = pipe(**filter_call_kwargs(pipe, kwargs))
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
+        return output.images[0].convert("RGB")
+
+    def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
+        model_target = MODEL_TARGETS.get(request.model, {})
+        self._loaded_lora_states["text"] = apply_loras_to_pipeline(
+            pipe,
+            request.loras,
+            adapter_id=self.id,
+            model_family=model_target.get("family"),
+            previous_state=self._loaded_lora_states.get("text"),
+        )
+
+    def _forget_loaded_loras(self, key: str) -> None:
+        self._loaded_lora_states.pop(key, None)
+
+    def _repo_for_request(self, request: ImageRequest, model_target: dict[str, Any]) -> str:
+        return request.advanced.get("modelRepo") or model_target["repo"]
+
+    def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        return safe_int(request.advanced.get("steps"), model_target["steps"], 1, 80)
+
+    def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:
+        default = model_target.get("guidanceScale", 3.0)
+        try:
+            return float(request.advanced.get("guidanceScale", default))
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _max_sequence_length(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        return safe_int(
+            request.advanced.get("maxSequenceLength"),
+            model_target.get("maxSequenceLength", 512),
+            1,
+            512,
+        )
+
+
 # Lens trains on two base resolutions crossed with nine aspect ratios and expects
 # `base_resolution` + `aspect_ratio` rather than free width/height. These mirror
 # scene_worker/_vendor/lens/resolution.py so we can snap a SceneWorks W×H request
@@ -2893,6 +3228,7 @@ def create_image_adapter(
     | LensTurboAdapter
     | SenseNovaU1Adapter
     | FluxDiffusersAdapter
+    | ChromaDiffusersAdapter
 ):
     payload = job.get("payload", {})
     requested = os.getenv("SCENEWORKS_IMAGE_ADAPTER", payload.get("adapter", "")).strip()
@@ -2906,6 +3242,7 @@ def create_image_adapter(
         LensTurboAdapter.id,
         SenseNovaU1Adapter.id,
         FluxDiffusersAdapter.id,
+        ChromaDiffusersAdapter.id,
     }:
         raise RuntimeError(f"Unsupported SCENEWORKS_IMAGE_ADAPTER value: {requested}.")
     if requested == ZImageDiffusersAdapter.id:
@@ -2918,6 +3255,8 @@ def create_image_adapter(
         return adapters.get("sensenova_u1") if adapters else SenseNovaU1Adapter()
     if requested == FluxDiffusersAdapter.id:
         return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
+    if requested == ChromaDiffusersAdapter.id:
+        return adapters.get("chroma_diffusers") if adapters else ChromaDiffusersAdapter()
     model_target = MODEL_TARGETS.get(payload.get("model", "z_image_turbo"), {})
     if model_target.get("adapter") == ZImageDiffusersAdapter.id:
         return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
@@ -2929,6 +3268,8 @@ def create_image_adapter(
         return adapters.get("sensenova_u1") if adapters else SenseNovaU1Adapter()
     if model_target.get("adapter") == FluxDiffusersAdapter.id:
         return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
+    if model_target.get("adapter") == ChromaDiffusersAdapter.id:
+        return adapters.get("chroma_diffusers") if adapters else ChromaDiffusersAdapter()
     return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
 
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -17,6 +17,7 @@ from sceneworks_shared import find_project_path, utc_now
 from .caption_adapters import run_training_caption_job
 from .gpu import cpu_worker_id, discover_gpu, discover_gpus, gpu_utilization, gpu_worker_id
 from .image_adapters import (
+    ChromaDiffusersAdapter,
     FluxDiffusersAdapter,
     LensTurboAdapter,
     ProceduralImageAdapter,
@@ -1252,6 +1253,7 @@ def run_worker_loop(settings: WorkerSettings) -> None:
         "lens_turbo": LensTurboAdapter(),
         "sensenova_u1": SenseNovaU1Adapter(),
         "flux_diffusers": FluxDiffusersAdapter(),
+        "chroma_diffusers": ChromaDiffusersAdapter(),
     }
     max_registration_attempts = 20
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -23,6 +23,7 @@ from scene_worker.caption_adapters import (
     normalize_processor_resample,
 )
 from scene_worker.image_adapters import (
+    ChromaDiffusersAdapter,
     FluxDiffusersAdapter,
     ImageAssetWriter,
     LensTurboAdapter,
@@ -1110,6 +1111,134 @@ def test_flux_adapter_rejects_incompatible_lora_family(tmp_path):
         assert "not compatible with model family flux" in str(exc)
     else:
         raise AssertionError("FLUX.1 must reject a LoRA whose family is not flux.")
+
+
+def test_create_image_adapter_routes_chroma_variants():
+    for model in ("chroma1_hd", "chroma1_base", "chroma1_flash"):
+        adapter = create_image_adapter({"payload": {"model": model}})
+        assert adapter.__class__.__name__ == "ChromaDiffusersAdapter"
+        assert adapter.id == "chroma_diffusers"
+
+
+def test_image_adapter_env_override_selects_chroma(monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "chroma_diffusers")
+    # Env override wins even when the payload names a different family's model.
+    adapter = create_image_adapter({"payload": {"model": "z_image_turbo"}})
+    assert adapter.__class__.__name__ == "ChromaDiffusersAdapter"
+
+
+def test_chroma_model_target_defaults():
+    hd = MODEL_TARGETS["chroma1_hd"]
+    base = MODEL_TARGETS["chroma1_base"]
+    flash = MODEL_TARGETS["chroma1_flash"]
+    for target in (hd, base, flash):
+        assert target["adapter"] == "chroma_diffusers"
+        assert target["family"] == "chroma"
+        assert target["supportsEdit"] is False
+        assert target["maxSequenceLength"] == 512
+    # HD/Base: real CFG with negative prompts (~40 steps, guidance 3.0).
+    assert hd["steps"] == 40
+    assert hd["guidanceScale"] == 3.0
+    assert hd["repo"] == "lodestones/Chroma1-HD"
+    assert base["steps"] == 40
+    assert base["guidanceScale"] == 3.0
+    assert base["repo"] == "lodestones/Chroma1-Base"
+    # Flash: CFG baked off (~8 steps, guidance 1.0).
+    assert flash["steps"] == 8
+    assert flash["guidanceScale"] == 1.0
+    assert flash["repo"] == "lodestones/Chroma1-Flash"
+
+
+def test_chroma_guidance_scale_uses_per_model_default_and_override():
+    adapter = ChromaDiffusersAdapter()
+    hd = MODEL_TARGETS["chroma1_hd"]
+    flash = MODEL_TARGETS["chroma1_flash"]
+    # Per-model default applies when the request does not override guidance.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={}), hd) == 3.0
+    assert adapter._guidance_scale(SimpleNamespace(advanced={}), flash) == 1.0
+    # An explicit request value wins.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={"guidanceScale": 4.5}), hd) == 4.5
+    # Unparseable override falls back to the per-model default.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={"guidanceScale": "x"}), hd) == 3.0
+
+
+def test_chroma_num_inference_steps_default_and_override():
+    adapter = ChromaDiffusersAdapter()
+    hd = MODEL_TARGETS["chroma1_hd"]
+    flash = MODEL_TARGETS["chroma1_flash"]
+    # Defaults come straight from the model target.
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), hd) == 40
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), flash) == 8
+    # Explicit override is honored and clamped to [1, 80].
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 20}), hd) == 20
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 999}), flash) == 80
+
+
+def test_chroma_rejects_image_edit():
+    job = {
+        "id": "job_chroma_edit",
+        "payload": {
+            "projectId": "project_x",
+            "mode": "edit_image",
+            "model": "chroma1_hd",
+            "prompt": "a cat",
+        },
+    }
+    noop = lambda *args, **kwargs: None  # noqa: E731
+    try:
+        ChromaDiffusersAdapter().generate(
+            settings=None, job=job, request=image_request_from_job(job), project_path=None,
+            progress=noop, cancel_requested=lambda: False,
+        )
+    except RuntimeError as exc:
+        assert "does not support image editing" in str(exc)
+    else:
+        raise AssertionError("Chroma1 is text-to-image only and must reject edit_image.")
+
+
+def test_chroma_adapter_applies_chroma_lora(tmp_path):
+    lora = tmp_path / "chroma_style.safetensors"
+    lora.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    adapter = ChromaDiffusersAdapter()
+    request = SimpleNamespace(
+        model="chroma1_hd",
+        loras=[
+            {
+                "id": "chroma_style",
+                "installedPath": str(lora),
+                "weight": 0.7,
+                "compatibility": {"families": ["chroma"]},
+            }
+        ],
+    )
+    adapter._apply_loras(pipe, request)
+    state = adapter._loaded_lora_states["text"]
+    assert [path for path, _name in pipe.loaded] == [str(lora)]
+    assert pipe.set_calls == [(list(state.adapter_names), [0.7])]
+
+
+def test_chroma_adapter_rejects_incompatible_lora_family(tmp_path):
+    lora = tmp_path / "flux_style.safetensors"
+    lora.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    adapter = ChromaDiffusersAdapter()
+    request = SimpleNamespace(
+        model="chroma1_base",
+        loras=[
+            {
+                "id": "flux_style",
+                "installedPath": str(lora),
+                "compatibility": {"families": ["flux"]},
+            }
+        ],
+    )
+    try:
+        adapter._apply_loras(pipe, request)
+    except RuntimeError as exc:
+        assert "not compatible with model family chroma" in str(exc)
+    else:
+        raise AssertionError("Chroma1 must reject a LoRA whose family is not chroma.")
 
 
 def test_create_image_adapter_routes_sensenova_u1():


### PR DESCRIPTION
## Summary
Second slice of epic [1828](https://app.shortcut.com/trefry/epic/1828). Worker-side Diffusers adapter for **Chroma1-HD / Base / Flash** via `diffusers.ChromaPipeline`, a near-clone of `FluxDiffusersAdapter` (Chroma1 is FLUX.1-schnell-derived and runs in the main worker venv — spike sc-1829).

**Stacked on #260 (sc-1830).** Base is `claude/chroma1-sc1830`; will retarget to `main` once #260 merges. The Python worker adapter is independent of #260's Rust/manifest, but they pair conceptually.

### Two deltas vs the Flux adapter
- **T5-XXL only** — single `prompt`, no CLIP / `prompt_2`.
- **Real CFG** — HD/Base honor a `negative_prompt` at guidance 3.0; Flash bakes CFG (guidance 1.0, negative prompt is a no-op). `filter_call_kwargs` drops `negative_prompt` for any pipeline build that doesn't accept it.

### Changes
- `image_adapters.py`: `ChromaDiffusersAdapter` + `MODEL_TARGETS` for `chroma1_hd/base/flash` (per-variant steps/guidance/maxSequenceLength) + `create_image_adapter` routing (env override + manifest-adapter dispatch) + return-type union.
- `runtime.py`: `chroma_diffusers` entry in the image-adapter registry.
- `tests/test_worker_runtime.py`: 8 light-dep tests.

Deferred: real LoRA detection / `Bucket::Chroma` (sc-1832); mocked-pipeline E2E + telemetry assertions (sc-1833). Text-to-image only (ChromaPipeline has no img2img/inpaint class).

## Test plan
- [x] `pytest tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` — **283 passed, 6 skipped** (CI's exact invocation, light-dep no-torch venv)
- [x] 8 new Chroma tests pass (routing, env override, target defaults, guidance/steps helpers, edit rejection, LoRA accept/reject)
- [ ] Real-HW inference (bf16 VRAM, coherent output) deferred to reference-GPU run, mirroring how FLUX shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)