### PR TITLE
fix: drop Z-Image-Turbo's misleading character_image flag [sc-2005]

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -31,7 +31,8 @@ export const fallbackModels = [
     id: "z_image_turbo",
     name: "Z-Image-Turbo",
     type: "image",
-    capabilities: ["text_to_image", "style_variations", "character_image"],
+    // No `character_image`: the worker adapter has no IP-Adapter wiring (sc-2005).
+    capabilities: ["text_to_image", "style_variations"],
     ui: {
       description: "Fast local text-to-image target.",
       promptGuide: { title: "Z-Image-Turbo Prompt Guide", path: "/prompt-guides/z-image-turbo.md" },

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -124,9 +124,10 @@ export const fallbackModels = [
     id: "flux_dev",
     name: "FLUX.1 [dev]",
     type: "image",
-    capabilities: ["text_to_image", "style_variations"],
+    // character_image: XLabs FLUX IP-Adapter (sc-2011 resemblance tier).
+    capabilities: ["text_to_image", "character_image", "style_variations"],
     ui: {
-      description: "FLUX.1 [dev] — higher-quality ~28-step text-to-image under the FLUX.1 [dev] Non-Commercial License (non-commercial only); gated download needs an HF token + license acceptance. ~34GB bf16, large-VRAM GPU.",
+      description: "FLUX.1 [dev] — higher-quality ~28-step text-to-image under the FLUX.1 [dev] Non-Commercial License (non-commercial only); gated download needs an HF token + license acceptance. ~34GB bf16, large-VRAM GPU. With a character reference, runs XLabs IP-Adapter for scene-flexible resemblance (faithful identity belongs to PuLID-FLUX).",
       promptGuide: { title: "FLUX.1 [dev] Prompt Guide", path: "/prompt-guides/flux-dev.md" },
     },
   },

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -316,6 +316,18 @@ MODEL_TARGETS = {
         "maxSequenceLength": 512,
         "repo": "black-forest-labs/FLUX.1-dev",
         "adapter": "flux_diffusers",
+        # XLabs FLUX IP-Adapter for Character Studio reference (sc-2011). The
+        # diffusers-blessed path: FluxIPAdapterMixin natively handles encoder load,
+        # weight load, and scale setting; FluxPipeline takes ip_adapter_image=
+        # alongside true_cfg_scale for real CFG against the negative prompt (FLUX
+        # is otherwise guidance-distilled). License: FLUX.1 [dev] NC — same posture
+        # as the base flux_dev built-in (already NC + gated). schnell has no native
+        # IP-Adapter, so this block lives only on flux_dev.
+        "ipAdapter": {
+            "repo": "XLabs-AI/flux-ip-adapter",
+            "weight": "ip_adapter.safetensors",
+            "imageEncoderRepo": "openai/clip-vit-large-patch14",
+        },
     },
     "kolors": {
         "label": "Kolors",
@@ -1674,7 +1686,18 @@ class FluxDiffusersAdapter:
         self._text_pipe: Any | None = None
         self._text_repo: str | None = None
         self._loaded_model: str | None = None
+        # Whether the resident pipe has the IP-Adapter (+ image encoder) loaded.
+        # A plain-T2I pipe and an IP-Adapter pipe are not interchangeable, so this
+        # is part of the cache key (mirrors KolorsDiffusersAdapter / SdxlDiffusersAdapter).
+        self._text_ip_adapter: bool = False
         self._loaded_lora_states: dict[str, LoraPipelineState] = {}
+
+    @staticmethod
+    def _use_ip_adapter(request: ImageRequest) -> bool:
+        # FLUX is T2I-only today (no edit_image); the reference branch still gates
+        # on mode for parity with the SDXL/Kolors templates and to future-proof
+        # FLUX.1 Kontext when it lands.
+        return request.mode != "edit_image" and bool(request.reference_asset_id)
 
     def loaded_models(self) -> list[str]:
         return sorted({value for value in (self._text_repo, self._loaded_model) if value})
@@ -1686,6 +1709,7 @@ class FluxDiffusersAdapter:
             return False
         self._text_pipe = None
         self._text_repo = None
+        self._text_ip_adapter = False
         self._loaded_model = None
         self._loaded_lora_states.clear()
         self._empty_cuda_cache(importlib.import_module("torch"))
@@ -1740,7 +1764,9 @@ class FluxDiffusersAdapter:
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                image = self._run_pipeline(settings, pipe, request, seed, cancel_requested=cancel_requested)
+                image = self._run_pipeline(
+                    settings, pipe, request, seed, project_path, cancel_requested=cancel_requested
+                )
             except Exception as exc:
                 emit_worker_event(
                     "image_inference_failed",
@@ -1794,8 +1820,18 @@ class FluxDiffusersAdapter:
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
+        use_ip_adapter = self._use_ip_adapter(request)
+        ip_adapter = model_target.get("ipAdapter") or {}
+        if use_ip_adapter and not ip_adapter:
+            raise RuntimeError(
+                f"{request.model} does not support reference-image (IP-Adapter) generation."
+            )
         cpu_offload = bool(request.advanced.get("cpuOffload", False))
-        if self._text_pipe is not None and self._text_repo == repo:
+        if (
+            self._text_pipe is not None
+            and self._text_repo == repo
+            and self._text_ip_adapter == use_ip_adapter
+        ):
             self._loaded_model = request.model
             progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
             emit_worker_event(
@@ -1812,6 +1848,7 @@ class FluxDiffusersAdapter:
         if self._text_pipe is not None:
             self._text_pipe = None
             self._text_repo = None
+            self._text_ip_adapter = False
             self._empty_cuda_cache(torch)
             self._forget_loaded_loras("text")
 
@@ -1832,10 +1869,24 @@ class FluxDiffusersAdapter:
             device=device,
             dtype=str(dtype),
             useImg2img=False,
+            useIpAdapter=use_ip_adapter,
             cpuOffload=cpu_offload,
             cached=huggingface_repo_cache_exists(repo),
         )
         pipe = pipeline_class.from_pretrained(repo, torch_dtype=dtype)
+        if use_ip_adapter:
+            # FluxIPAdapterMixin.load_ip_adapter takes the image-encoder repo/subfolder
+            # directly (no separate CLIPVisionModelWithProjection.from_pretrained step),
+            # unlike SDXL/Kolors. XLabs default = openai/clip-vit-large-patch14.
+            pipe.load_ip_adapter(
+                ip_adapter["repo"],
+                weight_name=ip_adapter["weight"],
+                subfolder=ip_adapter.get("subfolder", ""),
+                image_encoder_pretrained_model_name_or_path=ip_adapter["imageEncoderRepo"],
+                image_encoder_subfolder=ip_adapter.get("imageEncoderSubfolder", ""),
+                image_encoder_dtype=dtype,
+            )
+            pipe.set_ip_adapter_scale(self._ip_adapter_scale(request))
         emit_worker_event(
             "image_pipeline_load_complete",
             jobId=job_id,
@@ -1875,6 +1926,7 @@ class FluxDiffusersAdapter:
         )
         self._text_pipe = pipe
         self._text_repo = repo
+        self._text_ip_adapter = use_ip_adapter
         self._loaded_model = request.model
         return pipe
 
@@ -1887,6 +1939,7 @@ class FluxDiffusersAdapter:
         pipe: Any,
         request: ImageRequest,
         seed: int,
+        project_path: Path,
         cancel_requested: CancelCallback | None = None,
     ) -> Image.Image:
         torch = importlib.import_module("torch")
@@ -1900,11 +1953,22 @@ class FluxDiffusersAdapter:
             "width": request.width,
             "num_inference_steps": self._num_inference_steps(request, model_target),
             # FLUX uses embedded (distilled) guidance: schnell ignores it (0.0),
-            # dev follows it (~3.5). There is no separate negative-prompt CFG path.
+            # dev follows it (~3.5). Real CFG against negative_prompt rides on the
+            # parallel true_cfg_scale kwarg, set by the IP-Adapter branch below.
             "guidance_scale": self._guidance_scale(request, model_target),
             "max_sequence_length": self._max_sequence_length(request, model_target),
             "generator": generator,
         }
+        if self._use_ip_adapter(request):
+            # IP-Adapter conditions T2I on a reference image. FLUX is guidance-
+            # distilled, so the diffusers FLUX pipeline exposes true_cfg_scale to
+            # turn real classifier-free guidance against negative_prompt back on
+            # for the duration of the IP-Adapter run (XLabs default ~4.0).
+            kwargs["ip_adapter_image"] = load_reference_image(project_path, request.reference_asset_id)
+            kwargs["negative_prompt"] = request.negative_prompt
+            kwargs["true_cfg_scale"] = self._true_cfg_scale(request)
+            if hasattr(pipe, "set_ip_adapter_scale"):
+                pipe.set_ip_adapter_scale(self._ip_adapter_scale(request))
         step_callback = cancel_step_callback(pipe, cancel_requested)
         if step_callback is not None:
             kwargs["callback_on_step_end"] = step_callback
@@ -1946,6 +2010,29 @@ class FluxDiffusersAdapter:
             1,
             512,
         )
+
+    def _ip_adapter_scale(self, request: ImageRequest) -> float:
+        # How strongly the reference conditions the result (0 = ignore, 1 = maximal).
+        # XLabs+CLIP-L is a resemblance tier; 0.7 holds composition/style while
+        # leaving the prompt headroom. Faithful face identity belongs to PuLID-FLUX
+        # (sc-2012), not this engine.
+        try:
+            scale = float(request.advanced.get("ipAdapterScale", 0.7))
+        except (TypeError, ValueError):
+            return 0.7
+        return max(0.0, min(1.0, scale))
+
+    def _true_cfg_scale(self, request: ImageRequest) -> float:
+        # FLUX is guidance-distilled, so its `guidance_scale` is the distilled
+        # signal baked into the model — it does NOT do CFG against the negative
+        # prompt. With IP-Adapter, the diffusers FluxPipeline exposes the parallel
+        # `true_cfg_scale` kwarg that re-enables real classifier-free guidance for
+        # the duration of the run. XLabs docs default ~4.0 (range ~1.0 – 6.0).
+        try:
+            scale = float(request.advanced.get("trueCfgScale", 4.0))
+        except (TypeError, ValueError):
+            return 4.0
+        return max(1.0, min(10.0, scale))
 
 
 class KolorsDiffusersAdapter:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -500,7 +500,10 @@
       "family": "flux",
       "type": "image",
       "adapter": "flux_diffusers",
-      "capabilities": ["text_to_image", "style_variations"],
+      // character_image: XLabs-AI/flux-ip-adapter (sc-2011 resemblance tier);
+      // faithful face likeness belongs to PuLID-FLUX — sc-2012. flux_schnell has
+      // no native IP-Adapter trained for it, so this stays flux_dev-only.
+      "capabilities": ["text_to_image", "character_image", "style_variations"],
       "downloads": [
         {
           // Gated repo (Non-Commercial License). Whole-repo download (~53.9 GiB).
@@ -537,8 +540,8 @@
       "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
       "ui": {
         "label": "FLUX.1 [dev]",
-        "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and add a Hugging Face token under Settings → Service credentials (or set HF_TOKEN on a server) before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU.",
-        "recommendedFor": ["text_to_image", "style_variations"],
+        "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and add a Hugging Face token under Settings → Service credentials (or set HF_TOKEN on a server) before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU. With a character reference, runs XLabs IP-Adapter for scene-flexible resemblance (faithful identity belongs to PuLID-FLUX).",
+        "recommendedFor": ["text_to_image", "character_image", "style_variations"],
         "promptGuide": {
           "title": "FLUX.1 [dev] Prompt Guide",
           "path": "/prompt-guides/flux-dev.md",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -8,7 +8,12 @@
       "family": "z-image",
       "type": "image",
       "adapter": "z_image_diffusers",
-      "capabilities": ["text_to_image", "character_image", "style_variations"],
+      // No `character_image`: ZImageDiffusersAdapter has no IP-Adapter / reference-
+      // conditioning wiring, and no Z-Image IP-Adapter weights exist upstream. The
+      // flag previously caused Character Studio to silently ignore the reference
+      // image and generate from the prompt only (sc-2005). For SDXL-style reference
+      // work pick sdxl / realvisxl; for identity pick instantid_realvisxl.
+      "capabilities": ["text_to_image", "style_variations"],
       "downloads": [
         // Refresh estimatedSizeBytes from the Hugging Face recursive tree API:
         // https://huggingface.co/api/models/<repo>/tree/main?recursive=true

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -233,7 +233,11 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         model_type.trim().to_ascii_lowercase().as_str(),
         normalize_model_family(family).as_str(),
     ) {
-        ("image", "z-image") => vec!["text_to_image", "character_image", "style_variations"],
+        // No `character_image`: the worker's ZImageDiffusersAdapter has no IP-Adapter
+        // / reference-conditioning code, and no Z-Image IP-Adapter exists upstream
+        // (sc-2005). Custom z-image models that override capabilities can still
+        // re-declare it, but the family default shouldn't claim what it can't do.
+        ("image", "z-image") => vec!["text_to_image", "style_variations"],
         ("image", "qwen-image") => vec!["text_to_image", "style_variations"],
         ("image", "lens") => vec!["text_to_image", "style_variations"],
         ("image", "sensenova-u1") => vec!["text_to_image", "edit_image", "vqa", "interleave"],

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1260,6 +1260,14 @@ def test_flux_model_target_defaults():
     assert dev["guidanceScale"] == 3.5
     assert dev["maxSequenceLength"] == 512
     assert dev["repo"] == "black-forest-labs/FLUX.1-dev"
+    # XLabs FLUX IP-Adapter is the diffusers-blessed character-image path; CLIP-L
+    # encoder, no subfolder. flux_schnell has no native IP-Adapter trained for it,
+    # so the block lives on flux_dev only (sc-2011).
+    ip_adapter = dev["ipAdapter"]
+    assert ip_adapter["repo"] == "XLabs-AI/flux-ip-adapter"
+    assert ip_adapter["weight"] == "ip_adapter.safetensors"
+    assert ip_adapter["imageEncoderRepo"] == "openai/clip-vit-large-patch14"
+    assert "ipAdapter" not in schnell
 
 
 def test_flux_guidance_scale_uses_per_model_default_and_override():
@@ -1296,6 +1304,160 @@ def test_flux_max_sequence_length_default_and_override():
     # Override honored, clamped to the T5 max of 512.
     assert adapter._max_sequence_length(SimpleNamespace(advanced={"maxSequenceLength": 128}), dev) == 128
     assert adapter._max_sequence_length(SimpleNamespace(advanced={"maxSequenceLength": 4096}), dev) == 512
+
+
+def test_flux_reference_asset_id_parsed():
+    request = image_request_from_job(
+        {"payload": {"projectId": "p", "model": "flux_dev", "referenceAssetId": "asset-ref"}}
+    )
+    assert request.reference_asset_id == "asset-ref"
+
+
+def test_flux_use_ip_adapter_only_for_text_with_reference():
+    use = FluxDiffusersAdapter._use_ip_adapter
+    # IP-Adapter runs on the T2I pipeline with a reference image.
+    assert use(SimpleNamespace(mode="text_to_image", reference_asset_id="a")) is True
+    # FLUX is T2I-only today but the gate still mirrors SDXL/Kolors so reference +
+    # img2img (FLUX.1 Kontext) can opt in cleanly when that path lands.
+    assert use(SimpleNamespace(mode="edit_image", reference_asset_id="a")) is False
+    # No reference image → no IP-Adapter regardless of mode.
+    assert use(SimpleNamespace(mode="text_to_image", reference_asset_id=None)) is False
+
+
+def test_flux_ip_adapter_scale_default_and_clamp():
+    adapter = FluxDiffusersAdapter()
+    # XLabs+CLIP-L is the resemblance tier (faithful identity = PuLID-FLUX); the
+    # default 0.7 matches SDXL plus-face — same headroom for the prompt.
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={})) == 0.7
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": 0.4})) == 0.4
+    # Clamped to [0, 1]; unparseable falls back to the default.
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": 5})) == 1.0
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": -2})) == 0.0
+    assert adapter._ip_adapter_scale(SimpleNamespace(advanced={"ipAdapterScale": "x"})) == 0.7
+
+
+def test_flux_true_cfg_scale_default_and_clamp():
+    adapter = FluxDiffusersAdapter()
+    # FLUX is guidance-distilled, so real CFG against negative_prompt rides on
+    # the parallel true_cfg_scale kwarg. XLabs docs default 4.0; clamp [1, 10]
+    # (below 1.0 disables CFG, above 10 hard-bakes the negative prompt).
+    assert adapter._true_cfg_scale(SimpleNamespace(advanced={})) == 4.0
+    assert adapter._true_cfg_scale(SimpleNamespace(advanced={"trueCfgScale": 2.5})) == 2.5
+    assert adapter._true_cfg_scale(SimpleNamespace(advanced={"trueCfgScale": 0.0})) == 1.0
+    assert adapter._true_cfg_scale(SimpleNamespace(advanced={"trueCfgScale": 99})) == 10.0
+    assert adapter._true_cfg_scale(SimpleNamespace(advanced={"trueCfgScale": "x"})) == 4.0
+
+
+def test_flux_reference_run_pipeline_passes_ip_adapter_image_and_true_cfg(tmp_path, monkeypatch):
+    """A T2I FLUX job with referenceAssetId drives the IP-Adapter branch of
+    _run_pipeline: load_reference_image(project_path, reference_asset_id) →
+    ip_adapter_image kwarg, set_ip_adapter_scale() per request, and true_cfg_scale
+    + negative_prompt onto kwargs. Mirrors the SDXL torch-free pattern."""
+
+    class FakeImage:
+        def convert(self, _mode):
+            return self
+
+    class FakeOutput:
+        images = [FakeImage()]
+
+    class FakePipe:
+        def __init__(self):
+            self.scales: list[float] = []
+            self.last_kwargs: dict[str, Any] = {}
+
+        def set_ip_adapter_scale(self, scale):
+            self.scales.append(scale)
+
+        # Named params so filter_call_kwargs keeps the FLUX-specific kwargs we
+        # need to assert (it introspects __call__ via inspect.signature and drops
+        # anything not in the accepted-name set; a bare **kwargs is treated as
+        # accepting nothing because the var-keyword param itself is the only
+        # name in the signature).
+        def __call__(
+            self,
+            *,
+            prompt=None,
+            negative_prompt=None,
+            ip_adapter_image=None,
+            true_cfg_scale=None,
+            height=None,
+            width=None,
+            num_inference_steps=None,
+            guidance_scale=None,
+            max_sequence_length=None,
+            generator=None,
+            **kwargs,
+        ):
+            self.last_kwargs = {
+                "prompt": prompt,
+                "negative_prompt": negative_prompt,
+                "ip_adapter_image": ip_adapter_image,
+                "true_cfg_scale": true_cfg_scale,
+                "height": height,
+                "width": width,
+                "num_inference_steps": num_inference_steps,
+                "guidance_scale": guidance_scale,
+                "max_sequence_length": max_sequence_length,
+                "generator": generator,
+                **kwargs,
+            }
+            return FakeOutput()
+
+    class FakeTorch:
+        @staticmethod
+        def Generator(_device):
+            class Gen:
+                def manual_seed(self, _seed):
+                    return self
+
+            return Gen()
+
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.importlib.import_module",
+        lambda name: FakeTorch if name == "torch" else importlib.import_module(name),
+    )
+
+    seen: list[tuple] = []
+
+    def fake_load_reference_image(project_path, reference_asset_id):
+        seen.append((project_path, reference_asset_id))
+        return FakeImage()
+
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.load_reference_image", fake_load_reference_image
+    )
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    request = image_request_from_job(
+        {
+            "payload": {
+                "projectId": "project-1",
+                "mode": "text_to_image",
+                "model": "flux_dev",
+                "prompt": "a portrait of the character",
+                "negativePrompt": "blurry",
+                "referenceAssetId": "asset-ref",
+                "width": 16,
+                "height": 16,
+                "count": 1,
+                "advanced": {"ipAdapterScale": 0.5, "trueCfgScale": 3.0},
+            }
+        }
+    )
+    pipe = FakePipe()
+    result = FluxDiffusersAdapter()._run_pipeline(
+        SimpleNamespace(gpu_id="cpu"), pipe, request, 7, project_path
+    )
+    # IP-Adapter branch ran: reference loaded → ip_adapter_image kwarg, per-request
+    # scale applied, and true_cfg_scale + negative_prompt threaded through.
+    assert seen == [(project_path, "asset-ref")]
+    assert pipe.scales == [0.5]
+    assert pipe.last_kwargs["true_cfg_scale"] == 3.0
+    assert pipe.last_kwargs["negative_prompt"] == "blurry"
+    assert pipe.last_kwargs["ip_adapter_image"] is not None
+    assert result is FakeOutput.images[0]
 
 
 def test_flux_rejects_image_edit():


### PR DESCRIPTION
Z-Image-Turbo advertised `character_image` everywhere it was visible (web fallback, Rust builtin manifest, family-default capability map) but ZImageDiffusersAdapter has zero IP-Adapter / reference-conditioning code — no `load_ip_adapter`, no `ip_adapter_image` kwarg, no `reference_asset_id` handling. Picking it in Character Studio silently ignored the reference and generated from the prompt only, with no upstream Z-Image IP-Adapter available to wire it to.

Drop the flag at all three sources of truth:
  - config/manifests/builtin.models.jsonc — z_image_turbo capabilities
  - apps/web/src/constants.js — z_image_turbo fallback capabilities
  - crates/sceneworks-core/src/lora_family.rs — z-image family default in model_capabilities_for_type_and_family (custom z-image models can still re-declare it explicitly; the default shouldn't claim what can't be delivered)

For SDXL-style reference resemblance pick sdxl / realvisxl (sc-2007 / sc-2008); for identity-faithful reference pick instantid_realvisxl (sc-2009).

Validation:
  - cargo test -p sceneworks-core: 28 passed
  - cargo test -p sceneworks-rust-api: 84 passed (incl. the hand-rolled character_studio_routes_* test fixture, which declares its own capabilities and is unaffected)
  - cargo fmt --check --all: clean
  - pytest tests/: 401 passed, 1 skipped (no z_image test regressions)
  - node scripts/check-scaffold.mjs: passed
  - vite build: clean
  - Parity snapshot unchanged (model-level capabilities aren't in it)