### PR TITLE
feat(models): add LTX-2.3 10Eros alternate checkpoint (ltx_2_3_eros)

### DIFF
--- a/apps/web/public/prompt-guides/ltx-2-3-10eros.md
+++ b/apps/web/public/prompt-guides/ltx-2-3-10eros.md
@@ -1,0 +1,35 @@
+# LTX-2.3 10Eros Prompt Guide
+
+10Eros is a community LTX-2.3 merge tuned for image-to-video. It uses the same prompt shape as LTX-2.3, but is more literal: it has low self-reasoning, so motion, scene evolution, and audio must be commanded explicitly. Vague prompts produce static or drifting clips.
+
+## Best For
+
+Image-to-video and text-to-video short clips where you can describe the action precisely. Start from a strong source image for I2V.
+
+## Prompt Shape
+
+Write a single flowing paragraph:
+
+`shot + scene + action over time + character details + camera movement + lighting/atmosphere + audio or dialogue`
+
+Aim for 4 to 8 present-tense sentences. Spell out every beat of motion you want — the model will not infer it.
+
+## Command The Motion
+
+- State what moves, in what order, and where it ends: `she turns her head left, then looks down, then smiles`.
+- Give camera moves a destination: `the camera slowly pushes in to a close-up of her face`.
+- Name lighting and atmosphere directly: `warm key light from the left, soft shadows, shallow depth of field`.
+- For audio, put spoken words in quotes and add delivery cues (language, tone, volume).
+
+## Distill LoRAs
+
+10Eros pairs with TenStrip's distilled LoRA experiments — use the `cond_safe` versions. The model card warns that larger distill LoRAs harm the fine-tune, so prefer the lighter cond_safe variant. Any LTX-video LoRA is compatible (same `ltx-video` family).
+
+## What To Avoid
+
+Avoid overloaded scenes, many simultaneous actions, conflicting lighting, and relying on readable text or logos. Keep physics simple.
+
+## Sources
+
+- [LTX official prompting guide](https://docs.ltx.video/api-documentation/guides/prompting-guide)
+- [TenStrip LTX2.3-10Eros model card](https://huggingface.co/TenStrip/LTX2.3-10Eros)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -198,6 +198,24 @@ export const fallbackModels = [
     },
   },
   {
+    id: "ltx_2_3_eros",
+    name: "LTX-2.3 10Eros",
+    type: "video",
+    capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
+    defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+    limits: {
+      durations: [4, 6, 8, 10, 12, 15],
+      recommendedMaxDuration: 10,
+      fps: [24, 25, 30],
+      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+    },
+    ui: {
+      description: "Community LTX-2.3 merge tuned for image-to-video; uses LTX-video LoRAs.",
+      durationHint: "Best at 10s or less for the current workflow.",
+      promptGuide: { title: "LTX-2.3 10Eros Prompt Guide", path: "/prompt-guides/ltx-2-3-10eros.md" },
+    },
+  },
+  {
     id: "svd",
     name: "Stable Video Diffusion",
     type: "video",

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -148,8 +148,27 @@ export function presetMatchesWorkflow(preset, mode) {
   return preset?.workflow === mode;
 }
 
-export function presetMatchesModel(preset, model) {
-  return !preset?.model || !model?.id || preset.model === model.id;
+export function presetMatchesModel(preset, model, models = null) {
+  if (!preset?.model || !model?.id) {
+    return true;
+  }
+  if (preset.model === model.id) {
+    return true;
+  }
+  // Family-aware fallback: a preset pinned to a sibling model still applies when
+  // both models share a LoRA family (e.g. an ltx_2_3 preset under ltx_2_3_eros —
+  // both "ltx-video"). Needs the catalog to resolve the preset's pinned model id
+  // into its family; without it (e.g. offline fallback) we stay strict.
+  if (Array.isArray(models)) {
+    const presetModelFamilies = modelLoraFamilies(models.find((item) => item.id === preset.model));
+    const modelFamilies = modelLoraFamilies(model);
+    return (
+      presetModelFamilies.length > 0 &&
+      modelFamilies.length > 0 &&
+      presetModelFamilies.some((family) => modelFamilies.includes(family))
+    );
+  }
+  return false;
 }
 
 export function presetLoras(preset) {

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { presetMatchesModel } from "./presetUtils.js";
+
+const ltx = { id: "ltx_2_3", family: "ltx-video" };
+const ltxEros = { id: "ltx_2_3_eros", family: "ltx-video" };
+const sdxl = { id: "sdxl", family: "sdxl" };
+const catalog = [ltx, ltxEros, sdxl];
+
+describe("presetMatchesModel", () => {
+  it("matches when the preset pins no model", () => {
+    expect(presetMatchesModel({ id: "p" }, ltxEros, catalog)).toBe(true);
+  });
+
+  it("matches when the selected model has no id", () => {
+    expect(presetMatchesModel({ model: "ltx_2_3" }, {}, catalog)).toBe(true);
+  });
+
+  it("matches on exact model id", () => {
+    expect(presetMatchesModel({ model: "ltx_2_3" }, ltx, catalog)).toBe(true);
+  });
+
+  it("matches a sibling model in the same family (ltx_2_3 preset under ltx_2_3_eros)", () => {
+    expect(presetMatchesModel({ model: "ltx_2_3" }, ltxEros, catalog)).toBe(true);
+  });
+
+  it("does not match across families", () => {
+    expect(presetMatchesModel({ model: "ltx_2_3" }, sdxl, catalog)).toBe(false);
+  });
+
+  it("stays strict (no family fallback) when the catalog is unavailable", () => {
+    expect(presetMatchesModel({ model: "ltx_2_3" }, ltxEros)).toBe(false);
+  });
+});

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -59,8 +59,8 @@ export function useGenerationStudio({
   }, [characters, characterId]);
 
   const availablePresets = useMemo(
-    () => presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel)),
-    [mode, presets, selectedModel?.id],
+    () => presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel, models)),
+    [mode, presets, selectedModel?.id, models],
   );
   const selectedPreset =
     selectedPresetId === noPresetId

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -238,6 +238,22 @@ VIDEO_MODEL_TARGETS: dict[str, dict[str, Any]] = {
         "steps": {"fast": 6, "balanced": 8, "best": 20},
         "durationHint": "Best as short shots. Start with 4-8 seconds; 10 seconds is the current workflow ceiling.",
     },
