### PR TITLE
fix(tests): regenerate stale image-job modelManifestEntry contract snapshot

### DIFF
--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1600,6 +1600,49 @@
       "loras": [],
       "mode": "text_to_image",
       "model": "base-model",
+      "modelManifestEntry": {
+        "adapter": "z_image_diffusers",
+        "capabilities": [
+          "text_to_image"
+        ],
+        "defaults": {
+          "height": 1024,
+          "width": 1024
+        },
+        "downloads": [
+          {
+            "estimatedSizeBytes": 536870912,
+            "files": [
+              "*.bin"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/alternate-base-model"
+          },
+          {
+            "default": true,
+            "estimatedSizeBytes": 12884901888,
+            "files": [
+              "*.safetensors"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/base-model"
+          }
+        ],
+        "family": "z-image",
+        "id": "base-model",
+        "limits": {},
+        "loraCompatibility": {
+          "families": [
+            "z-image"
+          ]
+        },
+        "name": "User Model",
+        "paths": {},
+        "type": "image",
+        "ui": {
+          "label": "User"
+        }
+      },
       "negativePrompt": "",
       "projectId": "project_fixture",
       "projectName": "Parity Project",
@@ -1651,6 +1694,49 @@
       "loras": [],
       "mode": "text_to_image",
       "model": "base-model",
+      "modelManifestEntry": {
+        "adapter": "z_image_diffusers",
+        "capabilities": [
+          "text_to_image"
+        ],
+        "defaults": {
+          "height": 1024,
+          "width": 1024
+        },
+        "downloads": [
+          {
+            "estimatedSizeBytes": 536870912,
+            "files": [
+              "*.bin"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/alternate-base-model"
+          },
+          {
+            "default": true,
+            "estimatedSizeBytes": 12884901888,
+            "files": [
+              "*.safetensors"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/base-model"
+          }
+        ],
+        "family": "z-image",
+        "id": "base-model",
+        "limits": {},
+        "loraCompatibility": {
+          "families": [
+            "z-image"
+          ]
+        },
+        "name": "User Model",
+        "paths": {},
+        "type": "image",
+        "ui": {
+          "label": "User"
+        }
+      },
       "negativePrompt": "",
       "projectId": "project_fixture",
       "projectName": "Parity Project",
@@ -1697,6 +1783,49 @@
         "loras": [],
         "mode": "text_to_image",
         "model": "base-model",
+        "modelManifestEntry": {
+          "adapter": "z_image_diffusers",
+          "capabilities": [
+            "text_to_image"
+          ],
+          "defaults": {
+            "height": 1024,
+            "width": 1024
+          },
+          "downloads": [
+            {
+              "estimatedSizeBytes": 536870912,
+              "files": [
+                "*.bin"
+              ],
+              "provider": "huggingface",
+              "repo": "owner/alternate-base-model"
+            },
+            {
+              "default": true,
+              "estimatedSizeBytes": 12884901888,
+              "files": [
+                "*.safetensors"
+              ],
+              "provider": "huggingface",
+              "repo": "owner/base-model"
+            }
+          ],
+          "family": "z-image",
+          "id": "base-model",
+          "limits": {},
+          "loraCompatibility": {
+            "families": [
+              "z-image"
+            ]
+          },
+          "name": "User Model",
+          "paths": {},
+          "type": "image",
+          "ui": {
+            "label": "User"
+          }
+        },
         "negativePrompt": "",
         "projectId": "project_fixture",
         "projectName": "Parity Project",
@@ -1743,6 +1872,49 @@
       "loras": [],
       "mode": "text_to_image",
       "model": "base-model",
+      "modelManifestEntry": {
+        "adapter": "z_image_diffusers",
+        "capabilities": [
+          "text_to_image"
+        ],
+        "defaults": {
+          "height": 1024,
+          "width": 1024
+        },
+        "downloads": [
+          {
+            "estimatedSizeBytes": 536870912,
+            "files": [
+              "*.bin"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/alternate-base-model"
+          },
+          {
+            "default": true,
+            "estimatedSizeBytes": 12884901888,
+            "files": [
+              "*.safetensors"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/base-model"
+          }
+        ],
+        "family": "z-image",
+        "id": "base-model",
+        "limits": {},
+        "loraCompatibility": {
+          "families": [
+            "z-image"
+          ]
+        },
+        "name": "User Model",
+        "paths": {},
+        "type": "image",
+        "ui": {
+          "label": "User"
+        }
+      },
       "negativePrompt": "",
       "projectId": "project_fixture",
       "projectName": "Parity Project",
@@ -2687,6 +2859,49 @@
       "loras": [],
       "mode": "text_to_image",
       "model": "base-model",
+      "modelManifestEntry": {
+        "adapter": "z_image_diffusers",
+        "capabilities": [
+          "text_to_image"
+        ],
+        "defaults": {
+          "height": 1024,
+          "width": 1024
+        },
+        "downloads": [
+          {
+            "estimatedSizeBytes": 536870912,
+            "files": [
+              "*.bin"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/alternate-base-model"
+          },
+          {
+            "default": true,
+            "estimatedSizeBytes": 12884901888,
+            "files": [
+              "*.safetensors"
+            ],
+            "provider": "huggingface",
+            "repo": "owner/base-model"
+          }
+        ],
+        "family": "z-image",
+        "id": "base-model",
+        "limits": {},
+        "loraCompatibility": {
+          "families": [
+            "z-image"
+          ]
+        },
+        "name": "User Model",
+        "paths": {},
+        "type": "image",
+        "ui": {
+          "label": "User"
+        }
+      },
       "negativePrompt": "",
       "projectId": "project_fixture",
       "projectName": "Parity Project",


### PR DESCRIPTION
## Summary
Regenerates the Rust API contract snapshot that `daf4e70` ("Catalog Real-ESRGAN upscaler weights") left stale.

`daf4e70` started injecting `modelManifestEntry` into **image-job** payloads (`generation.rs:22-23`) so the worker can resolve upscaler weights — but it didn't regenerate `tests/fixtures/rust_api_contract_snapshots/snapshots.json`. The parity contract-snapshot test fails with:

```
AssertionError: image job response no longer matches the saved Rust API contract snapshot:
  $.payload.modelManifestEntry: only in candidate
```

This was masked because GitHub Actions was down when `daf4e70` merged; it surfaced once Actions recovered. **Not related to the Chroma1 epic** — it reproduces on a clean checkout of `main` (verified locally on a pure-main branch with no Chroma changes).

Regenerated with `UPDATE_SNAPSHOTS=1` over the **full** snapshot suite (so no labels are dropped). The diff is **purely additive — 215 insertions, 0 removals** — adding the resolved `modelManifestEntry` to the generation-job response payloads, matching `daf4e70`'s intentional behavior.

## ⚠️ Merge interdependency
`main` currently has **two** independent breaks that the Actions outage masked, both surfacing in the `parity` job:
1. **Scaffold:** chroma models lack `ui.promptGuide` → fixed by **#265** (sc-1844).
2. **Snapshot:** this PR.

Because the scaffold check runs *inside* the parity job, **no** branch off current `main` gets a fully-green `parity` job until **both** fixes are present. This PR's own `parity` will still red at the scaffold step until #265 lands. Recommended: merge **#265** and this PR; once both are on `main`, parity is green, then #264 (sc-1832) rebases clean.

## Test plan
- [x] `pytest -m parity` (12) + `-m e2e` (1) pass locally with the regenerated snapshot (rust-api debug binary)
- [x] Diff is additive-only (no snapshot labels removed/altered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)