### PR TITLE
feat(sc-1922): character-aware default prompt + variation suggestions

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5106,6 +5106,7 @@ describe("SceneWorks app shell", () => {
     let modelOptions = [...field(container, "Model").options].map((option) => option.textContent);
     expect(modelOptions).toContain("Kolors");
     expect(modelOptions).toContain("FLUX");
+    const sceneSuggestions = [...container.querySelectorAll(".suggestion")].map((button) => button.textContent).join("|");
 
     await act(async () => {
       [...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "With character").click();
@@ -5116,6 +5117,107 @@ describe("SceneWorks app shell", () => {
     modelOptions = [...field(container, "Model").options].map((option) => option.textContent);
     expect(modelOptions).toContain("Kolors");
     expect(modelOptions).not.toContain("FLUX");
+
+    // Suggestions swap to the variation-oriented set in character mode.
+    const characterSuggestions = [...container.querySelectorAll(".suggestion")].map((button) => button.textContent).join("|");
+    expect(characterSuggestions).not.toBe(sceneSuggestions);
+  });
+
+  it("seeds a character-aware default prompt from the character's notes", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            { id: "char-1", name: "Mira", type: "person", description: "A grizzled detective in a trench coat", looks: [], approvedReferences: [] },
+          ],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [{ id: "kolors", name: "Kolors", type: "image", capabilities: ["text_to_image", "character_image"] }],
+          latestAssets: [],
+          launchRequest: { id: "launch-prompt-1", view: "Image", characterId: "char-1", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    expect(container.querySelector(".prompt-input").value).toBe("A grizzled detective in a trench coat");
+  });
+
+  it("falls back to a type-specific default prompt when the character has no notes", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [{ id: "char-2", name: "Echo", type: "creature", looks: [], approvedReferences: [] }],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [{ id: "kolors", name: "Kolors", type: "image", capabilities: ["text_to_image", "character_image"] }],
+          latestAssets: [],
+          launchRequest: { id: "launch-prompt-2", view: "Image", characterId: "char-2", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    expect(container.querySelector(".prompt-input").value).toBe("The creature in a new setting, varied pose, natural lighting");
+  });
+
+  it("keeps an edited prompt when switching into character mode", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            { id: "char-1", name: "Mira", type: "person", description: "A grizzled detective", looks: [], approvedReferences: [] },
+          ],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [{ id: "kolors", name: "Kolors", type: "image", capabilities: ["text_to_image", "character_image"] }],
+          latestAssets: [],
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+
+    await changeField(container.querySelector(".prompt-input"), "my own deliberate scene");
+    await act(async () => {
+      [...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "With character").click();
+    });
+    await changeField(field(container, "Character"), "char-1");
+    await settle();
+
+    // The user's wording survives entering character mode.
+    expect(container.querySelector(".prompt-input").value).toBe("my own deliberate scene");
   });
 
   it("generates without a reference and warns when the character has no approved reference image", async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -20,14 +20,45 @@ const PROMPT_SUGGESTION_POOL = [
   "Lighthouse beam slicing through coastal fog",
 ];
 
-function pickSuggestions(count) {
-  const pool = [...PROMPT_SUGGESTION_POOL];
+// Character (IP-Adapter) variations: the reference image supplies identity, so
+// these describe scene / pose / lighting to vary rather than a standalone subject.
+const CHARACTER_SUGGESTION_POOL = [
+  "studio portrait, soft key light",
+  "in a sunlit park, candid",
+  "city street at dusk, cinematic",
+  "seated at a wooden desk, warm light",
+  "walking through a busy market, natural light",
+  "close-up, dramatic side lighting",
+  "outdoors at golden hour, backlit",
+  "neutral grey backdrop, even studio lighting",
+];
+
+function pickSuggestions(count, pool = PROMPT_SUGGESTION_POOL) {
+  const available = [...pool];
   const result = [];
-  for (let index = 0; index < count && pool.length; index += 1) {
-    const pick = Math.floor(Math.random() * pool.length);
-    result.push(pool.splice(pick, 1)[0]);
+  for (let index = 0; index < count && available.length; index += 1) {
+    const pick = Math.floor(Math.random() * available.length);
+    result.push(available.splice(pick, 1)[0]);
   }
   return result;
+}
+
+// Seeded into the prompt when entering character mode (only when untouched). The
+// character's own notes win if present; otherwise a neutral, type-appropriate
+// variation prompt — identity still comes from the reference image, not this text.
+function defaultCharacterPrompt(character) {
+  const note = (character?.description ?? "").trim();
+  if (note) {
+    return note;
+  }
+  switch (character?.type) {
+    case "creature":
+      return "The creature in a new setting, varied pose, natural lighting";
+    case "object":
+      return "The object from a fresh angle and setting, studio lighting";
+    default:
+      return "Portrait of the character, varied pose and expression, natural lighting";
+  }
 }
 import {
   loraMatchesModel,
@@ -151,9 +182,18 @@ export function ImageStudio() {
   const onOpenPresets = () => setActiveView("Presets");
   const onOpenQueue = () => setActiveView("Queue");
   const onPreview = setPreviewAsset;
-  const [suggestions] = useState(() => pickSuggestions(4));
+  const [sceneSuggestions] = useState(() => pickSuggestions(4));
+  const [characterSuggestions] = useState(() => pickSuggestions(4, CHARACTER_SUGGESTION_POOL));
   const [mode, setMode] = useState("text_to_image");
   const [prompt, setPrompt] = useState("A cinematic frame of a neon street at midnight");
+  // True once the user types or picks a suggestion, so the character-mode default
+  // prompt never clobbers their own wording.
+  const promptEdited = useRef(false);
+  const setPromptFromUser = (value) => {
+    promptEdited.current = true;
+    setPrompt(value);
+  };
+  const suggestions = mode === "character_image" ? characterSuggestions : sceneSuggestions;
   const [count, setCount] = useState(4);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [model, setModel] = useState(imageModels[0]?.id ?? "z_image_turbo");
@@ -297,6 +337,18 @@ export function ImageStudio() {
     }
     setReferenceAssetId(characterReferences[0]?.assetId ?? "");
   }, [mode, characterReferences, referenceAssetId]);
+  // Seed a character-appropriate default prompt when entering character mode, unless
+  // the user has already typed/picked their own. The generic text-to-image default
+  // ("neon street at midnight") makes no sense for character variations.
+  useEffect(() => {
+    if (mode !== "character_image" || !characterId || promptEdited.current) {
+      return;
+    }
+    const character = characters.find((item) => item.id === characterId);
+    if (character) {
+      setPrompt(defaultCharacterPrompt(character));
+    }
+  }, [mode, characterId, characters]);
   const resolutionOptions = useMemo(
     () =>
       selectedModel?.limits?.resolutions?.length
@@ -539,7 +591,7 @@ export function ImageStudio() {
             <textarea
               aria-label="Prompt"
               className="prompt-input"
-              onChange={(event) => setPrompt(event.target.value)}
+              onChange={(event) => setPromptFromUser(event.target.value)}
               onKeyDown={onPromptKeyDown}
               placeholder="Describe your shot — subject, lighting, mood, lens…"
               value={prompt}
@@ -556,7 +608,7 @@ export function ImageStudio() {
               <button
                 className="suggestion"
                 key={suggestion}
-                onClick={() => setPrompt(suggestion)}
+                onClick={() => setPromptFromUser(suggestion)}
                 type="button"
               >
                 <Icon.Sparkle size={11} />


### PR DESCRIPTION
## Summary
Follow-up UX polish to sc-1841 (Character Studio reference generation, #273). In Image Studio **"With character"** mode the prompt previously inherited the generic text-to-image default (*"A cinematic frame of a neon street at midnight"*), so clicking Generate dropped the character into an unrelated scene. With Kolors IP-Adapter, **identity comes from the reference image** — the prompt should describe the scene/pose/lighting to vary.

- **Character-aware default prompt** seeded on entering character mode: the character's own notes/description if present, otherwise a person/creature/object fallback. Only applied when the prompt is untouched — a `promptEdited` flag ensures typed or suggestion-chosen prompts are never overwritten.
- **Variation-oriented suggestion chips** in character mode (scene/pose/lighting that pairs with a reference identity) instead of the generic standalone-subject prompts.

Web-only (`ImageStudio.jsx` + tests). No Rust/worker/contract changes.

## Test plan
- [x] `vitest` full web suite — 131 passed (4 new/updated: default seeded from notes, type fallback, edited-prompt preserved, suggestions swap by mode).
- [x] `vite build` clean.
- [x] Merged latest `origin/main`; suite green post-merge.

Decision (Michael): character-aware default + fallback; yes to variation suggestions. Builds on sc-1841 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)