+    # Community LTX-2.3 merge (TenStrip/LTX2.3-10Eros), I2V-tuned. Same ltx-video
+    # family and ltx_video adapter as ltx_2_3, so it reuses the native torch pipeline
+    # (CUDA) and the MLX path; the bf16 checkpoint shares the official LTX-2.3 key
+    # layout. On Apple Silicon the MLX adapter loads a locally-converted Q4 dir.
+    "ltx_2_3_eros": {
+        "label": "LTX-2.3 10Eros",
+        "family": "ltx-video",
+        "adapter": "ltx_video",
+        "repo": "TenStrip/LTX2.3-10Eros",
+        "fallbackRepo": "Lightricks/LTX-2.3",
+        "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
+        "recommendedMaxDuration": 10,
+        "hardMaxDuration": 15,
+        "steps": {"fast": 6, "balanced": 8, "best": 20},
+        "durationHint": "Best as short shots. Start with 4-8 seconds; 10 seconds is the current workflow ceiling.",
+    },
     "wan_2_2": {
         "label": "Wan2.2",
         "family": "wan-video",
@@ -1687,7 +1703,7 @@ class MlxVideoAdapter(VideoGenerationAdapter):
     _ltx_repo = "notapalindrome/ltx23-mlx-av-q4"
     _ltx_text_encoder = "mlx-community/gemma-3-12b-it-bf16"
 
-    _supported_models = {"ltx_2_3", "wan_2_2", "wan_2_2_t2v_14b", "wan_2_2_i2v_14b"}
+    _supported_models = {"ltx_2_3", "ltx_2_3_eros", "wan_2_2", "wan_2_2_t2v_14b", "wan_2_2_i2v_14b"}
     # The mlx-video-with-audio high-level API exposes only text-to-video and
     # single-image image-to-video. first/last-frame, bridge, extend, and
     # replace_person stay on the PyTorch path (no spatial mask / multi-cond).
@@ -1736,6 +1752,7 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         # (the Model Manager gates on the manifest value); keep the two in sync.
         memory_estimates = {
             "ltx_2_3": {"peak_gb": 31, "description": "Q4 quantized, ~31 GB peak"},
+            "ltx_2_3_eros": {"peak_gb": 31, "description": "Q4 quantized, ~31 GB peak"},
             "wan_2_2": {"peak_gb": 45, "description": "bf16, 40 steps, ~45 GB peak"},
             "wan_2_2_t2v_14b": {"peak_gb": 133, "description": "bf16 + Lightning LoRA, 4 steps, ~133 GB peak"},
             "wan_2_2_i2v_14b": {"peak_gb": 133, "description": "bf16 + Lightning LoRA, 4 steps, ~133 GB peak"},
@@ -1764,7 +1781,7 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         cancel_requested: CancelCallback,
     ) -> dict[str, Any]:
         target = model_target(request.model)
-        if request.model == "ltx_2_3":
+        if target["family"] == "ltx-video":
             return self._run_ltx_mlx(settings, job, request, progress, cancel_requested)
         if request.model in {"wan_2_2", "wan_2_2_t2v_14b", "wan_2_2_i2v_14b"}:
             return self._run_wan_mlx(settings, job, request, progress, cancel_requested)
@@ -1804,7 +1821,8 @@ class MlxVideoAdapter(VideoGenerationAdapter):
             (project_path / folder).mkdir(parents=True, exist_ok=True)
 
         target = model_target(request.model)
-        progress("loading_model", "loading_model", 0.1, "Loading LTX-2.3 (MLX Q4).")
+        model_repo = self._ltx_mlx_repo(request.model)
+        progress("loading_model", "loading_model", 0.1, f"Loading {target['label']} (MLX Q4).")
         try:
             from mlx_video.generate_av import generate_video_with_audio
         except ImportError as e:
@@ -1852,11 +1870,11 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         self.track_temp_output(job["id"], temp_path)
 
         lora_token = self._apply_ltx_loras(request, progress)
-        progress("running", "generating", 0.3, f"Generating {num_frames} frames with LTX-2.3 (MLX).")
-        self._loaded_models.update({request.model, self._ltx_repo})
+        progress("running", "generating", 0.3, f"Generating {num_frames} frames with {target['label']} (MLX).")
+        self._loaded_models.update({request.model, model_repo})
         try:
             generate_video_with_audio(
-                model_repo=self._ltx_repo,
+                model_repo=model_repo,
                 text_encoder_repo=self._ltx_text_encoder,
                 prompt=request.prompt,
                 negative_prompt=request.negative_prompt or None,
@@ -1901,6 +1919,34 @@ class MlxVideoAdapter(VideoGenerationAdapter):
             mime_type="video/mp4",
             raw_settings=raw_settings,
             extra={"requirements": self.estimate_requirements(request)},
+        )
+
+    def _ltx_mlx_repo(self, model: str) -> str:
+        """Resolve the MLX model repo/dir for an ltx-video model.
+
+        Prefers a locally-converted MLX dir (what `mlx_video.convert` writes into
+        `<data>/models/mlx/<model>`) so a converted checkpoint transparently supersedes
+        any turnkey repo. ltx_2_3 falls back to the published community Q4 repo; models
+        with no published MLX repo (e.g. ltx_2_3_eros) must be converted locally first.
+        """
+        env = {
+            "ltx_2_3": "SCENEWORKS_MLX_LTX23_DIR",
+            "ltx_2_3_eros": "SCENEWORKS_MLX_LTX23_EROS_DIR",
+        }.get(model)
+        local_dir = self._local_mlx_dir(model, env)
+        if local_dir is not None:
+            return local_dir
+        if model == "ltx_2_3":
+            return self._ltx_repo
+        target_dir = (
+            Path(self._settings.data_dir) / "models" / "mlx" / model
+            if self._settings is not None
+            else Path("<data>/models/mlx") / model
+        )
+        raise RuntimeError(
+            f"{model_target(model)['label']} has no MLX weights. Convert the bf16 checkpoint into "
+            f"{target_dir} with `python -m mlx_video.convert --hf-path <checkpoint> "
+            f"--mlx-path {target_dir} --quantize --q-bits 4`."
         )
 
     def _apply_ltx_loras(self, request: VideoRequest, progress: ProgressCallback):

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -861,6 +861,96 @@
       }
     },
     {
+      "id": "ltx_2_3_eros",
+      "name": "LTX-2.3 10Eros",
+      "family": "ltx-video",
+      "type": "video",
+      "adapter": "ltx_video",
+      "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "TenStrip/LTX2.3-10Eros",
+          // Community LTX-2.3 merge (Sulphur-2-base, I2V-tuned). The repo also ships
+          // fp8 and fp8-transformer variants; we only need the bf16 all-in-one, which
+          // shares the official ltx-2.3-22b-distilled key layout (model.diffusion_model.*
+          // transformer + bundled vae/audio_vae/vocoder), so it is a drop-in checkpoint.
+          "files": ["10Eros_v1_bf16.safetensors"],
+          "default": true,
+          "estimatedSizeBytes": 46139885510
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/TenStrip/LTX2.3-10Eros"
+      },
+      "resources": {
+        "checkpoint": {
+          "repo": "TenStrip/LTX2.3-10Eros",
+          "file": "10Eros_v1_bf16.safetensors"
+        },
+        "distilledCheckpoint": {
+          "repo": "TenStrip/LTX2.3-10Eros",
+          "file": "10Eros_v1_bf16.safetensors"
+        },
+        "spatialUpscaler": {
+          "repo": "Lightricks/LTX-2.3",
+          "file": "ltx-2.3-spatial-upscaler-x2-1.1.safetensors"
+        },
+        "distilledLora": {
+          // TenStrip's recommended cond_safe distill LoRA for 10Eros (the model card
+          // warns that larger distill LoRAs harm the fine-tune). Only consumed by the
+          // CUDA ti2vid_two_stages torch path; the MLX path runs the converted dir.
+          "repo": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
+          "file": "ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors"
+        },
+        "gemma": {
+          "repo": "google/gemma-3-12b-it-qat-q4_0-unquantized"
+        }
+      },
+      "defaults": {
+        "duration": 6,
+        "fps": 25,
+        "resolution": "768x512",
+        "quality": "balanced",
+        "steps": 8
+      },
+      "limits": {
+        "durations": [4, 6, 8, 10, 12, 15],
+        "recommendedMaxDuration": 10,
+        "hardMaxDuration": 15,
+        "fps": [24, 25, 30],
+        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+        "requiresDimensionsMultipleOf": 32
+      },
+      "loraCompatibility": {
+        "families": ["ltx-video"],
+        "types": ["style", "motion", "character", "enhance"]
+      },
+      "mlx": {
+        // No published MLX repo; the bf16 checkpoint is converted locally
+        // (python -m mlx_video.convert --quantize --q-bits 4) into
+        // <data>/models/mlx/ltx_2_3_eros. minMemoryGb mirrors the LTX-2.3 Q4 tier.
+        "minMemoryGb": 31,
+        "requiresConversion": true,
+        "convertSourceRepo": "TenStrip/LTX2.3-10Eros",
+        "textEncoderRepo": "mlx-community/gemma-3-12b-it-bf16"
+      },
+      "ui": {
+        "label": "LTX-2.3 10Eros",
+        "description": "Community LTX-2.3 merge tuned for image-to-video. Same family as LTX-2.3 — uses LTX-video LoRAs. Responds to detailed, command-style prompts.",
+        "recommendedFor": ["image_to_video", "text_to_video"],
+        "durationHint": "Best for short clips. Start with 4-8 seconds; 10 seconds is the normal ceiling for the current workflow.",
+        "promptGuide": {
+          "title": "LTX-2.3 10Eros Prompt Guide",
+          "path": "/prompt-guides/ltx-2-3-10eros.md",
+          "sources": [
+            { "label": "LTX official prompting guide", "url": "https://docs.ltx.video/api-documentation/guides/prompting-guide" },
+            { "label": "TenStrip LTX2.3-10Eros model card", "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros" }
+          ]
+        }
+      }
+    },
+    {
       "id": "svd",
       "name": "Stable Video Diffusion",
       "family": "svd",


### PR DESCRIPTION
## Summary
Adds **`ltx_2_3_eros`** — the community LTX-2.3 merge [`TenStrip/LTX2.3-10Eros`](https://huggingface.co/TenStrip/LTX2.3-10Eros) (I2V-tuned) — as a second selectable LTX-2.3 video model in the **`ltx-video`** family, alongside the stock `ltx_2_3`. Because it stays in the same family it automatically reuses all LTX-video LoRAs, including TenStrip's recommended `cond_safe` distill LoRA.

**Key finding:** the `10Eros_v1_bf16.safetensors` checkpoint has the *identical* key layout and tensor count (5947) as the official `ltx-2.3-22b-distilled.safetensors` (`model.diffusion_model.*` transformer + bundled VAE/audio-VAE/vocoder), so it's a drop-in for both the native torch `ltx-core` pipeline and `mlx_video.convert` — no key remapping needed.

## Changes
- **`config/manifests/builtin.models.jsonc`** — `ltx_2_3_eros` entry mirroring `ltx_2_3`; checkpoint → `TenStrip/LTX2.3-10Eros`, reuses the official spatial upscaler + Gemma, `distilledLora` → TenStrip cond_safe. The `mlx` block uses `requiresConversion`/`convertSourceRepo` so a locally-converted MLX dir is surfaced as "converted" by the Model Manager.
- **`apps/web/src/constants.js`** — picker mirror entry.
- **`apps/web/public/prompt-guides/ltx-2-3-10eros.md`** — prompt guide (command-style prompting + distill-LoRA note).
- **`apps/worker/scene_worker/video_adapters.py`** — `VIDEO_MODEL_TARGETS` entry; `MlxVideoAdapter` now dispatches the whole `ltx-video` family to the LTX MLX path and resolves a per-model converted dir via new `_ltx_mlx_repo()` (mirrors the Wan `_local_mlx_dir` pattern). `ltx_2_3` still defaults to the published `notapalindrome/ltx23-mlx-av-q4` repo.

> MLX weights are produced locally with `python -m mlx_video.convert --hf-path <10Eros bf16 staged as ltx-2.3-22b-distilled.safetensors + upscaler> --mlx-path <data>/models/mlx/ltx_2_3_eros --quantize --q-bits 4`. They are not part of this PR (live under the app data dir).

## Validated (Apple Silicon / MLX)
- ✅ T2V render 448×320, 25 frames → valid MP4 (~31s).
- ✅ Distill-LoRA render: TenStrip cond_safe LoRA matched 1660 transformer modules → valid MP4 (~11s).
- ✅ `model_target` / `_supported_models` / `_ltx_mlx_repo()` resolve `ltx_2_3_eros` to the converted dir; `ltx_2_3` unchanged.
- ✅ 338 worker tests pass; `scripts/check-scaffold.mjs` passes.

## Not yet exercised
- Torch/CUDA `LtxPipelinesVideoAdapter` path (this box is Apple Silicon with no ltx-core deps). The `distilledLora` mapping for the `ti2vid_two_stages` path is a best guess pending a real CUDA run.
- Live Video Studio picker click-through (data-driven, mirrors `ltx_2_3`).

## Test plan
- [ ] Select **LTX-2.3 10Eros** in Video Studio (Apple Silicon) and run an image-to-video generation.
- [ ] Attach an LTX-video LoRA (and/or the TenStrip cond_safe distill LoRA) and confirm it applies.
- [ ] On CUDA: confirm the native LTX pipeline loads the 10Eros checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)