### PR TITLE
feat(video-studio): LoRA picker + recipe-preset parity with Image Studio

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -169,7 +169,22 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
         "stylePreset".to_owned(),
         Value::String(preset_id.to_owned()),
     );
-    let loras = lora_catalog(state, Some(&payload.project_id)).await?;
+    merge_preset_loras_into_payload(state, &payload.project_id, preset_id, preset, job_payload)
+        .await
+}
+
+/// Prepend a preset's declared LoRAs to whatever LoRAs the client already sent,
+/// skipping ids that are already present. Records ids the catalog can't resolve
+/// under advanced.presetMissingLoras and stamps advanced.recipePresetId. Shared
+/// by the image and video job paths so preset-LoRA semantics stay identical.
+pub(crate) async fn merge_preset_loras_into_payload(
+    state: &AppState,
+    project_id: &str,
+    preset_id: &str,
+    preset: &Value,
+    job_payload: &mut JsonObject,
+) -> Result<(), ApiError> {
+    let loras = lora_catalog(state, Some(project_id)).await?;
     let existing_lora_ids = job_payload
         .get("loras")
         .and_then(Value::as_array)
@@ -214,6 +229,7 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
         Value::String(preset_id.to_owned()),
     );
     advanced.remove("recipePresetName");
+    advanced.remove("recipePresetPrompt");
     if missing_lora_ids.is_empty() {
         advanced.remove("presetMissingLoras");
     } else {
@@ -293,6 +309,90 @@ pub(crate) fn parse_recipe_preset_resolution(value: &str) -> Result<(u32, u32), 
     Ok((width, height))
 }
 
