### PR TITLE
Add SDXL (image + LoRA training) and Stable Video Diffusion — epic 1787

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,16 @@ startup.
 
 ## LoRA Training
 
-SceneWorks can train an image LoRA for Z-Image-Turbo locally: build a captioned
-dataset, validate the plan with a dry run, train on a CUDA GPU worker, and the
-result is registered as a normal SceneWorks LoRA selectable in Image Studio.
+SceneWorks can train image LoRAs locally — for Z-Image-Turbo, Stable Diffusion
+XL, and Microsoft Lens (plus LTX-2.3 video LoRAs natively on Apple Silicon):
+build a captioned dataset, validate the plan with a dry run, train on a GPU
+worker, and the result is registered as a normal SceneWorks LoRA selectable in
+Image Studio. The Stable Diffusion XL kernel is the generic SDXL-UNet trainer
+that SDXL-family models (e.g. Kolors) extend.
 See [documents/TRAINING_QUICKSTART.md](documents/TRAINING_QUICKSTART.md) for a
-step-by-step first run, recommended dataset sizes and captions, VRAM/disk notes,
-where outputs live, and troubleshooting. Training contracts live in
-`crates/sceneworks-core/src/training.rs`; the execution kernel is
+step-by-step first run, per-target notes, recommended dataset sizes and captions,
+VRAM/disk notes, where outputs live, and troubleshooting. Training contracts live
+in `crates/sceneworks-core/src/training.rs`; the execution kernel is
 `apps/worker/scene_worker/training_adapters.py`.
 
 ## Structure

