### PR TITLE
Constrain angle-set result images to thumbnails [sc-2050]

### DIFF
--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -355,6 +355,7 @@ export function CharacterStudio() {
               imageLocalJobs={imageLocalJobs}
               importAsset={importAsset}
               latestAssets={latestAssets}
+              onPreview={onPreview}
               rememberLocalGenerationJob={rememberLocalGenerationJob}
               selectedCharacter={selectedCharacter}
             />

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -391,6 +391,7 @@ export function CharacterAngleSet({
   latestAssets = [],
   imageLocalJobs = [],
   rememberLocalGenerationJob,
+  onPreview,
 }) {
   const angleCount = angleModel?.ui?.viewAngles?.length ?? 0;
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
@@ -523,9 +524,17 @@ export function CharacterAngleSet({
       {activeJob ? <JobProgressCard job={activeJob} label={`Angle set · ${angleCount} views`} /> : null}
       {!activeJob && status ? <p className="inline-warning">{status}</p> : null}
       {characterImages.length ? (
-        <div className="review-grid">
+        <div className="reference-thumb-row">
           {characterImages.map((asset) => (
-            <AssetMedia asset={asset} controls={false} key={asset.id} />
+            <button
+              aria-label={`Preview ${asset.displayName ?? asset.id}`}
+              className="reference-thumb"
+              key={asset.id}
+              onClick={() => onPreview?.(asset)}
+              type="button"
+            >
+              <AssetMedia asset={asset} controls={false} />
+            </button>
           ))}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

Follow-up to #300/#303. The angle-set results streamed in at **full 1024px size** — each was a bare `<AssetMedia>` dropped into `.review-grid` (`minmax(190px, 1fr)`) with no width constraint, so the image overflowed its cell and dominated the panel.

Fix: render each result as a fixed **`.reference-thumb`** box (72px, `object-fit: cover`) in a wrapping row — matching the reference picker directly above it — and make each thumbnail clickable to open the full preview.

## Test plan

- [x] 142 web tests pass; Vite build clean.
- [ ] CI green.
- [ ] Desktop: generate an angle set → results appear as a neat row of thumbnails, click to preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)