### PR TITLE
Character Studio one-click angle set (InstantID turnaround) [sc-2050]

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2092,6 +2092,82 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Beta");
   });
 
+  it("fires a one-click angle-set batch job from the Character Studio panel", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-angle" }));
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      archiveCharacter: () => {},
+      assets: [],
+      attachCharacterLora: () => {},
+      characters: [
+        {
+          id: "char-1",
+          name: "Mira",
+          type: "person",
+          references: [],
+          approvedReferences: [{ assetId: "ref-1", role: "hero", asset: { id: "ref-1", type: "image", displayName: "Mira ref" } }],
+          looks: [],
+          loras: [],
+        },
+      ],
+      createCharacter: () => {},
+      createCharacterLook: () => {},
+      createCharacterTestJob: () => {},
+      createImageJob,
+      importAsset: vi.fn(),
+      deleteAsset: () => {},
+      deleteCharacterLook: () => {},
+      detachCharacterLora: () => {},
+      imageModels: [
+        {
+          id: "instantid_realvisxl",
+          name: "InstantID (RealVisXL)",
+          type: "image",
+          ui: { viewAngles: [{ id: "front", label: "Front" }, { id: "left_profile", label: "Left profile" }, { id: "up", label: "Looking up" }] },
+        },
+      ],
+      latestImageAssets: [],
+      loras: [],
+      setPreviewAsset: () => {},
+      sendCharacterToImage: () => {},
+      sendCharacterToVideo: () => {},
+      purgeAsset: () => {},
+      removeCharacterReference: () => {},
+      updateAssetStatus: () => {},
+      updateCharacter: () => {},
+      updateCharacterLook: () => {},
+      updateCharacterLora: () => {},
+      updateCharacterReference: () => {},
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+
+    // The angle-set panel renders with the model's angle count in the button.
+    const generateButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.startsWith("Generate angle set"),
+    );
+    expect(generateButton).toBeTruthy();
+    expect(generateButton.textContent).toContain("3 views");
+
+    await act(async () => {
+      generateButton.click();
+    });
+
+    // One batch job: character_image to the InstantID model with advanced.angleSet.
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        model: "instantid_realvisxl",
+        characterId: "char-1",
+        referenceAssetId: "ref-1",
+        advanced: expect.objectContaining({ angleSet: true, ipAdapterScale: 0.8 }),
+      }),
+    );
+  });
+
   it("launches reference-based generation from an approved character reference", async () => {
     const sendCharacterToImage = vi.fn();
     const reference = { assetId: "ref-1", approved: true, asset: { id: "ref-1", type: "image", displayName: "Mira ref" } };

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import {
+  CharacterAngleSet,
   CharacterLoras,
   CharacterLooks,
   CharacterReferences,
@@ -37,6 +38,8 @@ export function CharacterStudio() {
     updateCharacterLora,
     detachCharacterLora,
     createCharacterTestJob,
+    createImageJob,
+    importAsset,
     deleteAsset,
     purgeAsset,
     imageModels,
@@ -72,6 +75,11 @@ export function CharacterStudio() {
   );
   const selectedCharacter = characters.find((item) => item.id === selectedCharacterId) ?? characters[0] ?? null;
   const approvedReferences = selectedCharacter?.approvedReferences ?? [];
+  // The InstantID-style model that can render a one-click angle set (declares view angles).
+  const angleModel = useMemo(
+    () => imageModels.find((item) => Array.isArray(item.ui?.viewAngles) && item.ui.viewAngles.length > 0) ?? null,
+    [imageModels],
+  );
 
   useEffect(() => {
     if (!selectedCharacter && characters[0]?.id) {
@@ -384,6 +392,15 @@ export function CharacterStudio() {
               testPrompt={testPrompt}
               testResolution={testResolution}
               updateAssetStatus={updateAssetStatus}
+            />
+
+            <CharacterAngleSet
+              addCharacterReference={addCharacterReference}
+              angleModel={angleModel}
+              approvedReferences={approvedReferences}
+              createImageJob={createImageJob}
+              importAsset={importAsset}
+              selectedCharacter={selectedCharacter}
             />
           </section>
         </div>

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -356,3 +356,122 @@ export function CharacterTest({
     </section>
   );
 }
+
+// One-click multi-angle "turnaround": one reference -> all of the InstantID model's
+// view angles in a single batch job (advanced.angleSet). Only rendered when an
+// InstantID-style model (one that declares ui.viewAngles) is available.
+export function CharacterAngleSet({
+  selectedCharacter,
+  angleModel,
+  approvedReferences,
+  createImageJob,
+  importAsset,
+  addCharacterReference,
+}) {
+  const angleCount = angleModel?.ui?.viewAngles?.length ?? 0;
+  const [referenceAssetId, setReferenceAssetId] = React.useState("");
+  const [prompt, setPrompt] = React.useState("");
+  const [submitting, setSubmitting] = React.useState(false);
+  const [status, setStatus] = React.useState("");
+  const fileInputRef = React.useRef(null);
+  const characterId = selectedCharacter?.id;
+
+  React.useEffect(() => {
+    setReferenceAssetId(approvedReferences[0]?.assetId ?? "");
+  }, [characterId, approvedReferences]);
+  React.useEffect(() => {
+    setPrompt(`${selectedCharacter?.name || "the character"}, neutral expression, plain background, photorealistic`);
+    setStatus("");
+  }, [characterId, selectedCharacter?.name]);
+
+  if (!angleModel || !selectedCharacter) {
+    return null;
+  }
+
+  async function onUpload(event) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+    setStatus("Uploading reference…");
+    const asset = await importAsset(file, { throwOnError: false });
+    if (asset?.id) {
+      setReferenceAssetId(asset.id);
+      await addCharacterReference(characterId, { assetId: asset.id, approved: true, role: "angle-set-reference" });
+      setStatus("");
+    } else {
+      setStatus("Upload failed — try another image.");
+    }
+  }
+
+  async function generate() {
+    if (!referenceAssetId || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    setStatus("");
+    try {
+      const job = await createImageJob({
+        mode: "character_image",
+        model: angleModel.id,
+        characterId,
+        referenceAssetId,
+        prompt: prompt.trim(),
+        negativePrompt: "plastic skin, airbrushed, cgi, 3d render, cartoon, anime, waxy, overprocessed, deformed, multiple people",
+        count: angleCount,
+        width: 1024,
+        height: 1024,
+        advanced: { angleSet: true, ipAdapterScale: 0.8 },
+      });
+      setStatus(job ? `Generating ${angleCount} angles — they'll appear in your latest images shortly.` : "");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="character-section">
+      <div className="section-heading">
+        <p className="eyebrow">Angle set</p>
+        <h2>{angleModel.name} turnaround</h2>
+      </div>
+      <p>
+        Generate {angleCount} consistent views of this character (front, three-quarters, profiles, up/down and the
+        diagonals) from one reference, in a single job. A good starting set for curating a character LoRA.
+      </p>
+      {approvedReferences.length ? (
+        <div className="reference-thumb-row">
+          {approvedReferences.map((reference) => (
+            <button
+              aria-label={`Use ${reference.asset?.displayName ?? reference.assetId} as the angle-set reference`}
+              aria-pressed={reference.assetId === referenceAssetId}
+              className={reference.assetId === referenceAssetId ? "reference-thumb active" : "reference-thumb"}
+              key={reference.assetId}
+              onClick={() => setReferenceAssetId(reference.assetId)}
+              type="button"
+            >
+              {reference.asset ? <AssetMedia asset={reference.asset} controls={false} /> : <span>Missing asset</span>}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="inline-warning">No approved reference yet — upload one below or approve a reference above.</p>
+      )}
+      <div className="inline-create">
+        <button onClick={() => fileInputRef.current?.click()} type="button">
+          Upload reference
+        </button>
+        <input accept="image/*" hidden onChange={onUpload} ref={fileInputRef} type="file" />
+        <button disabled={!referenceAssetId || submitting} onClick={generate} type="button">
+          {submitting ? "Starting…" : `Generate angle set (${angleCount} views)`}
+        </button>
+      </div>
+      <label>
+        Prompt
+        <textarea onChange={(event) => setPrompt(event.target.value)} rows={2} value={prompt} />
+      </label>
+      {status ? <p className="inline-warning">{status}</p> : null}
+    </section>
+  );
+}

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -155,6 +155,14 @@ def _view_angle_kps(angle: str, side: int) -> np.ndarray | None:
     return np.array(points, dtype=np.float32) * float(side)
 
 
+# Order the one-click "angle set" (advanced.angleSet) generates the character in:
+# front, the two three-quarters, full profiles, then the up/down/diagonal tilts.
+ANGLE_SET_ORDER: tuple[str, ...] = (
+    "front", "three_quarter_left", "three_quarter_right", "left_profile", "right_profile",
+    "up", "down", "up_left", "up_right", "down_left", "down_right",
+)
+
+
 class InstantIDAdapter:
     """Identity-preserving SDXL generation via InstantID (face embedding + IdentityNet)."""
 
@@ -320,6 +328,7 @@ class InstantIDAdapter:
         seed: int,
         project_path: Path,
         cancel_requested: CancelCallback | None = None,
+        view_angle_override: str | None = None,
     ) -> Image.Image:
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)
@@ -328,7 +337,8 @@ class InstantIDAdapter:
         model_target = MODEL_TARGETS[request.model]
 
         reference = load_reference_image(project_path, request.reference_asset_id)
-        view_angle = self._view_angle(request)
+        # An explicit per-call angle (the angle-set batch) wins over advanced.viewAngle.
+        view_angle = view_angle_override if view_angle_override in VIEW_ANGLE_KPS else self._view_angle(request)
         if view_angle is not None:
             # View-angle mode: pose from the canonical landmark pack, identity from the
             # reference embedding. Square canvas so the pack kps share the output aspect
@@ -392,14 +402,21 @@ class InstantIDAdapter:
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)
         label = model_target["label"]
+        # One-click angle set (advanced.angleSet): generate the character once per packed
+        # view angle in a single job (pipeline already loaded), instead of `count` copies
+        # of one angle. Identity comes from the same reference embedding throughout.
+        angle_set = bool(request.advanced.get("angleSet"))
+        angles = [a for a in ANGLE_SET_ORDER if a in VIEW_ANGLE_KPS] if angle_set else []
+        total = len(angles) if angle_set else request.count
 
         def image_at_index(index: int) -> Image.Image:
             seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            angle = angles[index] if angle_set else None
             progress(
                 "running",
                 "generating",
-                image_batch_progress(index, request.count),
-                format_batch_running_message(label, index, request.count),
+                image_batch_progress(index, total),
+                format_batch_running_message(label, index, total),
             )
             emit_worker_event(
                 "image_inference_start",
@@ -407,12 +424,19 @@ class InstantIDAdapter:
                 adapter=self.id,
                 model=request.model,
                 imageIndex=index,
-                imageCount=request.count,
+                imageCount=total,
+                viewAngle=angle,
                 device=device,
             )
             try:
                 image = self._run_pipeline(
-                    settings, pipe, request, seed, project_path, cancel_requested=cancel_requested
+                    settings,
+                    pipe,
+                    request,
+                    seed,
+                    project_path,
+                    cancel_requested=cancel_requested,
+                    view_angle_override=angle,
                 )
             except Exception as exc:
                 emit_worker_event(
@@ -430,7 +454,7 @@ class InstantIDAdapter:
         return ImageAssetWriter().write_incremental_outputs(
             request=request,
             project_path=project_path,
-            image_count=request.count,
+            image_count=total,
             image_at_index=image_at_index,
             adapter_id=self.id,
             progress=progress,

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from scene_worker.image_adapters import MODEL_TARGETS, create_image_adapter, image_request_from_job
 from scene_worker.instantid_adapter import (
+    ANGLE_SET_ORDER,
     VIEW_ANGLE_KPS,
     InstantIDAdapter,
     _letterbox,
@@ -172,3 +173,11 @@ def test_view_angle_resolves_only_known_angles():
     assert InstantIDAdapter._view_angle(SimpleNamespace(advanced={"viewAngle": "left_profile"})) == "left_profile"
     assert InstantIDAdapter._view_angle(SimpleNamespace(advanced={"viewAngle": "bogus"})) is None
     assert InstantIDAdapter._view_angle(SimpleNamespace(advanced={})) is None
+
+
+def test_angle_set_order_covers_pack_without_dupes():
+    # The one-click angle set generates every packed angle exactly once, front first.
+    assert len(ANGLE_SET_ORDER) == 11
+    assert len(set(ANGLE_SET_ORDER)) == len(ANGLE_SET_ORDER)
+    assert ANGLE_SET_ORDER[0] == "front"
+    assert all(angle in VIEW_ANGLE_KPS for angle in ANGLE_SET_ORDER)


### PR DESCRIPTION
## Summary

A dedicated **"Angle set"** section in Character Studio: pick an approved reference **or** upload a new image, click one button, and it generates the InstantID model's full set of view angles (front, ¾ L/R, L/R profiles, up, down, 4 diagonals) as **one batch job** — the front half of the created-character bootstrap (sc-2033): one reference → consistent multi-angle set → curate → train a LoRA. Builds on the View-angle picker (sc-2048, merged via #296).

## How it works (no Rust change)

A "batch job" is just one `character_image` job to the InstantID model with `advanced.angleSet: true`. The worker adapter loops the packed angles in a single `generate()` (pipeline loads once) and writes them as one grouped generation set with one progress bar. `advanced` is already a passthrough, so no Rust/contract change.

- **Worker** (`72bb713`): `ANGLE_SET_ORDER` (11 angles); `generate()` branches on `advanced.angleSet` → `image_count = 11`, per-index `view_angle_override`; `_run_pipeline` accepts the override; identity embedding from the same reference throughout.
- **Web** (`d643b47`): `CharacterAngleSet` panel in Character Studio — reference picker (approved refs + upload via `importAsset`) + editable, character-named default prompt + a "Generate angle set" button firing the one job via `createImageJob`. Gated on an angle-capable model (`ui.viewAngles`). The 11 land as one generation set in latest images.

## Validation

- Real batch E2E through the adapter: one `generate()` → one generation set, `expectedCount: 11`, `angleSet: true` recorded, images saved incrementally (confirmed; slow only due to local MPS memory pressure).
- Per-angle identity already validated (sc-2048): 0.81–0.89 across the pack.
- Tests: worker `ANGLE_SET_ORDER` integrity (**319 worker** tests) + web panel fires the batch job with the right payload (**142 web** tests); Vite build + scaffold clean.

## Test plan

- [ ] CI green.
- [ ] Desktop E2E: in Character Studio, pick/upload a reference → "Generate angle set" → 11 consistent angles appear as one set.

## Notes / follow-ups

- Outputs save as one generation set (current character_image path); epic-2019 redesign will reorganize where character images live + a dedicated turnaround grid view.
- Per-image angle isn't yet recorded in asset metadata (write_incremental_outputs shares one raw_settings) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)