### PR TITLE
style(worker-progress-card): stack GPU meters, inline Stage/Elapsed

### DIFF
--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -388,23 +388,23 @@ export function WorkerProgressCard({
         <HardwarePills {...hardware} />
         {hardware.device === "GPU" ? (
           <div className="worker-progress-card__meters" data-meter-source={meters.source}>
-            <MeterBar label="Mem" value={meters.memUsedPct} />
-            <MeterBar label="Load" value={meters.loadPct} />
+            <MeterBar label="Mem:" value={meters.memUsedPct} />
+            <MeterBar label="Load:" value={meters.loadPct} />
           </div>
         ) : null}
       </div>
       <div className="worker-progress-card__status-row">
         <span>
-          <small>Stage</small>
+          <small>Stage:</small>
           <strong>{defaultChipLabel(job.stage ?? job.status)}</strong>
         </span>
         <span>
-          <small>Elapsed</small>
+          <small>Elapsed:</small>
           <strong>{formatSeconds(elapsedSeconds)}</strong>
         </span>
         {attempts > 1 || actionStatuses.has(job.status) ? (
           <span>
-            <small>Attempt</small>
+            <small>Attempt:</small>
             <strong>{attempts}/{MAX_ATTEMPTS}</strong>
           </span>
         ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6469,9 +6469,9 @@ label {
 
 .worker-progress-card__hardware {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px 12px;
-  align-items: center;
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
 }
 
 .worker-progress-card__hw-pills {
@@ -6513,19 +6513,16 @@ label {
 }
 
 .worker-progress-card__meters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  flex: 1 1 240px;
-  min-width: 200px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 4px;
 }
 
 .worker-progress-card__meter {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 6px;
-  flex: 1 1 120px;
+  gap: 8px;
   font-size: 11px;
   color: var(--text-muted);
 }
@@ -6567,14 +6564,16 @@ label {
 .worker-progress-card__status-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 14px;
-  font-size: 12px;
+  gap: 4px 16px;
+  font-size: 12.5px;
+  align-items: baseline;
 }
 
 .worker-progress-card__status-row > span {
   display: inline-flex;
-  flex-direction: column;
-  gap: 2px;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 6px;
   min-width: 0;
 }
 


### PR DESCRIPTION
Two layout tweaks from PR #311 review:

1. GPU mem + load meters were a side-by-side flex row that ate a lot of horizontal space on narrow cards. They now stack vertically:

       MEM:  ========------- 60%
       LOAD: ============-- 90%

   .worker-progress-card__hardware switches from `flex-row` to `flex-column`, so pills sit on top and the meters block drops below as a full-width grid of single-column rows. Each meter still uses the auto/1fr/auto grid for label / bar / value, so the bars line up. Mem and Load labels now end with `:` to match the visual spec.

2. Stage / Elapsed / Attempt were small-over-strong vertical stacks. They're now inline label-value pairs:

       STAGE: Generating   ELAPSED: 1m 12s   ATTEMPT: 1/5

   .worker-progress-card__status-row > span switches from `flex-direction: column` to `row` with 6px gap; labels gain `:`.

No JSX structure change beyond the colons and no behavior shift — just CSS direction + a few characters. 215/215 vitests still green; Vite build clean (CSS unchanged at 102 kB).

Story: sc-2083 (post-review polish)