### PR TITLE
fix(sc-1838): load Kolors with variant=fp16 (fp16-only checkpoint)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -319,6 +319,9 @@ MODEL_TARGETS = {
         "steps": 25,
         "guidanceScale": 5.0,
         "maxSequenceLength": 256,
+        # Kolors-diffusers ships fp16-variant weights only (*.fp16.safetensors),
+        # so from_pretrained must request the fp16 variant.
+        "variant": "fp16",
         "repo": "Kwai-Kolors/Kolors-diffusers",
         "adapter": "kolors_diffusers",
     },
@@ -1915,7 +1918,11 @@ class KolorsDiffusersAdapter:
             cpuOffload=cpu_offload,
             cached=cache_action == "Loading cached",
         )
-        pipe = pipeline_class.from_pretrained(repo, torch_dtype=dtype)
+        # fp16-only repo: pass the variant or from_pretrained looks for the
+        # nonexistent default diffusion_pytorch_model.bin and fails (e.g. in vae/).
+        pipe = pipeline_class.from_pretrained(
+            repo, torch_dtype=dtype, variant=model_target.get("variant")
+        )
         # Kolors-diffusers ships EulerDiscreteScheduler; the model card recommends
         # DPMSolverMultistep with Karras sigmas for the ~25-step config.
         scheduler_class = getattr(diffusers, "DPMSolverMultistepScheduler", None)

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1311,6 +1311,8 @@ def test_kolors_model_target_defaults():
     assert kolors["steps"] == 25
     assert kolors["guidanceScale"] == 5.0
     assert kolors["maxSequenceLength"] == 256
+    # fp16-only repo: from_pretrained must request the fp16 variant.
+    assert kolors["variant"] == "fp16"
     assert kolors["repo"] == "Kwai-Kolors/Kolors-diffusers"
 
 


### PR DESCRIPTION
## Summary
Fixes the runtime failure when generating with Kolors:
> Error no file named `diffusion_pytorch_model.bin` found in directory `.../models--Kwai-Kolors--Kolors-diffusers/snapshots/<hash>/vae`

`Kwai-Kolors/Kolors-diffusers` ships **only fp16-variant weights** (`diffusion_pytorch_model.fp16.safetensors`). `KolorsDiffusersAdapter` called `from_pretrained(repo, torch_dtype=dtype)` **without `variant=`**, so diffusers looked for the default non-variant `diffusion_pytorch_model.bin` and failed. The model card's own example uses `variant="fp16"`.

- Add `"variant": "fp16"` to `MODEL_TARGETS["kolors"]`.
- Thread `variant=model_target.get("variant")` into `KolorsDiffusersAdapter._load_pipeline.from_pretrained` (covers both `KolorsPipeline` T2I and `KolorsImg2ImgPipeline` edit). Other models pass `variant=None` → unchanged.

Found by the **sc-1836 Mac/MPS spike** — the mocked worker test suite never reaches `_run_pipeline` / `from_pretrained`, so this only shows up on a real run.

## Test plan
- [x] Worker pytest light suite (`tests/test_worker_runtime.py` + gpu + person): **294 passed, 6 skipped**.
- [ ] CI `Check` green
- [ ] Real generation on Mac (sc-1836) — Kolors T2I + img2img now load.

## Related / NOT fixed here
A second, separate issue blocks the *download→load* path: the Model Manager downloads HF models into `data/models/<__slug>` but the worker loads from the **HF cache** (`models--<--slug>`), so the downloaded weights aren't where `from_pretrained` looks (the HF snapshot has config.json only). That's **sc-1904** — with this variant fix, the first generation will re-download the fp16 weights into `~/.cache/huggingface`. sc-1904 is the proper fix (route HF downloads to the HF cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)