### PR TITLE
docs(sc-1894): document the credential system (Settings, storage, overrides)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,21 @@ SCENEWORKS_RUN_UTILITY_INPROCESS=false
 # Ctrl+C/SIGTERM before forcing exit. Also honored by the standalone worker.
 SCENEWORKS_WORKER_SHUTDOWN_TIMEOUT_SECONDS=10
 
-# Optional Hugging Face token for gated model or LoRA repos.
+# Download credentials (gated/authenticated model + LoRA repos).
+#
+# The primary way to add tokens is in the app: Settings -> Service credentials.
+# On a server those are persisted to a 0600 file `credentials.json` in the
+# config dir (the mounted SCENEWORKS_CONFIG_BIND volume) and read by the worker.
+# The two variables below are optional overrides for headless/orchestrated
+# deployments and are honored on top of that file (env wins per host):
+#
+# HF_TOKEN: dedicated Hugging Face token for gated repos (e.g. FLUX.1 [dev]);
+# the same variable `huggingface_hub` reads.
 HF_TOKEN=
+# SCENEWORKS_CREDENTIALS: optional JSON map of host -> credential, for any host
+# (Civit.ai, private mirrors, etc.). Overrides credentials.json per host.
+# Example: {"huggingface.co":{"token":"hf_xxx","scheme":"bearer"},"civitai.com":{"token":"key","scheme":"query"}}
+SCENEWORKS_CREDENTIALS=
 
 # Persist Diffusers/Hugging Face model caches inside the mounted data volume.
 SCENEWORKS_HF_HOME=/sceneworks/data/cache/huggingface

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ worker that already reports the requested model as warm before falling back to
 FIFO order. Explicit GPU selections and utility jobs keep their normal FIFO
 claim order.
 The Rust worker image installs Debian Bookworm `ffmpeg`; host-mode Rust workers
-use the `ffmpeg` found on `PATH`. Set `HF_TOKEN` when downloading from gated
-Hugging Face repositories.
+use the `ffmpeg` found on `PATH`. To download from gated/authenticated repos
+(e.g. gated Hugging Face models, Civit.ai), add a token in the app — see
+[Service Credentials](#service-credentials-api-tokens) below.
 
 ## Local Access Control
 
@@ -156,6 +157,42 @@ and extend `SCENEWORKS_CORS_ORIGINS` with LAN hostnames or IP origins when the
 web app is opened from another machine.
 
 For offline development or deterministic Rust API tests, set `SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1` to skip live Hugging Face model size lookups. The catalog still returns the same fields with unknown sizes.
+
+## Service Credentials (API tokens)
+
+Some model and LoRA downloads need an API token: gated Hugging Face repos (e.g.
+FLUX.1 [dev]), Civit.ai, or any other authenticated source. SceneWorks stores
+these as a generic, **host-keyed** credential — `{ host, label, scheme, token }`
+— and attaches the matching one (as a `Bearer` header or a `?token=` query
+parameter) when a download's URL host matches. Adding a new service needs no
+code change.
+
+**Where to add tokens:** open **Settings → Service credentials** and add the
+host (e.g. `huggingface.co`), an optional label, the scheme (`bearer` or
+`query`), and the token. Gated models on the **Models** screen show a notice
+with a button that jumps straight here. Tokens are write-only — the UI never
+displays a saved token again, only that one is present. Credential changes take
+effect on the next worker restart.
+
+**Where credentials live:**
+
+- **Desktop:** the per-user OS keychain — Windows Credential Manager (DPAPI),
+  macOS Keychain, or the Linux Secret Service. Nothing SceneWorks-managed holds
+  an encryption key; the OS guards the secret per user account.
+- **Server / Docker:** a `0600` JSON file, `credentials.json`, in the config
+  dir (`/sceneworks/config` in Compose), managed over the authenticated REST API
+  (`/api/v1/credentials`). There is no app-level encryption on the server — a key
+  would have to live beside the data — so the protection is the restricted file
+  mode plus your orchestrator's secret handling (Docker/Kubernetes secrets,
+  host file permissions). Keep the config volume off shared/world-readable paths.
+
+**Environment overrides (server):** the worker reads `credentials.json` and
+overlays the optional `SCENEWORKS_CREDENTIALS` env var, a JSON map
+`{ "host": { "token": "…", "scheme": "bearer|query" } }`; the env value **wins
+per host**, so operators can inject secrets from a vault without writing the
+file. Hugging Face keeps its dedicated path: set `HF_TOKEN` for gated HF repos
+(the same variable `huggingface_hub` reads). Both are picked up at worker
+startup.
 
 ## LoRA Training
 

