### PR TITLE
Provision InstantID extras into desktop sidecar venv [sc-2009]

### DIFF
--- a/apps/desktop/scripts/stage-python.mjs
+++ b/apps/desktop/scripts/stage-python.mjs
@@ -19,7 +19,15 @@ mkdirSync(outDir, { recursive: true });
 // requirements-lens.txt feeds the separate Lens sidecar venv (torch 2.11 /
 // transformers 5.8), provisioned alongside the main venv by setup.rs. scene_worker
 // (incl. lens_runner.py + _vendor/lens) is copied wholesale below.
-for (const file of ["requirements.txt", "requirements-ltx.txt", "requirements-mlx.txt", "requirements-lens.txt"]) {
+for (const file of [
+  "requirements.txt",
+  "requirements-ltx.txt",
+  "requirements-mlx.txt",
+  "requirements-lens.txt",
+  // InstantID face-identity extras (insightface/onnxruntime/onnx/peft/einops);
+  // installed into the main venv by setup.rs so the instantid_sdxl adapter runs.
+  "requirements-instantid.txt",
+]) {
   const src = join(workerDir, file);
   if (existsSync(src)) cpSync(src, join(outDir, file));
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -192,6 +192,27 @@ fn requirements_ltx_path(app: &AppHandle) -> PathBuf {
         .join("requirements-ltx.txt")
 }
 
+/// requirements-instantid.txt location (InstantID face-identity extras:
+/// insightface/onnxruntime/onnx/peft/einops): the bundled resource in a packaged
+/// app, or the repo copy during development. Optional — absent in older worker
+/// checkouts, in which case the InstantID character model is unavailable. Installed
+/// on all platforms (face analysis uses the CPU onnxruntime provider; the SDXL
+/// pipeline runs on CUDA or MPS like the other image adapters).
+fn requirements_instantid_path(app: &AppHandle) -> PathBuf {
+    if let Ok(resources) = app.path().resource_dir() {
+        let bundled = resources
+            .join("python-src")
+            .join("requirements-instantid.txt");
+        if bundled.exists() {
+            return bundled;
+        }
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("worker")
+        .join("requirements-instantid.txt")
+}
+
 /// requirements-lens.txt location (Microsoft Lens sidecar venv deps): the bundled
 /// resource in a packaged app, or the repo copy during development. Optional —
 /// absent in older worker checkouts, in which case Lens is unavailable.
@@ -483,6 +504,12 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     // torchaudio). Optional: absent in older worker checkouts.
     let requirements_ltx = requirements_ltx_path(app);
     let requirements_ltx_body = std::fs::read_to_string(&requirements_ltx).unwrap_or_default();
+    // InstantID face-identity extras (insightface/onnxruntime/onnx/peft/einops).
+    // Optional: absent in older worker checkouts, in which case the InstantID
+    // character model stays unavailable (the adapter reports a clear error).
+    let requirements_instantid = requirements_instantid_path(app);
+    let requirements_instantid_body =
+        std::fs::read_to_string(&requirements_instantid).unwrap_or_default();
     // Apple Silicon MLX video inference deps — macOS-only; empty body elsewhere so
     // the marker stays stable and the Windows/Linux PyTorch worker is untouched.
     #[cfg(target_os = "macos")]
@@ -493,7 +520,7 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     let requirements_mlx_body = String::new();
     let marker = marker_path();
     let expected = format!(
-        "v{SETUP_VERSION}\n{requirements_body}\n# ltx\n{requirements_ltx_body}\n# mlx\n{requirements_mlx_body}"
+        "v{SETUP_VERSION}\n{requirements_body}\n# ltx\n{requirements_ltx_body}\n# mlx\n{requirements_mlx_body}\n# instantid\n{requirements_instantid_body}"
     );
 
     if python.exists() {
@@ -549,6 +576,12 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     if requirements_mlx.exists() {
         requirement_files.push(requirements_mlx.clone());
+    }
+    // InstantID extras resolve cleanly alongside the pinned torch/diffusers stack
+    // (validated on the torch 2.8 / diffusers 0.39 worker venv) — add them to the
+    // same single uv pass so the dependency set stays ABI-consistent.
+    if requirements_instantid.exists() {
+        requirement_files.push(requirements_instantid.clone());
     }
     run_uv(app, pip_install_args(&python, &requirement_files)).await?;
 

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -20,6 +20,7 @@ Key constraints (from the sc-2009 spike):
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import sys
 from pathlib import Path
 from typing import Any
@@ -83,6 +84,23 @@ def _ensure_antelopev2() -> Path:
             data = Path(path).read_bytes()
             (dest / name).write_bytes(data)
     return root
+
+
+def _require_instantid_extras() -> None:
+    """Fail fast with an actionable message when the optional InstantID extras are
+    not installed (rather than a raw ModuleNotFoundError mid-generation). insightface
+    + onnxruntime drive the face embedding/landmarks; einops is used by the vendored
+    Resampler. See requirements-instantid.txt."""
+    missing = [
+        mod for mod in ("insightface", "onnxruntime", "einops") if importlib.util.find_spec(mod) is None
+    ]
+    if missing:
+        raise RuntimeError(
+            "InstantID needs extra dependencies that are not installed in this worker "
+            f"environment: {', '.join(missing)}. Install them with "
+            "`pip install -r apps/worker/requirements-instantid.txt`. In the desktop "
+            "app, restart it to auto-provision the InstantID extras."
+        )
 
 
 def _import_instantid() -> tuple[Any, Any]:
@@ -315,6 +333,7 @@ class InstantIDAdapter:
             raise RuntimeError(f"{request.model} does not support image editing.")
         if not request.reference_asset_id:
             raise RuntimeError("InstantID generation requires a character reference image.")
+        _require_instantid_extras()
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']} (InstantID).")
         pipe = self._load_pipeline(settings, request, model_target, progress=progress, job_id=job["id"])

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -136,3 +136,13 @@ def test_dispatch_accepts_instantid_adapter_override():
     # SCENEWORKS_IMAGE_ADAPTER=instantid_sdxl must be an accepted explicit override.
     job = {"id": "j", "payload": {"model": "z_image_turbo", "adapter": "instantid_sdxl"}}
     assert isinstance(create_image_adapter(job, None), InstantIDAdapter)
+
+
+def test_missing_extras_raises_actionable_error(instantid_model, monkeypatch):
+    # When the optional extras are absent, generate() must fail with an install hint
+    # (not a raw ModuleNotFoundError mid-run). Simulate insightface being missing.
+    monkeypatch.setattr(
+        "importlib.util.find_spec", lambda name: None if name == "insightface" else object()
+    )
+    with pytest.raises(RuntimeError, match="requirements-instantid.txt"):
+        _generate(_job(instantid_model, referenceAssetId="ref-x"))


### PR DESCRIPTION
## Summary

Follow-up to #292 (merged). #292 landed the InstantID feature (worker engine + selectable model + tuning slider), but the **desktop sidecar venv was never provisioned with the InstantID extras** — so a real generation failed with `ModuleNotFoundError: No module named 'insightface'`. This PR (single commit `b6f0b33`) closes that gap so InstantID runs in the bundled desktop worker on first launch, no manual install.

- `stage-python.mjs`: bundle `requirements-instantid.txt` into `python-src` (alongside `-ltx`/`-mlx`/`-lens`).
- `setup.rs` `provision_venv`: add a `requirements_instantid_path` helper, include the body in the `.venv-marker` (so the env re-provisions when it changes), and add it to the single `uv pip install` pass. Cross-platform (face analysis uses the CPU onnxruntime provider; the SDXL pipeline runs on CUDA/MPS like the other image adapters).
- `instantid_adapter.py`: preflight `_require_instantid_extras()` in `generate()` so a missing extra fails with an actionable install message instead of a raw `ModuleNotFoundError` mid-job.

## Validation

- Extras resolve cleanly on the real worker stack (torch 2.8 / diffusers 0.39.dev): `uv pip install -r requirements-instantid.txt` added insightface 1.0.1 / onnx 1.21 / onnxruntime 1.26 with no conflicts; `insightface` + adapter + dispatch import OK on the sidecar venv.
- `cargo check`/`clippy --all-targets -D warnings`/`fmt --check` clean for `sceneworks-desktop`.
- `stage-python.mjs` confirmed to stage `requirements-instantid.txt`.
- Worker: 11 InstantID unit tests pass (incl. the new missing-extras preflight test).

## Test plan

- [ ] CI green.
- [ ] On a desktop build: first launch provisions the extras; selecting InstantID with a character reference generates without the insightface error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)