+/// Server-side expansion of a video job's recipe preset, mirroring
+/// apply_recipe_preset_to_image_payload: the client sends the raw prompt plus
+/// recipePresetId and the server folds in the preset's prompt prefix/suffix,
+/// model, render defaults, and LoRAs. Keeps preset semantics identical across
+/// the image and video studios.
+pub(crate) async fn apply_recipe_preset_to_video_payload(
+    state: &AppState,
+    payload: &VideoJobRequest,
+    job_payload: &mut JsonObject,
+) -> Result<(), ApiError> {
+    let Some(preset_id) = payload.recipe_preset_id.as_deref() else {
+        return Ok(());
+    };
+    if payload.project_id.is_empty() {
+        return Err(ApiError::bad_request("projectId is required"));
+    }
+    let presets = recipe_preset_catalog(state, Some(&payload.project_id)).await?;
+    let preset = presets
+        .iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(preset_id))
+        .ok_or_else(|| ApiError::bad_request("Recipe preset not found"))?;
+
+    let expanded_prompt = preset_prompt(&payload.prompt, preset);
+    job_payload.insert("prompt".to_owned(), Value::String(expanded_prompt));
+    if payload.model == default_video_model() {
+        if let Some(model) = preset
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
+        }
+    }
+    apply_recipe_preset_video_defaults(preset, job_payload)?;
+    merge_preset_loras_into_payload(state, &payload.project_id, preset_id, preset, job_payload)
+        .await
+}
+
+pub(crate) fn apply_recipe_preset_video_defaults(
+    preset: &Value,
+    job_payload: &mut JsonObject,
+) -> Result<(), ApiError> {
+    let Some(defaults) = preset.get("defaults").and_then(Value::as_object) else {
+        return Ok(());
+    };
+    if let Some(duration) = defaults.get("duration") {
+        if !duration
+            .as_f64()
+            .is_some_and(|value| value.is_finite() && (1.0..=30.0).contains(&value))
+        {
+            return Err(ApiError::bad_request(
+                "Recipe preset duration must be between 1 and 30",
+            ));
+        }
+        job_payload.insert("duration".to_owned(), duration.clone());
+    }
+    if let Some(fps) = defaults.get("fps") {
+        if !fps.as_u64().is_some_and(|value| (1..=60).contains(&value)) {
+            return Err(ApiError::bad_request(
+                "Recipe preset fps must be between 1 and 60",
+            ));
+        }
+        job_payload.insert("fps".to_owned(), fps.clone());
+    }
+    if let Some(quality) = defaults.get("quality").and_then(Value::as_str) {
+        job_payload.insert("quality".to_owned(), Value::String(quality.to_owned()));
+    }
+    if let Some(resolution) = defaults.get("resolution").and_then(Value::as_str) {
+        let (width, height) = parse_recipe_preset_resolution(resolution)?;
+        validate_dimension(width, "width", MAX_VIDEO_DIMENSION)?;
+        validate_dimension(height, "height", MAX_VIDEO_DIMENSION)?;
+        job_payload.insert("width".to_owned(), json!(width));
+        job_payload.insert("height".to_owned(), json!(height));
+    }
+    if let Some(negative_prompt) = defaults.get("negativePrompt").and_then(Value::as_str) {
+        job_payload.insert(
+            "negativePrompt".to_owned(),
+            Value::String(negative_prompt.to_owned()),
+        );
+    }
+    Ok(())
+}
+
 pub(crate) async fn create_video_job(
     State(state): State<AppState>,
     ApiJson(payload): ApiJson<VideoJobRequest>,
@@ -312,6 +412,7 @@ pub(crate) async fn create_video_job(
     if payload.recipe_preset_id.is_none() {
         job_payload.remove("recipePresetId");
     }
+    apply_recipe_preset_to_video_payload(&state, &payload, &mut job_payload).await?;
     // Resolve the model manifest entry here so the GPU worker never re-parses
     // builtin/user.models.jsonc itself — Rust owns manifest parsing/merging
     // (story 1653). An unknown model resolves to {}, matching the worker's

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1715,8 +1715,8 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
     if !(1..=60).contains(&payload.fps) {
         return Err(ApiError::bad_request("fps must be between 1 and 60"));
     }
-    validate_dimension(payload.width, "width", 1920)?;
-    validate_dimension(payload.height, "height", 1920)?;
+    validate_dimension(payload.width, "width", MAX_VIDEO_DIMENSION)?;
+    validate_dimension(payload.height, "height", MAX_VIDEO_DIMENSION)?;
     match payload.mode.as_str() {
         "image_to_video" if payload.source_asset_id.is_none() => Err(ApiError::bad_request(
             "Image to Video requires a source image.",
@@ -1756,6 +1756,10 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
 /// governed by manifest `limits.resolutions` + the UI. Covers SenseNova-U1's
 /// largest trained bucket (3456) with headroom; video uses its own lower cap.
 const MAX_IMAGE_DIMENSION: u32 = 4096;
+
+/// Upper bound for video width/height — a lower backstop than images, matching
+/// the cap enforced when validating a video job request.
+const MAX_VIDEO_DIMENSION: u32 = 1920;
 
 fn validate_dimension(value: u32, field: &'static str, max: u32) -> Result<(), ApiError> {
     if !(256..=max).contains(&value) {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2737,6 +2737,142 @@ async fn generation_job_routes_reject_incompatible_loras() {
 }
 
 #[tokio::test]
+async fn video_jobs_expand_recipe_presets_server_side() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "vid-model",
+              "name": "Vid Model",
+              "family": "wan-video",
+              "type": "video",
+              "adapter": "wan_video",
+              "capabilities": ["text_to_video", "image_to_video"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/vid", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": { "families": ["wan-video"] },
+              "ui": { "label": "Vid" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "loras": [
+            {
+              "id": "motion-lora",
+              "name": "Motion LoRA",
+              "family": "wan-video",
+              "triggerWords": ["motion"],
+              "compatibility": { "families": ["wan-video"] },
+              "source": { "provider": "local", "path": "loras/motion.safetensors" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("user loras writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "dream_motion",
+              "name": "Dream Motion",
+              "workflow": "text_to_video",
+              "model": "vid-model",
+              "defaults": { "duration": 8, "fps": 30, "resolution": "1280x720", "quality": "best", "negativePrompt": "jitter" },
+              "prompt": { "prefix": "cinematic", "suffix": "smooth camera motion" },
+              "loras": [{ "id": "motion-lora", "weight": 0.5 }]
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+    let lora_dir = temp_dir.path().join("data/loras");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    write_test_safetensors(&lora_dir.join("motion.safetensors"));
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Video Preset Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, video_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "model": "vid-model",
+            "recipePresetId": "dream_motion"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    // Prompt prefix/suffix are folded in server-side around the raw client
+    // prompt — the regression that motivated this path.
+    assert_eq!(
+        video_job["payload"]["prompt"],
+        "cinematic, a fox runs, smooth camera motion"
+    );
+    // Render defaults come from the preset.
+    assert_eq!(video_job["payload"]["duration"], 8);
+    assert_eq!(video_job["payload"]["fps"], 30);
+    assert_eq!(video_job["payload"]["width"], 1280);
+    assert_eq!(video_job["payload"]["height"], 720);
+    assert_eq!(video_job["payload"]["quality"], "best");
+    assert_eq!(video_job["payload"]["negativePrompt"], "jitter");
+    // Preset LoRA merged in (client sent none) and stamped under advanced.
+    assert_eq!(video_job["payload"]["loras"][0]["id"], "motion-lora");
+    assert_eq!(
+        video_job["payload"]["advanced"]["recipePresetId"],
+        "dream_motion"
+    );
+}
+
+#[tokio::test]
 async fn model_and_lora_routes_match_manifest_behavior() {
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5437,6 +5437,128 @@ describe("SceneWorks app shell", () => {
     expect(createVideoJob).not.toHaveBeenCalled();
   });
 
+  it("surfaces compatible LoRAs in the Video Studio picker and sends the selection to the job", async () => {
+    const createVideoJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [{ id: "image-1", type: "image", displayName: "Frame One" }],
+            characters: [],
+            createPersonDetectionJob: () => {},
+            createPersonTrackJob: () => {},
+            createVideoJob,
+            deleteAsset: () => {},
+            gpuOptions: ["auto"],
+            latestVideoAssets: [],
+            loras: [
+              { id: "ltx_style", name: "LTX Style", family: "ltx-video", scope: "global", installState: "installed" },
+              { id: "z_glow", name: "Z Glow", family: "z-image", scope: "global", installState: "installed" },
+            ],
+            setPreviewAsset: () => {},
+            personTracks: [],
+            purgeAsset: () => {},
+            presets: [],
+            rememberLocalGenerationJob: () => {},
+            requestedGpu: "auto",
+            selectedAsset: { id: "image-1", type: "image", displayName: "Frame One" },
+            setRequestedGpu: () => {},
+            updateAssetStatus: () => {},
+            videoModels: [
+              {
+                id: "ltx_2_3",
+                name: "LTX",
+                type: "video",
+                family: "ltx-video",
+                capabilities: ["image_to_video"],
+                defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+                loraCompatibility: { families: ["ltx-video"] },
+              },
+            ],
+          },
+          <VideoStudio />,
+        ),
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+    });
+    await settle();
+
+    // Only the ltx-video LoRA is compatible; the z-image one is filtered out.
+    expect(container.textContent).toContain("LTX Style");
+    expect(container.textContent).not.toContain("Z Glow");
+
+    const loraCheckbox = container.querySelector(".lora-choice-list input[type=checkbox]");
+    await act(async () => {
+      loraCheckbox.click();
+    });
+    await settle();
+
+    const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Render clip");
+    expect(generate.disabled).toBe(false);
+
+    await act(async () => {
+      generate.click();
+    });
+
+    expect(createVideoJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "ltx_2_3",
+        loras: expect.arrayContaining([expect.objectContaining({ id: "ltx_style" })]),
+      }),
+    );
+  });
+
+  it("always exposes the preset selector in the Video Studio even with no presets", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            characters: [],
+            createPersonDetectionJob: () => {},
+            createPersonTrackJob: () => {},
+            createVideoJob: () => {},
+            deleteAsset: () => {},
+            gpuOptions: ["auto"],
+            latestVideoAssets: [],
+            loras: [],
+            setPreviewAsset: () => {},
+            personTracks: [],
+            purgeAsset: () => {},
+            presets: [],
+            requestedGpu: "auto",
+            selectedAsset: null,
+            setRequestedGpu: () => {},
+            updateAssetStatus: () => {},
+            videoModels: [
+              {
+                id: "ltx_2_3",
+                name: "LTX",
+                type: "video",
+                family: "ltx-video",
+                capabilities: ["image_to_video", "text_to_video"],
+                defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+                loraCompatibility: { families: ["ltx-video"] },
+              },
+            ],
+          },
+          <VideoStudio />,
+        ),
+      );
+    });
+
+    expect(container.textContent).toContain("Style preset");
+    const noneChip = [...container.querySelectorAll(".preset-chip")].find((chip) => chip.textContent === "None");
+    expect(noneChip).toBeTruthy();
+  });
+
   it("keeps Qwen selected when applying a Qwen image preset", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);
@@ -5710,14 +5832,19 @@ describe("SceneWorks app shell", () => {
         quality: "best",
         negativePrompt: "jitter",
         recipePresetId: "dream_motion",
-        loras: [expect.objectContaining({ id: "video_motion", weight: 0.8, presetManaged: true })],
+        // Preset prompt prefix/suffix and preset LoRAs are now folded in
+        // server-side from recipePresetId, so the client sends the raw prompt
+        // and only its own picker selections (none here).
+        prompt: "Camera slowly pushes in while the scene comes alive",
+        loras: [],
         advanced: expect.objectContaining({
-          recipePresetName: "Dream Motion",
-          recipePresetPrompt: { suffix: "smooth camera motion" },
           resolution: "1280x720",
         }),
       }),
     );
