### PR TITLE
refactor(prompt): run prompt refinement as in-process local inference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,15 +108,9 @@ SCENEWORKS_VIDEO_ADAPTER=
 # where MPS is the sole accelerator (sc-1335).
 NVIDIA_VISIBLE_DEVICES=all
 
-# "Refine my prompt" (sc-2041): the prompt composer can rewrite a prompt to
-# follow the selected model's guide by calling an OpenAI-compatible
-# /chat/completions endpoint from the worker. Leave BASE_URL/MODEL blank to
-# disable (the refine job then fails fast with a clear message). The suggested
-# default is a small local model such as
-# llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic (GGUF) served by
-# Ollama / llama.cpp / LM Studio. Most local servers ignore the API key.
-PROMPT_REFINE_BASE_URL=
-PROMPT_REFINE_API_KEY=
+# "Refine my prompt" (sc-2041) loads a small instruction LLM in-process on the
+# worker (like JoyCaption captioning) and downloads it on demand via the HF
+# cache — no setup required. Optionally override the default model repo, or cap
+# the rewrite length.
 PROMPT_REFINE_MODEL=
-PROMPT_REFINE_TIMEOUT_SECONDS=60
-PROMPT_REFINE_MAX_TOKENS=1024
+PROMPT_REFINE_MAX_NEW_TOKENS=512

--- a/apps/worker/scene_worker/prompt_refine.py
+++ b/apps/worker/scene_worker/prompt_refine.py
@@ -1,18 +1,27 @@
 """Prompt refinement (sc-2041).
 
-Rewrites a user's prompt to follow the selected model's prompt guide, by calling
-an OpenAI-compatible ``/chat/completions`` endpoint (e.g. a local gemma GGUF
-served by Ollama / llama.cpp / LM Studio). This mirrors the calling approach of
-the vendored Lens ``PromptReasoner`` (``_vendor/lens/reasoner.py``), but injects
-the model's guide and the image/video workflow into the system prompt — which the
-reasoner's fixed, image-only system prompt cannot do — and keeps the refine path
-free of the reasoner's torch/diffusers import side effects.
+Rewrites a user's prompt to follow the selected model's prompt guide, using a
+small instruction LLM loaded **in-process** via transformers — the same shape as
+JoyCaption captioning (`caption_adapters.py`). The model downloads on demand via
+the HF cache on first use and runs on the worker's device (MPS on Apple Silicon),
+so there is no external API endpoint and no env setup for users.
 """
 
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import Any, Optional
+
+from .image_adapters import (
+    require_inference_backend_for_gpu_worker,
+    select_torch_device,
+    select_torch_dtype,
+)
+
+# Default refinement model: a small, uncensored instruction LLM suitable for
+# unrestricted creative prompt rewriting on modest local hardware. Overridable
+# via PROMPT_REFINE_MODEL. Downloaded on demand (HF cache), like JoyCaption.
+DEFAULT_REFINE_MODEL = "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic"
 
 
 class PromptRefineError(RuntimeError):
@@ -20,15 +29,11 @@ class PromptRefineError(RuntimeError):
 
 
 class PromptRefineUnavailable(PromptRefineError):
-    """The refinement runtime is not configured or unreachable."""
-
-
-class PromptRefineTimeout(PromptRefineError):
-    """The refinement runtime did not respond in time."""
+    """The refinement model/backend could not be loaded."""
 
 
 class PromptRefineMalformed(PromptRefineError):
-    """The runtime returned an empty or unusable response."""
+    """The model returned an empty or unusable rewrite."""
 
 
 _THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
@@ -70,64 +75,104 @@ def clean_output(text: str) -> str:
     return text
 
 
