### PR TITLE
SDXL + FLUX IP-Adapter engines + RealVisXL + Z-Image cleanup [sc-2007, sc-2008, sc-2005, sc-2011]

### DIFF
--- a/apps/web/public/prompt-guides/realvisxl.md
+++ b/apps/web/public/prompt-guides/realvisxl.md
@@ -1,0 +1,90 @@
+# RealVisXL Prompt Guide
+
+## Best For
+
+Photoreal text-to-image, image-to-image, and reference-based generation across portraits, products, landscapes, and editorial-style scenes. RealVisXL_V5.0 is a community photoreal SDXL finetune — it shares the SDXL architecture, sdxl-family LoRA support, real CFG + negative prompt, and the 1024×1024 native resolution, but pushes skin, light, and material rendering toward a less "shiny/plastic" look than base SDXL. openrail++, commercial use OK, ungated.
+
+For faithful face identity from a reference image, use **InstantID (RealVisXL)** instead — same checkpoint, dedicated identity engine.
+
+## Prompt Shape
+
+RealVisXL responds best to **photoreal-leaning natural language** with concise quality tags. A reliable structure:
+
+`subject + key details + style/medium + composition + lighting + quality tags`
+
+CLIP encoders weight earlier tokens more heavily, so **lead with the subject and the most important attributes**.
+
+## Build The Prompt
+
+### Subject
+
+Front-load the subject in plain language:
+
+`a candid portrait of a woman in her early 30s holding a ceramic mug`
+
+### Details
+
+Add specific material, texture, and atmosphere — these are where RealVisXL pulls ahead of base SDXL:
+
+- `fine skin texture, visible pores, light freckles`
+- `soft cotton sweater, hand-knit cable pattern`
+- `morning steam rising from the mug`
+- `condensation beading on cold glass`
+
+### Style / Medium
+
+Reach for photographic vocabulary rather than illustrative terms:
+
+- `editorial portrait photography, 50mm`
+- `cinematic film still, 35mm anamorphic`
+- `documentary travel photography`
+- `studio product photography, matte backdrop`
+
+### Camera And Composition
+
+- `medium close-up, eye-level`
+- `shallow depth of field, f/1.8`
+- `low-angle hero shot`
+- `rule of thirds, centered subject`
+
+### Lighting
+
+Photoreal output lives or dies on lighting language — be specific:
+
+- `golden hour backlight, warm rim`
+- `soft north-window light, even diffusion`
+- `single key light, deep shadow falloff`
+- `overcast daylight, neutral white balance`
+
+### Quality Tags
+
+Keep these short and photo-realistic — avoid stacking long lists of "8k, masterpiece, best quality" that flatten the result:
+
+`sharp focus, natural skin tones, photorealistic, high detail`
+
+## Negative Prompts
+
+RealVisXL honors a negative prompt (guidance > 1). Use it to push away the common photoreal failure modes — keep it short and targeted:
+
+`blurry, lowres, overprocessed skin, plastic skin, oversaturated, deformed, extra fingers, watermark, text, jpeg artifacts, painting, illustration`
+
+## Tips
+
+- ~30 steps at guidance 7.0 is a solid baseline; lower guidance (4–6) often yields more natural, less "baked" results — try both.
+- Native 1024×1024; the canonical SDXL buckets (1152×896, 896×1152, 1216×832, 832×1216, 1344×768, 768×1344) are trained resolutions — prefer them.
+- Lighting words do more work than style words — invest in specific, physically-plausible lighting.
+- Keep skin/texture tags subtle; over-tagging "ultra-realistic skin" can produce the opposite (waxy or over-rendered) look.
+- Layer sdxl-family LoRAs for specific styles or characters — RealVisXL accepts the entire SDXL LoRA ecosystem.
+- With a character reference, use the reference-strength slider to balance prompt vs. likeness; faithful identity is **InstantID**'s job, not IP-Adapter's.
+
+## Example Prompts
+
+`A candid portrait of a fisherman in his sixties on a wooden dock at dawn, weathered hands holding a coil of rope, fine skin detail, soft golden backlight, shallow depth of field, editorial documentary photography, sharp focus.`
+
+`Studio product shot of a brushed aluminum espresso tamper on warm walnut, soft directional side light, subtle wood grain, minimalist composition, professional product photography, natural color, high detail.`
+
+## Sources
+
+- [RealVisXL_V5.0 model card](https://huggingface.co/SG161222/RealVisXL_V5.0)
+- [SDXL technical report](https://arxiv.org/abs/2307.01952)
+- [Diffusers SDXL pipeline docs](https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -173,10 +173,20 @@ export const fallbackModels = [
     id: "sdxl",
     name: "Stable Diffusion XL",
     type: "image",
-    capabilities: ["text_to_image", "edit_image", "style_variations"],
+    capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
     ui: {
-      description: "Stability AI Stable Diffusion XL base 1.0 — open text-to-image foundation with the largest LoRA/finetune ecosystem. CreativeML OpenRAIL++-M (commercial use OK, ungated). SDXL UNet + dual CLIP; ~6.9GB fp16, real CFG + negative prompt, ~30 steps at guidance 7.0; native 1024x1024.",
+      description: "Stability AI Stable Diffusion XL base 1.0 — open text-to-image foundation with the largest LoRA/finetune ecosystem. CreativeML OpenRAIL++-M (commercial use OK, ungated). SDXL UNet + dual CLIP; ~6.9GB fp16, real CFG + negative prompt, ~30 steps at guidance 7.0; native 1024x1024. With a character reference, runs IP-Adapter plus-face for scene-flexible resemblance (faithful likeness — see InstantID).",
       promptGuide: { title: "Stable Diffusion XL Prompt Guide", path: "/prompt-guides/sdxl.md" },
+    },
+  },
+  {
+    id: "realvisxl",
+    name: "RealVisXL (photoreal SDXL)",
+    type: "image",
+    capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
+    ui: {
+      description: "Photoreal SDXL finetune that targets the \"shiny/plastic\" look of base SDXL — the same RealVisXL_V5.0 checkpoint the InstantID built-in uses, exposed as a plain selectable. openrail++ (commercial use OK, ungated). Same SDXL UNet + dual CLIP, sdxl-family LoRA support, real CFG + negative prompt; ~30 steps at guidance 7.0, native 1024x1024. With a character reference, runs IP-Adapter plus-face for scene-flexible resemblance.",
+      promptGuide: { title: "RealVisXL Prompt Guide", path: "/prompt-guides/realvisxl.md" },
     },
   },
   {

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -391,6 +391,47 @@ MODEL_TARGETS = {
         "variant": "fp16",
         "repo": "stabilityai/stable-diffusion-xl-base-1.0",
         "adapter": "sdxl_diffusers",
+        # IP-Adapter for SDXL (Character Studio reference). plus-face holds facial
+        # structure via 16 patch tokens from a face-cropped training distribution,
+        # so it carries more identity than non-plus (4 global tokens) without
+        # copying clothing/composition as aggressively as plain plus (sc-2007).
+        # ViT-H image encoder shipped in the same repo. Any SDXL-UNet model
+        # (RealVisXL, etc.) can reuse this exact block. Stronger likeness still
+        # belongs to InstantID (sc-2009); IP-Adapter is the resemblance tier.
+        "ipAdapter": {
+            "repo": "h94/IP-Adapter",
+            "subfolder": "sdxl_models",
+            "weight": "ip-adapter-plus-face_sdxl_vit-h.safetensors",
+            "encoderSubfolder": "models/image_encoder",
+        },
+    },
+    "realvisxl": {
+        "label": "RealVisXL (photoreal SDXL)",
+        # SDXL UNet finetune — shares the sdxl LoRA family, sdxl_diffusers adapter,
+        # and the same IP-Adapter block. Use this for plain photoreal SDXL t2i /
+        # edit / reference work; InstantID (instantid_realvisxl) is the
+        # face-identity engine on the same checkpoint (sc-2008 vs sc-2009).
+        "family": "sdxl",
+        "supportsEdit": True,
+        # Real CFG with negative prompt: ~30 steps at guidance 7.0, native 1024.
+        "steps": 30,
+        "guidanceScale": 7.0,
+        # RealVisXL_V5.0 ships fp16-variant weights.
+        "variant": "fp16",
+        # Photoreal SDXL finetune that solves the "shiny/plastic" complaint —
+        # openrail++ (commercial use OK, ungated). Shares the HF cache with the
+        # InstantID built-in below (single ~6.6 GiB download).
+        "repo": "SG161222/RealVisXL_V5.0",
+        "adapter": "sdxl_diffusers",
+        # Same IP-Adapter as plain SDXL (h94/IP-Adapter is checkpoint-agnostic
+        # within the SDXL UNet family); identity-faithful likeness still belongs
+        # to instantid_realvisxl — IP-Adapter is the resemblance tier.
+        "ipAdapter": {
+            "repo": "h94/IP-Adapter",
+            "subfolder": "sdxl_models",
+            "weight": "ip-adapter-plus-face_sdxl_vit-h.safetensors",
+            "encoderSubfolder": "models/image_encoder",
+        },
     },
     "instantid_realvisxl": {
         "label": "InstantID (RealVisXL)",
@@ -2346,7 +2387,17 @@ class SdxlDiffusersAdapter:
         self._img2img_pipe: Any | None = None
         self._loaded_repo: str | None = None
         self._loaded_model: str | None = None
+        # Whether the resident text pipe has the IP-Adapter (+ image encoder) loaded.
+        # A plain-T2I pipe and an IP-Adapter pipe are not interchangeable, so this is
+        # part of the text-pipe cache key.
+        self._text_ip_adapter: bool = False
         self._loaded_lora_states: dict[str, LoraPipelineState] = {}
+
+    @staticmethod
+    def _use_ip_adapter(request: ImageRequest) -> bool:
+        # IP-Adapter reference conditioning runs on the text-to-image pipeline only
+        # (reference + img2img edit together is a future enhancement).
+        return request.mode != "edit_image" and bool(request.reference_asset_id)
 
     def loaded_models(self) -> list[str]:
         return sorted({value for value in (self._loaded_repo, self._loaded_model) if value})
@@ -2465,9 +2516,18 @@ class SdxlDiffusersAdapter:
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         use_img2img = request.mode == "edit_image"
+        use_ip_adapter = self._use_ip_adapter(request)
+        ip_adapter = model_target.get("ipAdapter") or {}
+        if use_ip_adapter and not ip_adapter:
+            raise RuntimeError(
+                f"{request.model} does not support reference-image (IP-Adapter) generation."
+            )
         cpu_offload = bool(request.advanced.get("cpuOffload", False))
         cached_pipe = self._img2img_pipe if use_img2img else self._text_pipe
-        if cached_pipe is not None and self._loaded_repo == repo:
+        # The text pipe's IP-Adapter state is part of its cache key: a plain-T2I pipe
+        # cannot serve a reference job, and vice versa.
+        text_state_matches = use_img2img or self._text_ip_adapter == use_ip_adapter
+        if cached_pipe is not None and self._loaded_repo == repo and text_state_matches:
             self._loaded_model = request.model
             progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
             emit_worker_event(
@@ -2482,17 +2542,22 @@ class SdxlDiffusersAdapter:
             )
             return cached_pipe
 
-        # Hold only one pipeline per repo: evict the stale pipe (other mode or
-        # stale repo) before loading so two large SDXL pipelines never sit
-        # resident at once.
+        # Hold only one pipeline per repo: evict stale pipes (other mode, stale repo,
+        # or a text pipe whose IP-Adapter state no longer matches) before loading so
+        # we don't keep two ~7GB SDXL pipelines resident.
         if self._loaded_repo and self._loaded_repo != repo:
             self._evict_pipelines(torch)
         elif use_img2img:
             if self._text_pipe is not None:
                 self._text_pipe = None
+                self._text_ip_adapter = False
                 self._forget_loaded_loras("text")
                 self._empty_cuda_cache(torch)
         else:
+            if self._text_pipe is not None:
+                self._text_pipe = None
+                self._forget_loaded_loras("text")
+                self._empty_cuda_cache(torch)
             if self._img2img_pipe is not None:
                 self._img2img_pipe = None
                 self._forget_loaded_loras("img2img")
@@ -2519,6 +2584,7 @@ class SdxlDiffusersAdapter:
             device=device,
             dtype=str(dtype),
             useImg2img=use_img2img,
+            useIpAdapter=use_ip_adapter,
             cpuOffload=cpu_offload,
             cached=cache_action == "Loading cached",
         )
@@ -2528,7 +2594,36 @@ class SdxlDiffusersAdapter:
             "torch_dtype": dtype,
             "variant": model_target.get("variant"),
         }
+        if use_ip_adapter:
+            # IP-Adapter (plus-face) needs the matching ViT-H CLIP image encoder,
+            # shipped in the same repo at models/image_encoder. Loading it here +
+            # passing image_encoder_folder=None to load_ip_adapter avoids a second
+            # fetch attempt against the SDXL repo (which has no image_encoder).
+            transformers = importlib.import_module("transformers")
+            encoder_class = getattr(transformers, "CLIPVisionModelWithProjection", None)
+            if encoder_class is None:
+                raise RuntimeError(
+                    "transformers does not expose CLIPVisionModelWithProjection, "
+                    "required for the SDXL IP-Adapter image encoder."
+                )
+            from_pretrained_kwargs["image_encoder"] = encoder_class.from_pretrained(
+                ip_adapter["repo"],
+                subfolder=ip_adapter.get("encoderSubfolder", "models/image_encoder"),
+                revision=ip_adapter.get("revision"),
+                torch_dtype=dtype,
+                low_cpu_mem_usage=True,
+            )
         pipe = pipeline_class.from_pretrained(repo, **from_pretrained_kwargs)
+        if use_ip_adapter:
+            # image_encoder_folder=None: we already supplied the encoder above.
+            pipe.load_ip_adapter(
+                ip_adapter["repo"],
+                subfolder=ip_adapter.get("subfolder", "sdxl_models"),
+                weight_name=ip_adapter["weight"],
+                revision=ip_adapter.get("revision"),
+                image_encoder_folder=None,
+            )
+            pipe.set_ip_adapter_scale(self._ip_adapter_scale(request))
         emit_worker_event(
             "image_pipeline_load_complete",
             jobId=job_id,
@@ -2568,6 +2663,7 @@ class SdxlDiffusersAdapter:
             self._img2img_pipe = pipe
         else:
             self._text_pipe = pipe
+            self._text_ip_adapter = use_ip_adapter
         self._loaded_repo = repo
         self._loaded_model = request.model
         return pipe
@@ -2575,6 +2671,7 @@ class SdxlDiffusersAdapter:
     def _evict_pipelines(self, torch: Any) -> None:
         self._text_pipe = None
         self._img2img_pipe = None
+        self._text_ip_adapter = False
         self._loaded_repo = None
         self._loaded_model = None
         self._loaded_lora_states.clear()
@@ -2615,6 +2712,12 @@ class SdxlDiffusersAdapter:
             # are dropped by filter_call_kwargs.
             kwargs["image"] = load_source_image(project_path, request)
             kwargs["strength"] = float(request.advanced.get("strength", 0.6))
+        elif self._use_ip_adapter(request):
+            # IP-Adapter conditions T2I on a reference image (style/identity). Vary
+            # prompt/seed across the batch to get many images of the same subject.
+            kwargs["ip_adapter_image"] = load_reference_image(project_path, request.reference_asset_id)
+            if hasattr(pipe, "set_ip_adapter_scale"):
+                pipe.set_ip_adapter_scale(self._ip_adapter_scale(request))
         step_callback = cancel_step_callback(pipe, cancel_requested)
         if step_callback is not None:
             kwargs["callback_on_step_end"] = step_callback
@@ -2649,6 +2752,16 @@ class SdxlDiffusersAdapter:
             return float(request.advanced.get("guidanceScale", default))
         except (TypeError, ValueError):
             return float(default)
+
+    def _ip_adapter_scale(self, request: ImageRequest) -> float:
+        # How strongly the reference conditions the result (0 = ignore,
+        # 1 = maximal). 0.7 holds plus-face identity while letting the prompt
+        # steer scene/pose; identity-faithful likeness belongs to InstantID.
+        try:
+            scale = float(request.advanced.get("ipAdapterScale", 0.7))
+        except (TypeError, ValueError):
+            return 0.7
+        return max(0.0, min(1.0, scale))
 
 
 class ChromaDiffusersAdapter:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -761,7 +761,9 @@
       "family": "sdxl",
       "type": "image",
       "adapter": "sdxl_diffusers",
-      "capabilities": ["text_to_image", "edit_image", "style_variations"],
+      // character_image: h94/IP-Adapter plus-face for Character Studio reference
+      // (sc-2007 resemblance tier; faithful likeness belongs to InstantID — sc-2009).
+      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
       "downloads": [
         {
           // Diffusers checkpoint: SDXL base 1.0 (UNet + dual CLIP text encoders
@@ -800,13 +802,70 @@
       },
       "ui": {
         "label": "Stable Diffusion XL",
-        "description": "Stability AI Stable Diffusion XL base 1.0 — the widely-supported open text-to-image foundation with the largest LoRA/finetune ecosystem. CreativeML OpenRAIL++-M (commercial use OK, ungated). SDXL UNet + dual CLIP text encoders; ~6.9GB fp16, real CFG + negative prompt. Recommended ~30 steps at guidance 7.0; native 1024x1024.",
-        "recommendedFor": ["text_to_image", "edit_image", "style_variations"],
+        "description": "Stability AI Stable Diffusion XL base 1.0 — the widely-supported open text-to-image foundation with the largest LoRA/finetune ecosystem. CreativeML OpenRAIL++-M (commercial use OK, ungated). SDXL UNet + dual CLIP text encoders; ~6.9GB fp16, real CFG + negative prompt. Recommended ~30 steps at guidance 7.0; native 1024x1024. With a character reference, runs IP-Adapter plus-face for scene-flexible resemblance (faithful likeness — see InstantID).",
+        "recommendedFor": ["text_to_image", "edit_image", "character_image", "style_variations"],
         "promptGuide": {
           "title": "Stable Diffusion XL Prompt Guide",
           "path": "/prompt-guides/sdxl.md",
           "sources": [
             { "label": "SDXL base 1.0 model card", "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0" },
+            { "label": "SDXL technical report", "url": "https://arxiv.org/abs/2307.01952" },
+            { "label": "Diffusers SDXL pipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "realvisxl",
+      "name": "RealVisXL (photoreal SDXL)",
+      "family": "sdxl",
+      "type": "image",
+      "adapter": "sdxl_diffusers",
+      // Photoreal SDXL finetune with the full SDXL feature set (t2i + edit +
+      // reference). Plain photoreal alternative to InstantID — IP-Adapter
+      // plus-face for resemblance, sdxl-family LoRA support.
+      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
+      "downloads": [
+        {
+          // Same checkpoint as the InstantID built-in below — single HF cache
+          // entry, no duplicate ~6.6 GiB download. openrail++ (commercial use OK,
+          // ungated). IP-Adapter weights are fetched on demand by the adapter.
+          "provider": "huggingface",
+          "repo": "SG161222/RealVisXL_V5.0",
+          "files": [],
+          "estimatedSizeBytes": 7105348096
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SG161222/RealVisXL_V5.0"
+      },
+      "defaults": {
+        // Model-card SDXL defaults: ~30 steps at guidance 7.0, native 1024x1024.
+        "resolution": "1024x1024",
+        "steps": 30,
+        "guidanceScale": 7.0,
+        "count": 4
+      },
+      "limits": {
+        // Native 1024x1024 plus the canonical SDXL aspect-ratio buckets.
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        // SDXL UNet, so sdxl-family LoRAs apply (per sc-1927 declare the real
+        // family rather than an empty list, which would match every LoRA).
+        "families": ["sdxl"],
+        "types": ["style", "enhance", "character"]
+      },
+      "ui": {
+        "label": "RealVisXL (photoreal SDXL)",
+        "description": "Photoreal SDXL finetune that targets the \"shiny/plastic\" look of base SDXL — the same RealVisXL_V5.0 checkpoint the InstantID built-in uses, exposed as a plain selectable for general photoreal work. openrail++ (commercial use OK, ungated). Drop-in SDXL: same UNet, same dual-CLIP, sdxl-family LoRA support, real CFG + negative prompt; ~30 steps at guidance 7.0, native 1024x1024. With a character reference, runs IP-Adapter plus-face for scene-flexible resemblance (faithful likeness — see InstantID).",
+        "recommendedFor": ["text_to_image", "edit_image", "character_image", "style_variations"],
+        "promptGuide": {
+          "title": "RealVisXL Prompt Guide",
+          "path": "/prompt-guides/realvisxl.md",
+          "sources": [
+            { "label": "RealVisXL_V5.0 model card", "url": "https://huggingface.co/SG161222/RealVisXL_V5.0" },
             { "label": "SDXL technical report", "url": "https://arxiv.org/abs/2307.01952" },
             { "label": "Diffusers SDXL pipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl" }
           ]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1726,6 +1726,14 @@ def test_sdxl_model_target_defaults():
     assert sdxl["variant"] == "fp16"
     assert "maxSequenceLength" not in sdxl
     assert sdxl["repo"] == "stabilityai/stable-diffusion-xl-base-1.0"
+    # IP-Adapter plus-face for Character Studio reference conditioning (sc-2007):
+    # ViT-H image encoder shipped in the same repo, sdxl_models subfolder for the
+    # weights. Plus-face is the identity-leaning variant without scene/outfit copy.
+    ip_adapter = sdxl["ipAdapter"]
+    assert ip_adapter["repo"] == "h94/IP-Adapter"
+    assert ip_adapter["subfolder"] == "sdxl_models"
+    assert ip_adapter["weight"] == "ip-adapter-plus-face_sdxl_vit-h.safetensors"
+    assert ip_adapter["encoderSubfolder"] == "models/image_encoder"
 
 
 def test_sdxl_supports_edit():
@@ -1759,6 +1767,142 @@ def test_sdxl_num_inference_steps_default_and_override():
     # Explicit override is honored and clamped to [1, 80].
     assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 45}), sdxl) == 45
     assert adapter._num_inference_steps(SimpleNamespace(advanced={"steps": 999}), sdxl) == 80
+
+
+def test_sdxl_reference_asset_id_parsed():
+    request = image_request_from_job(
+        {"payload": {"projectId": "p", "model": "sdxl", "referenceAssetId": "asset-ref"}}
+    )
+    assert request.reference_asset_id == "asset-ref"
+
+
+def test_sdxl_use_ip_adapter_only_for_text_with_reference():
+    use = SdxlDiffusersAdapter._use_ip_adapter
+    # IP-Adapter runs on the T2I pipeline with a reference image.
+    assert use(SimpleNamespace(mode="text_to_image", reference_asset_id="a")) is True
+    # Not for edit jobs (reference + img2img together is a future enhancement)...
+    assert use(SimpleNamespace(mode="edit_image", reference_asset_id="a")) is False
+    # ...and not without a reference image.
+    assert use(SimpleNamespace(mode="text_to_image", reference_asset_id=None)) is False
+
+
+def test_sdxl_ip_adapter_scale_default_and_clamp():
+    adapter = SdxlDiffusersAdapter()
+    # Plus-face default is 0.7 — identity-leaning while letting the prompt steer.
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={})) == 0.7
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": 0.4})) == 0.4
+    # Clamped to [0, 1]; unparseable falls back to the default.
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": 5})) == 1.0
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": -2})) == 0.0
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": "x"})) == 0.7
+
+
+def test_sdxl_reference_run_pipeline_passes_ip_adapter_image(tmp_path, monkeypatch):
+    """A T2I job with referenceAssetId drives the IP-Adapter branch of _run_pipeline:
+    load_reference_image(project_path, reference_asset_id) → ip_adapter_image kwarg, plus
+    a per-request set_ip_adapter_scale. Mirrors test_kolors_reference_run_pipeline_passes_ip_adapter_image
+    so it runs torch-free in CI."""
+
+    class FakeImage:
+        def convert(self, _mode):
+            return self
+
+    class FakeOutput:
+        images = [FakeImage()]
+
+    class FakePipe:
+        def __init__(self):
+            self.scales: list[float] = []
+
+        def set_ip_adapter_scale(self, scale):
+            self.scales.append(scale)
+
+        def __call__(self, **kwargs):
+            self.last_kwargs = kwargs
+            return FakeOutput()
+
+    class FakeTorch:
+        @staticmethod
+        def Generator(_device):
+            class Gen:
+                def manual_seed(self, _seed):
+                    return self
+
+            return Gen()
+
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.importlib.import_module",
+        lambda name: FakeTorch if name == "torch" else importlib.import_module(name),
+    )
+
+    seen: list[tuple] = []
+
+    def fake_load_reference_image(project_path, reference_asset_id):
+        seen.append((project_path, reference_asset_id))
+        return FakeImage()
+
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.load_reference_image", fake_load_reference_image
+    )
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    request = image_request_from_job(
+        {
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_image",
+                "model": "sdxl",
+                "prompt": "a portrait of the character",
+                "referenceAssetId": "asset-ref",
+                "width": 16,
+                "height": 16,
+                "count": 1,
+                "advanced": {"ipAdapterScale": 0.5},
+            }
+        }
+    )
+    pipe = FakePipe()
+    result = SdxlDiffusersAdapter()._run_pipeline(
+        SimpleNamespace(gpu_id="cpu"), pipe, request, 7, project_path
+    )
+    # The IP-Adapter branch ran: it loaded the reference image (→ ip_adapter_image
+    # kwarg) and applied the per-request scale. (filter_call_kwargs only keeps a
+    # pipe's *named* params, and FakePipe takes **kwargs, so we assert via the
+    # observable side effects rather than last_kwargs — same as the edit test.)
+    assert seen == [(project_path, "asset-ref")]
+    assert pipe.scales == [0.5]
+    assert result is FakeOutput.images[0]
+
+
+def test_create_image_adapter_routes_realvisxl():
+    # RealVisXL is a photoreal SDXL finetune that rides the same adapter; pickers
+    # filter by capability flag, not adapter id (sc-2008).
+    adapter = create_image_adapter({"payload": {"model": "realvisxl"}})
+    assert adapter.__class__.__name__ == "SdxlDiffusersAdapter"
+    assert adapter.id == "sdxl_diffusers"
+
+
+def test_realvisxl_model_target_defaults():
+    target = MODEL_TARGETS["realvisxl"]
+    # Same adapter + family as sdxl (sdxl-family LoRAs apply); plain photoreal
+    # selectable that complements instantid_realvisxl on the same checkpoint.
+    assert target["adapter"] == "sdxl_diffusers"
+    assert target["family"] == "sdxl"
+    assert target["supportsEdit"] is True
+    # SDXL defaults: ~30 steps at guidance 7.0, fp16 variant.
+    assert target["steps"] == 30
+    assert target["guidanceScale"] == 7.0
+    assert target["variant"] == "fp16"
+    # RealVisXL_V5.0: photoreal SDXL finetune (openrail++, ungated). Shares the
+    # HF cache with the InstantID built-in (no duplicate download).
+    assert target["repo"] == "SG161222/RealVisXL_V5.0"
+    # IP-Adapter block matches sdxl: any SDXL-UNet checkpoint can reuse it.
+    assert target["ipAdapter"] == MODEL_TARGETS["sdxl"]["ipAdapter"]
+
+
+def test_realvisxl_supports_edit():
+    assert model_supports_edit("realvisxl") is True
 
 
 def test_sdxl_adapter_applies_sdxl_lora(tmp_path):


### PR DESCRIPTION
## Summary

Four sequential slices on the SDXL + FLUX tracks of epic 2003. Character Studio reference conditioning now spans Kolors (existing) + SDXL + RealVisXL + FLUX [dev], all on a shared template.

- **sc-2007** — IP-Adapter wiring on `SdxlDiffusersAdapter` (cache-key flag, encoder load, `load_ip_adapter`, per-request scale), plus a `character_image` capability flag on `sdxl`. Default: `ip-adapter-plus-face_sdxl_vit-h` @ scale 0.7.
- **sc-2008** — New `realvisxl` built-in (`SG161222/RealVisXL_V5.0`) riding the sc-2007 engine. Full SDXL feature set; openrail++ (commercial-OK, ungated); HF cache shared with `instantid_realvisxl`.
- **sc-2005** — Z-Image-Turbo no longer advertises `character_image` (manifest + web fallback + Rust family default). `ZImageDiffusersAdapter` has no IP-Adapter wiring and no upstream Z-Image IP-Adapter exists.
- **sc-2011** — IP-Adapter wiring on `FluxDiffusersAdapter` via the diffusers-native `FluxIPAdapterMixin` + `XLabs-AI/flux-ip-adapter`. The FLUX-specific wrinkle is `true_cfg_scale` — FLUX is guidance-distilled, so real CFG against the negative prompt rides on a parallel kwarg (default 4.0, clamped [1, 10]). `character_image` added to `flux_dev`; `flux_schnell` stays unflagged (no native IP-Adapter for it). License posture unchanged from base flux_dev (NC + gated).

Identity-faithful likeness still belongs to **InstantID** (SDXL, sc-2009, shipped) and **PuLID-FLUX** (FLUX, sc-2012, next). IP-Adapter on SDXL/FLUX is the scene-flexible resemblance tier; descriptions/prompt guides call that out.

## Validation

Local on the worktree:
- `pytest tests/` — 406 passed, 1 skipped
- `cargo test -p sceneworks-core` — 28 passed; `cargo test -p sceneworks-rust-api` — 84 passed
- `cargo check -p sceneworks-rust-api` — clean
- `cargo fmt --check --all` — clean
- `node scripts/check-scaffold.mjs` — passed
- `vite build` — clean

## Test plan

- [ ] CI: parity, worker pytest, web build, build-windows, scaffold check
- [ ] Real Mac MPS E2E for SDXL: T2I + reference image → 4 varied images of the same subject; reference picker appears in Character Studio's "With character" model picker
- [ ] Real Mac MPS E2E for RealVisXL: plain t2i (photoreal vs base SDXL), edit, reference
- [ ] Real Mac MPS E2E for FLUX [dev]: T2I + reference image → 4 varied images of the same subject; confirm `true_cfg_scale=4.0` produces real prompt steering (not pure reference reproduction); ~42–46 GB peak memory headroom verified
- [ ] Confirm the cache-key flip evicts the pipe correctly when toggling reference on/off mid-session (SDXL + FLUX)
- [ ] Confirm Z-Image-Turbo no longer appears in Character Studio's "With character" picker after sc-2005

Owed before flipping sc-2007 / sc-2008 / sc-2011 to Done; sc-2005 + sc-2010 done at this point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)