### PR TITLE
feat(studios): per-LoRA weight slider in the LoRA pickers

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5578,6 +5578,12 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
+    // Selecting a LoRA reveals its weight slider, defaulting to the LoRA weight (0.8).
+    const weightSlider = container.querySelector(".lora-weight-row input[type=range]");
+    expect(weightSlider).toBeTruthy();
+    expect(container.querySelector(".lora-weight-value").textContent).toBe("0.80");
+    await changeField(weightSlider, "0.5");
+
     const generate = [...container.querySelectorAll("button")].find((button) => button.textContent === "Render clip");
     expect(generate.disabled).toBe(false);
 
@@ -5588,7 +5594,7 @@ describe("SceneWorks app shell", () => {
     expect(createVideoJob).toHaveBeenCalledWith(
       expect.objectContaining({
         model: "ltx_2_3",
-        loras: expect.arrayContaining([expect.objectContaining({ id: "ltx_style" })]),
+        loras: [expect.objectContaining({ id: "ltx_style", weight: 0.5 })],
       }),
     );
   });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -62,6 +62,7 @@ function defaultCharacterPrompt(character) {
 }
 import {
   loraMatchesModel,
+  loraWeight,
   serializeLora,
   clearPresetDefault,
   noPresetId,
@@ -211,6 +212,7 @@ export function ImageStudio() {
   const [upscaleFactor, setUpscaleFactor] = useState(2);
   const [upscaleEngine, setUpscaleEngine] = useState("real-esrgan");
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
+  const [loraWeights, setLoraWeights] = useState({});
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const presetDefaultSnapshots = useRef({});
@@ -456,6 +458,19 @@ export function ImageStudio() {
     });
   }
 
