### PR TITLE
Unify per-backbone reference-tuning sliders [sc-2017]

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -68,6 +68,10 @@ export const fallbackModels = [
     ui: {
       description: "Qwen image edit target. Dual-control architecture (semantic + appearance) handles both localized edits and subject-consistency across new scenes/poses (Character Studio reference). Apache-2.0, ungated.",
       promptGuide: { title: "Qwen Image Edit Prompt Guide", path: "/prompt-guides/qwen-image-edit.md" },
+      // Qwen's variation knob is trueCfgScale; the IP-Adapter reference-strength
+      // slider would be a no-op here. Hide it and surface variation instead (sc-2017).
+      hideReferenceStrength: true,
+      variationStrength: { label: "Variation", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
     },
   },
   {
@@ -78,6 +82,8 @@ export const fallbackModels = [
     ui: {
       description: "September monthly iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2509) via QwenImageEditPlusPipeline. Enhanced subject-consistency for character-in-new-context generation; multi-image reference support. Apache-2.0, ungated; ~50 steps at trueCfgScale 4.0.",
       promptGuide: { title: "Qwen Image Edit (2509) Prompt Guide", path: "/prompt-guides/qwen-image-edit-2509.md" },
+      hideReferenceStrength: true,
+      variationStrength: { label: "Variation", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
     },
   },
   {
@@ -141,6 +147,9 @@ export const fallbackModels = [
     ui: {
       description: "FLUX.1 [dev] — higher-quality ~28-step text-to-image under the FLUX.1 [dev] Non-Commercial License (non-commercial only); gated download needs an HF token + license acceptance. ~34GB bf16, large-VRAM GPU. With a character reference, runs XLabs IP-Adapter for scene-flexible resemblance (faithful identity belongs to PuLID-FLUX).",
       promptGuide: { title: "FLUX.1 [dev] Prompt Guide", path: "/prompt-guides/flux-dev.md" },
+      // FLUX is guidance-distilled; real CFG rides on the parallel trueCfgScale
+      // kwarg, distinct from the IP-Adapter reference-strength scalar (sc-2017).
+      variationStrength: { label: "Variation", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
     },
   },
   {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5687,6 +5687,169 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("surfaces the FLUX Variation slider alongside Reference strength and submits both knobs", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            {
+              id: "char-1",
+              name: "Mira",
+              type: "person",
+              looks: [],
+              approvedReferences: [
+                {
+                  assetId: "ref-1",
+                  approved: true,
+                  asset: {
+                    id: "ref-1",
+                    type: "image",
+                    displayName: "Mira ref",
+                    projectId: "project-1",
+                    file: { path: "assets/images/ref_0001.png", mimeType: "image/png" },
+                  },
+                },
+              ],
+            },
+          ],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "flux_dev",
+              name: "FLUX.1 [dev]",
+              type: "image",
+              family: "flux",
+              capabilities: ["character_image"],
+              ui: {
+                // FLUX exposes BOTH the IP-Adapter reference-strength slider
+                // (no override → global 0.6 default; the manifest sets 0.7 in
+                // production but this fixture intentionally omits that to verify
+                // the picker still renders correctly without a tuned default)
+                // AND the Variation slider for true_cfg_scale (sc-2017).
+                variationStrength: { label: "Variation", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
+              },
+            },
+          ],
+          latestAssets: [],
+          launchRequest: { id: "launch-flux", view: "Image", characterId: "char-1", referenceAssetId: "ref-1", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    // Both sliders are visible for FLUX: Reference strength (IP-Adapter) AND
+    // Variation (the trueCfgScale knob, which is FLUX's real-CFG lever since
+    // base FLUX is guidance-distilled).
+    expect(container.textContent).toContain("Reference strength");
+    expect(container.textContent).toContain("Variation");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    // Both knobs ride advanced: ipAdapterScale falls back to the global 0.6
+    // default (no per-model override) and trueCfgScale follows the model's
+    // declared default (4.0).
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        referenceAssetId: "ref-1",
+        advanced: expect.objectContaining({ ipAdapterScale: 0.6, trueCfgScale: 4.0 }),
+      }),
+    );
+  });
+
+  it("hides the Reference strength slider for Qwen and submits trueCfgScale alone", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [
+            {
+              id: "char-1",
+              name: "Mira",
+              type: "person",
+              looks: [],
+              approvedReferences: [
+                {
+                  assetId: "ref-1",
+                  approved: true,
+                  asset: {
+                    id: "ref-1",
+                    type: "image",
+                    displayName: "Mira ref",
+                    projectId: "project-1",
+                    file: { path: "assets/images/ref_0001.png", mimeType: "image/png" },
+                  },
+                },
+              ],
+            },
+          ],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "qwen_image_edit_2509",
+              name: "Qwen Image Edit (2509)",
+              type: "image",
+              family: "qwen-image",
+              capabilities: ["character_image"],
+              ui: {
+                // Qwen-Image-Edit's variation knob is trueCfgScale; the IP-Adapter
+                // reference-strength slider would be a no-op here (the worker
+                // adapter doesn't read ipAdapterScale). Hide the slider AND drop
+                // it from the submit payload (sc-2017).
+                hideReferenceStrength: true,
+                variationStrength: { label: "Variation", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
+              },
+            },
+          ],
+          latestAssets: [],
+          launchRequest: { id: "launch-qwen", view: "Image", characterId: "char-1", referenceAssetId: "ref-1", mode: "character_image" },
+          loras: [],
+          onPreview: () => {},
+          purgeAsset: () => {},
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    // The no-op Reference-strength slider is hidden; only Variation renders.
+    expect(container.textContent).not.toContain("Reference strength");
+    expect(container.textContent).not.toContain("Identity strength");
+    expect(container.textContent).toContain("Variation");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+
+    // advanced carries trueCfgScale but explicitly NOT ipAdapterScale.
+    const lastCall = createImageJob.mock.calls.at(-1)[0];
+    expect(lastCall.advanced.trueCfgScale).toBe(4.0);
+    expect(lastCall.advanced).not.toHaveProperty("ipAdapterScale");
+  });
+
   it("limits the character image model picker to reference-capable models", async () => {
     root = createRoot(container);
     await act(async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -225,6 +225,12 @@ export function ImageStudio() {
   const [referenceAssetId, setReferenceAssetId] = useState("");
   const [ipAdapterScale, setIpAdapterScale] = useState(saved.ipAdapterScale ?? 0.6);
   const [controlnetScale, setControlnetScale] = useState(saved.controlnetScale ?? 0.8);
+  // Variation knob for backbones whose CFG is decoupled from IP-Adapter:
+  // FLUX (true_cfg_scale alongside ipAdapterScale) and Qwen-Image-Edit (true_cfg_scale
+  // *replaces* the IP-Adapter slider because Qwen's edit pipeline doesn't use one).
+  // Per-model spec rides in ui.variationStrength; resets to the model default on
+  // model change like the other tuning knobs (sc-2017).
+  const [trueCfgScale, setTrueCfgScale] = useState(saved.trueCfgScale ?? 4.0);
   // InstantID canonical head angle ("" = match the reference's own angle). Rides advanced.viewAngle.
   const [viewAngle, setViewAngle] = useState(saved.viewAngle ?? "");
   // Pose library: selected pose ids. When non-empty, the job carries advanced.poses
@@ -342,6 +348,11 @@ export function ImageStudio() {
   const viewAngles = Array.isArray(selectedModel?.ui?.viewAngles) ? selectedModel.ui.viewAngles : null;
   // Whether the model supports the OpenPose pose library (InstantID).
   const poseLibrary = Boolean(selectedModel?.ui?.poseLibrary);
+  // Variation slider spec (FLUX / Qwen). When declared, the model exposes a
+  // trueCfgScale knob alongside (FLUX) or instead of (Qwen, via hideReferenceStrength)
+  // the IP-Adapter reference-strength slider (sc-2017).
+  const variationStrength = selectedModel?.ui?.variationStrength;
+  const hideReferenceStrength = Boolean(selectedModel?.ui?.hideReferenceStrength);
   // Reset the reference tuning to the selected model's declared defaults whenever the
   // model changes, so InstantID starts at its tuned 0.8/0.8 and Kolors at 0.6, and the
   // view angle never carries over to a model that doesn't support it. Skip the mount
@@ -355,6 +366,7 @@ export function ImageStudio() {
     const ui = imageModels.find((item) => item.id === model)?.ui ?? {};
     setIpAdapterScale(typeof ui.referenceStrengthDefault === "number" ? ui.referenceStrengthDefault : 0.6);
     setControlnetScale(typeof ui.identityStructure?.default === "number" ? ui.identityStructure.default : 0.8);
+    setTrueCfgScale(typeof ui.variationStrength?.default === "number" ? ui.variationStrength.default : 4.0);
     setViewAngle("");
     setSelectedPoseIds([]);
   }, [model]);
@@ -558,6 +570,7 @@ export function ImageStudio() {
     resolution,
     ipAdapterScale,
     controlnetScale,
+    trueCfgScale,
     viewAngle,
     upscaleEnabled,
     upscaleFactor,
@@ -674,12 +687,21 @@ export function ImageStudio() {
             ? { guidanceScale: Number(guidanceOverride) }
             : {}),
           // IP-Adapter / InstantID reference strength only applies when a character
-          // reference is attached; the worker reads advanced.ipAdapterScale.
-          ...(mode === "character_image" && referenceAssetId ? { ipAdapterScale } : {}),
+          // reference is attached AND the model uses the IP-Adapter knob; Qwen's
+          // edit pipeline ignores this scalar (hideReferenceStrength gates it out).
+          ...(mode === "character_image" && referenceAssetId && !hideReferenceStrength
+            ? { ipAdapterScale }
+            : {}),
           // Identity structure (controlnetConditioningScale) is InstantID-only — sent
           // only when the model exposes the control and a reference is attached.
           ...(mode === "character_image" && referenceAssetId && identityStructure
             ? { controlnetConditioningScale: controlnetScale }
+            : {}),
+          // Variation knob (trueCfgScale) — FLUX uses it alongside ipAdapterScale,
+          // Qwen uses it as the only variation lever. Sent only when the model
+          // declares a variationStrength slider AND a reference is attached.
+          ...(mode === "character_image" && referenceAssetId && variationStrength
+            ? { trueCfgScale }
             : {}),
           // View angle (InstantID) — only when a specific angle is chosen and no pose is
           // selected (a library pose drives the whole body, superseding the head angle).
@@ -838,18 +860,20 @@ export function ImageStudio() {
                           </button>
                         ))}
                       </div>
-                      <label className="reference-strength">
-                        {identityStructure ? "Identity strength" : "Reference strength"}
-                        <input
-                          max="1"
-                          min="0"
-                          onChange={(event) => setIpAdapterScale(Number(event.target.value))}
-                          step="0.05"
-                          type="range"
-                          value={ipAdapterScale}
-                        />
-                        <span>{ipAdapterScale.toFixed(2)}</span>
-                      </label>
+                      {hideReferenceStrength ? null : (
+                        <label className="reference-strength">
+                          {identityStructure ? "Identity strength" : "Reference strength"}
+                          <input
+                            max="1"
+                            min="0"
+                            onChange={(event) => setIpAdapterScale(Number(event.target.value))}
+                            step="0.05"
+                            type="range"
+                            value={ipAdapterScale}
+                          />
+                          <span>{ipAdapterScale.toFixed(2)}</span>
+                        </label>
+                      )}
                       {identityStructure ? (
                         <label className="reference-strength">
                           {identityStructure.label ?? "Identity structure"}
@@ -862,6 +886,20 @@ export function ImageStudio() {
                             value={controlnetScale}
                           />
                           <span>{controlnetScale.toFixed(2)}</span>
+                        </label>
+                      ) : null}
+                      {variationStrength ? (
+                        <label className="reference-strength">
+                          {variationStrength.label ?? "Variation"}
+                          <input
+                            max={variationStrength.max ?? 10}
+                            min={variationStrength.min ?? 1}
+                            onChange={(event) => setTrueCfgScale(Number(event.target.value))}
+                            step={variationStrength.step ?? 0.5}
+                            type="range"
+                            value={trueCfgScale}
+                          />
+                          <span>{trueCfgScale.toFixed(2)}</span>
                         </label>
                       ) : null}
                       {viewAngles ? (
@@ -903,6 +941,10 @@ export function ImageStudio() {
                         <span>
                           {identityStructure
                             ? "InstantID holds this person's face from the reference while the prompt drives the scene. Identity strength tunes likeness; Identity structure locks face geometry. Set a View angle to rotate the head (profiles, up/down, diagonals) with identity preserved. Raise Variations and leave the seed blank to explore takes."
+                            : variationStrength && hideReferenceStrength
+                            ? "Qwen's dual-control architecture (semantic + appearance) carries this reference's subject across new scenes and poses. Variation steers prompt-vs-reference balance: higher = more prompt-driven, lower = closer to the reference. Raise Variations and leave the seed blank to explore takes."
+                            : variationStrength
+                            ? "This reference's identity is carried across every variation. Reference strength tunes how strongly the reference conditions the result; Variation steers prompt adherence (raise for more variety, lower for closer to the reference). Raise Variations and leave the seed blank to explore takes."
                             : "This reference's identity is carried across every variation. Raise Variations and leave the seed blank to explore different takes."}
                         </span>
                       </div>

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -207,6 +207,18 @@
         "label": "Qwen Image Edit",
         "description": "Higher-control image edit target backed by Diffusers QwenImageEditPipeline. Dual-control architecture (Qwen2.5-VL for semantic, VAE encoder for appearance) supports both localized edits (background change, object swap) and subject-consistency across new scenes/poses (Character Studio reference). Apache-2.0, ungated. With a character reference, runs the same pipeline with the reference as the `image=` kwarg — variation steered by `trueCfgScale` (4.0 default).",
         "recommendedFor": ["edit_image", "character_image"],
+        // Qwen-Image-Edit's variation knob is true_cfg_scale (not an IP-Adapter
+        // reference-strength scalar): the existing "Reference strength" slider
+        // would be a no-op here. Hide it and surface variationStrength instead so
+        // the user has a real lever (sc-2017).
+        "hideReferenceStrength": true,
+        "variationStrength": {
+          "label": "Variation",
+          "default": 4.0,
+          "min": 1.0,
+          "max": 10.0,
+          "step": 0.5
+        },
         "promptGuide": {
           "title": "Qwen Image Edit Prompt Guide",
           "path": "/prompt-guides/qwen-image-edit.md",
@@ -264,6 +276,16 @@
         "label": "Qwen Image Edit (2509)",
         "description": "September monthly iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2509) backed by the multi-image `QwenImageEditPlusPipeline`. Enhanced subject-consistency for character-in-new-context generation — the model card calls out \"changing a person's pose while maintaining excellent identity consistency\". Apache-2.0, ungated. Recommended ~50 steps at trueCfgScale 4.0; bf16 MPS-supported per Qwen.",
         "recommendedFor": ["edit_image", "character_image"],
+        // Same variation-knob shape as qwen_image_edit (the picker hides the
+        // no-op IP-Adapter reference-strength slider and surfaces trueCfgScale).
+        "hideReferenceStrength": true,
+        "variationStrength": {
+          "label": "Variation",
+          "default": 4.0,
+          "min": 1.0,
+          "max": 10.0,
+          "step": 0.5
+        },
         "promptGuide": {
           "title": "Qwen Image Edit (2509) Prompt Guide",
           "path": "/prompt-guides/qwen-image-edit-2509.md",
@@ -603,6 +625,16 @@
         "label": "FLUX.1 [dev]",
         "description": "Black Forest Labs FLUX.1 [dev] — higher-quality ~28-step (guidance 3.5) text-to-image. Distributed under the FLUX.1 [dev] Non-Commercial License: generations are for non-commercial use only. Gated Hugging Face download — accept the license at huggingface.co/black-forest-labs/FLUX.1-dev and add a Hugging Face token under Settings → Service credentials (or set HF_TOKEN on a server) before downloading. For commercial use choose FLUX.1 [schnell] (Apache-2.0). 12B transformer + T5-XXL; ~34GB bf16 VRAM, large-VRAM GPU. With a character reference, runs XLabs IP-Adapter for scene-flexible resemblance (faithful identity belongs to PuLID-FLUX).",
         "recommendedFor": ["text_to_image", "character_image", "style_variations"],
+        // FLUX is guidance-distilled; real CFG against the negative prompt rides
+        // on the parallel true_cfg_scale kwarg, distinct from the IP-Adapter
+        // reference-strength scalar. Surface BOTH levers in the picker (sc-2017).
+        "variationStrength": {
+          "label": "Variation",
+          "default": 4.0,
+          "min": 1.0,
+          "max": 10.0,
+          "step": 0.5
+        },
         "promptGuide": {
           "title": "FLUX.1 [dev] Prompt Guide",
           "path": "/prompt-guides/flux-dev.md",


### PR DESCRIPTION
## Summary

Five backbones now ship `character_image` with three distinct tuning patterns; this slice unifies the picker UX so each model gets the right knobs declaratively. Generalizes the existing `ui.identityStructure` / `ui.referenceStrengthDefault` pattern with two new freeform manifest keys that flow straight through Rust's `ui.*` passthrough:

- `ui.variationStrength: { label, default, min, max, step }` — declares a Variation slider for `true_cfg_scale`.
- `ui.hideReferenceStrength: true` — opt-out for the IP-Adapter Reference-strength slider (Qwen).

Picker behavior per backbone after this:

| Backbone | Reference strength | Identity structure | Variation | View angle | Pose library |
|---|---|---|---|---|---|
| Kolors | ✅ | — | — | — | — |
| SDXL / RealVisXL | ✅ | — | — | — | — |
| InstantID (RealVisXL) | ✅ (relabeled "Identity strength") | ✅ | — | ✅ | ✅ |
| **FLUX [dev]** | ✅ | — | ✅ **NEW** | — | — |
| **Qwen-Image-Edit / 2509** | ❌ hidden (no-op) | — | ✅ **NEW** | — | — |

This fixes two latent dead-control bugs:
1. **FLUX [dev]'s variation knob was unreachable** from the UI before this slice — the worker fell back to its `true_cfg_scale=4.0` default with no user lever.
2. **Qwen's Reference-strength slider was a silent no-op** (the worker `QwenImageAdapter` doesn't read `ipAdapterScale`; same shape as the edit-image `strength` bug sc-2014 fixed).

## Implementation

**Image Studio** (`apps/web/src/screens/ImageStudio.jsx`)
- New `trueCfgScale` state with the same save/restore semantics as `ipAdapterScale` / `controlnetScale`; resets to `ui.variationStrength?.default` on model change like the other tuning knobs.
- Conditional render: hide "Reference strength" when `hideReferenceStrength`; render "Variation" when `variationStrength` is declared.
- Submit payload (`advanced`): `ipAdapterScale` ONLY when NOT `hideReferenceStrength`; `trueCfgScale` ONLY when `variationStrength` is declared (both still gated on `character_image` + reference).
- Guidance-strip blurb updated to explain the variation knob when present (Qwen vs FLUX vs InstantID get different copy).
- `useStudioSettingsWriter` now persists `trueCfgScale`.

**Manifest + constants** (`config/manifests/builtin.models.jsonc` + `apps/web/src/constants.js`)
- Add `variationStrength` to `flux_dev`.
- Add `variationStrength` + `hideReferenceStrength` to `qwen_image_edit` and `qwen_image_edit_2509`.

## Tests

`apps/web/src/main.test.jsx` — 2 new ImageStudio character_image tests:
- **"surfaces the FLUX Variation slider alongside Reference strength and submits both knobs"** — both sliders visible, both keys (`ipAdapterScale: 0.6` + `trueCfgScale: 4.0`) flow through `advanced`.
- **"hides the Reference strength slider for Qwen and submits trueCfgScale alone"** — Reference-strength hidden; `advanced` carries `trueCfgScale` and explicitly NOT `ipAdapterScale`.

## Validation

Local on the worktree:
- `pytest tests/` — 412 passed, 1 skipped
- `cargo test -p sceneworks-core --lib` — 65 passed
- `cargo check -p sceneworks-rust-api` — clean
- `cargo fmt --check --all` — clean
- `node scripts/check-scaffold.mjs` — passed
- `vite build` — clean
- Parity snapshot unchanged (`ui.*` is freeform passthrough, not in the API-surface snapshot)

The two new vitest cases would have caught regressions but the worktree's symlinked `node_modules` has a pre-existing JSDOM env breakage (same one I hit on sc-2014); the tests will run against the real `node_modules` in CI.

## Test plan

- [ ] CI: parity, worker pytest, web build, build-windows, scaffold check, **the two new vitest cases**
- [ ] Visual sanity: Character Studio "With character" picker shows the right slider set for each backbone (FLUX = Reference + Variation; Qwen = Variation only; InstantID unchanged; Kolors/SDXL/RealVisXL unchanged)
- [ ] Guidance-strip copy reads correctly for each backbone family

🤖 Generated with [Claude Code](https://claude.com/claude-code)