### PR TITLE
revert(ltx): drop 1024x1024 — out-of-distribution, renders black

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -221,7 +221,7 @@ export const fallbackModels = [
       durations: [4, 6, 8, 10, 12, 15],
       recommendedMaxDuration: 10,
       fps: [24, 25, 30],
-      resolutions: ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
+      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
     },
     ui: {
       description: "First-class short-shot video target.",
@@ -239,7 +239,7 @@ export const fallbackModels = [
       durations: [4, 6, 8, 10, 12, 15],
       recommendedMaxDuration: 10,
       fps: [24, 25, 30],
-      resolutions: ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
+      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
     },
     ui: {
       description: "Community LTX-2.3 merge tuned for image-to-video; uses LTX-video LoRAs.",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -972,7 +972,11 @@
         "recommendedMaxDuration": 10,
         "hardMaxDuration": 15,
         "fps": [24, 25, 30],
-        "resolutions": ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
+        // LTX is bucket-trained on 480p/720p derivatives; squares above 640x640
+        // fall outside the training distribution and produce black frames. Keep
+        // the square option at 640x640 even though normalized_dimensions would
+        // accept larger.
+        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
         "requiresDimensionsMultipleOf": 32
       },
       "loraCompatibility": {
@@ -1071,7 +1075,9 @@
         "recommendedMaxDuration": 10,
         "hardMaxDuration": 15,
         "fps": [24, 25, 30],
-        "resolutions": ["768x512", "512x768", "640x640", "1024x1024", "1280x720", "720x1280"],
+        // See LTX-2.3 note above: squares above 640x640 are out-of-distribution
+        // and render black.
+        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
         "requiresDimensionsMultipleOf": 32
       },
       "loraCompatibility": {


### PR DESCRIPTION
LTX-Video is bucket-trained on 480p/720p-derived resolutions; squares above 640x640 fall outside the training distribution and the model collapses to all- black frames. Empirically confirmed at 1024x1024 on LTX-2.3. Reverting the manifest + frontend-fallback addition and leaving a note next to the resolution list so this doesn't get re-added.

The aspect-match resolution-snap effect added earlier in this branch is unaffected and stays.