### PR TITLE
InstantID View-angle picker: multi-angle character generation [sc-2048]

### DIFF
--- a/apps/web/public/prompt-guides/instantid-realvisxl.md
+++ b/apps/web/public/prompt-guides/instantid-realvisxl.md
@@ -14,6 +14,10 @@ This is a **reference-driven** model: it only runs in the "With character" flow 
 - **The prompt drives the scene:** setting, action, pose, framing, wardrobe, lighting, and style.
 - **Reference strength** (the slider) controls how hard identity is pinned. Higher = closer likeness but stiffer; lower = more natural and prompt-flexible.
 
+## View Angle
+
+The head angle does **not** come from the prompt — describing "profile" or "looking left" won't rotate the face, because identity pins it toward the reference's angle. Instead use the **View angle** dropdown: front, three-quarter left/right, left/right profile, looking up, looking down, and the four diagonals. Each renders the *same* character at that angle with identity preserved (validated ~0.81–0.89 likeness across all of them). View-angle renders square. Leave it on **Match reference** to keep the reference's own angle. Generating one character across several angles is also how you build a consistent set for training a character LoRA.
+
 ## Choose A Good Reference
 
 Identity quality is set by the reference more than the prompt:

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -192,6 +192,20 @@ export const fallbackModels = [
       // InstantID; identityStructure adds the controlnetConditioningScale slider.
       referenceStrengthDefault: 0.8,
       identityStructure: { label: "Identity structure", default: 0.8, min: 0.3, max: 1.0, step: 0.05 },
+      // Canonical head angles (advanced.viewAngle; built-in landmark pack drives pose).
+      viewAngles: [
+        { id: "three_quarter_left", label: "Three-quarter left" },
+        { id: "three_quarter_right", label: "Three-quarter right" },
+        { id: "left_profile", label: "Left profile" },
+        { id: "right_profile", label: "Right profile" },
+        { id: "up", label: "Looking up" },
+        { id: "down", label: "Looking down" },
+        { id: "up_left", label: "Up · left" },
+        { id: "up_right", label: "Up · right" },
+        { id: "down_left", label: "Down · left" },
+        { id: "down_right", label: "Down · right" },
+        { id: "front", label: "Front" },
+      ],
     },
   },
   {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5194,6 +5194,89 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("offers the InstantID View angle picker and submits the chosen angle", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            {
+              id: "char-1",
+              name: "Mira",
+              type: "person",
+              looks: [],
+              approvedReferences: [
+                {
+                  assetId: "ref-1",
+                  approved: true,
+                  asset: {
+                    id: "ref-1",
+                    type: "image",
+                    displayName: "Mira ref",
+                    projectId: "project-1",
+                    file: { path: "assets/images/ref_0001.png", mimeType: "image/png" },
+                  },
+                },
+              ],
+            },
+          ],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "instantid_realvisxl",
+              name: "InstantID (RealVisXL)",
+              type: "image",
+              family: "sdxl",
+              capabilities: ["character_image"],
+              ui: {
+                referenceStrengthDefault: 0.8,
+                identityStructure: { label: "Identity structure", default: 0.8, min: 0.3, max: 1.0, step: 0.05 },
+                viewAngles: [
+                  { id: "three_quarter_left", label: "Three-quarter left" },
+                  { id: "left_profile", label: "Left profile" },
+                ],
+              },
+            },
+          ],
+          latestAssets: [],
+          launchRequest: { id: "launch-va", view: "Image", characterId: "char-1", referenceAssetId: "ref-1", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    // The dropdown lists "Match reference" plus the model's declared angles.
+    const angleOptions = [...field(container, "View angle").options].map((option) => option.textContent);
+    expect(angleOptions).toContain("Match reference");
+    expect(angleOptions).toContain("Left profile");
+
+    await changeField(field(container, "View angle"), "left_profile");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    // The chosen angle rides advanced.viewAngle for the worker's landmark pack.
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        referenceAssetId: "ref-1",
+        advanced: expect.objectContaining({ viewAngle: "left_profile", ipAdapterScale: 0.8 }),
+      }),
+    );
+  });
+
   it("limits the character image model picker to reference-capable models", async () => {
     root = createRoot(container);
     await act(async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -210,6 +210,8 @@ export function ImageStudio() {
   const [referenceAssetId, setReferenceAssetId] = useState("");
   const [ipAdapterScale, setIpAdapterScale] = useState(0.6);
   const [controlnetScale, setControlnetScale] = useState(0.8);
+  // InstantID canonical head angle ("" = match the reference's own angle). Rides advanced.viewAngle.
+  const [viewAngle, setViewAngle] = useState("");
   const [upscaleEnabled, setUpscaleEnabled] = useState(false);
   const [upscaleFactor, setUpscaleFactor] = useState(2);
   const [upscaleEngine, setUpscaleEngine] = useState("real-esrgan");
@@ -298,12 +300,16 @@ export function ImageStudio() {
   // (controlnetConditioningScale); models without these keys (e.g. Kolors) keep the
   // single reference-strength slider at the global default.
   const identityStructure = selectedModel?.ui?.identityStructure;
-  // Reset the reference sliders to the selected model's declared defaults whenever the
-  // model changes, so InstantID starts at its tuned 0.8/0.8 and Kolors at 0.6.
+  // Canonical head angles the model can render from a frontal reference (InstantID).
+  const viewAngles = Array.isArray(selectedModel?.ui?.viewAngles) ? selectedModel.ui.viewAngles : null;
+  // Reset the reference tuning to the selected model's declared defaults whenever the
+  // model changes, so InstantID starts at its tuned 0.8/0.8 and Kolors at 0.6, and the
+  // view angle never carries over to a model that doesn't support it.
   useEffect(() => {
     const ui = imageModels.find((item) => item.id === model)?.ui ?? {};
     setIpAdapterScale(typeof ui.referenceStrengthDefault === "number" ? ui.referenceStrengthDefault : 0.6);
     setControlnetScale(typeof ui.identityStructure?.default === "number" ? ui.identityStructure.default : 0.8);
+    setViewAngle("");
   }, [model]);
   // Approved reference images for the selected character (the IP-Adapter identity
   // source). Resolve the full asset from the catalog so thumbnails render even when
@@ -549,6 +555,11 @@ export function ImageStudio() {
           ...(mode === "character_image" && referenceAssetId && identityStructure
             ? { controlnetConditioningScale: controlnetScale }
             : {}),
+          // View angle (InstantID) — only when a specific angle is chosen; "" means
+          // match the reference's own angle (omit so the worker uses default behavior).
+          ...(mode === "character_image" && referenceAssetId && viewAngles && viewAngle
+            ? { viewAngle }
+            : {}),
         },
       });
       onLocalJobCreated?.(job);
@@ -710,11 +721,24 @@ export function ImageStudio() {
                           <span>{controlnetScale.toFixed(2)}</span>
                         </label>
                       ) : null}
+                      {viewAngles ? (
+                        <label className="reference-strength">
+                          View angle
+                          <select onChange={(event) => setViewAngle(event.target.value)} value={viewAngle}>
+                            <option value="">Match reference</option>
+                            {viewAngles.map((angle) => (
+                              <option key={angle.id} value={angle.id}>
+                                {angle.label}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      ) : null}
                       <div className="guidance-strip">
                         <strong>Identity from reference</strong>
                         <span>
                           {identityStructure
-                            ? "InstantID holds this person's face from the reference while the prompt drives the scene. Identity strength tunes likeness; Identity structure locks face geometry and pose (lower = more pose freedom). Raise Variations and leave the seed blank to explore takes."
+                            ? "InstantID holds this person's face from the reference while the prompt drives the scene. Identity strength tunes likeness; Identity structure locks face geometry. Set a View angle to rotate the head (profiles, up/down, diagonals) with identity preserved. Raise Variations and leave the seed blank to explore takes."
                             : "This reference's identity is carried across every variation. Raise Variations and leave the seed blank to explore different takes."}
                         </span>
                       </div>

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -124,6 +124,37 @@ def _letterbox(image: Image.Image, width: int, height: int) -> Image.Image:
     return canvas
 
 
+# Canonical view-angle landmark sets (insightface 5-point kps, order
+# [left_eye, right_eye, nose, mouth_left, mouth_right]), normalized to a SQUARE
+# canvas. sc-2009: extracted from a 9-cell turnaround sheet + full L/R profiles,
+# each validated to hold InstantID identity (cosine 0.81-0.89) at the target angle.
+# The pack supplies the IdentityNet *pose* while the character reference supplies
+# *identity*, so one constant rotates any character to any of these views. View-angle
+# generation outputs square (the kps must share the output aspect — the sc-2009
+# kps-distortion rule), and the reference image is still used for the face embedding.
+VIEW_ANGLE_KPS: dict[str, list[tuple[float, float]]] = {
+    "front": [(0.4460, 0.5227), (0.5755, 0.5166), (0.5106, 0.5947), (0.4653, 0.6660), (0.5630, 0.6613)],
+    "three_quarter_left": [(0.3679, 0.5325), (0.4514, 0.5354), (0.3553, 0.6007), (0.3724, 0.6718), (0.4349, 0.6733)],
+    "three_quarter_right": [(0.5946, 0.4930), (0.6882, 0.4955), (0.6948, 0.5598), (0.6202, 0.6408), (0.6885, 0.6421)],
+    "left_profile": [(0.4373, 0.3527), (0.4925, 0.3445), (0.3927, 0.4662), (0.4853, 0.5599), (0.5240, 0.5517)],
+    "right_profile": [(0.5075, 0.3445), (0.5627, 0.3527), (0.6073, 0.4662), (0.4760, 0.5517), (0.5147, 0.5599)],
+    "up": [(0.4535, 0.4371), (0.5765, 0.4332), (0.5077, 0.4918), (0.4647, 0.5704), (0.5646, 0.5667)],
+    "down": [(0.4457, 0.6231), (0.5848, 0.6228), (0.5174, 0.7337), (0.4726, 0.7771), (0.5645, 0.7770)],
+    "up_left": [(0.3757, 0.4584), (0.4504, 0.4681), (0.3490, 0.4918), (0.3430, 0.5857), (0.3936, 0.5924)],
+    "up_right": [(0.5787, 0.4431), (0.6673, 0.4337), (0.6799, 0.4601), (0.6331, 0.5601), (0.6989, 0.5515)],
+    "down_left": [(0.3344, 0.6464), (0.4363, 0.6282), (0.3749, 0.7418), (0.4090, 0.7905), (0.4662, 0.7762)],
+    "down_right": [(0.5963, 0.6165), (0.6823, 0.6271), (0.6650, 0.7171), (0.5668, 0.7524), (0.6198, 0.7640)],
+}
+
+
+def _view_angle_kps(angle: str, side: int) -> np.ndarray | None:
+    """Scaled (side x side) landmark array for a named view angle, or None if unknown."""
+    points = VIEW_ANGLE_KPS.get(angle)
+    if not points:
+        return None
+    return np.array(points, dtype=np.float32) * float(side)
+
+
 class InstantIDAdapter:
     """Identity-preserving SDXL generation via InstantID (face embedding + IdentityNet)."""
 
@@ -272,6 +303,15 @@ class InstantIDAdapter:
         except (TypeError, ValueError):
             return float(default)
 
+    @staticmethod
+    def _view_angle(request: ImageRequest) -> str | None:
+        """The requested canonical view angle (advanced.viewAngle), or None to take the
+        pose from the reference image's own landmarks (default behavior)."""
+        angle = request.advanced.get("viewAngle")
+        if isinstance(angle, str) and angle in VIEW_ANGLE_KPS:
+            return angle
+        return None
+
     def _run_pipeline(
         self,
         settings: WorkerSettings,
@@ -288,10 +328,22 @@ class InstantIDAdapter:
         model_target = MODEL_TARGETS[request.model]
 
         reference = load_reference_image(project_path, request.reference_asset_id)
-        canvas = _letterbox(reference, request.width, request.height)
-        face = self._largest_face(canvas)
+        view_angle = self._view_angle(request)
+        if view_angle is not None:
+            # View-angle mode: pose from the canonical landmark pack, identity from the
+            # reference embedding. Square canvas so the pack kps share the output aspect
+            # (kps-distortion rule); the requested dims only set the square side.
+            side = max(256, min(request.width, request.height))
+            side -= side % 8
+            face = self._largest_face(_letterbox(reference, side, side))
+            face_kps = draw_kps(Image.new("RGB", (side, side), (0, 0, 0)), _view_angle_kps(view_angle, side))
+            width = height = side
+        else:
+            canvas = _letterbox(reference, request.width, request.height)
+            face = self._largest_face(canvas)
+            face_kps = draw_kps(canvas, face["kps"])
+            width, height = request.width, request.height
         face_emb = face["embedding"]
-        face_kps = draw_kps(canvas, face["kps"])
 
         pipe.set_ip_adapter_scale(self._ip_adapter_scale(request))
         generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
@@ -302,8 +354,8 @@ class InstantIDAdapter:
             "image": face_kps,
             "controlnet_conditioning_scale": self._controlnet_scale(request),
             "ip_adapter_scale": self._ip_adapter_scale(request),
-            "width": request.width,
-            "height": request.height,
+            "width": width,
+            "height": height,
             "num_inference_steps": self._num_inference_steps(request, model_target),
             "guidance_scale": self._guidance_scale(request, model_target),
             "generator": generator,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -834,6 +834,23 @@
           "max": 1.0,
           "step": 0.05
         },
+        // Canonical head angles the adapter can render from a frontal reference
+        // (sc-2009: the IdentityNet landmarks come from a built-in pack; identity
+        // from the character reference). Selecting one rides advanced.viewAngle and
+        // forces square output. "" / absent = match the reference's own angle.
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
         "promptGuide": {
           "title": "InstantID (RealVisXL) Prompt Guide",
           "path": "/prompt-guides/instantid-realvisxl.md",

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -12,7 +12,12 @@ import pytest
 from PIL import Image
 
 from scene_worker.image_adapters import MODEL_TARGETS, create_image_adapter, image_request_from_job
-from scene_worker.instantid_adapter import InstantIDAdapter, _letterbox
+from scene_worker.instantid_adapter import (
+    VIEW_ANGLE_KPS,
+    InstantIDAdapter,
+    _letterbox,
+    _view_angle_kps,
+)
 
 _TEST_TARGET = {
     "label": "Test InstantID",
@@ -146,3 +151,24 @@ def test_missing_extras_raises_actionable_error(instantid_model, monkeypatch):
     )
     with pytest.raises(RuntimeError, match="requirements-instantid.txt"):
         _generate(_job(instantid_model, referenceAssetId="ref-x"))
+
+
+def test_view_angle_pack_is_well_formed():
+    # The canonical pack covers the 11 shipped angles, all normalized to [0,1].
+    expected = {
+        "front", "three_quarter_left", "three_quarter_right", "left_profile", "right_profile",
+        "up", "down", "up_left", "up_right", "down_left", "down_right",
+    }
+    assert expected <= set(VIEW_ANGLE_KPS)
+    for pts in VIEW_ANGLE_KPS.values():
+        assert len(pts) == 5
+        assert all(0.0 <= x <= 1.0 and 0.0 <= y <= 1.0 for x, y in pts)
+    scaled = _view_angle_kps("front", 1024)
+    assert scaled.shape == (5, 2) and float(scaled.max()) <= 1024.0
+    assert _view_angle_kps("nonexistent", 1024) is None
+
+
+def test_view_angle_resolves_only_known_angles():
+    assert InstantIDAdapter._view_angle(SimpleNamespace(advanced={"viewAngle": "left_profile"})) == "left_profile"
+    assert InstantIDAdapter._view_angle(SimpleNamespace(advanced={"viewAngle": "bogus"})) is None
+    assert InstantIDAdapter._view_angle(SimpleNamespace(advanced={})) is None


### PR DESCRIPTION
## Summary

Generate a character at a chosen **head angle** (profiles, up/down, diagonals) with identity preserved — building on the shipped InstantID model (epic 2003). Single commit on top of main (the prior InstantID work + provisioning fix already merged via #292/#293).

**The insight (spike-validated on MPS):** the head angle is set by the IdentityNet **landmark source**, not the prompt or the scales. Feeding InstantID *off-angle* landmarks while keeping the character's identity embedding renders them at that angle, identity intact. Earlier attempts failed for the opposite reasons — prompting did nothing, releasing the landmark lock got a profile but lost identity (cosine 0.87→0.15), FaceID+Canny sheets lost identity at small face sizes.

## What's in it

- **Worker** (`instantid_adapter.py`): `VIEW_ANGLE_KPS` pack — 11 normalized 5-point landmark sets (front, ¾ L/R, L/R profile, up, down, 4 diagonals) — + `_view_angle()` resolver. `_run_pipeline` branches on `advanced.viewAngle`: pose from the pack on a **square canvas** (kps-aspect rule), identity embedding still from the character reference. Default behavior unchanged when no angle is set. Right profile = horizontal mirror of left.
- **Manifest + web constants**: `ui.viewAngles` on the InstantID model.
- **Web ImageStudio**: "View angle" dropdown in character mode (default "Match reference"); rides `advanced.viewAngle`. **No Rust changes** (advanced is passthrough).
- **Prompt guide**: View Angle section.

The pack is pure coordinate data — no photos, no extra model downloads — so one constant rotates *any* character. This is also the multi-angle dataset engine for the created-character bootstrap (sc-2033).

## Validation (MPS, identity = ArcFace cosine vs reference)

Full 9-angle turnaround held **0.81–0.89** across up/down/diagonals; profiles via the shipped normalized pack: left −69° / **0.846**, right (mirror) +72° / **0.814**; up **0.888**, down **0.824**.

## Test plan

- [x] Worker: pack/resolver unit tests (13 InstantID, **318 worker** total green).
- [x] Web: View-angle picker test (**141 web** green); Vite build clean.
- [x] `scripts/check-scaffold.mjs` passes; manifest `viewAngles` parses (11 entries).
- [x] Per-angle identity validated on MPS via the shipped pack format.
- [ ] CI green.
- [ ] Real desktop E2E: pick an angle in the app, generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)