### PR TITLE
feat(prompt): prompt-guide popup + Refine My Prompt (epic 1323)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,16 @@ SCENEWORKS_VIDEO_ADAPTER=
 # Docker/NVIDIA runtime GPU selection. CUDA/Linux only — ignored on macOS,
 # where MPS is the sole accelerator (sc-1335).
 NVIDIA_VISIBLE_DEVICES=all
+
+# "Refine my prompt" (sc-2041): the prompt composer can rewrite a prompt to
+# follow the selected model's guide by calling an OpenAI-compatible
+# /chat/completions endpoint from the worker. Leave BASE_URL/MODEL blank to
+# disable (the refine job then fails fast with a clear message). The suggested
+# default is a small local model such as
+# llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic (GGUF) served by
+# Ollama / llama.cpp / LM Studio. Most local servers ignore the API key.
+PROMPT_REFINE_BASE_URL=
+PROMPT_REFINE_API_KEY=
+PROMPT_REFINE_MODEL=
+PROMPT_REFINE_TIMEOUT_SECONDS=60
+PROMPT_REFINE_MAX_TOKENS=1024

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -10,6 +10,18 @@ pub(crate) struct JobsQuery {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct PromptRefineRequest {
+    pub(crate) prompt: String,
+    pub(crate) model_id: Option<String>,
+    pub(crate) workflow: Option<String>,
+    /// The selected model's Markdown prompt guide, sent by the client so the
+    /// worker can build a guide-aware system prompt without filesystem access to
+    /// the web assets.
+    pub(crate) guide: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct AssetsQuery {
     pub(crate) include_rejected: Option<bool>,
     pub(crate) include_trashed: Option<bool>,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -96,6 +96,8 @@ mod recipe_presets;
 use recipe_presets::*;
 mod credentials;
 use credentials::*;
+mod prompts;
+use prompts::*;
 
 const PUBLIC_PATHS: &[&str] = &[
     "/api/v1/health",
@@ -584,6 +586,7 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         .route("/api/v1/image/vqa/jobs", post(create_vqa_job))
         .route("/api/v1/image/interleave/jobs", post(create_interleave_job))
         .route("/api/v1/video/jobs", post(create_video_job))
+        .route("/api/v1/prompts/refine", post(create_prompt_refine_job))
         .route(
             "/api/v1/credentials",
             get(list_credentials).put(set_credential),

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+/// Enqueue a `prompt_refine` job: a lightweight, non-GPU job that asks an
+/// OpenAI-compatible LLM to rewrite the user's prompt to follow the selected
+/// model's prompt guide. The job runs in the Python worker (which reuses the
+/// vendored Lens reasoner's calling approach) and the client reads the refined
+/// prompt from the completed job's `result.refinedPrompt`.
+pub(crate) async fn create_prompt_refine_job(
+    State(state): State<AppState>,
+    ApiJson(payload): ApiJson<PromptRefineRequest>,
+) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    let prompt = payload.prompt.trim();
+    if prompt.is_empty() {
+        return Err(ApiError::bad_request("Prompt cannot be empty"));
+    }
+
+    let mut job_payload = JsonObject::new();
+    job_payload.insert("prompt".to_owned(), Value::String(prompt.to_owned()));
+
+    let workflow = payload
+        .workflow
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("image")
+        .to_owned();
+    job_payload.insert("workflow".to_owned(), Value::String(workflow));
+
+    if let Some(model_id) = payload.model_id.as_deref() {
+        if !model_id.trim().is_empty() {
+            job_payload.insert(
+                "modelId".to_owned(),
+                Value::String(model_id.trim().to_owned()),
+            );
+        }
+    }
+    if let Some(guide) = payload.guide.as_deref() {
+        if !guide.trim().is_empty() {
+            job_payload.insert("guide".to_owned(), Value::String(guide.to_owned()));
+        }
+    }
+
+    let job = create_generation_job(
+        state,
+        JobType::PromptRefine,
+        None,
+        None,
+        job_payload,
+        "auto".to_owned(),
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(job)))
+}

--- a/apps/web/public/prompt-guides/sensenova-u1-8b.md
+++ b/apps/web/public/prompt-guides/sensenova-u1-8b.md
@@ -56,6 +56,14 @@ SenseNova-U1 is useful for dense text, but it still needs exact instructions. In
 
 For edits, say what to preserve first, then what to change. Keep the edit instruction concrete and ordered.
 
+### Avoid
+
+- Vague one-line prompts for infographics or posters — they under-constrain the layout.
+- Approximate or unquoted text; always quote the exact strings you want rendered.
+- Conflicting or overlapping layout instructions (e.g. "centered" and "left-aligned" for the same element).
+- Cramming too many competing sections into one image; fewer, clearly bounded sections render more reliably.
+- Generic quality tags like `masterpiece` or `best quality`; describe concrete content and structure instead.
+
 ## Example Prompts
 
 `Create a vertical educational infographic titled "RAIN GARDENS AT WORK". Use a clean flat vector style with a blue and green palette. Top section: a city street with rain falling. Middle section: a cutaway soil diagram with arrows labeled "runoff", "plant roots", and "filtered water". Bottom section: three benefit cards reading "Less flooding", "Cleaner rivers", and "More habitat". Large readable sans-serif text, clear margins, no overlapping elements.`

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1001,6 +1001,37 @@ export function App() {
     }
   }
 
+  // Refine a prompt via the prompt_refine worker job: POST creates the job, then
+  // poll until it reaches a terminal state and return the rewritten prompt. Project-
+  // independent (no activeProject gate); throws on failure so the studio can surface
+  // the message inline without clobbering the original prompt.
+  async function refinePrompt({ prompt, modelId, workflow, guide }) {
+    const created = await apiFetch("/api/v1/prompts/refine", token, {
+      method: "POST",
+      body: JSON.stringify({ prompt, modelId, workflow, guide }),
+    });
+    const jobId = created?.id;
+    if (!jobId) {
+      throw new Error("Could not start prompt refinement.");
+    }
+    const deadline = Date.now() + 120000;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const job = await apiFetch(`/api/v1/jobs/${jobId}`, token);
+      if (job.status === "completed") {
+        const refined = job.result?.refinedPrompt;
+        if (!refined) {
+          throw new Error("Refinement returned an empty prompt.");
+        }
+        return refined;
+      }
+      if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+        throw new Error(job.message || job.error || "Prompt refinement failed.");
+      }
+    }
+    throw new Error("Prompt refinement timed out. Is the refinement runtime running?");
+  }
+
   async function createVqaJob(asset, question, maxNewTokens) {
     if (!activeProject) {
       setError("Create or open a project first.");
@@ -1304,6 +1335,7 @@ export function App() {
     // Generation studios (sc-1651 Phase B batch 3)
     createVideoJob,
     createImageJob,
+    refinePrompt,
     latestVideoAssets,
     videoLocalJobs,
     imageLocalJobs,

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -36,6 +36,7 @@ export const Icon = {
   Moon: (p) => <I {...p} d="M21 13.5A9 9 0 1110.5 3a7 7 0 0010.5 10.5z" />,
   Bell: (p) => <I {...p} d="M6 16V11a6 6 0 0112 0v5l2 2H4zM10 20a2 2 0 004 0" />,
   Folder: (p) => <I {...p} d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />,
+  Book: (p) => <I {...p} d="M5 4h11a2 2 0 012 2v14H7a2 2 0 00-2 2zM5 4v16M9 8h6M9 12h5" />,
   ChevDown: (p) => <I {...p} d="M6 9l6 6 6-6" />,
   Sliders: (p) => <I {...p} d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h14M18 18h2M14 4v4M6 10v4M16 16v4" />,
   Play: (p) => <I {...p} fill d="M7 4l13 8-13 8z" />,

--- a/apps/web/src/components/Markdown.jsx
+++ b/apps/web/src/components/Markdown.jsx
@@ -1,0 +1,163 @@
+import React from "react";
+
+// Compact, dependency-free Markdown renderer for first-party prompt-guide
+// content shipped from /public/prompt-guides. It covers the subset those files
+// use — ATX headings, paragraphs, ordered/unordered lists, blockquotes, fenced
+// code blocks, and inline bold/italic/code/links. It builds React elements
+// directly (never dangerouslySetInnerHTML), so untrusted markup cannot inject
+// HTML, and link hrefs are restricted to safe schemes.
+
+const HEADING = /^(#{1,6})\s+(.*)$/;
+const LIST_ITEM = /^\s*([-*+]|\d+\.)\s+/;
+const ORDERED_ITEM = /^\s*\d+\.\s+/;
+const FENCE = /^```/;
+const QUOTE = /^\s*>\s?/;
+
+function safeHref(url) {
+  const trimmed = (url || "").trim();
+  if (/^(https?:|mailto:)/i.test(trimmed)) return trimmed;
+  if (/^[/#]/.test(trimmed)) return trimmed;
+  return undefined;
+}
+
+const INLINE_RULES = [
+  { re: /`([^`]+)`/, node: (m, key) => <code key={key}>{m[1]}</code> },
+  {
+    re: /\[([^\]]+)\]\(([^)\s]+)\)/,
+    node: (m, key) => {
+      const href = safeHref(m[2]);
+      if (!href) return <span key={key}>{renderInline(m[1], key)}</span>;
+      return (
+        <a key={key} href={href} target="_blank" rel="noopener noreferrer">
+          {renderInline(m[1], key)}
+        </a>
+      );
+    },
+  },
+  { re: /\*\*([^*]+)\*\*/, node: (m, key) => <strong key={key}>{renderInline(m[1], key)}</strong> },
+  { re: /\*([^*]+)\*/, node: (m, key) => <em key={key}>{renderInline(m[1], key)}</em> },
+  { re: /_([^_]+)_/, node: (m, key) => <em key={key}>{renderInline(m[1], key)}</em> },
+];
+
+function renderInline(text, keyPrefix) {
+  let earliest = null;
+  for (const rule of INLINE_RULES) {
+    const match = rule.re.exec(text);
+    if (match && (!earliest || match.index < earliest.match.index)) {
+      earliest = { rule, match };
+    }
+  }
+  if (!earliest) return text;
+  const { rule, match } = earliest;
+  const before = text.slice(0, match.index);
+  const after = text.slice(match.index + match[0].length);
+  const nodes = [];
+  if (before) nodes.push(before);
+  nodes.push(rule.node(match, `${keyPrefix}-${match.index}`));
+  const rest = renderInline(after, `${keyPrefix}-r`);
+  if (Array.isArray(rest)) nodes.push(...rest);
+  else if (rest) nodes.push(rest);
+  return nodes;
+}
+
+function parseBlocks(content) {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim()) {
+      i += 1;
+      continue;
+    }
+    const heading = HEADING.exec(line);
+    if (heading) {
+      blocks.push({ type: "heading", level: heading[1].length, text: heading[2].trim() });
+      i += 1;
+      continue;
+    }
+    if (FENCE.test(line.trim())) {
+      i += 1;
+      const code = [];
+      while (i < lines.length && !FENCE.test(lines[i].trim())) {
+        code.push(lines[i]);
+        i += 1;
+      }
+      i += 1; // skip closing fence
+      blocks.push({ type: "code", text: code.join("\n") });
+      continue;
+    }
+    if (LIST_ITEM.test(line)) {
+      const ordered = ORDERED_ITEM.test(line);
+      const items = [];
+      while (i < lines.length && LIST_ITEM.test(lines[i])) {
+        items.push(lines[i].replace(LIST_ITEM, ""));
+        i += 1;
+      }
+      blocks.push({ type: "list", ordered, items });
+      continue;
+    }
+    if (QUOTE.test(line)) {
+      const quote = [];
+      while (i < lines.length && QUOTE.test(lines[i])) {
+        quote.push(lines[i].replace(QUOTE, ""));
+        i += 1;
+      }
+      blocks.push({ type: "quote", text: quote.join(" ") });
+      continue;
+    }
+    const para = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() &&
+      !HEADING.test(lines[i]) &&
+      !LIST_ITEM.test(lines[i]) &&
+      !FENCE.test(lines[i].trim()) &&
+      !QUOTE.test(lines[i])
+    ) {
+      para.push(lines[i]);
+      i += 1;
+    }
+    blocks.push({ type: "paragraph", text: para.join(" ") });
+  }
+  return blocks;
+}
+
+function renderBlock(block, key) {
+  switch (block.type) {
+    case "heading": {
+      const Tag = `h${Math.min(block.level, 6)}`;
+      return <Tag key={key}>{renderInline(block.text, key)}</Tag>;
+    }
+    case "list": {
+      const Tag = block.ordered ? "ol" : "ul";
+      return (
+        <Tag key={key}>
+          {block.items.map((item, index) => (
+            <li key={`${key}-${index}`}>{renderInline(item, `${key}-${index}`)}</li>
+          ))}
+        </Tag>
+      );
+    }
+    case "quote":
+      return (
+        <blockquote key={key}>
+          <p>{renderInline(block.text, key)}</p>
+        </blockquote>
+      );
+    case "code":
+      return (
+        <pre key={key}>
+          <code>{block.text}</code>
+        </pre>
+      );
+    case "paragraph":
+    default:
+      return <p key={key}>{renderInline(block.text, key)}</p>;
+  }
+}
+
+export function Markdown({ content }) {
+  const blocks = parseBlocks(content || "");
+  return <div className="markdown-body">{blocks.map((block, index) => renderBlock(block, `b${index}`))}</div>;
+}

