### PR TITLE
feat(mlx): per-pass distill LoRA for ltx_2_3_eros (1.0 base / 0.4 upscale)

### DIFF
--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -1646,39 +1646,89 @@ def write_poster_frame(media_path: Path) -> None:
         poster.unlink(missing_ok=True)
 
 
-# LTX user-LoRA injection. mlx-video-with-audio's turnkey generate_video_with_audio
-# builds the LTX transformer (LTXModel) internally and exposes no loras kwarg, so we
-# wrap LTXModel.load_weights to merge the pending LoRAs (apply_loras_to_model: dequant
-# only the LoRA'd layers to bf16, no requant precision loss, no per-step overhead) right
-# after the quantized weights load — the same primitive the package uses for quantized
-# Wan. The per-generation module map is passed through this ContextVar.
+# LTX LoRA injection. mlx-video-with-audio's turnkey generate_video_with_audio builds
+# the LTX transformer (LTXModel) internally and exposes no loras kwarg, so we wrap
+# LTXModel.load_weights to apply the pending LoRAs right after the quantized weights
+# load. Two modes share the wrap, selected per generation by which ContextVar is set:
+#
+#  - Constant strength (_PENDING_LTX_LORAS, a module->loras map): merge the LoRA into
+#    the layers via the package's apply_loras_to_model (dequant the LoRA'd layers to
+#    bf16, no per-step overhead). Used for stock LTX-2.3 and plain user LoRAs.
+#  - Per-pass strength (_PENDING_LTX_LORA_PLAN, a dict): apply the LoRA as on-the-fly
+#    LoRALinear wrappers at the stage-1 strength, then drop them to the stage-2 strength
+#    at the spatial-upscale boundary (upsample_latents, called exactly once between the
+#    two sampling stages). The turnkey API runs one transformer for BOTH passes, so a
+#    merged/baked LoRA can't vary per pass; wrappers + the boundary hook let a distill
+#    LoRA run strong on the base pass and weak on the upscale/refine pass (TenStrip's
+#    10Eros guidance: ~1.0 first pass, ~0.4 upscale).
 _PENDING_LTX_LORAS: ContextVar[dict[str, Any] | None] = ContextVar("sceneworks_ltx_loras", default=None)
+_PENDING_LTX_LORA_PLAN: ContextVar[dict[str, Any] | None] = ContextVar("sceneworks_ltx_lora_plan", default=None)
 _ltx_lora_patch_installed = False
 
 
+def _wrap_loras_as_linears(model: Any, stage_map: dict[str, Any]) -> dict[str, Any]:
+    """Replace each LoRA-targeted Linear/QuantizedLinear with a LoRALinear wrapper
+    (on-the-fly delta, mutable strength) and return ``{module_key: LoRALinear}`` so the
+    caller can re-scale strengths at the stage boundary. Mirrors apply_loras_to_model's
+    traversal + key normalization but wraps instead of merging (merge is permanent and
+    cannot vary per pass)."""
+    import mlx.nn as nn
+    from mlx_video.lora.apply import LoRALinear, _normalize_lora_key
+
+    module_paths: set[str] = set()
+    for name, _ in model.named_modules():
+        module_paths.add(name)
+        module_paths.add(f"{name}.weight")
+    wrappers: dict[str, Any] = {}
+    for module_key, loras in stage_map.items():
+        normalized = _normalize_lora_key(module_key, module_paths)
+        if normalized.endswith(".weight"):
+            normalized = normalized[: -len(".weight")]
+        parts = normalized.split(".")
+        parent = model
+        try:
+            for part in parts[:-1]:
+                parent = getattr(parent, part) if not part.isdigit() else parent[int(part)]
+            leaf = parts[-1]
+            target = getattr(parent, leaf) if not leaf.isdigit() else parent[int(leaf)]
+        except (AttributeError, IndexError, TypeError):
+            continue
+        if isinstance(target, (nn.Linear, nn.QuantizedLinear)):
+            wrapper = LoRALinear(target, list(loras))
+            if leaf.isdigit():
+                parent[int(leaf)] = wrapper
+            else:
+                setattr(parent, leaf, wrapper)
+            wrappers[module_key] = wrapper
+    return wrappers
+
+
 def _install_ltx_lora_patch() -> None:
