### PR TITLE
InstantID SDXL face-identity character model [sc-2009]

### DIFF
--- a/apps/web/public/prompt-guides/instantid-realvisxl.md
+++ b/apps/web/public/prompt-guides/instantid-realvisxl.md
@@ -1,0 +1,74 @@
+# InstantID (RealVisXL) Prompt Guide
+
+## Best For
+
+Generating **the same person** across many different scenes, poses, and outfits from a **single reference image** — no LoRA training required. InstantID reads a face from your character's approved reference (an insightface ArcFace embedding + 5-point facial landmarks) and locks identity onto a photoreal RealVisXL render while your prompt drives everything else.
+
+Use it when you want faithful likeness *and* scene freedom — the combination plain IP-Adapter ("reference strength" copy) can't deliver. It is the bridge for **created characters**: build an identity-consistent set of images first, then (optionally) train a per-character LoRA from them.
+
+This is a **reference-driven** model: it only runs in the "With character" flow and always needs a clear reference face. There is no plain text-to-image or edit mode.
+
+## How It Works
+
+- **Identity comes from the reference image, not the prompt.** Do *not* describe the person's face, hair color, or features — the model takes those from the reference. Describing appearance only fights the reference.
+- **The prompt drives the scene:** setting, action, pose, framing, wardrobe, lighting, and style.
+- **Reference strength** (the slider) controls how hard identity is pinned. Higher = closer likeness but stiffer; lower = more natural and prompt-flexible.
+
+## Choose A Good Reference
+
+Identity quality is set by the reference more than the prompt:
+
+- A **clear, front-facing** photo where the face is large and well-lit.
+- **One** unobstructed face (no sunglasses, heavy shadow, or extreme profile).
+- Sharp focus, neutral expression works best as a baseline.
+
+A side profile, tiny face, or low-light crop will weaken the likeness no matter how good the prompt is.
+
+## Build The Prompt
+
+Front-load the scene and action, then layer style and lighting. Leave the face to the reference.
+
+### Scene & Action
+
+`sitting at a sidewalk cafe in the morning, holding a coffee cup`
+
+`walking through a rain-slick neon city street at night`
+
+### Wardrobe
+
+`wearing a tailored charcoal wool coat` · `in a worn denim jacket` · `in athletic running gear`
+
+### Framing & Camera
+
+`candid 35mm photograph, shallow depth of field` · `medium portrait, eye-level` · `wide environmental shot`
+
+### Lighting & Style
+
+`soft natural window light` · `golden hour backlight` · `cinematic film still` · `editorial fashion photography`
+
+## Negative Prompts
+
+RealVisXL honors a negative prompt — use it to push away the plastic look InstantID can drift toward:
+
+`plastic skin, airbrushed, cgi, 3d render, cartoon, illustration, anime, waxy, overprocessed, deformed, extra fingers, watermark, text`
+
+## Tips
+
+- **Don't describe the face.** Hair color, eye color, and features come from the reference; restating them only adds noise.
+- **Reference strength ~0.6–0.8.** Start mid-range. Raise it if the likeness drifts; lower it (≤0.5) for more natural skin and looser, more prompt-driven results.
+- **~30 steps at guidance 5.0** is the validated baseline. Lower guidance (3.5–5) reads more photographic; higher pushes prompt adherence at the cost of "baked" skin.
+- **Explore takes:** raise Variations and leave the seed blank to get different poses/scenes of the same person.
+- **Identity is idealized.** InstantID tends to glamorize (smoother skin, lighter makeup, fewer freckles). That's expected — great for invented characters, a mild flattering bias for real ones.
+- **First run downloads** the InstantID weights (~4GB) and the antelopev2 face pack on top of the RealVisXL checkpoint; later runs reuse them.
+
+## Example Prompts
+
+`Candid photograph at a sidewalk cafe in the morning, holding a coffee cup, wearing a denim jacket, soft natural light, 35mm, shallow depth of field, photorealistic.`
+
+`Cinematic film still, standing on a rain-slick neon city street at night, leather jacket, reflections on wet pavement, moody rim lighting, shallow depth of field.`
+
+## Sources
+
+- [InstantID project](https://github.com/instantX-research/InstantID)
+- [InstantID weights](https://huggingface.co/InstantX/InstantID)
+- [RealVisXL_V5.0 model card](https://huggingface.co/SG161222/RealVisXL_V5.0)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -180,6 +180,17 @@ export const fallbackModels = [
     },
   },
   {
+    id: "instantid_realvisxl",
+    name: "InstantID (RealVisXL)",
+    type: "image",
+    // Reference-driven only — appears solely in the "With character" picker.
+    capabilities: ["character_image"],
+    ui: {
+      description: "Identity-preserving character generation — holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) + InstantID ArcFace embedding & landmark ControlNet; faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference, then raise Variations. ~30 steps at guidance 5.0, ~22GB peak.",
+      promptGuide: { title: "InstantID (RealVisXL) Prompt Guide", path: "/prompt-guides/instantid-realvisxl.md" },
+    },
+  },
+  {
     id: "ltx_2_3",
     name: "LTX-2.3",
     type: "video",

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -188,6 +188,10 @@ export const fallbackModels = [
     ui: {
       description: "Identity-preserving character generation — holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) + InstantID ArcFace embedding & landmark ControlNet; faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference, then raise Variations. ~30 steps at guidance 5.0, ~22GB peak.",
       promptGuide: { title: "InstantID (RealVisXL) Prompt Guide", path: "/prompt-guides/instantid-realvisxl.md" },
+      // Identity tuning: reference strength (ipAdapterScale) defaults higher for
+      // InstantID; identityStructure adds the controlnetConditioningScale slider.
+      referenceStrengthDefault: 0.8,
+      identityStructure: { label: "Identity structure", default: 0.8, min: 0.3, max: 1.0, step: 0.05 },
     },
   },
   {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5115,6 +5115,85 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("exposes the InstantID Identity structure slider and submits its tuned defaults", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            {
+              id: "char-1",
+              name: "Mira",
+              type: "person",
+              looks: [],
+              approvedReferences: [
+                {
+                  assetId: "ref-1",
+                  approved: true,
+                  asset: {
+                    id: "ref-1",
+                    type: "image",
+                    displayName: "Mira ref",
+                    projectId: "project-1",
+                    file: { path: "assets/images/ref_0001.png", mimeType: "image/png" },
+                  },
+                },
+              ],
+            },
+          ],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "instantid_realvisxl",
+              name: "InstantID (RealVisXL)",
+              type: "image",
+              family: "sdxl",
+              capabilities: ["character_image"],
+              ui: {
+                referenceStrengthDefault: 0.8,
+                identityStructure: { label: "Identity structure", default: 0.8, min: 0.3, max: 1.0, step: 0.05 },
+              },
+            },
+          ],
+          latestAssets: [],
+          launchRequest: { id: "launch-iid", view: "Image", characterId: "char-1", referenceAssetId: "ref-1", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    // The second (InstantID-only) slider renders; the strength slider is relabeled.
+    expect(container.textContent).toContain("Identity structure");
+    expect(container.textContent).toContain("Identity strength");
+    expect(container.textContent).not.toContain("Reference strength");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    // Tuned InstantID defaults flow through advanced: ipAdapterScale 0.8 (raised from
+    // the global 0.6) + controlnetConditioningScale 0.8 (the IdentityNet lock).
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        referenceAssetId: "ref-1",
+        advanced: { resolution: "1024x1024", ipAdapterScale: 0.8, controlnetConditioningScale: 0.8 },
+      }),
+    );
+  });
+
   it("limits the character image model picker to reference-capable models", async () => {
     root = createRoot(container);
     await act(async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -204,10 +204,12 @@ export function ImageStudio() {
   const [sourceAssetId, setSourceAssetId] = useState(selectedAsset?.id ?? "");
   const [characterId, setCharacterId] = useState("");
   const [characterLookId, setCharacterLookId] = useState("");
-  // Character reference (IP-Adapter) — the approved reference image whose identity
-  // Kolors copies across variations. `ipAdapterScale` rides in `advanced`.
+  // Character reference (IP-Adapter / InstantID) — the approved reference image whose
+  // identity is carried across variations. `ipAdapterScale` rides in `advanced`; for
+  // InstantID, `controlnetScale` (IdentityNet landmark lock) rides there too.
   const [referenceAssetId, setReferenceAssetId] = useState("");
   const [ipAdapterScale, setIpAdapterScale] = useState(0.6);
+  const [controlnetScale, setControlnetScale] = useState(0.8);
   const [upscaleEnabled, setUpscaleEnabled] = useState(false);
   const [upscaleFactor, setUpscaleFactor] = useState(2);
   const [upscaleEngine, setUpscaleEngine] = useState("real-esrgan");
@@ -291,6 +293,18 @@ export function ImageStudio() {
     }
   }, [availableModels, model]);
   const selectedModel = imageModels.find((item) => item.id === model);
+  // Reference-tuning hints declared by the model (ui.*). InstantID raises the
+  // reference-strength default and exposes a second "Identity structure" slider
+  // (controlnetConditioningScale); models without these keys (e.g. Kolors) keep the
+  // single reference-strength slider at the global default.
+  const identityStructure = selectedModel?.ui?.identityStructure;
+  // Reset the reference sliders to the selected model's declared defaults whenever the
+  // model changes, so InstantID starts at its tuned 0.8/0.8 and Kolors at 0.6.
+  useEffect(() => {
+    const ui = imageModels.find((item) => item.id === model)?.ui ?? {};
+    setIpAdapterScale(typeof ui.referenceStrengthDefault === "number" ? ui.referenceStrengthDefault : 0.6);
+    setControlnetScale(typeof ui.identityStructure?.default === "number" ? ui.identityStructure.default : 0.8);
+  }, [model]);
   // Approved reference images for the selected character (the IP-Adapter identity
   // source). Resolve the full asset from the catalog so thumbnails render even when
   // the character payload only carries assetIds.
@@ -527,9 +541,14 @@ export function ImageStudio() {
           : {}),
         advanced: {
           resolution,
-          // IP-Adapter reference strength only applies when a character reference is
-          // attached; the worker reads advanced.ipAdapterScale (default 0.6).
+          // IP-Adapter / InstantID reference strength only applies when a character
+          // reference is attached; the worker reads advanced.ipAdapterScale.
           ...(mode === "character_image" && referenceAssetId ? { ipAdapterScale } : {}),
+          // Identity structure (controlnetConditioningScale) is InstantID-only — sent
+          // only when the model exposes the control and a reference is attached.
+          ...(mode === "character_image" && referenceAssetId && identityStructure
+            ? { controlnetConditioningScale: controlnetScale }
+            : {}),
         },
       });
       onLocalJobCreated?.(job);
@@ -666,7 +685,7 @@ export function ImageStudio() {
                         ))}
                       </div>
                       <label className="reference-strength">
-                        Reference strength
+                        {identityStructure ? "Identity strength" : "Reference strength"}
                         <input
                           max="1"
                           min="0"