--- a/apps/web/src/components/PromptGuide.test.jsx
+++ b/apps/web/src/components/PromptGuide.test.jsx
@@ -1,0 +1,160 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Markdown } from "./Markdown.jsx";
+import { PromptGuideModal } from "./PromptGuideModal.jsx";
+
+async function settle() {
+  await act(async () => {
+    for (let index = 0; index < 6; index += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+describe("Markdown renderer", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function render(ui) {
+    root = createRoot(container);
+    act(() => root.render(ui));
+  }
+
+  it("renders headings, lists, bold, inline code, and safe links", () => {
+    render(
+      <Markdown
+        content={[
+          "# Title",
+          "## Section",
+          "A paragraph with **bold**, `code`, and a [link](https://example.com/guide).",
+          "",
+          "- first item",
+          "- second item",
+        ].join("\n")}
+      />,
+    );
+
+    expect(container.querySelector("h1").textContent).toBe("Title");
+    expect(container.querySelector("h2").textContent).toBe("Section");
+    expect(container.querySelector("strong").textContent).toBe("bold");
+    expect(container.querySelector("code").textContent).toBe("code");
+    const link = container.querySelector("a");
+    expect(link.getAttribute("href")).toBe("https://example.com/guide");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    expect([...container.querySelectorAll("li")].map((li) => li.textContent)).toEqual(["first item", "second item"]);
+  });
+
+  it("renders ordered lists and fenced code blocks", () => {
+    render(<Markdown content={["1. step one", "2. step two", "", "```", "raw code line", "```"].join("\n")} />);
+    expect(container.querySelector("ol")).not.toBeNull();
+    expect([...container.querySelectorAll("ol li")].map((li) => li.textContent)).toEqual(["step one", "step two"]);
+    expect(container.querySelector("pre code").textContent).toBe("raw code line");
+  });
+
+  it("drops unsafe link hrefs instead of rendering a javascript: anchor", () => {
+    render(<Markdown content={"Click [here](javascript:alert(1)) now."} />);
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("here");
+  });
+});
+
+describe("PromptGuideModal", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the guide path and renders its markdown with the model name", async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, text: async () => "# Z-Image Guide\n\nUse short prompts." }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <PromptGuideModal
+          guide={{ title: "Z-Image-Turbo Prompt Guide", path: "/prompt-guides/z-image-turbo.md" }}
+          modelName="Z-Image-Turbo"
+          onClose={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledWith("/prompt-guides/z-image-turbo.md");
+    expect(container.querySelector("#prompt-guide-title").textContent).toBe("Z-Image-Turbo Prompt Guide");
+    expect(container.textContent).toContain("Z-Image-Turbo · Prompt guide");
+    expect(container.querySelector(".markdown-body h1").textContent).toBe("Z-Image Guide");
+    expect(container.textContent).toContain("Use short prompts.");
+  });
+
+  it("renders metadata source links when provided", async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, text: async () => "Body." }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <PromptGuideModal
+          guide={{
+            title: "Guide",
+            path: "/prompt-guides/x.md",
+            sources: [{ label: "Model card", url: "https://example.com/card" }],
+          }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await settle();
+
+    const source = container.querySelector(".prompt-guide-sources a");
+    expect(source.textContent).toBe("Model card");
+    expect(source.getAttribute("href")).toBe("https://example.com/card");
+  });
+
+  it("shows an error message when the guide cannot be loaded", async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 404, text: async () => "" }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<PromptGuideModal guide={{ title: "Guide", path: "/prompt-guides/missing.md" }} onClose={() => {}} />);
+    });
+    await settle();
+
+    expect(container.textContent).toContain("could not be loaded");
+    expect(container.querySelector(".markdown-body")).toBeNull();
+  });
+
+  it("closes on Escape", async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, text: async () => "Body." }));
+    const onClose = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<PromptGuideModal guide={{ title: "Guide", path: "/prompt-guides/x.md" }} onClose={onClose} />);
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector("[role=dialog]").dispatchEvent(new window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/PromptGuideModal.jsx
+++ b/apps/web/src/components/PromptGuideModal.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+import { Modal } from "./Modal.jsx";
+import { Markdown } from "./Markdown.jsx";
+
+// Fetches a model's static Markdown prompt guide (served from /public/prompt-guides)
+// and renders it inside the shared Modal. `guide` is the resolved metadata
+// ({ title, path, sources? }); callers pass a generic fallback when the selected
+// model declares none.
+export function PromptGuideModal({ guide, modelName, onClose }) {
+  const [state, setState] = useState({ status: "loading", content: "" });
+
+  useEffect(() => {
+    let active = true;
+    setState({ status: "loading", content: "" });
+    fetch(guide.path)
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.text();
+      })
+      .then((text) => {
+        if (active) setState({ status: "ready", content: text });
+      })
+      .catch(() => {
+        if (active) setState({ status: "error", content: "" });
+      });
+    return () => {
+      active = false;
+    };
+  }, [guide.path]);
+
+  return (
+    <Modal className="prompt-guide-modal" labelledBy="prompt-guide-title" onClose={onClose}>
+      <header className="prompt-guide-head">
+        <div>
+          <p className="eyebrow">{modelName ? `${modelName} · Prompt guide` : "Prompt guide"}</p>
+          <h2 id="prompt-guide-title">{guide.title}</h2>
+        </div>
+        <button className="modal-close" onClick={onClose} type="button">
+          Close
+        </button>
+      </header>
+
+      <div className="prompt-guide-body">
+        {state.status === "loading" ? <p className="prompt-guide-status">Loading guide…</p> : null}
+        {state.status === "error" ? (
+          <p className="prompt-guide-status">This guide could not be loaded. Please try again.</p>
+        ) : null}
+        {state.status === "ready" ? <Markdown content={state.content} /> : null}
+      </div>
+
+      {guide.sources?.length ? (
+        <footer className="prompt-guide-sources">
+          <span>Sources:</span>
+          {guide.sources.map((source) => (
+            <a key={source.url} href={source.url} target="_blank" rel="noopener noreferrer">
+              {source.label}
+            </a>
+          ))}
+        </footer>
+      ) : null}
+    </Modal>
+  );
+}

