### PR TITLE
style(rust-api): fix rustfmt drift on main blocking parity CI

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3126,7 +3126,10 @@ async fn model_and_lora_routes_match_manifest_behavior() {
     assert_eq!(image_job["payload"]["seeds"].as_array().unwrap().len(), 1);
     assert_eq!(image_job["payload"]["width"], 512);
     assert_eq!(image_job["payload"]["height"], 512);
-    assert_eq!(image_job["payload"]["negativePrompt"], "client negative prompt");
+    assert_eq!(
+        image_job["payload"]["negativePrompt"],
+        "client negative prompt"
+    );
     assert_eq!(image_job["payload"]["advanced"]["resolution"], "512x512");
     assert_eq!(
         image_job["payload"]["advanced"]["recipePresetId"],


### PR DESCRIPTION
## Summary
Reformats a single `assert_eq!` in `apps/rust-api/src/tests.rs` (added by #286) so `cargo fmt --all -- --check` passes. Pure formatting — no behavior change.

## Why
PR #286 was merged with a formatting violation: stable rustfmt (1.9.0) wraps
```
assert_eq!(image_job["payload"]["negativePrompt"], "client negative prompt");
```
across multiple lines. `cargo fmt --check` wasn't run before #286 merged, so the drift reached `main` and the `parity` job's `cargo fmt --all -- --check` step now fails for **every** open PR (the check runs over the whole workspace). This unblocks them, including #287.

## Test plan
- [x] `cargo fmt --all -- --check` → clean (0 diffs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)