### PR TITLE
fix(sc-1799): add CUDA upscaling runtime libs

### DIFF
--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -82,7 +82,7 @@ ENV PATH="/opt/venv/bin:${PATH}"
 # Triton bundles its own ptxas and CUDA headers and Python.h ships with the
 # base image, so gcc plus libc headers are all that is required.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc libc6-dev \
+    && apt-get install -y --no-install-recommends gcc libc6-dev libgl1 libglib2.0-0 libxcb1 \
     && rm -rf /var/lib/apt/lists/*
 ENV CC=gcc
 


### PR DESCRIPTION
## Summary
- add the OpenCV native runtime libraries required by Real-ESRGAN/basicSR in the slim CUDA worker image
- fixes CUDA upscaling validation failing at `cv2` import with missing `libxcb.so.1`, `libGL.so.1`, and GLib runtime libraries

## CUDA validation
- rebuilt and restarted the worker with `docker compose up -d --build worker`
- confirmed worker advertises CUDA inference capabilities via `python -m scene_worker --check`
- ran a synthetic Real-ESRGAN x2 asset-writer validation in the worker container
- observed Real-ESRGAN loading on `cuda:0` with `torch 2.8.0+cu128`
- verified original + upscaled assets were written, with `48x32 -> 96x64` output and matching lineage metadata

## Checks
- `python -m pytest tests/test_worker_runtime.py -k "real_esrgan or upscaled_variant or upscale_contract"`
- `node scripts/check-compose-config.mjs`