--- a/apps/web/src/components/RefinePrompt.test.jsx
+++ b/apps/web/src/components/RefinePrompt.test.jsx
@@ -1,0 +1,134 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RefinePromptControl } from "./RefinePromptControl.jsx";
+
+async function settle() {
+  await act(async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+function refineButton(container) {
+  return [...container.querySelectorAll("button")].find((button) => button.textContent.includes("Refine my prompt"));
+}
+
+function buttonByText(container, text) {
+  return [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === text);
+}
+
+describe("RefinePromptControl", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, text: async () => "# Guide\n\nWrite vividly." }));
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function render(ui) {
+    root = createRoot(container);
+    act(() => root.render(ui));
+  }
+
+  it("disables the button when the prompt is empty", () => {
+    render(<RefinePromptControl prompt="   " guidePath="/prompt-guides/z.md" modelId="z" workflow="image" refinePrompt={vi.fn()} onApply={vi.fn()} />);
+    expect(refineButton(container).disabled).toBe(true);
+  });
+
+  it("refines, shows the rewrite, and applies it only on Apply", async () => {
+    const refinePrompt = vi.fn(async () => "A vivid neon street at midnight, cinematic.");
+    const onApply = vi.fn();
+    render(
+      <RefinePromptControl
+        prompt="neon street"
+        guidePath="/prompt-guides/z-image-turbo.md"
+        modelId="z_image_turbo"
+        workflow="image"
+        refinePrompt={refinePrompt}
+        onApply={onApply}
+      />,
+    );
+
+    await act(async () => {
+      refineButton(container).click();
+    });
+    await settle();
+
+    // Sent the prompt + model + workflow + fetched guide; original not yet applied.
+    expect(refinePrompt).toHaveBeenCalledWith({
+      prompt: "neon street",
+      modelId: "z_image_turbo",
+      workflow: "image",
+      guide: "# Guide\n\nWrite vividly.",
+    });
+    expect(onApply).not.toHaveBeenCalled();
+    expect(container.querySelector(".refine-review-text").textContent).toBe("A vivid neon street at midnight, cinematic.");
+
+    await act(async () => {
+      buttonByText(container, "Apply").click();
+    });
+    expect(onApply).toHaveBeenCalledWith("A vivid neon street at midnight, cinematic.");
+    expect(container.querySelector(".refine-review")).toBeNull();
+  });
+
+  it("keeps the original when the user dismisses the rewrite", async () => {
+    const refinePrompt = vi.fn(async () => "rewritten");
+    const onApply = vi.fn();
+    render(<RefinePromptControl prompt="dog" guidePath="" modelId="z" workflow="image" refinePrompt={refinePrompt} onApply={onApply} />);
+
+    await act(async () => {
+      refineButton(container).click();
+    });
+    await settle();
+
+    await act(async () => {
+      buttonByText(container, "Keep original").click();
+    });
+    expect(onApply).not.toHaveBeenCalled();
+    expect(container.querySelector(".refine-review")).toBeNull();
+  });
+
+  it("surfaces a failure message and does not apply", async () => {
+    const refinePrompt = vi.fn(async () => {
+      throw new Error("Prompt refinement runtime is not configured.");
+    });
+    const onApply = vi.fn();
+    render(<RefinePromptControl prompt="dog" guidePath="" modelId="z" workflow="image" refinePrompt={refinePrompt} onApply={onApply} />);
+
+    await act(async () => {
+      refineButton(container).click();
+    });
+    await settle();
+
+    expect(container.querySelector(".refine-error").textContent).toContain("not configured");
+    expect(onApply).not.toHaveBeenCalled();
+    expect(container.querySelector(".refine-review")).toBeNull();
+  });
+
+  it("still refines (generically) when the guide cannot be fetched", async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 404, text: async () => "" }));
+    const refinePrompt = vi.fn(async () => "rewritten");
+    render(
+      <RefinePromptControl prompt="dog" guidePath="/prompt-guides/missing.md" modelId="z" workflow="video" refinePrompt={refinePrompt} onApply={vi.fn()} />,
+    );
+
+    await act(async () => {
+      refineButton(container).click();
+    });
+    await settle();
+
+    expect(refinePrompt).toHaveBeenCalledWith({ prompt: "dog", modelId: "z", workflow: "video", guide: "" });
+    expect(container.querySelector(".refine-review-text").textContent).toBe("rewritten");
+  });
+});