+    const submittedAdvanced = createVideoJob.mock.calls[0][0].advanced;
+    expect(submittedAdvanced).not.toHaveProperty("recipePresetName");
+    expect(submittedAdvanced).not.toHaveProperty("recipePresetPrompt");
   });
 
   it("lets a promptless video model (SVD) submit without a text prompt", async () => {

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -182,6 +182,32 @@ export function serializePresetLora(lora, presetLora = {}) {
   };
 }
 
+export function serializeLora(lora, override = {}) {
+  return {
+    id: lora.id,
+    name: lora.name ?? lora.id,
+    scope: lora.scope ?? "global",
+    weight: Number.isFinite(Number(override.weight)) ? Number(override.weight) : loraWeight(lora),
+    triggerWords: lora.triggerWords ?? [],
+    compatibility: lora.compatibility ?? {},
+    family: lora.family ?? null,
+    families: lora.families ?? null,
+    compatibleFamilies: lora.compatibleFamilies ?? null,
+    modelFamilies: lora.modelFamilies ?? null,
+    installedPath: lora.installedPath ?? null,
+    sourcePath: lora.sourcePath ?? null,
+    source: lora.source ?? null,
+    // `installedPath` points at the LoRA directory; for trained LoRAs that
+    // directory also holds step checkpoints, so the worker must be told the
+    // exact adapter file. Forward the manifest's declared `files`/`file` —
+    // without them the worker falls back to the first .safetensors on disk and
+    // can load an early checkpoint instead of the final adapter.
+    files: lora.files ?? null,
+    file: lora.file ?? null,
+    presetManaged: Boolean(lora.presetManaged),
+  };
+}
+
 export function presetLoraDetails(preset, loras) {
   return presetLoras(preset)
     .map((presetLora) => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -62,7 +62,7 @@ function defaultCharacterPrompt(character) {
 }
 import {
   loraMatchesModel,
-  loraWeight,
+  serializeLora,
   clearPresetDefault,
   noPresetId,
   rememberPresetDefault,
@@ -234,32 +234,6 @@ export function ImageStudio() {
     if (option && !option.factors.includes(upscaleFactor)) {
       setUpscaleFactor(option.factors[0]);
     }
-  }
-
-  function serializeLora(lora, override = {}) {
-    return {
-      id: lora.id,
-      name: lora.name ?? lora.id,
-      scope: lora.scope ?? "global",
-      weight: Number.isFinite(Number(override.weight)) ? Number(override.weight) : loraWeight(lora),
-      triggerWords: lora.triggerWords ?? [],
-      compatibility: lora.compatibility ?? {},
-      family: lora.family ?? null,
-      families: lora.families ?? null,
-      compatibleFamilies: lora.compatibleFamilies ?? null,
-      modelFamilies: lora.modelFamilies ?? null,
-      installedPath: lora.installedPath ?? null,
-      sourcePath: lora.sourcePath ?? null,
-      source: lora.source ?? null,
-      // `installedPath` points at the LoRA directory; for trained LoRAs that
-      // directory also holds step checkpoints, so the worker must be told the
-      // exact adapter file. Forward the manifest's declared `files`/`file` —
-      // without them the worker falls back to the first .safetensors on disk and
-      // can load an early checkpoint instead of the final adapter.
-      files: lora.files ?? null,
-      file: lora.file ?? null,
-      presetManaged: Boolean(lora.presetManaged),
-    };
   }
 
   useEffect(() => {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
@@ -39,8 +39,10 @@ function formatPlaybackTime(seconds) {
 import {
   clearPresetDefault,
   loraLooksLikeIcLora,
+  loraMatchesModel,
   noPresetId,
   rememberPresetDefault,
+  serializeLora,
 } from "../presetUtils.js";
 import {
   onPromptKeyDown,
@@ -110,6 +112,8 @@ export function VideoStudio() {
   const [distilledVariant, setDistilledVariant] = useState("1.1");
   const [precision, setPrecision] = useState("fp8");
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [selectedLoraIds, setSelectedLoraIds] = useState([]);
+  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
   const [model, setModel] = useState(videoModels[0]?.id ?? ltxVideoModelId);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
   const [duration, setDuration] = useState(selectedModel?.defaults?.duration ?? 6);
@@ -164,6 +168,60 @@ export function VideoStudio() {
   });
   const requiresLtxIcLora = selectedModel?.id === ltxVideoModelId && ltxIcLoraRequiredModes.has(mode);
   const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing && loraLooksLikeIcLora(lora));
+  const compatibleLoras = useMemo(() => loras.filter((lora) => {
+    if (lora.presetManaged) {
+      return false;
+    }
+    if (lora.installState === "missing") {
+      return false;
+    }
+    if (showIncompatibleLoras) {
+      return true;
+    }
+    return loraMatchesModel(lora, selectedModel);
+  }), [loras, selectedModel, showIncompatibleLoras]);
+  const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
+  const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
+  const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
+  const selectedLoraValidationResult = useMemo(() => {
+    const incompatible = selectedLoras.filter((lora) => !loraMatchesModel(lora, selectedModel)).map((lora) => lora.name ?? lora.id);
+    return {
+      incompatible,
+      ok: incompatible.length === 0,
+    };
+  }, [selectedLoras, selectedModel]);
+  const hasPendingCompatibleLoras = Boolean(selectedModel) && loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
+  const loraEmptyMessage = !selectedModel
+    ? "No model selected"
+    : hasPendingCompatibleLoras
+      ? "No installed compatible LoRAs. Imports appear after the Queue completes."
+      : showIncompatibleLoras
+        ? "No installed LoRAs in the library."
+        : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
+
+  useEffect(() => {
+    setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
+  }, [compatibleLoraKey]);
+
+  useEffect(() => {
+    if (selectedLoraValidationResult.incompatible.length && !advancedOpen) {
+      setAdvancedOpen(true);
+    }
+  }, [advancedOpen, selectedLoraValidationResult.incompatible.length]);
+
+  function toggleLora(lora) {
+    setSelectedLoraIds((ids) => {
+      if (ids.includes(lora.id)) {
+        return ids.filter((id) => id !== lora.id);
+      }
+      const selected = ids.map((id) => compatibleLoras.find((item) => item.id === id)).filter(Boolean);
+      const userCount = selected.filter((item) => item.scope !== "builtin").length;
+      if (lora.scope !== "builtin" && userCount >= 2) {
+        return ids;
+      }
+      return [...ids, lora.id];
+    });
+  }
 
   useEffect(() => {
     if (selectedAsset?.type === "image" || selectedAsset?.type === "frame") {
@@ -323,6 +381,7 @@ export function VideoStudio() {
       implementedMode &&
       hasInputs &&
       presetValidationResult.ok &&
+      selectedLoraValidationResult.ok &&
       (!requiresLtxIcLora || hasLtxIcLora) &&
       replaceReady,
   );
@@ -376,13 +435,11 @@ export function VideoStudio() {
         sourceClipAssetId: ["extend_clip", "replace_person"].includes(mode) ? sourceClipAssetId || null : null,
         personTrackId: mode === "replace_person" ? personTrackId || null : null,
         replacementMode: mode === "replace_person" ? replacementMode : "face_only",
-        loras: presetLoraDetails.filter((lora) => !lora.missing),
+        loras: selectedLoras.map((lora) => serializeLora(lora)),
         advanced: {
           resolution,
           durationHint,
           motion,
-          recipePresetName: selectedPreset?.name ?? null,
-          recipePresetPrompt: selectedPreset?.prompt ?? null,
           selectedPersonTrack: selectedTrack ?? null,
           replacementModeLabel: replacementModeLabels[replacementMode],
           ...(model === ltxVideoModelId ? { ltxPipeline, distilledVariant, precision } : {}),
@@ -673,6 +730,11 @@ export function VideoStudio() {
 
             {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
             <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
+            {selectedLoraValidationResult.incompatible.length ? (
+              <p className="inline-warning">
+                Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
+              </p>
+            ) : null}
           </div>
 
           <div className="video-rail">
@@ -693,30 +755,28 @@ export function VideoStudio() {
                 </select>
               </label>
 
-              {availablePresets.length ? (
-                <div className="style-preset-strip">
-                  <span className="style-preset-label">Style preset</span>
-                  <div className="preset-chips">
+              <div className="style-preset-strip">
+                <span className="style-preset-label">Style preset</span>
+                <div className="preset-chips">
+                  <button
+                    className={!selectedPreset ? "preset-chip active" : "preset-chip"}
+                    onClick={() => setSelectedPresetId(noPresetId)}
+                    type="button"
+                  >
+                    None
+                  </button>
+                  {availablePresets.map((preset) => (
                     <button
-                      className={!selectedPreset ? "preset-chip active" : "preset-chip"}
-                      onClick={() => setSelectedPresetId(noPresetId)}
+                      className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"}
+                      key={preset.id}
+                      onClick={() => setSelectedPresetId(preset.id)}
                       type="button"
                     >
-                      None
+                      {preset.name ?? preset.id}
                     </button>
-                    {availablePresets.map((preset) => (
-                      <button
-                        className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"}
-                        key={preset.id}
-                        onClick={() => setSelectedPresetId(preset.id)}
-                        type="button"
-                      >
-                        {preset.name ?? preset.id}
-                      </button>
-                    ))}
-                  </div>
+                  ))}
                 </div>
-              ) : null}
+              </div>
 
               <label>
                 Quality
@@ -852,6 +912,46 @@ export function VideoStudio() {
                     Negative prompt
                     <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
                   </label>
+                  <section className="lora-picker" aria-label="LoRA selection">
+                    <div>
+                      <strong>LoRAs</strong>
+                      <span>{selectedLoras.length ? `${selectedLoras.length} selected` : selectedModel ? "Installed and compatible" : "Choose a model"}</span>
+                    </div>
+                    <label className="checkline">
+                      <input
+                        checked={showIncompatibleLoras}
+                        onChange={(event) => setShowIncompatibleLoras(event.target.checked)}
+                        type="checkbox"
+                      />
+                      Show incompatible
+                    </label>
+                    {compatibleLoras.length ? (
+                      <div className="lora-choice-list">
+                        {compatibleLoras.map((lora) => {
+                          const checked = selectedLoraIds.includes(lora.id);
+                          const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
+                          return (
+                            <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
+                              <input
+                                checked={checked}
+                                disabled={userLimitReached}
+                                onChange={() => toggleLora(lora)}
+                                type="checkbox"
+                              />
+                              <span>
+                                <strong>{lora.name ?? lora.id}</strong>
+                                <small>
+                                  {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
+                                </small>
+                              </span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
+                    )}
+                  </section>
                   {characterId ? (
                     <div className="guidance-strip">
                       <strong>Character reference</strong>


### PR DESCRIPTION
## Summary

Brings Video Studio's LoRA and preset handling to parity with Image Studio. Prompted by a report that `ltx-video` LoRAs weren't selectable when generating LTX-2.3 — investigation found Video Studio simply never had a LoRA picker, and that video recipe presets were handled inconsistently from images.

## What changed

**LoRA picker (web)**
- Port Image Studio's LoRA picker into Video Studio: compatible-LoRA filtering via `loraMatchesModel`, a "Show incompatible" toggle, and the same 2-user-LoRA limit.
- Extract the shared `serializeLora` helper into `presetUtils.js` so both studios use one copy (dropped the now-unused `loraWeight` import from ImageStudio).

**Preset selector (web)**
- Always render the "Style preset" strip in Video Studio. It was previously gated behind `availablePresets.length`, so it vanished entirely when no video presets matched — i.e. before any were created. Now it always shows a "None" chip plus any matching presets, exactly like Image Studio.

**Symmetric recipe-preset expansion (rust-api)**
- New `apply_recipe_preset_to_video_payload` mirrors `apply_recipe_preset_to_image_payload`: it folds in the preset's prompt prefix/suffix, model, render defaults (duration/fps/quality/resolution/negativePrompt), and LoRAs server-side from `recipePresetId`.
- Extract the shared `merge_preset_loras_into_payload` helper used by both image and video paths (dedup by id, stamps `advanced.recipePresetId`, records missing LoRAs).
- Add `MAX_VIDEO_DIMENSION` (1920) and reuse it in `validate_video_job`.
- Thin the VideoStudio client to send the **raw** prompt and only picker-selected LoRAs, dropping the inline preset-LoRA workaround and the unused `recipePresetName`/`recipePresetPrompt` metadata.

## Why

Video preset **prompt prefix/suffix was silently dropped** — the client sent the raw prompt, the server never expanded it (no video equivalent of the image preset path), and the worker reads the raw prompt and ignores `recipePresetPrompt`. This change fixes that and makes the two studios behave identically.

## Reviewer notes

- **Behavior change to flag:** server-side defaults are now authoritative, so overriding a preset's *declared* render defaults (duration/fps/quality/resolution/negativePrompt) in the form while that preset is selected no longer sticks — the preset value wins. This now matches Image Studio. The user's typed prompt is always preserved (only prefix/suffix are added around it). Happy to switch both studios to "form override wins" if preferred.
- The image-path refactor (extracting `merge_preset_loras_into_payload`) is behavior-preserving and covered by existing tests.

## Test plan

- [x] rust-api: `cargo test -p sceneworks-rust-api` — 76 pass, incl. new `video_jobs_expand_recipe_presets_server_side` (asserts prompt expansion, defaults, LoRA merge)
- [x] web: `npm test` — 135 pass (updated the video-preset test for the thinned client; added picker + always-visible-selector tests)
- [x] `cargo fmt --check` clean
- [x] builds with and without `--features embed-web`
- [ ] Manual: not run — needs the full desktop stack (Rust API + worker) to exercise the picker/preset flow live in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)