### PR TITLE
Persistent per-character asset gallery in Character Studio [sc-2076]

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -5,16 +5,75 @@ pub(crate) async fn list_assets(
     Path(project_id): Path<String>,
     Query(query): Query<AssetsQuery>,
 ) -> Result<Json<Vec<serde_json::Value>>, ApiError> {
-    Ok(Json(
-        project_call(state, move |store| {
-            store.list_assets(
-                &project_id,
-                query.include_rejected.unwrap_or(false),
-                query.include_trashed.unwrap_or(false),
-            )
-        })
-        .await?,
-    ))
+    let character_id = query.character_id.clone();
+    let assets = project_call(state, move |store| {
+        store.list_assets(
+            &project_id,
+            query.include_rejected.unwrap_or(false),
+            query.include_trashed.unwrap_or(false),
+        )
+    })
+    .await?;
+    let assets = match character_id {
+        Some(character_id) if !character_id.is_empty() => assets
+            .into_iter()
+            .filter(|asset| asset_matches_character(asset, &character_id))
+            .collect(),
+        _ => assets,
+    };
+    Ok(Json(assets))
+}
+
+/// An asset belongs to a character when it was generated in association with it
+/// (recipe.normalizedSettings.characterId) or generated referencing it
+/// (metadata.characterReferences[].characterId). Powers the per-character gallery so
+/// character outputs persist beyond the transient "recent generations" window.
+fn asset_matches_character(asset: &serde_json::Value, character_id: &str) -> bool {
+    let by_recipe = asset
+        .get("recipe")
+        .and_then(|recipe| recipe.get("normalizedSettings"))
+        .and_then(|settings| settings.get("characterId"))
+        .and_then(serde_json::Value::as_str)
+        == Some(character_id);
+    let by_reference = asset
+        .get("metadata")
+        .and_then(|metadata| metadata.get("characterReferences"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|refs| {
+            refs.iter().any(|reference| {
+                reference
+                    .get("characterId")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(character_id)
+            })
+        });
+    by_recipe || by_reference
+}
+
+#[cfg(test)]
+mod character_filter_tests {
+    use super::asset_matches_character;
+    use serde_json::json;
+
+    #[test]
+    fn matches_by_recipe_character_id() {
+        let asset = json!({ "recipe": { "normalizedSettings": { "characterId": "char-1" } } });
+        assert!(asset_matches_character(&asset, "char-1"));
+        assert!(!asset_matches_character(&asset, "char-2"));
+    }
+
+    #[test]
+    fn matches_by_character_reference() {
+        let asset = json!({ "metadata": { "characterReferences": [{ "characterId": "char-9" }] } });
+        assert!(asset_matches_character(&asset, "char-9"));
+        assert!(!asset_matches_character(&asset, "char-1"));
+    }
+
+    #[test]
+    fn no_match_when_unassociated() {
+        let asset = json!({ "recipe": { "normalizedSettings": { "width": 1024 } } });
+        assert!(!asset_matches_character(&asset, "char-1"));
+    }
 }
 
 pub(crate) async fn get_asset(

--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -50,32 +50,6 @@ fn asset_matches_character(asset: &serde_json::Value, character_id: &str) -> boo
     by_recipe || by_reference
 }
 
-#[cfg(test)]
-mod character_filter_tests {
-    use super::asset_matches_character;
-    use serde_json::json;
-
-    #[test]
-    fn matches_by_recipe_character_id() {
-        let asset = json!({ "recipe": { "normalizedSettings": { "characterId": "char-1" } } });
-        assert!(asset_matches_character(&asset, "char-1"));
-        assert!(!asset_matches_character(&asset, "char-2"));
-    }
-
-    #[test]
-    fn matches_by_character_reference() {
-        let asset = json!({ "metadata": { "characterReferences": [{ "characterId": "char-9" }] } });
-        assert!(asset_matches_character(&asset, "char-9"));
-        assert!(!asset_matches_character(&asset, "char-1"));
-    }
-
-    #[test]
-    fn no_match_when_unassociated() {
-        let asset = json!({ "recipe": { "normalizedSettings": { "width": 1024 } } });
-        assert!(!asset_matches_character(&asset, "char-1"));
-    }
-}
-
 pub(crate) async fn get_asset(
     State(state): State<AppState>,
     Path((project_id, asset_id)): Path<(String, String)>,
@@ -202,4 +176,30 @@ pub(crate) async fn purge_asset(
         })
         .await?,
     ))