--- a/apps/web/src/components/RefinePromptControl.jsx
+++ b/apps/web/src/components/RefinePromptControl.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import { Icon } from "./Icons.jsx";
+
+// "Refine my prompt" affordance shared by Image and Video Studio (sc-2041).
+// Sends the current prompt + the selected model's guide to the refinement worker
+// (via the context `refinePrompt`), then shows the rewrite for review. The
+// original prompt is never changed until the user clicks Apply.
+export function RefinePromptControl({ prompt, guidePath, modelId, workflow, refinePrompt, onApply }) {
+  const [status, setStatus] = useState("idle"); // idle | loading | review | error
+  const [refined, setRefined] = useState("");
+  const [error, setError] = useState("");
+
+  const trimmed = (prompt ?? "").trim();
+  const busy = status === "loading";
+  const disabled = busy || !trimmed || typeof refinePrompt !== "function";
+
+  async function handleRefine() {
+    setStatus("loading");
+    setError("");
+    try {
+      // The guide is first-party context for the rewrite; fetch it best-effort and
+      // refine generically if it can't be loaded.
+      let guide = "";
+      if (guidePath) {
+        try {
+          const response = await fetch(guidePath);
+          if (response.ok) guide = await response.text();
+        } catch {
+          guide = "";
+        }
+      }
+      const result = await refinePrompt({ prompt: trimmed, modelId, workflow, guide });
+      setRefined(result);
+      setStatus("review");
+    } catch (err) {
+      setError(err?.message || "Prompt refinement failed.");
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div className="refine-control">
+      <button className="hero-link refine-button" disabled={disabled} onClick={handleRefine} type="button">
+        <Icon.Wand size={14} /> {busy ? "Refining…" : "Refine my prompt"}
+      </button>
+
+      {status === "error" ? (
+        <p className="refine-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {status === "review" ? (
+        <div className="refine-review">
+          <p className="refine-review-label">Suggested rewrite</p>
+          <p className="refine-review-text">{refined}</p>
+          <div className="refine-review-actions">
+            <button
+              className="secondary-action"
+              onClick={() => {
+                onApply(refined);
+                setStatus("idle");
+              }}
+              type="button"
+            >
+              Apply
+            </button>
+            <button className="secondary-action" onClick={() => setStatus("idle")} type="button">
+              Keep original
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -20,7 +20,13 @@ export const GPU_REQUIRED_JOB_TYPES = new Set([
 ]);
 
 // Utility job types that run on any worker (no GPU required).
-export const NON_GPU_JOB_TYPES = new Set(["model_download", "model_import", "model_convert", "lora_import"]);
+export const NON_GPU_JOB_TYPES = new Set([
+  "model_download",
+  "model_import",
+  "model_convert",
+  "lora_import",
+  "prompt_refine",
+]);
 
 // Terminal job statuses (no further progress expected).
 export const terminalStatuses = new Set(["completed", "failed", "canceled", "interrupted"]);

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -41,6 +41,7 @@ function withImageStudioContext(p) {
       assets: p.assets,
       characters: p.characters,
       createImageJob: p.createImageJob,
+      refinePrompt: p.refinePrompt,
       deleteAsset: p.deleteAsset,
       purgeAsset: p.purgeAsset,
       gpuOptions: p.gpuOptions,
@@ -7348,5 +7349,305 @@ describe("extractFamilies", () => {
   it("prefers top-level fields over manifest even with includeManifest", () => {
     const job = { families: ["top"], payload: { manifestEntry: { families: ["manifest"] } } };
     expect(extractFamilies(job, { includeManifest: true })).toEqual(["top"]);
+  });
+});
+
+describe("prompt guide popup (sc-1817)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    // Prompt guides are static assets fetched by path; echo the path back so
+    // each guide's rendered body is distinguishable in assertions.
+    global.fetch = vi.fn((url) => Promise.resolve({ ok: true, text: async () => `# Guide\n\nfetched ${url}` }));
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  const guideButton = () =>
+    [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === "Prompt guide");
+
+  it("opens the selected image model's guide without submitting the form", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "z_image_turbo",
+              name: "Z-Image",
+              type: "image",
+              capabilities: ["text_to_image"],
+              ui: { promptGuide: { title: "Z Guide", path: "/prompt-guides/z-image-turbo.md" } },
+            },
+            {
+              id: "qwen_image",
+              name: "Qwen",
+              type: "image",
+              capabilities: ["text_to_image"],
+              ui: { promptGuide: { title: "Qwen Guide", path: "/prompt-guides/qwen-image.md" } },
+            },
+          ],
+          latestAssets: [],
+          localJobs: [],
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+
+    await act(async () => {
+      guideButton().click();
+    });
+    await settle();
+
+    expect(container.querySelector("[role=dialog]")).not.toBeNull();
+    expect(container.querySelector("#prompt-guide-title").textContent).toBe("Z Guide");
+    expect(container.textContent).toContain("fetched /prompt-guides/z-image-turbo.md");
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+
+  it("renders the new model's guide after switching models", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "z_image_turbo",
+              name: "Z-Image",
+              type: "image",
+              capabilities: ["text_to_image"],
+              ui: { promptGuide: { title: "Z Guide", path: "/prompt-guides/z-image-turbo.md" } },
+            },
+            {
+              id: "qwen_image",
+              name: "Qwen",
+              type: "image",
+              capabilities: ["text_to_image"],
+              ui: { promptGuide: { title: "Qwen Guide", path: "/prompt-guides/qwen-image.md" } },
+            },
+          ],
+          latestAssets: [],
+          localJobs: [],
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+
+    await act(async () => {
+      guideButton().click();
+    });
+    await settle();
+    expect(container.querySelector("#prompt-guide-title").textContent).toBe("Z Guide");
+
+    await act(async () => {
+      container.querySelector(".modal-close").click();
+    });
+    await changeField(field(container, "Model"), "qwen_image");
+    await settle();
+
+    await act(async () => {
+      guideButton().click();
+    });
+    await settle();
+    expect(container.querySelector("#prompt-guide-title").textContent).toBe("Qwen Guide");
+    expect(container.textContent).toContain("fetched /prompt-guides/qwen-image.md");
+  });
+
+  it("falls back to the generic image guide when the model declares none", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob: () => {},
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [{ id: "z_image_turbo", name: "Z-Image", type: "image", capabilities: ["text_to_image"] }],
+          latestAssets: [],
+          localJobs: [],
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+
+    await act(async () => {
+      guideButton().click();
+    });
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledWith("/prompt-guides/generic-image.md");
+    expect(container.querySelector("#prompt-guide-title").textContent).toBe("Image Prompt Guide");
+  });
+
+  it("falls back to the generic video guide and does not submit the video form", async () => {
+    const createVideoJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            characters: [],
+            createPersonDetectionJob: () => {},
+            createPersonTrackJob: () => {},
+            createVideoJob,
+            deleteAsset: () => {},
+            gpuOptions: ["auto"],
+            latestVideoAssets: [],
+            loras: [],
+            setPreviewAsset: () => {},
+            personTracks: [],
+            purgeAsset: () => {},
+            presets: [],
+            rememberLocalGenerationJob: () => {},
+            requestedGpu: "auto",
+            selectedAsset: null,
+            setRequestedGpu: () => {},
+            updateAssetStatus: () => {},
+            videoModels: [
+              {
+                id: "ltx_2_3",
+                name: "LTX",
+                type: "video",
+                family: "ltx-video",
+                capabilities: ["text_to_video"],
+                defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+              },
+            ],
+          },
+          <VideoStudio />,
+        ),
+      );
+    });
+
+    await act(async () => {
+      guideButton().click();
+    });
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledWith("/prompt-guides/generic-video.md");
+    expect(container.querySelector("#prompt-guide-title").textContent).toBe("Video Prompt Guide");
+    expect(createVideoJob).not.toHaveBeenCalled();
+  });
+});
+
+describe("refine my prompt (sc-2041)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, text: async () => "# Guide\n\nWrite vividly." }));
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("refines the image prompt and applies it to the textarea on Apply", async () => {
+    const refinePrompt = vi.fn(async () => "A cinematic neon street at midnight, rain-slick.");
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob: () => {},
+          refinePrompt,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "z_image_turbo",
+              name: "Z-Image",
+              type: "image",
+              capabilities: ["text_to_image"],
+              ui: { promptGuide: { title: "Z Guide", path: "/prompt-guides/z-image-turbo.md" } },
+            },
+          ],
+          latestAssets: [],
+          localJobs: [],
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+
+    const refine = [...container.querySelectorAll("button")].find((button) => button.textContent.includes("Refine my prompt"));
+    await act(async () => {
+      refine.click();
+    });
+    await settle();
+
+    expect(refinePrompt).toHaveBeenCalledWith({
+      prompt: "A cinematic frame of a neon street at midnight",
+      modelId: "z_image_turbo",
+      workflow: "image",
+      guide: "# Guide\n\nWrite vividly.",
+    });
+    expect(container.querySelector(".refine-review-text").textContent).toBe("A cinematic neon street at midnight, rain-slick.");
+    // Original prompt unchanged until the user applies.
+    expect(container.querySelector(".prompt-input").value).toBe("A cinematic frame of a neon street at midnight");
+
+    const apply = [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === "Apply");
+    await act(async () => {
+      apply.click();
+    });
+    await settle();
+
+    expect(container.querySelector(".prompt-input").value).toBe("A cinematic neon street at midnight, rain-slick.");
+    expect(container.querySelector(".refine-review")).toBeNull();
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -4,6 +4,8 @@ import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
+import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
+import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 
 const PROMPT_SUGGESTION_POOL = [
   "Barista pouring espresso, morning light",
@@ -158,6 +160,7 @@ export function ImageStudio() {
     assets,
     characters,
     createImageJob,
+    refinePrompt,
     deleteAsset,
     purgeAsset,
     gpuOptions,
@@ -224,6 +227,7 @@ export function ImageStudio() {
   const [loraWeights, setLoraWeights] = useState(saved.loraWeights ?? {});
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
   const [submitting, setSubmitting] = useState(false);
+  const [guideOpen, setGuideOpen] = useState(false);
   const presetDefaultSnapshots = useRef({});
   const editImageAssets = useMemo(
     () => assets.filter((asset) => asset.type === "image" || asset.type === "frame"),
@@ -300,6 +304,12 @@ export function ImageStudio() {
     }
   }, [availableModels, model]);
   const selectedModel = imageModels.find((item) => item.id === model);
+  // Prompt guide for the selected model; fall back to the generic image guide
+  // when a model declares none, so the button is always useful (sc-1817).
+  const promptGuide = selectedModel?.ui?.promptGuide ?? {
+    title: "Image Prompt Guide",
+    path: "/prompt-guides/generic-image.md",
+  };
   // Reference-tuning hints declared by the model (ui.*). InstantID raises the
   // reference-strength default and exposes a second "Identity structure" slider
   // (controlnetConditioningScale); models without these keys (e.g. Kolors) keep the
@@ -645,11 +655,16 @@ export function ImageStudio() {
                 </button>
               ))}
             </div>
-            {onOpenPresets ? (
-              <button className="hero-link" onClick={onOpenPresets} type="button">
-                <Icon.Folder size={14} /> Saved presets
+            <div className="prompt-hero-links">
+              <button className="hero-link" onClick={() => setGuideOpen(true)} type="button">
+                <Icon.Book size={14} /> Prompt guide
               </button>
-            ) : null}
+              {onOpenPresets ? (
+                <button className="hero-link" onClick={onOpenPresets} type="button">
+                  <Icon.Folder size={14} /> Saved presets
+                </button>
+              ) : null}
+            </div>
           </div>
 
           <div className="prompt-input-row">
@@ -666,6 +681,15 @@ export function ImageStudio() {
               {submitting ? "Queueing…" : "Generate"}
             </button>
           </div>
+
+          <RefinePromptControl
+            guidePath={promptGuide.path}
+            modelId={model}
+            onApply={setPromptFromUser}
+            prompt={prompt}
+            refinePrompt={refinePrompt}
+            workflow="image"
+          />
 
           <div className="suggestion-row">
             <span className="suggestion-row-label">Try:</span>
@@ -1047,6 +1071,9 @@ export function ImageStudio() {
           </section>
         </div>
       </form>
+      {guideOpen ? (
+        <PromptGuideModal guide={promptGuide} modelName={selectedModel?.name} onClose={() => setGuideOpen(false)} />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -4,6 +4,8 @@ import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { JobProgressCard } from "../components/JobProgress.jsx";
+import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
+import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 
 const MOTIONS = [
   "static",
@@ -67,6 +69,7 @@ export function VideoStudio() {
     createPersonDetectionJob,
     createPersonTrackJob,
     createVideoJob,
+    refinePrompt,
     deleteAsset,
     purgeAsset,
     gpuOptions,
@@ -122,7 +125,14 @@ export function VideoStudio() {
   const [loraWeights, setLoraWeights] = useState(saved.loraWeights ?? {});
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
   const [model, setModel] = useState(saved.model ?? videoModels[0]?.id ?? ltxVideoModelId);
+  const [guideOpen, setGuideOpen] = useState(false);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
+  // Prompt guide for the selected model; fall back to the generic video guide
+  // when a model declares none, so the button is always useful (sc-1817).
+  const promptGuide = selectedModel?.ui?.promptGuide ?? {
+    title: "Video Prompt Guide",
+    path: "/prompt-guides/generic-video.md",
+  };
   const [duration, setDuration] = useState(saved.duration ?? selectedModel?.defaults?.duration ?? 6);
   const [resolution, setResolution] = useState(saved.resolution ?? selectedModel?.defaults?.resolution ?? "768x512");
   const [fps, setFps] = useState(saved.fps ?? selectedModel?.defaults?.fps ?? 25);
@@ -556,11 +566,16 @@ export function VideoStudio() {
                 </button>
               ))}
             </div>
-            {onOpenPresets ? (
-              <button className="hero-link" onClick={onOpenPresets} type="button">
-                <Icon.Folder size={14} /> Saved presets
+            <div className="prompt-hero-links">
+              <button className="hero-link" onClick={() => setGuideOpen(true)} type="button">
+                <Icon.Book size={14} /> Prompt guide
               </button>
-            ) : null}
+              {onOpenPresets ? (
+                <button className="hero-link" onClick={onOpenPresets} type="button">
+                  <Icon.Folder size={14} /> Saved presets
+                </button>
+              ) : null}
+            </div>
           </div>
 
           <div className="prompt-input-row">
@@ -581,6 +596,17 @@ export function VideoStudio() {
               {submitting ? "Queueing…" : renderLabel}
             </button>
           </div>
+
+          {promptless ? null : (
+            <RefinePromptControl
+              guidePath={promptGuide.path}
+              modelId={model}
+              onApply={setPrompt}
+              prompt={prompt}
+              refinePrompt={refinePrompt}
+              workflow="video"
+            />
+          )}
 
           <div className="motion-row">
             <span className="motion-row-label">Motion:</span>
@@ -1094,6 +1120,9 @@ export function VideoStudio() {
           </div>
         </div>
       </form>
+      {guideOpen ? (
+        <PromptGuideModal guide={promptGuide} modelName={selectedModel?.name} onClose={() => setGuideOpen(false)} />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1196,6 +1196,60 @@ label {
   flex-wrap: wrap;
 }
 
+.prompt-hero-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.refine-control {
+  display: grid;
+  gap: 8px;
+}
+
+.refine-button {
+  justify-self: start;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.refine-error {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--danger, #d14343);
+}
+
+.refine-review {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2, var(--surface));
+}
+
+.refine-review-label {
+  margin: 0;
+  font-size: 11.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.refine-review-text {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.refine-review-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .hero-link {
   display: inline-flex;
   align-items: center;
@@ -5240,6 +5294,135 @@ label {
 
 .modal-close {
   justify-self: end;
+}
+
+.prompt-guide-modal {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 14px;
+  width: min(760px, 96vw);
+  max-height: 90vh;
+  padding: 20px 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.prompt-guide-head {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.prompt-guide-head h2 {
+  margin: 2px 0 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.prompt-guide-body {
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.prompt-guide-status {
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.prompt-guide-sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  font-size: 12.5px;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.markdown-body {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  margin: 18px 0 8px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.markdown-body h1 {
+  font-size: 20px;
+}
+
+.markdown-body h2 {
+  font-size: 16.5px;
+}
+
+.markdown-body h3 {
+  font-size: 14.5px;
+  color: var(--text-muted);
+}
+
+.markdown-body > :first-child {
+  margin-top: 0;
+}
+
+.markdown-body p {
+  margin: 0 0 10px;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin: 0 0 10px;
+  padding-left: 22px;
+}
+
+.markdown-body li {
+  margin: 2px 0;
+}
+
+.markdown-body a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.markdown-body code {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12.5px;
+  padding: 1px 5px;
+  border-radius: var(--r-xs, 4px);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+}
+
+.markdown-body pre {
+  margin: 0 0 10px;
+  padding: 12px 14px;
+  overflow-x: auto;
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+}
+
+.markdown-body pre code {
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.markdown-body blockquote {
+  margin: 0 0 10px;
+  padding: 4px 0 4px 14px;
+  border-left: 3px solid var(--border-strong, var(--border));
+  color: var(--text-muted);
 }
 
 .asset-picker-modal {

--- a/apps/worker/scene_worker/prompt_refine.py
+++ b/apps/worker/scene_worker/prompt_refine.py
@@ -1,0 +1,133 @@
+"""Prompt refinement (sc-2041).
+
+Rewrites a user's prompt to follow the selected model's prompt guide, by calling
+an OpenAI-compatible ``/chat/completions`` endpoint (e.g. a local gemma GGUF
+served by Ollama / llama.cpp / LM Studio). This mirrors the calling approach of
+the vendored Lens ``PromptReasoner`` (``_vendor/lens/reasoner.py``), but injects
+the model's guide and the image/video workflow into the system prompt — which the
+reasoner's fixed, image-only system prompt cannot do — and keeps the refine path
+free of the reasoner's torch/diffusers import side effects.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+class PromptRefineError(RuntimeError):
+    """Base class for prompt-refinement failures."""
+
+
+class PromptRefineUnavailable(PromptRefineError):
+    """The refinement runtime is not configured or unreachable."""
+
+
+class PromptRefineTimeout(PromptRefineError):
+    """The refinement runtime did not respond in time."""
+
+
+class PromptRefineMalformed(PromptRefineError):
+    """The runtime returned an empty or unusable response."""
+
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+_BASE_RULES = """\
+You are a prompt rewriter for a generative {medium} model.
+Rewrite the user's input into a single, precise {medium} prompt that follows the model's prompt guide below.
+
+Rules:
+- Output exactly one rewritten prompt and nothing else — no explanations, reasoning, commentary, options, or labels.
+- Preserve the user's intent: do not change the subjects, attributes, actions, relationships, or core setting they described. You may add concrete details only when they make the {medium} more coherent and stay consistent with the user's meaning.
+- If the user's prompt is already detailed and on-guide, make only minimal edits for fluency.
+- Follow the guide's recommended structure, phrasing, and what-to-avoid guidance.
+- Match the user's language: if their prompt is not in English, respond in the same language.
+- Do not wrap the output in quotes, markdown, JSON, or code fences unless those are part of the described scene."""
+
+
+def build_system_prompt(guide: Optional[str], workflow: Optional[str]) -> str:
+    medium = "video" if (workflow or "").strip().lower() == "video" else "image"
+    rules = _BASE_RULES.format(medium=medium)
+    guide = (guide or "").strip()
+    if guide:
+        return f"{rules}\n\n# Model prompt guide\n\n{guide}"
+    return rules
+
+
+def clean_output(text: str) -> str:
+    """Strip reasoning blocks and surrounding decoration from a model reply."""
+    text = (text or "").strip()
+    text = _THINK_BLOCK_RE.sub("", text).strip()
+    if "</think>" in text.lower():
+        text = re.split(r"</think>", text, flags=re.IGNORECASE)[-1].strip()
+    if text.startswith("```") and text.endswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 2:
+            text = "\n".join(lines[1:-1]).strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+        text = text[1:-1].strip()
+    return text
+
+
+def refine_prompt(
+    prompt: str,
+    *,
+    guide: Optional[str],
+    workflow: Optional[str],
+    base_url: str,
+    api_key: str,
+    model: str,
+    timeout: float = 60.0,
+    max_tokens: int = 1024,
+) -> str:
+    """Refine ``prompt`` via an OpenAI-compatible endpoint and return the rewrite.
+
+    Raises ``PromptRefineUnavailable`` when the runtime is unconfigured or cannot
+    be reached, ``PromptRefineTimeout`` on timeout, and ``PromptRefineMalformed``
+    when the response is empty.
+    """
+    prompt = (prompt or "").strip()
+    if not prompt:
+        raise PromptRefineMalformed("Prompt is empty.")
+    if not base_url or not model:
+        raise PromptRefineUnavailable(
+            "Prompt refinement runtime is not configured. Set PROMPT_REFINE_BASE_URL "
+            "and PROMPT_REFINE_MODEL (and optionally PROMPT_REFINE_API_KEY) to an "
+            "OpenAI-compatible endpoint."
+        )
+
+    try:
+        from openai import OpenAI
+        from openai import APIConnectionError, APITimeoutError
+    except ImportError as exc:  # pragma: no cover - import guard
+        raise PromptRefineUnavailable(
+            "The 'openai' package is not installed in the worker environment."
+        ) from exc
+
+    # Many local servers (Ollama, llama.cpp) ignore the key but the client
+    # requires a non-empty value, so fall back to a placeholder.
+    client = OpenAI(api_key=api_key or "not-needed", base_url=base_url, timeout=timeout)
+    system_prompt = build_system_prompt(guide, workflow)
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=max_tokens,
+        )
+    except APITimeoutError as exc:
+        raise PromptRefineTimeout("The refinement runtime timed out.") from exc
+    except APIConnectionError as exc:
+        raise PromptRefineUnavailable(
+            f"Could not reach the refinement runtime at {base_url}."
+        ) from exc
+
+    choices = getattr(response, "choices", None) or []
+    raw = (choices[0].message.content if choices else "") or ""
+    refined = clean_output(raw)
+    if not refined:
+        raise PromptRefineMalformed("The refinement runtime returned an empty prompt.")
+    return refined

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -40,6 +40,7 @@ from .person_adapters import (
     segmenter_backend_available,
     tracker_backend_available,
 )
+from .prompt_refine import PromptRefineError, refine_prompt
 from .settings import WorkerSettings
 from .training_adapters import (
     SUPPORTED_TRAINING_PLAN_VERSION,
@@ -86,6 +87,13 @@ VQA_JOB_TYPES = ("image_vqa",)
 # replaced. Keep in sync with contracts.rs::JobType/WorkerCapability,
 # jobs_store::job_requires_gpu, and QueueScreen gpuRequiredJobTypes.
 INTERLEAVE_JOB_TYPES = ("image_interleave",)
+# Prompt refinement (sc-2041): a lightweight, non-GPU job that rewrites a user's
+# prompt via an OpenAI-compatible endpoint. Advertised by every Python worker
+# (it needs no inference backend), so the Rust utility worker — which lacks the
+# capability — never claims it. Keep in sync with
+# crates/sceneworks-core/src/contracts.rs::JobType/WorkerCapability and
+# jobs_store::NON_GPU_JOB_TYPES.
+PROMPT_REFINE_JOB_TYPES = ("prompt_refine",)
 # Every runtime-dispatchable job-type group, in a stable order, for the
 # ``--check`` diagnostic. Derived from the groups above so run_check can't drift
 # out of sync and underreport readiness (sc-1635: VQA + interleave were
@@ -99,6 +107,7 @@ ALL_JOB_TYPES = (
     + CAPTION_JOB_TYPES
     + VQA_JOB_TYPES
     + INTERLEAVE_JOB_TYPES
+    + PROMPT_REFINE_JOB_TYPES
 )
 
 
@@ -127,6 +136,12 @@ class ApiClient:
 def worker_capabilities(gpu: dict) -> list[str]:
     gpu_capabilities = set(gpu["capabilities"])
     capabilities = set(gpu["capabilities"]) - {"placeholder"}
+    # Prompt refinement needs only an OpenAI-compatible endpoint (no inference
+    # backend), so every Python worker advertises it. When the endpoint is
+    # unconfigured the job is still claimed and fails fast with a clear message,
+    # rather than sitting queued forever. The Rust utility worker never advertises
+    # this, so it never claims a refine job.
+    capabilities |= set(PROMPT_REFINE_JOB_TYPES)
     is_gpu_worker = "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities
     if is_gpu_worker:
         # Dry-run plan validation needs no inference backend, so a GPU worker can
@@ -1246,6 +1261,59 @@ def run_training_caption_worker_job(api: ApiClient, settings: WorkerSettings, jo
             restart_worker_after_oom(settings, job_id)
 
 
+def run_prompt_refine_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    job_id = job["id"]
+    payload = job.get("payload") or {}
+    prompt = (payload.get("prompt") or "").strip()
+    try:
+        heartbeat(api, settings, "busy", job_id)
+        update_job(
+            api,
+            job_id,
+            {"status": "running", "stage": "running", "progress": 0.2, "message": "Refining prompt…"},
+        )
+        refined = refine_prompt(
+            prompt,
+            guide=payload.get("guide"),
+            workflow=payload.get("workflow"),
+            base_url=settings.prompt_refine_base_url,
+            api_key=settings.prompt_refine_api_key,
+            model=settings.prompt_refine_model,
+            timeout=settings.prompt_refine_timeout_seconds,
+            max_tokens=settings.prompt_refine_max_tokens,
+        )
+        update_job(
+            api,
+            job_id,
+            {
+                "status": "completed",
+                "stage": "completed",
+                "progress": 1,
+                "message": "Prompt refined.",
+                "result": {"originalPrompt": prompt, "refinedPrompt": refined},
+            },
+        )
+    except InterruptedError as exc:
+        update_job(api, job_id, {"status": "canceled", "stage": "canceled", "progress": 1, "message": str(exc)})
+    except PromptRefineError as exc:
+        # Expected, user-facing failures (runtime unconfigured/unreachable, timeout,
+        # empty response) carry a clear message already.
+        update_job(
+            api,
+            job_id,
+            {"status": "failed", "stage": "failed", "progress": 1, "message": str(exc), "error": str(exc)},
+        )
+    except Exception as exc:
+        message, error = friendly_failure("Prompt refinement", exc)
+        update_job(
+            api,
+            job_id,
+            {"status": "failed", "stage": "failed", "progress": 1, "message": message, "error": error},
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def run_worker_loop(settings: WorkerSettings) -> None:
     gpu = discover_gpu(settings.gpu_id)
     api = ApiClient(settings)
@@ -1310,6 +1378,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
                 run_lora_train_job(api, settings, job)
             elif job["type"] in CAPTION_JOB_TYPES:
                 run_training_caption_worker_job(api, settings, job)
+            elif job["type"] in PROMPT_REFINE_JOB_TYPES:
+                run_prompt_refine_job(api, settings, job)
             else:
                 update_job(
                     api,

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -28,6 +28,15 @@ class WorkerSettings:
         # fraction of the card's own capacity so a smaller card isn't blocked forever
         # (see should_skip_claim_low_vram). 0 disables the gate. CPU/MPS are never gated.
         self.min_free_vram_mb = int(os.getenv("SCENEWORKS_MIN_FREE_VRAM_MB", "24000"))
+        # Prompt refinement (sc-2041) calls an OpenAI-compatible chat-completions
+        # endpoint (e.g. a local gemma GGUF served by Ollama/llama.cpp/LM Studio).
+        # Left blank by default; when base_url+model are unset the refine job fails
+        # fast with a clear "runtime not configured" message instead of sitting queued.
+        self.prompt_refine_base_url = os.getenv("PROMPT_REFINE_BASE_URL", "").strip()
+        self.prompt_refine_api_key = os.getenv("PROMPT_REFINE_API_KEY", "").strip()
+        self.prompt_refine_model = os.getenv("PROMPT_REFINE_MODEL", "").strip()
+        self.prompt_refine_timeout_seconds = float(os.getenv("PROMPT_REFINE_TIMEOUT_SECONDS", "60"))
+        self.prompt_refine_max_tokens = int(os.getenv("PROMPT_REFINE_MAX_TOKENS", "1024"))
 
     def for_worker(self, *, worker_id: str, gpu_id: str) -> "WorkerSettings":
         settings = object.__new__(WorkerSettings)
@@ -41,4 +50,9 @@ class WorkerSettings:
         settings.poll_seconds = self.poll_seconds
         settings.min_free_vram_mb = self.min_free_vram_mb
         settings.force_cancel_seconds = self.force_cancel_seconds
+        settings.prompt_refine_base_url = self.prompt_refine_base_url
+        settings.prompt_refine_api_key = self.prompt_refine_api_key
+        settings.prompt_refine_model = self.prompt_refine_model
+        settings.prompt_refine_timeout_seconds = self.prompt_refine_timeout_seconds
+        settings.prompt_refine_max_tokens = self.prompt_refine_max_tokens
         return settings

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -207,6 +207,7 @@ string_enum! {
         LoraImport => "lora_import",
         LoraTrain => "lora_train",
         TrainingCaption => "training_caption",
+        PromptRefine => "prompt_refine",
     }
 }
 
@@ -302,6 +303,11 @@ string_enum! {
         // so a real run only routes to a worker that can actually train. See
         // jobs_store::worker_supports_job and apps/worker/scene_worker/runtime.py.
         LoraTrainExecute => "lora_train_execute",
+        // Prompt refinement (LLM rewrite of a user prompt). A lightweight, non-GPU
+        // job advertised by the Python worker (it only needs an OpenAI-compatible
+        // endpoint, not an inference backend); the Rust utility worker never emits
+        // it. See jobs_store::NON_GPU_JOB_TYPES and apps/worker/scene_worker/runtime.py.
+        PromptRefine => "prompt_refine",
     }
 }
 

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -39,6 +39,7 @@ pub const NON_GPU_JOB_TYPES: &[&str] = &[
     "model_import",
     "model_convert",
     "lora_import",
+    "prompt_refine",
 ];
 pub const MAX_JOB_ATTEMPTS: u32 = 5;
 

--- a/tests/fixtures/rust_migration_contracts/api_surface.json
+++ b/tests/fixtures/rust_migration_contracts/api_surface.json
@@ -26,6 +26,7 @@
     { "family": "image", "path": "/api/v1/image/jobs", "methods": ["POST"], "usedBy": ["web"] },
     { "family": "image", "path": "/api/v1/image/vqa/jobs", "methods": ["POST"], "usedBy": ["web"] },
     { "family": "image", "path": "/api/v1/image/interleave/jobs", "methods": ["POST"], "usedBy": ["web"] },
+    { "family": "prompts", "path": "/api/v1/prompts/refine", "methods": ["POST"], "usedBy": ["web"] },
     { "family": "jobs", "path": "/api/v1/jobs", "methods": ["GET", "POST"], "usedBy": ["web", "worker"] },
     { "family": "jobs", "path": "/api/v1/jobs/claim", "methods": ["POST"], "usedBy": ["worker"] },
     { "family": "jobs", "path": "/api/v1/jobs/events", "methods": ["GET"], "usedBy": ["web"] },

--- a/tests/fixtures/rust_migration_contracts/job_protocol.json
+++ b/tests/fixtures/rust_migration_contracts/job_protocol.json
@@ -33,7 +33,7 @@
   ],
   "activeStatuses": ["preparing", "downloading", "loading_model", "running", "saving"],
   "terminalStatuses": ["completed", "failed", "canceled", "interrupted"],
-  "nonGpuJobTypes": ["model_download", "model_import", "model_convert", "lora_import"],
+  "nonGpuJobTypes": ["model_download", "model_import", "model_convert", "lora_import", "prompt_refine"],
   "workerStatuses": ["idle", "busy", "offline"],
   "progressStages": [
     "queued",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -86,8 +86,16 @@ from scene_worker.runtime import (
     resolve_loaded_models,
     run_check,
     run_lora_train_job,
+    run_prompt_refine_job,
     run_video_job,
     worker_capabilities,
+)
+from scene_worker.prompt_refine import (
+    PromptRefineMalformed,
+    PromptRefineUnavailable,
+    build_system_prompt,
+    clean_output,
+    refine_prompt,
 )
 from scene_worker.training_adapters import (
     SUPPORTED_LR_SCHEDULERS,
@@ -203,7 +211,8 @@ class FakePeftBackendErrorPipe:
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
 
-    assert capabilities == ["cpu"]
+    # prompt_refine is non-GPU and advertised by every Python worker (sc-2041).
+    assert capabilities == ["cpu", "prompt_refine"]
     assert "placeholder" not in capabilities
 
 
@@ -224,8 +233,9 @@ def test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs(monkeypatc
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu", "nvidia"]})
 
     # lora_train dry-run validation needs no inference backend, so it is
-    # advertised even without torch; generation job types are not.
-    assert capabilities == ["gpu", "lora_train", "nvidia"]
+    # advertised even without torch; generation job types are not. prompt_refine
+    # also needs no inference backend (sc-2041).
+    assert capabilities == ["gpu", "lora_train", "nvidia", "prompt_refine"]
     for job_type in ("image_generate", "image_edit", "image_vqa", "video_generate", "training_caption"):
         assert job_type not in capabilities
 
@@ -256,6 +266,7 @@ def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
         "lora_train",
         "lora_train_execute",
         "person_replace",
+        "prompt_refine",
         "training_caption",
         "video_bridge",
         "video_extend",
@@ -279,7 +290,7 @@ def test_gpu_worker_advertises_lora_train_execute_only_with_inference_backend(mo
 def test_python_cpu_worker_does_not_advertise_person_tracking_jobs():
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
 
-    assert capabilities == ["cpu"]
+    assert capabilities == ["cpu", "prompt_refine"]
 
 
 def test_gpu_worker_advertises_real_person_jobs_when_backends_installed(monkeypatch):
@@ -307,7 +318,7 @@ def test_cpu_worker_never_advertises_real_person_jobs_even_with_backends(monkeyp
     monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: True)
     monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: True)
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
-    assert capabilities == ["cpu"]
+    assert capabilities == ["cpu", "prompt_refine"]
 
 
 def test_python_cpu_child_disables_cuda():
@@ -2777,6 +2788,8 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         # must report them too.
         "image_vqa",
         "image_interleave",
+        # sc-2041: prompt refinement is dispatched on every Python worker.
+        "prompt_refine",
     ]
     assert events[0]["supportedJobTypes"] == events[0]["jobTypes"]
 
@@ -7267,3 +7280,133 @@ def test_repo_slug_functions_match_cross_language_contract():
         repo = case["repo"]
         assert safe_download_dir(repo) == case["safeDownloadDir"], f"safe_download_dir drift for {repo!r}"
         assert safe_repo_dir_name(repo) == case["safeRepoDirName"], f"safe_repo_dir_name drift for {repo!r}"
+
+
+# ---- Prompt refinement (sc-2041) ----
+
+
+def _refine_settings(**overrides):
+    base = {
+        "worker_id": "worker-1",
+        "gpu_id": "cpu",
+        "prompt_refine_base_url": "http://localhost:11434/v1",
+        "prompt_refine_api_key": "",
+        "prompt_refine_model": "gemma-heretic",
+        "prompt_refine_timeout_seconds": 60.0,
+        "prompt_refine_max_tokens": 1024,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _install_fake_openai(monkeypatch, *, content=None, raises=None):
+    module = ModuleType("openai")
+
+    class APITimeoutError(Exception):
+        pass
+
+    class APIConnectionError(Exception):
+        pass
+
+    captured = {}
+
+    class _OpenAI:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+
+            def create(**call_kwargs):
+                captured["call"] = call_kwargs
+                if raises is not None:
+                    raise raises
+                message = SimpleNamespace(content=content)
+                return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+
+    module.OpenAI = _OpenAI
+    module.APITimeoutError = APITimeoutError
+    module.APIConnectionError = APIConnectionError
+    monkeypatch.setitem(sys.modules, "openai", module)
+    return captured, APITimeoutError, APIConnectionError
+
+
+def test_build_system_prompt_uses_workflow_medium_and_embeds_guide():
+    image = build_system_prompt("# Z-Image Guide\n\nUse short prompts.", "image")
+    assert "generative image model" in image
+    assert "Z-Image Guide" in image
+
+    video = build_system_prompt(None, "video")
+    assert "generative video model" in video
+    assert "# Model prompt guide" not in video
+
+
+def test_clean_output_strips_reasoning_and_quoting():
+    assert clean_output("<think>plan</think>A vivid sunset over hills.") == "A vivid sunset over hills."
+    assert clean_output('"A vivid sunset over hills."') == "A vivid sunset over hills."
+    assert clean_output("```\nA vivid sunset over hills.\n```") == "A vivid sunset over hills."
+
+
+def test_refine_prompt_raises_when_runtime_unconfigured():
+    with pytest.raises(PromptRefineUnavailable):
+        refine_prompt("a dog", guide=None, workflow="image", base_url="", api_key="", model="")
+
+
+def test_refine_prompt_success_calls_endpoint(monkeypatch):
+    captured, _, _ = _install_fake_openai(monkeypatch, content="A golden retriever in a sunlit park.")
+    out = refine_prompt(
+        "dog in park",
+        guide="# Guide",
+        workflow="image",
+        base_url="http://localhost:11434/v1",
+        api_key="",
+        model="gemma-heretic",
+    )
+    assert out == "A golden retriever in a sunlit park."
+    # Placeholder key supplied when none configured; model + system prompt forwarded.
+    assert captured["init"]["api_key"] == "not-needed"
+    assert captured["call"]["model"] == "gemma-heretic"
+    assert captured["call"]["messages"][0]["role"] == "system"
+
+
+def test_refine_prompt_raises_malformed_on_empty_response(monkeypatch):
+    _install_fake_openai(monkeypatch, content="   ")
+    with pytest.raises(PromptRefineMalformed):
+        refine_prompt(
+            "dog",
+            guide=None,
+            workflow="image",
+            base_url="http://localhost:11434/v1",
+            api_key="",
+            model="gemma-heretic",
+        )
+
+
+def test_run_prompt_refine_job_writes_refined_result(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    monkeypatch.setattr("scene_worker.runtime.refine_prompt", lambda prompt, **kwargs: "Refined: " + prompt)
+    api = _DryRunApi()
+    job = {"id": "job-refine-1", "type": "prompt_refine", "payload": {"prompt": "dog in park", "workflow": "image"}}
+
+    run_prompt_refine_job(api, _refine_settings(), job)
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "completed"
+    assert terminal["result"]["refinedPrompt"] == "Refined: dog in park"
+    assert terminal["result"]["originalPrompt"] == "dog in park"
+
+
+def test_run_prompt_refine_job_reports_runtime_failure(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+
+    def _boom(prompt, **kwargs):
+        raise PromptRefineUnavailable("Prompt refinement runtime is not configured.")
+
+    monkeypatch.setattr("scene_worker.runtime.refine_prompt", _boom)
+    api = _DryRunApi()
+    job = {"id": "job-refine-2", "type": "prompt_refine", "payload": {"prompt": "dog", "workflow": "image"}}
+
+    run_prompt_refine_job(api, _refine_settings(prompt_refine_base_url="", prompt_refine_model=""), job)
+
+    terminal = api.progress[-1]
+    assert terminal["status"] == "failed"
+    assert "not configured" in terminal["message"]


### PR DESCRIPTION
## Summary

Completes the remaining prompt-related stories in [epic 1323](https://app.shortcut.com/trefry/epic/1323).

**Prompt-guide popup** (sc-1817 / sc-1818 / sc-1819)
- A `Prompt guide` button in Image Studio and Video Studio opens a modal that renders the currently-selected model's Markdown guide.
- New dependency-free, XSS-safe `Markdown` renderer (the web app deliberately ships only react/react-dom, so no new npm deps); uses the shared `Modal` (Escape/backdrop/Close, focus management). The button is `type="button"` and never submits the form.
- Models without `ui.promptGuide` fall back to a generic image/video guide.
- Guide content already existed for every model and met the bar; the only content fix was adding a missing "Avoid" section to the SenseNova-U1 8B guide.

**Refine My Prompt** (sc-2040 decision / sc-2041)
- New non-GPU `prompt_refine` worker job rewrites the user's prompt to follow the selected model's guide by calling an OpenAI-compatible `/chat/completions` endpoint (default: a small local model such as `llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic` GGUF, configured via `PROMPT_REFINE_*` env).
- Rust API enqueues it (`POST /api/v1/prompts/refine`); the Python worker runs it with a guide+workflow-aware system prompt (reusing the vendored Lens reasoner's calling approach) and advertises the capability so the Rust utility worker never claims it.
- The composer shows the rewrite for review; the original prompt is never overwritten until the user clicks **Apply**. Loading / success / empty / timeout / unavailable-runtime / missing-guide are all surfaced.

## Why
The user asked to "knock out the rest of the prompt-related stories" in epic 1323. sc-2040 documents the runtime decision (Python worker job over a synchronous Rust call) on the story.

## Notes for reviewers
- Adding `prompt_refine` to the shared `JobType` / `WorkerCapability` enums is additive — the `string_enum!` macro makes them `#[non_exhaustive]` with an `Unknown` arm, so no match breaks. It's added to `NON_GPU_JOB_TYPES` so it runs on the CPU lane and never blocks the GPU queue.
- The non-GPU "utility" lane is the **Rust** worker; `PromptReasoner` is Python, so `prompt_refine` runs in the Python `scene_worker` (always present locally) and only it advertises the capability.
- `job_protocol.json` / `api_surface.json` updated for documentation accuracy (not test-enforced).

## Test plan
- [x] Web: 167 vitest pass (Markdown render, unsafe-link dropping, guide modal + model-switch + fallback + no-submit, refine control states + apply-to-textarea)
- [x] Worker: 310 pytest pass (refine module success/unavailable/malformed, handler success/failure, updated capability/check assertions)
- [x] Rust: 28 core tests (routing), `cargo fmt --check`, `cargo build -p sceneworks-rust-api --features embed-web`
- [x] Scaffold check + Vite build clean
- [ ] **sc-2042**: live multi-model refinement QA — requires a configured endpoint (local gemma server) on a machine with the worker running; not runnable in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)