### PR TITLE
fix(sc-1897): thread project_path into ZImage/Qwen _run_pipeline

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -916,7 +916,7 @@ class ZImageDiffusersAdapter:
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                image = self._run_pipeline(settings, pipe, request, seed, cancel_requested=cancel_requested)
+                image = self._run_pipeline(settings, pipe, request, seed, project_path, cancel_requested=cancel_requested)
             except Exception as exc:
                 emit_worker_event(
                     "image_inference_failed",
@@ -1088,6 +1088,7 @@ class ZImageDiffusersAdapter:
         pipe: Any,
         request: ImageRequest,
         seed: int,
+        project_path: Path,
         cancel_requested: CancelCallback | None = None,
     ) -> Image.Image:
         torch = importlib.import_module("torch")
@@ -1218,7 +1219,7 @@ class QwenImageAdapter:
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                image = self._run_pipeline(settings, pipe, request, seed, cancel_requested=cancel_requested)
+                image = self._run_pipeline(settings, pipe, request, seed, project_path, cancel_requested=cancel_requested)
             except Exception as exc:
                 emit_worker_event(
                     "image_inference_failed",
@@ -1372,6 +1373,7 @@ class QwenImageAdapter:
         pipe: Any,
         request: ImageRequest,
         seed: int,
+        project_path: Path,
         cancel_requested: CancelCallback | None = None,
     ) -> Image.Image:
         torch = importlib.import_module("torch")

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -5936,6 +5936,91 @@ def test_z_image_adapter_fails_fast_when_pipeline_stays_on_cpu_with_offload_fall
         )
 
 
+def test_edit_run_pipeline_threads_project_path(tmp_path, monkeypatch):
+    """Regression: ZImage/Qwen ._run_pipeline must accept project_path.
+
+    sc-1678's resolver-threading refactor left project_path referenced inside the
+    edit_image branch (load_source_image(project_path, request)) without making it
+    a parameter — a latent NameError that only fires at real img2img inference,
+    which the mocked suite never exercises. KolorsDiffusersAdapter is the reference
+    pattern. This guards both the signature and the live edit-branch call site.
+    """
+    import inspect
+
+    # Signature guard: project_path must precede the optional cancel_requested,
+    # because every call site passes it positionally.
+    for adapter_cls in (ZImageDiffusersAdapter, QwenImageAdapter):
+        params = list(inspect.signature(adapter_cls._run_pipeline).parameters)
+        assert "project_path" in params, f"{adapter_cls.__name__}._run_pipeline must accept project_path"
+        assert params.index("project_path") < params.index("cancel_requested")
+
+    class FakeImage:
+        def convert(self, _mode):
+            return self
+
+    class FakeOutput:
+        images = [FakeImage()]
+
+    class FakePipe:
+        def __call__(self, **kwargs):
+            self.last_kwargs = kwargs
+            return FakeOutput()
+
+    class FakeTorch:
+        @staticmethod
+        def Generator(_device):
+            class Gen:
+                def manual_seed(self, _seed):
+                    return self
+
+            return Gen()
+
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.importlib.import_module",
+        lambda name: FakeTorch if name == "torch" else importlib.import_module(name),
+    )
+
+    seen_paths: list[Path] = []
+
+    def fake_load_source_image(project_path, _request):
+        seen_paths.append(project_path)
+        return FakeImage()
+
+    monkeypatch.setattr("scene_worker.image_adapters.load_source_image", fake_load_source_image)
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+
+    # Runtime guard: invoke the edit_image branch directly (gpu_id="cpu" keeps
+    # device selection off real torch) so project_path resolves at the exact line
+    # that raised NameError instead of crashing.
+    for adapter, model in ((ZImageDiffusersAdapter(), "z_image_edit"), (QwenImageAdapter(), "qwen_image_edit")):
+        seen_paths.clear()
+        request = image_request_from_job(
+            {
+                "payload": {
+                    "projectId": "project-1",
+                    "mode": "edit_image",
+                    "model": model,
+                    "prompt": "repaint the sky",
+                    "sourceAssetId": "asset-source",
+                    "width": 16,
+                    "height": 16,
+                    "count": 1,
+                }
+            }
+        )
+        result = adapter._run_pipeline(
+            SimpleNamespace(gpu_id="cpu"),
+            FakePipe(),
+            request,
+            7,
+            project_path,
+        )
+        assert seen_paths == [project_path], f"{adapter.id} edit branch must call load_source_image(project_path, ...)"
+        assert result is FakeOutput.images[0]
+
+
 # --- Cancellation: JobCancelMonitor watchdog + per-step interrupt ---------------
 
 


### PR DESCRIPTION
## Summary
- Fixes a latent `NameError` in `ZImageDiffusersAdapter._run_pipeline` and `QwenImageAdapter._run_pipeline`: the `if request.mode == "edit_image":` branch calls `load_source_image(project_path, request)`, but `project_path` was never a parameter (nor closure var / global). It only fires at real `z_image_edit` / `qwen_image_edit` img2img inference.
- Threads `project_path: Path` into both `_run_pipeline` signatures and passes it positionally from the `image_at_index` closure inside each `generate()` (which already has `project_path`), mirroring the correct `KolorsDiffusersAdapter` pattern. Flux/Kolors/Chroma `_run_pipeline` are unaffected.
- The mocked worker suite drives `generate()` with a fake torch/pipe and never reaches `_run_pipeline`, so CI stayed green. Regression from the sc-1678 resolver-threading refactor.
- Adds `test_edit_run_pipeline_threads_project_path` (signature guard + direct edit-mode `_run_pipeline` call with fake pipe/torch and monkeypatched `load_source_image`) — verified it fails on the pre-fix code and passes after.

Tracked by [sc-1897](https://app.shortcut.com/trefry/story/1897) (epic 1835). Independent of the Kolors work in #262.

## Test plan
- [x] Torch-free venv matching CI (`pytest==9.0.2 httpx==0.28.1 pillow numpy`): `python -m pytest -q tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` → 292 passed, 6 skipped
- [x] Confirmed the new test fails against the unpatched signature (NameError / missing param) and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)