### PR TITLE
fix(worker): nest video assets under per-generation UUID folder [sc-2001]

### DIFF
--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -499,8 +499,15 @@ class ProceduralVideoAdapter(VideoGenerationAdapter):
         target = model_target(request.model)
         raw_settings = self.map_settings(request, target)
         filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
-        media_rel = f"assets/videos/{filename_base}.webp"
+        # Nest under a per-generation UUID folder so two renders that share the
+        # same date + model + prompt slug (e.g. a recipe preset whose long prompt
+        # prefix dominates the 42-char slug) cannot collide on a flat
+        # `assets/videos/<date>_<model>_<prompt>.webp` name and overwrite each
+        # other's media, sidecar, or temp files. Mirrors the image adapter; the
+        # folder UUID carries uniqueness and discovery is path/sidecar-based.
+        media_rel = f"assets/videos/{generation_set_id}/{filename_base}.webp"
         media_path = project_path / media_rel
+        media_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = media_path.with_suffix(".tmp.webp")
         self.track_temp_output(job["id"], temp_path)
 
@@ -809,8 +816,15 @@ class LtxPipelinesVideoAdapter(ProceduralVideoAdapter):
         asset_id = f"asset_{uuid4().hex}"
         created_at = utc_now()
         filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
-        media_rel = f"assets/videos/{filename_base}.mp4"
+        # Nest under a per-generation UUID folder so two renders that share the
+        # same date + model + prompt slug (e.g. a recipe preset whose long prompt
+        # prefix dominates the 42-char slug) cannot collide on a flat
+        # `assets/videos/<date>_<model>_<prompt>.mp4` name and overwrite each
+        # other's media, sidecar, or temp files. Mirrors the image adapter; the
+        # folder UUID carries uniqueness and discovery is path/sidecar-based.
+        media_rel = f"assets/videos/{generation_set_id}/{filename_base}.mp4"
         media_path = project_path / media_rel
+        media_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = media_path.with_suffix(".tmp.mp4")
         self.track_temp_output(job["id"], temp_path)
 
@@ -1825,8 +1839,15 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         created_at = utc_now()
         raw_settings = self.map_settings(request, target)
         filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
-        media_rel = f"assets/videos/{filename_base}.mp4"
+        # Nest under a per-generation UUID folder so two renders that share the
+        # same date + model + prompt slug (e.g. a recipe preset whose long prompt
+        # prefix dominates the 42-char slug) cannot collide on a flat
+        # `assets/videos/<date>_<model>_<prompt>.mp4` name and overwrite each
+        # other's media, sidecar, or temp files. Mirrors the image adapter; the
+        # folder UUID carries uniqueness and discovery is path/sidecar-based.
+        media_rel = f"assets/videos/{generation_set_id}/{filename_base}.mp4"
         media_path = project_path / media_rel
+        media_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = media_path.with_suffix(".tmp.mp4")
         self.track_temp_output(job["id"], temp_path)
 
@@ -2059,8 +2080,15 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         created_at = utc_now()
         raw_settings = self.map_settings(request, target)
         filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
-        media_rel = f"assets/videos/{filename_base}.mp4"
+        # Nest under a per-generation UUID folder so two renders that share the
+        # same date + model + prompt slug (e.g. a recipe preset whose long prompt
+        # prefix dominates the 42-char slug) cannot collide on a flat
+        # `assets/videos/<date>_<model>_<prompt>.mp4` name and overwrite each
+        # other's media, sidecar, or temp files. Mirrors the image adapter; the
+        # folder UUID carries uniqueness and discovery is path/sidecar-based.
+        media_rel = f"assets/videos/{generation_set_id}/{filename_base}.mp4"
         media_path = project_path / media_rel
+        media_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = media_path.with_suffix(".tmp.mp4")
         self.track_temp_output(job["id"], temp_path)
 
@@ -2228,8 +2256,15 @@ class DiffusersVideoAdapter(VideoGenerationAdapter):
         created_at = utc_now()
         raw_settings = self.map_settings(request, target)
         filename_base = f"{created_at[:10]}_{request.model}_{slugify(request.prompt, fallback='video', max_length=42)}"
