### PR TITLE
feat(sc-1832): Chroma1 generation-side LoRA compatibility (chroma + flux)

### DIFF
--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -52,6 +52,24 @@ def normalize_lora_family(family: Any) -> str:
     return str(family or "").strip().lower().replace("_", "-")
 
 
+# Architecture families a model can load LoRAs from in addition to its own.
+# Chroma is FLUX.1-schnell-derived and keeps Flux's transformer-block layout, so
+# Flux LoRAs load on Chroma — and Chroma LoRAs that carry no chroma metadata are
+# classified as `flux` by the key-based detector (the keys are identical). The
+# relationship is one-directional: a Flux model does not accept chroma LoRAs.
+EXTRA_COMPATIBLE_LORA_FAMILIES: dict[str, set[str]] = {
+    "chroma": {"flux"},
+}
+
+
+def accepted_lora_families(model_family: Any) -> set[str]:
+    """The set of LoRA families a model of ``model_family`` can load."""
+    normalized = normalize_lora_family(model_family)
+    if not normalized:
+        return set()
+    return {normalized} | EXTRA_COMPATIBLE_LORA_FAMILIES.get(normalized, set())
+
+
 def lora_families(lora: dict[str, Any]) -> list[str]:
     compatibility = lora.get("compatibility") if isinstance(lora.get("compatibility"), dict) else {}
     values = next(
@@ -102,7 +120,8 @@ def lora_looks_like_ic_lora(lora: dict[str, Any]) -> bool:
 
 def validate_lora_compatibility(loras: list[dict[str, Any]], *, model_family: str | None, adapter_id: str) -> None:
     normalized_model_family = normalize_lora_family(model_family)
-    if not loras or not normalized_model_family:
+    accepted = accepted_lora_families(model_family)
+    if not loras or not accepted:
         return
     for index, item in enumerate(loras):
         lora = item if isinstance(item, dict) else {"id": str(item)}
@@ -110,7 +129,10 @@ def validate_lora_compatibility(loras: list[dict[str, Any]], *, model_family: st
         families = lora_families(lora)
         if not families:
             continue
-        if normalized_model_family not in families:
+        # Accept when any of the LoRA's declared families is one the model can
+        # load. For a single-family model this is exactly "model_family in families";
+        # chroma additionally accepts flux (see EXTRA_COMPATIBLE_LORA_FAMILIES).
+        if accepted.isdisjoint(families):
             raise RuntimeError(
                 f"LoRA {lora_id} is not compatible with model family {normalized_model_family} for {adapter_id}."
             )

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -524,7 +524,10 @@
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
-        "families": ["chroma"],
+        // Chroma is FLUX.1-schnell-derived and shares Flux's transformer layout,
+        // so Flux LoRAs load on Chroma — and Chroma LoRAs without chroma metadata
+        // are detected as `flux` (identical tensor keys). Accept both families.
+        "families": ["chroma", "flux"],
         "types": ["style", "enhance", "character"]
       },
       "ui": {
@@ -564,7 +567,10 @@
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
-        "families": ["chroma"],
+        // Chroma is FLUX.1-schnell-derived and shares Flux's transformer layout,
+        // so Flux LoRAs load on Chroma — and Chroma LoRAs without chroma metadata
+        // are detected as `flux` (identical tensor keys). Accept both families.
+        "families": ["chroma", "flux"],
         "types": ["style", "enhance", "character"]
       },
       "ui": {
@@ -604,7 +610,10 @@
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
-        "families": ["chroma"],
+        // Chroma is FLUX.1-schnell-derived and shares Flux's transformer layout,
+        // so Flux LoRAs load on Chroma — and Chroma LoRAs without chroma metadata
+        // are detected as `flux` (identical tensor keys). Accept both families.
+        "families": ["chroma", "flux"],
         "types": ["style", "enhance", "character"]
       },
       "ui": {

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -588,6 +588,13 @@ fn metadata_value_to_family(value: &str) -> Option<String> {
     if normalized.is_empty() {
         return None;
     }
+    // Check chroma before flux: Chroma is FLUX.1-schnell-derived, so a Chroma
+    // LoRA's metadata may name both. Only metadata can distinguish the two — by
+    // tensor keys a Chroma LoRA is identical to a Flux LoRA (same double/single
+    // transformer blocks), so the key-based detector classifies it as `flux`.
+    if normalized.contains("chroma") {
+        return Some("chroma".to_owned());
+    }
     if normalized.contains("flux") {
         return Some("flux".to_owned());
     }
@@ -766,6 +773,23 @@ mod tests {
         });
 
         assert_eq!(detect_lora_family(&header).as_deref(), Some("flux"));
+    }
+
+    #[test]
+    fn chroma_metadata_distinguishes_chroma_from_flux_keys() {
+        // Chroma is FLUX.1-schnell-derived: its LoRA tensor keys are identical to
+        // Flux (single/double transformer blocks), so only metadata can mark a
+        // LoRA as chroma. Metadata is checked before keys and chroma before flux.
+        let mut header = header_from_keys(&[
+            "transformer.single_transformer_blocks.0.attn.to_q.lora_A.weight",
+            "transformer.single_transformer_blocks.0.attn.to_q.lora_B.weight",
+            "transformer.transformer_blocks.0.attn.to_q.lora_A.weight",
+        ]);
+        header["__metadata__"] = json!({
+            "modelspec.architecture": "chroma/lora"
+        });
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("chroma"));
     }
 
     #[test]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -762,6 +762,28 @@ def test_lora_compatibility_guard_accepts_normalized_family_aliases():
     )
 
 
