### PR TITLE
feat(training): opt-in weight noising for character LoRAs [epic-2123]

### DIFF
--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -185,6 +185,7 @@ class TrainingRunConfig:
     sample_prompts: list[str]
     training_adapter_repo: str | None = None
     training_adapter_version: str | None = None
+    weight_noise_sigma: float = 0.0
     advanced: dict[str, Any] = field(default_factory=dict)
 
 
@@ -260,6 +261,7 @@ def read_run_config(plan: dict[str, Any]) -> TrainingRunConfig:
         sample_prompts=[str(prompt).strip() for prompt in sample_prompts if str(prompt).strip()][:4],
         training_adapter_repo=_as_optional_str(advanced.get("trainingAdapterRepo")),
         training_adapter_version=_as_optional_str(advanced.get("trainingAdapterVersion")),
+        weight_noise_sigma=max(0.0, _as_float(advanced.get("weightNoiseSigma"), 0.0)),
         advanced=advanced,
     )
 
@@ -844,6 +846,25 @@ def training_loss(torch: Any, prediction: Any, target: Any, loss_type: str) -> A
     return torch.nn.functional.mse_loss(prediction.float(), target.float())
 
 
+def apply_weight_noise(torch: Any, optimizer: Any, sigma: float) -> None:
+    """Add small Gaussian noise to every trainable parameter the optimizer owns.
+
+    Implements the "weight noising" regularizer from BuffaloBuffaloBuffaloBuffalo /
+    ai-toolkit-perceptual: a per-step Gaussian perturbation that biases LoRA
+    training toward flatter loss minima and reduces character-LoRA memorization.
+    Opt-in via ``advanced.weightNoiseSigma`` (``0`` disables — the default).
+    """
+
+    if not sigma or sigma <= 0.0:
+        return
+    with torch.no_grad():
+        for group in optimizer.param_groups:
+            for param in group.get("params", ()):
+                if param is None or not param.requires_grad:
+                    continue
+                param.add_(torch.randn_like(param) * sigma)
+
+
 def flow_matching_velocity_target(latents: Any, noise: Any) -> Any:
     """Training target for the RAW Z-Image transformer output: ``latents - noise``.
 
@@ -1241,6 +1262,7 @@ class _ZImageLoraBackend:
         (loss / accum).backward()
         if step % accum == 0 or step == total_steps:
             self._optimizer.step()
+            apply_weight_noise(torch, self._optimizer, config.weight_noise_sigma)
             self._optimizer.zero_grad()
             # Advance the LR scheduler once per optimizer update (``None`` for a
             # plain constant schedule, leaving the LR fixed).
@@ -1736,6 +1758,7 @@ class _SdxlLoraBackend:
         (loss / accum).backward()
         if step % accum == 0 or step == total_steps:
             self._optimizer.step()
+            apply_weight_noise(torch, self._optimizer, config.weight_noise_sigma)
             self._optimizer.zero_grad()
             if self._lr_scheduler is not None:
                 self._lr_scheduler.step()
@@ -2169,6 +2192,7 @@ class _WanLoraBackend:
         (loss / accum).backward()
         if step % accum == 0 or step == total_steps:
             self._optimizer.step()
+            apply_weight_noise(torch, self._optimizer, config.weight_noise_sigma)
             self._optimizer.zero_grad()
             if self._lr_scheduler is not None:
                 self._lr_scheduler.step()
@@ -2604,6 +2628,7 @@ class _WanMoeLoraBackend(_WanLoraBackend):
             micro = self._lo_micro
         if micro % accum == 0 or step >= total_steps - 1:
             optimizer.step()
+            apply_weight_noise(torch, optimizer, config.weight_noise_sigma)
             optimizer.zero_grad()
             if scheduler is not None:
                 scheduler.step()

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -112,6 +112,7 @@ from scene_worker.training_adapters import (
     _ZImageLoraBackend,
     _build_mlx_lr_schedule,
     _build_mlx_optimizer,
+    apply_weight_noise,
     build_lr_scheduler,
     build_optimizer,
     bucket_resolution,
@@ -3633,6 +3634,60 @@ def test_read_run_config_defaults_lr_scheduler_to_constant():
     config = read_run_config({"config": {}})
     assert config.lr_scheduler == "constant"
     assert config.lr_warmup_steps == 0
+
+
+def test_read_run_config_defaults_weight_noise_sigma_to_zero():
+    config = read_run_config({"config": {}})
+    assert config.weight_noise_sigma == 0.0
+
+
+def test_read_run_config_parses_weight_noise_sigma():
+    config = read_run_config(
+        {"config": {"advanced": {"weightNoiseSigma": 0.00125}}}
+    )
+    assert config.weight_noise_sigma == pytest.approx(0.00125)
+
+
+def test_read_run_config_clamps_negative_weight_noise_sigma_to_zero():
+    config = read_run_config(
+        {"config": {"advanced": {"weightNoiseSigma": -0.01}}}
+    )
+    assert config.weight_noise_sigma == 0.0
+
+
+def test_apply_weight_noise_is_no_op_when_sigma_is_zero():
+    torch = pytest.importorskip("torch")
+
+    param = torch.nn.Parameter(torch.zeros(4))
+    optimizer = torch.optim.SGD([param], lr=0.0)
+    apply_weight_noise(torch, optimizer, 0.0)
+    assert torch.equal(param.detach(), torch.zeros(4))
+
+
+def test_apply_weight_noise_perturbs_with_expected_magnitude():
+    torch = pytest.importorskip("torch")
+
+    torch.manual_seed(0)
+    param = torch.nn.Parameter(torch.zeros(4096))
+    optimizer = torch.optim.SGD([param], lr=0.0)
+    sigma = 0.01
+    apply_weight_noise(torch, optimizer, sigma)
+    # Population std of N(0, sigma) ~= sigma; allow a generous bound for 4096 samples.
+    std = float(param.detach().std())
+    assert std == pytest.approx(sigma, rel=0.1)
+    # Mean should be near zero — perturbation is centered.
+    assert abs(float(param.detach().mean())) < sigma
+
+
+def test_apply_weight_noise_skips_frozen_params():
+    torch = pytest.importorskip("torch")
+
+    trainable = torch.nn.Parameter(torch.zeros(8))
+    frozen = torch.nn.Parameter(torch.zeros(8), requires_grad=False)
+    optimizer = torch.optim.SGD([{"params": [trainable, frozen]}], lr=0.0)
+    apply_weight_noise(torch, optimizer, 0.01)
+    assert torch.equal(frozen.detach(), torch.zeros(8))
+    assert not torch.equal(trainable.detach(), torch.zeros(8))
 
 
 def test_build_mlx_lr_schedule_constant_no_warmup_is_plain_float():


### PR DESCRIPTION
## Summary

Adds **weight noising** as an opt-in regularizer for LoRA training — a per-step Gaussian perturbation of LoRA parameters that biases training toward flatter loss minima. Adopted from [BuffaloBuffaloBuffaloBuffalo/ai-toolkit-perceptual](https://github.com/BuffaloBuffaloBuffaloBuffalo/ai-toolkit-perceptual), whose author reports substantially better character likeness at the same step count on FLUX 2 Klein 9B with this technique. Filed under [Epic 2123 — Perceptual character LoRA training techniques](https://app.shortcut.com/trefry/epic/2123).

Default is **off** (sigma 0). Existing runs are unchanged unless the operator sets `advanced.weightNoiseSigma` on the training plan.

## What changed

- New module-level helper `apply_weight_noise(torch, optimizer, sigma)` in `apps/worker/scene_worker/training_adapters.py`. Walks `optimizer.param_groups`, adds `randn_like(p) * sigma` to each trainable param under `torch.no_grad()`. Frozen params are skipped.
- New `TrainingRunConfig.weight_noise_sigma` field, parsed from `advanced.weightNoiseSigma`, clamped to `>= 0`, default `0.0` (no-op).
- Wired into all four torch backends after `optimizer.step()`:
  - `_ZImageLoraBackend`
  - `_SdxlLoraBackend` (covers SDXL/Kolors via the existing subclass seam)
  - `_WanLoraBackend` (Wan 5B)
  - `_WanMoeLoraBackend` (Wan A14B MoE — applies on each expert's local optimizer)
- MLX LTX backend (`_LtxMlxLoraBackend`) intentionally **not** wired — different framework, separate spike candidate.

The Rust side requires no change: `advanced` is already a free-form `JsonObject` and passes through transparently.

## Why opt-in (not promoted to default)

The author's published numbers (sigma 0.00125, +20% stable rank, much better likeness at 750 steps) are on FLUX 2 Klein 9B + LoKr factor 8. We use vanilla LoRA on different backbones, so the optimal sigma is almost certainly different. Promotion to a recommended default is gated on the A/B in **sc-2124**.

## Follow-up stories (Epic 2123)

- **sc-2124** — A/B validate on SDXL/Kolors + Wan; sigma sweep; decide whether to promote past opt-in.
- **sc-2125** — Spike: depth anchoring (the author's prior style-LoRA technique, referenced but not described in the character post — needs repo read).
- **sc-2126** — Spike: subject masking + caption discipline.
- **sc-2127** — Spike: per-bucket repeat counts (depends on multi-bucket sampling we don't have yet).

## Test plan

- [x] `pytest -q tests/test_worker_runtime.py` — 339 passed, 2 skipped (existing skips); new tests included
- [x] `pytest -q tests/test_worker_runtime.py -k weight_noise` — 6 passed (3 config-parse, 3 torch-gated noise behaviour)
- [ ] Real training A/B (tracked in sc-2124, not blocking this PR — default 0.0 is a no-op)

## New tests

- `test_read_run_config_defaults_weight_noise_sigma_to_zero`
- `test_read_run_config_parses_weight_noise_sigma`
- `test_read_run_config_clamps_negative_weight_noise_sigma_to_zero`
- `test_apply_weight_noise_is_no_op_when_sigma_is_zero`
- `test_apply_weight_noise_perturbs_with_expected_magnitude`
- `test_apply_weight_noise_skips_frozen_params`

The three torch-gated tests use `pytest.importorskip("torch")` per the established repo pattern (CI doesn't install torch, runs locally when present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)