### PR TITLE
Fix character-scoped grids to read characterId from recipe.normalizedSettings [sc-2050]

### DIFF
--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -285,7 +285,7 @@ export function CharacterTest({
   // collapsed by default so it never turns the studio into an endless scroll.
   const characterAssets = (latestAssets ?? []).filter(
     (asset) =>
-      asset.characterId === selectedCharacter.id ||
+      asset.recipe?.normalizedSettings?.characterId === selectedCharacter.id ||
       (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === selectedCharacter.id),
   );
   return (
@@ -418,7 +418,7 @@ export function CharacterAngleSet({
   const activeJob = imageLocalJobs.find((job) => job.id === jobId);
   const characterImages = (latestAssets ?? []).filter(
     (asset) =>
-      asset.characterId === characterId ||
+      asset.recipe?.normalizedSettings?.characterId === characterId ||
       (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === characterId),
   );
 


### PR DESCRIPTION
## Summary

Follow-up to #300. The character-scoped grids (Test-Character outputs + the angle-set results) filtered on a **non-existent top-level `asset.characterId`**, so a character's generated images never matched and the grids stayed empty.

The API **does** persist the association — nested at `recipe.normalizedSettings.characterId` (project_store, story 1656) — and the web already reads `asset.recipe.normalizedSettings.*` elsewhere. So this is purely a **web path fix, no backend change**: both filters now read `asset.recipe?.normalizedSettings?.characterId` (plus the existing `metadata.characterReferences` check for approved refs).

Result: a character's generated angle sets / tests reliably appear in its own Character Studio panels.

## Test plan

- [x] 142 web tests pass; Vite build clean.
- [ ] CI green.
- [ ] Desktop: generate an angle set → the 11 images appear in the panel grid + the scoped Test-outputs grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)