+class PromptRefiner:
+    """Loads a small instruction LLM in-process and rewrites prompts. Mirrors
+    `JoyCaptioner`: lazy `load()`, shared MPS-aware device/dtype helpers, and a
+    `model.generate` call."""
+
+    def __init__(self, *, model_name_or_path: str, gpu_id: str, max_new_tokens: int = 512) -> None:
+        self.model_name_or_path = model_name_or_path or DEFAULT_REFINE_MODEL
+        self.gpu_id = gpu_id
+        self.max_new_tokens = int(max_new_tokens)
+        self.model = None
+        self.tokenizer = None
+        self.torch = None
+        self.device = None
+        self.torch_dtype = None
+
+    def loaded_models(self) -> list[str]:
+        return [self.model_name_or_path] if self.model is not None else []
+
+    def load(self) -> None:
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise PromptRefineUnavailable(
+                "transformers/torch are not available in this worker environment."
+            ) from exc
+
+        try:
+            require_inference_backend_for_gpu_worker(torch, self.gpu_id)
+            self.torch = torch
+            self.device = select_torch_device(torch, self.gpu_id)
+            self.torch_dtype = select_torch_dtype(torch, self.device, None)
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path)
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.model_name_or_path,
+                torch_dtype=self.torch_dtype,
+            )
+            self.model.to(self.device)
+            self.model.eval()
+        except PromptRefineError:
+            raise
+        except Exception as exc:
+            raise PromptRefineUnavailable(
+                f"Could not load the prompt-refinement model '{self.model_name_or_path}': {exc}"
+            ) from exc
+
+    def refine(self, prompt: str, *, guide: Optional[str], workflow: Optional[str]) -> str:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise PromptRefineMalformed("Prompt is empty.")
+        if self.model is None or self.tokenizer is None:
+            self.load()
+
+        # Fold the instructions + guide into a single user turn. Some chat
+        # templates (e.g. Gemma) reject a system role, so this stays portable.
+        system_prompt = build_system_prompt(guide, workflow)
+        content = f"{system_prompt}\n\n# Prompt to rewrite\n\n{prompt}"
+        messages = [{"role": "user", "content": content}]
+        input_ids = self.tokenizer.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            return_tensors="pt",
+        ).to(self.device)
+
+        pad_token_id = self.tokenizer.pad_token_id
+        if pad_token_id is None:
+            pad_token_id = self.tokenizer.eos_token_id
+        with self.torch.no_grad():
+            generated = self.model.generate(
+                input_ids=input_ids,
+                max_new_tokens=self.max_new_tokens,
+                do_sample=True,
+                temperature=0.7,
+                top_p=0.9,
+                use_cache=True,
+                pad_token_id=pad_token_id,
+            )[0]
+        generated = generated[input_ids.shape[1] :]
+        text = self.tokenizer.decode(generated, skip_special_tokens=True).strip()
+        refined = clean_output(text)
+        if not refined:
+            raise PromptRefineMalformed("The refinement model returned an empty prompt.")
+        return refined
+
+
 def refine_prompt(
     prompt: str,
     *,
     guide: Optional[str],
     workflow: Optional[str],
-    base_url: str,
-    api_key: str,
-    model: str,
-    timeout: float = 60.0,
-    max_tokens: int = 1024,
+    gpu_id: str,
+    model: Optional[str] = None,
+    max_new_tokens: int = 512,
 ) -> str:
