### PR TITLE
fix(api): include projectId in character test-job payload [sc-2074]

### DIFF
--- a/apps/rust-api/src/characters.rs
+++ b/apps/rust-api/src/characters.rs
@@ -352,6 +352,9 @@ pub(crate) async fn create_character_test_job(
         payload.look_id.map(Value::String).unwrap_or(Value::Null),
     );
     job_payload.insert("advanced".to_owned(), Value::Object(advanced));
+    // The worker's image_request_from_job requires payload.projectId; create_generation_job
+    // only stores it as the job column, so inject it here (as person/timeline/training jobs do).
+    job_payload.insert("projectId".to_owned(), Value::String(project_id.clone()));
     validate_job_lora_compatibility(&state, Some(&project_id), &mut job_payload, true).await?;
     let job = create_generation_job(
         state,

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5663,6 +5663,9 @@ async fn character_studio_routes_manage_references_loras_and_test_jobs() {
     assert_eq!(test_job["type"], "image_generate");
     assert_eq!(test_job["payload"]["mode"], "character_image");
     assert_eq!(test_job["payload"]["characterId"], character_id);
+    // Regression (sc-2074): the worker's image_request_from_job requires payload.projectId;
+    // the test-job handler must inject it (it isn't carried by the column alone).
+    assert_eq!(test_job["payload"]["projectId"], project_id);
     assert_eq!(
         test_job["payload"]["advanced"]["approvedReferenceIds"][0],
         asset_id


### PR DESCRIPTION
## Summary
Fixes "Test Character" (Character Studio → Sample Outputs) failing with `image generate: 'projectId'`.

`create_character_test_job` builds the worker payload from scratch and never inserts `projectId`. `create_generation_job` only records it as the job's column — it does not copy it into the payload — but the worker's `image_request_from_job` (`apps/worker/scene_worker/image_adapters.py:490`) hard-requires `payload["projectId"]` → `KeyError`. The normal Image Studio path works only because the web includes `projectId` in the request body. `person.rs`, `timelines.rs`, and `training.rs` already inject it; the character test-job handler was the outlier.

- Inject `projectId` into the test-job payload before `create_generation_job`.
- Assert `payload.projectId` in the existing character-routes test (regression guard).

Pre-existing on `main` (not from the pose-library work); found while building epic 2062.

## Test plan
- [x] `cargo fmt -p sceneworks-rust-api --check` clean
- [x] `cargo test -p sceneworks-rust-api character_studio_routes_manage_references_loras_and_test_jobs` passes (with the new `projectId` assertion)
- [ ] Manual: Character Studio → Sample Outputs → Test Character generates without the `projectId` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)