### PR TITLE
feat(video-studio): add 1024x1024 to LTX + aspect-match resolution on I2V image pick

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -221,7 +221,7 @@ export const fallbackModels = [
       durations: [4, 6, 8, 10, 12, 15],
       recommendedMaxDuration: 10,
       fps: [24, 25, 30],
-      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+      resolutions: ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
     },
     ui: {
       description: "First-class short-shot video target.",
@@ -239,7 +239,7 @@ export const fallbackModels = [
       durations: [4, 6, 8, 10, 12, 15],
       recommendedMaxDuration: 10,
       fps: [24, 25, 30],
-      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+      resolutions: ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
     },
     ui: {
       description: "Community LTX-2.3 merge tuned for image-to-video; uses LTX-video LoRAs.",

--- a/apps/web/src/resolutionMatch.js
+++ b/apps/web/src/resolutionMatch.js
@@ -1,0 +1,36 @@
+export function parseResolution(value) {
+  if (typeof value !== "string") return null;
+  const match = value.match(/^(\d+)x(\d+)$/);
+  if (!match) return null;
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+// Pick the option whose aspect ratio is closest to the source. Aspect distance
+// dominates; total-pixel distance breaks ties (a 1500×1500 source prefers
+// 1024×1024 over 640×640).
+export function pickClosestResolution(sourceWidth, sourceHeight, options) {
+  if (!Array.isArray(options) || options.length === 0) return null;
+  if (!Number.isFinite(sourceWidth) || !Number.isFinite(sourceHeight)) return null;
+  if (sourceWidth <= 0 || sourceHeight <= 0) return null;
+  const targetAspect = Math.log(sourceWidth / sourceHeight);
+  const targetPixels = Math.log(sourceWidth * sourceHeight);
+  let best = null;
+  let bestScore = null;
+  for (const option of options) {
+    const dims = parseResolution(option);
+    if (!dims) continue;
+    const aspectDistance = Math.abs(Math.log(dims.width / dims.height) - targetAspect);
+    const pixelDistance = Math.abs(Math.log(dims.width * dims.height) - targetPixels);
+    const score = aspectDistance * 100 + pixelDistance;
+    if (bestScore === null || score < bestScore) {
+      best = option;
+      bestScore = score;
+    }
+  }
+  return best;
+}

--- a/apps/web/src/resolutionMatch.test.js
+++ b/apps/web/src/resolutionMatch.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseResolution, pickClosestResolution } from "./resolutionMatch.js";
+
+describe("parseResolution", () => {
+  it("parses WxH strings", () => {
+    expect(parseResolution("1024x576")).toEqual({ width: 1024, height: 576 });
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseResolution("1024")).toBeNull();
+    expect(parseResolution("axb")).toBeNull();
+    expect(parseResolution("")).toBeNull();
+    expect(parseResolution(null)).toBeNull();
+    expect(parseResolution(undefined)).toBeNull();
+  });
+
+  it("rejects non-positive dimensions", () => {
+    expect(parseResolution("0x720")).toBeNull();
+  });
+});
+
+describe("pickClosestResolution", () => {
+  const ltxOptions = ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"];
+
+  it("returns null when options or source dims are missing/invalid", () => {
+    expect(pickClosestResolution(1024, 1024, [])).toBeNull();
+    expect(pickClosestResolution(1024, 1024, null)).toBeNull();
+    expect(pickClosestResolution(0, 1024, ltxOptions)).toBeNull();
+    expect(pickClosestResolution(1024, 0, ltxOptions)).toBeNull();
+    expect(pickClosestResolution(NaN, 1024, ltxOptions)).toBeNull();
+  });
+
+  it("picks the square option for a square source", () => {
+    expect(pickClosestResolution(1500, 1500, ltxOptions)).toBe("1024x1024");
+    expect(pickClosestResolution(500, 500, ltxOptions)).toBe("640x640");
+  });
+
+  it("picks landscape 16:9 for a 1920x1080 source", () => {
+    expect(pickClosestResolution(1920, 1080, ltxOptions)).toBe("1280x720");
+  });
+
+  it("picks portrait 9:16 for a 1080x1920 source", () => {
+    expect(pickClosestResolution(1080, 1920, ltxOptions)).toBe("720x1280");
+  });
+
+  it("picks landscape 3:2 for a 3000x2000 source", () => {
+    expect(pickClosestResolution(3000, 2000, ltxOptions)).toBe("768x512");
+  });
+
+  it("picks portrait 2:3 for a 2000x3000 source", () => {
+    expect(pickClosestResolution(2000, 3000, ltxOptions)).toBe("512x768");
+  });
+
+  it("skips malformed options without throwing", () => {
+    expect(pickClosestResolution(1500, 1500, ["bad", "1024x1024"])).toBe("1024x1024");
+  });
+});

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { pickClosestResolution } from "../resolutionMatch.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
@@ -381,6 +382,28 @@ export function VideoStudio() {
       return options.includes(Number(current)) ? current : selectedModel.defaults?.fps ?? options[0];
     });
   }, [selectedModel?.id]);