--- a/apps/web/public/prompt-guides/sdxl.md
+++ b/apps/web/public/prompt-guides/sdxl.md
@@ -1,0 +1,85 @@
+# Stable Diffusion XL Prompt Guide
+
+## Best For
+
+General-purpose text-to-image across photography, illustration, concept art, and design. SDXL base 1.0 is the open, widely-supported foundation with the largest LoRA and finetune ecosystem — if you want to layer community style/character LoRAs, this is the model. CreativeML OpenRAIL++-M, commercial use OK, ungated.
+
+SDXL uses two CLIP text encoders and **real classifier-free guidance**, so you get both a positive *and* a negative prompt. Native resolution is 1024×1024.
+
+## Prompt Shape
+
+SDXL responds well to both fluent natural-language descriptions and comma-separated tag lists — and to a blend of the two. A reliable structure:
+
+`subject + key details + style + composition + lighting + quality tags`
+
+CLIP encoders weight earlier tokens more heavily, so **lead with the subject and the most important attributes**. Keep the prompt focused; very long prompts dilute attention.
+
+## Build The Prompt
+
+### Subject
+
+State the subject plainly and front-load it:
+
+`a weathered fisherman mending a net on a wooden dock at dawn`
+
+### Details
+
+Add material, texture, and atmosphere:
+
+- `hand-stitched leather`
+- `condensation on cold glass`
+- `drifting morning fog`
+- `intricate filigree pattern`
+
+### Style
+
+- `editorial fashion photography`
+- `cinematic film still, 35mm`
+- `flat vector illustration`
+- `soft gouache painting`
+
+### Camera And Composition
+
+- `low-angle hero shot`
+- `extreme close-up macro`
+- `wide establishing shot`
+- `rule of thirds, centered subject`
+
+### Lighting
+
+- `golden hour backlight`
+- `soft window light`
+- `neon-lit night scene`
+- `dramatic rim lighting`
+
+### Quality Tags
+
+SDXL was trained with aesthetic and quality signals, so a few trailing tags help:
+
+`highly detailed, sharp focus, 8k, professional photography`
+
+## Negative Prompts
+
+SDXL honors a negative prompt (guidance > 1). Use it to push away common failure modes — keep it short and targeted:
+
+`blurry, lowres, deformed, extra fingers, bad anatomy, watermark, text, jpeg artifacts, oversaturated`
+
+## Tips
+
+- ~30 steps at guidance 7.0 is a solid baseline; raise guidance for stronger prompt adherence, lower it (4–6) for more natural, less "baked" results.
+- Native 1024×1024; the canonical aspect-ratio buckets (1152×896, 896×1152, 1216×832, 832×1216, 1344×768, 768×1344) are trained resolutions — prefer them over arbitrary sizes.
+- Front-load the subject and key attributes; CLIP weights early tokens more.
+- Layer community SDXL LoRAs for specific styles or characters — SDXL has the deepest LoRA ecosystem of any open model.
+- Use the negative prompt actively; it is one of SDXL's strongest levers.
+
+## Example Prompts
+
+`A cozy independent bookstore storefront at dusk, warm interior glow spilling onto a rain-slick cobblestone street, cinematic shallow depth of field, highly detailed, sharp focus.`
+
+`Studio product shot of a matte-black ceramic pour-over coffee set on pale oak, soft diffused side light, subtle steam rising, minimalist composition, professional photography, high detail.`
+
+## Sources
+
+- [SDXL base 1.0 model card](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0)
+- [SDXL technical report](https://arxiv.org/abs/2307.01952)
+- [Diffusers SDXL pipeline docs](https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl)

--- a/apps/web/public/prompt-guides/svd.md
+++ b/apps/web/public/prompt-guides/svd.md
@@ -1,0 +1,36 @@
+# Stable Video Diffusion Guide
+
+## Best For
+
+Animating a single still image into a short, natural-motion clip — subtle camera moves, drifting elements, living portraits, looping ambiance. Stable Video Diffusion (img2vid-XT) is **image-conditioned only**: it takes one source image and produces a ~25-frame clip. There is **no text prompt** — the motion comes from the image and the motion controls, not from words.
+
+## Licensing
+
+SVD ships under the **Stability AI Community License**: commercial use is free under $1M annual revenue (paid Enterprise above), and the weights are ungated (no Hugging Face token needed). SceneWorks downloads the weights for local use; it does not redistribute them. Review Stability's Acceptable Use Policy before commercial use.
+
+## How To Use It
+
+1. **Pick a strong source image.** SVD animates what it's given — composition, subject, and lighting all carry into the clip. Sharp, well-exposed images at the native aspect ratio work best.
+2. **Match the resolution.** SVD-XT is trained at **1024×576** (landscape) and **576×1024** (portrait). Pick the orientation that matches your image; off-ratio inputs get letterboxed or cropped.
+3. **Generate.** The model produces a fixed ~25-frame burst. Set the playback fps to pace it (lower fps = slower, more deliberate motion).
+
+## Motion Controls (Advanced)
+
+SVD's "prompt" is really a small set of conditioning knobs, available under advanced settings:
+
+- **Motion strength** (`motion bucket`) — how much movement the model introduces. Lower = subtle drift; higher = bold motion (and more risk of artifacts). The default is a balanced mid-range value.
+- **Conditioning fps** — the frame rate the model conditions on (separate from playback fps). Lower values read as slower, smoother motion.
+- **Noise augmentation** — how far the first frame is allowed to drift from the source. Small values keep the opening frame faithful to your image.
+
+## Tips
+
+- Start from a high-quality image — SVD amplifies whatever is already there, including blur and noise.
+- Keep motion strength moderate for portraits and product shots; raise it for landscapes and abstract motion.
+- SVD has no prompt and no negative prompt — to change the result, change the source image or the motion controls.
+- The clip length is fixed by the model (~25 frames); use playback fps to control pacing rather than expecting longer durations.
+
+## Sources
+
+- [SVD img2vid-XT model card](https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt)
+- [Stability AI Community License](https://stability.ai/community-license-agreement)
+- [Diffusers SVD pipeline docs](https://huggingface.co/docs/diffusers/main/en/api/pipelines/svd)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -198,6 +198,26 @@ export const fallbackModels = [
     },
   },
   {
+    id: "svd",
+    name: "Stable Video Diffusion",
+    type: "video",
+    capabilities: ["image_to_video"],
+    // Image-conditioned only — no text prompt (Video Studio drops the prompt requirement).
+    promptless: true,
+    defaults: { duration: 4, fps: 7, resolution: "1024x576", quality: "balanced" },
+    limits: {
+      durations: [4],
+      recommendedMaxDuration: 4,
+      fps: [6, 7, 8, 10, 12, 25],
+      resolutions: ["1024x576", "576x1024"],
+    },
+    ui: {
+      description: "Stable Video Diffusion (img2vid-XT) — animates a source image into a short ~25-frame clip; no text prompt. Stability AI Community License (commercial free under $1M revenue, ungated).",
+      durationHint: "Fixed ~25-frame clip from one image; adjust playback fps for pacing.",
+      promptGuide: { title: "Stable Video Diffusion Guide", path: "/prompt-guides/svd.md" },
+    },
+  },
+  {
     id: "wan_2_2",
     name: "Wan2.2",
     type: "video",

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -170,6 +170,16 @@ export const fallbackModels = [
     },
   },
   {
+    id: "sdxl",
+    name: "Stable Diffusion XL",
+    type: "image",
+    capabilities: ["text_to_image", "edit_image", "style_variations"],
+    ui: {
+      description: "Stability AI Stable Diffusion XL base 1.0 — open text-to-image foundation with the largest LoRA/finetune ecosystem. CreativeML OpenRAIL++-M (commercial use OK, ungated). SDXL UNet + dual CLIP; ~6.9GB fp16, real CFG + negative prompt, ~30 steps at guidance 7.0; native 1024x1024.",
+      promptGuide: { title: "Stable Diffusion XL Prompt Guide", path: "/prompt-guides/sdxl.md" },
+    },
+  },
+  {
     id: "ltx_2_3",
     name: "LTX-2.3",
     type: "video",

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5720,6 +5720,65 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("lets a promptless video model (SVD) submit without a text prompt", async () => {
+    const createVideoJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [{ id: "image-1", type: "image", displayName: "Frame One" }],
+            characters: [],
+            createPersonDetectionJob: () => {},
+            createPersonTrackJob: () => {},
+            createVideoJob,
+            deleteAsset: () => {},
+            gpuOptions: ["auto"],
+            latestVideoAssets: [],
+            loras: [],
+            rememberLocalGenerationJob: () => {},
+            setPreviewAsset: () => {},
+            personTracks: [],
+            purgeAsset: () => {},
+            presets: [],
+            requestedGpu: "auto",
+            selectedAsset: { id: "image-1", type: "image", displayName: "Frame One" },
+            setRequestedGpu: () => {},
+            updateAssetStatus: () => {},
+            videoModels: [
+              {
+                id: "svd",
+                name: "Stable Video Diffusion",
+                type: "video",
+                family: "svd",
+                capabilities: ["image_to_video"],
+                promptless: true,
+                defaults: { duration: 4, fps: 7, resolution: "1024x576", quality: "balanced" },
+                limits: { durations: [4], fps: [6, 7, 8], resolutions: ["1024x576", "576x1024"] },
+              },
+            ],
+          },
+          <VideoStudio />,
+        ),
+      );
+    });
+    await settle();
+
+    // The prompt field advertises that no prompt is needed for promptless models.
+    const promptField = container.querySelector("textarea[aria-label='Prompt']");
+    expect(promptField.placeholder).toContain("No prompt needed");
+
+    // With a source image selected and an empty prompt, Render clip is enabled
+    // and submits (a text-prompted model would be blocked here).
+    const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Render clip");
+    expect(generate.disabled).toBe(false);
+    await act(async () => {
+      generate.click();
+    });
+    expect(createVideoJob).toHaveBeenCalled();
+  });
+
   it("filters video presets by mode and selected model", async () => {
     root = createRoot(container);
     await act(async () => {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -313,9 +313,12 @@ export function VideoStudio() {
   // Don't let Replace Person queue a job the readiness endpoint says no live
   // worker can run — that would sit unclaimable instead of honoring the gate.
   const replaceReady = mode !== "replace_person" || personReadiness?.replace?.ready !== false;
+  // Image-conditioned models (e.g. Stable Video Diffusion) take no text prompt;
+  // they animate the source image, so don't gate submission on prompt text.
+  const promptless = Boolean(selectedModel?.promptless);
   const canSubmit = Boolean(
     activeProject &&
-      prompt.trim() &&
+      (promptless || prompt.trim()) &&
       supportsMode &&
       implementedMode &&
       hasInputs &&
@@ -448,7 +451,11 @@ export function VideoStudio() {
               className="prompt-input"
               onChange={(event) => setPrompt(event.target.value)}
               onKeyDown={onPromptKeyDown}
-              placeholder="Describe the motion — what moves, where the camera goes, how it feels…"
+              placeholder={
+                promptless
+                  ? "No prompt needed — this model animates the source image. Pick a first frame below and generate."
+                  : "Describe the motion — what moves, where the camera goes, how it feels…"
+              }
               value={prompt}
             />
             <button className="prompt-cta" disabled={generateDisabled} type="submit">

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -368,6 +368,23 @@ MODEL_TARGETS = {
         "repo": "lodestones/Chroma1-Flash",
         "adapter": "chroma_diffusers",
     },
+    "sdxl": {
+        "label": "Stable Diffusion XL",
+        "family": "sdxl",
+        # Unified base checkpoint: StableDiffusionXLPipeline (T2I) +
+        # StableDiffusionXLImg2ImgPipeline (edit).
+        "supportsEdit": True,
+        # Real CFG with negative prompt (not distilled): ~30 steps at guidance
+        # 7.0, native 1024x1024. Two CLIP text encoders, so no max_seq_len knob.
+        # Ships EulerDiscreteScheduler, which we keep (scheduler UI is epic 1753).
+        "steps": 30,
+        "guidanceScale": 7.0,
+        # SDXL base ships an fp16 variant alongside fp32; request it so
+        # from_pretrained loads the half-precision weights.
+        "variant": "fp16",
+        "repo": "stabilityai/stable-diffusion-xl-base-1.0",
+        "adapter": "sdxl_diffusers",
+    },
 }
 
 
@@ -2255,6 +2272,338 @@ class KolorsDiffusersAdapter:
         return max(0.0, min(1.0, scale))
 
 
+class SdxlDiffusersAdapter:
+    """Stability AI Stable Diffusion XL base 1.0 via diffusers.StableDiffusionXLPipeline.
+
+    Mirrors KolorsDiffusersAdapter (Kolors is built on the same SDXL UNet):
+    HF-cache check, device/dtype selection, progress + cancel callbacks,
+    incremental asset writing, and worker events for pipeline load + inference.
+    Runs in the MAIN worker venv (diffusers + transformers) — no sidecar.
+
+    SDXL uses real classifier-free guidance, so it honors the negative prompt and
+    a non-zero guidance_scale (~7.0); the pipeline assembles the SDXL
+    added_cond_kwargs (pooled text embeds + add_time_ids) itself. Two CLIP text
+    encoders (no T5/ChatGLM), so there is no max_sequence_length knob. The
+    checkpoint ships EulerDiscreteScheduler, which we keep (sampler/scheduler
+    selection is epic 1753).
+
+    Supports text-to-image (StableDiffusionXLPipeline) and img2img editing
+    (StableDiffusionXLImg2ImgPipeline) on the same checkpoint, switched by
+    request.mode.
+    """
+
+    id = "sdxl_diffusers"
+
+    def __init__(self) -> None:
+        self._text_pipe: Any | None = None
+        self._img2img_pipe: Any | None = None
+        self._loaded_repo: str | None = None
+        self._loaded_model: str | None = None
+        self._loaded_lora_states: dict[str, LoraPipelineState] = {}
+
+    def loaded_models(self) -> list[str]:
+        return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
+
+    def unload(self) -> bool:
+        """Free any resident pipeline so another family can load (cross-adapter
+        eviction). Returns True if it actually freed something."""
+        if self._text_pipe is None and self._img2img_pipe is None:
+            return False
+        self._evict_pipelines(importlib.import_module("torch"))
+        return True
+
+    def generate(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        if request.mode == "edit_image" and not model_supports_edit(request.model):
+            raise RuntimeError(f"{request.model} does not support image editing.")
+        model_target = MODEL_TARGETS.get(request.model, {})
+        if model_target.get("adapter") != self.id:
+            raise RuntimeError(f"{request.model} is not an SDXL Diffusers target.")
+
+        use_img2img = request.mode == "edit_image"
+        progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress, job_id=job["id"])
+        emit_worker_event(
+            "image_lora_apply_start",
+            jobId=job["id"],
+            adapter=self.id,
+            loraCount=len(request.loras),
+        )
+        self._apply_loras(pipe, request)
+        emit_worker_event("image_lora_apply_complete", jobId=job["id"], adapter=self.id)
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        label = f"{model_target['label']} edit" if use_img2img else model_target["label"]
+
+        def image_at_index(index: int) -> Image.Image:
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            progress(
+                "running",
+                "generating",
+                image_batch_progress(index, request.count),
+                format_batch_running_message(label, index, request.count),
+            )
+            emit_worker_event(
+                "image_inference_start",
+                jobId=job["id"],
+                adapter=self.id,
+                model=request.model,
+                imageIndex=index,
+                imageCount=request.count,
+                device=device,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            try:
+                image = self._run_pipeline(
+                    settings, pipe, request, seed, project_path, cancel_requested=cancel_requested
+                )
+            except Exception as exc:
+                emit_worker_event(
+                    "image_inference_failed",
+                    jobId=job["id"],
+                    adapter=self.id,
+                    imageIndex=index,
+                    error=str(exc),
+                    errorType=exc.__class__.__name__,
+                )
+                raise
+            emit_worker_event(
+                "image_inference_complete",
+                jobId=job["id"],
+                adapter=self.id,
+                imageIndex=index,
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return image
+
+        return ImageAssetWriter().write_incremental_outputs(
+            request=request,
+            project_path=project_path,
+            image_count=request.count,
+            image_at_index=image_at_index,
+            adapter_id=self.id,
+            progress=progress,
+            cancel_requested=cancel_requested,
+            raw_settings={
+                **request.advanced,
+                "repo": self._repo_for_request(request, model_target),
+                "numInferenceSteps": self._num_inference_steps(request, model_target),
+                "guidanceScale": self._guidance_scale(request, model_target),
+                "realModelInference": True,
+            },
+        )
+
+    def _load_pipeline(
+        self,
+        settings: WorkerSettings,
+        request: ImageRequest,
+        model_target: dict[str, Any],
+        progress: ProgressCallback,
+        *,
+        job_id: str,
+    ) -> Any:
+        torch = importlib.import_module("torch")
+        diffusers = importlib.import_module("diffusers")
+        repo = self._repo_for_request(request, model_target)
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+        use_img2img = request.mode == "edit_image"
+        cpu_offload = bool(request.advanced.get("cpuOffload", False))
+        cached_pipe = self._img2img_pipe if use_img2img else self._text_pipe
+        if cached_pipe is not None and self._loaded_repo == repo:
+            self._loaded_model = request.model
+            progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
+            emit_worker_event(
+                "image_pipeline_cache_hit",
+                jobId=job_id,
+                adapter=self.id,
+                model=request.model,
+                repo=repo,
+                device=device,
+                componentDevices=pipeline_component_devices(cached_pipe),
+                gpuMemory=gpu_memory_snapshot(torch, device),
+            )
+            return cached_pipe
+
+        # Hold only one pipeline per repo: evict the stale pipe (other mode or
+        # stale repo) before loading so two large SDXL pipelines never sit
+        # resident at once.
+        if self._loaded_repo and self._loaded_repo != repo:
+            self._evict_pipelines(torch)
+        elif use_img2img:
+            if self._text_pipe is not None:
+                self._text_pipe = None
+                self._forget_loaded_loras("text")
+                self._empty_cuda_cache(torch)
+        else:
+            if self._img2img_pipe is not None:
+                self._img2img_pipe = None
+                self._forget_loaded_loras("img2img")
+                self._empty_cuda_cache(torch)
+
+        pipeline_name = (
+            "StableDiffusionXLImg2ImgPipeline" if use_img2img else "StableDiffusionXLPipeline"
+        )
+        pipeline_class = getattr(diffusers, pipeline_name, None)
+        if pipeline_class is None:
+            raise RuntimeError(
+                f"The installed diffusers package does not expose {pipeline_name}. "
+                "Install diffusers >= 0.19 for Stable Diffusion XL support."
+            )
+
+        cache_action = "Loading cached" if huggingface_repo_cache_exists(repo) else "Downloading"
+        progress("loading_model", "loading_model", 0.2, f"{cache_action} {model_target['label']} model files.")
+        emit_worker_event(
+            "image_pipeline_load_start",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            device=device,
+            dtype=str(dtype),
+            useImg2img=use_img2img,
+            cpuOffload=cpu_offload,
+            cached=cache_action == "Loading cached",
+        )
+        # SDXL base ships an fp16 variant alongside fp32; request it so
+        # from_pretrained loads the half-precision weights.
+        from_pretrained_kwargs: dict[str, Any] = {
+            "torch_dtype": dtype,
+            "variant": model_target.get("variant"),
+        }
+        pipe = pipeline_class.from_pretrained(repo, **from_pretrained_kwargs)
+        emit_worker_event(
+            "image_pipeline_load_complete",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            componentDevices=pipeline_component_devices(pipe),
+        )
+        offload_enabled = cpu_offload and hasattr(pipe, "enable_model_cpu_offload")
+        if offload_enabled:
+            pipe.enable_model_cpu_offload()
+        else:
+            pipe.to(device)
+        # VAE tiling keeps high-resolution decodes within memory.
+        vae = getattr(pipe, "vae", None)
+        if vae is not None and hasattr(vae, "enable_tiling"):
+            vae.enable_tiling()
+        elif hasattr(pipe, "enable_vae_tiling"):
+            pipe.enable_vae_tiling()
+        component_devices = verify_pipeline_on_device(
+            pipe,
+            requested_device=device,
+            model_label=model_target["label"],
+            allow_offload=offload_enabled,
+        )
+        emit_worker_event(
+            "image_pipeline_on_device",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            requestedDevice=device,
+            cpuOffload=offload_enabled,
+            componentDevices=component_devices,
+            gpuMemory=gpu_memory_snapshot(torch, device),
+        )
+        if use_img2img:
+            self._img2img_pipe = pipe
+        else:
+            self._text_pipe = pipe
+        self._loaded_repo = repo
+        self._loaded_model = request.model
+        return pipe
+
+    def _evict_pipelines(self, torch: Any) -> None:
+        self._text_pipe = None
+        self._img2img_pipe = None
+        self._loaded_repo = None
+        self._loaded_model = None
+        self._loaded_lora_states.clear()
+        self._empty_cuda_cache(torch)
+
+    def _empty_cuda_cache(self, torch: Any) -> None:
+        release_inference_memory(torch)
+
+    def _run_pipeline(
+        self,
+        settings: WorkerSettings,
+        pipe: Any,
+        request: ImageRequest,
+        seed: int,
+        project_path: Path,
+        cancel_requested: CancelCallback | None = None,
+    ) -> Image.Image:
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
+        model_target = MODEL_TARGETS[request.model]
+        kwargs = {
+            "prompt": request.prompt,
+            # SDXL uses real classifier-free guidance, so the negative prompt is
+            # honored (unlike the guidance-distilled FLUX path).
+            "negative_prompt": request.negative_prompt,
+            "height": request.height,
+            "width": request.width,
+            "num_inference_steps": self._num_inference_steps(request, model_target),
+            "guidance_scale": self._guidance_scale(request, model_target),
+            "generator": generator,
+        }
+        if request.mode == "edit_image":
+            # StableDiffusionXLImg2ImgPipeline blends a source image; strength
+            # controls how far the result moves from it (0 = unchanged, 1 = full
+            # re-generation). It sizes the output from the source, so height/width
+            # are dropped by filter_call_kwargs.
+            kwargs["image"] = load_source_image(project_path, request)
+            kwargs["strength"] = float(request.advanced.get("strength", 0.6))
+        step_callback = cancel_step_callback(pipe, cancel_requested)
+        if step_callback is not None:
+            kwargs["callback_on_step_end"] = step_callback
+        output = pipe(**filter_call_kwargs(pipe, kwargs))
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
+        return output.images[0].convert("RGB")
+
+    def _apply_loras(self, pipe: Any, request: ImageRequest) -> None:
+        key = "img2img" if request.mode == "edit_image" else "text"
+        model_target = MODEL_TARGETS.get(request.model, {})
+        self._loaded_lora_states[key] = apply_loras_to_pipeline(
+            pipe,
+            request.loras,
+            adapter_id=self.id,
+            model_family=model_target.get("family"),
+            previous_state=self._loaded_lora_states.get(key),
+        )
+
+    def _forget_loaded_loras(self, key: str) -> None:
+        self._loaded_lora_states.pop(key, None)
+
+    def _repo_for_request(self, request: ImageRequest, model_target: dict[str, Any]) -> str:
+        return request.advanced.get("modelRepo") or model_target["repo"]
+
+    def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        return safe_int(request.advanced.get("steps"), model_target["steps"], 1, 80)
+
+    def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:
+        default = model_target.get("guidanceScale", 7.0)
+        try:
+            return float(request.advanced.get("guidanceScale", default))
+        except (TypeError, ValueError):
+            return float(default)
+
+
 class ChromaDiffusersAdapter:
     """Lodestones Chroma1-HD / Base / Flash text-to-image via diffusers.ChromaPipeline.
 
@@ -3780,6 +4129,7 @@ def create_image_adapter(
     | SenseNovaU1Adapter
     | FluxDiffusersAdapter
     | KolorsDiffusersAdapter
+    | SdxlDiffusersAdapter
     | ChromaDiffusersAdapter
 ):
     payload = job.get("payload", {})
@@ -3795,6 +4145,7 @@ def create_image_adapter(
         SenseNovaU1Adapter.id,
         FluxDiffusersAdapter.id,
         KolorsDiffusersAdapter.id,
+        SdxlDiffusersAdapter.id,
         ChromaDiffusersAdapter.id,
     }:
         raise RuntimeError(f"Unsupported SCENEWORKS_IMAGE_ADAPTER value: {requested}.")
@@ -3810,6 +4161,8 @@ def create_image_adapter(
         return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
     if requested == KolorsDiffusersAdapter.id:
         return adapters.get("kolors_diffusers") if adapters else KolorsDiffusersAdapter()
+    if requested == SdxlDiffusersAdapter.id:
+        return adapters.get("sdxl_diffusers") if adapters else SdxlDiffusersAdapter()
     if requested == ChromaDiffusersAdapter.id:
         return adapters.get("chroma_diffusers") if adapters else ChromaDiffusersAdapter()
     model_target = MODEL_TARGETS.get(payload.get("model", "z_image_turbo"), {})
@@ -3825,6 +4178,8 @@ def create_image_adapter(
         return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
     if model_target.get("adapter") == KolorsDiffusersAdapter.id:
         return adapters.get("kolors_diffusers") if adapters else KolorsDiffusersAdapter()
+    if model_target.get("adapter") == SdxlDiffusersAdapter.id:
+        return adapters.get("sdxl_diffusers") if adapters else SdxlDiffusersAdapter()
     if model_target.get("adapter") == ChromaDiffusersAdapter.id:
         return adapters.get("chroma_diffusers") if adapters else ChromaDiffusersAdapter()
     return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -23,6 +23,7 @@ from .image_adapters import (
     LensTurboAdapter,
     ProceduralImageAdapter,
     QwenImageAdapter,
+    SdxlDiffusersAdapter,
     SenseNovaU1Adapter,
     ZImageDiffusersAdapter,
     create_image_adapter,
@@ -1255,6 +1256,7 @@ def run_worker_loop(settings: WorkerSettings) -> None:
         "sensenova_u1": SenseNovaU1Adapter(),
         "flux_diffusers": FluxDiffusersAdapter(),
         "kolors_diffusers": KolorsDiffusersAdapter(),
+        "sdxl_diffusers": SdxlDiffusersAdapter(),
         "chroma_diffusers": ChromaDiffusersAdapter(),
     }
     max_registration_attempts = 20

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -1374,6 +1374,490 @@ class _ZImageLoraBackend:
 
 
 # --------------------------------------------------------------------------- #
+# SDXL-UNet LoRA backend (torch / diffusers / PEFT) — the shared foundation for
+# every SDXL-architecture LoRA target. Kolors (epic 1929) subclasses it by
+# swapping the pipeline class + the prompt encoder (see the seams below).
+# --------------------------------------------------------------------------- #
+
+
+class _SdxlLoraBackend:
+    """Real SDXL-UNet LoRA training backend.
+
+    Loads ``StableDiffusionXLPipeline``, caches per-item VAE latents + frozen
+    dual-CLIP prompt embeddings (text + pooled), attaches a PEFT LoRA to
+    ``pipe.unet``, and runs the SDXL epsilon/v-prediction objective with the
+    SDXL ``added_cond_kwargs`` (pooled text embeds + ``add_time_ids``) on a DDPM
+    noise schedule. This is the **first U-Net (non-DiT) trainer** in the repo;
+    the existing kernels are flow-matching transformer trainers, so the noise
+    schedule, the integer timesteps, and the ``added_cond_kwargs`` forward are
+    deliberately isolated here from the shared orchestration.
+
+    Extension seams for epic 1929 (Kolors = SDXL UNet + ChatGLM3): override
+    :attr:`pipeline_class_name` and :meth:`_encode_prompt`. Everything else —
+    the UNet LoRA injection, the training loop, the save path — is shared.
+    """
+
+    # Seams a same-architecture subclass (Kolors) overrides.
+    kernel_id = "sdxl_lora"
+    pipeline_class_name = "StableDiffusionXLPipeline"
+    # SDXL base ships an fp16 variant; Kolors-diffusers is also fp16-only.
+    load_variant: str | None = "fp16"
+
+    def __init__(self) -> None:
+        self._torch: Any | None = None
+        self._device: str | None = None
+        self._dtype: Any | None = None
+        self._pipeline: Any | None = None
+        self._unet: Any | None = None
+        self._vae: Any | None = None
+        self._noise_scheduler: Any | None = None
+        self._num_train_timesteps: int = 1000
+        self._prediction_type: str = "epsilon"
+        self._optimizer: Any | None = None
+        self._lr_scheduler: Any | None = None
+        self._generator: Any | None = None
+        self._loaded_source: str | None = None
+        self._latents: list[Any] = []
+        self._prompt_embeds: list[Any] = []
+        self._pooled_embeds: list[Any] = []
+        self._add_time_ids: Any | None = None
+        self._vae_scaling: float = 1.0
+        self._diagnosed_forward = False
+
+    def loaded_models(self) -> list[str]:
+        return [self._loaded_source] if self._loaded_source else []
+
+    def load(
+        self,
+        *,
+        settings: WorkerSettings,
+        plan: dict[str, Any],
+        config: TrainingRunConfig,
+        progress: ProgressCallback,
+    ) -> None:
+        torch = importlib.import_module("torch")
+        diffusers = importlib.import_module("diffusers")
+        peft = importlib.import_module("peft")
+        self._torch = torch
+
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        dtype = select_torch_dtype(torch, device, config.mixed_precision)
+        source = resolve_pretrained_source(plan.get("target") or {})
+
+        pipeline_class = getattr(diffusers, self.pipeline_class_name, None)
+        if pipeline_class is None:
+            raise TrainingKernelError(
+                f"The installed diffusers build does not expose {self.pipeline_class_name}; "
+                "install a diffusers build with SDXL support."
+            )
+        ddpm_class = getattr(diffusers, "DDPMScheduler", None)
+        if ddpm_class is None:
+            raise TrainingKernelError(
+                "The installed diffusers build does not expose DDPMScheduler, "
+                "required for the SDXL training noise schedule."
+            )
+
+        emit_worker_event(
+            "training_pipeline_load_start",
+            kernel=self.kernel_id,
+            source=source,
+            device=device,
+            dtype=str(dtype),
+        )
+        progress("loading_model", "loading_model", 0.12, "Loading SDXL base model files.")
+        from_pretrained_kwargs: dict[str, Any] = {"torch_dtype": dtype}
+        if self.load_variant:
+            from_pretrained_kwargs["variant"] = self.load_variant
+        pipe = pipeline_class.from_pretrained(source, **from_pretrained_kwargs)
+        pipe.to(device)
+        # The SDXL fp16 VAE emits NaN latents; it is frozen and only used for the
+        # one-time latent cache, so upcast it to fp32 for numerically safe encodes.
+        pipe.vae.to(dtype=torch.float32)
+
+        unet = pipe.unet
+        unet.requires_grad_(False)
+        pipe.vae.requires_grad_(False)
+        for encoder_attr in ("text_encoder", "text_encoder_2"):
+            encoder = getattr(pipe, encoder_attr, None)
+            if encoder is not None:
+                encoder.requires_grad_(False)
+
+        # Train on a DDPM schedule derived from the base model's own scheduler
+        # config so num_train_timesteps + prediction_type match (SDXL base is
+        # epsilon). The inference scheduler (Euler) is a different object.
+        self._noise_scheduler = ddpm_class.from_config(pipe.scheduler.config)
+        self._num_train_timesteps = int(
+            getattr(self._noise_scheduler.config, "num_train_timesteps", 1000) or 1000
+        )
+        self._prediction_type = str(
+            getattr(self._noise_scheduler.config, "prediction_type", "epsilon") or "epsilon"
+        )
+
+        progress("loading_model", "loading_model", 0.16, "Attaching LoRA adapter to the U-Net.")
+        lora_config = peft.LoraConfig(
+            r=config.rank,
+            lora_alpha=config.alpha,
+            init_lora_weights="gaussian",
+            target_modules=list(config.lora_target_modules)
+            if isinstance(config.lora_target_modules, (list, tuple))
+            else config.lora_target_modules,
+        )
+        unet.add_adapter(lora_config)
+        self._activate_lora_adapter(unet)
+        if config.gradient_checkpointing:
+            # Frozen base + LoRA: force inputs to require grad so reentrant
+            # checkpointing doesn't drop gradients to the adapter.
+            if hasattr(unet, "enable_input_require_grads"):
+                try:
+                    unet.enable_input_require_grads()
+                except Exception:
+                    pass
+            if hasattr(unet, "enable_gradient_checkpointing"):
+                unet.enable_gradient_checkpointing()
+            elif hasattr(unet, "gradient_checkpointing_enable"):
+                unet.gradient_checkpointing_enable()
+            else:
+                emit_worker_event(
+                    "training_gradient_checkpointing_unavailable",
+                    kernel=self.kernel_id,
+                    unet=type(unet).__name__,
+                )
+        unet.train()
+        trainable = [param for param in unet.parameters() if param.requires_grad]
+        if not trainable:
+            raise TrainingKernelError(
+                "LoRA adapter attached no trainable parameters; the configured "
+                "target modules did not match any U-Net layers. Adjust "
+                "advanced.loraTargetModules for this base model."
+            )
+
+        self._optimizer = build_optimizer(
+            config.optimizer, trainable, config.learning_rate, config.weight_decay
+        )
+        self._optimizer.zero_grad()
+        total_updates, warmup_updates = lr_schedule_updates(
+            config.steps, config.gradient_accumulation, config.lr_warmup_steps
+        )
+        self._lr_scheduler = build_lr_scheduler(
+            torch,
+            self._optimizer,
+            config.lr_scheduler,
+            total_updates=total_updates,
+            warmup_updates=warmup_updates,
+        )
+        vae_config = getattr(pipe.vae, "config", None)
+        self._vae_scaling = float(getattr(vae_config, "scaling_factor", 1.0) or 1.0)
+        self._pipeline = pipe
+        self._unet = unet
+        self._vae = pipe.vae
+        self._device = device
+        self._dtype = dtype
+        self._loaded_source = source
+        generator_device = device if str(device).startswith("cuda") else "cpu"
+        self._generator = torch.Generator(generator_device).manual_seed(int(config.seed))
+        lora_a_norm, lora_b_norm = self._lora_param_norms()
+        emit_worker_event(
+            "training_pipeline_load_complete",
+            kernel=self.kernel_id,
+            source=source,
+            trainableTensors=len(trainable),
+            predictionType=self._prediction_type,
+            loraANorm=lora_a_norm,
+            loraBNorm=lora_b_norm,
+            lrScheduler=config.lr_scheduler,
+            lrWarmupSteps=config.lr_warmup_steps,
+            gpuMemory=gpu_memory_snapshot(torch, device),
+        )
+
+    def _encode_prompt(self, pipe: Any, caption: str, device: str) -> tuple[Any, Any]:
+        """Return ``(prompt_embeds, pooled_prompt_embeds)`` for one caption.
+
+        Overridable seam: SDXL uses the dual-CLIP ``encode_prompt``; epic 1929's
+        Kolors backend swaps in ``KolorsPipeline.encode_prompt`` (ChatGLM3,
+        ``max_sequence_length=256``) here and changes nothing else.
+        """
+        prompt_embeds, _, pooled_prompt_embeds, _ = pipe.encode_prompt(
+            prompt=caption,
+            prompt_2=None,
+            device=device,
+            num_images_per_prompt=1,
+            do_classifier_free_guidance=False,
+        )
+        return prompt_embeds, pooled_prompt_embeds
+
+    def _lora_param_norms(self) -> tuple[float, float]:
+        unet = self._unet
+        if unet is None or not hasattr(unet, "named_parameters"):
+            return 0.0, 0.0
+        a_sq = 0.0
+        b_sq = 0.0
+        for name, param in unet.named_parameters():
+            if not getattr(param, "requires_grad", False):
+                continue
+            try:
+                value = float(param.detach().float().pow(2).sum().to("cpu"))
+            except Exception:
+                continue
+            if "lora_B" in name or "lora_b" in name:
+                b_sq += value
+            elif "lora_A" in name or "lora_a" in name:
+                a_sq += value
+        return round(a_sq**0.5, 6), round(b_sq**0.5, 6)
+
+    def _activate_lora_adapter(self, unet: Any) -> None:
+        for method_name in ("set_adapter", "enable_adapters"):
+            method = getattr(unet, method_name, None)
+            if method is None:
+                continue
+            try:
+                if method_name == "set_adapter":
+                    method("default")
+                else:
+                    method()
+                return
+            except Exception as exc:
+                emit_worker_event(
+                    "training_lora_adapter_activation_failed",
+                    kernel=self.kernel_id,
+                    method=method_name,
+                    error=str(exc),
+                )
+
+    def prepare_dataset(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        config: TrainingRunConfig,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        torch = self._torch
+        pipe = self._pipeline
+        vae = self._vae
+        resolution = bucket_resolution(config.resolution)
+        count = len(items)
+        self._latents = []
+        self._prompt_embeds = []
+        self._pooled_embeds = []
+        # SDXL micro-conditioning: [orig_h, orig_w, crop_top, crop_left,
+        # target_h, target_w]. We square center-crop, so original == target and
+        # the crop offset is 0. Built once and shared across the (bsz=1) loop.
+        self._add_time_ids = torch.tensor(
+            [[resolution, resolution, 0, 0, resolution, resolution]],
+            dtype=self._dtype,
+            device=self._device,
+        )
+        with torch.no_grad():
+            for index, item in enumerate(items):
+                if cancel_requested():
+                    raise InterruptedError("LoRA training canceled by user.")
+                image = _load_training_image(item["imagePath"], resolution)
+                # Encode in fp32 (VAE was upcast in load) to avoid fp16 NaN latents.
+                pixel = _image_to_tensor(torch, image, torch.float32, self._device)
+                latent = vae.encode(pixel).latent_dist.sample(generator=self._generator)
+                latent = latent * self._vae_scaling
+                self._latents.append(latent.detach().to("cpu"))
+
+                prompt_embeds, pooled = self._encode_prompt(
+                    pipe, str(item.get("caption") or ""), self._device
+                )
+                self._prompt_embeds.append(prompt_embeds.detach().to("cpu"))
+                self._pooled_embeds.append(pooled.detach().to("cpu"))
+
+                if (index + 1) % 4 == 0 or index + 1 == count:
+                    progress(
+                        "running",
+                        "caching_latents",
+                        _scaled(_CACHE_PROGRESS_START, _CACHE_PROGRESS_END, index + 1, count),
+                        f"Encoded {index + 1} of {count} dataset item(s).",
+                    )
+        return {"itemCount": count, "resolution": resolution}
+
+    def train_step(self, *, step: int, total_steps: int, config: TrainingRunConfig) -> float:
+        torch = self._torch
+        unet = self._unet
+        device = self._device
+        index = (step - 1) % len(self._latents)
+        latents = self._latents[index].to(device=device, dtype=self._dtype)
+        prompt_embeds = self._prompt_embeds[index].to(device=device, dtype=self._dtype)
+        pooled = self._pooled_embeds[index].to(device=device, dtype=self._dtype)
+
+        noise = seeded_sample(
+            torch, torch.randn, latents.shape, generator=self._generator, device=device, dtype=latents.dtype
+        )
+        # SDXL trains on the discrete DDPM schedule: integer timesteps + add_noise,
+        # not the flow-matching interpolation the DiT kernels use. The cpu generator
+        # (MPS-safe) draws on its own device, then we move to the compute device.
+        generator_device = self._generator.device
+        timesteps = torch.randint(
+            0,
+            self._num_train_timesteps,
+            (latents.shape[0],),
+            generator=self._generator,
+            device=generator_device,
+        ).to(device)
+        noisy = self._noise_scheduler.add_noise(latents, noise, timesteps)
+        added_cond_kwargs = {"text_embeds": pooled, "time_ids": self._add_time_ids}
+        model_pred = unet(
+            noisy,
+            timesteps,
+            encoder_hidden_states=prompt_embeds,
+            added_cond_kwargs=added_cond_kwargs,
+            return_dict=False,
+        )[0]
+        if self._prediction_type == "v_prediction":
+            target = self._noise_scheduler.get_velocity(latents, noise, timesteps)
+        else:
+            target = noise
+        if not self._diagnosed_forward:
+            emit_worker_event(
+                "training_forward_shapes",
+                kernel=self.kernel_id,
+                latent=list(latents.shape),
+                prediction=list(model_pred.shape),
+                target=list(target.shape),
+                predictionType=self._prediction_type,
+            )
+            self._diagnosed_forward = True
+
+        loss = training_loss(torch, model_pred, target, config.loss_type)
+        accum = max(1, config.gradient_accumulation)
+        (loss / accum).backward()
+        if step % accum == 0 or step == total_steps:
+            self._optimizer.step()
+            self._optimizer.zero_grad()
+            if self._lr_scheduler is not None:
+                self._lr_scheduler.step()
+        return float(loss.detach().to("cpu"))
+
+    def save_checkpoint(self, *, step: int, output_dir: str, file_name: str) -> str | None:
+        stem = Path(file_name).stem or "lora"
+        checkpoint_name = f"{stem}-step{step:06d}.safetensors"
+        return self._save_lora(output_dir=output_dir, file_name=checkpoint_name)
+
+    def generate_samples(
+        self,
+        *,
+        step: int,
+        prompts: list[str],
+        output_dir: str,
+        file_name: str,
+        plan: dict[str, Any],
+        config: TrainingRunConfig,
+    ) -> list[dict[str, Any]]:
+        torch = self._torch
+        pipe = self._pipeline
+        unet = self._unet
+        if torch is None or pipe is None or unet is None or not prompts:
+            return []
+
+        sample_dir = Path(output_dir) / "samples" / f"step-{step:06d}"
+        sample_dir.mkdir(parents=True, exist_ok=True)
+        stem = Path(file_name).stem or "lora"
+        was_training = bool(getattr(unet, "training", False))
+        self._activate_lora_adapter(unet)
+        unet.eval()
+        edge = min(1024, bucket_resolution(config.resolution))
+        samples: list[dict[str, Any]] = []
+        try:
+            with torch.no_grad():
+                for index, prompt in enumerate(prompts[:4]):
+                    generator_device = self._device if str(self._device).startswith("cuda") else "cpu"
+                    generator = torch.Generator(generator_device).manual_seed(int(config.seed) + step + index)
+                    kwargs = {
+                        "prompt": prompt,
+                        "height": edge,
+                        "width": edge,
+                        "num_inference_steps": config.sample_steps,
+                        "guidance_scale": config.sample_guidance_scale,
+                        "generator": generator,
+                    }
+                    output = pipe(**filter_call_kwargs(pipe, kwargs))
+                    image = output.images[0].convert("RGB")
+                    sample_name = f"{stem}-step{step:06d}-{index + 1}.png"
+                    sample_path = sample_dir / sample_name
+                    image.save(sample_path)
+                    samples.append(
+                        {
+                            "step": step,
+                            "prompt": prompt,
+                            "path": str(sample_path),
+                            "relativePath": project_relative_path(plan, sample_path),
+                            "sampleSource": "live_adapter",
+                            "numInferenceSteps": config.sample_steps,
+                            "guidanceScale": config.sample_guidance_scale,
+                            "createdAt": utc_now(),
+                        }
+                    )
+        finally:
+            if was_training:
+                unet.train()
+        return samples
+
+    def save_final(self, *, output_dir: str, file_name: str) -> str:
+        return self._save_lora(output_dir=output_dir, file_name=file_name)
+
+    def _save_lora(self, *, output_dir: str, file_name: str) -> str:
+        from peft.utils import get_peft_model_state_dict
+
+        os.makedirs(output_dir, exist_ok=True)
+        lora_state_dict = get_peft_model_state_dict(self._unet)
+        type(self._pipeline).save_lora_weights(
+            output_dir,
+            unet_lora_layers=lora_state_dict,
+            weight_name=file_name,
+            safe_serialization=True,
+        )
+        lora_a_norm, lora_b_norm = self._lora_param_norms()
+        emit_worker_event(
+            "training_lora_weight_norm",
+            kernel=self.kernel_id,
+            fileName=file_name,
+            tensors=len(lora_state_dict),
+            loraANorm=lora_a_norm,
+            loraBNorm=lora_b_norm,
+        )
+        return os.path.join(output_dir, file_name)
+
+    def cleanup(self) -> None:
+        torch = self._torch
+        self._latents = []
+        self._prompt_embeds = []
+        self._pooled_embeds = []
+        self._add_time_ids = None
+        self._optimizer = None
+        self._unet = None
+        self._vae = None
+        self._pipeline = None
+        self._noise_scheduler = None
+        self._loaded_source = None
+        if torch is not None:
+            try:
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:
+                pass
+
+
+class SdxlLoraTrainer(ZImageLoraTrainer):
+    """Generic SDXL-UNet LoRA trainer.
+
+    Reuses :class:`ZImageLoraTrainer`'s backend-agnostic staged orchestration
+    (prepare → load → cache → train → checkpoint → save) with the SDXL U-Net
+    backend. Trained from a still-image dataset; the output is an ``sdxl`` family
+    LoRA the SDXL adapter loads at inference. This is the shared foundation epic
+    1929 extends for Kolors (subclass + swap the pipeline class + prompt encoder).
+    """
+
+    kernel_id = "sdxl_lora"
+
+    def _create_backend(self) -> _SdxlLoraBackend:
+        return _SdxlLoraBackend()
+
+
+# --------------------------------------------------------------------------- #
 # Native MLX LTX-2.3 LoRA backend (Apple Silicon)
 # --------------------------------------------------------------------------- #
 
@@ -2402,6 +2886,7 @@ class LensLoraTrainer:
 
 _TRAINING_KERNELS: dict[str, Callable[[], Any]] = {
     ZImageLoraTrainer.kernel_id: ZImageLoraTrainer,
+    SdxlLoraTrainer.kernel_id: SdxlLoraTrainer,
     LensLoraTrainer.kernel_id: LensLoraTrainer,
     LtxMlxLoraTrainer.kernel_id: LtxMlxLoraTrainer,
 }

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -281,6 +281,27 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "noImageEncoder": True,
         "durationHint": "A14B is heavier than 5B; keep clips at 5s or less. Native cadence is 16fps.",
     },
+    # Stable Video Diffusion (img2vid-XT): image-conditioned only, no text prompt.
+    # Runs through DiffusersVideoAdapter (StableVideoDiffusionPipeline). Emits a
+    # fixed ~25-frame burst, so num_frames is model-fixed (not duration-derived);
+    # motion_bucket_id / conditioning fps / noise_aug_strength drive the motion.
+    "svd": {
+        "label": "Stable Video Diffusion",
+        "family": "svd",
+        "adapter": "svd_video",
+        "repo": "stabilityai/stable-video-diffusion-img2vid-xt",
+        "variant": "fp16",
+        "capabilities": ["image_to_video"],
+        "recommendedMaxDuration": 4,
+        "hardMaxDuration": 4,
+        "steps": {"fast": 15, "balanced": 25, "best": 30},
+        "numFrames": 25,
+        "motionBucketId": 127,
+        "condFps": 7,
+        "noiseAugStrength": 0.02,
+        "decodeChunkSize": 8,
+        "durationHint": "Animates one source image into a fixed ~25-frame clip; no text prompt.",
+    },
 }
 
 
@@ -2222,6 +2243,10 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         self._evict_pipeline(torch)
         pipeline_class = self._pipeline_class(diffusers, request, target)
         kwargs: dict[str, Any] = {"torch_dtype": dtype}
+        # SVD-XT ships fp16-variant weights; request the variant so from_pretrained
+        # loads the half-precision files instead of the full-precision default.
+        if target.get("variant"):
+            kwargs["variant"] = target["variant"]
 
         if target["adapter"] == "wan_video":
             vae_class = getattr(diffusers, "AutoencoderKLWan", None)
@@ -2270,6 +2295,15 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         )
 
     def _pipeline_class(self, diffusers: Any, request: VideoRequest, target: dict[str, Any]) -> Any:
+        if target["adapter"] == "svd_video":
+            pipeline_class = getattr(diffusers, "StableVideoDiffusionPipeline", None)
+            if pipeline_class is None:
+                raise RuntimeError(
+                    "The installed diffusers package does not expose StableVideoDiffusionPipeline; "
+                    "install a diffusers build with Stable Video Diffusion support."
+                )
+            return pipeline_class
+
         if target["adapter"] == "wan_video":
             if request.mode == "text_to_video":
                 return getattr(diffusers, "WanPipeline")
@@ -2294,6 +2328,8 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         return f"{self._repo_for_request(request, target)}:{self._pipeline_kind(request, target)}"
 
     def _pipeline_kind(self, request: VideoRequest, target: dict[str, Any]) -> str:
+        if target["adapter"] == "svd_video":
+            return "image"
         if target["adapter"] == "wan_video":
             if request.mode == "text_to_video":
                 return "text"
@@ -2327,11 +2363,16 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
 
     def _num_frames(self, request: VideoRequest) -> int:
         raw_frames = max(1, int(round(request.duration * request.fps)))
-        adapter = model_target(request.model)["adapter"]
+        target = model_target(request.model)
+        adapter = target["adapter"]
         if adapter == "ltx_video":
             return ltx_frame_count(raw_frames)
         if adapter == "wan_video":
             return max(5, raw_frames - ((raw_frames - 1) % 4))
+        if adapter == "svd_video":
+            # SVD emits a fixed-length clip defined by the checkpoint (XT = 25);
+            # duration only paces playback, so it never drives the frame count.
+            return safe_int(request.advanced.get("numFrames"), int(target.get("numFrames", 25)), 1, 25)
         return raw_frames
 
     def _pipeline_kwargs(
@@ -2349,6 +2390,33 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         torch = importlib.import_module("torch")
         device = select_torch_device(torch)
         generator = torch.Generator("cuda" if device == "cuda" else "cpu").manual_seed(seed)
+        if target["adapter"] == "svd_video":
+            # StableVideoDiffusionPipeline takes no prompt/height/width/guidance: it
+            # animates the source image, conditioned on motion strength + fps. The
+            # output size follows the input image, so we resize it to the request.
+            try:
+                noise_aug = float(
+                    request.advanced.get("noiseAugStrength", target.get("noiseAugStrength", 0.02))
+                )
+            except (TypeError, ValueError):
+                noise_aug = float(target.get("noiseAugStrength", 0.02))
+            svd_kwargs: dict[str, Any] = {
+                "image": first_image.resize((request.width, request.height)) if first_image is not None else None,
+                "num_frames": num_frames,
+                "num_inference_steps": self._num_inference_steps(request, target),
+                "decode_chunk_size": safe_int(
+                    request.advanced.get("decodeChunkSize"), int(target.get("decodeChunkSize", 8)), 1, 64
+                ),
+                "motion_bucket_id": safe_int(
+                    request.advanced.get("motionBucketId"), int(target.get("motionBucketId", 127)), 1, 255
+                ),
+                "fps": safe_int(
+                    request.advanced.get("conditioningFps"), int(target.get("condFps", 7)), 1, 30
+                ),
+                "noise_aug_strength": noise_aug,
+                "generator": generator,
+            }
+            return filter_call_kwargs(pipe, svd_kwargs)
         kwargs: dict[str, Any] = {
             "prompt": request.prompt,
             "negative_prompt": request.negative_prompt or default_negative_prompt(target),

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -861,6 +861,68 @@
       }
     },
     {
+      "id": "svd",
+      "name": "Stable Video Diffusion",
+      "family": "svd",
+      "type": "video",
+      "adapter": "svd_video",
+      "capabilities": ["image_to_video"],
+      // SVD is image-conditioned only — it animates a source image and ignores
+      // any text prompt. The Video Studio keys off this to drop the prompt
+      // requirement (the prompt field stays hidden/optional).
+      "promptless": true,
+      "downloads": [
+        {
+          // Diffusers checkpoint (img2vid-XT): UNet + VAE + CLIP image encoder.
+          // Stability AI Community License — commercial use free under $1M annual
+          // revenue, ungated (no HF token). Worker loads the fp16 variant.
+          "provider": "huggingface",
+          "repo": "stabilityai/stable-video-diffusion-img2vid-xt",
+          "files": [],
+          "estimatedSizeBytes": 9560000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/stabilityai/stable-video-diffusion-img2vid-xt"
+      },
+      "defaults": {
+        "duration": 4,
+        "fps": 7,
+        "resolution": "1024x576",
+        "quality": "balanced"
+      },
+      "limits": {
+        // SVD-XT emits a fixed ~25-frame burst; "duration" only sets playback
+        // pacing (export fps), so the duration choice is single-valued.
+        "durations": [4],
+        "recommendedMaxDuration": 4,
+        "hardMaxDuration": 4,
+        "fps": [6, 7, 8, 10, 12, 25],
+        "resolutions": ["1024x576", "576x1024"]
+      },
+      "loraCompatibility": {
+        // No SVD LoRA ecosystem (generation-only); declare the family so the
+        // picker never offers cross-architecture LoRAs (per sc-1927).
+        "families": ["svd"],
+        "types": []
+      },
+      "ui": {
+        "label": "Stable Video Diffusion",
+        "description": "Stability AI Stable Video Diffusion (img2vid-XT) — animates a single source image into a short ~25-frame clip; image-conditioned only, no text prompt. Stability AI Community License: commercial use free under $1M annual revenue (paid Enterprise above), ungated. ~9.5GB fp16; motion strength + conditioning fps tunable in advanced settings.",
+        "recommendedFor": ["image_to_video"],
+        "durationHint": "Produces a fixed ~25-frame clip from one image; adjust playback fps for pacing.",
+        "promptGuide": {
+          "title": "Stable Video Diffusion Guide",
+          "path": "/prompt-guides/svd.md",
+          "sources": [
+            { "label": "SVD img2vid-XT model card", "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt" },
+            { "label": "Stability AI Community License", "url": "https://stability.ai/community-license-agreement" },
+            { "label": "Diffusers SVD pipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/svd" }
+          ]
+        }
+      }
+    },
+    {
       "id": "wan_2_2",
       "name": "Wan2.2",
       "family": "wan-video",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -712,6 +712,64 @@
       }
     },
     {
+      "id": "sdxl",
+      "name": "Stable Diffusion XL",
+      "family": "sdxl",
+      "type": "image",
+      "adapter": "sdxl_diffusers",
+      "capabilities": ["text_to_image", "edit_image", "style_variations"],
+      "downloads": [
+        {
+          // Diffusers checkpoint: SDXL base 1.0 (UNet + dual CLIP text encoders
+          // + VAE). Whole-repo download; the worker loads the fp16 variant.
+          // CreativeML OpenRAIL++-M: use-based restrictions, commercial use OK,
+          // ungated (no HF token required).
+          "provider": "huggingface",
+          "repo": "stabilityai/stable-diffusion-xl-base-1.0",
+          "files": [],
+          "estimatedSizeBytes": 6938040320
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/stabilityai/stable-diffusion-xl-base-1.0"
+      },
+      "defaults": {
+        // SDXL base 1.0: EulerDiscreteScheduler default; real CFG with a
+        // negative prompt. ~30 steps at guidance 7.0 is a solid baseline.
+        "resolution": "1024x1024",
+        "steps": 30,
+        "guidanceScale": 7.0,
+        "count": 4
+      },
+      "limits": {
+        // Native 1024x1024 plus the canonical SDXL aspect-ratio buckets.
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        // Declare the real family so the picker only offers sdxl-family LoRAs
+        // (per sc-1927: an empty families list would match EVERY LoRA). SDXL is
+        // the most common community LoRA architecture, so imported sdxl LoRAs
+        // become compatible immediately.
+        "families": ["sdxl"],
+        "types": ["style", "enhance", "character"]
+      },
+      "ui": {
+        "label": "Stable Diffusion XL",
+        "description": "Stability AI Stable Diffusion XL base 1.0 — the widely-supported open text-to-image foundation with the largest LoRA/finetune ecosystem. CreativeML OpenRAIL++-M (commercial use OK, ungated). SDXL UNet + dual CLIP text encoders; ~6.9GB fp16, real CFG + negative prompt. Recommended ~30 steps at guidance 7.0; native 1024x1024.",
+        "recommendedFor": ["text_to_image", "edit_image", "style_variations"],
+        "promptGuide": {
+          "title": "Stable Diffusion XL Prompt Guide",
+          "path": "/prompt-guides/sdxl.md",
+          "sources": [
+            { "label": "SDXL base 1.0 model card", "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0" },
+            { "label": "SDXL technical report", "url": "https://arxiv.org/abs/2307.01952" },
+            { "label": "Diffusers SDXL pipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl" }
+          ]
+        }
+      }
+    },
+    {
       "id": "ltx_2_3",
       "name": "LTX-2.3",
       "family": "ltx-video",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -141,6 +141,7 @@ string_enum! {
         FluxDiffusers => "flux_diffusers",
         ChromaDiffusers => "chroma_diffusers",
         KolorsDiffusers => "kolors_diffusers",
+        SdxlDiffusers => "sdxl_diffusers",
         ProceduralVideo => "procedural_video",
         ProceduralPersonTracking => "procedural_person_tracking",
         FfmpegFrameExtract => "ffmpeg-frame-extract",
@@ -1364,6 +1365,18 @@ mod tests {
             serde_json::to_value(RecipeAdapter::ChromaDiffusers)
                 .expect("chroma adapter serializes"),
             json!("chroma_diffusers")
+        );
+    }
+
+    #[test]
+    fn sdxl_diffusers_recipe_adapter_round_trips() {
+        assert_eq!(RecipeAdapter::SdxlDiffusers.as_str(), "sdxl_diffusers");
+        let parsed: RecipeAdapter =
+            serde_json::from_value(json!("sdxl_diffusers")).expect("sdxl adapter parses");
+        assert_eq!(parsed, RecipeAdapter::SdxlDiffusers);
+        assert_eq!(
+            serde_json::to_value(RecipeAdapter::SdxlDiffusers).expect("sdxl adapter serializes"),
+            json!("sdxl_diffusers")
         );
     }
 }

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -223,6 +223,7 @@ pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
         "sdxl" => Some("sdxl_diffusers"),
         "ltx-video" => Some("ltx_video"),
         "wan-video" => Some("wan_video"),
+        "svd" => Some("svd_video"),
         _ => None,
     }
 }
@@ -255,6 +256,9 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
             "video_bridge",
             "replace_person",
         ],
+        // Stable Video Diffusion is image-conditioned only (no text prompt) and
+        // does not support the timeline/replacement modes.
+        ("video", "svd") => vec!["image_to_video"],
         _ => Vec::new(),
     }
 }
@@ -847,6 +851,16 @@ mod tests {
         assert_eq!(
             model_capabilities_for_type_and_family("image", "sdxl"),
             vec!["text_to_image", "edit_image", "style_variations"],
+        );
+    }
+
+    #[test]
+    fn svd_family_maps_to_svd_video_adapter_and_image_to_video_only() {
+        assert_eq!(model_adapter_for_family("svd"), Some("svd_video"));
+        // SVD is image-conditioned only — no text-to-video or timeline modes.
+        assert_eq!(
+            model_capabilities_for_type_and_family("video", "svd"),
+            vec!["image_to_video"],
         );
     }
 

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -220,6 +220,7 @@ pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
         "flux" => Some("flux_diffusers"),
         "chroma" => Some("chroma_diffusers"),
         "kolors" => Some("kolors_diffusers"),
+        "sdxl" => Some("sdxl_diffusers"),
         "ltx-video" => Some("ltx_video"),
         "wan-video" => Some("wan_video"),
         _ => None,
@@ -238,6 +239,7 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         ("image", "flux") => vec!["text_to_image", "style_variations"],
         ("image", "chroma") => vec!["text_to_image", "style_variations"],
         ("image", "kolors") => vec!["text_to_image", "character_image", "style_variations"],
+        ("image", "sdxl") => vec!["text_to_image", "edit_image", "style_variations"],
         ("video", "ltx-video") => vec![
             "image_to_video",
             "text_to_video",
@@ -836,6 +838,15 @@ mod tests {
         assert_eq!(
             model_capabilities_for_type_and_family("image", "kolors"),
             vec!["text_to_image", "character_image", "style_variations"],
+        );
+    }
+
+    #[test]
+    fn sdxl_family_maps_to_sdxl_diffusers_adapter_and_image_capabilities() {
+        assert_eq!(model_adapter_for_family("sdxl"), Some("sdxl_diffusers"));
+        assert_eq!(
+            model_capabilities_for_type_and_family("image", "sdxl"),
+            vec!["text_to_image", "edit_image", "style_variations"],
         );
     }
 

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -399,6 +399,7 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
         schema_version: TRAINING_CONTRACT_SCHEMA_VERSION,
         targets: vec![
             z_image_turbo_lora_target(),
+            sdxl_lora_target(),
             lens_turbo_lora_target(),
             ltx_video_lora_target(),
         ],
@@ -409,6 +410,7 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
 /// The built-in training presets Rust owns out of the box.
 pub fn builtin_training_presets() -> TrainingPresetRegistry {
     let target = z_image_turbo_lora_target();
+    let sdxl_target = sdxl_lora_target();
     TrainingPresetRegistry {
         schema_version: TRAINING_CONTRACT_SCHEMA_VERSION,
         presets: vec![
@@ -529,6 +531,70 @@ pub fn builtin_training_presets() -> TrainingPresetRegistry {
                     "order": 60
                 })),
             ),
+            sdxl_preset(
+                &sdxl_target,
+                "sdxl_lora.character.adamw8bit.balanced",
+                "Character balanced",
+                &["character"],
+                ("adamw8bit", "balanced"),
+                |config| config,
+                object(json!({
+                    "description": "Balanced first run for 12-25 clean character images on SDXL.",
+                    "default": true,
+                    "order": 10
+                })),
+            ),
+            sdxl_preset(
+                &sdxl_target,
+                "sdxl_lora.character.adamw8bit.conservative",
+                "Character conservative",
+                &["character"],
+                ("adamw8bit", "conservative"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.learning_rate = number(0.00005);
+                    config
+                },
+                object(json!({
+                    "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+                    "order": 20
+                })),
+            ),
+            sdxl_preset(
+                &sdxl_target,
+                "sdxl_lora.style.adamw8bit.balanced",
+                "Style balanced",
+                &["style"],
+                ("adamw8bit", "balanced"),
+                |mut config| {
+                    config.rank = 32;
+                    config.alpha = 16;
+                    config
+                },
+                object(json!({
+                    "description": "Higher-capacity style LoRA defaults for texture and look transfer.",
+                    "order": 30
+                })),
+            ),
+            sdxl_preset(
+                &sdxl_target,
+                "sdxl_lora.character.adamw8bit.low_vram",
+                "Low VRAM character",
+                &["character"],
+                ("adamw8bit", "low_vram"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.resolution = 768;
+                    config.steps = 1200;
+                    config
+                },
+                object(json!({
+                    "description": "768px preset for tighter-VRAM SDXL training.",
+                    "order": 40
+                })),
+            ),
         ],
         extra: ExtraFields::new(),
     }
@@ -569,6 +635,58 @@ where
     config
         .advanced
         .insert("timestepBias".to_owned(), json!("high_noise"));
+    config.advanced.insert("lossType".to_owned(), json!("mse"));
+    config
+        .advanced
+        .insert("gradientCheckpointing".to_owned(), json!(true));
+    config
+        .advanced
+        .insert("cacheTextEmbeddings".to_owned(), json!(true));
+    config
+        .advanced
+        .insert("weightDecay".to_owned(), json!(0.0001));
+    TrainingPreset {
+        id: id.to_owned(),
+        version: 1,
+        target_id: target.id.clone(),
+        name: name.to_owned(),
+        recommended_for: recommended_for
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+        optimizer: optimizer.to_owned(),
+        quality_preset: quality_preset.to_owned(),
+        config,
+        ui,
+        extra: ExtraFields::new(),
+    }
+}
+
+fn sdxl_preset<F>(
+    target: &TrainingTarget,
+    id: &str,
+    name: &str,
+    recommended_for: &[&str],
+    optimizer_quality: (&str, &str),
+    mutate: F,
+    ui: JsonObject,
+) -> TrainingPreset
+where
+    F: FnOnce(TrainingConfig) -> TrainingConfig,
+{
+    let (optimizer, quality_preset) = optimizer_quality;
+    let mut config = mutate(target.defaults.clone());
+    config.optimizer = optimizer.to_owned();
+    config
+        .advanced
+        .insert("qualityPreset".to_owned(), json!(quality_preset));
+    // SDXL uses real CFG, so previews render at a positive guidance (the
+    // flow-matching Z-Image presets sample at guidance 0.0). No de-distill
+    // training adapter applies (SDXL base is not step-distilled).
+    config.advanced.insert("sampleSteps".to_owned(), json!(30));
+    config
+        .advanced
+        .insert("sampleGuidanceScale".to_owned(), json!(7.0));
     config.advanced.insert("lossType".to_owned(), json!("mse"));
     config
         .advanced
@@ -828,6 +946,84 @@ fn ltx_video_lora_target() -> TrainingTarget {
             "appleSiliconOnly": true,
             "backend": "mlx",
             "datasetModality": "image"
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Generic SDXL-UNet image LoRA training, applied at inference to the SDXL base
+/// model (and the shared foundation epic 1929 extends for Kolors).
+///
+/// SDXL is the first U-Net (non-DiT) training target: the `sdxl_lora` kernel
+/// runs an epsilon/v-prediction loop on a DDPM noise schedule with the SDXL
+/// `added_cond_kwargs` (pooled text embeds + add_time_ids), unlike the
+/// flow-matching transformer kernels. The LoRA injects into the SDXL UNet's
+/// separate `to_q`/`to_k`/`to_v` attention projections plus the `to_out.0`
+/// output projection; the output registers as an `sdxl` family LoRA the SDXL
+/// adapter loads at generation time.
+fn sdxl_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "sdxl_lora".to_owned(),
+        name: "Stable Diffusion XL LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "sdxl".to_owned(),
+        base_model: "sdxl".to_owned(),
+        base_model_repo: Some("stabilityai/stable-diffusion-xl-base-1.0".to_owned()),
+        kernel: "sdxl_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 1500,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                // Learning-rate scheduler (see the Z-Image target); the worker
+                // honors `constant`/`linear`/`cosine` with an optional warmup.
+                "lrScheduler": "constant",
+                // SDXL UNet attention modules: separate q/k/v projections plus the
+                // attention output projection. These match the PEFT target names
+                // the diffusers SDXL DreamBooth-LoRA reference uses.
+                "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+                // SDXL uses real classifier-free guidance, so in-training previews
+                // render at a positive guidance (unlike distilled Z-Image at 0.0).
+                "sampleEvery": 250,
+                "sampleSteps": 30,
+                "sampleGuidanceScale": 7.0,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            "resolutions": [768, 1024],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "qualityPresets": ["speed", "balanced", "quality"],
+            "outputScopes": ["project", "global"]
+        })),
+        ui: object(json!({
+            "label": "Stable Diffusion XL LoRA",
+            "description": "Train an image LoRA for Stable Diffusion XL. The generic SDXL-UNet trainer and the shared foundation for SDXL-family models.",
+            "recommendedFor": ["character", "style"]
         })),
         extra: ExtraFields::new(),
     }

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -160,6 +160,60 @@ fn builtin_registry_exposes_z_image_turbo_target() {
 }
 
 #[test]
+fn builtin_registry_exposes_sdxl_target() {
+    let registry = builtin_training_targets();
+    let target = registry
+        .targets
+        .iter()
+        .find(|target| target.id == "sdxl_lora")
+        .expect("sdxl_lora target present");
+
+    assert_eq!(target.modality, TrainingModality::Image);
+    assert_eq!(target.output_kind, TrainingOutputKind::Lora);
+    assert_eq!(target.family, "sdxl");
+    assert_eq!(target.base_model, "sdxl");
+    assert_eq!(target.kernel, "sdxl_lora");
+    assert_eq!(target.defaults.rank, 16);
+    assert_eq!(target.defaults.resolution, 1024);
+    // Real CFG previews (positive guidance), unlike the distilled Z-Image target.
+    assert_eq!(
+        target.defaults.advanced.get("sampleGuidanceScale"),
+        Some(&serde_json::json!(7.0))
+    );
+    // SDXL UNet attention modules drive the LoRA injection.
+    assert_eq!(
+        target.defaults.advanced.get("loraTargetModules"),
+        Some(&serde_json::json!(["to_q", "to_k", "to_v", "to_out.0"]))
+    );
+}
+
+#[test]
+fn builtin_presets_expose_sdxl_character_default() {
+    let registry = sceneworks_core::training::builtin_training_presets();
+    let default_character = registry
+        .presets
+        .iter()
+        .find(|preset| preset.id == "sdxl_lora.character.adamw8bit.balanced")
+        .expect("sdxl character balanced preset present");
+
+    assert_eq!(default_character.target_id, "sdxl_lora");
+    assert_eq!(default_character.optimizer, "adamw8bit");
+    assert_eq!(default_character.config.rank, 16);
+    assert_eq!(
+        default_character.ui.get("default"),
+        Some(&serde_json::json!(true))
+    );
+
+    let style = registry
+        .presets
+        .iter()
+        .find(|preset| preset.id == "sdxl_lora.style.adamw8bit.balanced")
+        .expect("sdxl style preset present");
+    assert_eq!(style.config.rank, 32);
+    assert_eq!(style.config.alpha, 16);
+}
+
+#[test]
 fn builtin_registry_exposes_ltx_video_target() {
     let registry = builtin_training_targets();
     let target = registry

--- a/documents/TRAINING_QUICKSTART.md
+++ b/documents/TRAINING_QUICKSTART.md
@@ -238,6 +238,26 @@ AI Toolkit features such as EMA and Differential Output Preservation are not
 exposed as SceneWorks presets yet because the current worker does not implement
 their extra training passes.
 
+> **Stable Diffusion XL LoRA (`sdxl_lora`):** the `sdxl_lora` kernel
+> (`target.kernel`) trains an image LoRA for Stable Diffusion XL base 1.0, and is
+> the **generic SDXL-UNet trainer** — the shared foundation epic 1929 (Kolors
+> LoRA training) extends by swapping the pipeline class + text encoder. It is the
+> first **U-Net (non-DiT)** trainer in the repo: unlike the flow-matching
+> transformer kernels (Z-Image / Lens / LTX), it runs the SDXL **ε/v-prediction**
+> objective on a **DDPM** noise schedule (integer timesteps) with the SDXL
+> `added_cond_kwargs` (pooled CLIP text embeds + `add_time_ids`). SDXL base is
+> **not** step-distilled, so — unlike Z-Image — it needs **no de-distill adapter**;
+> and it uses real classifier-free guidance, so in-training previews render at a
+> positive `sampleGuidanceScale` (7.0). The LoRA injects into the UNet attention
+> projections (`to_q`/`to_k`/`to_v`/`to_out.0`) and is saved as an `sdxl`-family
+> diffusers safetensors the SDXL adapter loads at generation. Install **Stable
+> Diffusion XL** (`stabilityai/stable-diffusion-xl-base-1.0`) from the Model
+> Manager before a real run; defaults are rank 16 / alpha 16 / lr 1e-4 / ~1500
+> steps / 1024px, with character / style / low-VRAM presets. CreativeML
+> OpenRAIL++-M (commercial-OK, ungated). Watch the worker
+> `training_lora_weight_norm` event — a growing `loraBNorm` across checkpoints
+> confirms the adapter is learning.
+
 ## 5. Where the output goes
 
 On a successful real run the adapter is registered as a normal SceneWorks LoRA:

--- a/tests/fixtures/rust_migration_contracts/training/preset-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/preset-registry.json
@@ -273,6 +273,175 @@
         "description": "12GB-friendly 768px preset based on public Z-Image Turbo training reports.",
         "order": 60
       }
+    },
+    {
+      "id": "sdxl_lora.character.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "sdxl_lora",
+      "name": "Character balanced",
+      "recommendedFor": ["character"],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "mixedPrecision": "bf16",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "networkType": "lora",
+          "lossType": "mse",
+          "weightDecay": 0.0001,
+          "lrScheduler": "constant",
+          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+          "sampleEvery": 250,
+          "sampleSteps": 30,
+          "sampleGuidanceScale": 7.0,
+          "qualityPreset": "balanced",
+          "outputScope": "project",
+          "requestedGpu": "auto"
+        }
+      },
+      "ui": {
+        "description": "Balanced first run for 12-25 clean character images on SDXL.",
+        "default": true,
+        "order": 10
+      }
+    },
+    {
+      "id": "sdxl_lora.character.adamw8bit.conservative",
+      "version": 1,
+      "targetId": "sdxl_lora",
+      "name": "Character conservative",
+      "recommendedFor": ["character"],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "conservative",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.00005,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "mixedPrecision": "bf16",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "networkType": "lora",
+          "lossType": "mse",
+          "weightDecay": 0.0001,
+          "lrScheduler": "constant",
+          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+          "sampleEvery": 250,
+          "sampleSteps": 30,
+          "sampleGuidanceScale": 7.0,
+          "qualityPreset": "conservative",
+          "outputScope": "project",
+          "requestedGpu": "auto"
+        }
+      },
+      "ui": {
+        "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+        "order": 20
+      }
+    },
+    {
+      "id": "sdxl_lora.style.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "sdxl_lora",
+      "name": "Style balanced",
+      "recommendedFor": ["style"],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 32,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "mixedPrecision": "bf16",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "networkType": "lora",
+          "lossType": "mse",
+          "weightDecay": 0.0001,
+          "lrScheduler": "constant",
+          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+          "sampleEvery": 250,
+          "sampleSteps": 30,
+          "sampleGuidanceScale": 7.0,
+          "qualityPreset": "balanced",
+          "outputScope": "project",
+          "requestedGpu": "auto"
+        }
+      },
+      "ui": {
+        "description": "Higher-capacity style LoRA defaults for texture and look transfer.",
+        "order": 30
+      }
+    },
+    {
+      "id": "sdxl_lora.character.adamw8bit.low_vram",
+      "version": 1,
+      "targetId": "sdxl_lora",
+      "name": "Low VRAM character",
+      "recommendedFor": ["character"],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "low_vram",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.0001,
+        "steps": 1200,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 768,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "mixedPrecision": "bf16",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "networkType": "lora",
+          "lossType": "mse",
+          "weightDecay": 0.0001,
+          "lrScheduler": "constant",
+          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+          "sampleEvery": 250,
+          "sampleSteps": 30,
+          "sampleGuidanceScale": 7.0,
+          "qualityPreset": "low_vram",
+          "outputScope": "project",
+          "requestedGpu": "auto"
+        }
+      },
+      "ui": {
+        "description": "768px preset for tighter-VRAM SDXL training.",
+        "order": 40
+      }
     }
   ]
 }

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -58,6 +58,61 @@
       }
     },
     {
+      "id": "sdxl_lora",
+      "name": "Stable Diffusion XL LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "sdxl",
+      "baseModel": "sdxl",
+      "baseModelRepo": "stabilityai/stable-diffusion-xl-base-1.0",
+      "kernel": "sdxl_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "mixedPrecision": "bf16",
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "networkType": "lora",
+          "lossType": "mse",
+          "weightDecay": 0.0001,
+          "lrScheduler": "constant",
+          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+          "sampleEvery": 250,
+          "sampleSteps": 30,
+          "sampleGuidanceScale": 7.0,
+          "qualityPreset": "balanced",
+          "outputScope": "project",
+          "requestedGpu": "auto"
+        }
+      },
+      "limits": {
+        "rank": [4, 128],
+        "alpha": [1, 128],
+        "steps": [200, 6000],
+        "resolutions": [768, 1024],
+        "batchSize": [1, 4],
+        "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt"],
+        "lrSchedulers": ["constant", "linear", "cosine"],
+        "qualityPresets": ["speed", "balanced", "quality"],
+        "outputScopes": ["project", "global"]
+      },
+      "ui": {
+        "label": "Stable Diffusion XL LoRA",
+        "description": "Train an image LoRA for Stable Diffusion XL. The generic SDXL-UNet trainer and the shared foundation for SDXL-family models.",
+        "recommendedFor": ["character", "style"]
+      }
+    },
+    {
       "id": "lens_turbo_lora",
       "name": "Lens LoRA",
       "modality": "image",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -4342,6 +4342,121 @@ def test_video_adapter_override_aliases_and_unknown_values(monkeypatch):
         raise AssertionError("Unknown video adapter override should fail loudly.")
 
 
+def test_create_video_adapter_routes_svd_to_diffusers(monkeypatch):
+    # SVD is a diffusers pipeline (not the native LTX stack), so it routes to the
+    # generic DiffusersVideoAdapter. Force the non-MPS path so MLX eligibility
+    # (which SVD is not part of) doesn't shadow the assertion on Apple Silicon.
+    monkeypatch.delenv("SCENEWORKS_VIDEO_ADAPTER", raising=False)
+    monkeypatch.setattr("scene_worker.video_adapters._mps_available", lambda: False)
+    adapter = create_video_adapter({"payload": {"model": "svd", "mode": "image_to_video"}})
+    assert adapter.__class__.__name__ == "DiffusersVideoAdapter"
+
+
+def test_svd_video_model_target_defaults():
+    target = VIDEO_MODEL_TARGETS["svd"]
+    assert target["adapter"] == "svd_video"
+    assert target["family"] == "svd"
+    # Image-conditioned only — no text_to_video or timeline modes.
+    assert target["capabilities"] == ["image_to_video"]
+    assert target["repo"] == "stabilityai/stable-video-diffusion-img2vid-xt"
+    assert target["variant"] == "fp16"
+    # Fixed-length clip defined by the checkpoint.
+    assert target["numFrames"] == 25
+
+
+def test_svd_num_frames_is_fixed_regardless_of_duration():
+    adapter = DiffusersVideoAdapter()
+    # Duration/fps would imply 60 frames for a 6s clip, but SVD emits its fixed
+    # 25-frame burst regardless.
+    request = video_request_from_job(
+        {"id": "job-svd", "payload": {"projectId": "p", "mode": "image_to_video", "model": "svd", "duration": 6, "fps": 10}}
+    )
+    assert adapter._num_frames(request) == 25
+
+
+def test_svd_pipeline_class_resolves_stable_video_diffusion():
+    adapter = DiffusersVideoAdapter()
+    target = VIDEO_MODEL_TARGETS["svd"]
+    request = video_request_from_job({"id": "j", "payload": {"projectId": "p", "mode": "image_to_video", "model": "svd"}})
+    fake_diffusers = SimpleNamespace(StableVideoDiffusionPipeline="SVD_PIPE_CLASS")
+    assert adapter._pipeline_class(fake_diffusers, request, target) == "SVD_PIPE_CLASS"
+    # Missing pipeline class fails loudly rather than silently mis-routing.
+    try:
+        adapter._pipeline_class(SimpleNamespace(), request, target)
+    except RuntimeError as exc:
+        assert "StableVideoDiffusionPipeline" in str(exc)
+    else:
+        raise AssertionError("SVD must require StableVideoDiffusionPipeline.")
+
+
+def test_svd_pipeline_kwargs_build_image_conditioning_without_prompt(monkeypatch):
+    # The SVD branch of _pipeline_kwargs animates the source image with motion
+    # controls and passes NO prompt/height/width/guidance (unlike Wan/LTX).
+    adapter = DiffusersVideoAdapter()
+    target = VIDEO_MODEL_TARGETS["svd"]
+
+    class FakeGen:
+        def manual_seed(self, _seed):
+            return self
+
+    fake_torch = SimpleNamespace(Generator=lambda _device: FakeGen())
+    monkeypatch.setattr(
+        "scene_worker.video_adapters.importlib.import_module",
+        lambda name: fake_torch if name == "torch" else importlib.import_module(name),
+    )
+    monkeypatch.setattr("scene_worker.video_adapters.select_torch_device", lambda *_a, **_k: "cpu")
+
+    class FakeImage:
+        def resize(self, _size):
+            return "RESIZED_IMAGE"
+
+    class FakePipe:
+        # filter_call_kwargs keeps only named params, so this signature gates
+        # which kwargs survive — proving the SVD branch produces these and no prompt.
+        def __call__(
+            self,
+            *,
+            image=None,
+            num_frames=None,
+            num_inference_steps=None,
+            decode_chunk_size=None,
+            motion_bucket_id=None,
+            fps=None,
+            noise_aug_strength=None,
+            generator=None,
+        ):
+            return None
+
+    request = video_request_from_job(
+        {
+            "id": "job-svd",
+            "payload": {
+                "projectId": "p",
+                "mode": "image_to_video",
+                "model": "svd",
+                "advanced": {"motionBucketId": 90, "conditioningFps": 6},
+            },
+        }
+    )
+    kwargs = adapter._pipeline_kwargs(
+        pipe=FakePipe(),
+        project_path=Path("/tmp/project"),
+        request=request,
+        target=target,
+        first_image=FakeImage(),
+        last_image=None,
+        seed=7,
+        num_frames=25,
+    )
+    assert kwargs["image"] == "RESIZED_IMAGE"
+    assert kwargs["num_frames"] == 25
+    assert kwargs["motion_bucket_id"] == 90
+    assert kwargs["fps"] == 6
+    assert kwargs["noise_aug_strength"] == 0.02
+    assert "prompt" not in kwargs
+    assert "guidance_scale" not in kwargs
+
+
 def test_mlx_routing_is_mode_aware_on_mps(monkeypatch):
     # On an MPS host the MLX adapter only handles text_to_video / image_to_video;
     # every other mode must stay on the PyTorch path or it fails in ensure_models.

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1538,6 +1538,94 @@ def test_sdxl_num_inference_steps_default_and_override():
     assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 999}), sdxl) == 80
 
 
+def test_sdxl_adapter_applies_sdxl_lora(tmp_path):
+    # A trained sdxl-family LoRA loads onto the SDXL pipeline via
+    # StableDiffusionXLPipeline.load_lora_weights and its weight is applied (sc-1943).
+    lora = tmp_path / "aurora_style.safetensors"
+    lora.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    adapter = SdxlDiffusersAdapter()
+    request = SimpleNamespace(
+        model="sdxl",
+        mode="text_to_image",
+        loras=[
+            {
+                "id": "aurora_style",
+                "installedPath": str(lora),
+                "weight": 0.75,
+                "compatibility": {"families": ["sdxl"]},
+            }
+        ],
+    )
+    adapter._apply_loras(pipe, request)
+    state = adapter._loaded_lora_states["text"]
+    assert [path for path, _name in pipe.loaded] == [str(lora)]
+    assert pipe.set_calls == [(list(state.adapter_names), [0.75])]
+
+
+def test_sdxl_adapter_rejects_incompatible_lora_family(tmp_path):
+    # SDXL accepts only sdxl-family LoRAs (no extra-compatible families, unlike
+    # chroma↔flux): a flux LoRA is filtered out before it can load (sc-1927/sc-1943).
+    lora = tmp_path / "flux_style.safetensors"
+    lora.write_bytes(b"lora")
+    pipe = FakeLoraPipe()
+    adapter = SdxlDiffusersAdapter()
+    request = SimpleNamespace(
+        model="sdxl",
+        mode="text_to_image",
+        loras=[
+            {
+                "id": "flux_style",
+                "installedPath": str(lora),
+                "compatibility": {"families": ["flux"]},
+            }
+        ],
+    )
+    try:
+        adapter._apply_loras(pipe, request)
+    except RuntimeError as exc:
+        assert "not compatible with model family sdxl" in str(exc)
+    else:
+        raise AssertionError("SDXL must reject a LoRA whose family is not sdxl.")
+
+
+def test_sdxl_backend_save_lora_writes_unet_diffusers_format(tmp_path, monkeypatch):
+    # The trainer saves an sdxl-family LoRA via StableDiffusionXLPipeline's own
+    # save_lora_weights(unet_lora_layers=...) — the diffusers format the inference
+    # loader (load_lora_weights) round-trips. Torch-free: fake peft + pipeline.
+    import sys
+    import types as types_module
+
+    fake_state = {"unet.down_blocks.0.attentions.0.lora_A.weight": "tensor"}
+    fake_peft_utils = types_module.ModuleType("peft.utils")
+    fake_peft_utils.get_peft_model_state_dict = lambda _module: fake_state
+    monkeypatch.setitem(sys.modules, "peft.utils", fake_peft_utils)
+
+    saved: dict[str, object] = {}
+
+    class FakeSdxlPipeline:
+        @staticmethod
+        def save_lora_weights(
+            output_dir, *, unet_lora_layers=None, weight_name=None, safe_serialization=None, **_kwargs
+        ):
+            saved["output_dir"] = output_dir
+            saved["unet_lora_layers"] = unet_lora_layers
+            saved["weight_name"] = weight_name
+            saved["safe_serialization"] = safe_serialization
+
+    backend = _SdxlLoraBackend()
+    backend._unet = object()
+    backend._pipeline = FakeSdxlPipeline()
+    output_path = backend._save_lora(output_dir=str(tmp_path), file_name="aurora_style.safetensors")
+
+    # unet_lora_layers carries the PEFT state dict; this is the only LoRA layer
+    # kwarg the trainer passes (UNet-only), and the key the SDXL loader consumes.
+    assert saved["unet_lora_layers"] is fake_state
+    assert saved["weight_name"] == "aurora_style.safetensors"
+    assert saved["safe_serialization"] is True
+    assert output_path == str(tmp_path / "aurora_style.safetensors")
+
+
 def test_create_image_adapter_routes_sensenova_u1():
     adapter = create_image_adapter({"payload": {"model": "sensenova_u1_8b"}})
     assert adapter.__class__.__name__ == "SenseNovaU1Adapter"

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -94,8 +94,10 @@ from scene_worker.training_adapters import (
     SUPPORTED_TRAINING_PLAN_VERSION,
     LensLoraTrainer,
     LtxMlxLoraTrainer,
+    SdxlLoraTrainer,
     TrainingKernelError,
     ZImageLoraTrainer,
+    _SdxlLoraBackend,
     _ZImageLoraBackend,
     _build_mlx_lr_schedule,
     _build_mlx_optimizer,
@@ -3208,9 +3210,39 @@ def test_z_image_lora_backend_generates_samples_with_turbo_guidance(tmp_path):
 
 def test_create_training_kernel_resolves_known_and_rejects_unknown():
     assert isinstance(create_training_kernel("z_image_lora"), ZImageLoraTrainer)
+    assert isinstance(create_training_kernel("sdxl_lora"), SdxlLoraTrainer)
     assert isinstance(create_training_kernel("lens_lora"), LensLoraTrainer)
     with pytest.raises(TrainingKernelError, match="No training kernel"):
         create_training_kernel("not_a_kernel")
+
+
+def test_sdxl_lora_trainer_reuses_zimage_orchestration_with_sdxl_backend():
+    # SdxlLoraTrainer subclasses ZImageLoraTrainer (shared staged orchestration)
+    # and only swaps the kernel id + the backend it builds.
+    trainer = create_training_kernel("sdxl_lora")
+    assert isinstance(trainer, ZImageLoraTrainer)
+    assert trainer.kernel_id == "sdxl_lora"
+    backend = trainer._create_backend()
+    assert isinstance(backend, _SdxlLoraBackend)
+    # Extension seams epic 1929 (Kolors) overrides: the pipeline class + the
+    # prompt encoder. Everything else is shared.
+    assert backend.kernel_id == "sdxl_lora"
+    assert backend.pipeline_class_name == "StableDiffusionXLPipeline"
+    assert backend.load_variant == "fp16"
+
+
+def test_sdxl_lora_backend_read_run_config_uses_sdxl_target_modules():
+    # The Rust sdxl_lora target declares the SDXL UNet attention modules; the
+    # kernel reads them straight from the plan's advanced config.
+    plan = {
+        "config": {
+            "rank": 16,
+            "steps": 1500,
+            "advanced": {"loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"]},
+        }
+    }
+    config = read_run_config(plan)
+    assert list(config.lora_target_modules) == ["to_q", "to_k", "to_v", "to_out.0"]
 
 
 class _FakeLensSidecarPopen:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -33,6 +33,7 @@ from scene_worker.image_adapters import (
     QwenImageAdapter,
     REAL_ESRGAN_MODEL_SPECS,
     RealEsrganUpscaler,
+    SdxlDiffusersAdapter,
     ZImageDiffusersAdapter,
     create_image_adapter,
     create_image_upscaler,
@@ -1472,6 +1473,67 @@ def test_kolors_reference_run_pipeline_passes_ip_adapter_image(tmp_path, monkeyp
     assert seen == [(project_path, "asset-ref")]
     assert pipe.scales == [0.7]
     assert result is FakeOutput.images[0]
+
+
+def test_create_image_adapter_routes_sdxl():
+    adapter = create_image_adapter({"payload": {"model": "sdxl"}})
+    assert adapter.__class__.__name__ == "SdxlDiffusersAdapter"
+    assert adapter.id == "sdxl_diffusers"
+
+
+def test_image_adapter_env_override_selects_sdxl(monkeypatch):
+    monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "sdxl_diffusers")
+    # Env override wins even when the payload names a different family's model.
+    adapter = create_image_adapter({"payload": {"model": "z_image_turbo"}})
+    assert adapter.__class__.__name__ == "SdxlDiffusersAdapter"
+
+
+def test_sdxl_model_target_defaults():
+    sdxl = MODEL_TARGETS["sdxl"]
+    assert sdxl["adapter"] == "sdxl_diffusers"
+    assert sdxl["family"] == "sdxl"
+    # Unified base checkpoint does both T2I and img2img edit.
+    assert sdxl["supportsEdit"] is True
+    # Real CFG with negative prompt: ~30 steps at guidance 7.0.
+    assert sdxl["steps"] == 30
+    assert sdxl["guidanceScale"] == 7.0
+    # fp16 variant; two CLIP encoders so there is no max_sequence_length knob.
+    assert sdxl["variant"] == "fp16"
+    assert "maxSequenceLength" not in sdxl
+    assert sdxl["repo"] == "stabilityai/stable-diffusion-xl-base-1.0"
+
+
+def test_sdxl_supports_edit():
+    # SDXL base is a unified checkpoint: StableDiffusionXLPipeline (T2I) +
+    # StableDiffusionXLImg2ImgPipeline (edit).
+    assert model_supports_edit("sdxl") is True
+
+
+def test_create_image_adapter_routes_sdxl_edit():
+    # Edit jobs route to the same adapter; it switches pipeline by mode.
+    adapter = create_image_adapter({"payload": {"model": "sdxl", "mode": "edit_image"}})
+    assert adapter.__class__.__name__ == "SdxlDiffusersAdapter"
+    assert adapter.id == "sdxl_diffusers"
+
+
+def test_sdxl_guidance_scale_uses_per_model_default_and_override():
+    adapter = SdxlDiffusersAdapter()
+    sdxl = MODEL_TARGETS["sdxl"]
+    # SDXL uses real CFG; the per-model default (7.0) applies without an override.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={}), sdxl) == 7.0
+    # An explicit request value wins.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={"guidanceScale": 5.0}), sdxl) == 5.0
+    # Unparseable override falls back to the per-model default.
+    assert adapter._guidance_scale(SimpleNamespace(advanced={"guidanceScale": "x"}), sdxl) == 7.0
+
+
+def test_sdxl_num_inference_steps_default_and_override():
+    adapter = SdxlDiffusersAdapter()
+    sdxl = MODEL_TARGETS["sdxl"]
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), sdxl) == 30
+    # Explicit override is honored and clamped to [1, 80].
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 45}), sdxl) == 45
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 999}), sdxl) == 80
 
 
 def test_create_image_adapter_routes_sensenova_u1():
@@ -6271,7 +6333,7 @@ def test_edit_run_pipeline_threads_project_path(tmp_path, monkeypatch):
 
     # Signature guard: project_path must precede the optional cancel_requested,
     # because every call site passes it positionally.
-    for adapter_cls in (ZImageDiffusersAdapter, QwenImageAdapter):
+    for adapter_cls in (ZImageDiffusersAdapter, QwenImageAdapter, SdxlDiffusersAdapter):
         params = list(inspect.signature(adapter_cls._run_pipeline).parameters)
         assert "project_path" in params, f"{adapter_cls.__name__}._run_pipeline must accept project_path"
         assert params.index("project_path") < params.index("cancel_requested")
@@ -6316,7 +6378,11 @@ def test_edit_run_pipeline_threads_project_path(tmp_path, monkeypatch):
     # Runtime guard: invoke the edit_image branch directly (gpu_id="cpu" keeps
     # device selection off real torch) so project_path resolves at the exact line
     # that raised NameError instead of crashing.
-    for adapter, model in ((ZImageDiffusersAdapter(), "z_image_edit"), (QwenImageAdapter(), "qwen_image_edit")):
+    for adapter, model in (
+        (ZImageDiffusersAdapter(), "z_image_edit"),
+        (QwenImageAdapter(), "qwen_image_edit"),
+        (SdxlDiffusersAdapter(), "sdxl"),
+    ):
         seen_paths.clear()
         request = image_request_from_job(
             {


### PR DESCRIPTION
Implements epic [1787](https://app.shortcut.com/trefry/epic/1787): first-class Stable Diffusion XL support in Image Studio, a generic SDXL-UNet LoRA training kernel, and Stable Video Diffusion in Video Studio. All six stories (sc-1939/1940/1941/1942/1943/1944) are included.

## What changed

**SDXL image generation (sc-1939, sc-1940)**
- `RecipeAdapter::SdxlDiffusers` contract variant; `sdxl` family → `sdxl_diffusers` adapter + `[text_to_image, edit_image, style_variations]` capabilities in `lora_family.rs`.
- `SdxlDiffusersAdapter` worker adapter — `StableDiffusionXLPipeline` (T2I) + `StableDiffusionXLImg2ImgPipeline` (edit), real CFG (negative prompt + guidance), fp16 variant, one-pipe-per-repo eviction, LoRA application, VAE tiling, opt-in cpu offload. Mirrors the Kolors adapter minus the IP-Adapter machinery and scheduler swap.
- Manifest + web fallback entry + `/prompt-guides/sdxl.md`. OpenRAIL++-M (commercial-OK, ungated) so no `gated` flag.

**Generic SDXL-UNet LoRA trainer (sc-1942)** — the headline deliverable
- `SdxlLoraTrainer` + `_SdxlLoraBackend` in `training_adapters.py`: the first U-Net (non-DiT) trainer in the repo. Custom diffusers/PEFT loop (DDPM ε/v-prediction with SDXL `added_cond_kwargs`), fp32-upcast VAE latent caching, dual-CLIP prompt+pooled embedding caching, PEFT LoRA on `pipe.unet`, checkpoint + sdxl-family safetensors save. Reuses the existing `ZImageLoraTrainer` staged orchestration.
- `pipeline_class_name` + `_encode_prompt` are deliberate swap seams so **epic 1929 (Kolors LoRA) reduces to a thin subclass**.
- Rust `sdxl_lora` training target + character/style/low-VRAM presets; committed registry snapshots updated.

**SDXL inference LoRA loader (sc-1943)**
- The inference LoRA path already worked generically; added round-trip guards: sdxl LoRA loads + applies, non-sdxl families are rejected, and the trainer's `save_lora_weights(unet_lora_layers=...)` matches what the loader consumes.

**Stable Video Diffusion (sc-1941)**
- Image-to-video via `StableVideoDiffusionPipeline`, wired as a third branch in `DiffusersVideoAdapter` (no prompt; motion bucket / fps / noise-aug controls; fixed ~25-frame output).
- `svd` family + manifest/constants entry with a `promptless` flag; Video Studio drops the prompt requirement for promptless models and reuses the existing `image_to_video` source-picker scaffolding. Stability AI Community License surfaced in the description. `/prompt-guides/svd.md`.

**Docs (sc-1944)**
- `TRAINING_QUICKSTART.md` `sdxl_lora` note + README LoRA-training update.

## Why
Adds the most widely-supported open image model (SDXL, the deepest community LoRA ecosystem) and an open image→video model (SVD), and — most importantly — builds the **shared SDXL-UNet LoRA training foundation** that epic 1929 (Kolors LoRA) depends on.

## Testing
All automated checks green:
- `cargo fmt --check`, clippy `-D warnings` (core + rust-api with `embed-web`)
- `cargo test`: core (incl. `lora_family` sdxl/svd, `training_contracts` snapshots) + rust-api (75)
- Worker light suite (`test_worker_runtime` + `test_worker_gpu` + `test_person_adapters`): 321 passed
- pytest parity (12) + e2e (1)
- web vitest (133, incl. promptless-submit) + `vite build`
- scaffold check + embed-web build

## Reviewer notes
- **Not yet validated on real hardware.** There is no torch/diffusers/GPU/browser in the implementation environment, so real SDXL T2I, an SDXL LoRA train→load→output-shift, and an SVD clip are **owed desk-side**. The recipe/prediction-type/memory-peak findings will be recorded on the stories after that run. Everything is structurally complete and test-covered.
- Video adapters are intentionally **not** in the `RecipeAdapter` enum (neither are ltx_video/wan_video), so SVD needed no contract change.
- The training-registry JSON snapshots are hand-formatted (compact arrays, struct-field key order) — the new entries were inserted by hand to match, not machine-regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)