--- a/apps/web/public/prompt-guides/flux-dev.md
+++ b/apps/web/public/prompt-guides/flux-dev.md
@@ -4,7 +4,7 @@
 
 Highest-quality FLUX text-to-image: detailed photography, illustration, concept art, and crisp, legible text. [dev] is the guided ~28-step variant — slower than [schnell] but with finer detail and guidance control.
 
-> **License:** FLUX.1 [dev] is distributed under the FLUX.1 [dev] Non-Commercial License — generations are for non-commercial use only. It is a gated Hugging Face download (accept the license and configure an HF token first). For commercial use, choose FLUX.1 [schnell] (Apache-2.0).
+> **License:** FLUX.1 [dev] is distributed under the FLUX.1 [dev] Non-Commercial License — generations are for non-commercial use only. It is a gated Hugging Face download (accept the license and add a Hugging Face token under Settings → Service credentials first). For commercial use, choose FLUX.1 [schnell] (Apache-2.0).
 
 ## Prompt Shape
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -488,7 +488,7 @@
       "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
       "ui": {
         "label": "FLUX.1 [dev]",
-        "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and configure an HF token before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU.",
+        "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and add a Hugging Face token under Settings → Service credentials (or set HF_TOKEN on a server) before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU.",
         "recommendedFor": ["text_to_image", "style_variations"],
         "promptGuide": {
           "title": "FLUX.1 [dev] Prompt Guide",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,12 @@ services:
       # a long download. Only applies in dedicated cpu mode.
       SCENEWORKS_UTILITY_WORKERS: ${SCENEWORKS_UTILITY_WORKERS:-4}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
+      # Download credentials. The rust-worker reads `credentials.json` (written by
+      # the API's Settings -> Service credentials screen) from the mounted config
+      # volume below. HF_TOKEN and SCENEWORKS_CREDENTIALS are optional overrides
+      # for headless deployments and win per host over that file.
       HF_TOKEN: ${HF_TOKEN:-}
+      SCENEWORKS_CREDENTIALS: ${SCENEWORKS_CREDENTIALS:-}
       HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}


### PR DESCRIPTION
Closes out **epic 1890** by documenting the credential system end to end. Docs-only — no code or contract changes.

## What changed
- **README** — new **Service Credentials (API tokens)** section: the host-keyed model (`{ host, label, scheme, token }`), where to add tokens (Settings → Service credentials; gated models on the Models screen link here), desktop OS-keychain vs server `0600` `credentials.json` storage, the security posture (no app-level encryption server-side — restricted file mode + orchestrator secrets), and the `SCENEWORKS_CREDENTIALS` / `HF_TOKEN` env overrides (env wins per host, applied at worker restart). Repointed the old `HF_TOKEN` note at the new section.
- **.env.example** — expanded the token block to explain the in-app path + the persisted file, and documented `SCENEWORKS_CREDENTIALS` (JSON `host → credential` map) alongside `HF_TOKEN` as optional server overrides, with an example.
- **docker-compose.yml** — pass `SCENEWORKS_CREDENTIALS` to the `rust-worker` (it already reads `credentials.json` from the mounted config volume) so the per-host env override actually reaches the container; added an explanatory comment.
- **Gated help text** — FLUX.1 [dev] manifest description and the `flux-dev.md` prompt guide now point users at **Settings → Service credentials** instead of "configure an HF token".

## Acceptance
- ✅ A new user can find, from docs alone, how to add an HF or Civit.ai token in both desktop and server modes.
- ✅ Security posture (per-user keychain on desktop; restricted file + orchestrator secrets on server) is stated plainly.

## Validation
- `builtin.models.jsonc` re-parsed as JSONC (FLUX.1 [dev] description updated); `docker-compose.yml` validated as YAML with the new `rust-worker` env key present. No tests reference the old wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)