### PR TITLE
Keep the InstantID angle set consistent: one seed + tighter prompt [sc-2050]

### DIFF
--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -405,9 +405,14 @@ export function CharacterAngleSet({
     setReferenceAssetId(approvedReferences[0]?.assetId ?? "");
   }, [characterId, approvedReferences]);
   React.useEffect(() => {
-    setPrompt(`${selectedCharacter?.name || "the character"}, neutral expression, plain background, photorealistic`);
+    // Seed with the character's appearance notes (InstantID preserves the face but NOT
+    // hair/wardrobe, so describe them here for a consistent turnaround) + tight framing.
+    const appearance = (selectedCharacter?.description ?? "").trim() || selectedCharacter?.name || "the character";
+    setPrompt(
+      `${appearance}, head and shoulders, neutral expression, consistent outfit, plain grey background, face clearly visible, sharp focus, photorealistic`,
+    );
     setStatus("");
-  }, [characterId, selectedCharacter?.name]);
+  }, [characterId, selectedCharacter?.name, selectedCharacter?.description]);
 
   if (!angleModel || !selectedCharacter) {
     return null;
@@ -452,7 +457,9 @@ export function CharacterAngleSet({
         characterId,
         referenceAssetId,
         prompt: prompt.trim(),
-        negativePrompt: "plastic skin, airbrushed, cgi, 3d render, cartoon, anime, waxy, overprocessed, deformed, multiple people",
+        negativePrompt:
+          "hat, hood, hoodie, scarf, holding object, paper, hands near face, covering face, occluded face, cropped, " +
+          "multiple people, plastic skin, airbrushed, cgi, 3d render, cartoon, anime, waxy, deformed, blurry",
         // angleSet makes the worker emit one image per pack angle regardless of count;
         // count must satisfy the API's 1-8 guard, so send 1 (the worker overrides it).
         count: 1,

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -408,9 +408,13 @@ class InstantIDAdapter:
         angle_set = bool(request.advanced.get("angleSet"))
         angles = [a for a in ANGLE_SET_ORDER if a in VIEW_ANGLE_KPS] if angle_set else []
         total = len(angles) if angle_set else request.count
+        # Every angle in a set shares ONE seed so the noise-derived attributes InstantID
+        # does NOT lock (hair, wardrobe, lighting) stay consistent across the turnaround —
+        # only the pose (kps) changes. Plain batches keep per-image seeds for variety.
+        set_seed = resolve_seed(request.seed, request.prompt, 0, request.seeds)
 
         def image_at_index(index: int) -> Image.Image:
-            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            seed = set_seed if angle_set else resolve_seed(request.seed, request.prompt, index, request.seeds)
             angle = angles[index] if angle_set else None
             progress(
                 "running",


### PR DESCRIPTION
## Summary

Follow-up to #300/#302. A generated angle set "got artistic" — varied hairstyles, random hoodies, even paper over the face — because **InstantID preserves the face (ArcFace geometry) but not hair / wardrobe / framing**, and each angle was generated with a *different* seed under a loose prompt.

- **Worker:** in angle-set mode all angles now share **one seed**, so the noise-derived attributes InstantID doesn't lock (hair, outfit, lighting) stay consistent across the turnaround — only the pose (kps) changes. Plain batches keep per-image seeds for variety.
- **Web:** the angle-set default prompt now seeds from the **character's appearance notes** (`description`) + tight framing (*head and shoulders, consistent outfit, face clearly visible*), and the negative prompt is strengthened against hats/hoods/props/paper/occlusion.

Honest limit: InstantID still won't lock hair/wardrobe *perfectly* across extreme angles — the set is meant to be curated, and the trained per-character LoRA (sc-2033) is what makes it fully consistent. These changes substantially reduce the drift.

## Test plan

- [x] 14 worker + 142 web tests pass; Vite build clean.
- [ ] CI green.
- [ ] Desktop: regenerate an angle set → consistent hair/outfit across the 11, faces unobscured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)