-    """Idempotently wrap LTXModel.load_weights to apply the LoRAs in _PENDING_LTX_LORAS
-    after each load. Targets only LTXModel (the text encoder, VAEs, and vocoder are
-    distinct classes), and fires after nn.quantize so the LoRA'd layers are quantized.
+    """Idempotently wrap LTXModel.load_weights (apply pending LoRAs after load) and
+    mlx_video.generate_av.upsample_latents (flip per-pass wrappers to the stage-2
+    strength at the stage boundary). Fires after nn.quantize so merged LoRA'd layers are
+    handled correctly.
 
     Drift guard (sc-1647): targets symbols pinned to mlx-video-with-audio>=0.1.36,<0.2
-    (``requirements-mlx.txt``). The two imports below fail loudly (ImportError) if the
-    package moves ``apply_loras_to_model`` or ``LTXModel``; we additionally assert
-    ``LTXModel.load_weights`` exists and is callable so a rename surfaces as an
-    actionable VendorPatchDriftError instead of a bare AttributeError. Re-validate on
-    any mlx-video-with-audio bump."""
+    (``requirements-mlx.txt``). The imports below fail loudly (ImportError) if the
+    package moves ``apply_loras_to_model`` / ``LoRALinear`` / ``LTXModel`` /
+    ``upsample_latents``; _require_patch_target additionally asserts the wrapped symbols
+    exist and are callable, so a rename surfaces as an actionable VendorPatchDriftError.
+    Re-validate on any mlx-video-with-audio bump."""
     global _ltx_lora_patch_installed
     if _ltx_lora_patch_installed:
         return
+    import mlx_video.generate_av as gav
     from mlx_video.lora import apply_loras_to_model
+    from mlx_video.lora.apply import LoRALinear  # noqa: F401 — presence/drift check
     from mlx_video.models.ltx.ltx import LTXModel
 
+    pin = "mlx-video-with-audio>=0.1.36,<0.2 (requirements-mlx.txt)"
     original_load_weights = _require_patch_target(
-        LTXModel,
-        "load_weights",
-        pin="mlx-video-with-audio>=0.1.36,<0.2 (requirements-mlx.txt)",
-        patch="LTX LoRA load_weights wrap (sc-1647)",
-        require_callable=True,
+        LTXModel, "load_weights", pin=pin, patch="LTX LoRA load_weights wrap (sc-1647)", require_callable=True
+    )
+    original_upsample = _require_patch_target(
+        gav, "upsample_latents", pin=pin, patch="LTX per-pass LoRA upsample boundary (sc-1647)", require_callable=True
     )
     if getattr(original_load_weights, "_sw_lora_wrapped", False):  # guard against double-wrap
         _ltx_lora_patch_installed = True
@@ -1686,6 +1736,15 @@ def _install_ltx_lora_patch() -> None:
 
     def _load_weights_with_loras(self, *args, **kwargs):
         result = original_load_weights(self, *args, **kwargs)
+        plan = _PENDING_LTX_LORA_PLAN.get()
+        if plan is not None:
+            wrappers = _wrap_loras_as_linears(self, plan["stage1_map"])
+            if not wrappers:
+                raise RuntimeError(
+                    "Selected LoRA(s) matched no LTX-2.3 transformer layers — confirm the file is an LTX-video adapter."
+                )
+            plan["wrappers"] = wrappers
+            return result
         pending = _PENDING_LTX_LORAS.get()
         if pending and apply_loras_to_model(self, pending) == 0:
             raise RuntimeError(
@@ -1693,8 +1752,20 @@ def _install_ltx_lora_patch() -> None:
             )
         return result
 
+    def _upsample_with_perpass(*args, **kwargs):
+        plan = _PENDING_LTX_LORA_PLAN.get()
+        if plan is not None:
+            stage2_map = plan["stage2_map"]
+            for module_key, wrapper in plan.get("wrappers", {}).items():
+                stage2 = stage2_map.get(module_key)
+                if stage2 is not None:
+                    wrapper.lora_weights_and_strengths = list(stage2)
+        return original_upsample(*args, **kwargs)
+
     _load_weights_with_loras._sw_lora_wrapped = True
+    _upsample_with_perpass._sw_lora_wrapped = True
     LTXModel.load_weights = _load_weights_with_loras
+    gav.upsample_latents = _upsample_with_perpass
     _ltx_lora_patch_installed = True
 
 
