### PR TITLE
fix(prompt): default refine model to a text-only causal LM

### DIFF
--- a/apps/worker/scene_worker/prompt_refine.py
+++ b/apps/worker/scene_worker/prompt_refine.py
@@ -18,10 +18,12 @@ from .image_adapters import (
     select_torch_dtype,
 )
 
-# Default refinement model: a small, uncensored instruction LLM suitable for
-# unrestricted creative prompt rewriting on modest local hardware. Overridable
-# via PROMPT_REFINE_MODEL. Downloaded on demand (HF cache), like JoyCaption.
-DEFAULT_REFINE_MODEL = "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic"
+# Default refinement model: a small, text-only, uncensored (abliterated)
+# instruction LLM. Loads via AutoModelForCausalLM on any recent transformers
+# (model_type "llama"), unlike multimodal models that need a processor + an
+# image-text-to-text class. Overridable via PROMPT_REFINE_MODEL; downloaded on
+# demand (HF cache), like JoyCaption. NOTE: point this only at text causal LMs.
+DEFAULT_REFINE_MODEL = "huihui-ai/Llama-3.2-3B-Instruct-abliterated"
 
 
 class PromptRefineError(RuntimeError):


### PR DESCRIPTION
## Summary

Follow-up fix to #301. On the first real run, prompt refinement crashed with:

> Could not load the prompt-refinement model 'llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic': 'list' object has no attribute 'keys'

**Root cause:** that model is a multimodal **text+image+audio** model on the brand-new `gemma4` architecture (`Gemma4ForConditionalGeneration` / `Gemma4Processor`, with `text_config`/`vision_config`/`audio_config`). Loading it via `AutoModelForCausalLM` + `AutoTokenizer` is the wrong loader pair — multimodal models need `AutoProcessor` + an image-text-to-text class — and `gemma4` also needs a very recent transformers build.

**Fix:** switch the default to **`huihui-ai/Llama-3.2-3B-Instruct-abliterated`** — a small, text-only, uncensored (abliterated) instruct model (`model_type: llama`) that loads cleanly through the existing causal-LM path on any recent transformers, runs faster, and uses less memory. Prompt rewriting is a text→text task, so a text-only model is the right fit. Still overridable via `PROMPT_REFINE_MODEL` (point only at text causal LMs).

## Test plan
- [x] Worker refine/handler tests pass (use explicit model ids; default change is isolated)
- [ ] First real run on the Mac to confirm the model downloads + generates (couldn't run here — no torch/MPS). `huihui-ai` re-uploads are typically ungated; if not, set `HF_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)