+def test_lora_compatibility_chroma_accepts_flux_but_not_vice_versa():
+    # Chroma accepts flux LoRAs (FLUX.1-schnell-derived, identical keys). sc-1832.
+    validate_lora_compatibility(
+        [{"id": "flux_style", "compatibility": {"families": ["flux"]}}],
+        model_family="chroma",
+        adapter_id="diffusers_test",
+    )
+    # ...and chroma-tagged LoRAs.
+    validate_lora_compatibility(
+        [{"id": "chroma_style", "compatibility": {"families": ["chroma"]}}],
+        model_family="chroma",
+        adapter_id="diffusers_test",
+    )
+    # The relationship is one-directional: a Flux model rejects a chroma LoRA.
+    with pytest.raises(RuntimeError, match="not compatible with model family flux"):
+        validate_lora_compatibility(
+            [{"id": "chroma_style", "compatibility": {"families": ["chroma"]}}],
+            model_family="flux",
+            adapter_id="diffusers_test",
+        )
+
+
 def test_lora_weight_defaults_on_unparseable_values():
     assert lora_weight({"weight": "not-a-number"}) == 0.8
 
@@ -1219,8 +1241,32 @@ def test_chroma_adapter_applies_chroma_lora(tmp_path):
     assert pipe.set_calls == [(list(state.adapter_names), [0.7])]
 
 
-def test_chroma_adapter_rejects_incompatible_lora_family(tmp_path):
+def test_chroma_adapter_applies_flux_lora(tmp_path):
+    # Chroma is FLUX.1-schnell-derived: Flux LoRAs (and Chroma LoRAs detected as
+    # flux by their identical tensor keys) load on Chroma. sc-1832.
     lora = tmp_path / "flux_style.safetensors"
+    lora.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    adapter = ChromaDiffusersAdapter()
+    request = SimpleNamespace(
+        model="chroma1_hd",
+        loras=[
+            {
+                "id": "flux_style",
+                "installedPath": str(lora),
+                "weight": 0.8,
+                "compatibility": {"families": ["flux"]},
+            }
+        ],
+    )
+    adapter._apply_loras(pipe, request)
+    state = adapter._loaded_lora_states["text"]
+    assert [path for path, _name in pipe.loaded] == [str(lora)]
+    assert pipe.set_calls == [(list(state.adapter_names), [0.8])]
+
+
+def test_chroma_adapter_rejects_incompatible_lora_family(tmp_path):
+    lora = tmp_path / "qwen_style.safetensors"
     lora.write_bytes(b"lora")
     pipe = FakeLoraPipe()
     adapter = ChromaDiffusersAdapter()
@@ -1228,9 +1274,9 @@ def test_chroma_adapter_rejects_incompatible_lora_family(tmp_path):
         model="chroma1_base",
         loras=[
             {
-                "id": "flux_style",
+                "id": "qwen_style",
                 "installedPath": str(lora),
-                "compatibility": {"families": ["flux"]},
+                "compatibility": {"families": ["qwen-image"]},
             }
         ],
     )
@@ -1239,7 +1285,7 @@ def test_chroma_adapter_rejects_incompatible_lora_family(tmp_path):
     except RuntimeError as exc:
         assert "not compatible with model family chroma" in str(exc)
     else:
-        raise AssertionError("Chroma1 must reject a LoRA whose family is not chroma.")
+        raise AssertionError("Chroma1 must reject a LoRA whose family is neither chroma nor flux.")
 
 
 def test_create_image_adapter_routes_kolors():


### PR DESCRIPTION
## Summary
Third slice of epic [1828](https://app.shortcut.com/trefry/epic/1828). Wires generation-side LoRA support for Chroma1 (branched fresh off main, now that #260 landed).

**Key finding:** Chroma1 is FLUX.1-schnell-derived and keeps Flux's transformer-block layout, so Chroma LoRAs are **structurally identical to Flux LoRAs** (same `single_transformer_blocks.`/`double_blocks.` tensor keys). The key-based detector classifies a Chroma LoRA as `flux`; only metadata can mark it `chroma`.

**Policy (per Michael):** Chroma accepts **both** `chroma`- and `flux`-family LoRAs — real Chroma LoRAs (detected as flux) load, and genuine Flux LoRAs load on Chroma too (structurally valid, matches community usage). One-directional: a Flux model still rejects chroma-tagged LoRAs.

### Changes
- `lora_family.rs`: `metadata_value_to_family` detects `chroma` (checked **before** flux, since Chroma metadata may name both). Key-only Chroma LoRAs remain `flux`.
- `lora_adapters.py`: `EXTRA_COMPATIBLE_LORA_FAMILIES` expands `chroma → {chroma, flux}`; `validate_lora_compatibility` accepts a LoRA when any of its families is one the model can load (behavior-preserving for single-family models).
- `builtin.models.jsonc`: `chroma1_hd/base/flash` `loraCompatibility.families = ["chroma", "flux"]`.

### Tests
- Rust: chroma metadata distinguishes a Chroma LoRA from Flux despite identical keys.
- Worker: flux LoRA loads on Chroma (compatible); qwen LoRA rejected (incompatible); one-directional guard (flux model rejects chroma LoRA); plus the updated sc-1831 adapter tests.

## Test plan
- [x] `cargo` core tests pass (50 in lora_family incl. new chroma-metadata test); full `npm run rust:check` green (fmt + clippy -D warnings + test + build)
- [x] Worker suite: **293 passed, 6 skipped** (`test_worker_runtime` + `test_worker_gpu` + `test_person_adapters`, light-dep no-torch)
- [ ] Real Chroma/Flux LoRA application on the reference GPU deferred to the HW pass

> Note: CI's `parity`/`build-windows` may still show red from the ongoing GitHub Actions `codeload`/rust-toolchain outage (not code). Validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)