@@ -1869,7 +1940,7 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         temp_path = media_path.with_suffix(".tmp.mp4")
         self.track_temp_output(job["id"], temp_path)
 
-        lora_token = self._apply_ltx_loras(request, progress)
+        lora_reset = self._apply_ltx_loras(request, progress)
         progress("running", "generating", 0.3, f"Generating {num_frames} frames with {target['label']} (MLX).")
         self._loaded_models.update({request.model, model_repo})
         try:
@@ -1892,8 +1963,9 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         except Exception as e:
             raise RuntimeError(f"MLX LTX-2.3 generation failed: {e}")
         finally:
-            if lora_token is not None:
-                _PENDING_LTX_LORAS.reset(lora_token)
+            if lora_reset is not None:
+                lora_ctxvar, lora_token = lora_reset
+                lora_ctxvar.reset(lora_token)
             if tmp_image is not None:
                 tmp_image.unlink(missing_ok=True)
 
@@ -1949,26 +2021,95 @@ class MlxVideoAdapter(VideoGenerationAdapter):
             f"--mlx-path {target_dir} --quantize --q-bits 4`."
         )
 
-    def _apply_ltx_loras(self, request: VideoRequest, progress: ProgressCallback):
-        """Stage user LoRAs for the next LTX generation. Returns a ContextVar token
-        (reset in the caller's finally) or None when there are no LoRAs. The patched
-        LTXModel.load_weights merges the staged map into the transformer."""
-        specs = normalize_lora_specs(request.loras)
-        if not specs:
-            return None
-        progress("loading_model", "loading_model", 0.25, "Applying LoRA to LTX-2.3 transformer.")
-        _install_ltx_lora_patch()
-        return _PENDING_LTX_LORAS.set(self._ltx_lora_module_map(specs))
+    def _collect_ltx_lora_specs(self, request: VideoRequest) -> list[tuple[str, float, float]]:
+        """Collect ``(path, stage1_strength, stage2_strength)`` for every LoRA to apply.
 
-    def _ltx_lora_module_map(self, specs: list[LoraSpec]) -> dict[str, Any]:
+        User-selected LoRAs are constant (stage1 == stage2 == weight). When the model's
+        manifest declares ``mlx.autoDistillLora`` (10Eros), the recommended distill LoRA
+        is auto-injected with per-pass strengths (default 1.0 base pass / 0.4 upscale
+        pass) so the user gets usable output without selecting it and without
+        over-applying it on the upscale/refine pass.
+        """
+        specs: list[tuple[str, float, float]] = [
+            (spec.path, spec.weight, spec.weight) for spec in normalize_lora_specs(request.loras)
+        ]
+        distill = self._resolve_distill_lora(request)
+        if distill is not None:
+            specs.append(distill)
+        return specs
+
+    def _resolve_distill_lora(self, request: VideoRequest) -> tuple[str, float, float] | None:
+        """Resolve the auto-injected per-pass distill LoRA from the manifest, or None.
+
+        Returns ``(path, stage1_strength, stage2_strength)``. Active only when the
+        manifest's ``mlx.autoDistillLora`` block is present and ``advanced.useDistillLora``
+        is not disabled. Raises if declared+enabled but the LoRA file is not available
+        locally — it is a required runtime component for that model (without it 10Eros
+        text-to-video degrades to noise), so failing loud beats silently degrading.
+        """
+        entry = request.model_manifest_entry
+        mlx_cfg = entry.get("mlx") if isinstance(entry.get("mlx"), dict) else {}
+        auto = mlx_cfg.get("autoDistillLora") if isinstance(mlx_cfg, dict) else None
+        if not isinstance(auto, dict):
+            return None
+        if not bool(request.advanced.get("useDistillLora", True)):
+            return None
+        resources = entry.get("resources") if isinstance(entry.get("resources"), dict) else {}
+        resource = resources.get("distilledLora") if isinstance(resources.get("distilledLora"), dict) else {}
+        repo = resource.get("repo")
+        file_name = resource.get("file")
+        settings = self._settings or WorkerSettings()
+        path: str | None = None
+        if repo and file_name:
+            cached = huggingface_cached_resource_file(settings, str(repo), str(file_name))
+            if cached is not None and Path(cached).is_file():
+                path = str(cached)
+            else:
+                local = settings.data_dir / "models" / safe_download_dir(str(repo)) / str(file_name)
+                if local.is_file():
+                    path = str(local)
+        if path is None:
+            raise RuntimeError(
+                f"{model_target(request.model)['label']} requires its distill LoRA "
+                f"({file_name or 'distilledLora'}) for usable output, but it was not found locally. "
+                f"Install the '{repo}' LoRA in Model Manager, or set advanced.useDistillLora=false to skip it."
+            )
+        stage1 = safe_float(request.advanced.get("distillStage1Strength"), float(auto.get("stage1Strength", 1.0)), 0.0, 2.0)
+        stage2 = safe_float(request.advanced.get("distillStage2Strength"), float(auto.get("stage2Strength", 0.4)), 0.0, 2.0)
+        return (path, stage1, stage2)
+
+    def _load_lora_map(self, configs: list[tuple[str, float]]) -> dict[str, Any]:
+        """Build a module->[(LoRAWeights, strength)] map from (path, strength) configs
+        via the mlx-video LoRA loader. Isolated so the mlx import stays out of the
+        light-dep callers and tests can stub it. Raises if nothing matched."""
         from mlx_video.lora import LoRAConfig, load_multiple_loras
 
