### PR TITLE
feat(sc-1898): gated-model banner + credential-screen link on Models screen

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use sceneworks_core::credentials::normalize_host;
+
 const ALLOWED_MODEL_TYPES: &[&str] = &["image", "video", "utility"];
 const MODEL_SIZE_CACHE_LIMIT: usize = 64;
 
@@ -728,6 +730,28 @@ pub(crate) async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiErr
             "removable".to_owned(),
             Value::Bool(user_managed || installed),
         );
+        // Gated-model signal (sc-1898): a machine-readable `gated` flag plus the
+        // credential host the download requires, so the Models screen can route the
+        // user to the credential screen before a download will succeed. The host
+        // honors an explicit manifest `credentialHost` and otherwise derives from
+        // the download provider/source URL; `licenseUrl` passes through untouched.
+        let gated = object
+            .get("gated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        object.insert("gated".to_owned(), Value::Bool(gated));
+        if gated {
+            let credential_host = object
+                .get("credentialHost")
+                .and_then(Value::as_str)
+                .map(normalize_host)
+                .filter(|host| !host.is_empty())
+                .or_else(|| derive_credential_host(object));
+            object.insert(
+                "credentialHost".to_owned(),
+                credential_host.map(Value::String).unwrap_or(Value::Null),
+            );
+        }
         // macOS Model Manager: MLX availability + conversion status for models that
         // declare an `mlx` variant. Additive fields the web/Docker build ignores; the
         // probes are cheap and portable, so a const `cfg!` check gates them rather
@@ -854,6 +878,37 @@ pub(crate) fn model_download(model: &Value) -> Option<Value> {
         }
     }
     fallback.cloned()
+}
+
+/// Best-effort credential host for a gated model when the manifest entry doesn't
+/// set `credentialHost` explicitly: an explicit per-download `credentialHost`,
+/// else the well-known host for the provider (`huggingface` ⇒ `huggingface.co`),
+/// else the host of a `sourceUrl`. Normalized (scheme/path stripped, lower-cased)
+/// to match how credentials are keyed in the store.
+fn derive_credential_host(model: &serde_json::Map<String, Value>) -> Option<String> {
+    let downloads = model.get("downloads")?.as_array()?;
+    for download in downloads {
+        if let Some(host) = download
+            .get("credentialHost")
+            .and_then(Value::as_str)
+            .map(normalize_host)
+            .filter(|host| !host.is_empty())
+        {
+            return Some(host);
+        }
+        if download.get("provider").and_then(Value::as_str) == Some("huggingface") {
+            return Some("huggingface.co".to_owned());
+        }
+        if let Some(host) = download
+            .get("sourceUrl")
+            .and_then(Value::as_str)
+            .map(normalize_host)
+            .filter(|host| !host.is_empty())
+        {
+            return Some(host);
+        }
+    }
+    None
 }
 
 pub(crate) fn is_supported_model_download(download: &Value) -> bool {
@@ -1077,4 +1132,52 @@ pub(crate) fn model_manifest_installed_path(model: &Value, data_dir: &FsPath) ->
     } else {
         data_dir.join(path)
     })