+
+  // I2V: when the user picks a source image (or first/last frame) after mount,
+  // snap resolution to whichever option in the model's list best matches the
+  // image's aspect ratio. The ref tracks the last-seen id so polling-driven
+  // assets refreshes don't re-fire, and so the saved snapshot's resolution is
+  // preserved when the asset id is just being restored on mount.
+  const i2vSourceAssetId = sourceAssetId || lastFrameAssetId;
+  const lastI2vAssetIdRef = useRef(i2vSourceAssetId);
+  useEffect(() => {
+    if (i2vSourceAssetId === lastI2vAssetIdRef.current) {
+      return;
+    }
+    lastI2vAssetIdRef.current = i2vSourceAssetId;
+    if (!i2vSourceAssetId) return;
+    if (!["image_to_video", "first_last_frame"].includes(mode)) return;
+    const asset = assets.find((item) => item.id === i2vSourceAssetId);
+    const width = asset?.file?.width;
+    const height = asset?.file?.height;
+    if (!width || !height) return;
+    const match = pickClosestResolution(width, height, selectedModel?.limits?.resolutions);
+    if (match) setResolution(match);
+  }, [i2vSourceAssetId, mode, selectedModel?.id, assets]);
 
   useEffect(() => {
     if (mode !== "replace_person" || supportsMode) {


### PR DESCRIPTION
## Summary

- Add `1024x1024` to the resolution dropdown for **LTX-2.3** and **LTX-2.3 10Eros**. The backend already accepts any dim in 256–1920 divisible by 32 via `normalized_dimensions`; the option was just missing from the frontend list.
- When the user picks a source image (or first/last frame) in `image_to_video` / `first_last_frame` mode, **auto-snap the resolution** to whichever option in the current model's `limits.resolutions` best matches the image's aspect ratio.

## How the match works

`pickClosestResolution(width, height, options)` scores each option by `|log(option_aspect) - log(source_aspect)| * 100 + |log(option_pixels) - log(source_pixels)|`. Aspect distance dominates (so 16:9 sources land on 16:9 options); pixel distance breaks ties (a 1500×1500 source prefers 1024×1024 over 640×640).

The helper lives in [`apps/web/src/resolutionMatch.js`](apps/web/src/resolutionMatch.js) with 10 unit tests covering parsing, edge cases, and every aspect bucket.

## Behavior notes

- Gated to `image_to_video` and `first_last_frame` — the modes that actually take an image input.
- Reads `asset.file.width` / `asset.file.height` (populated by Rust media ingest). Missing dims → no-op, saved resolution preserved.
- Uses a ref to skip the initial mount (so a hydrated saved snapshot's resolution isn't clobbered when the asset id is just being restored) and to ignore repeated polling-driven `assets` array updates for the same id.
- Doesn't override the user: once they manually change the dropdown after a snap, it stays put until they pick a different image.

## Test plan

- [x] `npm test` in `apps/web` — 232 tests pass (including 10 new resolution-match tests).
- [x] Verified live in dev server that `MODEL_CATALOG` (via `fallbackModels`) exposes `1024x1024` for both `ltx_2_3` and `ltx_2_3_eros`.
- [ ] In a real workspace, pick a 16:9 image in Video Studio → confirm resolution snaps to `1280x720`.
- [ ] Pick a portrait image → confirm resolution snaps to `720x1280` (or `512x768` for 2:3).
- [ ] Pick a square image with LTX selected → confirm `1024x1024`.
- [ ] Reload a saved Video Studio snapshot that already has a source image and a saved resolution → confirm the saved resolution is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)