### PR TITLE
[codex] Add AuraSR v2 upscaler engine

### DIFF
--- a/apps/web/public/prompt-guides/aura-sr.md
+++ b/apps/web/public/prompt-guides/aura-sr.md
@@ -1,0 +1,7 @@
+# AuraSR Upscaling Guide
+
+AuraSR v2 is a 4x post-process upscaler for generated and real-world images. It runs after the base image is saved, so prompts, seeds, LoRAs, and the selected image model determine the source image before AuraSR adds detail.
+
+Use AuraSR when you want a higher-quality 4x upscale and can spend more memory and time than Real-ESRGAN. The original image is retained alongside the upscaled variant.
+
+AuraSR v2 uses Apache-2.0 weights from `fal/AuraSR-v2`. The older `fal/AuraSR` checkpoint uses CC-BY-SA-4.0 and is not wired into SceneWorks.

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4933,6 +4933,24 @@ describe("SceneWorks app shell", () => {
         },
       }),
     );
+
+    await changeField(field(container, "Engine"), "aura-sr");
+    expect(field(container, "Scale").value).toBe("4");
+    expect([...field(container, "Scale").querySelectorAll("option")].map((option) => option.value)).toEqual(["4"]);
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    expect(createImageJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        upscale: {
+          enabled: true,
+          factor: 4,
+          engine: "aura-sr",
+        },
+      }),
+    );
   });
 
   it("blocks image presets whose managed LoRAs do not match the selected model", async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -46,6 +46,10 @@ import { errorStatuses } from "../jobTypes.js";
 
 // Used only for models that don't declare limits.resolutions (e.g. user-imported).
 const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x1280"];
+const UPSCALE_ENGINES = [
+  { id: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
+  { id: "aura-sr", label: "AuraSR", factors: [4] },
+];
 
 function formatResolutionLabel(value) {
   const [width, height] = String(value).split("x");
@@ -177,6 +181,14 @@ export function ImageStudio() {
       setCount(4);
     }
     setMode(nextMode);
+  }
+
+  function handleUpscaleEngineChange(nextEngine) {
+    setUpscaleEngine(nextEngine);
+    const option = UPSCALE_ENGINES.find((candidate) => candidate.id === nextEngine);
+    if (option && !option.factors.includes(upscaleFactor)) {
+      setUpscaleFactor(option.factors[0]);
+    }
   }
 
   function serializeLora(lora, override = {}) {
@@ -698,14 +710,21 @@ export function ImageStudio() {
                 <label>
                   Scale
                   <select disabled={!upscaleEnabled} onChange={(event) => setUpscaleFactor(Number(event.target.value))} value={upscaleFactor}>
-                    <option value={2}>2x</option>
-                    <option value={4}>4x</option>
+                    {(UPSCALE_ENGINES.find((engine) => engine.id === upscaleEngine)?.factors ?? [2, 4]).map((factor) => (
+                      <option key={factor} value={factor}>
+                        {factor}x
+                      </option>
+                    ))}
                   </select>
                 </label>
                 <label>
                   Engine
-                  <select disabled={!upscaleEnabled} onChange={(event) => setUpscaleEngine(event.target.value)} value={upscaleEngine}>
-                    <option value="real-esrgan">Real-ESRGAN</option>
+                  <select disabled={!upscaleEnabled} onChange={(event) => handleUpscaleEngineChange(event.target.value)} value={upscaleEngine}>
+                    {UPSCALE_ENGINES.map((engine) => (
+                      <option key={engine.id} value={engine.id}>
+                        {engine.label}
+                      </option>
+                    ))}
                   </select>
                 </label>
                 <label className="prompt-field">

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -22,3 +22,4 @@ safetensors>=0.6
 prodigyopt>=1.1,<2
 diffusers @ git+https://github.com/huggingface/diffusers.git
 realesrgan>=0.3,<0.4
+aura-sr>=0.0.4,<0.1

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -683,6 +683,13 @@ REAL_ESRGAN_MODEL_SPECS: dict[int, dict[str, Any]] = {
     },
 }
 
+AURA_SR_MODEL_SPEC: dict[str, Any] = {
+    "name": "AuraSR-v2",
+    "repo": "fal/AuraSR-v2",
+    "file": "model.safetensors",
+    "scale": 4,
+}
+
 
 def create_image_upscaler(
     request: ImageRequest,
@@ -695,6 +702,8 @@ def create_image_upscaler(
     engine = request.upscale.engine.strip().lower()
     if engine in {"real-esrgan", "realesrgan", "real_esrgan"}:
         return RealEsrganUpscaler(settings=settings, job_id=job_id)
+    if engine in {"aura-sr", "aurasr", "aura_sr"}:
+        return AuraSrUpscaler(settings=settings, job_id=job_id)
     raise RuntimeError(f"Unsupported image upscale engine: {request.upscale.engine}.")
 
 
@@ -844,6 +853,142 @@ class RealEsrganUpscaler:
         if not isinstance(real_esrgan, dict):
             return {}
         resource = real_esrgan.get(f"x{factor}") or real_esrgan.get(str(factor)) or {}
+        return resource if isinstance(resource, dict) else {}
+
+
+class AuraSrUpscaler:
+    id = "aura-sr"
+
+    def __init__(self, *, settings: WorkerSettings | None = None, job_id: str | None = None) -> None:
+        self._settings = settings
+        self._job_id = job_id
+        self._model: Any | None = None
+
+    def upscale(
+        self,
+        image: Image.Image,
+        *,
+        request: ImageRequest,
+        cancel_requested: CancelCallback,
+    ) -> Image.Image:
+        if cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
+        if request.upscale.factor != AURA_SR_MODEL_SPEC["scale"]:
+            raise RuntimeError("AuraSR upscaling supports only 4x output.")
+        model = self._load_model(request)
+        max_batch_size = safe_int(request.advanced.get("auraSrMaxBatchSize"), 8, 1, 64)
+        use_overlap = request.advanced.get("auraSrOverlap", request.advanced.get("upscaleOverlap", True)) is not False
+        if use_overlap and hasattr(model, "upscale_4x_overlapped"):
+            output = model.upscale_4x_overlapped(image.convert("RGB"), max_batch_size=max_batch_size)
+        else:
+            output = model.upscale_4x(image.convert("RGB"), max_batch_size=max_batch_size)
+        if cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
+        return output.convert("RGB")
+
+    def _load_model(self, request: ImageRequest) -> Any:
+        if self._model is not None:
+            return self._model
+        try:
+            torch = importlib.import_module("torch")
+            aura_sr = importlib.import_module("aura_sr")
+        except Exception as exc:  # noqa: BLE001 - convert optional dependency failures.
+            raise RuntimeError(
+                "AuraSR upscaling requires the optional worker package `aura-sr` to be installed."
+            ) from exc
+
+        device = select_torch_device(torch, self._settings.gpu_id if self._settings else None)
+        activate_torch_device(torch, device)
+        model_path = self._resolve_model_path(request)
+        emit_worker_event(
+            "image_upscaler_load_start",
+            jobId=self._job_id,
+            engine=self.id,
+            factor=request.upscale.factor,
+            model=AURA_SR_MODEL_SPEC["name"],
+            modelPath=str(model_path),
+            device=device,
+        )
+        self._model = aura_sr.AuraSR.from_pretrained(str(model_path), use_safetensors=True)
+        upsampler = getattr(self._model, "upsampler", None)
+        if upsampler is not None and hasattr(upsampler, "to"):
+            upsampler.to(device)
+        if upsampler is not None and hasattr(upsampler, "eval"):
+            upsampler.eval()
+        emit_worker_event(
+            "image_upscaler_load_complete",
+            jobId=self._job_id,
+            engine=self.id,
+            factor=request.upscale.factor,
+            model=AURA_SR_MODEL_SPEC["name"],
+            device=device,
+        )
+        return self._model
+
+    def _resolve_model_path(self, request: ImageRequest) -> Path:
+        explicit = (
+            request.advanced.get("upscaleModelPath")
+            or request.advanced.get("auraSrModelPath")
+            or os.getenv("SCENEWORKS_AURASR_MODEL_PATH")
+        )
+        if explicit:
+            path = Path(str(explicit)).expanduser()
+            if path.is_dir():
+                path = path / str(AURA_SR_MODEL_SPEC["file"])
+            if not path.is_file():
+                raise RuntimeError(f"AuraSR model file does not exist: {path}")
+            config_path = path.with_name("config.json")
+            if not config_path.is_file():
+                raise RuntimeError(f"AuraSR config file does not exist next to model file: {config_path}")
+            return path
+        resource = self._manifest_resource(request)
+        repo = str(resource.get("repo") or AURA_SR_MODEL_SPEC["repo"])
+        file_name = str(resource.get("file") or AURA_SR_MODEL_SPEC["file"])
+        return self._hf_snapshot_file(repo, file_name)
+
+    def _hf_snapshot_file(self, repo: str, file_name: str) -> Path:
+        from huggingface_hub import snapshot_download
+
+        allow_patterns = [file_name, "config.json", "LICENSE.md", "README.md"]
+        roots = huggingface_cache_roots(self._settings)
+        first_error: Exception | None = None
+        for cache_root in roots:
+            try:
+                snapshot_dir = Path(
+                    snapshot_download(
+                        repo_id=repo,
+                        allow_patterns=allow_patterns,
+                        cache_dir=str(cache_root),
+                        local_files_only=True,
+                    )
+                )
+                return snapshot_dir / file_name
+            except Exception as exc:  # noqa: BLE001 - try the next configured cache root.
+                first_error = exc
+
+        cache_root = roots[0]
+        try:
+            snapshot_dir = Path(
+                snapshot_download(repo_id=repo, allow_patterns=allow_patterns, cache_dir=str(cache_root))
+            )
+            return snapshot_dir / file_name
+        except Exception as exc:  # noqa: BLE001 - surface the download context.
+            raise RuntimeError(f"Unable to resolve AuraSR weight {file_name} from Hugging Face repo {repo}.") from (
+                first_error or exc
+            )
+
+    @staticmethod
+    def _manifest_resource(request: ImageRequest) -> dict[str, Any]:
+        resources = request.model_manifest_entry.get("resources", {})
+        if not isinstance(resources, dict):
+            return {}
+        upscalers = resources.get("imageUpscalers") or resources.get("upscalers")
+        if not isinstance(upscalers, dict):
+            return {}
+        aura_sr = upscalers.get("aura-sr") or upscalers.get("auraSr") or upscalers.get("aura_sr") or {}
+        if not isinstance(aura_sr, dict):
+            return {}
+        resource = aura_sr.get("x4") or aura_sr.get("4") or {}
         return resource if isinstance(resource, dict) else {}
 
 

--- a/apps/worker/scene_worker/upscalers.py
+++ b/apps/worker/scene_worker/upscalers.py
@@ -55,6 +55,8 @@ def create_upscaler_engine(engine: str | None = None) -> UpscalerEngine:
     engine_id = (engine or "real_esrgan").strip().lower().replace("-", "_")
     if engine_id in {"real_esrgan", "realesrgan"}:
         return RealESRGANUpscaler()
+    if engine_id in {"aura_sr", "aurasr"}:
+        return AuraSRUpscaler()
     raise RuntimeError(f"Unsupported upscaler engine: {engine}.")
 
 
@@ -125,6 +127,38 @@ class RealESRGANUpscaler:
         tile_pad: int,
     ) -> Image.Image:
         return _run_tiled(torch, model, image, factor=factor, device=device, dtype=dtype, tile_size=tile_size, tile_pad=tile_pad)
+
+
+class AuraSRUpscaler:
+    id = "aura_sr"
+
+    def upscale(
+        self,
+        image: Image.Image,
+        *,
+        job: UpscaleJob,
+        settings: Any,
+    ) -> Image.Image:
+        if job.factor != 4:
+            raise RuntimeError("AuraSR upscaling supports only 4x output.")
+        if not job.weights_path.exists():
+            raise RuntimeError(f"AuraSR weights are missing: {job.weights_path}")
+
+        torch = importlib.import_module("torch")
+        aura_sr = importlib.import_module("aura_sr")
+        from .image_adapters import activate_torch_device, select_torch_device
+
+        device = select_torch_device(torch, getattr(settings, "gpu_id", None))
+        activate_torch_device(torch, device)
+        model = aura_sr.AuraSR.from_pretrained(str(job.weights_path), use_safetensors=True)
+        upsampler = getattr(model, "upsampler", None)
+        if upsampler is not None and hasattr(upsampler, "to"):
+            upsampler.to(device)
+        if upsampler is not None and hasattr(upsampler, "eval"):
+            upsampler.eval()
+        if job.tile_pad > 0 and hasattr(model, "upscale_4x_overlapped"):
+            return model.upscale_4x_overlapped(image.convert("RGB"))
+        return model.upscale_4x(image.convert("RGB"))
 
 
 def _load_state_dict(torch: Any, weights_path: Path) -> dict[str, Any]:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1025,6 +1025,60 @@
           ]
         }
       }
+    },
+    {
+      "id": "aura_sr_v2",
+      "name": "AuraSR v2 Upscaler",
+      "family": "aura-sr",
+      "type": "utility",
+      "adapter": "aura-sr",
+      "capabilities": [],
+      "downloads": [
+        {
+          // AuraSR v2 weights are Apache-2.0 on Hugging Face. The older
+          // fal/AuraSR checkpoint is CC-BY-SA-4.0 and is intentionally not used.
+          "provider": "huggingface",
+          "repo": "fal/AuraSR-v2",
+          "files": ["model.safetensors", "config.json", "LICENSE.md", "README.md"],
+          "estimatedSizeBytes": 2470000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/fal/AuraSR-v2"
+      },
+      "resources": {
+        "imageUpscalers": {
+          "aura-sr": {
+            "x4": {
+              "repo": "fal/AuraSR-v2",
+              "file": "model.safetensors",
+              "license": "Apache-2.0",
+              "licenseUrl": "https://huggingface.co/fal/AuraSR-v2/blob/main/LICENSE.md",
+              "originalUrl": "https://huggingface.co/fal/AuraSR-v2"
+            }
+          }
+        }
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "AuraSR v2 Upscaler",
+        "description": "Optional Apache-2.0 GigaGAN-style 4x image upscaling weights used only when Image Studio AuraSR upscaling is enabled.",
+        "recommendedFor": ["image_upscale"],
+        "promptGuide": {
+          "title": "AuraSR Upscaling Guide",
+          "path": "/prompt-guides/aura-sr.md",
+          "sources": [
+            { "label": "AuraSR v2 model card", "url": "https://huggingface.co/fal/AuraSR-v2" },
+            { "label": "AuraSR v2 announcement", "url": "https://blog.fal.ai/aurasr-v2/" },
+            { "label": "AuraSR GitHub", "url": "https://github.com/fal-ai/aura-sr" }
+          ]
+        }
+      }
     }
   ]
 }

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -23,6 +23,7 @@ from scene_worker.caption_adapters import (
     normalize_processor_resample,
 )
 from scene_worker.image_adapters import (
+    AuraSrUpscaler,
     ChromaDiffusersAdapter,
     FluxDiffusersAdapter,
     ImageAssetWriter,
@@ -54,6 +55,7 @@ from scene_worker.image_adapters import (
     verify_pipeline_on_device,
 )
 from scene_worker.upscalers import (
+    AuraSRUpscaler,
     RealESRGANUpscaler,
     TileSlice,
     UpscaleJob,
@@ -1721,6 +1723,22 @@ def test_create_image_upscaler_rejects_unknown_engine():
         create_image_upscaler(request)
 
 
+def test_create_image_upscaler_accepts_aurasr_engine():
+    request = image_request_from_job(
+        {
+            "payload": {
+                "projectId": "p",
+                "upscale": {"enabled": True, "factor": 4, "engine": "aura-sr"},
+            }
+        }
+    )
+
+    upscaler = create_image_upscaler(request, settings=SimpleNamespace(gpu_id="cpu"))
+
+    assert isinstance(upscaler, AuraSrUpscaler)
+    assert upscaler.id == "aura-sr"
+
+
 def test_real_esrgan_resolves_manifest_weight_through_hf_cache(monkeypatch, tmp_path):
     calls: list[dict[str, object]] = []
     resolved_path = tmp_path / "RealESRGAN_x2plus.pth"
@@ -1769,6 +1787,73 @@ def test_real_esrgan_resolves_manifest_weight_through_hf_cache(monkeypatch, tmp_
     assert calls[0]["cache_dir"] == str(settings.data_dir / "cache" / "huggingface" / "hub")
     assert calls[0]["local_files_only"] is True
     assert calls[-1].get("local_files_only") is not True
+
+
+def test_aurasr_resolves_manifest_snapshot_through_hf_cache(monkeypatch, tmp_path):
+    calls: list[dict[str, object]] = []
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "model.safetensors").write_bytes(b"weights")
+    (snapshot_dir / "config.json").write_text("{}", encoding="utf-8")
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("local_files_only"):
+            raise RuntimeError("cache miss")
+        return str(snapshot_dir)
+
+    fake_hub = ModuleType("huggingface_hub")
+    fake_hub.snapshot_download = fake_snapshot_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    monkeypatch.delenv("HF_HOME", raising=False)
+
+    settings = SimpleNamespace(data_dir=tmp_path / "data", gpu_id="cpu")
+    request = image_request_from_job(
+        {
+            "payload": {
+                "projectId": "p",
+                "upscale": {"enabled": True, "factor": 4, "engine": "aura-sr"},
+                "modelManifestEntry": {
+                    "resources": {
+                        "imageUpscalers": {
+                            "aura-sr": {
+                                "x4": {"repo": "example/aura-sr", "file": "model.safetensors"}
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    path = AuraSrUpscaler(settings=settings)._resolve_model_path(request)
+
+    assert path == snapshot_dir / "model.safetensors"
+    assert calls[0]["repo_id"] == "example/aura-sr"
+    assert calls[0]["allow_patterns"] == ["model.safetensors", "config.json", "LICENSE.md", "README.md"]
+    assert calls[0]["cache_dir"] == str(settings.data_dir / "cache" / "huggingface" / "hub")
+    assert calls[0]["local_files_only"] is True
+    assert calls[-1].get("local_files_only") is not True
+
+
+def test_aurasr_upscaler_rejects_non_4x_request(monkeypatch):
+    request = image_request_from_job(
+        {
+            "payload": {
+                "projectId": "p",
+                "upscale": {"enabled": True, "factor": 2, "engine": "aura-sr"},
+            }
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="supports only 4x"):
+        AuraSrUpscaler(settings=SimpleNamespace(gpu_id="cpu")).upscale(
+            Image.new("RGB", (2, 2), "white"),
+            request=request,
+            cancel_requested=lambda: False,
+        )
 
 
 def test_image_asset_writer_retains_original_and_adds_upscaled_variant(monkeypatch, tmp_path):
@@ -5673,6 +5758,23 @@ def test_upscaler_engine_selection_is_import_safe_without_torch(monkeypatch):
     assert imported == []
 
 
+def test_aurasr_engine_selection_is_import_safe_without_torch(monkeypatch):
+    imported: list[str] = []
+
+    def fail_torch_import(name):
+        imported.append(name)
+        if name == "torch":
+            raise AssertionError("torch must not be imported while selecting an upscaler")
+        return importlib.import_module(name)
+
+    monkeypatch.setattr("scene_worker.upscalers.importlib.import_module", fail_torch_import)
+
+    engine = create_upscaler_engine("aura-sr")
+
+    assert isinstance(engine, AuraSRUpscaler)
+    assert imported == []
+
+
 def test_upscaler_tile_slices_cover_edges_without_overlap_gaps():
     assert tile_slices(5, 3, 2) == [
         TileSlice(0, 0, 2, 2),
@@ -5740,6 +5842,63 @@ def test_real_esrgan_upscale_lazily_imports_torch_and_reuses_device_helpers(tmp_
         "dtype": "float32",
         "tile_size": 64,
         "tile_pad": 4,
+    }
+
+
+def test_aurasr_upscale_lazily_imports_torch_and_uses_local_weight_file(tmp_path, monkeypatch):
+    weights = tmp_path / "model.safetensors"
+    weights.write_bytes(b"stub")
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+
+    class FakeTorch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+        class backends:
+            mps = None
+
+    seen: dict[str, Any] = {}
+
+    class FakeAuraModel:
+        def upscale_4x_overlapped(self, image, max_batch_size=16, weight_type="checkboard"):
+            seen.update({"method": "overlapped", "max_batch_size": max_batch_size, "weight_type": weight_type})
+            return image.resize((image.width * 4, image.height * 4))
+
+    class FakeAuraSR:
+        @staticmethod
+        def from_pretrained(model_id, use_safetensors=True):
+            seen.update({"model_id": model_id, "use_safetensors": use_safetensors})
+            return FakeAuraModel()
+
+    fake_aura_module = SimpleNamespace(AuraSR=FakeAuraSR)
+    imports: list[str] = []
+
+    def fake_import_module(name):
+        imports.append(name)
+        if name == "torch":
+            return FakeTorch
+        if name == "aura_sr":
+            return fake_aura_module
+        return importlib.import_module(name)
+
+    monkeypatch.setattr("scene_worker.upscalers.importlib.import_module", fake_import_module)
+
+    result = AuraSRUpscaler().upscale(
+        Image.new("RGB", (3, 4), "white"),
+        job=UpscaleJob(factor=4, weights_path=weights, tile_pad=16),
+        settings=SimpleNamespace(gpu_id="cpu"),
+    )
+
+    assert result.size == (12, 16)
+    assert imports == ["torch", "aura_sr"]
+    assert seen == {
+        "model_id": str(weights),
+        "use_safetensors": True,
+        "method": "overlapped",
+        "max_batch_size": 16,
+        "weight_type": "checkboard",
     }
 
 


### PR DESCRIPTION
﻿## Summary

- add AuraSR v2 (`fal/AuraSR-v2`) as an optional 4x image upscaler behind the existing upscaler abstraction
- expose AuraSR in Image Studio and constrain its scale selector to 4x
- register AuraSR v2 as a lazy Hugging Face download with license metadata and add a prompt guide
- document that the older `fal/AuraSR` checkpoint is intentionally not wired because it is CC-BY-SA-4.0, while `fal/AuraSR-v2` is Apache-2.0

## Validation

- `python -m pytest tests/test_worker_runtime.py`
- `npm test -- --run src/main.test.jsx`
- `npm run build`
- `git diff --check`
- live CUDA one-off worker container: `64x64 -> 256x256` through `AuraSrUpscaler` on `cuda:0`, peak torch allocation ~2572.64 MB, output saved to `data/cache/aurasr-live-test.png`

## Notes

Live validation found that `aura-sr 0.0.4` does not accept `device=` in `AuraSR.from_pretrained`, so the implementation loads from the local snapshot first, moves `model.upsampler` to the selected device, and sets eval mode.

Shortcut: https://app.shortcut.com/trefry/story/1800/optional-aurasr-gigagan-engine-gated-on-weight-license-verification
