### PR TITLE
feat(sc-1841): Character Studio reference-image generation (Kolors IP-Adapter)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1104,11 +1104,18 @@ export function App() {
     setActiveView("Video");
   }
 
-  function sendCharacterToImage(character, lookId = null) {
+  function sendCharacterToImage(character, lookId = null, referenceAssetId = null) {
     if (!character) {
       return;
     }
-    setStudioLaunch({ id: crypto.randomUUID(), view: "Image", characterId: character.id, lookId, mode: "character_image" });
+    setStudioLaunch({
+      id: crypto.randomUUID(),
+      view: "Image",
+      characterId: character.id,
+      lookId,
+      referenceAssetId,
+      mode: "character_image",
+    });
     setActiveView("Image");
   }
 

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -163,7 +163,7 @@ export const fallbackModels = [
     id: "kolors",
     name: "Kolors",
     type: "image",
-    capabilities: ["text_to_image", "style_variations"],
+    capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
     ui: {
       description: "Kwai-Kolors Kolors — photorealistic text-to-image with strong Chinese + English prompting and text rendering. Apache-2.0 (commercial-safe). ChatGLM3-6B + SDXL-style UNet; ~16.5GB, real CFG + negative prompt, ~25 steps at guidance 5.0.",
       promptGuide: { title: "Kolors Prompt Guide", path: "/prompt-guides/kolors.md" },

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2092,6 +2092,54 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Beta");
   });
 
+  it("launches reference-based generation from an approved character reference", async () => {
+    const sendCharacterToImage = vi.fn();
+    const reference = { assetId: "ref-1", approved: true, asset: { id: "ref-1", type: "image", displayName: "Mira ref" } };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference: () => {},
+            archiveCharacter: () => {},
+            assets: [],
+            attachCharacterLora: () => {},
+            characters: [
+              { id: "char-1", name: "Mira", type: "person", references: [reference], approvedReferences: [reference], looks: [], loras: [] },
+            ],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: [],
+            loras: [],
+            setPreviewAsset: () => {},
+            sendCharacterToImage,
+            sendCharacterToVideo: () => {},
+            purgeAsset: () => {},
+            removeCharacterReference: () => {},
+            updateAssetStatus: () => {},
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate variations").click();
+    });
+
+    expect(sendCharacterToImage).toHaveBeenCalledWith(expect.objectContaining({ id: "char-1" }), null, "ref-1");
+  });
+
   it("keeps the shell usable when presets are unavailable", async () => {
     global.fetch.mockImplementation((url) => {
       const path = new URL(url).pathname;
@@ -4931,6 +4979,167 @@ describe("SceneWorks app shell", () => {
           factor: 4,
           engine: "real-esrgan",
         },
+      }),
+    );
+  });
+
+  it("submits a Kolors character job with the approved reference and IP-Adapter scale", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            {
+              id: "char-1",
+              name: "Mira",
+              type: "person",
+              looks: [],
+              approvedReferences: [
+                {
+                  assetId: "ref-1",
+                  approved: true,
+                  asset: {
+                    id: "ref-1",
+                    type: "image",
+                    displayName: "Mira ref",
+                    projectId: "project-1",
+                    file: { path: "assets/images/ref_0001.png", mimeType: "image/png" },
+                  },
+                },
+              ],
+            },
+          ],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "kolors",
+              name: "Kolors",
+              type: "image",
+              family: "kolors",
+              capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
+            },
+          ],
+          latestAssets: [],
+          launchRequest: { id: "launch-1", view: "Image", characterId: "char-1", referenceAssetId: "ref-1", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    // The approved reference renders as a selected identity thumbnail.
+    expect(container.textContent).toContain("Reference identity");
+    expect(container.querySelector(".reference-thumb.active")).not.toBeNull();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        characterId: "char-1",
+        referenceAssetId: "ref-1",
+        count: 4,
+        advanced: { resolution: "1024x1024", ipAdapterScale: 0.6 },
+      }),
+    );
+  });
+
+  it("limits the character image model picker to reference-capable models", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [{ id: "char-1", name: "Mira", type: "person", looks: [], approvedReferences: [] }],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            { id: "kolors", name: "Kolors", type: "image", capabilities: ["text_to_image", "character_image"] },
+            { id: "flux_dev", name: "FLUX", type: "image", capabilities: ["text_to_image"] },
+          ],
+          latestAssets: [],
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+
+    // Text mode lists every image model.
+    let modelOptions = [...field(container, "Model").options].map((option) => option.textContent);
+    expect(modelOptions).toContain("Kolors");
+    expect(modelOptions).toContain("FLUX");
+
+    await act(async () => {
+      [...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "With character").click();
+    });
+    await settle();
+
+    // Character mode hides models without a reference (IP-Adapter) engine.
+    modelOptions = [...field(container, "Model").options].map((option) => option.textContent);
+    expect(modelOptions).toContain("Kolors");
+    expect(modelOptions).not.toContain("FLUX");
+  });
+
+  it("generates without a reference and warns when the character has no approved reference image", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [{ id: "char-2", name: "Echo", type: "creature", looks: [], approvedReferences: [] }],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [{ id: "kolors", name: "Kolors", type: "image", capabilities: ["text_to_image", "character_image"] }],
+          latestAssets: [],
+          launchRequest: { id: "launch-2", view: "Image", characterId: "char-2", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    expect(container.textContent).toContain("No approved reference");
+    expect(container.querySelector(".reference-thumb")).toBeNull();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        characterId: "char-2",
+        referenceAssetId: null,
+        advanced: { resolution: "1024x1024" },
       }),
     );
   });

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -308,7 +308,10 @@ export function CharacterStudio() {
                 <button onClick={() => archiveCharacter(selectedCharacter.id)} type="button">
                   Archive
                 </button>
-                <button onClick={() => onSendImage(selectedCharacter, testLookId || null)} type="button">
+                <button
+                  onClick={() => onSendImage(selectedCharacter, testLookId || null, approvedReferences[0]?.assetId ?? null)}
+                  type="button"
+                >
                   Image
                 </button>
                 <button onClick={() => onSendVideo(selectedCharacter, testLookId || null)} type="button">
@@ -317,12 +320,13 @@ export function CharacterStudio() {
               </div>
             </form>
             <div className="guidance-strip">
-              <strong>Character conditioning</strong>
-              <span>Character selections are recorded in presets now; adapter-level reference and LoRA conditioning will activate in a later runtime slice.</span>
+              <strong>Reference identity</strong>
+              <span>Approve a reference image, then use Generate variations (or the Image button) to create new images that keep this character's appearance with Kolors IP-Adapter. LoRA conditioning activates in a later runtime slice.</span>
             </div>
 
             <CharacterReferences
               imageAssets={imageAssets}
+              onGenerateFromReference={(assetId) => onSendImage(selectedCharacter, testLookId || null, assetId)}
               onPreview={onPreview}
               referenceMessage={referenceMessage}
               referenceAssetIds={referenceAssetIds}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
+import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 
@@ -158,6 +159,10 @@ export function ImageStudio() {
   const [sourceAssetId, setSourceAssetId] = useState(selectedAsset?.id ?? "");
   const [characterId, setCharacterId] = useState("");
   const [characterLookId, setCharacterLookId] = useState("");
+  // Character reference (IP-Adapter) — the approved reference image whose identity
+  // Kolors copies across variations. `ipAdapterScale` rides in `advanced`.
+  const [referenceAssetId, setReferenceAssetId] = useState("");
+  const [ipAdapterScale, setIpAdapterScale] = useState(0.6);
   const [upscaleEnabled, setUpscaleEnabled] = useState(false);
   const [upscaleFactor, setUpscaleFactor] = useState(2);
   const [upscaleEngine, setUpscaleEngine] = useState("real-esrgan");
@@ -173,7 +178,7 @@ export function ImageStudio() {
   function handleModeChange(nextMode) {
     if (nextMode === "edit_image") {
       setCount(1);
-    } else if (nextMode === "text_to_image") {
+    } else if (nextMode === "text_to_image" || nextMode === "character_image") {
       setCount(4);
     }
     setMode(nextMode);
@@ -219,6 +224,9 @@ export function ImageStudio() {
       setMode(launchRequest.mode ?? "character_image");
       setCharacterId(launchRequest.characterId);
       setCharacterLookId(launchRequest.lookId ?? "");
+      if (launchRequest.referenceAssetId) {
+        setReferenceAssetId(launchRequest.referenceAssetId);
+      }
       return;
     }
     if (launchRequest.assetId !== selectedAsset?.id) {
@@ -237,6 +245,11 @@ export function ImageStudio() {
         if (mode === "edit_image") {
           return caps.includes("edit_image") || caps.includes("image_edit");
         }
+        if (mode === "character_image") {
+          // Only models with a reference-image (IP-Adapter) engine can preserve a
+          // character's identity from one reference; gate the picker to them.
+          return caps.includes("character_image");
+        }
         return item.type === "image";
       }),
     [imageModels, mode],
@@ -250,6 +263,28 @@ export function ImageStudio() {
     }
   }, [availableModels, model]);
   const selectedModel = imageModels.find((item) => item.id === model);
+  // Approved reference images for the selected character (the IP-Adapter identity
+  // source). Resolve the full asset from the catalog so thumbnails render even when
+  // the character payload only carries assetIds.
+  const characterReferences = useMemo(() => {
+    const character = characters.find((item) => item.id === characterId);
+    return (character?.approvedReferences ?? []).map((reference) => ({
+      assetId: reference.assetId,
+      role: reference.role ?? null,
+      asset: reference.asset ?? assets.find((item) => item.id === reference.assetId) ?? null,
+    }));
+  }, [characters, characterId, assets]);
+  // Keep the selected reference valid: default to the first approved reference when
+  // none is chosen or the current one no longer belongs to this character.
+  useEffect(() => {
+    if (mode !== "character_image") {
+      return;
+    }
+    if (characterReferences.some((reference) => reference.assetId === referenceAssetId)) {
+      return;
+    }
+    setReferenceAssetId(characterReferences[0]?.assetId ?? "");
+  }, [mode, characterReferences, referenceAssetId]);
   const resolutionOptions = useMemo(
     () =>
       selectedModel?.limits?.resolutions?.length
@@ -426,6 +461,7 @@ export function ImageStudio() {
         characterId: mode === "character_image" ? characterId || null : null,
         characterLookId: mode === "character_image" ? characterLookId || null : null,
         sourceAssetId: mode === "edit_image" ? sourceAssetId || null : null,
+        referenceAssetId: mode === "character_image" ? referenceAssetId || null : null,
         loras: selectedLoras.map((lora) => serializeLora(lora)),
         ...(upscaleEnabled
           ? {
@@ -438,6 +474,9 @@ export function ImageStudio() {
           : {}),
         advanced: {
           resolution,
+          // IP-Adapter reference strength only applies when a character reference is
+          // attached; the worker reads advanced.ipAdapterScale (default 0.6).
+          ...(mode === "character_image" && referenceAssetId ? { ipAdapterScale } : {}),
         },
       });
       onLocalJobCreated?.(job);
@@ -554,10 +593,54 @@ export function ImageStudio() {
                     </select>
                   </label>
                 </div>
-                <div className="guidance-strip">
-                  <strong>Preset-only character</strong>
-                  <span>Character and look are saved with the preset; adapter-level reference and LoRA conditioning are not active yet.</span>
-                </div>
+                {characterId ? (
+                  characterReferences.length ? (
+                    <div className="character-reference-picker">
+                      <span className="reference-picker-label">Reference identity</span>
+                      <div className="reference-thumb-row">
+                        {characterReferences.map((reference) => (
+                          <button
+                            aria-label={`Use ${reference.asset?.displayName ?? reference.assetId} as reference`}
+                            aria-pressed={reference.assetId === referenceAssetId}
+                            className={reference.assetId === referenceAssetId ? "reference-thumb active" : "reference-thumb"}
+                            key={reference.assetId}
+                            onClick={() => setReferenceAssetId(reference.assetId)}
+                            title={reference.asset?.displayName ?? reference.assetId}
+                            type="button"
+                          >
+                            {reference.asset ? <AssetMedia asset={reference.asset} controls={false} /> : <span>Missing asset</span>}
+                          </button>
+                        ))}
+                      </div>
+                      <label className="reference-strength">
+                        Reference strength
+                        <input
+                          max="1"
+                          min="0"
+                          onChange={(event) => setIpAdapterScale(Number(event.target.value))}
+                          step="0.05"
+                          type="range"
+                          value={ipAdapterScale}
+                        />
+                        <span>{ipAdapterScale.toFixed(2)}</span>
+                      </label>
+                      <div className="guidance-strip">
+                        <strong>Identity from reference</strong>
+                        <span>Kolors IP-Adapter carries this reference's appearance across every variation. Raise Variations and leave the seed blank to explore different takes.</span>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="guidance-strip">
+                      <strong>No approved reference</strong>
+                      <span>Approve a reference image for this character in Character Studio to generate identity-preserving variations. Generating now uses the prompt only.</span>
+                    </div>
+                  )
+                ) : (
+                  <div className="guidance-strip">
+                    <strong>Select a character</strong>
+                    <span>Choose a character with an approved reference image to copy its identity across variations.</span>
+                  </div>
+                )}
               </>
             ) : null}
           </div>

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -21,6 +21,7 @@ function summarizeCompatibility(item) {
 
 export function CharacterReferences({
   imageAssets,
+  onGenerateFromReference,
   onPreview,
   referenceMessage,
   referenceAssetIds,
@@ -69,6 +70,11 @@ export function CharacterReferences({
               >
                 {reference.approved ? "Approved" : "Approve"}
               </button>
+              {reference.approved && onGenerateFromReference ? (
+                <button onClick={() => onGenerateFromReference(reference.assetId)} type="button">
+                  Generate variations
+                </button>
+              ) : null}
               <button onClick={() => removeCharacterReference(selectedCharacter.id, reference.assetId)} type="button">
                 Remove
               </button>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1402,6 +1402,61 @@ label {
   border-radius: var(--r-md);
 }
 
+.character-reference-picker {
+  display: grid;
+  gap: 10px;
+}
+
+.reference-picker-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.reference-thumb-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.reference-thumb {
+  display: grid;
+  place-items: center;
+  width: 72px;
+  height: 72px;
+  padding: 0;
+  overflow: hidden;
+  background: var(--bg-2);
+  border: 2px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text-faint);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.reference-thumb.active {
+  border-color: var(--accent);
+}
+
+.reference-thumb img,
+.reference-thumb video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.reference-strength {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.reference-strength input[type="range"] {
+  flex: 1;
+}
+
 .review-panel-head {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
## Summary
Headline deliverable for epic 1835: generate many identity-preserving images of a character from a single approved reference image, using the Kolors IP-Adapter-Plus engine shipped in sc-1840 (PR #270).

**This is web + tests only** — the Rust contract (`referenceAssetId` on `ImageJobRequest`) and the worker (`KolorsDiffusersAdapter`, which reads `referenceAssetId` and `advanced.ipAdapterScale`) already flow generically from sc-1840. No Rust/worker changes here.

### Changes
- **ImageStudio "With character" mode** (`ImageStudio.jsx`): approved-reference thumbnail picker, **Reference strength** control (`ipAdapterScale`, default 0.6), model picker gated to the `character_image` capability, default count 4. Submit now sends `referenceAssetId` (character mode) + `advanced.ipAdapterScale` (when a reference is attached). `count` drives N variations; leave the seed blank for varied takes.
- **App.jsx**: `sendCharacterToImage(character, lookId, referenceAssetId)` carries the chosen reference into `studioLaunch`.
- **Character Studio** (`CharacterStudio.jsx` / `characterPanels.jsx`): per-approved-reference **Generate variations** affordance; the **Image** button pre-selects the first approved reference; refreshed the stale "activate in a later runtime slice" guidance.
- **constants.js**: Kolors fallback capabilities now match the manifest (`edit_image` + `character_image`).
- **Graceful no-reference handling**: characters with no approved reference show a warning and generate prompt-only (`referenceAssetId: null`, no `ipAdapterScale`).
- **styles.css**: thumbnail picker + reference-strength styling.

### Works for
person / creature / object characters (general IP-Adapter reference, not face-only). FaceID-Plus human-face identity remains staged (sc-1882).

## Test plan
- [x] `vitest` full web suite — 125 passed (4 new: character payload w/ referenceAssetId + ipAdapterScale + count; capability gating; no-approved-reference path; Character Studio Generate-variations affordance).
- [x] `vite build` clean.
- [x] Merged latest `origin/main` (incl. #271/#272); suite green post-merge.
- [ ] Real IP-Adapter inference on Mac/MPS (the >24GB reference pipeline) — pending desk-side spike on this branch.

Depends on: sc-1840 (#270, merged). Out of scope (filed): FaceID-Plus (sc-1882), inpainting (sc-1880), ControlNet (sc-1881).

🤖 Generated with [Claude Code](https://claude.com/claude-code)