+  // Per-LoRA strength: the override map falls back to the LoRA's default weight.
+  // Order of application is intentionally not exposed — the worker combines
+  // adapters additively (set_adapters / dequant-to-bf16 merge), so order has no
+  // effect on output.
+  function effectiveLoraWeight(lora) {
+    const override = loraWeights[lora.id];
+    return Number.isFinite(override) ? override : loraWeight(lora);
+  }
+
+  function setLoraWeight(id, value) {
+    setLoraWeights((current) => ({ ...current, [id]: value }));
+  }
+
   const reviewSlots = useMemo(() => {
     if (!localJobs.length) {
       return latestAssets.map((asset) => ({ type: "asset", id: asset.id, asset }));
@@ -500,7 +515,7 @@ export function ImageStudio() {
         characterLookId: mode === "character_image" ? characterLookId || null : null,
         sourceAssetId: mode === "edit_image" ? sourceAssetId || null : null,
         referenceAssetId: mode === "character_image" ? referenceAssetId || null : null,
-        loras: selectedLoras.map((lora) => serializeLora(lora)),
+        loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
         ...(upscaleEnabled
           ? {
               upscale: {
@@ -858,21 +873,39 @@ export function ImageStudio() {
                       {compatibleLoras.map((lora) => {
                         const checked = selectedLoraIds.includes(lora.id);
                         const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
+                        const weight = effectiveLoraWeight(lora);
                         return (
-                          <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
-                            <input
-                              checked={checked}
-                              disabled={userLimitReached}
-                              onChange={() => toggleLora(lora)}
-                              type="checkbox"
-                            />
-                            <span>
-                              <strong>{lora.name ?? lora.id}</strong>
-                              <small>
-                                {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
-                              </small>
-                            </span>
-                          </label>
+                          <div className="lora-choice-item" key={lora.id}>
+                            <label className={checked ? "lora-choice active" : "lora-choice"}>
+                              <input
+                                checked={checked}
+                                disabled={userLimitReached}
+                                onChange={() => toggleLora(lora)}
+                                type="checkbox"
+                              />
+                              <span>
+                                <strong>{lora.name ?? lora.id}</strong>
+                                <small>
+                                  {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
+                                </small>
+                              </span>
+                            </label>
+                            {checked ? (
+                              <div className="lora-weight-row">
+                                <span>Weight</span>
+                                <input
+                                  aria-label={`${lora.name ?? lora.id} weight`}
+                                  max="2"
+                                  min="0"
+                                  onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
+                                  step="0.05"
+                                  type="range"
+                                  value={weight}
+                                />
+                                <span className="lora-weight-value">{weight.toFixed(2)}</span>
+                              </div>
+                            ) : null}
+                          </div>
                         );
                       })}
                     </div>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -40,6 +40,7 @@ import {
   clearPresetDefault,
   loraLooksLikeIcLora,
   loraMatchesModel,
+  loraWeight,
   noPresetId,
   rememberPresetDefault,
   serializeLora,
@@ -114,6 +115,7 @@ export function VideoStudio() {
   const [quantization, setQuantization] = useState("auto");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [selectedLoraIds, setSelectedLoraIds] = useState([]);
+  const [loraWeights, setLoraWeights] = useState({});
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
   const [model, setModel] = useState(videoModels[0]?.id ?? ltxVideoModelId);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
@@ -227,6 +229,19 @@ export function VideoStudio() {
       }
       return [...ids, lora.id];
     });
+  }
+
+  // Per-LoRA strength: the override map falls back to the LoRA's default weight.
+  // Order of application is intentionally not exposed — the worker combines
+  // adapters additively (set_adapters / dequant-to-bf16 merge), so order has no
+  // effect on output.
+  function effectiveLoraWeight(lora) {
+    const override = loraWeights[lora.id];
+    return Number.isFinite(override) ? override : loraWeight(lora);
+  }
+
+  function setLoraWeight(id, value) {
+    setLoraWeights((current) => ({ ...current, [id]: value }));
   }
 
   useEffect(() => {
@@ -441,7 +456,7 @@ export function VideoStudio() {
         sourceClipAssetId: ["extend_clip", "replace_person"].includes(mode) ? sourceClipAssetId || null : null,
         personTrackId: mode === "replace_person" ? personTrackId || null : null,
         replacementMode: mode === "replace_person" ? replacementMode : "face_only",
-        loras: selectedLoras.map((lora) => serializeLora(lora)),
+        loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
         advanced: {
           resolution,
           durationHint,
@@ -951,21 +966,39 @@ export function VideoStudio() {
                         {compatibleLoras.map((lora) => {
                           const checked = selectedLoraIds.includes(lora.id);
                           const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
+                          const weight = effectiveLoraWeight(lora);
                           return (
-                            <label className={checked ? "lora-choice active" : "lora-choice"} key={lora.id}>
-                              <input
-                                checked={checked}
-                                disabled={userLimitReached}
-                                onChange={() => toggleLora(lora)}
-                                type="checkbox"
-                              />
-                              <span>
-                                <strong>{lora.name ?? lora.id}</strong>
-                                <small>
-                                  {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
-                                </small>
-                              </span>
-                            </label>
+                            <div className="lora-choice-item" key={lora.id}>
+                              <label className={checked ? "lora-choice active" : "lora-choice"}>
+                                <input
+                                  checked={checked}
+                                  disabled={userLimitReached}
+                                  onChange={() => toggleLora(lora)}
+                                  type="checkbox"
+                                />
+                                <span>
+                                  <strong>{lora.name ?? lora.id}</strong>
+                                  <small>
+                                    {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
+                                  </small>
+                                </span>
+                              </label>
+                              {checked ? (
+                                <div className="lora-weight-row">
+                                  <span>Weight</span>
+                                  <input
+                                    aria-label={`${lora.name ?? lora.id} weight`}
+                                    max="2"
+                                    min="0"
+                                    onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
+                                    step="0.05"
+                                    type="range"
+                                    value={weight}
+                                  />
+                                  <span className="lora-weight-value">{weight.toFixed(2)}</span>
+                                </div>
+                              ) : null}
+                            </div>
                           );
                         })}
                       </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4496,6 +4496,36 @@ label {
   min-width: 0;
 }
 
+.lora-choice-item {
+  display: grid;
+  gap: 6px;
+}
+
+.lora-weight-row {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 10px;
+  padding: 0 10px 2px;
+}
+
+.lora-weight-row > span:first-child {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.lora-weight-row input[type="range"] {
+  width: 100%;
+}
+
+.lora-weight-value {
+  min-width: 34px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
 .editable-lora-choice {
   display: grid;
   grid-template-columns: minmax(0, 1fr) max-content;


### PR DESCRIPTION
## Summary

Adds a per-LoRA strength control to the LoRA picker in **both** Image Studio and Video Studio. When a LoRA is selected, a `0–2` weight slider appears (step 0.05) with a live value readout, defaulting to the LoRA's own `defaultWeight`/`weight` (or 0.8). The chosen weight flows through `serializeLora(lora, { weight })` into the job payload.

## Why no reordering

The original request also asked about controlling LoRA **application order**. I traced every generation path and confirmed order has **no effect on output**, so I deliberately did not add a reorder control (it would imply order matters when it doesn't):

- **Diffusers / PEFT** (image, Wan-diffusers, lens): LoRAs are loaded as separate named adapters and activated together via `set_adapters(names, adapter_weights=...)` — combined additively (`Σ wᵢ·BᵢAᵢ`, commutative). The pipeline cache key even sorts the specs, so `[A,B]` and `[B,A]` are the same cached state.
- **MLX LTX (q4)**: the merge dequantizes the LoRA'd layers to bf16 and applies them without requantizing (no per-LoRA rounding) — additive, order-independent.
- **Native LTX (Lightricks)**: standard additive application.

Order only matters with sequential `fuse_lora`-into-requantized-weights or TIES/DARE-style merges, none of which this codebase uses for generation.

## Changes

- `ImageStudio.jsx` / `VideoStudio.jsx`: `loraWeights` state + `effectiveLoraWeight`/`setLoraWeight` helpers; weight slider rendered under each checked LoRA; weight passed to `serializeLora`. Restructured each picker row into a `.lora-choice-item` wrapper (the existing `.lora-choice` label is unchanged).
- `styles.css`: `.lora-choice-item` / `.lora-weight-row` / `.lora-weight-value`.
- `presetUtils.serializeLora` already accepts a `{ weight }` override — no change needed there.

## Reviewer notes

- Weights only apply to picker-selected LoRAs; preset-managed LoRAs are excluded from the picker (their weights live in the preset, as before).
- Range is `0–2` to match the preset editor's positive range.

## Test plan

- [x] web vitest: 136 pass (extended the Video Studio picker test to drag the slider to 0.5 and assert `weight: 0.5` in the payload)
- [x] `npm run build` clean
- [ ] Manual: not run — needs the full desktop stack to exercise the slider live

🤖 Generated with [Claude Code](https://claude.com/claude-code)