### PR TITLE
Remember last-used Image/Video Studio settings per workspace

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1504,11 +1504,11 @@ export function App() {
         ) : null}
 
         {activeView === "Image" ? (
-          <ImageStudio />
+          <ImageStudio key={activeProject?.id ?? "default"} />
         ) : null}
 
         {activeView === "Video" ? (
-          <VideoStudio />
+          <VideoStudio key={activeProject?.id ?? "default"} />
         ) : null}
 
         {activeView === "Document" ? (

--- a/apps/web/src/hooks/useStudioSettings.js
+++ b/apps/web/src/hooks/useStudioSettings.js
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+
+// Per-workspace "last used" settings for the Image / Video studios, so leaving a
+// studio and coming back restores the prompt, model, resolution, length, advanced
+// options, LoRAs and preset exactly as they were — scoped to the active workspace.
+const PREFIX = "sceneworks-studio";
+
+function storageKey(studio, workspaceId) {
+  return `${PREFIX}-${studio}-${workspaceId ?? "default"}`;
+}
+
+// Read the saved snapshot once at mount. Returns {} when nothing is stored or
+// localStorage is unavailable (private mode, quota), so callers can `?? default`.
+export function loadStudioSettings(studio, workspaceId) {
+  try {
+    const raw = window.localStorage.getItem(storageKey(studio, workspaceId));
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+// Persist `settings` for the workspace whenever they change. Serializing on every
+// render is cheap for a couple dozen fields and lets the effect skip writes when
+// nothing actually changed.
+export function useStudioSettingsWriter(studio, workspaceId, settings) {
+  const serialized = JSON.stringify(settings);
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey(studio, workspaceId), serialized);
+    } catch {
+      // localStorage unavailable — settings just won't persist this session.
+    }
+  }, [studio, workspaceId, serialized]);
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4315,6 +4315,52 @@ describe("SceneWorks app shell", () => {
     expect(onLocalJobCreated).toHaveBeenCalledWith({ id: "image-job-1" });
   });
 
+  it("remembers studio settings per workspace across remounts", async () => {
+    const imageProps = {
+      activeProject: { id: "project-1", name: "Noir" },
+      assets: [],
+      characters: [],
+      createImageJob: () => {},
+      deleteAsset: () => {},
+      gpuOptions: ["auto"],
+      imageModels: [{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }],
+      latestAssets: [],
+      localJobs: [],
+      loras: [],
+      onPreview: () => {},
+      purgeAsset: () => {},
+      requestedGpu: "auto",
+      selectedAsset: null,
+      setRequestedGpu: () => {},
+      updateAssetStatus: () => {},
+    };
+    const promptField = () => container.querySelector("textarea[aria-label='Prompt']");
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withImageStudioContext(imageProps));
+    });
+    const defaultPrompt = promptField().value;
+    await changeField(promptField(), "a custom remembered prompt");
+    await settle();
+
+    // Leaving the studio and returning to the same workspace restores the prompt.
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withImageStudioContext(imageProps));
+    });
+    expect(promptField().value).toBe("a custom remembered prompt");
+
+    // A different workspace starts from its own settings, not workspace-1's.
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withImageStudioContext({ ...imageProps, activeProject: { id: "project-2", name: "Other" } }));
+    });
+    expect(promptField().value).toBe(defaultPrompt);
+  });
+
   it("keeps completed image progress visible until the generated asset renders", async () => {
     const completedJob = {
       id: "image-job-1",

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -75,6 +75,7 @@ import {
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { errorStatuses } from "../jobTypes.js";
 
 // Used only for models that don't declare limits.resolutions (e.g. user-imported).
@@ -183,24 +184,28 @@ export function ImageStudio() {
   const onOpenPresets = () => setActiveView("Presets");
   const onOpenQueue = () => setActiveView("Queue");
   const onPreview = setPreviewAsset;
+  // Last-used settings for this workspace, restored on mount. The component is keyed
+  // by workspace in App.jsx, so this reads the right snapshot per workspace.
+  const saved = useMemo(() => loadStudioSettings("image", activeProject?.id ?? null), [activeProject?.id]);
   const [sceneSuggestions] = useState(() => pickSuggestions(4));
   const [characterSuggestions] = useState(() => pickSuggestions(4, CHARACTER_SUGGESTION_POOL));
-  const [mode, setMode] = useState("text_to_image");
-  const [prompt, setPrompt] = useState("A cinematic frame of a neon street at midnight");
+  const [mode, setMode] = useState(saved.mode ?? "text_to_image");
+  const [prompt, setPrompt] = useState(saved.prompt ?? "A cinematic frame of a neon street at midnight");
   // True once the user types or picks a suggestion, so the character-mode default
-  // prompt never clobbers their own wording.
-  const promptEdited = useRef(false);
+  // prompt never clobbers their own wording. A restored prompt counts as edited so
+  // re-entering character mode doesn't overwrite it.
+  const promptEdited = useRef(saved.prompt != null);
   const setPromptFromUser = (value) => {
     promptEdited.current = true;
     setPrompt(value);
   };
   const suggestions = mode === "character_image" ? characterSuggestions : sceneSuggestions;
-  const [count, setCount] = useState(4);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [model, setModel] = useState(imageModels[0]?.id ?? "z_image_turbo");
-  const [seed, setSeed] = useState("");
-  const [negativePrompt, setNegativePrompt] = useState("");
-  const [resolution, setResolution] = useState("1024x1024");
+  const [count, setCount] = useState(saved.count ?? 4);
+  const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
+  const [model, setModel] = useState(saved.model ?? imageModels[0]?.id ?? "z_image_turbo");
+  const [seed, setSeed] = useState(saved.seed ?? "");
+  const [negativePrompt, setNegativePrompt] = useState(saved.negativePrompt ?? "");
+  const [resolution, setResolution] = useState(saved.resolution ?? "1024x1024");
   const [sourceAssetId, setSourceAssetId] = useState(selectedAsset?.id ?? "");
   const [characterId, setCharacterId] = useState("");
   const [characterLookId, setCharacterLookId] = useState("");
@@ -208,16 +213,16 @@ export function ImageStudio() {
   // identity is carried across variations. `ipAdapterScale` rides in `advanced`; for
   // InstantID, `controlnetScale` (IdentityNet landmark lock) rides there too.
   const [referenceAssetId, setReferenceAssetId] = useState("");
-  const [ipAdapterScale, setIpAdapterScale] = useState(0.6);
-  const [controlnetScale, setControlnetScale] = useState(0.8);
+  const [ipAdapterScale, setIpAdapterScale] = useState(saved.ipAdapterScale ?? 0.6);
+  const [controlnetScale, setControlnetScale] = useState(saved.controlnetScale ?? 0.8);
   // InstantID canonical head angle ("" = match the reference's own angle). Rides advanced.viewAngle.
-  const [viewAngle, setViewAngle] = useState("");
-  const [upscaleEnabled, setUpscaleEnabled] = useState(false);
-  const [upscaleFactor, setUpscaleFactor] = useState(2);
-  const [upscaleEngine, setUpscaleEngine] = useState("real-esrgan");
-  const [selectedLoraIds, setSelectedLoraIds] = useState([]);
-  const [loraWeights, setLoraWeights] = useState({});
-  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
+  const [viewAngle, setViewAngle] = useState(saved.viewAngle ?? "");
+  const [upscaleEnabled, setUpscaleEnabled] = useState(saved.upscaleEnabled ?? false);
+  const [upscaleFactor, setUpscaleFactor] = useState(saved.upscaleFactor ?? 2);
+  const [upscaleEngine, setUpscaleEngine] = useState(saved.upscaleEngine ?? "real-esrgan");
+  const [selectedLoraIds, setSelectedLoraIds] = useState(saved.selectedLoraIds ?? []);
+  const [loraWeights, setLoraWeights] = useState(saved.loraWeights ?? {});
+  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
   const [submitting, setSubmitting] = useState(false);
   const presetDefaultSnapshots = useRef({});
   const editImageAssets = useMemo(
@@ -304,8 +309,14 @@ export function ImageStudio() {
   const viewAngles = Array.isArray(selectedModel?.ui?.viewAngles) ? selectedModel.ui.viewAngles : null;
   // Reset the reference tuning to the selected model's declared defaults whenever the
   // model changes, so InstantID starts at its tuned 0.8/0.8 and Kolors at 0.6, and the
-  // view angle never carries over to a model that doesn't support it.
+  // view angle never carries over to a model that doesn't support it. Skip the mount
+  // run when restoring a snapshot so the user's saved tuning survives.
+  const skipReferenceTuningReset = useRef(saved.ipAdapterScale != null);
   useEffect(() => {
+    if (skipReferenceTuningReset.current) {
+      skipReferenceTuningReset.current = false;
+      return;
+    }
     const ui = imageModels.find((item) => item.id === model)?.ui ?? {};
     setIpAdapterScale(typeof ui.referenceStrengthDefault === "number" ? ui.referenceStrengthDefault : 0.6);
     setControlnetScale(typeof ui.identityStructure?.default === "number" ? ui.identityStructure.default : 0.8);
@@ -370,6 +381,7 @@ export function ImageStudio() {
   const {
     availablePresets,
     selectedPreset,
+    selectedPresetId,
     setSelectedPresetId,
     presetPromptParts,
     presetLoraDetails,
@@ -391,6 +403,7 @@ export function ImageStudio() {
     assets,
     latestAssets,
     trackedLocalJobs,
+    initialPresetId: saved.selectedPresetId ?? null,
   });
   const compatibleLoras = useMemo(() => loras.filter((lora) => {
     if (lora.presetManaged) {
@@ -429,7 +442,18 @@ export function ImageStudio() {
         : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
   const [width, height] = resolution.split("x").map((value) => Number(value));
 
+  // When restoring a snapshot, the saved count/resolution/negativePrompt already
+  // reflect the user's last state — skip the one preset-default pass that fires as the
+  // restored preset resolves so it doesn't overwrite them. "None" applies no defaults,
+  // so no guard is needed there.
+  const skipPresetDefaultsOnHydrate = useRef(
+    Object.keys(saved).length > 0 && saved.selectedPresetId !== noPresetId,
+  );
   useEffect(() => {
+    if (skipPresetDefaultsOnHydrate.current && selectedPreset) {
+      skipPresetDefaultsOnHydrate.current = false;
+      return;
+    }
     if (!selectedPreset) {
       clearPresetDefault(setCount, presetDefaultSnapshots, "count");
       clearPresetDefault(setResolution, presetDefaultSnapshots, "resolution");
@@ -459,6 +483,27 @@ export function ImageStudio() {
       });
     }
   }, [selectedPreset?.id]);
+
+  useStudioSettingsWriter("image", activeProject?.id ?? null, {
+    mode,
+    prompt,
+    count,
+    advancedOpen,
+    model,
+    seed,
+    negativePrompt,
+    resolution,
+    ipAdapterScale,
+    controlnetScale,
+    viewAngle,
+    upscaleEnabled,
+    upscaleFactor,
+    upscaleEngine,
+    selectedLoraIds,
+    loraWeights,
+    showIncompatibleLoras,
+    selectedPresetId,
+  });
 
   useEffect(() => {
     setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -53,6 +53,7 @@ import {
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { qualityChoices } from "../jobTypes.js";
 
 const ltxVideoModelId = "ltx_2_3";
@@ -103,27 +104,30 @@ export function VideoStudio() {
     }
     setActiveView("Editor");
   };
-  const [motion, setMotion] = useState("slow push-in");
+  // Last-used settings for this workspace, restored on mount. The component is keyed
+  // by workspace in App.jsx, so this reads the right snapshot per workspace.
+  const saved = useMemo(() => loadStudioSettings("video", activeProject?.id ?? null), [activeProject?.id]);
+  const [motion, setMotion] = useState(saved.motion ?? "slow push-in");
   const imageAssets = assets.filter((asset) => asset.type === "image" || asset.type === "frame");
   const videoAssets = assets.filter((asset) => asset.type === "video");
-  const [mode, setMode] = useState("image_to_video");
-  const [prompt, setPrompt] = useState("Camera slowly pushes in while the scene comes alive");
-  const [quality, setQuality] = useState("balanced");
-  const [ltxPipeline, setLtxPipeline] = useState("auto");
-  const [distilledVariant, setDistilledVariant] = useState("1.1");
-  const [precision, setPrecision] = useState("fp8");
-  const [quantization, setQuantization] = useState("auto");
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [selectedLoraIds, setSelectedLoraIds] = useState([]);
-  const [loraWeights, setLoraWeights] = useState({});
-  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(false);
-  const [model, setModel] = useState(videoModels[0]?.id ?? ltxVideoModelId);
+  const [mode, setMode] = useState(saved.mode ?? "image_to_video");
+  const [prompt, setPrompt] = useState(saved.prompt ?? "Camera slowly pushes in while the scene comes alive");
+  const [quality, setQuality] = useState(saved.quality ?? "balanced");
+  const [ltxPipeline, setLtxPipeline] = useState(saved.ltxPipeline ?? "auto");
+  const [distilledVariant, setDistilledVariant] = useState(saved.distilledVariant ?? "1.1");
+  const [precision, setPrecision] = useState(saved.precision ?? "fp8");
+  const [quantization, setQuantization] = useState(saved.quantization ?? "auto");
+  const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
+  const [selectedLoraIds, setSelectedLoraIds] = useState(saved.selectedLoraIds ?? []);
+  const [loraWeights, setLoraWeights] = useState(saved.loraWeights ?? {});
+  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
+  const [model, setModel] = useState(saved.model ?? videoModels[0]?.id ?? ltxVideoModelId);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
-  const [duration, setDuration] = useState(selectedModel?.defaults?.duration ?? 6);
-  const [resolution, setResolution] = useState(selectedModel?.defaults?.resolution ?? "768x512");
-  const [fps, setFps] = useState(selectedModel?.defaults?.fps ?? 25);
-  const [seed, setSeed] = useState("");
-  const [negativePrompt, setNegativePrompt] = useState("");
+  const [duration, setDuration] = useState(saved.duration ?? selectedModel?.defaults?.duration ?? 6);
+  const [resolution, setResolution] = useState(saved.resolution ?? selectedModel?.defaults?.resolution ?? "768x512");
+  const [fps, setFps] = useState(saved.fps ?? selectedModel?.defaults?.fps ?? 25);
+  const [seed, setSeed] = useState(saved.seed ?? "");
+  const [negativePrompt, setNegativePrompt] = useState(saved.negativePrompt ?? "");
   const [sourceAssetId, setSourceAssetId] = useState(["image", "frame"].includes(selectedAsset?.type) ? selectedAsset.id : "");
   const [lastFrameAssetId, setLastFrameAssetId] = useState("");
   const [sourceClipAssetId, setSourceClipAssetId] = useState(selectedAsset?.type === "video" ? selectedAsset.id : "");
@@ -152,6 +156,7 @@ export function VideoStudio() {
   const {
     availablePresets,
     selectedPreset,
+    selectedPresetId,
     setSelectedPresetId,
     presetPromptParts,
     presetLoraDetails,
@@ -173,6 +178,7 @@ export function VideoStudio() {
     assets,
     latestAssets,
     trackedLocalJobs,
+    initialPresetId: saved.selectedPresetId ?? null,
   });
   const requiresLtxIcLora = selectedModel?.id === ltxVideoModelId && ltxIcLoraRequiredModes.has(mode);
   const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing && loraLooksLikeIcLora(lora));
@@ -303,7 +309,18 @@ export function VideoStudio() {
     }
   }, [mode, supportsMode, videoModels]);
 
+  // When restoring a snapshot, the saved length/fps/quality/resolution/negativePrompt
+  // already reflect the user's last state — skip the one preset-default pass that fires
+  // as the restored preset resolves so it doesn't overwrite them. "None" applies no
+  // defaults, so no guard is needed there.
+  const skipPresetDefaultsOnHydrate = useRef(
+    Object.keys(saved).length > 0 && saved.selectedPresetId !== noPresetId,
+  );
   useEffect(() => {
+    if (skipPresetDefaultsOnHydrate.current && selectedPreset) {
+      skipPresetDefaultsOnHydrate.current = false;
+      return;
+    }
     if (!selectedPreset) {
       clearPresetDefault(setDuration, presetDefaultSnapshots, "duration");
       clearPresetDefault(setFps, presetDefaultSnapshots, "fps");
@@ -349,6 +366,28 @@ export function VideoStudio() {
       });
     }
   }, [selectedPreset?.id]);
+
+  useStudioSettingsWriter("video", activeProject?.id ?? null, {
+    motion,
+    mode,
+    prompt,
+    quality,
+    ltxPipeline,
+    distilledVariant,
+    precision,
+    quantization,
+    advancedOpen,
+    selectedLoraIds,
+    loraWeights,
+    showIncompatibleLoras,
+    model,
+    duration,
+    resolution,
+    fps,
+    seed,
+    negativePrompt,
+    selectedPresetId,
+  });
 
   useEffect(() => {
     if (mode !== "replace_person") {

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -94,8 +94,9 @@ export function useGenerationStudio({
   assets,
   latestAssets,
   trackedLocalJobs,
+  initialPresetId = null,
 }) {
-  const [selectedPresetId, setSelectedPresetId] = useState(null);
+  const [selectedPresetId, setSelectedPresetId] = useState(initialPresetId);
   const [resultFallbackTick, setResultFallbackTick] = useState(0);
 
   // Snap the model back into range when the catalog changes out from under it.


### PR DESCRIPTION
## Summary

Both the Image Studio and Video Studio now remember the settings you last used and restore them when you leave the screen and come back — **scoped per workspace**. Switching workspaces shows that workspace's own last settings.

Restored fields: prompt, model, resolution, length/duration, fps, quality, mode, advanced options (seed, negative prompt, LTX pipeline/precision/quantization, upscale, IP-Adapter/InstantID reference tuning), selected LoRAs + per-LoRA weights, and the selected preset.

## What changed

- **`apps/web/src/hooks/useStudioSettings.js`** (new) — `loadStudioSettings(studio, workspaceId)` + `useStudioSettingsWriter(studio, workspaceId, settings)`, backed by `localStorage` key `sceneworks-studio-<image|video>-<workspaceId>`. Mirrors the app's existing `sceneworks-theme` / `sceneworks-token` localStorage pattern.
- **`ImageStudio.jsx` / `VideoStudio.jsx`** — each `useState` initializer now falls back to the saved snapshot; a writer effect persists the bundle on change.
- **`generationStudio.jsx`** — `useGenerationStudio` takes a new `initialPresetId` param so the restored preset seeds `selectedPresetId`.
- **`App.jsx`** — both studios are keyed by `activeProject?.id` so switching workspace while on a studio remounts and re-reads that workspace's snapshot.

## Notes for reviewers

- The studios already unmount on view switch (`activeView === "Image" ? <ImageStudio/> : null`), so leaving and returning naturally re-runs the `useState` initializers and restores. The `key={activeProject?.id}` covers the remaining case: switching workspace *while staying on* the studio.
- Two mount-time effects would otherwise overwrite restored values, so small hydration guards were added (they still fire normally on later user changes):
  1. the preset-default effect (re-applies preset count/resolution/negativePrompt; duration/fps/quality/resolution/negativePrompt) — guarded to skip the first pass as the restored preset resolves (handles async preset load),
  2. the Image-only per-model reference-tuning reset (ipAdapterScale/controlnetScale/viewAngle).
- A restored prompt marks `promptEdited` so the character-mode default-prompt seeding doesn't clobber it.
- Transient/contextual state is intentionally not persisted (submitting flag; source/reference asset + character selections, which are driven by the launch/selection flows).

## Test plan

- [x] `npm run test` — 151 pass, including a new test that changes a setting, remounts the studio, and asserts it's restored for the same workspace but **not** for a different workspace.
- [x] `npm run build` — Vite production build clean.
- [ ] Full browser click-through not performed in this environment (needs the FastAPI backend + auth running). The new test renders the real studio components against real `localStorage`, exercising the same code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)