### PR TITLE
fix(sc-1904): download HF models into the shared hub cache, not the private app store

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -92,6 +92,81 @@ pub(crate) struct DownloadContext<'a> {
     pub(crate) cancel_message: &'a str,
 }
 
+/// Download a single file to `dest` (resumable via HTTP Range), reporting transfer
+/// progress and rejecting a truncated response. `label` names the file in the
+/// size-mismatch error.
+async fn download_file(
+    context: &DownloadContext<'_>,
+    url: &str,
+    dest: &Path,
+    expected_size: Option<u64>,
+    label: &str,
+    progress: &mut DownloadProgress<'_>,
+) -> WorkerResult<()> {
+    let existing_bytes = existing_download_bytes(dest, expected_size).await?;
+    if expected_size.is_some_and(|size| existing_bytes == size) {
+        return Ok(());
+    }
+    let mut request = context.client.get(url);
+    if existing_bytes > 0 {
+        request = request.header(header::RANGE, format!("bytes={existing_bytes}-"));
+    }
+    let response = with_hf_auth(context.settings, request).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(WorkerError::Http(response.error_for_status().unwrap_err()));
+    }
+    let appending = existing_bytes > 0 && status == StatusCode::PARTIAL_CONTENT;
+    if existing_bytes > 0 && !appending {
+        progress.discard_started_bytes(existing_bytes);
+    }
+    let mut response = response;
+    let mut output = if appending {
+        tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dest)
+            .await?
+    } else {
+        tokio::fs::File::create(dest).await?
+    };
+    let mut interval = tokio::time::interval(progress.report_interval());
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            chunk = response.chunk() => {
+                let Some(chunk) = chunk? else {
+                    break;
+                };
+                output.write_all(&chunk).await?;
+                progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
+            }
+            _ = interval.tick() => {
+                report_download_progress(context, progress).await?;
+            }
+        }
+    }
+    output.flush().await?;
+    // A truncated transfer (e.g. the server closes the stream at what looks like a
+    // clean EOF) would otherwise be treated as success and the bad file only surface
+    // as an opaque load failure later. When the expected size is known, verify it and
+    // remove the partial so the next attempt re-downloads.
+    if let Some(expected) = expected_size {
+        let written = tokio::fs::metadata(dest).await?.len();
+        if written != expected {
+            let _ = tokio::fs::remove_file(dest).await;
+            return Err(WorkerError::InvalidPayload(format!(
+                "{label} download ended at {} but expected {}",
+                format_bytes(written),
+                format_bytes(expected)
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Download a Hugging Face snapshot as a flat file tree under `target_dir`. Used by
+/// the model-import flow, which intentionally populates the app's import store.
 pub(crate) async fn download_snapshot(
     context: &DownloadContext<'_>,
     target_dir: &Path,
@@ -105,69 +180,152 @@ pub(crate) async fn download_snapshot(
         if let Some(parent) = target_path.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
-        let existing_bytes = existing_download_bytes(&target_path, file.size).await?;
-        if file.size.is_some_and(|size| existing_bytes == size) {
-            continue;
+        download_file(
+            context,
+            &file.download_url,
+            &target_path,
+            file.size,
+            &file.path,
+            progress,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Download a Hugging Face snapshot into the standard hub cache layout under
+/// `repo_dir` (`models--<org>--<name>`): content lands in `blobs/<etag>`, the
+/// checkpoint is materialized as `snapshots/<commit>/<path>` (a relative symlink to
+/// its blob, or a copy where symlinks are unavailable), and `refs/<rev>` records the
+/// commit. This matches `huggingface_hub`, so HF-sourced downloads dedupe with other
+/// tools and the Python loader instead of duplicating into the private app store
+/// (sc-1904).
+pub(crate) async fn download_snapshot_into_cache(
+    context: &DownloadContext<'_>,
+    repo_dir: &Path,
+    revision: &str,
+    snapshot: &HuggingFaceSnapshot,
+    progress: &mut DownloadProgress<'_>,
+) -> WorkerResult<()> {
+    let blobs_dir = repo_dir.join("blobs");
+    tokio::fs::create_dir_all(&blobs_dir).await?;
+    // A no-redirect client so the metadata HEAD reads huggingface.co's headers
+    // (X-Repo-Commit, and X-Linked-Etag for LFS) rather than the CDN's after a
+    // redirect — exactly how huggingface_hub resolves an etag/commit.
+    let meta_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+    let mut commit: Option<String> = None;
+    let mut placements: Vec<(String, String)> = Vec::with_capacity(snapshot.files.len());
+
+    for file in &snapshot.files {
+        check_cancel(context.api, context.job_id, context.cancel_message).await?;
+        let head = with_hf_auth(context.settings, meta_client.head(&file.download_url))
+            .send()
+            .await?;
+        if commit.is_none() {
+            commit = header_value(&head, "x-repo-commit");
         }
-        let mut request = context.client.get(&file.download_url);
-        if existing_bytes > 0 {
-            request = request.header(header::RANGE, format!("bytes={existing_bytes}-"));
+        let etag = header_value(&head, "x-linked-etag")
+            .or_else(|| header_value(&head, "etag"))
+            .map(|value| normalize_etag(&value))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| blob_fallback_name(&file.path));
+        download_file(
+            context,
+            &file.download_url,
+            &blobs_dir.join(&etag),
+            file.size,
+            &file.path,
+            progress,
+        )
+        .await?;
+        placements.push((file.path.clone(), etag));
+    }
+
+    // Materialize the snapshot once every blob is present: refs/<rev> -> commit and
+    // snapshots/<commit>/<path> -> ../../blobs/<etag>.
+    let commit = commit.unwrap_or_else(|| revision.to_owned());
+    let refs_dir = repo_dir.join("refs");
+    tokio::fs::create_dir_all(&refs_dir).await?;
+    tokio::fs::write(refs_dir.join(revision), commit.as_bytes()).await?;
+    let snapshot_dir = repo_dir.join("snapshots").join(&commit);
+    for (relpath, etag) in &placements {
+        let link = safe_join(&snapshot_dir, relpath)?;
+        if let Some(parent) = link.parent() {
+            tokio::fs::create_dir_all(parent).await?;
         }
-        let response = with_hf_auth(context.settings, request).send().await?;
-        let status = response.status();
-        if !status.is_success() {
-            return Err(WorkerError::Http(response.error_for_status().unwrap_err()));
+        if tokio::fs::symlink_metadata(&link).await.is_ok() {
+            let _ = tokio::fs::remove_file(&link).await;
         }
-        let appending = existing_bytes > 0 && status == StatusCode::PARTIAL_CONTENT;
-        if existing_bytes > 0 && !appending {
-            progress.discard_started_bytes(existing_bytes);
+        let depth = link
+            .parent()
+            .and_then(|parent| parent.strip_prefix(repo_dir).ok())
+            .map(|relative| relative.components().count())
+            .unwrap_or(2);
+        let mut rel_target = PathBuf::new();
+        for _ in 0..depth {
+            rel_target.push("..");
         }
-        let mut response = response;
-        let mut output = if appending {
-            tokio::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&target_path)
-                .await?
-        } else {
-            tokio::fs::File::create(&target_path).await?
-        };
-        let mut interval = tokio::time::interval(progress.report_interval());
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        loop {
-            tokio::select! {
-                chunk = response.chunk() => {
-                    let Some(chunk) = chunk? else {
-                        break;
-                    };
-                    output.write_all(&chunk).await?;
-                    progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
-                }
-                _ = interval.tick() => {
-                    report_download_progress(context, progress).await?;
-                }
-            }
-        }
-        output.flush().await?;
-        // A truncated transfer (e.g. the server closes the stream at what looks
-        // like a clean EOF) would otherwise be treated as success: the install
-        // marker gets written over a corrupt dir and the bad shard only surfaces
-        // as an opaque load failure later. When the expected size is known,
-        // verify it and remove the partial so the next attempt re-downloads.
-        if let Some(expected) = file.size {
-            let written = tokio::fs::metadata(&target_path).await?.len();
-            if written != expected {
-                let _ = tokio::fs::remove_file(&target_path).await;
-                return Err(WorkerError::InvalidPayload(format!(
-                    "{} download ended at {} but expected {}",
-                    file.path,
-                    format_bytes(written),
-                    format_bytes(expected)
-                )));
-            }
+        rel_target.push("blobs");
+        rel_target.push(etag);
+        if !link_blob(&rel_target, &link).await {
+            tokio::fs::copy(blobs_dir.join(etag), &link).await?;
         }
     }
     Ok(())
+}
+
+fn header_value(response: &reqwest::Response, name: &str) -> Option<String> {
+    response
+        .headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// Strip the surrounding quotes and any weak-validator prefix HTTP/HF put around an
+/// ETag, leaving the bare blob name huggingface_hub uses.
+fn normalize_etag(raw: &str) -> String {
+    raw.trim()
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_owned()
+}
+
+/// Blob name when the server returns no etag (a non-HF stub or an endpoint that
+/// omits ETag): a filesystem-safe rendering of the repo path. Keeps the download
+/// working; only weakens cross-app dedup for that one file.
+fn blob_fallback_name(path: &str) -> String {
+    path.chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Create a relative symlink from `link` to its blob, returning whether it
+/// succeeded. Mirrors huggingface_hub: symlink where supported, and the caller
+/// copies instead when this returns false (Windows without privilege).
+async fn link_blob(rel_target: &Path, link: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        tokio::fs::symlink(rel_target, link).await.is_ok()
+    }
+    #[cfg(windows)]
+    {
+        tokio::fs::symlink_file(rel_target, link).await.is_ok()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (rel_target, link);
+        false
+    }
 }
 
 pub(crate) async fn download_lora_source_url(

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -132,6 +132,9 @@ async fn download_file(
     };
     let mut interval = tokio::time::interval(progress.report_interval());
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // A tokio interval's first tick is immediate; consume it so the first chunk
+    // doesn't spuriously fire a zero-byte progress report before any transfer.
+    interval.tick().await;
     loop {
         tokio::select! {
             chunk = response.chunk() => {

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -93,6 +93,14 @@ pub(crate) async fn run_model_download_job(
         return Ok(());
     }
 
+    // Download into the standard Hugging Face hub cache (models--<org>--<name>),
+    // not the private app store, so HF-sourced weights dedupe with other tools and
+    // the Python loader instead of being duplicated under data/models (sc-1904).
+    let repo_dir = huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Unable to resolve Hugging Face cache path for {repo}."
+        ))
+    })?;
     let snapshot =
         HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
     if let Some(total_bytes) = snapshot.total_bytes() {
@@ -114,11 +122,11 @@ pub(crate) async fn run_model_download_job(
 
     let mut progress = DownloadProgress::new(
         repo,
-        directory_size(&target_dir).await,
+        directory_size(&repo_dir.join("blobs")).await,
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );
-    download_snapshot(
+    download_snapshot_into_cache(
         &DownloadContext {
             api,
             client: http_client,
@@ -126,14 +134,19 @@ pub(crate) async fn run_model_download_job(
             job_id: &job.id,
             cancel_message: "Model download canceled by user.",
         },
-        &target_dir,
+        &repo_dir,
+        revision,
         &snapshot,
         &mut progress,
     )
     .await?;
+    let cache_path = huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_dir);
+    // A lightweight install marker stays in the app store (parity with the CLI
+    // path's marker_dir) so the catalog's data/models pointer and bookkeeping
+    // remain intact; the weights themselves live only in the shared HF cache.
     write_model_install_marker(&target_dir, &job.payload, repo, &job.id).await?;
 
-    if !reconcile_downloaded_model_family(api, job, &target_dir).await? {
+    if !reconcile_downloaded_model_family(api, job, &cache_path).await? {
         return Ok(());
     }
 
@@ -145,7 +158,11 @@ pub(crate) async fn run_model_download_job(
     result.insert("repo".to_owned(), Value::String(repo.to_owned()));
     result.insert(
         "path".to_owned(),
-        Value::String(target_dir.display().to_string()),
+        Value::String(cache_path.display().to_string()),
+    );
+    result.insert(
+        "storage".to_owned(),
+        Value::String("huggingface_cache".to_owned()),
     );
     result.insert("completedAt".to_owned(), Value::String(now_rfc3339()));
     update_job(
@@ -155,7 +172,7 @@ pub(crate) async fn run_model_download_job(
             JobStatus::Completed,
             ProgressStage::Completed,
             1.0,
-            "Model download completed.",
+            "Model download completed in the Hugging Face cache.",
             None,
             Some(result),
             None,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -15,8 +15,9 @@ use tempfile::tempdir;
 
 use super::api_client::ApiClient;
 use super::downloads::{
-    credential_for_host, download_lora_source_url, download_progress_payload, download_snapshot,
-    DownloadContext, DownloadProgress, HuggingFaceSnapshot, SnapshotFile,
+    credential_for_host, download_lora_source_url, download_progress_payload,
+    download_snapshot_into_cache, DownloadContext, DownloadProgress, HuggingFaceSnapshot,
+    SnapshotFile,
 };
 use super::gpu::{
     cpu_gpu, cpu_worker_id, fallback_gpu, gpu_worker_id, parse_nvidia_smi_gpus, visible_gpu_ids,
@@ -606,7 +607,7 @@ async fn download_snapshot_rejects_truncated_file() {
     settings.api_url = base_url.clone();
     let api = ApiClient::new(&settings);
     let client = reqwest::Client::new();
-    let target_dir = temp.path().join("model");
+    let repo_dir = temp.path().join("models--owner--model");
 
     let snapshot = HuggingFaceSnapshot {
         files: vec![SnapshotFile {
@@ -622,7 +623,7 @@ async fn download_snapshot_rejects_truncated_file() {
         Duration::from_secs(3600),
     );
 
-    let error = download_snapshot(
+    let error = download_snapshot_into_cache(
         &DownloadContext {
             api: &api,
             client: &client,
@@ -630,7 +631,8 @@ async fn download_snapshot_rejects_truncated_file() {
             job_id: "job-1",
             cancel_message: "canceled",
         },
-        &target_dir,
+        &repo_dir,
+        "main",
         &snapshot,
         &mut progress,
     )
@@ -638,8 +640,172 @@ async fn download_snapshot_rejects_truncated_file() {
     .expect_err("truncated shard is rejected");
 
     assert!(error.to_string().contains("expected"));
-    // The partial file is removed so a retry re-downloads from scratch.
-    assert!(!target_dir.join("shard.safetensors").exists());
+    // The partial blob is removed so a retry re-downloads, and the snapshot is
+    // never materialized over a corrupt blob.
+    assert!(!repo_dir
+        .join("blobs")
+        .join("etag-shard.safetensors")
+        .exists());
+    assert!(!repo_dir.join("snapshots").exists());
+}
+
+#[tokio::test]
+async fn download_snapshot_writes_hugging_face_cache_layout() {
+    let temp = tempdir().expect("tempdir creates");
+    let base_url = spawn_binary_stub(b"weights!!".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base_url.clone();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let repo_dir = temp.path().join("models--owner--model");
+
+    let snapshot = HuggingFaceSnapshot {
+        files: vec![SnapshotFile {
+            path: "model.safetensors".to_owned(),
+            size: Some(9),
+            download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+        }],
+    };
+    let mut progress = DownloadProgress::new(
+        "owner/model",
+        0,
+        snapshot.total_bytes(),
+        Duration::from_secs(3600),
+    );
+
+    download_snapshot_into_cache(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+        },
+        &repo_dir,
+        "main",
+        &snapshot,
+        &mut progress,
+    )
+    .await
+    .expect("snapshot downloads into the hub cache layout");
+
+    // refs/<rev> records the commit reported by the resolve metadata.
+    assert_eq!(
+        tokio::fs::read_to_string(repo_dir.join("refs").join("main"))
+            .await
+            .unwrap(),
+        "stubcommit"
+    );
+    // Content lands in a blob named by etag.
+    assert_eq!(
+        tokio::fs::read(repo_dir.join("blobs").join("etag-model.safetensors"))
+            .await
+            .unwrap(),
+        b"weights!!"
+    );
+    // The snapshot entry resolves to that content (symlink on unix, copy otherwise).
+    assert_eq!(
+        tokio::fs::read(
+            repo_dir
+                .join("snapshots")
+                .join("stubcommit")
+                .join("model.safetensors")
+        )
+        .await
+        .unwrap(),
+        b"weights!!"
+    );
+}
+
+/// Opt-in: hits the real huggingface.co to confirm the cache layout we write
+/// matches what huggingface_hub expects — exercising the live resolve tree, the
+/// metadata HEAD (`ETag` for regular files, `X-Linked-Etag` + a CDN redirect for
+/// LFS files), and `X-Repo-Commit`. Ignored by default so CI/offline runs never
+/// hit the network. Run it with:
+///   cargo test -p sceneworks-worker -- --ignored real_huggingface
+#[tokio::test]
+#[ignore = "network: downloads a tiny public repo from huggingface.co"]
+async fn download_snapshot_into_cache_matches_real_huggingface_layout() {
+    let temp = tempdir().expect("tempdir creates");
+    // Cancel/heartbeat checks go to a benign local stub; the files download from the
+    // real huggingface.co set as the HF base URL.
+    let api_base = spawn_binary_stub(b"ignored".to_vec()).await;
+    let mut settings = test_settings("https://huggingface.co".to_owned(), None);
+    settings.api_url = api_base;
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let repo = "hf-internal-testing/tiny-random-bert";
+    let repo_dir = temp
+        .path()
+        .join("models--hf-internal-testing--tiny-random-bert");
+
+    // A small regular file (config.json, ETag path) plus any safetensors weights
+    // (LFS path) so both header behaviors are exercised.
+    let snapshot = HuggingFaceSnapshot::resolve(
+        &client,
+        &settings,
+        repo,
+        "main",
+        &["config.json".to_owned(), "*.safetensors".to_owned()],
+    )
+    .await
+    .expect("resolves the live repo tree");
+    assert!(
+        snapshot.files.iter().any(|file| file.path == "config.json"),
+        "expected config.json in the resolved tree"
+    );
+
+    let mut progress =
+        DownloadProgress::new(repo, 0, snapshot.total_bytes(), Duration::from_secs(3600));
+    download_snapshot_into_cache(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "real",
+            cancel_message: "canceled",
+        },
+        &repo_dir,
+        "main",
+        &snapshot,
+        &mut progress,
+    )
+    .await
+    .expect("downloads the live repo into the hub cache layout");
+
+    // refs/main records the real git commit sha (40 hex chars).
+    let commit = tokio::fs::read_to_string(repo_dir.join("refs").join("main"))
+        .await
+        .expect("refs/main written");
+    let commit = commit.trim();
+    assert_eq!(
+        commit.len(),
+        40,
+        "commit should be a 40-char git sha: {commit}"
+    );
+
+    // Every resolved file materializes under snapshots/<commit>/ with its exact
+    // declared size — confirming both the ETag and X-Linked-Etag (LFS) paths.
+    let snapshot_dir = repo_dir.join("snapshots").join(commit);
+    for file in &snapshot.files {
+        let path = snapshot_dir.join(&file.path);
+        let bytes = tokio::fs::read(&path)
+            .await
+            .unwrap_or_else(|_| panic!("{} present in snapshot", file.path));
+        assert!(!bytes.is_empty(), "{} is empty", file.path);
+        if let Some(size) = file.size {
+            assert_eq!(bytes.len() as u64, size, "{} size mismatch", file.path);
+        }
+    }
+    // The blob store is populated (the snapshot entries point into it).
+    assert!(
+        repo_dir
+            .join("blobs")
+            .read_dir()
+            .map(|mut entries| entries.next().is_some())
+            .unwrap_or(false),
+        "blobs/ should hold the downloaded content"
+    );
 }
 
 #[tokio::test]
@@ -1344,13 +1510,29 @@ async fn binary_stub(State(state): State<BinaryStubState>, headers: HeaderMap) -
     response
 }
 
-async fn binary_head_stub(State(state): State<BinaryStubState>) -> Response {
+async fn binary_head_stub(
+    State(state): State<BinaryStubState>,
+    axum::extract::Path(path): axum::extract::Path<String>,
+) -> Response {
     let mut response = Response::new(Body::empty());
     *response.status_mut() = state.status;
-    response.headers_mut().insert(
+    let headers = response.headers_mut();
+    headers.insert(
         axum::http::header::CONTENT_LENGTH,
         axum::http::HeaderValue::from_str(&state.bytes.len().to_string())
             .expect("content length header"),
+    );
+    // Mirror Hugging Face's resolve metadata so download_snapshot can name blobs by
+    // etag and record the commit (sc-1904).
+    let last_segment = path.rsplit('/').next().unwrap_or("blob");
+    headers.insert(
+        axum::http::header::ETAG,
+        axum::http::HeaderValue::from_str(&format!("\"etag-{last_segment}\""))
+            .expect("etag header"),
+    );
+    headers.insert(
+        "x-repo-commit",
+        axum::http::HeaderValue::from_static("stubcommit"),
     );
     response
 }


### PR DESCRIPTION
-