### PR TITLE
feat(sc-1924): default HF_HOME to the OS cache for host-mode binaries

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -241,7 +241,10 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // huggingface so the catalog and downloads agree on the OS cache rather than
     // the private data dir (sc-1904 follow-up). Desktop/Compose already inject it.
     if let Some(home) = sceneworks_core::hf_home::ensure_default_huggingface_home() {
-        println!("SceneWorks Rust API defaulting HF_HOME to {}", home.display());
+        println!(
+            "SceneWorks Rust API defaulting HF_HOME to {}",
+            home.display()
+        );
     }
     let settings = Settings::from_env();
     let address: SocketAddr = format!("{}:{}", settings.host, settings.port).parse()?;

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -237,6 +237,12 @@ fn json_rejection_response(rejection: JsonRejection) -> Response {
 }
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    // Host mode (no HF cache env set): default HF_HOME to the shared ~/.cache/
+    // huggingface so the catalog and downloads agree on the OS cache rather than
+    // the private data dir (sc-1904 follow-up). Desktop/Compose already inject it.
+    if let Some(home) = sceneworks_core::hf_home::ensure_default_huggingface_home() {
+        println!("SceneWorks Rust API defaulting HF_HOME to {}", home.display());
+    }
     let settings = Settings::from_env();
     let address: SocketAddr = format!("{}:{}", settings.host, settings.port).parse()?;
     let run_utility_inprocess = settings.run_utility_inprocess;