@@ -677,9 +696,27 @@ export function ImageStudio() {
                         />
                         <span>{ipAdapterScale.toFixed(2)}</span>
                       </label>
+                      {identityStructure ? (
+                        <label className="reference-strength">
+                          {identityStructure.label ?? "Identity structure"}
+                          <input
+                            max={identityStructure.max ?? 1}
+                            min={identityStructure.min ?? 0}
+                            onChange={(event) => setControlnetScale(Number(event.target.value))}
+                            step={identityStructure.step ?? 0.05}
+                            type="range"
+                            value={controlnetScale}
+                          />
+                          <span>{controlnetScale.toFixed(2)}</span>
+                        </label>
+                      ) : null}
                       <div className="guidance-strip">
                         <strong>Identity from reference</strong>
-                        <span>Kolors IP-Adapter carries this reference's appearance across every variation. Raise Variations and leave the seed blank to explore different takes.</span>
+                        <span>
+                          {identityStructure
+                            ? "InstantID holds this person's face from the reference while the prompt drives the scene. Identity strength tunes likeness; Identity structure locks face geometry and pose (lower = more pose freedom). Raise Variations and leave the seed blank to explore takes."
+                            : "This reference's identity is carried across every variation. Raise Variations and leave the seed blank to explore different takes."}
+                        </span>
                       </div>
                     </div>
                   ) : (

--- a/apps/worker/requirements-instantid.txt
+++ b/apps/worker/requirements-instantid.txt
@@ -1,0 +1,16 @@
+# InstantID SDXL face-identity adapter (sc-2009) — optional extras on top of
+# requirements.txt. Install into the MAIN worker venv; deps coexist with the
+# diffusers/torch stack (validated on Apple Silicon, sc-2009 spike).
+#
+#   pip install -r apps/worker/requirements.txt -r apps/worker/requirements-instantid.txt
+#
+# insightface provides the antelopev2 ArcFace face embedding + 5-point landmarks
+# that drive InstantID's IdentityNet ControlNet. onnxruntime runs the face models
+# (standard arm64 wheel works on macOS — no onnxruntime-silicon needed). peft is
+# required by diffusers to load the companion adapter LoRAs; einops by the
+# vendored ip_adapter Resampler.
+insightface>=1.0,<2
+onnxruntime>=1.20
+onnx>=1.20
+peft>=0.17
+einops>=0.8

--- a/apps/worker/scene_worker/_vendor/README.md
+++ b/apps/worker/scene_worker/_vendor/README.md
@@ -65,3 +65,31 @@ SceneWorks-local edits to `sensenova_u1/models/neo_unify/modeling_neo_chat.py`:
 
 To update: re-copy `src/sensenova_u1/` from the upstream repo at the desired
 commit, update the commit hash above, and re-apply the local patches.
+
+## instantid
+
+InstantID SDXL face-identity pipeline + the `ip_adapter` support module it
+imports. InstantID preserves a person's identity from one reference image via an
+insightface ArcFace embedding + a 5-point-landmark ControlNet ("IdentityNet"),
+while the prompt drives scene/pose. Selected over IP-Adapter / FaceID in the
+sc-2009 A/B (the only method that held identity AND followed the prompt).
+
+- `pipeline_stable_diffusion_xl_instantid.py`
+  - Source: https://github.com/instantX-research/InstantID (`main`, 2026-05-27)
+  - License: Apache-2.0 (see `LICENSE`)
+  - Imports clean against `diffusers==0.38.0` (no local patches).
+- `ip_adapter/` (`resampler.py`, `utils.py`, `attention_processor.py`; empty
+  `__init__.py` to avoid pulling upstream's diffusers-heavy `ip_adapter.py`)
+  - Source: https://github.com/tencent-ailab/IP-Adapter (`main`, 2026-05-27)
+  - License: Apache-2.0
+- Consumed by: `scene_worker/instantid_adapter.py::InstantIDAdapter`
+- Runs in the MAIN worker venv. Extra deps in `requirements-instantid.txt`
+  (insightface, onnxruntime, onnx, peft, einops). The adapter inserts this dir
+  on `sys.path` (so the pipeline's top-level `from ip_adapter...` resolves) only
+  when an InstantID job runs — all heavy imports are lazy, so registering the
+  adapter is cheap on workers without the extras installed.
+- Models (downloaded on demand): `InstantX/InstantID` (ControlNet + ip-adapter.bin)
+  and the antelopev2 face pack (mirror `DIAMONIK7777/antelopev2`).
+
+To update: re-copy both directories from their upstream repos at the desired
+commit and update the dates above.

--- a/apps/worker/scene_worker/_vendor/instantid/LICENSE
+++ b/apps/worker/scene_worker/_vendor/instantid/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/worker/scene_worker/_vendor/instantid/ip_adapter/attention_processor.py
+++ b/apps/worker/scene_worker/_vendor/instantid/ip_adapter/attention_processor.py
@@ -1,0 +1,568 @@
+# modified from https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class AttnProcessor(nn.Module):
+    r"""
+    Default processor for performing attention-related computations.
+    """
+
+    def __init__(
+        self,
+        hidden_size=None,
+        cross_attention_dim=None,
+    ):
+        super().__init__()
+
+    def __call__(
+        self,
+        attn,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        temb=None,
+        *args,
+        **kwargs,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+        attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        elif attn.norm_cross:
+            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        query = attn.head_to_batch_dim(query)
+        key = attn.head_to_batch_dim(key)
+        value = attn.head_to_batch_dim(value)
+
+        attention_probs = attn.get_attention_scores(query, key, attention_mask)
+        hidden_states = torch.bmm(attention_probs, value)
+        hidden_states = attn.batch_to_head_dim(hidden_states)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states
+
+
+class IPAttnProcessor(nn.Module):
+    r"""
+    Attention processor for IP-Adapater.
+    Args:
+        hidden_size (`int`):
+            The hidden size of the attention layer.
+        cross_attention_dim (`int`):
+            The number of channels in the `encoder_hidden_states`.
+        scale (`float`, defaults to 1.0):
+            the weight scale of image prompt.
+        num_tokens (`int`, defaults to 4 when do ip_adapter_plus it should be 16):
+            The context length of the image features.
+    """
+
+    def __init__(self, hidden_size, cross_attention_dim=None, scale=1.0, num_tokens=4):
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.cross_attention_dim = cross_attention_dim
+        self.scale = scale
+        self.num_tokens = num_tokens
+
+        self.to_k_ip = nn.Linear(cross_attention_dim or hidden_size, hidden_size, bias=False)
+        self.to_v_ip = nn.Linear(cross_attention_dim or hidden_size, hidden_size, bias=False)
+
+    def __call__(
+        self,
+        attn,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        temb=None,
+        *args,
+        **kwargs,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+        attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        else:
+            # get encoder_hidden_states, ip_hidden_states
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states, ip_hidden_states = (
+                encoder_hidden_states[:, :end_pos, :],
+                encoder_hidden_states[:, end_pos:, :],
+            )
+            if attn.norm_cross:
+                encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        query = attn.head_to_batch_dim(query)
+        key = attn.head_to_batch_dim(key)
+        value = attn.head_to_batch_dim(value)
+
+        attention_probs = attn.get_attention_scores(query, key, attention_mask)
+        hidden_states = torch.bmm(attention_probs, value)
+        hidden_states = attn.batch_to_head_dim(hidden_states)
+
+        # for ip-adapter
+        ip_key = self.to_k_ip(ip_hidden_states)
+        ip_value = self.to_v_ip(ip_hidden_states)
+
+        ip_key = attn.head_to_batch_dim(ip_key)
+        ip_value = attn.head_to_batch_dim(ip_value)
+
+        ip_attention_probs = attn.get_attention_scores(query, ip_key, None)
+        self.attn_map = ip_attention_probs
+        ip_hidden_states = torch.bmm(ip_attention_probs, ip_value)
+        ip_hidden_states = attn.batch_to_head_dim(ip_hidden_states)
+
+        hidden_states = hidden_states + self.scale * ip_hidden_states
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states
+
+
+class AttnProcessor2_0(torch.nn.Module):
+    r"""
+    Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0).
+    """
+
+    def __init__(
+        self,
+        hidden_size=None,
+        cross_attention_dim=None,
+    ):
+        super().__init__()
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
+
+    def __call__(
+        self,
+        attn,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        temb=None,
+        *args,
+        **kwargs,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+            # scaled_dot_product_attention expects attention_mask shape to be
+            # (batch, heads, source_length, target_length)
+            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        elif attn.norm_cross:
+            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # the output of sdp = (batch, num_heads, seq_len, head_dim)
+        # TODO: add support for attn.scale when we move to Torch 2.1
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+
+        hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        hidden_states = hidden_states.to(query.dtype)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states
+
+
+class IPAttnProcessor2_0(torch.nn.Module):
+    r"""
+    Attention processor for IP-Adapater for PyTorch 2.0.
+    Args:
+        hidden_size (`int`):
+            The hidden size of the attention layer.
+        cross_attention_dim (`int`):
+            The number of channels in the `encoder_hidden_states`.
+        scale (`float`, defaults to 1.0):
+            the weight scale of image prompt.
+        num_tokens (`int`, defaults to 4 when do ip_adapter_plus it should be 16):
+            The context length of the image features.
+    """
+
+    def __init__(self, hidden_size, cross_attention_dim=None, scale=1.0, num_tokens=4):
+        super().__init__()
+
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
+
+        self.hidden_size = hidden_size
+        self.cross_attention_dim = cross_attention_dim
+        self.scale = scale
+        self.num_tokens = num_tokens
+
+        self.to_k_ip = nn.Linear(cross_attention_dim or hidden_size, hidden_size, bias=False)
+        self.to_v_ip = nn.Linear(cross_attention_dim or hidden_size, hidden_size, bias=False)
+
+    def __call__(
+        self,
+        attn,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        temb=None,
+        *args,
+        **kwargs,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+            # scaled_dot_product_attention expects attention_mask shape to be
+            # (batch, heads, source_length, target_length)
+            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        else:
+            # get encoder_hidden_states, ip_hidden_states
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states, ip_hidden_states = (
+                encoder_hidden_states[:, :end_pos, :],
+                encoder_hidden_states[:, end_pos:, :],
+            )
+            if attn.norm_cross:
+                encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # the output of sdp = (batch, num_heads, seq_len, head_dim)
+        # TODO: add support for attn.scale when we move to Torch 2.1
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+
+        hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        hidden_states = hidden_states.to(query.dtype)
+
+        # for ip-adapter
+        ip_key = self.to_k_ip(ip_hidden_states)
+        ip_value = self.to_v_ip(ip_hidden_states)
+
+        ip_key = ip_key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        ip_value = ip_value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # the output of sdp = (batch, num_heads, seq_len, head_dim)
+        # TODO: add support for attn.scale when we move to Torch 2.1
+        ip_hidden_states = F.scaled_dot_product_attention(
+            query, ip_key, ip_value, attn_mask=None, dropout_p=0.0, is_causal=False
+        )
+        with torch.no_grad():
+            self.attn_map = query @ ip_key.transpose(-2, -1).softmax(dim=-1)
+            #print(self.attn_map.shape)
+
+        ip_hidden_states = ip_hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        ip_hidden_states = ip_hidden_states.to(query.dtype)
+
+        hidden_states = hidden_states + self.scale * ip_hidden_states
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states
+
+
+## for controlnet
+class CNAttnProcessor:
+    r"""
+    Default processor for performing attention-related computations.
+    """
+
+    def __init__(self, num_tokens=4):
+        self.num_tokens = num_tokens
+
+    def __call__(self, attn, hidden_states, encoder_hidden_states=None, attention_mask=None, temb=None, *args, **kwargs,):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+        attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        else:
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states = encoder_hidden_states[:, :end_pos]  # only use text
+            if attn.norm_cross:
+                encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        query = attn.head_to_batch_dim(query)
+        key = attn.head_to_batch_dim(key)
+        value = attn.head_to_batch_dim(value)
+
+        attention_probs = attn.get_attention_scores(query, key, attention_mask)
+        hidden_states = torch.bmm(attention_probs, value)
+        hidden_states = attn.batch_to_head_dim(hidden_states)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states
+
+
+class CNAttnProcessor2_0:
+    r"""
+    Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0).
+    """
+
+    def __init__(self, num_tokens=4):
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
+        self.num_tokens = num_tokens
+
+    def __call__(
+        self,
+        attn,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        temb=None,
+        *args,
+        **kwargs,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+            # scaled_dot_product_attention expects attention_mask shape to be
+            # (batch, heads, source_length, target_length)
+            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        else:
+            end_pos = encoder_hidden_states.shape[1] - self.num_tokens
+            encoder_hidden_states = encoder_hidden_states[:, :end_pos]  # only use text
+            if attn.norm_cross:
+                encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # the output of sdp = (batch, num_heads, seq_len, head_dim)
+        # TODO: add support for attn.scale when we move to Torch 2.1
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+
+        hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        hidden_states = hidden_states.to(query.dtype)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states

--- a/apps/worker/scene_worker/_vendor/instantid/ip_adapter/resampler.py
+++ b/apps/worker/scene_worker/_vendor/instantid/ip_adapter/resampler.py
@@ -1,0 +1,158 @@
+# modified from https://github.com/mlfoundations/open_flamingo/blob/main/open_flamingo/src/helpers.py
+# and https://github.com/lucidrains/imagen-pytorch/blob/main/imagen_pytorch/imagen_pytorch.py
+
+import math
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+from einops.layers.torch import Rearrange
+
+
+# FFN
+def FeedForward(dim, mult=4):
+    inner_dim = int(dim * mult)
+    return nn.Sequential(
+        nn.LayerNorm(dim),
+        nn.Linear(dim, inner_dim, bias=False),
+        nn.GELU(),
+        nn.Linear(inner_dim, dim, bias=False),
+    )
+
+
+def reshape_tensor(x, heads):
+    bs, length, width = x.shape
+    # (bs, length, width) --> (bs, length, n_heads, dim_per_head)
+    x = x.view(bs, length, heads, -1)
+    # (bs, length, n_heads, dim_per_head) --> (bs, n_heads, length, dim_per_head)
+    x = x.transpose(1, 2)
+    # (bs, n_heads, length, dim_per_head) --> (bs*n_heads, length, dim_per_head)
+    x = x.reshape(bs, heads, length, -1)
+    return x
+
+
+class PerceiverAttention(nn.Module):
+    def __init__(self, *, dim, dim_head=64, heads=8):
+        super().__init__()
+        self.scale = dim_head**-0.5
+        self.dim_head = dim_head
+        self.heads = heads
+        inner_dim = dim_head * heads
+
+        self.norm1 = nn.LayerNorm(dim)
+        self.norm2 = nn.LayerNorm(dim)
+
+        self.to_q = nn.Linear(dim, inner_dim, bias=False)
+        self.to_kv = nn.Linear(dim, inner_dim * 2, bias=False)
+        self.to_out = nn.Linear(inner_dim, dim, bias=False)
+
+    def forward(self, x, latents):
+        """
+        Args:
+            x (torch.Tensor): image features
+                shape (b, n1, D)
+            latent (torch.Tensor): latent features
+                shape (b, n2, D)
+        """
+        x = self.norm1(x)
+        latents = self.norm2(latents)
+
+        b, l, _ = latents.shape
+
+        q = self.to_q(latents)
+        kv_input = torch.cat((x, latents), dim=-2)
+        k, v = self.to_kv(kv_input).chunk(2, dim=-1)
+
+        q = reshape_tensor(q, self.heads)
+        k = reshape_tensor(k, self.heads)
+        v = reshape_tensor(v, self.heads)
+
+        # attention
+        scale = 1 / math.sqrt(math.sqrt(self.dim_head))
+        weight = (q * scale) @ (k * scale).transpose(-2, -1)  # More stable with f16 than dividing afterwards
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        out = weight @ v
+
+        out = out.permute(0, 2, 1, 3).reshape(b, l, -1)
+
+        return self.to_out(out)
+
+
+class Resampler(nn.Module):
+    def __init__(
+        self,
+        dim=1024,
+        depth=8,
+        dim_head=64,
+        heads=16,
+        num_queries=8,
+        embedding_dim=768,
+        output_dim=1024,
+        ff_mult=4,
+        max_seq_len: int = 257,  # CLIP tokens + CLS token
+        apply_pos_emb: bool = False,
+        num_latents_mean_pooled: int = 0,  # number of latents derived from mean pooled representation of the sequence
+    ):
+        super().__init__()
+        self.pos_emb = nn.Embedding(max_seq_len, embedding_dim) if apply_pos_emb else None
+
+        self.latents = nn.Parameter(torch.randn(1, num_queries, dim) / dim**0.5)
+
+        self.proj_in = nn.Linear(embedding_dim, dim)
+
+        self.proj_out = nn.Linear(dim, output_dim)
+        self.norm_out = nn.LayerNorm(output_dim)
+
+        self.to_latents_from_mean_pooled_seq = (
+            nn.Sequential(
+                nn.LayerNorm(dim),
+                nn.Linear(dim, dim * num_latents_mean_pooled),
+                Rearrange("b (n d) -> b n d", n=num_latents_mean_pooled),
+            )
+            if num_latents_mean_pooled > 0
+            else None
+        )
+
+        self.layers = nn.ModuleList([])
+        for _ in range(depth):
+            self.layers.append(
+                nn.ModuleList(
+                    [
+                        PerceiverAttention(dim=dim, dim_head=dim_head, heads=heads),
+                        FeedForward(dim=dim, mult=ff_mult),
+                    ]
+                )
+            )
+
+    def forward(self, x):
+        if self.pos_emb is not None:
+            n, device = x.shape[1], x.device
+            pos_emb = self.pos_emb(torch.arange(n, device=device))
+            x = x + pos_emb
+
+        latents = self.latents.repeat(x.size(0), 1, 1)
+
+        x = self.proj_in(x)
+
+        if self.to_latents_from_mean_pooled_seq:
+            meanpooled_seq = masked_mean(x, dim=1, mask=torch.ones(x.shape[:2], device=x.device, dtype=torch.bool))
+            meanpooled_latents = self.to_latents_from_mean_pooled_seq(meanpooled_seq)
+            latents = torch.cat((meanpooled_latents, latents), dim=-2)
+
+        for attn, ff in self.layers:
+            latents = attn(x, latents) + latents
+            latents = ff(latents) + latents
+
+        latents = self.proj_out(latents)
+        return self.norm_out(latents)
+
+
+def masked_mean(t, *, dim, mask=None):
+    if mask is None:
+        return t.mean(dim=dim)
+
+    denom = mask.sum(dim=dim, keepdim=True)
+    mask = rearrange(mask, "b n -> b n 1")
+    masked_t = t.masked_fill(~mask, 0.0)
+
+    return masked_t.sum(dim=dim) / denom.clamp(min=1e-5)

--- a/apps/worker/scene_worker/_vendor/instantid/ip_adapter/utils.py
+++ b/apps/worker/scene_worker/_vendor/instantid/ip_adapter/utils.py
@@ -1,0 +1,93 @@
+import torch
+import torch.nn.functional as F
+import numpy as np
+from PIL import Image
+
+attn_maps = {}
+def hook_fn(name):
+    def forward_hook(module, input, output):
+        if hasattr(module.processor, "attn_map"):
+            attn_maps[name] = module.processor.attn_map
+            del module.processor.attn_map
+
+    return forward_hook
+
+def register_cross_attention_hook(unet):
+    for name, module in unet.named_modules():
+        if name.split('.')[-1].startswith('attn2'):
+            module.register_forward_hook(hook_fn(name))
+
+    return unet
+
+def upscale(attn_map, target_size):
+    attn_map = torch.mean(attn_map, dim=0)
+    attn_map = attn_map.permute(1,0)
+    temp_size = None
+
+    for i in range(0,5):
+        scale = 2 ** i
+        if ( target_size[0] // scale ) * ( target_size[1] // scale) == attn_map.shape[1]*64:
+            temp_size = (target_size[0]//(scale*8), target_size[1]//(scale*8))
+            break
+
+    assert temp_size is not None, "temp_size cannot is None"
+
+    attn_map = attn_map.view(attn_map.shape[0], *temp_size)
+
+    attn_map = F.interpolate(
+        attn_map.unsqueeze(0).to(dtype=torch.float32),
+        size=target_size,
+        mode='bilinear',
+        align_corners=False
+    )[0]
+
+    attn_map = torch.softmax(attn_map, dim=0)
+    return attn_map
+def get_net_attn_map(image_size, batch_size=2, instance_or_negative=False, detach=True):
+
+    idx = 0 if instance_or_negative else 1
+    net_attn_maps = []
+
+    for name, attn_map in attn_maps.items():
+        attn_map = attn_map.cpu() if detach else attn_map
+        attn_map = torch.chunk(attn_map, batch_size)[idx].squeeze()
+        attn_map = upscale(attn_map, image_size) 
+        net_attn_maps.append(attn_map) 
+
+    net_attn_maps = torch.mean(torch.stack(net_attn_maps,dim=0),dim=0)
+
+    return net_attn_maps
+
+def attnmaps2images(net_attn_maps):
+
+    #total_attn_scores = 0
+    images = []
+
+    for attn_map in net_attn_maps:
+        attn_map = attn_map.cpu().numpy()
+        #total_attn_scores += attn_map.mean().item()
+
+        normalized_attn_map = (attn_map - np.min(attn_map)) / (np.max(attn_map) - np.min(attn_map)) * 255
+        normalized_attn_map = normalized_attn_map.astype(np.uint8)
+        #print("norm: ", normalized_attn_map.shape)
+        image = Image.fromarray(normalized_attn_map)
+
+        #image = fix_save_attn_map(attn_map)
+        images.append(image)
+
+    #print(total_attn_scores)
+    return images
+def is_torch2_available():
+    return hasattr(F, "scaled_dot_product_attention")
+
+def get_generator(seed, device):
+
+    if seed is not None:
+        if isinstance(seed, list):
+            generator = [torch.Generator(device).manual_seed(seed_item) for seed_item in seed]
+        else:
+            generator = torch.Generator(device).manual_seed(seed)
+    else:
+        generator = None
+
+    return generator

--- a/apps/worker/scene_worker/_vendor/instantid/pipeline_stable_diffusion_xl_instantid.py
+++ b/apps/worker/scene_worker/_vendor/instantid/pipeline_stable_diffusion_xl_instantid.py
@@ -1,0 +1,787 @@
+# Copyright 2024 The InstantX Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import cv2
+import math
+
+import numpy as np
+import PIL.Image
+import torch
+import torch.nn.functional as F
+
+from diffusers.image_processor import PipelineImageInput
+
+from diffusers.models import ControlNetModel
+
+from diffusers.utils import (
+    deprecate,
+    logging,
+    replace_example_docstring,
+)
+from diffusers.utils.torch_utils import is_compiled_module, is_torch_version
+from diffusers.pipelines.stable_diffusion_xl import StableDiffusionXLPipelineOutput
+
+from diffusers import StableDiffusionXLControlNetPipeline
+from diffusers.pipelines.controlnet.multicontrolnet import MultiControlNetModel
+from diffusers.utils.import_utils import is_xformers_available
+
+from ip_adapter.resampler import Resampler
+from ip_adapter.utils import is_torch2_available
+
+if is_torch2_available():
+    from ip_adapter.attention_processor import IPAttnProcessor2_0 as IPAttnProcessor, AttnProcessor2_0 as AttnProcessor
+else:
+    from ip_adapter.attention_processor import IPAttnProcessor, AttnProcessor
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+EXAMPLE_DOC_STRING = """
+    Examples:
+        ```py
+        >>> # !pip install opencv-python transformers accelerate insightface
+        >>> import diffusers
+        >>> from diffusers.utils import load_image
+        >>> from diffusers.models import ControlNetModel
+
+        >>> import cv2
+        >>> import torch
+        >>> import numpy as np
+        >>> from PIL import Image
+        
+        >>> from insightface.app import FaceAnalysis
+        >>> from pipeline_stable_diffusion_xl_instantid import StableDiffusionXLInstantIDPipeline, draw_kps
+
+        >>> # download 'antelopev2' under ./models
+        >>> app = FaceAnalysis(name='antelopev2', root='./', providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+        >>> app.prepare(ctx_id=0, det_size=(640, 640))
+        
+        >>> # download models under ./checkpoints
+        >>> face_adapter = f'./checkpoints/ip-adapter.bin'
+        >>> controlnet_path = f'./checkpoints/ControlNetModel'
+        
+        >>> # load IdentityNet
+        >>> controlnet = ControlNetModel.from_pretrained(controlnet_path, torch_dtype=torch.float16)
+        
+        >>> pipe = StableDiffusionXLInstantIDPipeline.from_pretrained(
+        ...     "stabilityai/stable-diffusion-xl-base-1.0", controlnet=controlnet, torch_dtype=torch.float16
+        ... )
+        >>> pipe.cuda()
+        
+        >>> # load adapter
+        >>> pipe.load_ip_adapter_instantid(face_adapter)
+
+        >>> prompt = "analog film photo of a man. faded film, desaturated, 35mm photo, grainy, vignette, vintage, Kodachrome, Lomography, stained, highly detailed, found footage, masterpiece, best quality"
+        >>> negative_prompt = "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, painting, drawing, illustration, glitch, deformed, mutated, cross-eyed, ugly, disfigured (lowres, low quality, worst quality:1.2), (text:1.2), watermark, painting, drawing, illustration, glitch,deformed, mutated, cross-eyed, ugly, disfigured"
+
+        >>> # load an image
+        >>> image = load_image("your-example.jpg")
+        
+        >>> face_info = app.get(cv2.cvtColor(np.array(face_image), cv2.COLOR_RGB2BGR))[-1]
+        >>> face_emb = face_info['embedding']
+        >>> face_kps = draw_kps(face_image, face_info['kps'])
+        
+        >>> pipe.set_ip_adapter_scale(0.8)
+
+        >>> # generate image
+        >>> image = pipe(
+        ...     prompt, image_embeds=face_emb, image=face_kps, controlnet_conditioning_scale=0.8
+        ... ).images[0]
+        ```
+"""
+
+def draw_kps(image_pil, kps, color_list=[(255,0,0), (0,255,0), (0,0,255), (255,255,0), (255,0,255)]):
+    
+    stickwidth = 4
+    limbSeq = np.array([[0, 2], [1, 2], [3, 2], [4, 2]])
+    kps = np.array(kps)
+
+    w, h = image_pil.size
+    out_img = np.zeros([h, w, 3])
+
+    for i in range(len(limbSeq)):
+        index = limbSeq[i]
+        color = color_list[index[0]]
+
+        x = kps[index][:, 0]
+        y = kps[index][:, 1]
+        length = ((x[0] - x[1]) ** 2 + (y[0] - y[1]) ** 2) ** 0.5
+        angle = math.degrees(math.atan2(y[0] - y[1], x[0] - x[1]))
+        polygon = cv2.ellipse2Poly((int(np.mean(x)), int(np.mean(y))), (int(length / 2), stickwidth), int(angle), 0, 360, 1)
+        out_img = cv2.fillConvexPoly(out_img.copy(), polygon, color)
+    out_img = (out_img * 0.6).astype(np.uint8)
+
+    for idx_kp, kp in enumerate(kps):
+        color = color_list[idx_kp]
+        x, y = kp
+        out_img = cv2.circle(out_img.copy(), (int(x), int(y)), 10, color, -1)
+
+    out_img_pil = PIL.Image.fromarray(out_img.astype(np.uint8))
+    return out_img_pil
+    
+class StableDiffusionXLInstantIDPipeline(StableDiffusionXLControlNetPipeline):
+    
+    def cuda(self, dtype=torch.float16, use_xformers=False):
+        self.to('cuda', dtype)
+        
+        if hasattr(self, 'image_proj_model'):
+            self.image_proj_model.to(self.unet.device).to(self.unet.dtype)
+        
+        if use_xformers:
+            if is_xformers_available():
+                import xformers
+                from packaging import version
+
+                xformers_version = version.parse(xformers.__version__)
+                if xformers_version == version.parse("0.0.16"):
+                    logger.warn(
+                        "xFormers 0.0.16 cannot be used for training in some GPUs. If you observe problems during training, please update xFormers to at least 0.0.17. See https://huggingface.co/docs/diffusers/main/en/optimization/xformers for more details."
+                    )
+                self.enable_xformers_memory_efficient_attention()
+            else:
+                raise ValueError("xformers is not available. Make sure it is installed correctly")
+    
+    def load_ip_adapter_instantid(self, model_ckpt, image_emb_dim=512, num_tokens=16, scale=0.5):     
+        self.set_image_proj_model(model_ckpt, image_emb_dim, num_tokens)
+        self.set_ip_adapter(model_ckpt, num_tokens, scale)
+        
+    def set_image_proj_model(self, model_ckpt, image_emb_dim=512, num_tokens=16):
+        
+        image_proj_model = Resampler(
+            dim=1280,
+            depth=4,
+            dim_head=64,
+            heads=20,
+            num_queries=num_tokens,
+            embedding_dim=image_emb_dim,
+            output_dim=self.unet.config.cross_attention_dim,
+            ff_mult=4,
+        )
+
+        image_proj_model.eval()
+        
+        self.image_proj_model = image_proj_model.to(self.device, dtype=self.dtype)
+        state_dict = torch.load(model_ckpt, map_location="cpu")
+        if 'image_proj' in state_dict:
+            state_dict = state_dict["image_proj"]
+        self.image_proj_model.load_state_dict(state_dict)
+        
+        self.image_proj_model_in_features = image_emb_dim
+    
+    def set_ip_adapter(self, model_ckpt, num_tokens, scale):
+        
+        unet = self.unet
+        attn_procs = {}
+        for name in unet.attn_processors.keys():
+            cross_attention_dim = None if name.endswith("attn1.processor") else unet.config.cross_attention_dim
+            if name.startswith("mid_block"):
+                hidden_size = unet.config.block_out_channels[-1]
+            elif name.startswith("up_blocks"):
+                block_id = int(name[len("up_blocks.")])
+                hidden_size = list(reversed(unet.config.block_out_channels))[block_id]
+            elif name.startswith("down_blocks"):
+                block_id = int(name[len("down_blocks.")])
+                hidden_size = unet.config.block_out_channels[block_id]
+            if cross_attention_dim is None:
+                attn_procs[name] = AttnProcessor().to(unet.device, dtype=unet.dtype)
+            else:
+                attn_procs[name] = IPAttnProcessor(hidden_size=hidden_size, 
+                                                   cross_attention_dim=cross_attention_dim, 
+                                                   scale=scale,
+                                                   num_tokens=num_tokens).to(unet.device, dtype=unet.dtype)
+        unet.set_attn_processor(attn_procs)
+        
+        state_dict = torch.load(model_ckpt, map_location="cpu")
+        ip_layers = torch.nn.ModuleList(self.unet.attn_processors.values())
+        if 'ip_adapter' in state_dict:
+            state_dict = state_dict['ip_adapter']
+        ip_layers.load_state_dict(state_dict)
+    
+    def set_ip_adapter_scale(self, scale):
+        unet = getattr(self, self.unet_name) if not hasattr(self, "unet") else self.unet
+        for attn_processor in unet.attn_processors.values():
+            if isinstance(attn_processor, IPAttnProcessor):
+                attn_processor.scale = scale
+
+    def _encode_prompt_image_emb(self, prompt_image_emb, device, num_images_per_prompt, dtype, do_classifier_free_guidance):
+        
+        if isinstance(prompt_image_emb, torch.Tensor):
+            prompt_image_emb = prompt_image_emb.clone().detach()
+        else:
+            prompt_image_emb = torch.tensor(prompt_image_emb)
+            
+        prompt_image_emb = prompt_image_emb.reshape([1, -1, self.image_proj_model_in_features])
+        
+        if do_classifier_free_guidance:
+            prompt_image_emb = torch.cat([torch.zeros_like(prompt_image_emb), prompt_image_emb], dim=0)
+        else:
+            prompt_image_emb = torch.cat([prompt_image_emb], dim=0)
+        
+        prompt_image_emb = prompt_image_emb.to(device=self.image_proj_model.latents.device, 
+                                               dtype=self.image_proj_model.latents.dtype)
+        prompt_image_emb = self.image_proj_model(prompt_image_emb)
+
+        bs_embed, seq_len, _ = prompt_image_emb.shape
+        prompt_image_emb = prompt_image_emb.repeat(1, num_images_per_prompt, 1)
+        prompt_image_emb = prompt_image_emb.view(bs_embed * num_images_per_prompt, seq_len, -1)
+        
+        return prompt_image_emb.to(device=device, dtype=dtype)
+
+    @torch.no_grad()
+    @replace_example_docstring(EXAMPLE_DOC_STRING)
+    def __call__(
+        self,
+        prompt: Union[str, List[str]] = None,
+        prompt_2: Optional[Union[str, List[str]]] = None,
+        image: PipelineImageInput = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        negative_prompt: Optional[Union[str, List[str]]] = None,
+        negative_prompt_2: Optional[Union[str, List[str]]] = None,
+        num_images_per_prompt: Optional[int] = 1,
+        eta: float = 0.0,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.FloatTensor] = None,
+        prompt_embeds: Optional[torch.FloatTensor] = None,
+        negative_prompt_embeds: Optional[torch.FloatTensor] = None,
+        pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
+        negative_pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
+        image_embeds: Optional[torch.FloatTensor] = None,
+        output_type: Optional[str] = "pil",
+        return_dict: bool = True,
+        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
+        controlnet_conditioning_scale: Union[float, List[float]] = 1.0,
+        guess_mode: bool = False,
+        control_guidance_start: Union[float, List[float]] = 0.0,
+        control_guidance_end: Union[float, List[float]] = 1.0,
+        original_size: Tuple[int, int] = None,
+        crops_coords_top_left: Tuple[int, int] = (0, 0),
+        target_size: Tuple[int, int] = None,
+        negative_original_size: Optional[Tuple[int, int]] = None,
+        negative_crops_coords_top_left: Tuple[int, int] = (0, 0),
+        negative_target_size: Optional[Tuple[int, int]] = None,
+        clip_skip: Optional[int] = None,
+        callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,
+        callback_on_step_end_tensor_inputs: List[str] = ["latents"],
+
+        # IP adapter
+        ip_adapter_scale=None,
+
+        **kwargs,
+    ):
+        r"""
+        The call function to the pipeline for generation.
+
+        Args:
+            prompt (`str` or `List[str]`, *optional*):
+                The prompt or prompts to guide image generation. If not defined, you need to pass `prompt_embeds`.
+            prompt_2 (`str` or `List[str]`, *optional*):
+                The prompt or prompts to be sent to `tokenizer_2` and `text_encoder_2`. If not defined, `prompt` is
+                used in both text-encoders.
+            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.FloatTensor]`, `List[PIL.Image.Image]`, `List[np.ndarray]`,:
+                    `List[List[torch.FloatTensor]]`, `List[List[np.ndarray]]` or `List[List[PIL.Image.Image]]`):
+                The ControlNet input condition to provide guidance to the `unet` for generation. If the type is
+                specified as `torch.FloatTensor`, it is passed to ControlNet as is. `PIL.Image.Image` can also be
+                accepted as an image. The dimensions of the output image defaults to `image`'s dimensions. If height
+                and/or width are passed, `image` is resized accordingly. If multiple ControlNets are specified in
+                `init`, images must be passed as a list such that each element of the list can be correctly batched for
+                input to a single ControlNet.
+            height (`int`, *optional*, defaults to `self.unet.config.sample_size * self.vae_scale_factor`):
+                The height in pixels of the generated image. Anything below 512 pixels won't work well for
+                [stabilityai/stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0)
+                and checkpoints that are not specifically fine-tuned on low resolutions.
+            width (`int`, *optional*, defaults to `self.unet.config.sample_size * self.vae_scale_factor`):
+                The width in pixels of the generated image. Anything below 512 pixels won't work well for
+                [stabilityai/stable-diffusion-xl-base-1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0)
+                and checkpoints that are not specifically fine-tuned on low resolutions.
+            num_inference_steps (`int`, *optional*, defaults to 50):
+                The number of denoising steps. More denoising steps usually lead to a higher quality image at the
+                expense of slower inference.
+            guidance_scale (`float`, *optional*, defaults to 5.0):
+                A higher guidance scale value encourages the model to generate images closely linked to the text
+                `prompt` at the expense of lower image quality. Guidance scale is enabled when `guidance_scale > 1`.
+            negative_prompt (`str` or `List[str]`, *optional*):
+                The prompt or prompts to guide what to not include in image generation. If not defined, you need to
+                pass `negative_prompt_embeds` instead. Ignored when not using guidance (`guidance_scale < 1`).
+            negative_prompt_2 (`str` or `List[str]`, *optional*):
+                The prompt or prompts to guide what to not include in image generation. This is sent to `tokenizer_2`
+                and `text_encoder_2`. If not defined, `negative_prompt` is used in both text-encoders.
+            num_images_per_prompt (`int`, *optional*, defaults to 1):
+                The number of images to generate per prompt.
+            eta (`float`, *optional*, defaults to 0.0):
+                Corresponds to parameter eta (η) from the [DDIM](https://arxiv.org/abs/2010.02502) paper. Only applies
+                to the [`~schedulers.DDIMScheduler`], and is ignored in other schedulers.
+            generator (`torch.Generator` or `List[torch.Generator]`, *optional*):
+                A [`torch.Generator`](https://pytorch.org/docs/stable/generated/torch.Generator.html) to make
+                generation deterministic.
+            latents (`torch.FloatTensor`, *optional*):
+                Pre-generated noisy latents sampled from a Gaussian distribution, to be used as inputs for image
+                generation. Can be used to tweak the same generation with different prompts. If not provided, a latents
+                tensor is generated by sampling using the supplied random `generator`.
+            prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated text embeddings. Can be used to easily tweak text inputs (prompt weighting). If not
+                provided, text embeddings are generated from the `prompt` input argument.
+            negative_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated negative text embeddings. Can be used to easily tweak text inputs (prompt weighting). If
+                not provided, `negative_prompt_embeds` are generated from the `negative_prompt` input argument.
+            pooled_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated pooled text embeddings. Can be used to easily tweak text inputs (prompt weighting). If
+                not provided, pooled text embeddings are generated from `prompt` input argument.
+            negative_pooled_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated negative pooled text embeddings. Can be used to easily tweak text inputs (prompt
+                weighting). If not provided, pooled `negative_prompt_embeds` are generated from `negative_prompt` input
+                argument.
+            image_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated image embeddings.
+            output_type (`str`, *optional*, defaults to `"pil"`):
+                The output format of the generated image. Choose between `PIL.Image` or `np.array`.
+            return_dict (`bool`, *optional*, defaults to `True`):
+                Whether or not to return a [`~pipelines.stable_diffusion.StableDiffusionPipelineOutput`] instead of a
+                plain tuple.
+            cross_attention_kwargs (`dict`, *optional*):
+                A kwargs dictionary that if specified is passed along to the [`AttentionProcessor`] as defined in
+                [`self.processor`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
+            controlnet_conditioning_scale (`float` or `List[float]`, *optional*, defaults to 1.0):
+                The outputs of the ControlNet are multiplied by `controlnet_conditioning_scale` before they are added
+                to the residual in the original `unet`. If multiple ControlNets are specified in `init`, you can set
+                the corresponding scale as a list.
+            guess_mode (`bool`, *optional*, defaults to `False`):
+                The ControlNet encoder tries to recognize the content of the input image even if you remove all
+                prompts. A `guidance_scale` value between 3.0 and 5.0 is recommended.
+            control_guidance_start (`float` or `List[float]`, *optional*, defaults to 0.0):
+                The percentage of total steps at which the ControlNet starts applying.
+            control_guidance_end (`float` or `List[float]`, *optional*, defaults to 1.0):
+                The percentage of total steps at which the ControlNet stops applying.
+            original_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+                If `original_size` is not the same as `target_size` the image will appear to be down- or upsampled.
+                `original_size` defaults to `(height, width)` if not specified. Part of SDXL's micro-conditioning as
+                explained in section 2.2 of
+                [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
+            crops_coords_top_left (`Tuple[int]`, *optional*, defaults to (0, 0)):
+                `crops_coords_top_left` can be used to generate an image that appears to be "cropped" from the position
+                `crops_coords_top_left` downwards. Favorable, well-centered images are usually achieved by setting
+                `crops_coords_top_left` to (0, 0). Part of SDXL's micro-conditioning as explained in section 2.2 of
+                [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
+            target_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+                For most cases, `target_size` should be set to the desired height and width of the generated image. If
+                not specified it will default to `(height, width)`. Part of SDXL's micro-conditioning as explained in
+                section 2.2 of [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
+            negative_original_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+                To negatively condition the generation process based on a specific image resolution. Part of SDXL's
+                micro-conditioning as explained in section 2.2 of
+                [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more
+                information, refer to this issue thread: https://github.com/huggingface/diffusers/issues/4208.
+            negative_crops_coords_top_left (`Tuple[int]`, *optional*, defaults to (0, 0)):
+                To negatively condition the generation process based on a specific crop coordinates. Part of SDXL's
+                micro-conditioning as explained in section 2.2 of
+                [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more
+                information, refer to this issue thread: https://github.com/huggingface/diffusers/issues/4208.
+            negative_target_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+                To negatively condition the generation process based on a target image resolution. It should be as same
+                as the `target_size` for most cases. Part of SDXL's micro-conditioning as explained in section 2.2 of
+                [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more
+                information, refer to this issue thread: https://github.com/huggingface/diffusers/issues/4208.
+            clip_skip (`int`, *optional*):
+                Number of layers to be skipped from CLIP while computing the prompt embeddings. A value of 1 means that
+                the output of the pre-final layer will be used for computing the prompt embeddings.
+            callback_on_step_end (`Callable`, *optional*):
+                A function that calls at the end of each denoising steps during the inference. The function is called
+                with the following arguments: `callback_on_step_end(self: DiffusionPipeline, step: int, timestep: int,
+                callback_kwargs: Dict)`. `callback_kwargs` will include a list of all tensors as specified by
+                `callback_on_step_end_tensor_inputs`.
+            callback_on_step_end_tensor_inputs (`List`, *optional*):
+                The list of tensor inputs for the `callback_on_step_end` function. The tensors specified in the list
+                will be passed as `callback_kwargs` argument. You will only be able to include variables listed in the
+                `._callback_tensor_inputs` attribute of your pipeine class.
+
+        Examples:
+
+        Returns:
+            [`~pipelines.stable_diffusion.StableDiffusionPipelineOutput`] or `tuple`:
+                If `return_dict` is `True`, [`~pipelines.stable_diffusion.StableDiffusionPipelineOutput`] is returned,
+                otherwise a `tuple` is returned containing the output images.
+        """
+
+        callback = kwargs.pop("callback", None)
+        callback_steps = kwargs.pop("callback_steps", None)
+
+        if callback is not None:
+            deprecate(
+                "callback",
+                "1.0.0",
+                "Passing `callback` as an input argument to `__call__` is deprecated, consider using `callback_on_step_end`",
+            )
+        if callback_steps is not None:
+            deprecate(
+                "callback_steps",
+                "1.0.0",
+                "Passing `callback_steps` as an input argument to `__call__` is deprecated, consider using `callback_on_step_end`",
+            )
+
+        controlnet = self.controlnet._orig_mod if is_compiled_module(self.controlnet) else self.controlnet
+
+        # align format for control guidance
+        if not isinstance(control_guidance_start, list) and isinstance(control_guidance_end, list):
+            control_guidance_start = len(control_guidance_end) * [control_guidance_start]
+        elif not isinstance(control_guidance_end, list) and isinstance(control_guidance_start, list):
+            control_guidance_end = len(control_guidance_start) * [control_guidance_end]
+        elif not isinstance(control_guidance_start, list) and not isinstance(control_guidance_end, list):
+            mult = len(controlnet.nets) if isinstance(controlnet, MultiControlNetModel) else 1
+            control_guidance_start, control_guidance_end = (
+                mult * [control_guidance_start],
+                mult * [control_guidance_end],
+            )
+        
+        # 0. set ip_adapter_scale
+        if ip_adapter_scale is not None:
+            self.set_ip_adapter_scale(ip_adapter_scale)
+
+        # 1. Check inputs. Raise error if not correct
+        self.check_inputs(
+            prompt=prompt,
+            prompt_2=prompt_2,
+            image=image,
+            callback_steps=callback_steps,
+            negative_prompt=negative_prompt,
+            negative_prompt_2=negative_prompt_2,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+            controlnet_conditioning_scale=controlnet_conditioning_scale,
+            control_guidance_start=control_guidance_start,
+            control_guidance_end=control_guidance_end,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._clip_skip = clip_skip
+        self._cross_attention_kwargs = cross_attention_kwargs
+
+        # 2. Define call parameters
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        device = self._execution_device
+
+        if isinstance(controlnet, MultiControlNetModel) and isinstance(controlnet_conditioning_scale, float):
+            controlnet_conditioning_scale = [controlnet_conditioning_scale] * len(controlnet.nets)
+
+        global_pool_conditions = (
+            controlnet.config.global_pool_conditions
+            if isinstance(controlnet, ControlNetModel)
+            else controlnet.nets[0].config.global_pool_conditions
+        )
+        guess_mode = guess_mode or global_pool_conditions
+
+        # 3.1 Encode input prompt
+        text_encoder_lora_scale = (
+            self.cross_attention_kwargs.get("scale", None) if self.cross_attention_kwargs is not None else None
+        )
+        (
+            prompt_embeds,
+            negative_prompt_embeds,
+            pooled_prompt_embeds,
+            negative_pooled_prompt_embeds,
+        ) = self.encode_prompt(
+            prompt,
+            prompt_2,
+            device,
+            num_images_per_prompt,
+            self.do_classifier_free_guidance,
+            negative_prompt,
+            negative_prompt_2,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+            lora_scale=text_encoder_lora_scale,
+            clip_skip=self.clip_skip,
+        )
+        
+        # 3.2 Encode image prompt
+        prompt_image_emb = self._encode_prompt_image_emb(image_embeds, 
+                                                         device,
+                                                         num_images_per_prompt,
+                                                         self.unet.dtype,
+                                                         self.do_classifier_free_guidance)
+        
+        # 4. Prepare image
+        if isinstance(controlnet, ControlNetModel):
+            image = self.prepare_image(
+                image=image,
+                width=width,
+                height=height,
+                batch_size=batch_size * num_images_per_prompt,
+                num_images_per_prompt=num_images_per_prompt,
+                device=device,
+                dtype=controlnet.dtype,
+                do_classifier_free_guidance=self.do_classifier_free_guidance,
+                guess_mode=guess_mode,
+            )
+            height, width = image.shape[-2:]
+        elif isinstance(controlnet, MultiControlNetModel):
+            images = []
+
+            for image_ in image:
+                image_ = self.prepare_image(
+                    image=image_,
+                    width=width,
+                    height=height,
+                    batch_size=batch_size * num_images_per_prompt,
+                    num_images_per_prompt=num_images_per_prompt,
+                    device=device,
+                    dtype=controlnet.dtype,
+                    do_classifier_free_guidance=self.do_classifier_free_guidance,
+                    guess_mode=guess_mode,
+                )
+
+                images.append(image_)
+
+            image = images
+            height, width = image[0].shape[-2:]
+        else:
+            assert False
+
+        # 5. Prepare timesteps
+        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        timesteps = self.scheduler.timesteps
+        self._num_timesteps = len(timesteps)
+
+        # 6. Prepare latent variables
+        num_channels_latents = self.unet.config.in_channels
+        latents = self.prepare_latents(
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            device,
+            generator,
+            latents,
+        )
+
+        # 6.5 Optionally get Guidance Scale Embedding
+        timestep_cond = None
+        if self.unet.config.time_cond_proj_dim is not None:
+            guidance_scale_tensor = torch.tensor(self.guidance_scale - 1).repeat(batch_size * num_images_per_prompt)
+            timestep_cond = self.get_guidance_scale_embedding(
+                guidance_scale_tensor, embedding_dim=self.unet.config.time_cond_proj_dim
+            ).to(device=device, dtype=latents.dtype)
+
+        # 7. Prepare extra step kwargs. TODO: Logic should ideally just be moved out of the pipeline
+        extra_step_kwargs = self.prepare_extra_step_kwargs(generator, eta)
+
+        # 7.1 Create tensor stating which controlnets to keep
+        controlnet_keep = []
+        for i in range(len(timesteps)):
+            keeps = [
+                1.0 - float(i / len(timesteps) < s or (i + 1) / len(timesteps) > e)
+                for s, e in zip(control_guidance_start, control_guidance_end)
+            ]
+            controlnet_keep.append(keeps[0] if isinstance(controlnet, ControlNetModel) else keeps)
+
+        # 7.2 Prepare added time ids & embeddings
+        if isinstance(image, list):
+            original_size = original_size or image[0].shape[-2:]
+        else:
+            original_size = original_size or image.shape[-2:]
+        target_size = target_size or (height, width)
+
+        add_text_embeds = pooled_prompt_embeds
+        if self.text_encoder_2 is None:
+            text_encoder_projection_dim = int(pooled_prompt_embeds.shape[-1])
+        else:
+            text_encoder_projection_dim = self.text_encoder_2.config.projection_dim
+
+        add_time_ids = self._get_add_time_ids(
+            original_size,
+            crops_coords_top_left,
+            target_size,
+            dtype=prompt_embeds.dtype,
+            text_encoder_projection_dim=text_encoder_projection_dim,
+        )
+
+        if negative_original_size is not None and negative_target_size is not None:
+            negative_add_time_ids = self._get_add_time_ids(
+                negative_original_size,
+                negative_crops_coords_top_left,
+                negative_target_size,
+                dtype=prompt_embeds.dtype,
+                text_encoder_projection_dim=text_encoder_projection_dim,
+            )
+        else:
+            negative_add_time_ids = add_time_ids
+
+        if self.do_classifier_free_guidance:
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+            add_text_embeds = torch.cat([negative_pooled_prompt_embeds, add_text_embeds], dim=0)
+            add_time_ids = torch.cat([negative_add_time_ids, add_time_ids], dim=0)
+
+        prompt_embeds = prompt_embeds.to(device)
+        add_text_embeds = add_text_embeds.to(device)
+        add_time_ids = add_time_ids.to(device).repeat(batch_size * num_images_per_prompt, 1)
+        encoder_hidden_states = torch.cat([prompt_embeds, prompt_image_emb], dim=1)
+
+        # 8. Denoising loop
+        num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
+        is_unet_compiled = is_compiled_module(self.unet)
+        is_controlnet_compiled = is_compiled_module(self.controlnet)
+        is_torch_higher_equal_2_1 = is_torch_version(">=", "2.1")
+                
+        with self.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(timesteps):
+                # Relevant thread:
+                # https://dev-discuss.pytorch.org/t/cudagraphs-in-pytorch-2-0/1428
+                if (is_unet_compiled and is_controlnet_compiled) and is_torch_higher_equal_2_1:
+                    torch._inductor.cudagraph_mark_step_begin()
+                # expand the latents if we are doing classifier free guidance
+                latent_model_input = torch.cat([latents] * 2) if self.do_classifier_free_guidance else latents
+                latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
+
+                added_cond_kwargs = {"text_embeds": add_text_embeds, "time_ids": add_time_ids}
+
+                # controlnet(s) inference
+                if guess_mode and self.do_classifier_free_guidance:
+                    # Infer ControlNet only for the conditional batch.
+                    control_model_input = latents
+                    control_model_input = self.scheduler.scale_model_input(control_model_input, t)
+                    controlnet_prompt_embeds = prompt_embeds.chunk(2)[1]
+                    controlnet_added_cond_kwargs = {
+                        "text_embeds": add_text_embeds.chunk(2)[1],
+                        "time_ids": add_time_ids.chunk(2)[1],
+                    }
+                else:
+                    control_model_input = latent_model_input
+                    controlnet_prompt_embeds = prompt_embeds
+                    controlnet_added_cond_kwargs = added_cond_kwargs
+                
+                if isinstance(controlnet_keep[i], list):
+                    cond_scale = [c * s for c, s in zip(controlnet_conditioning_scale, controlnet_keep[i])]
+                else:
+                    controlnet_cond_scale = controlnet_conditioning_scale
+                    if isinstance(controlnet_cond_scale, list):
+                        controlnet_cond_scale = controlnet_cond_scale[0]
+                    cond_scale = controlnet_cond_scale * controlnet_keep[i]
+
+                down_block_res_samples, mid_block_res_sample = self.controlnet(
+                    control_model_input,
+                    t,
+                    encoder_hidden_states=prompt_image_emb,
+                    controlnet_cond=image,
+                    conditioning_scale=cond_scale,
+                    guess_mode=guess_mode,
+                    added_cond_kwargs=controlnet_added_cond_kwargs,
+                    return_dict=False,
+                )
+
+                if guess_mode and self.do_classifier_free_guidance:
+                    # Infered ControlNet only for the conditional batch.
+                    # To apply the output of ControlNet to both the unconditional and conditional batches,
+                    # add 0 to the unconditional batch to keep it unchanged.
+                    down_block_res_samples = [torch.cat([torch.zeros_like(d), d]) for d in down_block_res_samples]
+                    mid_block_res_sample = torch.cat([torch.zeros_like(mid_block_res_sample), mid_block_res_sample])
+
+                # predict the noise residual
+                noise_pred = self.unet(
+                    latent_model_input,
+                    t,
+                    encoder_hidden_states=encoder_hidden_states,
+                    timestep_cond=timestep_cond,
+                    cross_attention_kwargs=self.cross_attention_kwargs,
+                    down_block_additional_residuals=down_block_res_samples,
+                    mid_block_additional_residual=mid_block_res_sample,
+                    added_cond_kwargs=added_cond_kwargs,
+                    return_dict=False,
+                )[0]
+
+                # perform guidance
+                if self.do_classifier_free_guidance:
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                    noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+
+                # compute the previous noisy sample x_t -> x_t-1
+                latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs, return_dict=False)[0]
+
+                if callback_on_step_end is not None:
+                    callback_kwargs = {}
+                    for k in callback_on_step_end_tensor_inputs:
+                        callback_kwargs[k] = locals()[k]
+                    callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+
+                    latents = callback_outputs.pop("latents", latents)
+                    prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
+                    negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+
+                # call the callback, if provided
+                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                    progress_bar.update()
+                    if callback is not None and i % callback_steps == 0:
+                        step_idx = i // getattr(self.scheduler, "order", 1)
+                        callback(step_idx, t, latents)
+        
+        if not output_type == "latent":
+            # make sure the VAE is in float32 mode, as it overflows in float16
+            needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast
+
+            if needs_upcasting:
+                self.upcast_vae()
+                latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)
+
+            # unscale/denormalize the latents
+            # denormalize with the mean and std if available and not None
+            has_latents_mean = hasattr(self.vae.config, "latents_mean") and self.vae.config.latents_mean is not None
+            has_latents_std = hasattr(self.vae.config, "latents_std") and self.vae.config.latents_std is not None
+            if has_latents_mean and has_latents_std:
+                latents_mean = (
+                    torch.tensor(self.vae.config.latents_mean).view(1, 4, 1, 1).to(latents.device, latents.dtype)
+                )
+                latents_std = (
+                    torch.tensor(self.vae.config.latents_std).view(1, 4, 1, 1).to(latents.device, latents.dtype)
+                )
+                latents = latents * latents_std / self.vae.config.scaling_factor + latents_mean
+            else:
+                latents = latents / self.vae.config.scaling_factor
+
+            image = self.vae.decode(latents, return_dict=False)[0]
+
+            # cast back to fp16 if needed
+            if needs_upcasting:
+                self.vae.to(dtype=torch.float16)
+        else:
+            image = latents
+
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
+
+            image = self.image_processor.postprocess(image, output_type=output_type)
+
+        # Offload all models
+        self.maybe_free_model_hooks()
+
+        if not return_dict:
+            return (image,)
+
+        return StableDiffusionXLPipelineOutput(images=image)

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -14,7 +14,7 @@ import tempfile
 import warnings
 from pathlib import Path
 from textwrap import wrap
-from typing import Any, Callable, Iterable, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Protocol, TypeVar
 from uuid import uuid4
 
 from PIL import Image, ImageDraw, ImageFont
@@ -41,6 +41,12 @@ from .lora_adapters import (
 )
 from .settings import WorkerSettings
 from .upscalers import RealESRGANUpscaler, UpscaleJob
+
+if TYPE_CHECKING:
+    # instantid_adapter imports from this module, so it can only be referenced for
+    # typing (the runtime instance is created in runtime.py and passed in via the
+    # adapters dict; create_image_adapter lazily imports it for the no-dict path).
+    from .instantid_adapter import InstantIDAdapter
 
 
 Image.MAX_IMAGE_PIXELS = 64_000_000
@@ -384,6 +390,36 @@ MODEL_TARGETS = {
         "variant": "fp16",
         "repo": "stabilityai/stable-diffusion-xl-base-1.0",
         "adapter": "sdxl_diffusers",
+    },
+    "instantid_realvisxl": {
+        "label": "InstantID (RealVisXL)",
+        # SDXL UNet under the hood, so it shares the sdxl LoRA family. Identity is
+        # driven by an insightface ArcFace embedding + a 5-point-landmark ControlNet
+        # ("IdentityNet"), NOT by an SDXL img2img/inpaint path — so it is strictly a
+        # reference-driven character model (no plain text_to_image / edit_image).
+        "family": "sdxl",
+        "supportsEdit": False,
+        # Per the sc-2009 spike: ~30 steps at guidance 5.0; identity holds with
+        # ip_adapter_scale ~0.8 and controlnet_conditioning_scale 0.45 (looser pose)
+        # .. 0.8 (frontal lock). Both ride advanced (ipAdapterScale /
+        # controlnetConditioningScale); the adapter defaults them when absent.
+        "steps": 30,
+        "guidanceScale": 5.0,
+        # RealVisXL ships fp16-variant weights; from_pretrained falls back to the
+        # default precision if the variant is absent (see InstantIDAdapter).
+        "variant": "fp16",
+        # RealVisXL_V5.0: photoreal SDXL finetune (openrail++, commercial-OK) that
+        # solves the "shiny/plastic" look; the sc-2009 A/B winner over base SDXL.
+        "repo": "SG161222/RealVisXL_V5.0",
+        "adapter": "instantid_sdxl",
+        # InstantID IdentityNet ControlNet + ip-adapter image projection. Fetched on
+        # demand by the adapter (mirrors the Kolors IP-Adapter pattern); the
+        # antelopev2 face pack is fetched separately into the insightface root.
+        "instantId": {
+            "repo": "InstantX/InstantID",
+            "controlnetSubfolder": "ControlNetModel",
+            "ipAdapter": "ip-adapter.bin",
+        },
     },
 }
 
@@ -4131,6 +4167,7 @@ def create_image_adapter(
     | KolorsDiffusersAdapter
     | SdxlDiffusersAdapter
     | ChromaDiffusersAdapter
+    | "InstantIDAdapter"
 ):
     payload = job.get("payload", {})
     requested = os.getenv("SCENEWORKS_IMAGE_ADAPTER", payload.get("adapter", "")).strip()
@@ -4138,6 +4175,8 @@ def create_image_adapter(
         requested = ""
     if requested in {"procedural", "procedural_preview"}:
         return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
+    # InstantID lives in instantid_adapter.py (imports from this module), so match by
+    # its string id and lazily import for the no-adapters-dict (test/direct) path.
     if requested and requested not in {
         ZImageDiffusersAdapter.id,
         QwenImageAdapter.id,
@@ -4147,6 +4186,7 @@ def create_image_adapter(
         KolorsDiffusersAdapter.id,
         SdxlDiffusersAdapter.id,
         ChromaDiffusersAdapter.id,
+        "instantid_sdxl",
     }:
         raise RuntimeError(f"Unsupported SCENEWORKS_IMAGE_ADAPTER value: {requested}.")
     if requested == ZImageDiffusersAdapter.id:
@@ -4165,6 +4205,8 @@ def create_image_adapter(
         return adapters.get("sdxl_diffusers") if adapters else SdxlDiffusersAdapter()
     if requested == ChromaDiffusersAdapter.id:
         return adapters.get("chroma_diffusers") if adapters else ChromaDiffusersAdapter()
+    if requested == "instantid_sdxl":
+        return _instantid_adapter(adapters)
     model_target = MODEL_TARGETS.get(payload.get("model", "z_image_turbo"), {})
     if model_target.get("adapter") == ZImageDiffusersAdapter.id:
         return adapters.get("z_image_diffusers") if adapters else ZImageDiffusersAdapter()
@@ -4182,7 +4224,20 @@ def create_image_adapter(
         return adapters.get("sdxl_diffusers") if adapters else SdxlDiffusersAdapter()
     if model_target.get("adapter") == ChromaDiffusersAdapter.id:
         return adapters.get("chroma_diffusers") if adapters else ChromaDiffusersAdapter()
+    if model_target.get("adapter") == "instantid_sdxl":
+        return _instantid_adapter(adapters)
     return adapters.get("procedural_preview") if adapters else ProceduralImageAdapter()
+
+
+def _instantid_adapter(adapters: dict[str, object] | None) -> "InstantIDAdapter":
+    """Resolve the registered InstantID adapter, or lazily construct one when no
+    runtime adapters dict is supplied (tests / direct calls). Kept separate to
+    avoid a module-level import cycle (instantid_adapter imports from here)."""
+    if adapters and "instantid_sdxl" in adapters:
+        return adapters["instantid_sdxl"]
+    from .instantid_adapter import InstantIDAdapter
+
+    return InstantIDAdapter()
 
 
 def model_supports_edit(model_id: str) -> bool:

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -1,0 +1,379 @@
+"""InstantID SDXL face-identity adapter (sc-2009).
+
+Zero-shot face-identity generation: an insightface (antelopev2) ArcFace embedding
++ 5-point landmark ControlNet ("IdentityNet") preserve a person's identity from a
+single reference while the prompt drives scene/pose/wardrobe. Validated in the
+sc-2009 A/B as the only method that holds identity AND follows the prompt; plain
+IP-Adapter (sc-2006/2007) only captures coarse resemblance.
+
+Runs in the MAIN worker venv. Extra deps (see requirements-instantid.txt):
+insightface, onnxruntime, onnx, peft, einops. The InstantX pipeline +
+tencent-ailab ip_adapter module are vendored under _vendor/instantid (both
+Apache-2.0); placed on sys.path here, mirroring lens_runner.
+
+Key constraints (from the sc-2009 spike):
+* bf16 on MPS — fp16 NaNs on Metal (the pipeline uses self.dtype throughout).
+* The landmark control image MUST match the output aspect or faces stretch, so
+  the reference is letterboxed onto a (width x height) canvas before face
+  detection and draw_kps.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+from .image_adapters import (
+    CancelCallback,
+    ImageAssetWriter,
+    ImageRequest,
+    MODEL_TARGETS,
+    ProgressCallback,
+    activate_torch_device,
+    cancel_step_callback,
+    emit_worker_event,
+    filter_call_kwargs,
+    image_batch_progress,
+    format_batch_running_message,
+    huggingface_repo_cache_exists,
+    load_reference_image,
+    require_inference_backend_for_gpu_worker,
+    resolve_seed,
+    safe_int,
+    select_torch_device,
+    select_torch_dtype,
+)
+from .settings import WorkerSettings
+
+_VENDOR = Path(__file__).resolve().parent / "_vendor" / "instantid"
+
+# antelopev2 face-analysis pack (insightface root/models/antelopev2/*.onnx). Not a
+# standard insightface auto-download, so we mirror-fetch the 5 files on demand.
+_ANTELOPEV2_REPO = "DIAMONIK7777/antelopev2"
+_ANTELOPEV2_FILES = (
+    "1k3d68.onnx",
+    "2d106det.onnx",
+    "genderage.onnx",
+    "glintr100.onnx",
+    "scrfd_10g_bnkps.onnx",
+)
+
+
+def _insightface_root() -> Path:
+    import os
+
+    return Path(os.environ.get("INSTANTID_INSIGHTFACE_ROOT", str(Path.home() / ".insightface")))
+
+
+def _ensure_antelopev2() -> Path:
+    """Make sure antelopev2 onnx models exist under the insightface root; return root."""
+    from huggingface_hub import hf_hub_download
+
+    root = _insightface_root()
+    dest = root / "models" / "antelopev2"
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in _ANTELOPEV2_FILES:
+        if not (dest / name).exists():
+            path = hf_hub_download(repo_id=_ANTELOPEV2_REPO, filename=name)
+            # hf cache stores a symlink target; copy into the insightface layout.
+            data = Path(path).read_bytes()
+            (dest / name).write_bytes(data)
+    return root
+
+
+def _import_instantid() -> tuple[Any, Any]:
+    """Import the vendored InstantX pipeline (+ draw_kps). Inserts _vendor/instantid
+    on sys.path so its top-level `from ip_adapter...` imports resolve."""
+    vendor = str(_VENDOR)
+    if vendor not in sys.path:
+        sys.path.insert(0, vendor)
+    mod = importlib.import_module("pipeline_stable_diffusion_xl_instantid")
+    return mod.StableDiffusionXLInstantIDPipeline, mod.draw_kps
+
+
+def _letterbox(image: Image.Image, width: int, height: int) -> Image.Image:
+    """Resize keeping aspect and pad onto a width x height canvas, so the landmark
+    control image and the output share an aspect ratio (no face stretching)."""
+    ratio = min(width / image.width, height / image.height)
+    new_w, new_h = max(1, round(image.width * ratio)), max(1, round(image.height * ratio))
+    resized = image.resize((new_w, new_h), Image.LANCZOS)
+    canvas = Image.new("RGB", (width, height), (0, 0, 0))
+    canvas.paste(resized, ((width - new_w) // 2, (height - new_h) // 2))
+    return canvas
+
+
+class InstantIDAdapter:
+    """Identity-preserving SDXL generation via InstantID (face embedding + IdentityNet)."""
+
+    id = "instantid_sdxl"
+
+    def __init__(self) -> None:
+        self._pipe: Any | None = None
+        self._loaded_repo: str | None = None
+        self._loaded_model: str | None = None
+        self._face_app: Any | None = None
+
+    def loaded_models(self) -> list[str]:
+        return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
+
+    def unload(self) -> bool:
+        if self._pipe is None:
+            return False
+        self._pipe = None
+        self._loaded_repo = None
+        self._loaded_model = None
+        self._empty_cache(importlib.import_module("torch"))
+        return True
+
+    @staticmethod
+    def _empty_cache(torch: Any) -> None:
+        try:
+            if torch.backends.mps.is_available():
+                torch.mps.empty_cache()
+            elif torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    # ---- face analysis -------------------------------------------------
+    def _face_analysis(self) -> Any:
+        if self._face_app is None:
+            root = _ensure_antelopev2()
+            from insightface.app import FaceAnalysis
+
+            app = FaceAnalysis(name="antelopev2", root=str(root), providers=["CPUExecutionProvider"])
+            app.prepare(ctx_id=0, det_size=(640, 640))
+            self._face_app = app
+        return self._face_app
+
+    def _largest_face(self, canvas: Image.Image) -> Any:
+        import cv2
+
+        bgr = cv2.cvtColor(np.array(canvas), cv2.COLOR_RGB2BGR)
+        faces = self._face_analysis().get(bgr)
+        if not faces:
+            raise RuntimeError(
+                "No face detected in the reference image. InstantID needs a clear, "
+                "front-facing face crop as the character reference."
+            )
+        return sorted(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))[-1]
+
+    # ---- pipeline ------------------------------------------------------
+    def _load_pipeline(
+        self,
+        settings: WorkerSettings,
+        request: ImageRequest,
+        model_target: dict[str, Any],
+        progress: ProgressCallback,
+        *,
+        job_id: str,
+    ) -> Any:
+        torch = importlib.import_module("torch")
+        repo = request.advanced.get("modelRepo") or model_target["repo"]
+        require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+
+        if self._pipe is not None and self._loaded_repo == repo:
+            progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
+            self._loaded_model = request.model
+            return self._pipe
+        if self._pipe is not None:
+            self.unload()
+
+        instant = model_target.get("instantId") or {}
+        if not instant:
+            raise RuntimeError(f"{request.model} has no InstantID configuration.")
+        instant_repo = instant.get("repo", "InstantX/InstantID")
+        cache_action = "Loading cached" if huggingface_repo_cache_exists(repo) else "Downloading"
+        progress("loading_model", "loading_model", 0.2, f"{cache_action} {model_target['label']} (InstantID).")
+        emit_worker_event(
+            "image_pipeline_load_start",
+            jobId=job_id,
+            adapter=self.id,
+            model=request.model,
+            repo=repo,
+            device=device,
+            dtype=str(dtype),
+            useInstantId=True,
+        )
+
+        pipeline_class, _ = _import_instantid()
+        diffusers = importlib.import_module("diffusers")
+        from huggingface_hub import hf_hub_download
+
+        controlnet = diffusers.ControlNetModel.from_pretrained(
+            instant_repo, subfolder=instant.get("controlnetSubfolder", "ControlNetModel"), torch_dtype=dtype
+        )
+        from_pretrained_kwargs: dict[str, Any] = {"controlnet": controlnet, "torch_dtype": dtype}
+        if model_target.get("variant"):
+            from_pretrained_kwargs["variant"] = model_target["variant"]
+        try:
+            pipe = pipeline_class.from_pretrained(repo, **from_pretrained_kwargs)
+        except Exception:
+            from_pretrained_kwargs.pop("variant", None)
+            pipe = pipeline_class.from_pretrained(repo, **from_pretrained_kwargs)
+
+        ip_bin = hf_hub_download(repo_id=instant_repo, filename=instant.get("ipAdapter", "ip-adapter.bin"))
+        pipe.load_ip_adapter_instantid(ip_bin)
+        pipe.to(device)
+        vae = getattr(pipe, "vae", None)
+        if vae is not None and hasattr(vae, "enable_tiling"):
+            vae.enable_tiling()
+
+        emit_worker_event("image_pipeline_load_complete", jobId=job_id, adapter=self.id, model=request.model, repo=repo)
+        self._pipe = pipe
+        self._loaded_repo = repo
+        self._loaded_model = request.model
+        return pipe
+
+    def _ip_adapter_scale(self, request: ImageRequest) -> float:
+        try:
+            return float(request.advanced.get("ipAdapterScale", 0.8))
+        except (TypeError, ValueError):
+            return 0.8
+
+    def _controlnet_scale(self, request: ImageRequest) -> float:
+        try:
+            return float(request.advanced.get("controlnetConditioningScale", 0.8))
+        except (TypeError, ValueError):
+            return 0.8
+
+    def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        return safe_int(request.advanced.get("steps"), model_target.get("steps", 30), 1, 80)
+
+    def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:
+        default = model_target.get("guidanceScale", 5.0)
+        try:
+            return float(request.advanced.get("guidanceScale", default))
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _run_pipeline(
+        self,
+        settings: WorkerSettings,
+        pipe: Any,
+        request: ImageRequest,
+        seed: int,
+        project_path: Path,
+        cancel_requested: CancelCallback | None = None,
+    ) -> Image.Image:
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        activate_torch_device(torch, device)
+        _, draw_kps = _import_instantid()
+        model_target = MODEL_TARGETS[request.model]
+
+        reference = load_reference_image(project_path, request.reference_asset_id)
+        canvas = _letterbox(reference, request.width, request.height)
+        face = self._largest_face(canvas)
+        face_emb = face["embedding"]
+        face_kps = draw_kps(canvas, face["kps"])
+
+        pipe.set_ip_adapter_scale(self._ip_adapter_scale(request))
+        generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
+        kwargs: dict[str, Any] = {
+            "prompt": request.prompt,
+            "negative_prompt": request.negative_prompt,
+            "image_embeds": face_emb,
+            "image": face_kps,
+            "controlnet_conditioning_scale": self._controlnet_scale(request),
+            "ip_adapter_scale": self._ip_adapter_scale(request),
+            "width": request.width,
+            "height": request.height,
+            "num_inference_steps": self._num_inference_steps(request, model_target),
+            "guidance_scale": self._guidance_scale(request, model_target),
+            "generator": generator,
+        }
+        step_callback = cancel_step_callback(pipe, cancel_requested)
+        if step_callback is not None:
+            kwargs["callback_on_step_end"] = step_callback
+        output = pipe(**filter_call_kwargs(pipe, kwargs))
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Image generation canceled by user.")
+        return output.images[0].convert("RGB")
+
+    def generate(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        model_target = MODEL_TARGETS.get(request.model, {})
+        if model_target.get("adapter") != self.id:
+            raise RuntimeError(f"{request.model} is not an InstantID target.")
+        if request.mode == "edit_image":
+            raise RuntimeError(f"{request.model} does not support image editing.")
+        if not request.reference_asset_id:
+            raise RuntimeError("InstantID generation requires a character reference image.")
+
+        progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']} (InstantID).")
+        pipe = self._load_pipeline(settings, request, model_target, progress=progress, job_id=job["id"])
+        torch = importlib.import_module("torch")
+        device = select_torch_device(torch, settings.gpu_id)
+        label = model_target["label"]
+
+        def image_at_index(index: int) -> Image.Image:
+            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            progress(
+                "running",
+                "generating",
+                image_batch_progress(index, request.count),
+                format_batch_running_message(label, index, request.count),
+            )
+            emit_worker_event(
+                "image_inference_start",
+                jobId=job["id"],
+                adapter=self.id,
+                model=request.model,
+                imageIndex=index,
+                imageCount=request.count,
+                device=device,
+            )
+            try:
+                image = self._run_pipeline(
+                    settings, pipe, request, seed, project_path, cancel_requested=cancel_requested
+                )
+            except Exception as exc:
+                emit_worker_event(
+                    "image_inference_failed",
+                    jobId=job["id"],
+                    adapter=self.id,
+                    imageIndex=index,
+                    error=str(exc),
+                    errorType=exc.__class__.__name__,
+                )
+                raise
+            emit_worker_event("image_inference_complete", jobId=job["id"], adapter=self.id, imageIndex=index)
+            return image
+
+        return ImageAssetWriter().write_incremental_outputs(
+            request=request,
+            project_path=project_path,
+            image_count=request.count,
+            image_at_index=image_at_index,
+            adapter_id=self.id,
+            progress=progress,
+            cancel_requested=cancel_requested,
+            raw_settings={
+                **request.advanced,
+                "repo": request.advanced.get("modelRepo") or model_target["repo"],
+                "instantId": True,
+                "ipAdapterScale": self._ip_adapter_scale(request),
+                "controlnetConditioningScale": self._controlnet_scale(request),
+                "numInferenceSteps": self._num_inference_steps(request, model_target),
+                "guidanceScale": self._guidance_scale(request, model_target),
+                "realModelInference": True,
+            },
+            settings=settings,
+            job_id=job["id"],
+        )

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -32,6 +32,7 @@ from .image_adapters import (
     release_image_worker_memory,
     torch_inference_backend_available,
 )
+from .instantid_adapter import InstantIDAdapter
 from .person_adapters import (
     detector_backend_available,
     run_person_detect,
@@ -1258,6 +1259,7 @@ def run_worker_loop(settings: WorkerSettings) -> None:
         "kolors_diffusers": KolorsDiffusersAdapter(),
         "sdxl_diffusers": SdxlDiffusersAdapter(),
         "chroma_diffusers": ChromaDiffusersAdapter(),
+        "instantid_sdxl": InstantIDAdapter(),
     }
     max_registration_attempts = 20
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -821,6 +821,19 @@
         "label": "InstantID (RealVisXL)",
         "description": "Identity-preserving character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) with InstantID's ArcFace embedding + 5-point-landmark ControlNet — the sc-2009 winner for faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 5.0; ~22GB peak on Apple Silicon. Needs the InstantID weights (~4GB) + antelopev2 face pack, fetched on first use.",
         "recommendedFor": ["character_image"],
+        // InstantID identity tuning surfaced in the character-image picker. The
+        // reference-strength slider drives ipAdapterScale (default raised to 0.8 for
+        // InstantID vs the global 0.6); identityStructure adds a second slider for
+        // controlnetConditioningScale (IdentityNet/landmark lock — the lever that
+        // measurably trades pose freedom for face-geometry likeness, sc-2009 sweep).
+        "referenceStrengthDefault": 0.8,
+        "identityStructure": {
+          "label": "Identity structure",
+          "default": 0.8,
+          "min": 0.3,
+          "max": 1.0,
+          "step": 0.05
+        },
         "promptGuide": {
           "title": "InstantID (RealVisXL) Prompt Guide",
           "path": "/prompt-guides/instantid-realvisxl.md",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -770,6 +770,69 @@
       }
     },
     {
+      "id": "instantid_realvisxl",
+      "name": "InstantID (RealVisXL)",
+      "family": "sdxl",
+      "type": "image",
+      "adapter": "instantid_sdxl",
+      // Reference-driven only: identity comes from an insightface ArcFace embedding
+      // + a 5-point-landmark ControlNet, so there is no text_to_image / edit_image
+      // path. Advertise character_image alone so it appears solely in the "With
+      // character" picker (a clear reference image is required).
+      "capabilities": ["character_image"],
+      "downloads": [
+        {
+          // Photoreal SDXL finetune (UNet + dual CLIP + VAE); the worker loads the
+          // fp16 variant. openrail++ (commercial use OK, ungated). The InstantID
+          // IdentityNet ControlNet + ip-adapter.bin (~4 GiB) and the antelopev2
+          // face pack are fetched on demand by the adapter (mirrors Kolors
+          // IP-Adapter), so they are not listed here.
+          "provider": "huggingface",
+          "repo": "SG161222/RealVisXL_V5.0",
+          "files": [],
+          "estimatedSizeBytes": 7105348096
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SG161222/RealVisXL_V5.0"
+      },
+      "defaults": {
+        // sc-2009 spike: ~30 steps at guidance 5.0; identity scale 0.8, landmark
+        // scale 0.45 (looser pose) .. 0.8 (frontal lock). The reference-strength
+        // slider drives ipAdapterScale; controlnetConditioningScale rides advanced.
+        "resolution": "1024x1024",
+        "steps": 30,
+        "guidanceScale": 5.0,
+        "count": 4
+      },
+      "limits": {
+        // Letterboxed to the output aspect before landmark detection, so any SDXL
+        // bucket is safe (no face stretching — the sc-2009 kps-aspect fix).
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        // SDXL UNet, so sdxl-family LoRAs apply (per sc-1927 declare the real
+        // family rather than an empty list, which would match every LoRA).
+        "families": ["sdxl"],
+        "types": ["style", "enhance", "character"]
+      },
+      "ui": {
+        "label": "InstantID (RealVisXL)",
+        "description": "Identity-preserving character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) with InstantID's ArcFace embedding + 5-point-landmark ControlNet — the sc-2009 winner for faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 5.0; ~22GB peak on Apple Silicon. Needs the InstantID weights (~4GB) + antelopev2 face pack, fetched on first use.",
+        "recommendedFor": ["character_image"],
+        "promptGuide": {
+          "title": "InstantID (RealVisXL) Prompt Guide",
+          "path": "/prompt-guides/instantid-realvisxl.md",
+          "sources": [
+            { "label": "InstantID project", "url": "https://github.com/instantX-research/InstantID" },
+            { "label": "InstantID weights", "url": "https://huggingface.co/InstantX/InstantID" },
+            { "label": "RealVisXL_V5.0 model card", "url": "https://huggingface.co/SG161222/RealVisXL_V5.0" }
+          ]
+        }
+      }
+    },
+    {
       "id": "ltx_2_3",
       "name": "LTX-2.3",
       "family": "ltx-video",

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image
 
-from scene_worker.image_adapters import MODEL_TARGETS, image_request_from_job
+from scene_worker.image_adapters import MODEL_TARGETS, create_image_adapter, image_request_from_job
 from scene_worker.instantid_adapter import InstantIDAdapter, _letterbox
 
 _TEST_TARGET = {
@@ -102,3 +102,37 @@ def test_requires_reference_image(instantid_model):
 
 def test_unload_when_empty_is_false():
     assert InstantIDAdapter().unload() is False
+
+
+def test_builtin_realvisxl_target_is_wired():
+    # The public sc-2009 target: model id matches the builtin manifest + web
+    # constants, routes to the registered adapter, and carries the spike-validated
+    # params. Guards the worker MODEL_TARGETS <-> adapter-registry wiring.
+    target = MODEL_TARGETS["instantid_realvisxl"]
+    assert target["adapter"] == InstantIDAdapter.id == "instantid_sdxl"
+    assert target["family"] == "sdxl"
+    assert target["supportsEdit"] is False
+    assert target["repo"] == "SG161222/RealVisXL_V5.0"
+    assert target["steps"] == 30
+    assert target["guidanceScale"] == 5.0
+    instant = target["instantId"]
+    assert instant["repo"] == "InstantX/InstantID"
+    assert instant["controlnetSubfolder"] == "ControlNetModel"
+    assert instant["ipAdapter"] == "ip-adapter.bin"
+
+
+def test_dispatch_routes_instantid_model_to_adapter():
+    # Regression: the model -> adapter dispatch must route instantid_realvisxl to
+    # the InstantID adapter, NOT fall through to the procedural placeholder.
+    job = {"id": "j", "payload": {"model": "instantid_realvisxl", "mode": "character_image"}}
+    # No adapters dict (test/direct path) -> lazily constructed.
+    assert isinstance(create_image_adapter(job, None), InstantIDAdapter)
+    # Runtime path: resolves the registered instance from the adapters dict.
+    registered = InstantIDAdapter()
+    assert create_image_adapter(job, {"instantid_sdxl": registered}) is registered
+
+
+def test_dispatch_accepts_instantid_adapter_override():
+    # SCENEWORKS_IMAGE_ADAPTER=instantid_sdxl must be an accepted explicit override.
+    job = {"id": "j", "payload": {"model": "z_image_turbo", "adapter": "instantid_sdxl"}}
+    assert isinstance(create_image_adapter(job, None), InstantIDAdapter)

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -1,0 +1,104 @@
+"""Unit coverage for the InstantID SDXL face-identity adapter (sc-2009).
+
+Covers the pure engine logic + generate() guard rails without loading any real
+models (no torch/diffusers/insightface). Full _run_pipeline / end-to-end identity
+behavior is validated by the sc-2009 spike + a real worker job, not here.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from scene_worker.image_adapters import MODEL_TARGETS, image_request_from_job
+from scene_worker.instantid_adapter import InstantIDAdapter, _letterbox
+
+_TEST_TARGET = {
+    "label": "Test InstantID",
+    "family": "sdxl",
+    "supportsEdit": False,
+    "steps": 30,
+    "guidanceScale": 5.0,
+    "variant": "fp16",
+    "repo": "stabilityai/stable-diffusion-xl-base-1.0",
+    "adapter": "instantid_sdxl",
+    "instantId": {
+        "repo": "InstantX/InstantID",
+        "controlnetSubfolder": "ControlNetModel",
+        "ipAdapter": "ip-adapter.bin",
+    },
+}
+
+_NOOP = lambda *args, **kwargs: None  # noqa: E731
+
+
+@pytest.fixture
+def instantid_model(monkeypatch):
+    monkeypatch.setitem(MODEL_TARGETS, "test_instantid", _TEST_TARGET)
+    return "test_instantid"
+
+
+def _job(model, **payload):
+    base = {"projectId": "p", "mode": "character_image", "model": model, "prompt": "a person at a cafe"}
+    base.update(payload)
+    return {"id": "job_instantid", "payload": base}
+
+
+def _generate(job):
+    InstantIDAdapter().generate(
+        settings=None,
+        job=job,
+        request=image_request_from_job(job),
+        project_path=None,
+        progress=_NOOP,
+        cancel_requested=lambda: False,
+    )
+
+
+def test_letterbox_matches_target_and_preserves_aspect():
+    # Square ref -> portrait output: padded, never stretched.
+    out = _letterbox(Image.new("RGB", (1024, 1024)), 832, 1216)
+    assert out.size == (832, 1216)
+    # Wide ref -> square output.
+    out2 = _letterbox(Image.new("RGB", (1600, 600)), 1024, 1024)
+    assert out2.size == (1024, 1024)
+
+
+def test_scale_defaults_and_overrides():
+    adapter = InstantIDAdapter()
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={})) == 0.8
+    assert adapter._controlnet_scale(SimpleNamespace(advanced={})) == 0.8
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": 0.55})) == 0.55
+    assert adapter._controlnet_scale(SimpleNamespace(advanced={"controlnetConditioningScale": 0.4})) == 0.4
+    # Unparseable values fall back to the defaults.
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": "x"})) == 0.8
+    assert adapter._controlnet_scale(SimpleNamespace(advanced={"controlnetConditioningScale": None})) == 0.8
+
+
+def test_steps_and_guidance_from_target():
+    adapter = InstantIDAdapter()
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={}), _TEST_TARGET) == 30
+    assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 999}), _TEST_TARGET) == 80
+    assert adapter._guidance_scale(SimpleNamespace(advanced={}), _TEST_TARGET) == 5.0
+    assert adapter._guidance_scale(SimpleNamespace(advanced={"guidanceScale": 3.5}), _TEST_TARGET) == 3.5
+
+
+def test_rejects_non_instantid_model():
+    with pytest.raises(RuntimeError, match="not an InstantID target"):
+        _generate(_job("z_image_turbo"))
+
+
+def test_rejects_edit_mode(instantid_model):
+    with pytest.raises(RuntimeError, match="does not support image editing"):
+        _generate(_job(instantid_model, mode="edit_image"))
+
+
+def test_requires_reference_image(instantid_model):
+    # character_image mode but no referenceAssetId -> guarded before any model load.
+    with pytest.raises(RuntimeError, match="requires a character reference image"):
+        _generate(_job(instantid_model))
+
+
+def test_unload_when_empty_is_false():
+    assert InstantIDAdapter().unload() is False


### PR DESCRIPTION
## Summary

Adds **InstantID (RealVisXL)** as a selectable, identity-preserving character model — the sc-2009 A/B winner that holds a person's face from a single reference while the prompt drives scene/pose/wardrobe (vs IP-Adapter "resemblance only"). Part of epic 2003; unblocks the created-character bootstrap (sc-2033).

Three slices on this branch:

1. **Worker engine** (`166475a`) — `InstantIDAdapter` (`instantid_sdxl`): insightface ArcFace embedding + 5-point-landmark ControlNet (IdentityNet), bf16-on-MPS, letterbox-to-output-aspect (the kps-distortion fix). Vendored InstantX pipeline + tencent-ailab `ip_adapter` (both **Apache-2.0**, provenance in `_vendor/README.md`); extra deps in `requirements-instantid.txt`; heavy imports lazy so registration stays cheap without the extras.
2. **Selectable end-to-end** (`bac969f`) — public `instantid_realvisxl` model: worker `MODEL_TARGETS` + `create_image_adapter` dispatch wiring, `builtin.models.jsonc` entry (`character_image` only), web constants, prompt guide. Base = `SG161222/RealVisXL_V5.0` (photoreal SDXL, **openrail++ commercial-OK**). Drivable through the existing Character Studio → Image Studio flow; no Rust changes (`advanced` + `referenceAssetId` already thread through).
3. **Identity tuning UI** (`2648424`) — declarative `ui.*` hints raise InstantID's reference-strength default to 0.8 and add an **"Identity structure" slider** (`controlnetConditioningScale`), gated to the model so it doesn't leak onto Kolors.

## Hardware validation (Apple Silicon / MPS, bf16)

Ran the real worker path (`create_image_adapter` → `generate()`) against real RealVisXL + InstantID + antelopev2 at portrait 832×1216 with the Kelsie reference:

- Dispatch routed correctly; load ~66s (incl. first-run ~4GB InstantID download), 30 steps, generate 167s.
- **Identity: ArcFace cosine(reference, output) = 0.876 [STRONG]**; no face distortion at portrait aspect (letterbox fix validated); photoreal, not "shiny/plastic".
- Tuning sweep: `controlnetConditioningScale` is the measurable identity lever (cosine 0.834 @ 0.45 → 0.887 @ 1.0 — a pose-freedom ↔ face-geometry trade-off); `ipAdapterScale` is near-flat for parity.

## Notes / deferred (follow-ups, not blockers)

- The Character Studio **"test generate"** panel is prompt-only for *all* character models today (it never threads a specific `referenceAssetId`); InstantID requires a reference, so drive it via the Image Studio character flow. Pre-existing; out of scope.
- Model Manager pre-fetch of antelopev2 + InstantID aux weights (on-demand today).

## Test plan

- [x] Worker: 10 InstantID unit tests (dispatch routing/override, builtin wiring, letterbox, scale/step/guidance, guards); full worker suite **361 passed**.
- [x] Web: vitest **140 passed** (incl. new Identity-structure slider test); Vite build clean.
- [x] `scripts/check-scaffold.mjs` passes (prompt guide present); manifest schema-consistent.
- [x] Real MPS end-to-end generation + objective identity score (above).
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)