-        media_rel = f"assets/videos/{filename_base}.mp4"
+        # Nest under a per-generation UUID folder so two renders that share the
+        # same date + model + prompt slug (e.g. a recipe preset whose long prompt
+        # prefix dominates the 42-char slug) cannot collide on a flat
+        # `assets/videos/<date>_<model>_<prompt>.mp4` name and overwrite each
+        # other's media, sidecar, or temp files. Mirrors the image adapter; the
+        # folder UUID carries uniqueness and discovery is path/sidecar-based.
+        media_rel = f"assets/videos/{generation_set_id}/{filename_base}.mp4"
         media_path = project_path / media_rel
+        media_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = media_path.with_suffix(".tmp.mp4")
         self.track_temp_output(job["id"], temp_path)
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -6146,11 +6146,11 @@ def test_native_ltx_cleanup_deletes_temp_output_and_evicts_pipeline(monkeypatch,
             progress=lambda *_args: None,
             cancel_requested=lambda: False,
         )
-    assert list((project_path / "assets" / "videos").glob("*.tmp.mp4"))
+    assert list((project_path / "assets" / "videos").rglob("*.tmp.mp4"))
 
     adapter.cleanup(job["id"])
 
-    assert list((project_path / "assets" / "videos").glob("*.tmp.mp4")) == []
+    assert list((project_path / "assets" / "videos").rglob("*.tmp.mp4")) == []
     assert adapter.loaded_models() == []
     assert adapter._pipeline is None
 


### PR DESCRIPTION
## Summary
Generated **video** assets were written to a flat, deterministic path — `assets/videos/<date>_<model>_<slugify(prompt, 42)>.{mp4,webp}` — with **no uniqueness token**. Two renders that collapse to the same name silently overwrote each other's media file, `.sceneworks.json` sidecar, and mid-render temp files. This nests video output under a per-generation UUID folder, mirroring the image adapter.

Fixes sc-2001.

## Why
- `asset_id` / `generation_set_id` were already UUIDs but were **not** part of the file path; the path keyed only on date + model + 42-char prompt slug.
- Recipe presets make it worse: the prompt prefix is prepended and `slugify` caps at 42 chars, so a long prefix dominates the slug and even **different** user prompts under the same preset collide (same day + same model → same path → overwrite).
- Images were already safe (`assets/images/{generation_set_id}/...`, image_adapters.py); video never got the same treatment.

## Change
- `apps/worker/scene_worker/video_adapters.py`: all 5 render paths now write to `assets/videos/{generation_set_id}/{filename_base}.{mp4,webp}` and `mkdir` the parent. Sidecar / poster / `.tmp` / `.control` files derive from `media_path`, so they nest automatically — fixing the media overwrite, sidecar collision, and temp-file race in one move.
- `tests/test_worker_runtime.py`: the LTX cleanup test now `rglob`s the now-nested temp output.

## Why this is safe downstream
- Rust `persist_generated_asset` stores the worker-reported `mediaPath` verbatim (jobs.rs) — it doesn't re-derive a flat path.
- Worker resolution (source-frame extraction, person replace, posters) reads `payload["file"]["path"]` — the stored nested path.
- Parity sidecar discovery uses a recursive `assets/**/*.sceneworks.json` glob.
- No Rust changes; no flat `assets/videos` path assumptions anywhere.

## Test plan
- [x] `python -m pytest tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` — 332 passed, 6 skipped
- [x] `python -m pytest -m e2e` — 1 passed
- [x] `py_compile` clean
- [x] Parity unaffected (Rust unchanged; sidecar discovery is recursive)

## Notes
- Pre-existing bug, independent of #286 (preset-override); surfaced while reviewing that change.
- No isolated render-level unit test added: the path is built inside torch-gated adapter methods the light CI can't drive, matching how the analogous image-nesting fix shipped. The cleanup test + e2e exercise the nested layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)