-    """Refine ``prompt`` via an OpenAI-compatible endpoint and return the rewrite.
-
-    Raises ``PromptRefineUnavailable`` when the runtime is unconfigured or cannot
-    be reached, ``PromptRefineTimeout`` on timeout, and ``PromptRefineMalformed``
-    when the response is empty.
-    """
-    prompt = (prompt or "").strip()
-    if not prompt:
-        raise PromptRefineMalformed("Prompt is empty.")
-    if not base_url or not model:
-        raise PromptRefineUnavailable(
-            "Prompt refinement runtime is not configured. Set PROMPT_REFINE_BASE_URL "
-            "and PROMPT_REFINE_MODEL (and optionally PROMPT_REFINE_API_KEY) to an "
-            "OpenAI-compatible endpoint."
-        )
-
-    try:
-        from openai import OpenAI
-        from openai import APIConnectionError, APITimeoutError
-    except ImportError as exc:  # pragma: no cover - import guard
-        raise PromptRefineUnavailable(
-            "The 'openai' package is not installed in the worker environment."
-        ) from exc
-
-    # Many local servers (Ollama, llama.cpp) ignore the key but the client
-    # requires a non-empty value, so fall back to a placeholder.
-    client = OpenAI(api_key=api_key or "not-needed", base_url=base_url, timeout=timeout)
-    system_prompt = build_system_prompt(guide, workflow)
-    try:
-        response = client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": prompt},
-            ],
-            max_tokens=max_tokens,
-        )
-    except APITimeoutError as exc:
-        raise PromptRefineTimeout("The refinement runtime timed out.") from exc
-    except APIConnectionError as exc:
-        raise PromptRefineUnavailable(
-            f"Could not reach the refinement runtime at {base_url}."
-        ) from exc
-
-    choices = getattr(response, "choices", None) or []
-    raw = (choices[0].message.content if choices else "") or ""
-    refined = clean_output(raw)
-    if not refined:
-        raise PromptRefineMalformed("The refinement runtime returned an empty prompt.")
-    return refined
+    """Convenience: load the model and refine a single prompt in one call."""
+    refiner = PromptRefiner(
+        model_name_or_path=model or DEFAULT_REFINE_MODEL,
+        gpu_id=gpu_id,
+        max_new_tokens=max_new_tokens,
+    )
+    return refiner.refine(prompt, guide=guide, workflow=workflow)

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -40,7 +40,7 @@ from .person_adapters import (
     segmenter_backend_available,
     tracker_backend_available,
 )
