### PR TITLE
SenseNova-U1 wardrobe-preserving Character Studio reference [sc-2016]

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -110,22 +110,32 @@ export const fallbackModels = [
     id: "sensenova_u1_8b",
     name: "SenseNova-U1 8B",
     type: "image",
-    capabilities: ["text_to_image", "edit_image", "vqa", "interleave"],
+    // character_image (sc-2016): SenseNova's it2i edit path doubles as a
+    // wardrobe-preserving Character Studio backbone. Distinct tradeoff vs the
+    // face-locked options — sc-2015 spike measured outfit + accessories +
+    // tattoos preserved across new scenes, face may drift.
+    capabilities: ["text_to_image", "edit_image", "character_image", "vqa", "interleave"],
     limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
     ui: {
-      description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
+      description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. In Character Studio, drives a wardrobe-preserving reference flow — outfit + accessories + tattoos + hair color carry through to new scenes, but face geometry may drift. Pick InstantID or PuLID-FLUX for face-locked identity. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
       promptGuide: { title: "SenseNova-U1 8B Prompt Guide", path: "/prompt-guides/sensenova-u1-8b.md" },
+      // Edit-style variation knob (imageGuidanceScale): higher = closer to the
+      // reference, lower = more prompt-driven variation. Drives advanced.imageGuidanceScale.
+      variationStrength: { label: "Reference strength", default: 1.5, min: 0.5, max: 4.0, step: 0.1 },
     },
   },
   {
     id: "sensenova_u1_8b_fast",
     name: "SenseNova-U1 8B Fast",
     type: "image",
-    capabilities: ["text_to_image", "edit_image"],
+    // character_image (sc-2016): same wardrobe-preserving reference flow as the
+    // base 8B target, on the 8-step distilled variant (~50s/image vs ~4.6 min).
+    capabilities: ["text_to_image", "edit_image", "character_image"],
     limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
     ui: {
-      description: "8-step distilled SenseNova-U1; ~5-6x faster text-to-image and editing (~50s/image on MPS) at a small quality trade-off. Shares the base 8B weights; a ~0.4GB distill LoRA downloads automatically. Distilled editing is experimental — use the base model for max-quality edits.",
+      description: "8-step distilled SenseNova-U1; ~5-6x faster text-to-image, editing, and Character Studio reference (~50s/image on MPS) at a small quality trade-off. Same wardrobe-preserving reference tradeoff as the base 8B (carries outfit + accessories across new scenes; face may drift). Shares the base 8B weights; a ~0.4GB distill LoRA downloads automatically. Distilled editing is experimental — use the base model for max-quality reference work.",
       promptGuide: { title: "SenseNova-U1 8B Fast Prompt Guide", path: "/prompt-guides/sensenova-u1-8b-fast.md" },
+      variationStrength: { label: "Reference strength", default: 1.5, min: 0.5, max: 4.0, step: 0.1 },
     },
   },
   {

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -3751,12 +3751,33 @@ class SenseNovaU1Adapter:
             return default
 
     @staticmethod
-    def _image_guidance_scale(request: ImageRequest) -> float:
+    def _image_guidance_scale(request: ImageRequest, default: float = 1.0) -> float:
         # Image-conditioning guidance for editing (it2i); upstream default is 1.0.
+        # The character_image reference path raises the default to 1.5 so the model
+        # is pulled harder toward the reference subject (the sc-2015 spike found
+        # face-identity holds best when the reference is more heavily weighted).
         try:
-            return float(request.advanced.get("imageGuidanceScale", 1.0))
+            return float(request.advanced.get("imageGuidanceScale", default))
         except (TypeError, ValueError):
-            return 1.0
+            return default
+
+    @staticmethod
+    def _use_reference(request: ImageRequest) -> bool:
+        # Character Studio reference path (sc-2016): feed the reference asset
+        # through the same it2i_generate machinery the edit_image mode uses, but
+        # the reference (vs source_asset_id) drives subject identity while the
+        # prompt drives the new scene/pose. Mutually exclusive with edit_image
+        # — character_image is a subject-variation flow, edit_image is a
+        # localized modification flow. Mirrors QwenImageAdapter._use_reference.
+        #
+        # Honest tradeoff (sc-2015 hardware spike): SenseNova-U1's it2i path
+        # preserves the reference's wardrobe + accessories + tattoos + hair
+        # color very faithfully across scene variations, but face geometry
+        # drifts unless the framing stays close to the reference (ArcFace
+        # cosine 0.10–0.75 across cafe / pier / studio prompts). It's the
+        # right pick when outfit consistency matters more than face fidelity;
+        # InstantID-SDXL and PuLID-FLUX are the face-locked options.
+        return request.mode == "character_image" and bool(request.reference_asset_id)
 
     def generate(
         self,
@@ -3773,6 +3794,7 @@ class SenseNovaU1Adapter:
         if model_target.get("adapter") != self.id:
             raise RuntimeError(f"{request.model} is not a SenseNova-U1 target.")
         is_edit = request.mode == "edit_image"
+        is_character_image = self._use_reference(request)
         if is_edit and not model_supports_edit(request.model):
             raise RuntimeError(f"{request.model} does not support image editing.")
 
@@ -3795,9 +3817,20 @@ class SenseNovaU1Adapter:
             timestep_shift = 3.0
         if timestep_shift <= 0.0:
             timestep_shift = 3.0
-        img_guidance_scale = self._image_guidance_scale(request)
+        # Default image-conditioning guidance is 1.0 for edit (upstream default),
+        # 1.5 for character_image (pull harder toward the reference subject).
+        img_guidance_scale = self._image_guidance_scale(request, default=1.5 if is_character_image else 1.0)
         width, height = sensenova_resolution_for(request.width, request.height)
-        source_image = load_source_image(project_path, request) if is_edit else None
+        if is_edit:
+            source_image = load_source_image(project_path, request)
+        elif is_character_image:
+            # Reference is loaded at the requested W×H so the model can match the
+            # output bucket directly (matches the edit path's resize behavior).
+            source_image = load_reference_image(project_path, request.reference_asset_id).resize(
+                (width, height)
+            )
+        else:
+            source_image = None
 
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']}.")
         model, tokenizer = self._load_model(torch, repo, device, dtype, distill_lora=distill_lora, job_id=job["id"])
@@ -3824,7 +3857,9 @@ class SenseNovaU1Adapter:
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                if is_edit:
+                if is_edit or is_character_image:
+                    # Both modes route through it2i_generate; the difference is
+                    # which asset the source_image points at (source vs reference).
                     image = self._run_edit_inference(
                         torch, model, tokenizer, request.prompt, source_image,
                         width, height, steps, guidance_scale, img_guidance_scale, timestep_shift, seed,
@@ -3866,7 +3901,9 @@ class SenseNovaU1Adapter:
                 "repo": repo,
                 "numInferenceSteps": steps,
                 "guidanceScale": guidance_scale,
-                **({"imageGuidanceScale": img_guidance_scale} if is_edit else {}),
+                **(
+                    {"imageGuidanceScale": img_guidance_scale} if (is_edit or is_character_image) else {}
+                ),
                 "timestepShift": timestep_shift,
                 "resolution": f"{width}x{height}",
                 "realModelInference": True,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -414,7 +414,15 @@
       "family": "sensenova-u1",
       "type": "image",
       "adapter": "sensenova_u1",
-      "capabilities": ["text_to_image", "edit_image", "vqa", "interleave"],
+      // character_image (sc-2016): the instruction-edit (it2i) path doubles as a
+      // Character Studio backbone — the reference is fed via the same it2i kwarg
+      // edit_image uses, but driven by referenceAssetId. sc-2015 hardware spike
+      // measured a unique tradeoff: SenseNova preserves wardrobe + accessories +
+      // tattoos + hair color across scene variations, but face geometry drifts
+      // (cosine 0.10–0.75 vs InstantID's 0.876). The right pick when outfit
+      // consistency matters more than face fidelity; the manifest description
+      // is honest about that.
+      "capabilities": ["text_to_image", "edit_image", "character_image", "vqa", "interleave"],
       "downloads": [
         {
           "provider": "huggingface",
@@ -456,8 +464,15 @@
       },
       "ui": {
         "label": "SenseNova-U1 8B",
-        "description": "Unified multimodal model (NEO-unify, ~16B). Native text-to-image and instruction-based editing with strong prompt following, dense text, and infographics. Heavy: ~42GB bf16, ~50 steps; runs on large-VRAM GPUs and 96GB+ Apple Silicon (MPS). VQA/interleaved not wired yet.",
-        "recommendedFor": ["text_to_image", "edit_image"],
+        "description": "Unified multimodal model (NEO-unify, ~16B). Native text-to-image and instruction-based editing with strong prompt following, dense text, and infographics. In Character Studio, drives a *wardrobe-preserving* reference flow: SenseNova carries the tank, jacket, props, tattoos, and hair color from the reference into new scenes very faithfully, but face geometry can drift — best when outfit consistency matters more than face identity (for face-locked identity, pick InstantID or PuLID-FLUX). Heavy: ~42GB bf16, ~50 steps; runs on large-VRAM GPUs and 96GB+ Apple Silicon (MPS).",
+        "recommendedFor": ["text_to_image", "edit_image", "character_image"],
+        // Edit-style backbone (no IP-Adapter / face-ID engine): the variation knob
+        // rides imageGuidanceScale. Higher = closer to the source/reference, lower
+        // = more prompt-driven variation. sc-2018 audit accepts this as the
+        // character_image engine declaration. Default 1.5 for character_image
+        // (the adapter raises the default vs the 1.0 edit baseline so the
+        // reference subject pulls harder by default).
+        "variationStrength": { "label": "Reference strength", "default": 1.5, "min": 0.5, "max": 4.0, "step": 0.1 },
         "promptGuide": {
           "title": "SenseNova-U1 8B Prompt Guide",
           "path": "/prompt-guides/sensenova-u1-8b.md",
@@ -475,7 +490,11 @@
       "family": "sensenova-u1",
       "type": "image",
       "adapter": "sensenova_u1",
-      "capabilities": ["text_to_image", "edit_image"],
+      // character_image (sc-2016): same it2i Character Studio path as the base
+      // SenseNova-U1 8B target, on the 8-step distilled variant (~50s/image vs
+      // ~4.6 min). Distilled editing is upstream-marked experimental, so the
+      // base model is recommended for max-quality reference work.
+      "capabilities": ["text_to_image", "edit_image", "character_image"],
       "downloads": [
         {
           // Shares the SenseNova-U1 8B base weights; the ~0.4GB 8-step distill
@@ -515,8 +534,11 @@
       },
       "ui": {
         "label": "SenseNova-U1 8B Fast",
-        "description": "8-step distilled SenseNova-U1 — ~5–6× faster text-to-image and editing (~50s/image on MPS vs ~4.6 min) at a small quality trade-off. Shares the SenseNova-U1 8B base weights (~35GB); a ~0.4GB distill LoRA downloads automatically on first use. Distilled editing is experimental — use the base SenseNova-U1 8B for max-quality edits.",
-        "recommendedFor": ["text_to_image", "edit_image"],
+        "description": "8-step distilled SenseNova-U1 — ~5–6× faster text-to-image, editing, and Character Studio reference (~50s/image on MPS vs ~4.6 min) at a small quality trade-off. Same wardrobe-preserving reference tradeoff as the base SenseNova-U1 8B (carries outfit + accessories + tattoos across new scenes, face may drift — pick InstantID or PuLID-FLUX for face-locked identity). Shares the SenseNova-U1 8B base weights (~35GB); a ~0.4GB distill LoRA downloads automatically on first use. Distilled editing is experimental — use the base SenseNova-U1 8B for max-quality reference work.",
+        "recommendedFor": ["text_to_image", "edit_image", "character_image"],
+        // Edit-style variation knob (imageGuidanceScale); see SenseNova-U1 8B
+        // for context. The fast variant defaults match the base variant.
+        "variationStrength": { "label": "Reference strength", "default": 1.5, "min": 0.5, "max": 4.0, "step": 0.1 },
         "promptGuide": {
           "title": "SenseNova-U1 8B Fast Prompt Guide",
           "path": "/prompt-guides/sensenova-u1-8b-fast.md",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2346,6 +2346,62 @@ def test_sensenova_u1_edit_support():
     assert model_supports_edit("sensenova_u1_8b_fast") is True
 
 
+# ---- sc-2016: SenseNova-U1 character_image (wardrobe-preserving reference) ----
+
+
+def test_sensenova_u1_use_reference_gates_on_mode_and_asset():
+    """The Character Studio reference path activates only when mode is
+    `character_image` AND a referenceAssetId is present. Mutually exclusive with
+    `edit_image` (mirrors QwenImageAdapter._use_reference)."""
+    from types import SimpleNamespace
+    use_ref = SenseNovaU1Adapter._use_reference
+    assert use_ref(SimpleNamespace(mode="character_image", reference_asset_id="asset_x")) is True
+    # No reference asset → falls back to plain t2i, never to the edit path with a None source.
+    assert use_ref(SimpleNamespace(mode="character_image", reference_asset_id=None)) is False
+    # Edit mode is its own branch; character_image gating must not catch it.
+    assert use_ref(SimpleNamespace(mode="edit_image", reference_asset_id="asset_x")) is False
+    # Plain text-to-image with a stray referenceAssetId stays t2i.
+    assert use_ref(SimpleNamespace(mode="text_to_image", reference_asset_id="asset_x")) is False
+
+
+def test_sensenova_u1_image_guidance_scale_default_pulls_for_character_image():
+    """The image-conditioning guidance defaults to 1.0 for edit_image (upstream
+    default) and 1.5 for character_image (pull harder toward the reference).
+    Per-request overrides via advanced.imageGuidanceScale win in both modes."""
+    from types import SimpleNamespace
+    img_cfg = SenseNovaU1Adapter._image_guidance_scale
+    # Default per-mode:
+    assert img_cfg(SimpleNamespace(advanced={})) == 1.0  # edit baseline
+    assert img_cfg(SimpleNamespace(advanced={}), default=1.5) == 1.5  # character_image default
+    # Override wins regardless of the default:
+    assert img_cfg(SimpleNamespace(advanced={"imageGuidanceScale": 2.5}), default=1.5) == 2.5
+    # Unparseable values fall back to the supplied default.
+    assert img_cfg(SimpleNamespace(advanced={"imageGuidanceScale": "x"}), default=1.5) == 1.5
+
+
+def test_sensenova_u1_advertises_character_image_capability():
+    """Both sensenova_u1 targets must advertise `character_image` in the builtin
+    manifest now that the worker dispatches it through the it2i_generate path
+    (sc-2016). Without this the sc-2018 reverse-drift guard would mark the
+    engine as 'wired but unreachable from the picker'."""
+    manifest = _load_builtin_models_manifest()
+    by_id = {model["id"]: model for model in manifest.get("models", [])}
+    for model_id in ("sensenova_u1_8b", "sensenova_u1_8b_fast"):
+        capabilities = by_id[model_id].get("capabilities") or []
+        assert "character_image" in capabilities, (
+            f"{model_id} must advertise character_image in the builtin manifest "
+            f"so the Image Studio picker surfaces the SenseNova reference flow."
+        )
+        ui = by_id[model_id].get("ui") or {}
+        # sc-2018 audit accepts ui.variationStrength as the edit-backbone engine
+        # declaration. SenseNova has no IP-Adapter / face-ID engine block, so
+        # this is the required gate for the character_image capability to be honest.
+        assert ui.get("variationStrength"), (
+            f"{model_id} declares character_image but no ui.variationStrength; "
+            f"the sc-2018 audit will fail (engine declaration missing)."
+        )
+
+
 def test_sensenova_u1_vqa_strips_reasoning():
     strip = SenseNovaU1Adapter._strip_reasoning
     # A complete think block is removed, leaving only the answer.


### PR DESCRIPTION
## Summary

Adds `character_image` mode to the existing `SenseNovaU1Adapter` — the `it2i_generate` edit path doubles as a Character Studio backbone with a distinct tradeoff vs the face-locked options.

The [sc-2015 hardware spike](https://app.shortcut.com/trefry/story/2015/spike-sensenovau1-interleave-identity-stretch#activity-2138) measured ArcFace cosine **0.10 / 0.10 / 0.75** across cafe / pier / studio prompts (mean **0.33**). The qualitative "looks like Kelsie" came from the model preserving the reference's **wardrobe + accessories + tattoos + hair color**, while face geometry drifts. That's the wrong tradeoff for face-fidelity work, but a strong unique tier when **outfit consistency** matters more than face identity (e.g. a character whose specific tank pattern + jacket + tattoo matter, in a new scene). Shipping it as an option with honest UI copy that names the tradeoff:

> *"In Character Studio, drives a wardrobe-preserving reference flow — outfit + accessories + tattoos + hair color carry through to new scenes, but face geometry may drift. Pick InstantID or PuLID-FLUX for face-locked identity."*

## Implementation

- **Worker** — `SenseNovaU1Adapter._use_reference` gates `character_image` on (mode + reference_asset_id present), mirroring `QwenImageAdapter._use_reference` from sc-2014. `generate()` routes both `edit_image` and `character_image` through `_run_edit_inference` / `it2i_generate`; the only difference is `load_source_image(source_asset_id)` vs `load_reference_image(reference_asset_id)`. `_image_guidance_scale` raises the default from 1.0 (edit) to 1.5 (character_image) so the model pulls harder toward the reference subject; `advanced.imageGuidanceScale` overrides still win.
- **Manifest + web** — both `sensenova_u1_8b` and `sensenova_u1_8b_fast` advertise `character_image` + `recommendedFor` + `ui.variationStrength: { label: "Reference strength", default: 1.5, min: 0.5, max: 4.0, step: 0.1 }`. The variationStrength declaration satisfies the sc-2018 cross-backbone audit (edit-backbone engine declaration; SenseNova has no IP-Adapter / face-ID engine block) and drives the slider that controls `advanced.imageGuidanceScale`.
- **No vendoring, no new deps.** SenseNova already runs in-process in the main worker venv; only the capability flag, UI copy, and a small dispatch branch change.

## Final Character Studio backbone matrix

| Backbone | Tradeoff |
|---|---|
| **InstantID-SDXL** | face geometry locked, scene from prompt |
| **PuLID-FLUX** | face geometry locked, scene from prompt (FLUX look) |
| **Kolors IP-Adapter** | coarse resemblance |
| **SDXL / FLUX IP-Adapter** | coarse resemblance |
| **Qwen-Image-Edit 2509** | input image content preserved |
| **SenseNova-U1 (this PR)** | wardrobe + accessories + props preserved, face drifts |

Users pick the engine that matches the shot they're trying to make.

## Test plan

- [x] **pytest** 383 (3 new for sc-2016 in `tests/test_worker_runtime.py`): `_use_reference` gating, `_image_guidance_scale` per-mode default, manifest+UI declaration audit.
- [x] **vitest** 234 (sensitivity unchanged — capability list + UI fields surfacing verified via preview eval).
- [x] **scaffold** `node scripts/check-scaffold.mjs` green.
- [x] **rustfmt** clean.
- [x] **web preview** — `pulid_flux_dev` + both `sensenova_u1` targets surface `character_image` with the new variationStrength declaration; no console errors.
- [ ] **live Mac inference** through the worker (deferred — sc-2015 already validated the underlying it2i path; this PR is the dispatch wiring + UI surfacing).

Closes sc-2016 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)