+}
+
+#[cfg(test)]
+mod character_filter_tests {
+    use super::asset_matches_character;
+    use serde_json::json;
+
+    #[test]
+    fn matches_by_recipe_character_id() {
+        let asset = json!({ "recipe": { "normalizedSettings": { "characterId": "char-1" } } });
+        assert!(asset_matches_character(&asset, "char-1"));
+        assert!(!asset_matches_character(&asset, "char-2"));
+    }
+
+    #[test]
+    fn matches_by_character_reference() {
+        let asset = json!({ "metadata": { "characterReferences": [{ "characterId": "char-9" }] } });
+        assert!(asset_matches_character(&asset, "char-9"));
+        assert!(!asset_matches_character(&asset, "char-1"));
+    }
+
+    #[test]
+    fn no_match_when_unassociated() {
+        let asset = json!({ "recipe": { "normalizedSettings": { "width": 1024 } } });
+        assert!(!asset_matches_character(&asset, "char-1"));
+    }
 }

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -25,6 +25,10 @@ pub(crate) struct PromptRefineRequest {
 pub(crate) struct AssetsQuery {
     pub(crate) include_rejected: Option<bool>,
     pub(crate) include_trashed: Option<bool>,
+    /// Scope to one character: assets generated in association with it
+    /// (recipe.normalizedSettings.characterId) or referencing it
+    /// (metadata.characterReferences[].characterId).
+    pub(crate) character_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -8,6 +8,7 @@ import { liveElapsedSeconds } from "./formatting.js";
 import { foldUpscaledAssetVariants } from "./assetVariants.js";
 import { extractFamilies } from "./presetUtils.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
+import { CharacterAssets } from "./screens/characterPanels.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { DocumentStudio } from "./screens/DocumentStudio.jsx";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
@@ -2278,6 +2279,33 @@ describe("SceneWorks app shell", () => {
       }),
     );
     expect(baseContext.rememberLocalGenerationJob).toHaveBeenCalledWith("image", { id: "job-pose" });
+  });
+
+  it("collects all character-associated assets in the Character Studio gallery (sc-2076)", async () => {
+    const onPreview = vi.fn();
+    const selectedCharacter = { id: "char-1", name: "Mira" };
+    const assets = [
+      { id: "a1", type: "image", displayName: "by recipe", recipe: { normalizedSettings: { characterId: "char-1" } } },
+      { id: "a2", type: "image", displayName: "by reference", metadata: { characterReferences: [{ characterId: "char-1" }] } },
+      { id: "a3", type: "image", displayName: "other character", recipe: { normalizedSettings: { characterId: "char-2" } } },
+      { id: "a4", type: "image", displayName: "unassociated" },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<CharacterAssets assets={assets} onPreview={onPreview} selectedCharacter={selectedCharacter} />);
+    });
+
+    // Counts only assets associated with this character (by recipe characterId or by
+    // characterReferences) — not other characters' or unassociated assets.
+    expect(container.textContent).toContain("Generated for Mira (2)");
+    const previewButtons = [...container.querySelectorAll("button")].filter((button) =>
+      (button.getAttribute("aria-label") ?? "").startsWith("Preview "),
+    );
+    expect(previewButtons).toHaveLength(2);
+    await act(async () => {
+      previewButtons[0].click();
+    });
+    expect(onPreview).toHaveBeenCalled();
   });
 
   it("launches reference-based generation from an approved character reference", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import {
   CharacterAngleSet,
+  CharacterAssets,
   CharacterLoras,
   CharacterLooks,
   CharacterPoseLibrary,
@@ -352,6 +353,8 @@ export function CharacterStudio() {
               submitReference={submitReference}
               updateCharacterReference={updateCharacterReference}
             />
+
+            <CharacterAssets assets={assets} onPreview={onPreview} selectedCharacter={selectedCharacter} />
 
             <CharacterAngleSet
               addCharacterReference={addCharacterReference}

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -544,6 +544,55 @@ export function CharacterAngleSet({
   );
 }
 
+// Persistent per-character asset gallery: every image generated in association with the
+// character (recipe.normalizedSettings.characterId) or referencing it
+// (metadata.characterReferences). Reads the full project asset list, so character outputs
+// persist beyond the transient "recent generations" window (sc-2076).
+export function CharacterAssets({ selectedCharacter, assets = [], onPreview }) {
+  const characterId = selectedCharacter?.id;
+  if (!selectedCharacter) {
+    return null;
+  }
+  const characterAssets = (assets ?? [])
+    .filter(
+      (asset) =>
+        (asset.type === "image" || asset.type === "frame") &&
+        (asset.recipe?.normalizedSettings?.characterId === characterId ||
+          (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === characterId)),
+    )
+    .sort((left, right) => new Date(right.createdAt ?? 0) - new Date(left.createdAt ?? 0));
+  return (
+    <section className="character-section">
+      <div className="section-heading">
+        <p className="eyebrow">Character assets</p>
+        <h2>
+          Generated for {selectedCharacter.name}
+          {characterAssets.length ? ` (${characterAssets.length})` : ""}
+        </h2>
+      </div>
+      {characterAssets.length ? (
+        <div className="reference-thumb-row">
+          {characterAssets.map((asset) => (
+            <button
+              aria-label={`Preview ${asset.displayName ?? asset.id}`}
+              className="reference-thumb"
+              key={asset.id}
+              onClick={() => onPreview?.(asset)}
+              type="button"
+            >
+              <AssetMedia asset={asset} controls={false} />
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="muted">
+          No images yet. Angle sets, pose generations, character tests, and any character-image render collect here automatically.
+        </p>
+      )}
+    </section>
+  );
+}
+
 // Pose library: pick one or more poses from the bundled OpenPose gallery and generate
 // the character in each, in a single batch job (advanced.poses) sharing one seed for
 // wardrobe/hair consistency. An OpenPose ControlNet drives the pose; a face-restoration


### PR DESCRIPTION
## Summary
Character-associated outputs (angle sets, pose library, character tests, any character-image render) didn't *stay* visible in Character Studio — the panels filtered the transient "recent generations" window. The association data was always persisted (`recipe.normalizedSettings.characterId`); the gap was a durable view.

- **Web** — new **"Character assets"** section in Character Studio collects every image associated with the character (by `recipe.normalizedSettings.characterId` or `metadata.characterReferences[].characterId`), reading the **full** project asset list so outputs persist regardless of recency. Newest-first, click-to-preview, empty-state hint.
- **API** — optional `characterId` filter on `GET /projects/:id/assets` (returns the same association set). The scalable path for the gallery / future paginated views; the web currently filters the already-loaded full asset list (instant, auto-refreshing), so this endpoint param is forward-looking for pagination (coordinates with sc-2024).

Epic 2019 (Character/Dataset redesign). Pairs with sc-2024 (Library scoping) and sc-2020 (redesign IA).

## Validation
- `cargo fmt -p sceneworks-rust-api --check` clean; `cargo test -p sceneworks-rust-api character_filter_tests` (3 tests) pass.
- Web: 171 tests pass incl. a new gallery test (counts only associated assets, excludes other characters' + unassociated); Vite build clean.

## Test plan
- [ ] Open Character Studio for a character with prior angle-set / pose / test outputs → "Character assets" lists them all, persisting after the recent window.
- [ ] Generate a new character image → it appears in the gallery after the asset list refreshes.
- [ ] Confirm other characters' / unassociated images don't appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)