### PR TITLE
Character Studio angle-set UX fixes (button, live progress, layout) [sc-2050]

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2116,6 +2116,8 @@ describe("SceneWorks app shell", () => {
       createCharacterTestJob: () => {},
       createImageJob,
       importAsset: vi.fn(),
+      imageLocalJobs: [],
+      rememberLocalGenerationJob: vi.fn(),
       deleteAsset: () => {},
       deleteCharacterLook: () => {},
       detachCharacterLora: () => {},
@@ -2156,16 +2158,19 @@ describe("SceneWorks app shell", () => {
       generateButton.click();
     });
 
-    // One batch job: character_image to the InstantID model with advanced.angleSet.
+    // One batch job with a valid count (worker expands to all pack angles) +
+    // advanced.angleSet; the job is tracked for live in-panel progress.
     expect(createImageJob).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: "character_image",
         model: "instantid_realvisxl",
         characterId: "char-1",
         referenceAssetId: "ref-1",
+        count: 1,
         advanced: expect.objectContaining({ angleSet: true, ipAdapterScale: 0.8 }),
       }),
     );
+    expect(baseContext.rememberLocalGenerationJob).toHaveBeenCalledWith("image", { id: "job-angle" });
   });
 
   it("launches reference-based generation from an approved character reference", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -345,6 +345,15 @@ export function CharacterStudio() {
               updateCharacterReference={updateCharacterReference}
             />
 
+            <CharacterAngleSet
+              addCharacterReference={addCharacterReference}
+              angleModel={angleModel}
+              approvedReferences={approvedReferences}
+              createImageJob={createImageJob}
+              importAsset={importAsset}
+              selectedCharacter={selectedCharacter}
+            />
+
             <CharacterLooks
               approvedReferences={approvedReferences}
               createCharacterLook={createCharacterLook}
@@ -392,15 +401,6 @@ export function CharacterStudio() {
               testPrompt={testPrompt}
               testResolution={testResolution}
               updateAssetStatus={updateAssetStatus}
-            />
-
-            <CharacterAngleSet
-              addCharacterReference={addCharacterReference}
-              angleModel={angleModel}
-              approvedReferences={approvedReferences}
-              createImageJob={createImageJob}
-              importAsset={importAsset}
-              selectedCharacter={selectedCharacter}
             />
           </section>
         </div>

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -40,6 +40,8 @@ export function CharacterStudio() {
     createCharacterTestJob,
     createImageJob,
     importAsset,
+    imageLocalJobs,
+    rememberLocalGenerationJob,
     deleteAsset,
     purgeAsset,
     imageModels,
@@ -350,7 +352,10 @@ export function CharacterStudio() {
               angleModel={angleModel}
               approvedReferences={approvedReferences}
               createImageJob={createImageJob}
+              imageLocalJobs={imageLocalJobs}
               importAsset={importAsset}
+              latestAssets={latestAssets}
+              rememberLocalGenerationJob={rememberLocalGenerationJob}
               selectedCharacter={selectedCharacter}
             />
 

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
+import { JobProgressCard } from "../components/JobProgress.jsx";
 import { extractFamilies } from "../presetUtils.js";
 
 export function editableLora(link) {
@@ -387,12 +388,16 @@ export function CharacterAngleSet({
   createImageJob,
   importAsset,
   addCharacterReference,
+  latestAssets = [],
+  imageLocalJobs = [],
+  rememberLocalGenerationJob,
 }) {
   const angleCount = angleModel?.ui?.viewAngles?.length ?? 0;
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
   const [status, setStatus] = React.useState("");
+  const [jobId, setJobId] = React.useState(null);
   const fileInputRef = React.useRef(null);
   const characterId = selectedCharacter?.id;
 
@@ -407,6 +412,15 @@ export function CharacterAngleSet({
   if (!angleModel || !selectedCharacter) {
     return null;
   }
+
+  // The just-launched batch job (live progress while it runs) + this character's
+  // images (they stream in as the worker writes each angle).
+  const activeJob = imageLocalJobs.find((job) => job.id === jobId);
+  const characterImages = (latestAssets ?? []).filter(
+    (asset) =>
+      asset.characterId === characterId ||
+      (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === characterId),
+  );
 
   async function onUpload(event) {
     const file = event.target.files?.[0];
@@ -439,12 +453,20 @@ export function CharacterAngleSet({
         referenceAssetId,
         prompt: prompt.trim(),
         negativePrompt: "plastic skin, airbrushed, cgi, 3d render, cartoon, anime, waxy, overprocessed, deformed, multiple people",
-        count: angleCount,
+        // angleSet makes the worker emit one image per pack angle regardless of count;
+        // count must satisfy the API's 1-8 guard, so send 1 (the worker overrides it).
+        count: 1,
         width: 1024,
         height: 1024,
         advanced: { angleSet: true, ipAdapterScale: 0.8 },
       });
-      setStatus(job ? `Generating ${angleCount} angles — they'll appear in your latest images shortly.` : "");
+      if (job?.id) {
+        rememberLocalGenerationJob?.("image", job);
+        setJobId(job.id);
+        setStatus("");
+      } else {
+        setStatus("Could not start the job — check the error banner.");
+      }
     } finally {
       setSubmitting(false);
     }
@@ -491,7 +513,15 @@ export function CharacterAngleSet({
         Prompt
         <textarea onChange={(event) => setPrompt(event.target.value)} rows={2} value={prompt} />
       </label>
-      {status ? <p className="inline-warning">{status}</p> : null}
+      {activeJob ? <JobProgressCard job={activeJob} label={`Angle set · ${angleCount} views`} /> : null}
+      {!activeJob && status ? <p className="inline-warning">{status}</p> : null}
+      {characterImages.length ? (
+        <div className="review-grid">
+          {characterImages.map((asset) => (
+            <AssetMedia asset={asset} controls={false} key={asset.id} />
+          ))}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -278,6 +278,15 @@ export function CharacterTest({
   testResolution,
   updateAssetStatus,
 }) {
+  const [showOutputs, setShowOutputs] = React.useState(false);
+  // Scope the outputs grid to THIS character (its generated images + approved
+  // references) instead of dumping every recent project image, and keep it
+  // collapsed by default so it never turns the studio into an endless scroll.
+  const characterAssets = (latestAssets ?? []).filter(
+    (asset) =>
+      asset.characterId === selectedCharacter.id ||
+      (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === selectedCharacter.id),
+  );
   return (
     <section className="character-section test-character-panel">
       <div className="section-heading">
@@ -333,26 +342,37 @@ export function CharacterTest({
           Test Character
         </button>
       </form>
-      <div className="review-grid">
-        {latestAssets.map((asset) => (
-          <div className="test-result" key={asset.id}>
-            <AssetCard
-              asset={asset}
-              deleteAsset={deleteAsset}
-              onPreview={onPreview}
-              purgeAsset={purgeAsset}
-              updateAssetStatus={updateAssetStatus}
-            />
-            <button
-              onClick={() => addCharacterReference(selectedCharacter.id, { assetId: asset.id, approved: true, role: "test-output" })}
-              type="button"
-            >
-              Approve as Reference
-            </button>
-          </div>
-        ))}
-        {latestAssets.length ? null : <div className="empty-panel compact-panel">No test outputs yet</div>}
+      <div className="review-panel-head">
+        <button className="advanced-toggle" onClick={() => setShowOutputs((value) => !value)} type="button">
+          {showOutputs ? "Hide" : "Show"} this character's images ({characterAssets.length})
+        </button>
       </div>
+      {showOutputs ? (
+        <div className="review-grid">
+          {characterAssets.map((asset) => (
+            <div className="test-result" key={asset.id}>
+              <AssetCard
+                asset={asset}
+                deleteAsset={deleteAsset}
+                onPreview={onPreview}
+                purgeAsset={purgeAsset}
+                updateAssetStatus={updateAssetStatus}
+              />
+              <button
+                onClick={() => addCharacterReference(selectedCharacter.id, { assetId: asset.id, approved: true, role: "test-output" })}
+                type="button"
+              >
+                Approve as Reference
+              </button>
+            </div>
+          ))}
+          {characterAssets.length ? null : (
+            <div className="empty-panel compact-panel">
+              No images for this character yet — generate an angle set or a test above.
+            </div>
+          )}
+        </div>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Fixes + UX polish for the Character Studio one-click angle set (follow-up to #297). Three commits:

1. **Fix: the "Generate angle set" button did nothing.** It sent `count: 11`, which the image-jobs API rejects (`count must be between 1 and 8`) → 400 → no job created (the error was swallowed into the banner). `advanced.angleSet` makes the worker emit all 11 pack angles regardless of `count`, so the panel now sends `count: 1`.
2. **Live in-panel progress + streaming results.** The panel now tracks the launched job (`rememberLocalGenerationJob`) and renders `JobProgressCard` (status / % / stage / elapsed) like the other studios, with this character's images streaming into a grid below as the worker writes each angle — instead of a static text hint.
3. **Layout cleanup.** Angle-set panel moved directly under References; the "Test Character" outputs grid is collapsed-by-default and scoped to this character instead of dumping the whole project library.

## Caveat / follow-up

The streaming results grid + scoped test grid filter on `asset.characterId` / `metadata.characterReferences`. Generated images carry `characterId` in the worker write, but the API may not persist it onto every asset record yet — so freshly generated angles reliably appear in the global latest-images, and in these scoped grids once `characterId` persistence is wired (a small worker→API follow-up; part of the epic-2019 asset-scoping work). The live progress card is unaffected.

## Test plan

- [x] 142 web tests pass (panel fires one batch job with valid count + advanced.angleSet, tracks it for progress); Vite build clean.
- [ ] CI green.
- [ ] Desktop E2E: pick/upload reference → Generate angle set → live progress → 11 angles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)