### PR TITLE
feat(web): bring Document Studio to stacking parity with Image/Video

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -68,6 +68,10 @@ function isVideoGenerationJob(job) {
   return ["video_generate", "video_extend", "video_bridge"].includes(job.type);
 }
 
+function isInterleaveJob(job) {
+  return job.type === "image_interleave";
+}
+
 function isLoraImportNotice(message) {
   return String(message ?? "").startsWith("lora import: ");
 }
@@ -389,7 +393,7 @@ export function App() {
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
   const [jobs, setJobs] = useState([]);
-  const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [] });
+  const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [], document: [] });
   const [workers, setWorkers] = useState([]);
   const [queueSummary, setQueueSummary] = useState(null);
   const [trainingTargets, setTrainingTargets] = useState({ schemaVersion: 1, targets: [] });
@@ -559,6 +563,10 @@ export function App() {
   const videoLocalJobs = useMemo(
     () => buildLocalJobStack(localGenerationJobIds.video, jobs, activeProject?.id, isVideoGenerationJob),
     [activeProject?.id, jobs, localGenerationJobIds.video],
+  );
+  const documentLocalJobs = useMemo(
+    () => buildLocalJobStack(localGenerationJobIds.document, jobs, activeProject?.id, isInterleaveJob),
+    [activeProject?.id, jobs, localGenerationJobIds.document],
   );
   const queueCounts = useMemo(() => {
     if (queueSummary?.counts) {
@@ -1064,6 +1072,9 @@ export function App() {
     if (active === "Video" && localIds.video.includes(job.id)) {
       return true;
     }
+    if (active === "Document" && localIds.document.includes(job.id)) {
+      return true;
+    }
     return active === "Models" && job.type === "model_download";
   }
 
@@ -1296,6 +1307,7 @@ export function App() {
     latestVideoAssets,
     videoLocalJobs,
     imageLocalJobs,
+    documentLocalJobs,
     studioLaunch,
     rememberLocalGenerationJob,
     // Person tracks (Video Studio + Replace Person)

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -6906,6 +6906,8 @@ describe("SceneWorks app shell", () => {
     const createInterleaveJob = vi.fn(() =>
       Promise.resolve({ id: "job-il-new", type: "image_interleave", status: "queued" }),
     );
+    const setActiveView = vi.fn();
+    const rememberLocalGenerationJob = vi.fn();
     const imageAsset = {
       id: "img-1",
       type: "image",
@@ -6934,14 +6936,15 @@ describe("SceneWorks app shell", () => {
             activeProject: { id: "project-1", name: "Noir" },
             assets: [imageAsset],
             createInterleaveJob,
+            documentLocalJobs: [completedJob],
             gpuOptions: ["auto"],
             imageModels: [
               { id: "sensenova_u1_8b", name: "SenseNova-U1 8B", type: "image", capabilities: ["text_to_image", "interleave"] },
               { id: "z_image_turbo", name: "Z-Image Turbo", type: "image", capabilities: ["text_to_image"] },
             ],
-            jobs: [completedJob],
             jobAction: () => {},
-            setActiveView: () => {},
+            rememberLocalGenerationJob,
+            setActiveView,
             requestedGpu: "auto",
             setRequestedGpu: () => {},
           },
@@ -6985,6 +6988,69 @@ describe("SceneWorks app shell", () => {
     expect(payload.height).toBe(1152);
     // Unedited system prompt is not sent (worker uses its own default).
     expect(payload.advanced?.systemMessage).toBeUndefined();
+
+    // Submitting stacks the run in the studio rather than routing to the Queue.
+    await settle();
+    expect(rememberLocalGenerationJob).toHaveBeenCalledWith(
+      "document",
+      expect.objectContaining({ id: "job-il-new" }),
+    );
+    expect(setActiveView).not.toHaveBeenCalledWith("Queue");
+  });
+
+  it("DocumentStudio stacks a queued compose run beneath the active document", async () => {
+    const completedJob = {
+      id: "doc-job-done",
+      type: "image_interleave",
+      status: "completed",
+      createdAt: "2026-05-27T10:00:00Z",
+      payload: { prompt: "tea guide" },
+      result: {
+        segments: [
+          { type: "text", text: "Boil the water." },
+          { type: "text", text: "Steep three minutes." },
+        ],
+      },
+    };
+    const queuedJob = {
+      id: "doc-job-queued",
+      type: "image_interleave",
+      status: "queued",
+      createdAt: "2026-05-27T10:01:00Z",
+      payload: { prompt: "coffee guide" },
+      result: {},
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            createInterleaveJob: () => {},
+            documentLocalJobs: [completedJob, queuedJob],
+            gpuOptions: ["auto"],
+            imageModels: [
+              { id: "sensenova_u1_8b", name: "SenseNova-U1 8B", type: "image", capabilities: ["text_to_image", "interleave"] },
+            ],
+            jobAction: () => {},
+            rememberLocalGenerationJob: () => {},
+            setActiveView: () => {},
+            requestedGpu: "auto",
+            setRequestedGpu: () => {},
+          },
+          <DocumentStudio />,
+        ),
+      );
+    });
+    await settle();
+
+    // Both runs stack: the finished document plus the queued run's progress card.
+    expect(container.querySelectorAll(".local-job-group").length).toBe(2);
+    expect(container.textContent).toContain("Boil the water.");
+    expect(container.querySelector(".document-view")).not.toBeNull();
+    expect(container.querySelector(".local-job-card.queued")).not.toBeNull();
+    expect(container.textContent).not.toContain("Your generated document will appear here.");
   });
 
   it("AssetDetail reopens a saved document from the Library", async () => {

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -8,6 +8,7 @@ import {
   INTERLEAVE_RESOLUTION_OPTIONS,
 } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
+import { selectStackedJobs } from "./generationStudio.jsx";
 
 const MAX_IMAGES_DEFAULT = 6;
 const MAX_IMAGES_LIMIT = 10;
@@ -21,12 +22,9 @@ function formatResolutionLabel(value) {
   return height ? `${width} × ${height}` : value;
 }
 
-function DocumentResult({ job, assets, projectId, onCancel, onOpenQueue }) {
+function documentSegments(job) {
   const segments = job.result?.segments;
-  if (job.status !== "completed" || !Array.isArray(segments) || !segments.length) {
-    return <JobProgressCard job={job} label="Interleaved document" onCancel={onCancel} onOpenQueue={onOpenQueue} />;
-  }
-  return <DocumentView assets={assets} projectId={projectId} segments={segments} />;
+  return Array.isArray(segments) && segments.length ? segments : null;
 }
 
 export function DocumentStudio() {
@@ -34,10 +32,11 @@ export function DocumentStudio() {
     activeProject,
     assets,
     createInterleaveJob,
+    documentLocalJobs = [],
     gpuOptions,
     imageModels,
-    jobs,
     jobAction,
+    rememberLocalGenerationJob,
     setActiveView,
     requestedGpu,
     setRequestedGpu,
@@ -67,9 +66,9 @@ export function DocumentStudio() {
     [assets],
   );
 
-  const latestJob = useMemo(() => {
-    return (jobs ?? []).find((job) => job.type === "image_interleave") ?? null;
-  }, [jobs]);
+  // Running and queued compose runs stack (oldest/active on top, queued below) and
+  // each run streams its output beneath it, mirroring the Image and Video studios.
+  const localJobs = useMemo(() => selectStackedJobs(documentLocalJobs), [documentLocalJobs]);
 
   const ready = Boolean(activeProject) && interleaveModels.length > 0;
   const canSubmit = ready && prompt.trim().length > 0 && !submitting;
@@ -98,7 +97,9 @@ export function DocumentStudio() {
     });
     setSubmitting(false);
     if (job) {
-      onOpenQueue?.();
+      // Stack the run in the studio instead of routing to the Queue, so its output
+      // streams in below the prompt as it composes.
+      rememberLocalGenerationJob?.("document", job);
     }
   }
 
@@ -201,14 +202,21 @@ export function DocumentStudio() {
       </form>
 
       <section className="studio-results">
-        {latestJob ? (
-          <DocumentResult
-            assets={assets ?? []}
-            job={latestJob}
-            onCancel={onCancelJob}
-            onOpenQueue={onOpenQueue}
-            projectId={activeProject?.id}
-          />
+        {localJobs.length ? (
+          <div className="local-job-stack">
+            {localJobs.map((job) => {
+              const segments = job.status === "completed" ? documentSegments(job) : null;
+              return (
+                <article className="local-job-group" key={job.id}>
+                  {segments ? (
+                    <DocumentView assets={assets ?? []} projectId={activeProject?.id} segments={segments} />
+                  ) : (
+                    <JobProgressCard job={job} label="Interleaved document" onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+                  )}
+                </article>
+              );
+            })}
+          </div>
         ) : (
           <p className="empty-panel">Your generated document will appear here.</p>
         )}

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -19,6 +19,60 @@ export function onPromptKeyDown(event) {
   }
 }
 
+function jobCreatedMs(job) {
+  const parsed = Date.parse(job?.createdAt ?? "");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+// Pick the runs that belong in a studio's live stack from the tracked set, shared
+// by every studio so stacking behaves identically. Runs are kept in the order they
+// arrive (callers order oldest-first, so the active run sits on top and queued runs
+// follow). Rules:
+//   - canceled runs drop immediately (no output to show),
+//   - running and queued runs always stack,
+//   - a finished run slides out the moment a strictly-newer run starts (leaves the
+//     queue), so the next run takes its place,
+//   - a finished run with a run still queued behind it stays on top until that run
+//     starts.
+// `resultRendered(job)` reports whether a lone completed run's output has surfaced
+// elsewhere (e.g. the Image studio's latest-batch grid); when it has, the run
+// collapses out of the stack. Omit it for studios whose output ships in the job
+// result itself (documents), where a lone completed run simply stays as the output.
+export function selectStackedJobs(trackedLocalJobs, resultRendered) {
+  const successorStarted = (job) =>
+    trackedLocalJobs.some(
+      (other) =>
+        other.id !== job.id &&
+        other.status !== "queued" &&
+        other.status !== "canceled" &&
+        jobCreatedMs(other) > jobCreatedMs(job),
+    );
+  const hasPendingSuccessor = (job) =>
+    trackedLocalJobs.some(
+      (other) => other.id !== job.id && other.status !== "canceled" && jobCreatedMs(other) > jobCreatedMs(job),
+    );
+  return trackedLocalJobs.filter((job) => {
+    if (job.status === "canceled") {
+      return false;
+    }
+    if (!terminalStatuses.has(job.status)) {
+      return true;
+    }
+    if (successorStarted(job)) {
+      return false;
+    }
+    if (job.status === "completed") {
+      if (hasPendingSuccessor(job)) {
+        return true;
+      }
+      return resultRendered ? !resultRendered(job) : true;
+    }
+    // Failed/interrupted runs with nothing started behind them stay visible so the
+    // outcome is clear until the user moves on.
+    return true;
+  });
+}
+
 // Shared state/derivations for the Image and Video studios: preset selection and
 // validation, the catalog-driven model/character resets, and the completed-job
 // "keep the progress card until the asset renders" machinery. The studios keep
@@ -95,30 +149,6 @@ export function useGenerationStudio({
     return assetIds.length > 0 && assetIds.every((id) => assets.some((asset) => asset.id === id));
   }
 
-  function jobCreatedMs(job) {
-    const parsed = Date.parse(job?.createdAt ?? "");
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-
-  // A finished run is replaced once a strictly-newer run leaves the queue (i.e.
-  // a worker picked it up). Canceled runs never "start", so they don't bump the
-  // run above them off the stack.
-  function successorStarted(job) {
-    return trackedLocalJobs.some(
-      (other) =>
-        other.id !== job.id &&
-        other.status !== "queued" &&
-        other.status !== "canceled" &&
-        jobCreatedMs(other) > jobCreatedMs(job),
-    );
-  }
-
-  function hasPendingSuccessor(job) {
-    return trackedLocalJobs.some(
-      (other) => other.id !== job.id && other.status !== "canceled" && jobCreatedMs(other) > jobCreatedMs(job),
-    );
-  }
-
   function completedAnchorMs(job) {
     return Date.parse(job.completedAt ?? job.updatedAt ?? "");
   }
@@ -150,39 +180,11 @@ export function useGenerationStudio({
     return () => window.clearTimeout(timer);
   }, [assets, latestAssets, trackedLocalJobs, resultFallbackTick]);
 
-  // The visible stack: every running and queued run, plus the most recent finished
-  // run, ordered (by trackedLocalJobs) oldest-first so the active run sits on top
-  // and queued runs follow. A finished run holds its place — showing its rendered
-  // batch above the pending queue — until the next run actually starts, at which
-  // point that run slides up to replace it. Canceled runs drop immediately.
+  // The visible stack (see selectStackedJobs). A lone completed run collapses once
+  // its batch renders in the latest-batch grid or the SSE-lag window expires, so a
+  // stale progress card never lingers.
   const localJobs = useMemo(
-    () =>
-      trackedLocalJobs.filter((job) => {
-        if (job.status === "canceled") {
-          return false;
-        }
-        // Running and queued runs always stack.
-        if (!terminalStatuses.has(job.status)) {
-          return true;
-        }
-        // A finished run slides out the moment its successor starts.
-        if (successorStarted(job)) {
-          return false;
-        }
-        if (job.status === "completed") {
-          // With a run still queued behind it, keep the completed run (and its
-          // rendered batch) on top until that run starts. Standing alone, collapse
-          // to the plain latest-batch grid once its assets render (or the wait
-          // window expires) so a stale progress card never lingers.
-          if (hasPendingSuccessor(job)) {
-            return true;
-          }
-          return !resultVisible(job) && !completedWaitExpired(job);
-        }
-        // Failed/interrupted runs with nothing started behind them stay visible so
-        // the outcome is clear until the user moves on.
-        return true;
-      }),
+    () => selectStackedJobs(trackedLocalJobs, (job) => resultVisible(job) || completedWaitExpired(job)),
     [assets, latestAssets, trackedLocalJobs, resultFallbackTick],
   );
 


### PR DESCRIPTION
Document Studio no longer routes to the Queue on submit. Compose runs now stack in the studio the same way Image/Video runs do — the active/oldest run on top, queued runs below — and each run streams its document output beneath its card as it finishes.

- generationStudio.jsx: extract the stack-retention filter into an exported pure selectStackedJobs(trackedLocalJobs, resultRendered?) so every studio shares one rule. The optional resultRendered predicate collapses a lone completed run once its output has surfaced elsewhere (Image/Video latest-batch grid); omitted for studios whose output ships in the job result (documents), where a lone completed run stays as the output. useGenerationStudio now delegates to it (no behavior change for Image/Video).
- App.jsx: track a "document" local-job kind (documentLocalJobs via the shared buildLocalJobStack + isInterleaveJob), expose it, and suppress the redundant global failure toast when a document run's failure is already shown in-studio.
- DocumentStudio.jsx: remember the submitted run instead of navigating to the Queue; render documentLocalJobs as a stack (progress card while pending, DocumentView once complete).

Tests: 149 passing (added doc-stacking test; updated the existing doc test to the new context shape and to assert submit stacks rather than navigates). Vite build clean.