### PR TITLE
fix(presets): make recipe-preset render settings overrideable in Video/Image Studio

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -164,7 +164,9 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
             job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
         }
     }
-    apply_recipe_preset_defaults(preset, job_payload)?;
+    // Render defaults (count/resolution/negativePrompt) are intentionally NOT
+    // applied here — the studio seeds those into the form from the preset and the
+    // user can override them, so the submitted values are authoritative.
     job_payload.insert(
         "stylePreset".to_owned(),
         Value::String(preset_id.to_owned()),
@@ -248,52 +250,6 @@ pub(crate) async fn merge_preset_loras_into_payload(
     Ok(())
 }
 
-pub(crate) fn apply_recipe_preset_defaults(
-    preset: &Value,
-    job_payload: &mut JsonObject,
-) -> Result<(), ApiError> {
-    let Some(defaults) = preset.get("defaults").and_then(Value::as_object) else {
-        return Ok(());
-    };
-    if let Some(count) = defaults.get("count").and_then(Value::as_u64) {
-        let count = u32::try_from(count)
-            .map_err(|_| ApiError::bad_request("Recipe preset count is out of range"))?;
-        if !(1..=8).contains(&count) {
-            return Err(ApiError::bad_request(
-                "Recipe preset count must be between 1 and 8",
-            ));
-        }
-        job_payload.insert("count".to_owned(), json!(count));
-    }
-    if let Some(resolution) = defaults.get("resolution").and_then(Value::as_str) {
-        let (width, height) = parse_recipe_preset_resolution(resolution)?;
-        validate_dimension(width, "width", MAX_IMAGE_DIMENSION)?;
-        validate_dimension(height, "height", MAX_IMAGE_DIMENSION)?;
-        job_payload.insert("width".to_owned(), json!(width));
-        job_payload.insert("height".to_owned(), json!(height));
-        let advanced = job_payload
-            .entry("advanced".to_owned())
-            .or_insert_with(|| Value::Object(JsonObject::new()));
-        if !advanced.is_object() {
-            *advanced = Value::Object(JsonObject::new());
-        }
-        advanced
-            .as_object_mut()
-            .ok_or_else(|| ApiError::internal("advanced payload must be an object"))?
-            .insert(
-                "resolution".to_owned(),
-                Value::String(resolution.to_owned()),
-            );
-    }
-    if let Some(negative_prompt) = defaults.get("negativePrompt").and_then(Value::as_str) {
-        job_payload.insert(
-            "negativePrompt".to_owned(),
-            Value::String(negative_prompt.to_owned()),
-        );
-    }
-    Ok(())
-}
-
 pub(crate) fn parse_recipe_preset_resolution(value: &str) -> Result<(u32, u32), ApiError> {
     let Some((width, height)) = value.split_once('x') else {
         return Err(ApiError::bad_request(
@@ -312,8 +268,10 @@ pub(crate) fn parse_recipe_preset_resolution(value: &str) -> Result<(u32, u32), 
 /// Server-side expansion of a video job's recipe preset, mirroring
 /// apply_recipe_preset_to_image_payload: the client sends the raw prompt plus
 /// recipePresetId and the server folds in the preset's prompt prefix/suffix,
-/// model, render defaults, and LoRAs. Keeps preset semantics identical across
-/// the image and video studios.
+/// model, and LoRAs. Render defaults (duration/fps/resolution/quality/
+/// negativePrompt) are intentionally NOT applied here — the studio seeds those
+/// into the form from the preset and the user can override them, so the
+/// submitted values are authoritative.
 pub(crate) async fn apply_recipe_preset_to_video_payload(
     state: &AppState,
     payload: &VideoJobRequest,
@@ -343,54 +301,8 @@ pub(crate) async fn apply_recipe_preset_to_video_payload(
             job_payload.insert("model".to_owned(), Value::String(model.to_owned()));
         }
     }
-    apply_recipe_preset_video_defaults(preset, job_payload)?;
     merge_preset_loras_into_payload(state, &payload.project_id, preset_id, preset, job_payload)
         .await
-}
-
-pub(crate) fn apply_recipe_preset_video_defaults(
-    preset: &Value,
-    job_payload: &mut JsonObject,
-) -> Result<(), ApiError> {
-    let Some(defaults) = preset.get("defaults").and_then(Value::as_object) else {
-        return Ok(());
-    };
-    if let Some(duration) = defaults.get("duration") {
-        if !duration
-            .as_f64()
-            .is_some_and(|value| value.is_finite() && (1.0..=30.0).contains(&value))
-        {
-            return Err(ApiError::bad_request(
-                "Recipe preset duration must be between 1 and 30",
-            ));
-        }
-        job_payload.insert("duration".to_owned(), duration.clone());
-    }
-    if let Some(fps) = defaults.get("fps") {
-        if !fps.as_u64().is_some_and(|value| (1..=60).contains(&value)) {
-            return Err(ApiError::bad_request(
-                "Recipe preset fps must be between 1 and 60",
-            ));
-        }
-        job_payload.insert("fps".to_owned(), fps.clone());
-    }
-    if let Some(quality) = defaults.get("quality").and_then(Value::as_str) {
-        job_payload.insert("quality".to_owned(), Value::String(quality.to_owned()));
-    }
-    if let Some(resolution) = defaults.get("resolution").and_then(Value::as_str) {
-        let (width, height) = parse_recipe_preset_resolution(resolution)?;
-        validate_dimension(width, "width", MAX_VIDEO_DIMENSION)?;
-        validate_dimension(height, "height", MAX_VIDEO_DIMENSION)?;
-        job_payload.insert("width".to_owned(), json!(width));
-        job_payload.insert("height".to_owned(), json!(height));
-    }
-    if let Some(negative_prompt) = defaults.get("negativePrompt").and_then(Value::as_str) {
-        job_payload.insert(
-            "negativePrompt".to_owned(),
-            Value::String(negative_prompt.to_owned()),
-        );
-    }
-    Ok(())
 }
 
 pub(crate) async fn create_video_job(

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2862,6 +2862,15 @@ async fn video_jobs_expand_recipe_presets_server_side() {
             "mode": "text_to_video",
             "prompt": "a fox runs",
             "model": "vid-model",
+            // Client render settings that DIFFER from the preset's declared
+            // defaults — the studio seeds the form from the preset but the user
+            // is free to override, so these submitted values must win.
+            "duration": 10,
+            "fps": 24,
+            "width": 640,
+            "height": 640,
+            "quality": "fast",
+            "negativePrompt": "client jitter",
             "recipePresetId": "dream_motion"
         }),
     )
@@ -2873,13 +2882,14 @@ async fn video_jobs_expand_recipe_presets_server_side() {
         video_job["payload"]["prompt"],
         "cinematic, a fox runs, smooth camera motion"
     );
-    // Render defaults come from the preset.
-    assert_eq!(video_job["payload"]["duration"], 8);
-    assert_eq!(video_job["payload"]["fps"], 30);
-    assert_eq!(video_job["payload"]["width"], 1280);
-    assert_eq!(video_job["payload"]["height"], 720);
-    assert_eq!(video_job["payload"]["quality"], "best");
-    assert_eq!(video_job["payload"]["negativePrompt"], "jitter");
+    // Render settings are client-owned and overrideable: the submitted values
+    // win over the preset's declared defaults (8 / 30 / 1280x720 / best / jitter).
+    assert_eq!(video_job["payload"]["duration"], 10);
+    assert_eq!(video_job["payload"]["fps"], 24);
+    assert_eq!(video_job["payload"]["width"], 640);
+    assert_eq!(video_job["payload"]["height"], 640);
+    assert_eq!(video_job["payload"]["quality"], "fast");
+    assert_eq!(video_job["payload"]["negativePrompt"], "client jitter");
     // Preset LoRA merged in (client sent none) and stamped under advanced.
     assert_eq!(video_job["payload"]["loras"][0]["id"], "motion-lora");
     assert_eq!(
@@ -3075,11 +3085,16 @@ async fn model_and_lora_routes_match_manifest_behavior() {
             "projectId": project_id,
             "prompt": "city at night",
             "model": "base-model",
+            // Client render settings that DIFFER from the preset's declared
+            // defaults (count 2 / 1280x720 / "flat lighting") — the studio seeds
+            // the form from the preset but the user can override, so these
+            // submitted values must win.
             "count": 1,
             "width": 512,
             "height": 512,
             "negativePrompt": "client negative prompt",
-            "recipePresetId": "cinematic"
+            "recipePresetId": "cinematic",
+            "advanced": { "resolution": "512x512" }
         }),
     )
     .await;
@@ -3105,12 +3120,14 @@ async fn model_and_lora_routes_match_manifest_behavior() {
         image_job["payload"]["loras"][0]["compatibility"]["families"][0],
         "z-image"
     );
-    assert_eq!(image_job["payload"]["count"], 2);
-    assert_eq!(image_job["payload"]["seeds"].as_array().unwrap().len(), 2);
-    assert_eq!(image_job["payload"]["width"], 1280);
-    assert_eq!(image_job["payload"]["height"], 720);
-    assert_eq!(image_job["payload"]["negativePrompt"], "flat lighting");
-    assert_eq!(image_job["payload"]["advanced"]["resolution"], "1280x720");
+    // Render settings are client-owned and overrideable: the submitted values
+    // win over the preset's declared defaults.
+    assert_eq!(image_job["payload"]["count"], 1);
+    assert_eq!(image_job["payload"]["seeds"].as_array().unwrap().len(), 1);
+    assert_eq!(image_job["payload"]["width"], 512);
+    assert_eq!(image_job["payload"]["height"], 512);
+    assert_eq!(image_job["payload"]["negativePrompt"], "client negative prompt");
+    assert_eq!(image_job["payload"]["advanced"]["resolution"], "512x512");
     assert_eq!(
         image_job["payload"]["advanced"]["recipePresetId"],
         "cinematic"


### PR DESCRIPTION
## Summary
- Recipe-preset render settings (duration, fps, resolution, quality, negativePrompt, and image count) are now **overrideable** in both Video Studio and Image Studio. Selecting a preset still seeds the form, but if you change a field, your value sticks.
- Removed the server-side render-defaults re-application that was clobbering the submitted form values.

## Why
The studios already seed the form from the selected preset and let the user edit those fields, then send the edited values to the API. But `create_video_job`/`create_image_job` then re-applied the preset's *declared* render defaults on top of the payload (`apply_recipe_preset_video_defaults` / `apply_recipe_preset_defaults`), overwriting the user's edits. Net effect: picking a 6s preset and bumping duration to 10s still rendered 6s. Same for resolution/fps/quality/negativePrompt and image count.

The fix makes render settings client-owned (authoritative at submit time). The server still does the things only it can do for presets:
- expand the prompt prefix/suffix around the raw client prompt
- apply the preset model when the request used the default model
- stamp `stylePreset` (image) and `advanced.recipePresetId`
- merge preset LoRAs from the catalog

Both `apply_recipe_preset_video_defaults` and `apply_recipe_preset_defaults` are deleted; the shared `parse_recipe_preset_resolution` helper is kept (still used by recipe-preset validation). Submitted dimensions are still bounds-checked by `validate_video_job`/`validate_image_job`.

## Notes for reviewers
- No client changes were needed — the UI already seeds and sends overrideable values; this is a pure server-side fix.
- This also fixes the same latent bug on the **image** path for symmetry, even though it was reported against video.
- Behavioral edge: a direct API call that sends only `recipePresetId` with no render fields now gets the request struct's serde defaults (duration 6 / 25fps / 768x512 / balanced; count 4 / 1024²) rather than the preset's defaults. The studio UI (the only caller) always sends those fields, so real usage is unaffected.

## Test plan
- [x] `cargo build -p sceneworks-rust-api` — clean, no warnings
- [x] `cargo test -p sceneworks-rust-api` — 81 passed
- [x] Rewrote `video_jobs_expand_recipe_presets_server_side` and `model_and_lora_routes_match_manifest_behavior` to submit render values that differ from the preset and assert the client overrides win (while prompt expansion + LoRA merge + `recipePresetId` still apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)