-        module_to_loras = load_multiple_loras([LoRAConfig(path=spec.path, strength=spec.weight) for spec in specs])
-        if not module_to_loras:
+        module_map = load_multiple_loras([LoRAConfig(path=path, strength=strength) for path, strength in configs])
+        if not module_map:
             raise RuntimeError(
                 "Selected LoRA(s) matched no LTX-2.3 transformer layers — confirm the file is an LTX-video adapter."
             )
-        return module_to_loras
+        return module_map
+
+    def _apply_ltx_loras(self, request: VideoRequest, progress: ProgressCallback):
+        """Stage LoRAs for the next LTX generation. Returns ``(contextvar, token)`` to
+        reset in the caller's finally, or None when there are no LoRAs. Builds a per-pass
+        plan (LoRALinear wrappers + stage-boundary strength drop) when any LoRA has
+        differing stage strengths; otherwise a constant merge map."""
+        specs = self._collect_ltx_lora_specs(request)
+        if not specs:
+            return None
+        progress("loading_model", "loading_model", 0.25, "Applying LoRA to the LTX transformer.")
+        _install_ltx_lora_patch()
+        if any(abs(stage1 - stage2) > 1e-6 for _, stage1, stage2 in specs):
+            plan = {
+                "stage1_map": self._load_lora_map([(path, s1) for path, s1, _ in specs]),
+                "stage2_map": self._load_lora_map([(path, s2) for path, _, s2 in specs]),
+                "wrappers": {},
+            }
+            return (_PENDING_LTX_LORA_PLAN, _PENDING_LTX_LORA_PLAN.set(plan))
+        merge_map = self._load_lora_map([(path, s1) for path, s1, _ in specs])
+        return (_PENDING_LTX_LORAS, _PENDING_LTX_LORAS.set(merge_map))
 
     def _first_condition_image(self, project_path: Path, request: VideoRequest) -> Any:
         return self._condition_image(project_path, request.source_asset_id)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -878,6 +878,15 @@
           "files": ["10Eros_v1_bf16.safetensors"],
           "default": true,
           "estimatedSizeBytes": 46139885510