-from .prompt_refine import PromptRefineError, refine_prompt
+from .prompt_refine import PromptRefineError, PromptRefiner
 from .settings import WorkerSettings
 from .training_adapters import (
     SUPPORTED_TRAINING_PLAN_VERSION,
@@ -87,12 +87,11 @@ VQA_JOB_TYPES = ("image_vqa",)
 # replaced. Keep in sync with contracts.rs::JobType/WorkerCapability,
 # jobs_store::job_requires_gpu, and QueueScreen gpuRequiredJobTypes.
 INTERLEAVE_JOB_TYPES = ("image_interleave",)
-# Prompt refinement (sc-2041): a lightweight, non-GPU job that rewrites a user's
-# prompt via an OpenAI-compatible endpoint. Advertised by every Python worker
-# (it needs no inference backend), so the Rust utility worker — which lacks the
-# capability — never claims it. Keep in sync with
-# crates/sceneworks-core/src/contracts.rs::JobType/WorkerCapability and
-# jobs_store::NON_GPU_JOB_TYPES.
+# Prompt refinement (sc-2041): rewrites a user's prompt with a small instruction
+# LLM loaded in-process (like JoyCaption captioning). It needs the torch inference
+# backend, so it is advertised only by a backend-capable Python worker — the Rust
+# utility worker never claims it. Keep in sync with
+# crates/sceneworks-core/src/contracts.rs::JobType/WorkerCapability.
 PROMPT_REFINE_JOB_TYPES = ("prompt_refine",)
 # Every runtime-dispatchable job-type group, in a stable order, for the
 # ``--check`` diagnostic. Derived from the groups above so run_check can't drift
@@ -136,12 +135,6 @@ class ApiClient:
 def worker_capabilities(gpu: dict) -> list[str]:
     gpu_capabilities = set(gpu["capabilities"])
     capabilities = set(gpu["capabilities"]) - {"placeholder"}
-    # Prompt refinement needs only an OpenAI-compatible endpoint (no inference
-    # backend), so every Python worker advertises it. When the endpoint is
-    # unconfigured the job is still claimed and fails fast with a clear message,
-    # rather than sitting queued forever. The Rust utility worker never advertises
-    # this, so it never claims a refine job.
-    capabilities |= set(PROMPT_REFINE_JOB_TYPES)
     is_gpu_worker = "cpu" not in gpu_capabilities and "gpu" in gpu_capabilities
     if is_gpu_worker:
         # Dry-run plan validation needs no inference backend, so a GPU worker can
@@ -152,6 +145,9 @@ def worker_capabilities(gpu: dict) -> list[str]:
             capabilities |= set(CAPTION_JOB_TYPES)
             capabilities |= set(VQA_JOB_TYPES)
             capabilities |= set(INTERLEAVE_JOB_TYPES)
+            # Prompt refinement loads a small LLM in-process (like captioning), so
+            # it needs the inference backend and is advertised alongside it.
+            capabilities |= set(PROMPT_REFINE_JOB_TYPES)
             # Only a backend-capable worker advertises real training execution, so
             # the queue won't route a dryRun:false job to a worker that can't train.
             capabilities |= set(TRAINING_EXECUTE_CAPABILITIES)
@@ -1265,23 +1261,25 @@ def run_prompt_refine_job(api: ApiClient, settings: WorkerSettings, job: dict) -
     job_id = job["id"]
     payload = job.get("payload") or {}
     prompt = (payload.get("prompt") or "").strip()
+    refiner = PromptRefiner(
+        model_name_or_path=payload.get("model") or getattr(settings, "prompt_refine_model", "") or "",
+        gpu_id=getattr(settings, "gpu_id", "auto"),
+        max_new_tokens=getattr(settings, "prompt_refine_max_new_tokens", 512),
+    )
     try:
-        heartbeat(api, settings, "busy", job_id)
+        heartbeat_with_loaded_models(api, settings, "busy", job_id, refiner.loaded_models)
         update_job(
             api,
             job_id,
-            {"status": "running", "stage": "running", "progress": 0.2, "message": "Refining prompt…"},
+            {"status": "loading_model", "stage": "loading_model", "progress": 0.1, "message": "Loading refinement model."},
         )
-        refined = refine_prompt(
-            prompt,
-            guide=payload.get("guide"),
-            workflow=payload.get("workflow"),
-            base_url=settings.prompt_refine_base_url,
-            api_key=settings.prompt_refine_api_key,
-            model=settings.prompt_refine_model,
-            timeout=settings.prompt_refine_timeout_seconds,
-            max_tokens=settings.prompt_refine_max_tokens,
+        refiner.load()
+        update_job(
+            api,
+            job_id,
+            {"status": "running", "stage": "running", "progress": 0.4, "message": "Refining prompt…"},
         )
+        refined = refiner.refine(prompt, guide=payload.get("guide"), workflow=payload.get("workflow"))
         update_job(
             api,
             job_id,
@@ -1296,8 +1294,8 @@ def run_prompt_refine_job(api: ApiClient, settings: WorkerSettings, job: dict) -
     except InterruptedError as exc:
         update_job(api, job_id, {"status": "canceled", "stage": "canceled", "progress": 1, "message": str(exc)})
     except PromptRefineError as exc:
-        # Expected, user-facing failures (runtime unconfigured/unreachable, timeout,
-        # empty response) carry a clear message already.
+        # Expected, user-facing failures (model couldn't load, empty rewrite) carry
+        # a clear message already.
         update_job(
             api,
             job_id,

--- a/apps/worker/scene_worker/settings.py
+++ b/apps/worker/scene_worker/settings.py
@@ -28,15 +28,11 @@ class WorkerSettings:
         # fraction of the card's own capacity so a smaller card isn't blocked forever
         # (see should_skip_claim_low_vram). 0 disables the gate. CPU/MPS are never gated.
         self.min_free_vram_mb = int(os.getenv("SCENEWORKS_MIN_FREE_VRAM_MB", "24000"))
-        # Prompt refinement (sc-2041) calls an OpenAI-compatible chat-completions
-        # endpoint (e.g. a local gemma GGUF served by Ollama/llama.cpp/LM Studio).
-        # Left blank by default; when base_url+model are unset the refine job fails
-        # fast with a clear "runtime not configured" message instead of sitting queued.
-        self.prompt_refine_base_url = os.getenv("PROMPT_REFINE_BASE_URL", "").strip()
-        self.prompt_refine_api_key = os.getenv("PROMPT_REFINE_API_KEY", "").strip()
+        # Prompt refinement (sc-2041) loads a small instruction LLM in-process
+        # (like JoyCaption captioning) and runs it on the worker's device. Blank
+        # uses the default model; PROMPT_REFINE_MODEL overrides the HF repo id.
         self.prompt_refine_model = os.getenv("PROMPT_REFINE_MODEL", "").strip()
-        self.prompt_refine_timeout_seconds = float(os.getenv("PROMPT_REFINE_TIMEOUT_SECONDS", "60"))
-        self.prompt_refine_max_tokens = int(os.getenv("PROMPT_REFINE_MAX_TOKENS", "1024"))
+        self.prompt_refine_max_new_tokens = int(os.getenv("PROMPT_REFINE_MAX_NEW_TOKENS", "512"))
 
     def for_worker(self, *, worker_id: str, gpu_id: str) -> "WorkerSettings":
         settings = object.__new__(WorkerSettings)
@@ -50,9 +46,6 @@ class WorkerSettings:
         settings.poll_seconds = self.poll_seconds
         settings.min_free_vram_mb = self.min_free_vram_mb
         settings.force_cancel_seconds = self.force_cancel_seconds
-        settings.prompt_refine_base_url = self.prompt_refine_base_url
-        settings.prompt_refine_api_key = self.prompt_refine_api_key
         settings.prompt_refine_model = self.prompt_refine_model
-        settings.prompt_refine_timeout_seconds = self.prompt_refine_timeout_seconds
-        settings.prompt_refine_max_tokens = self.prompt_refine_max_tokens
+        settings.prompt_refine_max_new_tokens = self.prompt_refine_max_new_tokens
         return settings

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -39,7 +39,6 @@ pub const NON_GPU_JOB_TYPES: &[&str] = &[
     "model_import",
     "model_convert",
     "lora_import",
-    "prompt_refine",
 ];
 pub const MAX_JOB_ATTEMPTS: u32 = 5;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,10 @@ services:
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      # "Refine my prompt" (sc-2041) loads a small LLM in-process and downloads on
+      # demand — no setup needed. Optionally override the default model repo.
+      PROMPT_REFINE_MODEL: ${PROMPT_REFINE_MODEL:-}
+      PROMPT_REFINE_MAX_NEW_TOKENS: ${PROMPT_REFINE_MAX_NEW_TOKENS:-512}
       # expandable_segments reduces CUDA fragmentation OOM and is recommended by
       # the LTX stack alongside FP8, BUT it relies on the CUDA virtual-memory
       # (cuMem*) API, which is unsupported under Docker Desktop's WSL2/WDDM

--- a/tests/fixtures/rust_migration_contracts/job_protocol.json
+++ b/tests/fixtures/rust_migration_contracts/job_protocol.json
@@ -33,7 +33,7 @@
   ],
   "activeStatuses": ["preparing", "downloading", "loading_model", "running", "saving"],
   "terminalStatuses": ["completed", "failed", "canceled", "interrupted"],
-  "nonGpuJobTypes": ["model_download", "model_import", "model_convert", "lora_import", "prompt_refine"],
+  "nonGpuJobTypes": ["model_download", "model_import", "model_convert", "lora_import"],
   "workerStatuses": ["idle", "busy", "offline"],
   "progressStages": [
     "queued",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -91,11 +91,10 @@ from scene_worker.runtime import (
     worker_capabilities,
 )
 from scene_worker.prompt_refine import (
-    PromptRefineMalformed,
     PromptRefineUnavailable,
+    PromptRefiner,
     build_system_prompt,
     clean_output,
-    refine_prompt,
 )
 from scene_worker.training_adapters import (
     SUPPORTED_LR_SCHEDULERS,
@@ -211,8 +210,7 @@ class FakePeftBackendErrorPipe:
 def test_cpu_worker_does_not_advertise_gpu_generation_capabilities():
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
 
-    # prompt_refine is non-GPU and advertised by every Python worker (sc-2041).
-    assert capabilities == ["cpu", "prompt_refine"]
+    assert capabilities == ["cpu"]
     assert "placeholder" not in capabilities
 
 
@@ -233,10 +231,9 @@ def test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs(monkeypatc
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu", "nvidia"]})
 
     # lora_train dry-run validation needs no inference backend, so it is
-    # advertised even without torch; generation job types are not. prompt_refine
-    # also needs no inference backend (sc-2041).
-    assert capabilities == ["gpu", "lora_train", "nvidia", "prompt_refine"]
-    for job_type in ("image_generate", "image_edit", "image_vqa", "video_generate", "training_caption"):
+    # advertised even without torch; generation job types are not.
+    assert capabilities == ["gpu", "lora_train", "nvidia"]
+    for job_type in ("image_generate", "image_edit", "image_vqa", "video_generate", "training_caption", "prompt_refine"):
         assert job_type not in capabilities
 
 
@@ -290,7 +287,7 @@ def test_gpu_worker_advertises_lora_train_execute_only_with_inference_backend(mo
 def test_python_cpu_worker_does_not_advertise_person_tracking_jobs():
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
 
-    assert capabilities == ["cpu", "prompt_refine"]
+    assert capabilities == ["cpu"]
 
 
 def test_gpu_worker_advertises_real_person_jobs_when_backends_installed(monkeypatch):
@@ -318,7 +315,7 @@ def test_cpu_worker_never_advertises_real_person_jobs_even_with_backends(monkeyp
     monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: True)
     monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: True)
     capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
-    assert capabilities == ["cpu", "prompt_refine"]
+    assert capabilities == ["cpu"]
 
 
 def test_python_cpu_child_disables_cuda():
@@ -7289,45 +7286,33 @@ def _refine_settings(**overrides):
     base = {
         "worker_id": "worker-1",
         "gpu_id": "cpu",
-        "prompt_refine_base_url": "http://localhost:11434/v1",
-        "prompt_refine_api_key": "",
-        "prompt_refine_model": "gemma-heretic",
-        "prompt_refine_timeout_seconds": 60.0,
-        "prompt_refine_max_tokens": 1024,
+        "prompt_refine_model": "",
+        "prompt_refine_max_new_tokens": 512,
     }
     base.update(overrides)
     return SimpleNamespace(**base)
 
 
-def _install_fake_openai(monkeypatch, *, content=None, raises=None):
-    module = ModuleType("openai")
+class _FakeRefiner:
+    """Stands in for PromptRefiner in handler tests — no torch/transformers."""
 
-    class APITimeoutError(Exception):
-        pass
+    instances = []
 
-    class APIConnectionError(Exception):
-        pass
+    def __init__(self, *, model_name_or_path, gpu_id, max_new_tokens):
+        self.model_name_or_path = model_name_or_path
+        self.gpu_id = gpu_id
+        self.max_new_tokens = max_new_tokens
+        self.loaded = False
+        _FakeRefiner.instances.append(self)
 
-    captured = {}
+    def loaded_models(self):
+        return [self.model_name_or_path] if self.loaded and self.model_name_or_path else []
 
-    class _OpenAI:
-        def __init__(self, **kwargs):
-            captured["init"] = kwargs
+    def load(self):
+        self.loaded = True
 
-            def create(**call_kwargs):
-                captured["call"] = call_kwargs
-                if raises is not None:
-                    raise raises
-                message = SimpleNamespace(content=content)
-                return SimpleNamespace(choices=[SimpleNamespace(message=message)])
-
-            self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
-
-    module.OpenAI = _OpenAI
-    module.APITimeoutError = APITimeoutError
-    module.APIConnectionError = APIConnectionError
-    monkeypatch.setitem(sys.modules, "openai", module)
-    return captured, APITimeoutError, APIConnectionError
+    def refine(self, prompt, *, guide, workflow):
+        return f"Refined ({workflow}): {prompt}"
 
 
 def test_build_system_prompt_uses_workflow_medium_and_embeds_guide():
@@ -7346,44 +7331,67 @@ def test_clean_output_strips_reasoning_and_quoting():
     assert clean_output("```\nA vivid sunset over hills.\n```") == "A vivid sunset over hills."
 
 
-def test_refine_prompt_raises_when_runtime_unconfigured():
+def test_prompt_refiner_load_unavailable_without_backend():
+    # torch/transformers aren't installed in the CI worker-test env, so load()
+    # surfaces a clear PromptRefineUnavailable rather than an opaque ImportError.
     with pytest.raises(PromptRefineUnavailable):
-        refine_prompt("a dog", guide=None, workflow="image", base_url="", api_key="", model="")
+        PromptRefiner(model_name_or_path="some/model", gpu_id="cpu").load()
 
 
-def test_refine_prompt_success_calls_endpoint(monkeypatch):
-    captured, _, _ = _install_fake_openai(monkeypatch, content="A golden retriever in a sunlit park.")
-    out = refine_prompt(
-        "dog in park",
-        guide="# Guide",
-        workflow="image",
-        base_url="http://localhost:11434/v1",
-        api_key="",
-        model="gemma-heretic",
-    )
-    assert out == "A golden retriever in a sunlit park."
-    # Placeholder key supplied when none configured; model + system prompt forwarded.
-    assert captured["init"]["api_key"] == "not-needed"
-    assert captured["call"]["model"] == "gemma-heretic"
-    assert captured["call"]["messages"][0]["role"] == "system"
+def test_prompt_refiner_refine_applies_chat_template_and_cleans():
+    # Drive refine() with a fake tokenizer/model so we exercise the chat-template
+    # → generate → decode → clean path without real weights.
+    refiner = PromptRefiner(model_name_or_path="some/model", gpu_id="cpu")
 
+    class _Ids:
+        shape = (1, 3)
 
-def test_refine_prompt_raises_malformed_on_empty_response(monkeypatch):
-    _install_fake_openai(monkeypatch, content="   ")
-    with pytest.raises(PromptRefineMalformed):
-        refine_prompt(
-            "dog",
-            guide=None,
-            workflow="image",
-            base_url="http://localhost:11434/v1",
-            api_key="",
-            model="gemma-heretic",
-        )
+        def to(self, _device):
+            return self
+
+    captured = {}
+
+    class _Tokenizer:
+        pad_token_id = 0
+        eos_token_id = 0
+
+        def apply_chat_template(self, messages, **kwargs):
+            captured["messages"] = messages
+            return _Ids()
+
+        def decode(self, tokens, **kwargs):
+            return "<think>scheming</think>A vivid neon street at midnight."
+
+    class _Model:
+        def generate(self, **kwargs):
+            captured["generate"] = kwargs
+            return [[101, 102, 103, 201, 202]]
+
+    class _NoGrad:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    refiner.tokenizer = _Tokenizer()
+    refiner.model = _Model()
+    refiner.device = "cpu"
+    refiner.torch = SimpleNamespace(no_grad=lambda: _NoGrad())
+
+    out = refiner.refine("neon street", guide="# Guide", workflow="image")
+
+    assert out == "A vivid neon street at midnight."  # think-block stripped
+    # Instruction + guide folded into a single user turn (portable across templates).
+    assert captured["messages"][0]["role"] == "user"
+    assert "# Guide" in captured["messages"][0]["content"]
+    assert "neon street" in captured["messages"][0]["content"]
 
 
 def test_run_prompt_refine_job_writes_refined_result(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
-    monkeypatch.setattr("scene_worker.runtime.refine_prompt", lambda prompt, **kwargs: "Refined: " + prompt)
+    monkeypatch.setattr("scene_worker.runtime.PromptRefiner", _FakeRefiner)
+    _FakeRefiner.instances = []
     api = _DryRunApi()
     job = {"id": "job-refine-1", "type": "prompt_refine", "payload": {"prompt": "dog in park", "workflow": "image"}}
 
@@ -7391,22 +7399,26 @@ def test_run_prompt_refine_job_writes_refined_result(monkeypatch):
 
     terminal = api.progress[-1]
     assert terminal["status"] == "completed"
-    assert terminal["result"]["refinedPrompt"] == "Refined: dog in park"
+    assert terminal["result"]["refinedPrompt"] == "Refined (image): dog in park"
     assert terminal["result"]["originalPrompt"] == "dog in park"
+    # Loaded the model before refining; emitted a loading_model stage.
+    assert _FakeRefiner.instances[0].loaded is True
+    assert any(entry["stage"] == "loading_model" for entry in api.progress)
 
 
-def test_run_prompt_refine_job_reports_runtime_failure(monkeypatch):
+def test_run_prompt_refine_job_reports_failure(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
 
-    def _boom(prompt, **kwargs):
-        raise PromptRefineUnavailable("Prompt refinement runtime is not configured.")
+    class _BoomRefiner(_FakeRefiner):
+        def refine(self, prompt, *, guide, workflow):
+            raise PromptRefineUnavailable("Could not load the prompt-refinement model.")
 
-    monkeypatch.setattr("scene_worker.runtime.refine_prompt", _boom)
+    monkeypatch.setattr("scene_worker.runtime.PromptRefiner", _BoomRefiner)
     api = _DryRunApi()
     job = {"id": "job-refine-2", "type": "prompt_refine", "payload": {"prompt": "dog", "workflow": "image"}}
 
-    run_prompt_refine_job(api, _refine_settings(prompt_refine_base_url="", prompt_refine_model=""), job)
+    run_prompt_refine_job(api, _refine_settings(), job)
 
     terminal = api.progress[-1]
     assert terminal["status"] == "failed"
-    assert "not configured" in terminal["message"]
+    assert "Could not load" in terminal["message"]


### PR DESCRIPTION
## Summary

Reworks **Refine my prompt** (sc-2041, shipped in #299) to run as **in-process local inference** — the same pattern as JoyCaption captioning — instead of calling an external OpenAI-compatible endpoint.

For a Mac desktop app, requiring users to stand up a model server (Ollama/llama.cpp) and set `PROMPT_REFINE_*` env vars was the wrong design. We already load local models in-process for captioning; prompt refinement is the same shape and should match it.

## What changed
- **`prompt_refine.py`**: new `PromptRefiner` mirroring `JoyCaptioner` — lazy `load()` via `AutoModelForCausalLM` + `AutoTokenizer` using the shared MPS-aware device/dtype helpers, then chat-template → `model.generate` → decode → clean. The default model (`llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic`) **downloads on demand via the HF cache** on first use — zero setup.
- **Routing**: `prompt_refine` is now a **backend-gated inference job** (advertised only by a Python worker with the inference backend, runs on its device — MPS on Apple Silicon), not a non-GPU utility job. Removed from `NON_GPU_JOB_TYPES`; advertised alongside captioning. The handler emits a `loading_model` stage.
- **Dropped the external-endpoint config**: removed `PROMPT_REFINE_BASE_URL` / `API_KEY` / `TIMEOUT` env, the docker-compose passthrough, and the `.env.example` endpoint block. Kept only optional `PROMPT_REFINE_MODEL` (repo override) and `PROMPT_REFINE_MAX_NEW_TOKENS` (default 512). Generation params are hardcoded (`do_sample`, temp 0.7, top_p 0.9).
- **Web is unchanged** — still a job + poll; users click "Refine my prompt" and get a result with no configuration.

## Defaults (no config needed)
- Model: `llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic`, downloaded on demand.
- Max new tokens: 512.

## Test plan
- [x] Worker: 309 pytest pass (refine module unit + handler success/failure reworked to the in-process path; capability assertions updated — `prompt_refine` is now backend-gated)
- [x] Rust: 28 core tests (routing after `NON_GPU_JOB_TYPES` revert), `cargo fmt --check`, `cargo build -p sceneworks-rust-api --features embed-web`
- [x] `docker compose config` valid
- [ ] **Not run on real hardware** (no torch/MPS in CI/this env): the gemma download + `AutoModelForCausalLM` load + generation need a first run on the Mac. The model id is configurable and load failures surface a clear message, so a different loader class (if the repo needs one) is a one-line swap.

## Follow-up
- Optional resident model caching for >64GB machines (currently load-per-job, memory-safe like JoyCaption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)