### PR TITLE
Worker Progress: deferred backend slices + meter-layout polish (sc-2080)

### DIFF
--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -153,15 +153,20 @@ function StatusBadge({ status }) {
   return <span className={`status-badge worker-progress-card__status ${status}`}>{label}</span>;
 }
 
-function HardwarePills({ device, vendor, architecture }) {
+function HardwarePills({ device, gpuLabel, architecture }) {
   if (!device) return null;
+  // Apple Silicon / MLX runs against Unified Memory — the Mem meter reflects
+  // shared system memory, not dedicated VRAM. Worth surfacing so the meter
+  // number isn't misread as a discrete-VRAM figure.
+  const sharedMem = architecture === "mps" || architecture === "mlx";
   return (
-    <div className="worker-progress-card__hw-pills">
+    <div className="worker-progress-card__hw-info">
       <span className="worker-progress-card__pill device">{device}</span>
-      {vendor ? <span className="worker-progress-card__pill vendor">{vendor}</span> : null}
+      {gpuLabel ? <span className="worker-progress-card__hw-name" title={gpuLabel}>{gpuLabel}</span> : null}
       {architecture ? (
         <span className={`worker-progress-card__pill arch arch-${architecture}`}>{architecture}</span>
       ) : null}
+      {sharedMem ? <span className="worker-progress-card__hw-note">shared mem</span> : null}
     </div>
   );
 }
@@ -394,26 +399,33 @@ export function WorkerProgressCard({
         ) : null}
       </div>
       <div className="worker-progress-card__status-row">
-        <span>
+        <span className="worker-progress-card__status-stage">
           <small>Stage:</small>
           <strong>{defaultChipLabel(job.stage ?? job.status)}</strong>
         </span>
-        <span>
-          <small>Elapsed:</small>
-          <strong>{formatSeconds(elapsedSeconds)}</strong>
-        </span>
-        {attempts > 1 || actionStatuses.has(job.status) ? (
-          <span>
-            <small>Attempt:</small>
-            <strong>{attempts}/{MAX_ATTEMPTS}</strong>
+        {job.message ? (
+          <span className="worker-progress-card__status-message" title={job.message}>
+            {job.message}
           </span>
-        ) : null}
+        ) : (
+          <span aria-hidden="true" />
+        )}
+        <span className="worker-progress-card__status-right">
+          {attempts > 1 || actionStatuses.has(job.status) ? (
+            <span className="worker-progress-card__status-attempt">
+              <small>Attempt:</small>
+              <strong>{attempts}/{MAX_ATTEMPTS}</strong>
+            </span>
+          ) : null}
+          <span>
+            <small>Elapsed:</small>
+            <strong>{formatSeconds(elapsedSeconds)}</strong>
+          </span>
+        </span>
       </div>
       <ProgressBar status={job.status} progress={job.progress} />
-      {job.error || job.message ? (
-        <p className={`worker-progress-card__message${job.error ? " error" : ""}`}>
-          {job.error ?? job.message}
-        </p>
+      {job.error ? (
+        <p className="worker-progress-card__message error">{job.error}</p>
       ) : null}
       <div className="worker-progress-card__actions">
         {canCancel ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6468,16 +6468,39 @@ label {
 }
 
 .worker-progress-card__hardware {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(160px, auto);
+  gap: 12px;
+  align-items: center;
 }
 
-.worker-progress-card__hw-pills {
+.worker-progress-card__hardware:not(:has(.worker-progress-card__meters)) {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.worker-progress-card__hw-info {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+
+.worker-progress-card__hw-name {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 240px;
+}
+
+.worker-progress-card__hw-note {
+  font-size: 10.5px;
+  font-style: italic;
+  color: var(--text-muted);
+  white-space: nowrap;
 }
 
 .worker-progress-card__pill {
@@ -6562,19 +6585,35 @@ label {
 }
 
 .worker-progress-card__status-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 16px;
-  font-size: 12.5px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: baseline;
+  column-gap: 14px;
+  font-size: 12.5px;
 }
 
-.worker-progress-card__status-row > span {
+.worker-progress-card__status-stage,
+.worker-progress-card__status-right,
+.worker-progress-card__status-right > span {
   display: inline-flex;
   flex-direction: row;
   align-items: baseline;
   gap: 6px;
   min-width: 0;
+}
+
+.worker-progress-card__status-right {
+  justify-self: end;
+  gap: 14px;
+}
+
+.worker-progress-card__status-message {
+  display: block;
+  color: var(--text-muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .worker-progress-card__status-row small {


### PR DESCRIPTION
## Summary

Finishes the deferred backend slices of [epic sc-2080](https://app.shortcut.com/trefry/epic/2080) — the three protocol stories that PR #311 deferred — and includes the meter-layout polish from review feedback. After this lands, the entire epic is shipped.

## Commits

1. **`8fa09e5`** — Layout polish: pills + GPU name on the left, meters stacked on the right; status row goes inline with Elapsed right-aligned (round-2 review polish from #311).
2. **`10125fd` — sc-2086** — Per-job peak GPU memory + load capture. Fixes the screenshot bug where completed-row meters were empty.
3. **`b528111` — sc-2087** — Server-side `JobSnapshot.title` derivation. Frontend's client-side fallback stays for the few job types the server intentionally returns `None` for.
4. **`43b5b25` — sc-2085** — Verification + documentation: the "image batches always stream thumbnails" acceptance criterion is already met by the existing per-asset streaming flow. No new code; updates the design doc to document the model and call out what's explicitly out of scope (per-denoising-step preview).

## sc-2086 (peak GPU stats) — what changed

**Worker** (`apps/worker/scene_worker/runtime.py`):
- New `track_job_peaks(payload, peaks, gpu_id)` helper — samples `gpu_utilization`, ratchets a per-job running max into a `peaks` dict, and folds the peak values into the progress payload as `peakGpuMemoryPct` / `peakGpuLoadPct`.
- Every per-job `progress()` closure (image, image-edit, document, video, person, lora-train dry-run + real, training-caption, vqa — 8 in total) now carries its own `peaks` dict and calls the helper before `update_job()`.

**Contracts** (`crates/sceneworks-core/src/contracts.rs`):
- `ProgressRequest` + `JobSnapshot` gain optional `peakGpuMemoryPct` + `peakGpuLoadPct`. Both `skip_serializing_if = "Option::is_none"` so existing snapshots are bit-compatible when no peaks are reported.

**Jobs store** (`crates/sceneworks-core/src/jobs_store.rs`):
- Two new columns via `ensure_column` migration (compatible with existing dbs).
- `update_job_progress` SQL uses `max(coalesce(existing, 0), coalesce(incoming, 0))` so a stale lower sample late in the run can't ratchet the recorded peak back down. Incoming values clamp to 0..100.
- `row_to_job` reads the new columns into `JobSnapshot`.

**API** (`apps/rust-api/src/jobs.rs`):
- `update_job_progress` forwards the new fields from `ProgressRequest` into `ProgressUpdate`.

## sc-2087 (server-side title) — what changed

**Contract** (`JobSnapshot`):
- New `title: Option<String>` with `skip_serializing_if`.

**Derivation** (`derive_job_title(job_type, payload)` in `jobs_store.rs::row_to_job`):
- Mirrors the table in `docs/design/worker-progress-card.md` exactly — `LoraTrain` → `Training Run — <loraName | outputName | targetName | plan.output.loraId | loraId | (unnamed LoRA)>`, `TrainingCaption` → `Dataset Captioning — <…>`, image/video generate with prompt truncation at 80 chars (60 for `PromptRefine`), `Character Turnaround — <characterName>` override when `payload.characterId` is set, `Model Import` / `LoRA Import` with name-or-filename fallback. Returns `None` for `PersonDetect` / `PersonTrack` / `PersonSegment` / `TimelineExport` / `FrameExtract` — the frontend's existing client-side fallback covers those.
- Prompt truncation honors a word boundary > 60% of the limit, then appends `…`.

**Parity fixtures** (`tests/fixtures/rust_api_contract_snapshots/snapshots.json`):
- 12 `JobSnapshot`-shaped fixtures gained the expected `title` field (image_generate × 9, lora_import × 1, model_download × 1, person_replace × 1). The 4 that resolve to `None` intentionally omit it.
- Regenerate locally if anything drifts: `UPDATE_SNAPSHOTS=1 pytest -q -m parity --strict-markers`.

## sc-2085 (interim thumbnail streaming) — what changed

No new code — the design doc gets an explainer subsection covering how the existing `assetWrites → persist_reported_assets → SSE → card re-render` pipeline already satisfies the "image batches stream thumbnails" acceptance criterion. Per-denoising-step single-image previews are explicitly called out as out-of-scope follow-up.

## Test plan

- [x] `cargo test -p sceneworks-core -p sceneworks-rust-api` — **221 → 223 tests, all green** (3 new: `progress_keeps_running_max_for_peak_gpu_meters`, `job_snapshot_title_is_derived_from_payload`, `job_snapshot_title_truncates_long_prompts`).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `npm test` in apps/web — **222/222 green**.
- [ ] Manual: run a job in Image Studio. Once it completes, confirm the Mem + Load bars are no longer empty in the queue.
- [ ] Manual: confirm the queue's Job Title row reads e.g. "Generate Image — \<prompt\>" rather than just the job id.
- [ ] (Optional) Run parity locally: `UPDATE_SNAPSHOTS=1 pytest -q -m parity --strict-markers` then `pytest -q -m parity --strict-markers` to confirm zero drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)