+        },
+        {
+          // Recommended cond_safe distill LoRA. Required runtime component on the MLX
+          // path: it is auto-injected per-pass (see mlx.autoDistillLora) so 10Eros
+          // produces usable text-to-video. Only the cond_safe variant is fetched.
+          "provider": "huggingface",
+          "repo": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
+          "files": ["ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors"],
+          "estimatedSizeBytes": 662072824
         }
       ],
       "paths": {
@@ -933,7 +942,14 @@
         "minMemoryGb": 31,
         "requiresConversion": true,
         "convertSourceRepo": "TenStrip/LTX2.3-10Eros",
-        "textEncoderRepo": "mlx-community/gemma-3-12b-it-bf16"
+        "textEncoderRepo": "mlx-community/gemma-3-12b-it-bf16",
+        // 10Eros's base is not pre-distilled, so the MLX adapter auto-injects the
+        // cond_safe distill LoRA (resources.distilledLora) at runtime with per-pass
+        // strengths: full on the base sampling pass, reduced on the spatial-upscale /
+        // refine pass (TenStrip's guidance for rank<=72 cond_safe LoRAs). Without it,
+        // text-to-video degrades to noise. Overridable via advanced.useDistillLora /
+        // distillStage1Strength / distillStage2Strength.
+        "autoDistillLora": { "stage1Strength": 1.0, "stage2Strength": 0.4 }
       },
       "ui": {
         "label": "LTX-2.3 10Eros",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -130,6 +130,7 @@ from scene_worker.video_adapters import (
     VIDEO_MODEL_TARGETS,
     VendorPatchDriftError,
     _PENDING_LTX_LORAS,
+    _PENDING_LTX_LORA_PLAN,
     _require_patch_target,
     character_reference_images,
     create_video_adapter,
@@ -841,7 +842,7 @@ def test_mlx_ltx_stages_loras_in_contextvar_only_when_present(tmp_path, monkeypa
     lora_file.write_bytes(b"lora")
     adapter = MlxVideoAdapter()
     monkeypatch.setattr("scene_worker.video_adapters._install_ltx_lora_patch", lambda: None)
-    monkeypatch.setattr(adapter, "_ltx_lora_module_map", lambda specs: {"transformer_blocks.0.attn": [("w", specs[0].weight)]})
+    monkeypatch.setattr(adapter, "_load_lora_map", lambda configs: {"transformer_blocks.0.attn": [("w", configs[0][1])]})
     progress_calls: list[tuple] = []
 
     def progress(*args, **kwargs):
@@ -859,14 +860,88 @@ def test_mlx_ltx_stages_loras_in_contextvar_only_when_present(tmp_path, monkeypa
             [{"id": "ltx_style", "installedPath": str(lora_file), "weight": 0.6, "family": "ltx-video"}],
         )
     )
-    token = adapter._apply_ltx_loras(lora_request, progress)
+    reset = adapter._apply_ltx_loras(lora_request, progress)
     try:
-        assert token is not None
+        assert reset is not None
+        ctxvar, token = reset
+        # A plain user LoRA is constant strength → merge map (not the per-pass plan).
+        assert ctxvar is _PENDING_LTX_LORAS
         assert _PENDING_LTX_LORAS.get() == {"transformer_blocks.0.attn": [("w", 0.6)]}
+        assert _PENDING_LTX_LORA_PLAN.get() is None
         assert progress_calls  # merge progress emitted
     finally:
-        _PENDING_LTX_LORAS.reset(token)
+        ctxvar.reset(token)
     assert _PENDING_LTX_LORAS.get() is None
+
+
+def _eros_distill_job(advanced=None, loras=None):
+    entry = {
+        "mlx": {"autoDistillLora": {"stage1Strength": 1.0, "stage2Strength": 0.4}},
+        "resources": {
+            "distilledLora": {
+                "repo": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
+                "file": "ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors",
+            }
+        },
+    }
+    return {
+        "id": "job",
+        "payload": {
+            "projectId": "proj",
+            "model": "ltx_2_3_eros",
+            "mode": "text_to_video",
+            "loras": loras or [],
+            "advanced": advanced or {},
+            "modelManifestEntry": entry,
+        },
+    }
+
+
+def test_mlx_ltx_eros_auto_injects_distill_lora_per_pass(tmp_path, monkeypatch):
+    distill = tmp_path / "condsafe.safetensors"
+    distill.write_bytes(b"lora")
+    monkeypatch.setattr("scene_worker.video_adapters._install_ltx_lora_patch", lambda: None)
+    monkeypatch.setattr(
+        "scene_worker.video_adapters.huggingface_cached_resource_file",
+        lambda settings, repo, file_name: distill,
+    )
+    monkeypatch.setattr(
+        MlxVideoAdapter, "_load_lora_map", lambda self, configs: {path: [("w", strength)] for path, strength in configs}
+    )
+    adapter = MlxVideoAdapter()
+
+    # 10Eros auto-injects its manifest distill LoRA at per-pass strengths (1.0 base / 0.4 upscale).
+    specs = adapter._collect_ltx_lora_specs(video_request_from_job(_eros_distill_job()))
+    assert specs == [(str(distill), 1.0, 0.4)]
+
+    # Differing stage strengths route to the per-pass plan (LoRALinear wrappers + boundary drop).
+    reset = adapter._apply_ltx_loras(video_request_from_job(_eros_distill_job()), lambda *a, **k: None)
+    try:
+        ctxvar, token = reset
+        assert ctxvar is _PENDING_LTX_LORA_PLAN
+        plan = _PENDING_LTX_LORA_PLAN.get()
+        assert plan["stage1_map"] == {str(distill): [("w", 1.0)]}
+        assert plan["stage2_map"] == {str(distill): [("w", 0.4)]}
+        assert plan["wrappers"] == {}
+        assert _PENDING_LTX_LORAS.get() is None
+    finally:
+        ctxvar.reset(token)
+
+    # Opt-out and per-stage strength overrides.
+    assert adapter._resolve_distill_lora(video_request_from_job(_eros_distill_job(advanced={"useDistillLora": False}))) is None
+    override = _eros_distill_job(advanced={"distillStage1Strength": 0.8, "distillStage2Strength": 0.3})
+    assert adapter._collect_ltx_lora_specs(video_request_from_job(override)) == [(str(distill), 0.8, 0.3)]
+
+
+def test_mlx_ltx_eros_distill_missing_raises_actionable(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "scene_worker.video_adapters.huggingface_cached_resource_file", lambda settings, repo, file_name: None
+    )
+    adapter = MlxVideoAdapter()
+    adapter._settings = SimpleNamespace(data_dir=tmp_path)
+    request = video_request_from_job(_eros_distill_job())
+    with pytest.raises(RuntimeError, match="requires its distill LoRA"):
+        adapter._resolve_distill_lora(request)
 
 
 def test_lora_compatibility_guard_rejects_mismatched_family_before_load(tmp_path):


### PR DESCRIPTION
## Summary
Makes **LTX-2.3 10Eros** produce usable output on the MLX path — including **text-to-video**, which was degrading to noise — by auto-injecting its recommended `cond_safe` distill LoRA at **per-pass strengths** (TenStrip's guidance: ~1.0 on the base pass, ~0.4 on the upscale/refine pass).

### Why not just bake the LoRA in?
`generate_av` builds **one** transformer and runs **both** the base pass and the spatial-upscale/refine pass with it. A merged/baked LoRA is a single fixed strength across both passes, so it can't honor the 1.0-base / 0.4-upscale split. Per-pass strength has to be a runtime mechanism.

## How
- **On-the-fly wrappers, not merge.** When any LoRA's stage strengths differ, apply LoRAs as `LoRALinear` wrappers (mutable strength) instead of merging. Patch `mlx_video.generate_av.upsample_latents` — the once-per-run stage-1→stage-2 boundary — to drop the wrappers to the stage-2 strength. Drift-guarded (`_require_patch_target`) exactly like the existing `LTXModel.load_weights` patch. Plain user LoRAs (constant strength) keep the existing merge path.
- **Auto-inject from the manifest.** Models that declare `mlx.autoDistillLora` (only `ltx_2_3_eros`) auto-apply their `resources.distilledLora` at stage strengths `1.0`/`0.4`. Overridable via `advanced.useDistillLora` / `distillStage1Strength` / `distillStage2Strength`. Raises an actionable error if declared+enabled but the LoRA isn't installed (rather than silently producing noise).
- **Manifest:** add `mlx.autoDistillLora` and the cond_safe distill LoRA to `downloads` (it's now a required runtime component).

Stock `ltx_2_3` is untouched (no `autoDistillLora`; its prebuilt MLX weights are already distilled).

## Validation (Apple Silicon / MLX)
- ✅ End-to-end through the real adapter path: wrappers applied at 1.0 → `upsample_latents` boundary fired once → dropped to 0.4 (1644 modules) → Stage-1→Stage-2 refine → valid MP4.
- ✅ Logic: auto-inject 1.0/0.4, `useDistillLora=false` opt-out, strength overrides, stock model unaffected, missing-LoRA raises.
- ✅ 340 worker tests (+2 new) and `check-scaffold.mjs` pass.

## Test plan
- [ ] In Video Studio (Apple Silicon), select **LTX-2.3 10Eros** and run **text-to-video** — confirm it's coherent (the bug this fixes).
- [ ] Run image-to-video — confirm still good.
- [ ] Try `advanced.distillStage2Strength` tweaks if the upscale pass needs tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)