--- a/crates/sceneworks-core/src/hf_home.rs
+++ b/crates/sceneworks-core/src/hf_home.rs
@@ -1,0 +1,105 @@
+//! Default Hugging Face cache home for the server/host-mode binaries (sc-1904
+//! follow-up).
+//!
+//! Hugging Face tooling caches under `~/.cache/huggingface` on every platform
+//! (huggingface_hub's `HF_HOME` default; mirrored by the Python worker's
+//! `hf_cache.huggingface_cache_root` and the desktop's `shared_huggingface_home`).
+//! When the rust-api / rust-worker binaries are started with none of the HF cache
+//! env vars set (host mode), they otherwise fall back to `<data_dir>/cache/...`,
+//! dumping downloads into the app's private data folder. Defaulting `HF_HOME` to
+//! the OS Hugging Face home at startup keeps host-mode downloads in the shared
+//! per-user cache, deduplicated with every other HF tool. The desktop and Docker
+//! Compose already inject `HF_HOME`, so this only changes the env-less case.
+
+use std::path::PathBuf;
+
+/// The OS Hugging Face home, `~/.cache/huggingface` (the literal `~/.cache`, not
+/// the platform cache dir — matching huggingface_hub and `Path.home()/.cache/
+/// huggingface` in the Python worker). `None` when no home dir can be resolved.
+pub fn os_huggingface_home() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|base| base.home_dir().join(".cache").join("huggingface"))
+}
+
+/// Pure decision: the value to default `HF_HOME` to when the process set none of
+/// the HF cache env vars. Returns `None` (leave the environment untouched) when
+/// any HF cache var is already set, or when no home dir is available. Taking the
+/// env values + home as arguments keeps it deterministically testable.
+pub fn default_huggingface_home(
+    hf_hub_cache: Option<&str>,
+    huggingface_hub_cache: Option<&str>,
+    hf_home: Option<&str>,
+    os_home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    let is_set = |value: Option<&str>| value.map(str::trim).is_some_and(|value| !value.is_empty());
+    if is_set(hf_hub_cache) || is_set(huggingface_hub_cache) || is_set(hf_home) {
+        return None;
+    }
+    os_home
+}
+
+/// If no HF cache env var (`HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME`)
+/// is set, point `HF_HOME` at the OS Hugging Face home so downloads land in the
+/// shared `~/.cache/huggingface` cache rather than the app's data dir. Returns the
+/// path it set, or `None` when it left the environment unchanged. Call once at
+/// binary startup, before any cache resolution or worker spawn.
+pub fn ensure_default_huggingface_home() -> Option<PathBuf> {
+    let read = |key: &str| std::env::var(key).ok();
+    let chosen = default_huggingface_home(
+        read("HF_HUB_CACHE").as_deref(),
+        read("HUGGINGFACE_HUB_CACHE").as_deref(),
+        read("HF_HOME").as_deref(),
+        os_huggingface_home(),
+    )?;
+    std::env::set_var("HF_HOME", &chosen);
+    Some(chosen)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn defaults_to_os_home_when_no_hf_env_is_set() {
+        let home = Some(PathBuf::from("/home/alice/.cache/huggingface"));
+        assert_eq!(
+            default_huggingface_home(None, None, None, home.clone()),
+            home
+        );
+        // Blank/whitespace env values count as unset.
+        assert_eq!(
+            default_huggingface_home(Some(""), Some("   "), None, home.clone()),
+            home
+        );
+    }
+
+    #[test]
+    fn leaves_env_untouched_when_any_hf_var_is_set() {
+        let home = Some(PathBuf::from("/home/alice/.cache/huggingface"));
+        assert_eq!(
+            default_huggingface_home(Some("/mnt/hub"), None, None, home.clone()),
+            None
+        );
+        assert_eq!(
+            default_huggingface_home(None, Some("/mnt/hub"), None, home.clone()),
+            None
+        );
+        assert_eq!(
+            default_huggingface_home(None, None, Some("/srv/hf"), home),
+            None
+        );
+    }
+
+    #[test]
+    fn yields_none_without_a_home_dir() {
+        assert_eq!(default_huggingface_home(None, None, None, None), None);
+    }
+
+    #[test]
+    fn os_home_ends_in_cache_huggingface() {
+        // Environment-dependent, but every CI/dev runner has a home dir.
+        if let Some(home) = os_huggingface_home() {
+            assert!(home.ends_with(Path::new(".cache").join("huggingface")));
+        }
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod asset_index;
 pub mod character_store;
 pub mod contracts;
 pub mod credentials;
+pub mod hf_home;
 pub mod jobs_store;
 pub mod lora_family;
 pub mod lora_url;

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -311,6 +311,13 @@ fn emit_json(payload: Value) {
 }
 
 pub async fn run() -> WorkerResult<()> {
+    // Host mode (no HF cache env set): default HF_HOME to the shared ~/.cache/
+    // huggingface so downloads land in the OS cache rather than the private data
+    // dir (sc-1904 follow-up). Set before spawning child workers so they inherit
+    // it; desktop/Compose already inject HF_HOME, making this a no-op there.
+    if let Some(home) = sceneworks_core::hf_home::ensure_default_huggingface_home() {
+        println!("rust_worker defaulting HF_HOME to {}", home.display());
+    }
     let settings = Settings::from_env();
     if !settings.is_child_worker {
         if settings.gpu_id == "auto" {


### PR DESCRIPTION
**sc-1904 follow-up** (epic 1890). Completes sc-1904's intent for the env-less host-mode case: model downloads should land in the shared `~/.cache/huggingface` cache, not the app's private data folder.

## Problem
`huggingface_hub_cache_dir` honors `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME`, but with none set it falls back to `<data_dir>/cache/huggingface/hub` — the private data folder. Desktop and Docker Compose always inject `HF_HOME`, so only host-mode (env-less) runs hit this.

## Approach
Rather than change that leaf fallback — which would make the env-less unit/integration tests read the developer's **real** `~/.cache` and break their isolation (e.g. this machine has `Wan2.2-TI2V-5B` and `Z-Image-Turbo` cached) — the binaries default `HF_HOME` at startup, exactly like the desktop already does:

- **`crates/sceneworks-core/src/hf_home.rs`** (new): a pure `default_huggingface_home(...)` decision plus `ensure_default_huggingface_home()`, which sets `HF_HOME` to the OS Hugging Face home (`~/.cache/huggingface`, the literal `~/.cache` — matching `huggingface_hub` and the Python worker's `hf_cache.huggingface_cache_root`) only when no HF cache env var is set.
- **`rust-api run()` / `rust-worker run()`**: call it at startup (the worker sets it before spawning child workers so they inherit it).

Tests call `create_app`/`from_env` directly (not `run()`), so they keep the data-dir fallback and stay isolated. Desktop/Compose already set `HF_HOME`, so this is a no-op there.

`hf_cache.py` already defaults to `~/.cache/huggingface` and reads through multiple roots — parity confirmed, no change.

## Acceptance
- ✅ With no HF env set, the binaries point `HF_HOME` at `~/.cache/huggingface`, so downloads and the catalog's installed check both resolve under `~/.cache/huggingface/hub/models--<repo>`.
- ✅ Rust and Python resolve the same default root.
- ✅ Tests cover the default, the "any HF var set → leave alone" case, and the no-home fallback.

## Validation
- `cargo test`: 4 new `hf_home` unit tests; full worker (41) + rust-api (72) suites green
- `cargo fmt --all --check` + `cargo clippy -D warnings` (core + worker + rust-api) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)