### PR TITLE
fix(manifest): add 1024x1024 to LTX-2.3 + 10Eros builtin manifest

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -972,7 +972,7 @@
         "recommendedMaxDuration": 10,
         "hardMaxDuration": 15,
         "fps": [24, 25, 30],
-        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+        "resolutions": ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
         "requiresDimensionsMultipleOf": 32
       },
       "loraCompatibility": {
@@ -1071,7 +1071,7 @@
         "recommendedMaxDuration": 10,
         "hardMaxDuration": 15,
         "fps": [24, 25, 30],
-        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+        "resolutions": ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
         "requiresDimensionsMultipleOf": 32
       },
       "loraCompatibility": {


### PR DESCRIPTION
The authoritative model catalog the API serves comes from config/manifests/builtin.models.jsonc; the frontend fallbackModels in constants.js is only used when the API is offline. Updating just the fallback left online users still seeing the old 5-resolution list. Add 1024x1024 to both LTX-2.3 and LTX-2.3 10Eros manifest entries so the dropdown matches.

Scaffold check passes; Rust API model tests pass.