+}
+
+#[cfg(test)]
+mod gated_credential_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn map(value: Value) -> serde_json::Map<String, Value> {
+        value.as_object().expect("object").clone()
+    }
+
+    #[test]
+    fn derives_huggingface_host_from_provider() {
+        let model = map(json!({
+            "downloads": [{ "provider": "huggingface", "repo": "black-forest-labs/FLUX.1-dev", "files": [] }]
+        }));
+        assert_eq!(
+            derive_credential_host(&model).as_deref(),
+            Some("huggingface.co")
+        );
+    }
+
+    #[test]
+    fn prefers_explicit_download_credential_host() {
+        let model = map(json!({
+            "downloads": [{ "provider": "civitai", "credentialHost": "https://Civitai.com/", "sourceUrl": "https://civitai.com/api/x" }]
+        }));
+        assert_eq!(
+            derive_credential_host(&model).as_deref(),
+            Some("civitai.com")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_source_url_host() {
+        let model = map(json!({
+            "downloads": [{ "provider": "url", "sourceUrl": "https://models.example.com/path/file.safetensors" }]
+        }));
+        assert_eq!(
+            derive_credential_host(&model).as_deref(),
+            Some("models.example.com")
+        );
+    }
+
+    #[test]
+    fn no_downloads_yields_none() {
+        assert_eq!(derive_credential_host(&map(json!({}))), None);
+    }
 }

--- a/apps/web/src/credentials.js
+++ b/apps/web/src/credentials.js
@@ -1,0 +1,77 @@
+import { apiFetch } from "./api.js";
+
+// Service-credential transport shared by the Settings screen (where users manage
+// tokens) and the Models screen (which checks token presence for gated models).
+// The desktop build stores credentials in the OS keychain via Tauri (sc-1891);
+// the server/Docker build manages them over the authed REST API (sc-1893). These
+// helpers hide that split so both screens use one transport + presence check.
+export const credentialsIsDesktop =
+  typeof window !== "undefined" && !!window.__TAURI__;
+
+const invoke = (command, args) => window.__TAURI__.core.invoke(command, args);
+
+export const SCHEME_LABELS = {
+  bearer: "Bearer header",
+  query: "Query token",
+};
+
+// Server mode authenticates with the same access token the rest of the app uses.
+export function serverToken() {
+  return (
+    (typeof window !== "undefined" && window.localStorage.getItem("sceneworks-token")) || ""
+  );
+}
+
+export async function loadCredentials() {
+  if (credentialsIsDesktop) {
+    return (await invoke("list_credentials")) ?? [];
+  }
+  return (await apiFetch("/api/v1/credentials", serverToken())) ?? [];
+}
+
+// Returns the updated, redacted credential list (both transports yield it).
+export async function saveCredential({ host, label, scheme, token }) {
+  if (credentialsIsDesktop) {
+    await invoke("set_credential", { host, label, scheme, token });
+    return loadCredentials();
+  }
+  return apiFetch("/api/v1/credentials", serverToken(), {
+    method: "PUT",
+    body: JSON.stringify({ host, label, scheme, token }),
+  });
+}
+
+export async function removeCredentialRequest(host) {
+  if (credentialsIsDesktop) {
+    await invoke("delete_credential", { host });
+    return loadCredentials();
+  }
+  return apiFetch(`/api/v1/credentials/${encodeURIComponent(host)}`, serverToken(), {
+    method: "DELETE",
+  });
+}
+
+// Normalize a host or URL the way the Rust store does (strip scheme + path,
+// lower-case) so a manifest's `credentialHost: "huggingface.co"` matches a stored
+// credential that was keyed from e.g. "https://huggingface.co/black-forest-labs".
+export function normalizeCredentialHost(value) {
+  return String(value ?? "")
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .split("/")[0]
+    .trim()
+    .toLowerCase();
+}
+
+// Whether a credential for `host` exists with its token actually present (the
+// redacted listing flags missing tokens via `present: false`).
+export function hasPresentCredential(credentials, host) {
+  const target = normalizeCredentialHost(host);
+  if (!target) {
+    return false;
+  }
+  return (credentials ?? []).some(
+    (credential) =>
+      normalizeCredentialHost(credential.host) === target && credential.present !== false,
+  );
+}

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { JobProgressCard } from "../components/JobProgress.jsx";
 import { terminalStatuses } from "../constants.js";
+import { hasPresentCredential, loadCredentials } from "../credentials.js";
 import { extractFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
 
@@ -74,6 +75,37 @@ const MODEL_TYPE_OPTIONS = [
   { value: "video", label: "Video" },
   { value: "utility", label: "Utility" },
 ];
+
+// Gated models (e.g. FLUX.1 [dev]) need an accepted license + a saved credential
+// before a download can succeed. The catalog flags these with `gated`/
+// `credentialHost`/`licenseUrl` (sc-1898). When the matching credential is already
+// present we soften the notice to a ready state; otherwise we point the user at the
+// Settings credential screen. `present` is undefined while presence is still
+// unknown (e.g. the credential list hasn't loaded) — we still show the link then.
+function GatedModelNotice({ host, licenseUrl, present, onOpenSettings }) {
+  const hostLabel = host || "the required service";
+  return (
+    <div className={present ? "model-gated-notice ready" : "model-gated-notice"}>
+      <p className={present ? "inline-success" : "inline-warning"}>
+        {present
+          ? `Credential for ${hostLabel} saved — ready to download.`
+          : `Gated download. Add a ${hostLabel} token, then accept the model's license before downloading.`}
+      </p>
+      <div className="model-gated-actions">
+        {present ? null : (
+          <button type="button" onClick={onOpenSettings}>
+            Add token in Settings
+          </button>
+        )}
+        {licenseUrl ? (
+          <a href={licenseUrl} target="_blank" rel="noreferrer noopener">
+            Review license
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}
 
 function referencedPresetNames(recipePresets, kind, id) {
   return recipePresets
@@ -165,6 +197,10 @@ export function ModelManagerScreen() {
   // their memory tier. Browser/Docker builds have no Tauri bridge and skip this.
   const isDesktop = typeof window !== "undefined" && Boolean(window.__TAURI__);
   const [unifiedMemoryGb, setUnifiedMemoryGb] = useState(null);
+  // Gated-model credential presence (sc-1898): only fetched when the catalog has a
+  // gated model, so non-gated deployments make no extra credential request.
+  const [credentials, setCredentials] = useState([]);
+  const hasGatedModel = models.some((model) => model.gated);
   const visibleLoras = loras.filter((lora) => matchesFamily(lora, familyFilter));
 
   useEffect(() => {
@@ -194,6 +230,28 @@ export function ModelManagerScreen() {
       cancelled = true;
     };
   }, [isDesktop]);
+
+  useEffect(() => {
+    if (!hasGatedModel) {
+      return undefined;
+    }
+    let cancelled = false;
+    loadCredentials()
+      .then((list) => {
+        if (!cancelled) {
+          setCredentials(Array.isArray(list) ? list : []);
+        }
+      })
+      // Presence unknown (e.g. not authenticated yet) — the notice still links to Settings.
+      .catch(() => {
+        if (!cancelled) {
+          setCredentials([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasGatedModel]);
 
   function downloadJobsFor(model) {
     return jobs.filter((job) => job.type === "model_download" && job.payload?.modelId === model.id);
@@ -383,6 +441,8 @@ export function ModelManagerScreen() {
             (job) => terminalStatuses.has(job.status) && job.status !== "completed",
           );
           const showConvertButton = mlxState === "needs_conversion" || mlxState === "converted";
+          const gated = Boolean(model.gated);
+          const credentialPresent = gated && hasPresentCredential(credentials, model.credentialHost);
           return (
             <article className="model-card" key={model.id}>
               <div>
@@ -396,6 +456,14 @@ export function ModelManagerScreen() {
                 </span>
               ) : null}
               <p>{model.ui?.description ?? model.family ?? model.id}</p>
+              {gated && !installed ? (
+                <GatedModelNotice
+                  host={model.credentialHost}
+                  licenseUrl={model.licenseUrl}
+                  present={credentialPresent}
+                  onOpenSettings={() => setActiveView("Settings")}
+                />
+              ) : null}
               <dl>
                 <div>
                   <dt>Family</dt>

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -1,0 +1,138 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ModelManagerScreen reads `window.__TAURI__` at module load (via ../credentials.js)
+// to pick the keychain transport, so we set the Tauri bridge and re-import the
+// module fresh in each test. Credentials are served by the mocked `list_credentials`
+// command. AppContext is imported from the same fresh graph so the provider matches.
+async function click(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+const GATED_MODEL = {
+  id: "flux_dev",
+  name: "FLUX.1 [dev]",
+  type: "image",
+  family: "flux",
+  installState: "missing",
+  downloadable: true,
+  gated: true,
+  credentialHost: "huggingface.co",
+  licenseUrl: "https://huggingface.co/black-forest-labs/FLUX.1-dev",
+  ui: { description: "Gated FLUX model." },
+};
+
+const PLAIN_MODEL = {
+  id: "z_image_turbo",
+  name: "Z-Image-Turbo",
+  type: "image",
+  family: "z-image",
+  installState: "missing",
+  downloadable: true,
+  ui: { description: "Open model." },
+};
+
+describe("ModelManagerScreen gated-model notice", () => {
+  let container;
+  let root;
+  let invoke;
+  let credentials;
+  let setActiveView;
+  let ModelManagerScreen;
+  let AppContext;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    credentials = [];
+    setActiveView = vi.fn();
+    invoke = vi.fn(async (command) => {
+      switch (command) {
+        case "get_gpu_info":
+          return { platform: "windows", devices: [] };
+        case "list_credentials":
+          return credentials;
+        default:
+          return null;
+      }
+    });
+    window.__TAURI__ = { core: { invoke } };
+    vi.resetModules();
+    ({ AppContext } = await import("../context/AppContext.js"));
+    ({ ModelManagerScreen } = await import("./ModelManagerScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render(models) {
+    const value = {
+      activeProject: null,
+      jobs: [],
+      loras: [],
+      models,
+      presets: [],
+      jobAction: () => {},
+      setActiveView,
+      deleteLora: () => {},
+      deleteModel: () => {},
+      createModelDownloadJob: () => {},
+      createModelConvertJob: () => {},
+      createLoraImportJob: () => {},
+      createModelImportJob: () => {},
+    };
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    // Flush the gated-credential and GPU-info effect promises.
+    await act(async () => {});
+  }
+
+  it("shows a gated notice with a Settings link when no credential is saved", async () => {
+    await render([GATED_MODEL]);
+    expect(invoke).toHaveBeenCalledWith("list_credentials", undefined);
+    expect(container.textContent).toContain("Gated download");
+    expect(container.textContent).toContain("huggingface.co");
+
+    const settingsButton = [...container.querySelectorAll(".model-gated-actions button")].find(
+      (button) => button.textContent === "Add token in Settings",
+    );
+    expect(settingsButton).toBeTruthy();
+    await click(settingsButton);
+    expect(setActiveView).toHaveBeenCalledWith("Settings");
+
+    const license = container.querySelector(".model-gated-actions a");
+    expect(license?.getAttribute("href")).toBe(
+      "https://huggingface.co/black-forest-labs/FLUX.1-dev",
+    );
+  });
+
+  it("softens the notice once a matching credential is present", async () => {
+    credentials = [{ host: "huggingface.co", label: "Hugging Face", scheme: "bearer", present: true }];
+    await render([GATED_MODEL]);
+    expect(container.textContent).toContain("ready to download");
+    expect(container.textContent).not.toContain("Add token in Settings");
+  });
+
+  it("renders no gated notice for a non-gated model", async () => {
+    await render([PLAIN_MODEL]);
+    expect(invoke).not.toHaveBeenCalledWith("list_credentials", undefined);
+    expect(container.textContent).not.toContain("Gated download");
+    expect(container.querySelector(".model-gated-notice")).toBeNull();
+  });
+});

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -1,55 +1,17 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { apiFetch } from "../api.js";
+import {
+  SCHEME_LABELS,
+  credentialsIsDesktop as isDesktop,
+  loadCredentials,
+  removeCredentialRequest,
+  saveCredential,
+} from "../credentials.js";
 
 // The data-dir / GPU / worker / wizard controls are desktop-only (backed by Tauri
-// commands in the shell). Service credentials work in both deployments: the desktop
-// stores them in the OS keychain via Tauri, and the server/Docker build manages them
-// over the authed REST API (sc-1893).
-const isDesktop = typeof window !== "undefined" && !!window.__TAURI__;
+// commands in the shell). Service credentials work in both deployments and route
+// through the shared ../credentials.js transport (keychain on desktop, authed REST
+// on the server). The remaining commands here are desktop-only Tauri invokes.
 const invoke = (command, args) => window.__TAURI__.core.invoke(command, args);
-
-const SCHEME_LABELS = {
-  bearer: "Bearer header",
-  query: "Query token",
-};
-
-// Server mode authenticates with the same access token the rest of the app uses.
-function serverToken() {
-  return (
-    (typeof window !== "undefined" &&
-      window.localStorage.getItem("sceneworks-token")) ||
-    ""
-  );
-}
-
-async function loadCredentials() {
-  if (isDesktop) {
-    return (await invoke("list_credentials")) ?? [];
-  }
-  return (await apiFetch("/api/v1/credentials", serverToken())) ?? [];
-}
-
-// Returns the updated, redacted credential list (both transports yield it).
-async function saveCredential({ host, label, scheme, token }) {
-  if (isDesktop) {
-    await invoke("set_credential", { host, label, scheme, token });
-    return loadCredentials();
-  }
-  return apiFetch("/api/v1/credentials", serverToken(), {
-    method: "PUT",
-    body: JSON.stringify({ host, label, scheme, token }),
-  });
-}
-
-async function removeCredentialRequest(host) {
-  if (isDesktop) {
-    await invoke("delete_credential", { host });
-    return loadCredentials();
-  }
-  return apiFetch(`/api/v1/credentials/${encodeURIComponent(host)}`, serverToken(), {
-    method: "DELETE",
-  });
-}
 
 export function SettingsScreen() {
   const [settings, setSettings] = useState(null);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2982,6 +2982,22 @@ label {
   gap: 8px;
 }
 
+.model-gated-notice {
+  display: grid;
+  gap: 8px;
+}
+
+.model-gated-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.model-gated-actions a {
+  font-size: 13px;
+}
+
 .mlx-status {
   display: grid;
   gap: 8px;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -479,6 +479,13 @@
         "families": ["flux"],
         "types": ["style", "enhance", "character"]
       },
+      // Gated download: accept the FLUX.1 [dev] Non-Commercial License on the model
+      // card and add a Hugging Face token before downloading. `credentialHost`/
+      // `licenseUrl` drive the Models-screen gated banner + credential-screen link
+      // (sc-1898); `credentialHost` would otherwise derive from the HF provider.
+      "gated": true,
+      "credentialHost": "huggingface.co",
+      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
       "ui": {
         "label": "FLUX.1 [dev]",
         "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and configure an HF token before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU.",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -1102,6 +1102,19 @@ pub struct ModelManifestEntry {
     pub limits: JsonObject,
     pub lora_compatibility: JsonObject,
     pub ui: JsonObject,
+    /// Machine-readable signal that the download is gated and needs a credential
+    /// (e.g. an accepted license + token) before it can be fetched. The Models
+    /// screen uses this to point the user at the credential screen (sc-1898).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub gated: bool,
+    /// Credential host the gated download requires (e.g. `huggingface.co`). When
+    /// omitted the catalog derives it from the download provider/source URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_host: Option<String>,
+    /// Optional license/model-card URL the user must accept (surfaced as a
+    /// "Review license" link next to the gated notice).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license_url: Option<String>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }
@@ -1276,6 +1289,69 @@ mod tests {
         assert!(request.is_disabled());
         assert_eq!(request.factor, 2);
         assert_eq!(request.engine, "real-esrgan");
+    }
+
+    #[test]
+    fn non_gated_model_entry_omits_gated_fields() {
+        // The common case: a non-gated entry must not gain `gated`/`credentialHost`/
+        // `licenseUrl` keys on serialize (keeps existing manifests/fixtures stable).
+        let entry: ModelManifestEntry = serde_json::from_value(json!({
+            "id": "z_image_turbo",
+            "name": "Z-Image-Turbo",
+            "family": "z-image",
+            "type": "image",
+            "adapter": "z_image_diffusers",
+            "capabilities": ["text_to_image"],
+            "downloads": [{ "provider": "huggingface", "repo": "Tongyi-MAI/Z-Image-Turbo", "files": [] }],
+            "paths": {},
+            "defaults": {},
+            "limits": {},
+            "loraCompatibility": {},
+            "ui": {}
+        }))
+        .expect("entry parses");
+
+        assert!(!entry.gated);
+        assert_eq!(entry.credential_host, None);
+        let encoded = serde_json::to_value(&entry).expect("entry serializes");
+        let object = encoded.as_object().expect("object");
+        assert!(!object.contains_key("gated"));
+        assert!(!object.contains_key("credentialHost"));
+        assert!(!object.contains_key("licenseUrl"));
+    }
+
+    #[test]
+    fn gated_model_entry_round_trips() {
+        let value = json!({
+            "id": "flux_dev",
+            "name": "FLUX.1 [dev]",
+            "family": "flux",
+            "type": "image",
+            "adapter": "flux_diffusers",
+            "capabilities": ["text_to_image"],
+            "downloads": [{ "provider": "huggingface", "repo": "black-forest-labs/FLUX.1-dev", "files": [] }],
+            "paths": {},
+            "defaults": {},
+            "limits": {},
+            "loraCompatibility": {},
+            "ui": {},
+            "gated": true,
+            "credentialHost": "huggingface.co",
+            "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.1-dev"
+        });
+        let entry: ModelManifestEntry =
+            serde_json::from_value(value.clone()).expect("gated entry parses");
+
+        assert!(entry.gated);
+        assert_eq!(entry.credential_host.as_deref(), Some("huggingface.co"));
+        assert_eq!(
+            entry.license_url.as_deref(),
+            Some("https://huggingface.co/black-forest-labs/FLUX.1-dev")
+        );
+        assert_eq!(
+            serde_json::to_value(entry).expect("gated entry serializes"),
+            value
+        );
     }
 
     #[test]

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2120,6 +2120,7 @@
         }
       ],
       "family": "z-image",
+      "gated": false,
       "id": "base-model",
       "installState": "missing",
       "installedPath": "<runtime-root>/data/models/owner__base-model",
@@ -2155,6 +2156,7 @@
       "downloadable": false,
       "downloads": [],
       "family": "z-image",
+      "gated": false,
       "id": "z_image_turbo",
       "installState": "missing",
       "installedPath": null,


### PR DESCRIPTION
Closes the discoverability gap for gated models (e.g. FLUX.1 [dev]): a machine-readable `gated` signal now flows from the manifest through the catalog to the Models screen, which shows an inline notice and a button that takes the user to the Settings credential screen to add the required token. **Slice 5 (final) of epic 1890.**

## What changed
- **Contract** (`crates/sceneworks-core/src/contracts.rs`): typed `gated` / `credentialHost` / `licenseUrl` on `ModelManifestEntry`, all skip-serialized when default so existing manifests/fixtures round-trip unchanged.
- **Catalog** (`apps/rust-api/src/models.rs`): `model_catalog` always emits a boolean `gated`; for gated models it derives `credentialHost` — explicit manifest value, else the well-known host for the download provider (`huggingface` → `huggingface.co`), else the `sourceUrl` host (normalized to match how the credential store keys hosts).
- **Manifest** (`config/manifests/builtin.models.jsonc`): FLUX.1 [dev] marked `gated: true` with `credentialHost: huggingface.co` and the model-card `licenseUrl`. (Only gated entry today.)
- **Web** — extracted a shared `apps/web/src/credentials.js` transport (OS keychain on desktop / authed REST on server, per sc-1891/sc-1893) plus a `hasPresentCredential` presence check. `SettingsScreen` now imports it; `ModelManagerScreen` uses it to render a gated notice with **Add token in Settings** + **Review license**, softened to a "ready to download" state once a matching credential is present. Credentials are only fetched when a gated model is actually in the catalog, so non-gated deployments make no extra request.

## Acceptance
- ✅ Gated model shows a clear message + working button to the credential screen.
- ✅ Saving a matching credential de-emphasizes the warning.
- ✅ Non-gated models render unchanged.
- ✅ Tests: gated banner+link, present-softens, non-gated-none.

## Validation
- web vitest **124 passed** (+3) and `vite build` OK
- `cargo test` — core contract round-trip (gated + non-gated) + rust-api `derive_credential_host` (4) + full rust-api suite (72) green
- `cargo fmt --all --check` clean, `cargo clippy -D warnings` clean (core + rust-api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)