### PR TITLE
fix(sc-1927): stop Kolors offering cross-family (z-image) LoRAs

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4676,6 +4676,46 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("excludes cross-family LoRAs from a Kolors selection (sc-1927)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          // Mirrors the Kolors manifest entry: family "kolors", LoRA families ["kolors"].
+          imageModels: [
+            { id: "kolors", name: "Kolors", type: "image", family: "kolors", loraCompatibility: { families: ["kolors"] }, capabilities: ["text_to_image"] },
+          ],
+          latestAssets: [],
+          loras: [
+            { id: "z_style", name: "Z Style", family: "z-image", scope: "global" },
+            { id: "kolors_style", name: "Kolors Style", family: "kolors", scope: "global" },
+          ],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+
+    const loraNames = [...container.querySelectorAll(".lora-choice strong")].map((node) => node.textContent);
+    // A kolors-family model must not offer a z-image LoRA as compatible.
+    expect(loraNames).toContain("Kolors Style");
+    expect(loraNames).not.toContain("Z Style");
+  });
+
   it("blocks image submit when a visible incompatible LoRA is selected", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -688,9 +688,12 @@
         "count": [1, 2, 4]
       },
       "loraCompatibility": {
-        // Kolors uses an SDXL-style UNet; generation-side Kolors LoRA is not wired
-        // yet, so advertise no compatible families until that lands.
-        "families": [],
+        // Kolors uses an SDXL-style UNet. Advertise only the kolors family so the
+        // picker never offers cross-architecture LoRAs (e.g. z-image): an empty
+        // list makes loraMatchesModel treat Kolors as compatible with EVERY LoRA.
+        // No kolors-family LoRAs exist yet, so the compatible list stays empty
+        // until generation-side Kolors LoRA support lands.
+        "families": ["kolors"],
         "types": ["style", "enhance", "character"]
       },
       "ui": {


### PR DESCRIPTION
## Summary
Bug: in Image Studio → Advanced → LoRAs, selecting **Kolors** listed **z-image** LoRAs as compatible.

Root cause: `loraMatchesModel` (apps/web/src/presetUtils.js) treats a model with no declared LoRA families as compatible with *every* LoRA (`!modelFamilies.length || …`). The Kolors manifest entry set `loraCompatibility.families: []` intending "no compatible families", but that empty array is returned verbatim by `modelLoraFamilies` (it shadows the model's `family: "kolors"`), so Kolors matched all LoRAs.

Fix: declare Kolors' actual LoRA family — `loraCompatibility.families: ["kolors"]`. Only kolors-family LoRAs match; none exist yet, so the compatible list stays empty (the intended state) and z-image LoRAs no longer appear. Forward-compatible when Kolors LoRA support lands. The permissive empty-families default for user-imported models is intentionally unchanged.

## Test plan
- [x] `vitest` full web suite — 129 passed, incl. new regression "excludes cross-family LoRAs from a Kolors selection (sc-1927)".
- [x] `node scripts/check-scaffold.mjs` passes (manifest valid).
- [x] No snapshot impact (no Kolors job captured in rust_api_contract_snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)