### PR TITLE
fix(lora): detect ComfyUI/Kohya Wan LoRA key layouts (sc-1994)

### DIFF
--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -386,10 +386,12 @@ const SIGNATURES: &[BucketSignature] = &[
     },
     BucketSignature {
         bucket: Bucket::WanVideo,
-        // Wan transformers expose their blocks under `transformer.blocks.<n>.`
-        // (not `transformer.transformer_blocks.`) and use `self_attn`/`cross_attn`/`ffn`
-        // module names. Discriminating against the MMDiT-style key prefix
-        // keeps Wan separate from Qwen/Z-Image.
+        // Diffusers-format Wan LoRAs expose their blocks under
+        // `transformer.blocks.<n>.` (not `transformer.transformer_blocks.`) and
+        // use either the native `self_attn`/`cross_attn`/`ffn` module names or
+        // the diffusers `attn1`/`attn2` names. The `transformer.blocks.` prefix
+        // marker alone scores every key; discriminating against the MMDiT-style
+        // key prefix keeps Wan separate from Qwen/Z-Image.
         require_all_of: &[&["transformer.blocks."]],
         disqualifiers: &[
             "transformer.transformer_blocks.",
@@ -401,6 +403,47 @@ const SIGNATURES: &[BucketSignature] = &[
             ".cross_attn.",
             ".ffn.",
         ],
+    },
+    BucketSignature {
+        bucket: Bucket::WanVideo,
+        // ComfyUI / native Wan checkpoints and LoRAs prefix every block key with
+        // `diffusion_model.blocks.<n>.` and keep the native `self_attn`/
+        // `cross_attn`/`ffn` module names. Requiring both the prefix and a Wan
+        // module marker keeps this from colliding with ComfyUI Flux
+        // (`diffusion_model.double_blocks.` / `diffusion_model.single_blocks.`)
+        // or LTX (`diffusion_model.transformer_blocks.`), none of which contain
+        // the bare `.blocks.` segment.
+        require_all_of: &[
+            &["diffusion_model.blocks."],
+            &[".self_attn.", ".cross_attn.", ".ffn."],
+        ],
+        disqualifiers: &[
+            "transformer.transformer_blocks.",
+            "single_transformer_blocks.",
+            "double_blocks.",
+        ],
+        markers: &[
+            "diffusion_model.blocks.",
+            ".self_attn.",
+            ".cross_attn.",
+            ".ffn.",
+        ],
+    },
+    BucketSignature {
+        bucket: Bucket::WanVideo,
+        // Kohya / musubi-tuner Wan LoRAs flatten the native module path into
+        // underscore-delimited keys: `lora_unet_blocks_<n>_self_attn_q...`.
+        // `lora_unet_blocks_` is Wan-specific — SD/SDXL UNet keys are
+        // `lora_unet_down_blocks_` / `lora_unet_up_blocks_` / `lora_unet_mid_block_`,
+        // never the bare `lora_unet_blocks_`. Disqualifying the SD/SDXL
+        // text-encoder prefixes (which Wan lacks) prevents any collision with the
+        // Sd15/Sdxl signatures, whose text-encoder keys also contain `_self_attn_`.
+        require_all_of: &[
+            &["lora_unet_blocks_"],
+            &["_self_attn_", "_cross_attn_", "_ffn_"],
+        ],
+        disqualifiers: &["lora_te_", "lora_te1_", "lora_te2_"],
+        markers: &["lora_unet_blocks_", "_self_attn_", "_cross_attn_", "_ffn_"],
     },
     BucketSignature {
         bucket: Bucket::LtxVideo,
@@ -737,6 +780,64 @@ mod tests {
             ] {
                 keys.push(format!("transformer.blocks.{block}.{module}.lora_A.weight"));
                 keys.push(format!("transformer.blocks.{block}.{module}.lora_B.weight"));
+            }
+        }
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("wan-video"));
+    }
+
+    #[test]
+    fn detects_comfyui_native_wan_video() {
+        // ComfyUI / native Wan LoRAs prefix every block with
+        // `diffusion_model.blocks.<n>.` and keep the native self_attn/cross_attn/ffn
+        // module names. These contain `.blocks.` but not `transformer.blocks.`, so
+        // the diffusers Wan signature misses them — the ComfyUI sibling must catch them.
+        let mut keys = Vec::new();
+        for block in 0..30 {
+            for module in [
+                "self_attn.q",
+                "self_attn.k",
+                "self_attn.v",
+                "self_attn.o",
+                "cross_attn.q",
+                "cross_attn.k",
+                "ffn.0",
+                "ffn.2",
+            ] {
+                keys.push(format!(
+                    "diffusion_model.blocks.{block}.{module}.lora_A.weight"
+                ));
+                keys.push(format!(
+                    "diffusion_model.blocks.{block}.{module}.lora_B.weight"
+                ));
+            }
+        }
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("wan-video"));
+    }
+
+    #[test]
+    fn detects_kohya_wan_video() {
+        // Kohya / musubi-tuner Wan LoRAs flatten the path into underscore-delimited
+        // keys with a `lora_unet_blocks_<n>_` prefix and no text-encoder keys.
+        let mut keys = Vec::new();
+        for block in 0..30 {
+            for module in [
+                "self_attn_q",
+                "self_attn_k",
+                "self_attn_v",
+                "self_attn_o",
+                "cross_attn_q",
+                "cross_attn_k",
+                "ffn_0",
+                "ffn_2",
+            ] {
+                keys.push(format!(
+                    "lora_unet_blocks_{block}_{module}.lora_down.weight"
+                ));
+                keys.push(format!("lora_unet_blocks_{block}_{module}.lora_up.weight"));
             }
         }
         let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());


### PR DESCRIPTION
## Summary
Extends the LoRA family detector (`crates/sceneworks-core/src/lora_family.rs`) so bring-your-own Wan LoRAs in **ComfyUI/native** and **Kohya/musubi-tuner** key layouts auto-detect as `wan-video`, instead of scoring 0 and importing with no family.

Previously only diffusers-style `transformer.blocks.` keys were recognized. A LoRA that detected nothing imported as generically "compatible" (empty family matches every model) and silently skipped the `wan-video` base-model gate, forcing users to set the family by hand.

Adds two sibling `Bucket::WanVideo` `BucketSignature`s:
- **ComfyUI / native:** require `diffusion_model.blocks.` + a `self_attn`/`cross_attn`/`ffn` marker. Disqualifies `double_blocks.` / `transformer*_blocks.` so it can't catch ComfyUI Flux/LTX.
- **Kohya / musubi-tuner:** require `lora_unet_blocks_` + `_self_attn_`/`_cross_attn_`/`_ffn_`. Disqualifies the SD/SDXL text-encoder prefixes (`lora_te_`/`lora_te1_`/`lora_te2_`) so a Wan `lora_unet_` LoRA never collides with the Sd15/Sdxl signatures (whose text-encoder keys also contain `_self_attn_`). `lora_unet_blocks_` is itself Wan-specific — SD/SDXL UNet keys are `lora_unet_down_blocks_`/`lora_unet_up_blocks_`/`lora_unet_mid_block_`.

The three Wan prefixes are mutually exclusive, so only one Wan signature scores per file — no within-bucket runner-up-margin contention.

> Note: implemented against the documented community conventions (per the story's key-layout examples), not verified against real sample `.safetensors` files — none were available in this environment. Worth a spot-check against an actual ComfyUI/Kohya Wan LoRA before close.

## Test plan
- [x] `cargo test -p sceneworks-core lora_family` — 31 pass (2 new: `detects_comfyui_native_wan_video`, `detects_kohya_wan_video`)
- [x] Full crate suite — 65 unit + integration tests pass, no regressions in SD1.5/SDXL/Flux/LTX/Qwen/Z-Image detection
- [x] `cargo fmt --check -p sceneworks-core` clean
- [x] `cargo clippy -p sceneworks-core --all-targets` clean
- [ ] Spot-check against a real community ComfyUI / Kohya Wan LoRA file

🤖 Generated with [Claude Code](https://claude.com/claude-code)