### PR TITLE
feat(worker): upgrade Qwen-Image-Edit to 2511 + Lightning distill [sc-2160]

### DIFF
--- a/apps/web/public/prompt-guides/qwen-image-edit-2511-lightning.md
+++ b/apps/web/public/prompt-guides/qwen-image-edit-2511-lightning.md
@@ -1,0 +1,41 @@
+# Qwen Image Edit (2511) Lightning Prompt Guide
+
+## Best For
+
+Fast Character Studio iteration and quick image edits on top of Qwen-Image-Edit-2511 — about **10× faster** than the base 40-step model. Same Qwen2.5-VL + VAE dual-control identity behavior as the full 2511 release; trades a small amount of quality for speed.
+
+Use **Qwen Image Edit (2511)** when you want the full-quality 40-step result; use Lightning for iteration, batch passes, and exploratory work where wall-clock dominates.
+
+## How It Works
+
+The lightx2v 4-step Lightning LoRA is fused into the Qwen-Image-Edit-2511 base on first load and stays cached in-process. The fused model runs in **4 inference steps** with classifier-free guidance disabled (`guidanceScale=1.0`, `trueCfgScale=1.0`) per the distill recipe.
+
+User LoRAs (style, character, enhancement) still apply on top of the fused base via the normal LoRA slot — the Lightning LoRA is absorbed into the base weights, leaving the slot free.
+
+## Prompt Shape
+
+Same as the base 2511 model — the prompting recipe doesn't change, only the step count and CFG.
+
+For Character Studio:
+
+`The same character + new context + scene/lighting/composition + style anchor.`
+
+For localized edits:
+
+`Describe the modification only; the model preserves the rest.`
+
+See the **[Qwen Image Edit (2511) Prompt Guide](qwen-image-edit-2511.md)** for full prompting structure and Character Studio examples.
+
+## Tips
+
+- **Don't override step count**: 4 is the trained sweet spot. Higher step counts on a distilled model degrade quality (overshooting the schedule).
+- **Don't override `trueCfgScale`**: Lightning is distilled at cfg=1.0; raising it produces ghosting and color shift. The variation slider is intentionally hidden in this model's UI.
+- **Use for ideation, switch for finals**: prototype prompts and references with Lightning, then re-render the keepers with **Qwen Image Edit (2511)** for max quality.
+- **First run downloads ~1 GB** for the Lightning LoRA from `lightx2v/Qwen-Image-Edit-2511-Lightning`; subsequent runs hit the cache.
+- **User LoRAs still work**: character/style LoRAs you've trained or imported apply normally on top of the fused base.
+
+## Sources
+
+- [Qwen-Image-Edit-2511 model card](https://huggingface.co/Qwen/Qwen-Image-Edit-2511)
+- [lightx2v Qwen-Image-Edit-2511-Lightning](https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning)
+- [Qwen-Image-Lightning GitHub (recipe)](https://github.com/ModelTC/Qwen-Image-Lightning)

--- a/apps/web/public/prompt-guides/qwen-image-edit-2511.md
+++ b/apps/web/public/prompt-guides/qwen-image-edit-2511.md
@@ -1,0 +1,85 @@
+# Qwen Image Edit (2511) Prompt Guide
+
+## Best For
+
+Character Studio reference generation, localized image editing, and subject-consistency tasks where you want the **same person in a new scene, pose, or style** while preserving identity. The December 2025 release of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2511) is the third iteration in the family and the current default for Qwen-based edit and character work. Apache-2.0, ungated.
+
+For text-to-image only (no reference), use **Qwen Image**. For ~10× faster inference at a small quality cost, use **Qwen Image Edit (2511) Lightning**.
+
+## What's New In 2511
+
+Building on the September 2509 release, 2511 brings:
+
+- **Mitigated image drift** — repeated edits and high-step runs stay closer to the source.
+- **Improved character consistency in multi-person scenes** — 2509 was strong on single subjects; 2511 holds identity for groups too.
+- **Integrated popular LoRAs** — common style/quality LoRAs are baked into the base, so you get their effects without loading them separately.
+- **Stronger geometric reasoning** — better at constraints like camera angle, perspective, and object placement.
+
+The pipeline shape is unchanged from 2509: same `QwenImageEditPlusPipeline`, same `image=` + `true_cfg_scale` knobs.
+
+## How It Works
+
+Qwen-Image-Edit doesn't blend a reference embedding into the diffusion process the way IP-Adapter models do. The reference image goes through **two parallel encoders**:
+
+- **Qwen2.5-VL** for visual *semantics* (who the subject is, what the scene contains)
+- **VAE encoder** for visual *appearance* (color, texture, lighting)
+
+The diffusion then renders the prompt while both encoders steer toward the reference. The variation knob is `trueCfgScale`:
+
+- **High `trueCfgScale` (5–6)** = prompt-dominant → more variation from the reference (new pose, new outfit, new scene work better here).
+- **Low `trueCfgScale` (~1–2)** = reference-dominant → closer to the source (subtle prompt-driven adjustments, style transfer).
+- **Default 4.0** is the model-card sweet spot.
+
+`guidanceScale` should be left at 1.0 (the 2511 recipe disables classifier-free guidance on the conditioning side; `true_cfg_scale` carries the steering).
+
+## Prompt Shape For Character Studio
+
+When you pick a character with an approved reference, the reference becomes the model's `image=` input — your prompt describes **what the same character is doing now**, not the reference itself.
+
+Effective structure:
+
+`same subject + new context + scene/lighting/composition + style anchor`
+
+### Examples
+
+`The same character at a sunlit beach café, reading a paperback, soft morning haze, candid editorial photograph, shallow depth of field.`
+
+`The same person on a foggy New York street at night, wearing a long wool coat, neon storefront reflections, cinematic 35mm.`
+
+`The same character in a sunlit kitchen, mid-laugh, holding a coffee mug, documentary photograph, warm window light.`
+
+## Prompt Shape For Edit Mode
+
+When using the model for localized edits (no character reference, just a source image), describe the **modification**, not the whole scene:
+
+- `Remove the watermark in the bottom-right corner.`
+- `Change the background to a snowy mountain at dusk; keep the subject and pose unchanged.`
+- `Replace the green shirt with a navy turtleneck.`
+
+The model preserves everything you don't mention, and 2511's drift mitigation makes this more reliable than 2509 on multi-pass edits.
+
+## Tips
+
+- **For Character Studio**: lead with "the same character/person/subject" so the model treats the reference as identity rather than as a scene to modify. Avoid "of the woman in the reference" — that often reproduces the reference's composition.
+- **Negative prompts** are required for `trueCfgScale > 1` to function. Even an empty string is accepted; common defaults: `lowres, deformed, oversaturated, distorted face, watermark`.
+- **Resolution**: 1024×1024 is the trained center; canonical aspect-ratio buckets (768×768, 1280×720, 720×1280) work well.
+- **Multi-person scenes**: 2511 holds group identity better than 2509 — name each subject in the prompt ("the same two characters, walking side by side …") to let the model track them.
+- **Multi-image references**: supply multiple approved references for stronger identity averaging. Useful for invented characters with multiple hero shots.
+- **Step count**: 40 is the 2511 recipe (vs. 50 for 2509). Drop to 30 for speed if quality holds.
+
+## Comparison To Other Character Studio Backbones
+
+| Backbone | Identity tier | When to pick |
+|---|---|---|
+| **InstantID (RealVisXL)** | Faithful face geometry (ArcFace + landmarks) | Highest-fidelity face likeness for real people |
+| **Kolors / SDXL / RealVisXL IP-Adapter** | Resemblance (CLIP/face embed) | Scene-flexible "looks like" without faithful identity |
+| **FLUX IP-Adapter** | Resemblance (XLabs CLIP-L) | Scene-flexible resemblance on FLUX's quality |
+| **Qwen Image Edit (2511)** | **Semantic + appearance** of the whole reference | Subject + outfit + setting continuity, varied poses/scenes, multi-person, multi-reference |
+
+Qwen complements the IP-Adapter family — it carries more of the reference's *context* (outfit, lighting) along with the subject, where IP-Adapter focuses on the subject alone.
+
+## Sources
+
+- [Qwen-Image-Edit-2511 model card](https://huggingface.co/Qwen/Qwen-Image-Edit-2511)
+- [Qwen-Image-Edit-2511 announcement](https://qwen.ai/blog?id=qwen-image-edit-2511)
+- [Diffusers QwenImage pipeline docs](https://huggingface.co/docs/diffusers/main/en/api/pipelines/qwenimage)

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -59,34 +59,37 @@ export const fallbackModels = [
     },
   },
   {
-    id: "qwen_image_edit",
-    name: "Qwen Image Edit",
+    id: "qwen_image_edit_2511",
+    name: "Qwen Image Edit (2511)",
     type: "image",
-    // character_image (sc-2014): subject consistency via QwenImageEditPipeline's
-    // dual-control architecture; reference goes through `image=` + trueCfgScale.
+    // character_image (sc-2014): subject consistency via QwenImageEditPlusPipeline;
+    // reference goes through `image=` + trueCfgScale. sc-2160 replaces the
+    // August/September iterations with the December 2511 release.
     capabilities: ["edit_image", "character_image"],
     ui: {
-      description: "Qwen image edit target. Dual-control architecture (semantic + appearance) handles both localized edits and subject-consistency across new scenes/poses (Character Studio reference). Apache-2.0, ungated. trueCfgScale is the slider lever; sc-2013 spike measured identity steady across the range — the knob controls prompt adherence, not identity-vs-variation.",
-      promptGuide: { title: "Qwen Image Edit Prompt Guide", path: "/prompt-guides/qwen-image-edit.md" },
+      description: "December 2025 iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2511) on QwenImageEditPlusPipeline. Drift mitigation, multi-person consistency, integrated popular LoRAs. Apache-2.0, ungated; 40 steps at trueCfgScale 4.0 / guidanceScale 1.0.",
+      promptGuide: { title: "Qwen Image Edit (2511) Prompt Guide", path: "/prompt-guides/qwen-image-edit-2511.md" },
       // Qwen's slider drives trueCfgScale; the IP-Adapter reference-strength
       // slider would be a no-op here. Hide it and surface trueCfgScale instead
-      // (sc-2017). Labeled "Prompt strength" because the sc-2013 spike showed
-      // identity holds across the range (ArcFace cosine Δ0.011 at tc 2→6); the
-      // knob is a prompt-adherence vs reference-surroundings tradeoff.
+      // (sc-2017). Label is "Prompt strength" per sc-2013: identity holds
+      // across the range, the knob is a prompt-adherence vs reference tradeoff.
       hideReferenceStrength: true,
       variationStrength: { label: "Prompt strength", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
     },
   },
   {
-    id: "qwen_image_edit_2509",
-    name: "Qwen Image Edit (2509)",
+    id: "qwen_image_edit_2511_lightning",
+    name: "Qwen Image Edit (2511) Lightning",
     type: "image",
     capabilities: ["edit_image", "character_image"],
     ui: {
-      description: "September monthly iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2509) via QwenImageEditPlusPipeline. Enhanced subject-consistency for character-in-new-context generation; multi-image reference support. Apache-2.0, ungated; ~50 steps at trueCfgScale 4.0. sc-2013 spike: 2nd-strongest face-identity engine in the epic (mean ArcFace 0.75) behind InstantID, but slowest by ~8x on Mac (~16 min/image at 50 steps; drop to 20 steps in advanced for ~7 min).",
-      promptGuide: { title: "Qwen Image Edit (2509) Prompt Guide", path: "/prompt-guides/qwen-image-edit-2509.md" },
+      description: "4-step distilled Qwen-Image-Edit-2511 (lightx2v Lightning LoRA fused at load). ~10x faster at a small quality trade-off; CFG disabled.",
+      promptGuide: { title: "Qwen Image Edit (2511) Lightning Prompt Guide", path: "/prompt-guides/qwen-image-edit-2511-lightning.md" },
       hideReferenceStrength: true,
-      variationStrength: { label: "Prompt strength", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
+      // Distill is trained at cfg 1.0; the lever is exposed only as a narrow
+      // safety range (1.0–2.0) for users willing to trade ghosting for stronger
+      // prompt adherence. Default stays at 1.0.
+      variationStrength: { label: "Prompt strength", default: 1.0, min: 1.0, max: 2.0, step: 0.25 },
     },
   },
   {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5806,8 +5806,8 @@ describe("SceneWorks app shell", () => {
           gpuOptions: ["auto"],
           imageModels: [
             {
-              id: "qwen_image_edit_2509",
-              name: "Qwen Image Edit (2509)",
+              id: "qwen_image_edit_2511",
+              name: "Qwen Image Edit (2511)",
               type: "image",
               family: "qwen-image",
               capabilities: ["character_image"],

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -1804,7 +1804,7 @@ class QwenImageAdapter:
         # Default differs by target: text-to-image qwen_image uses 4.0; the Edit
         # / Edit-Plus pipelines (incl. Lightning distill) require 1.0 per the
         # model card. Per-target default lives in MODEL_TARGETS.guidanceScale.
-        model_target = MODEL_TARGETS.get(request.model, {})
+        model_target = MODEL_TARGETS.get(getattr(request, "model", None) or "", {})
         default = model_target.get("guidanceScale", 4.0)
         try:
             return float(request.advanced.get("guidanceScale", default))
@@ -1852,7 +1852,7 @@ class QwenImageAdapter:
     def _true_cfg_scale_default(self, request: ImageRequest) -> float:
         # Per-model default for true_cfg_scale. Base Qwen Edit uses 4.0; Lightning
         # distill uses 1.0 (CFG disabled). MODEL_TARGETS.trueCfgScale overrides.
-        model_target = MODEL_TARGETS.get(request.model, {})
+        model_target = MODEL_TARGETS.get(getattr(request, "model", None) or "", {})
         default = model_target.get("trueCfgScale", 4.0)
         try:
             return float(request.advanced.get("trueCfgScale", default))

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -245,26 +245,59 @@ MODEL_TARGETS = {
         "repo": "Qwen/Qwen-Image",
         "adapter": "qwen_image",
     },
+    # sc-2160: qwen_image_edit (Aug 2025) and qwen_image_edit_2509 (Sep 2025) are
+    # aliased to Qwen-Image-Edit-2511 (Dec 2025) — the 2511 weights are a drop-in
+    # successor on the same QwenImageEditPlusPipeline, with drift mitigation,
+    # multi-person consistency, integrated popular LoRAs, and stronger geometric
+    # reasoning. Keeping the legacy IDs here means old jobs/presets/characters
+    # pinned to them still resolve. The manifest exposes only qwen_image_edit_2511
+    # + qwen_image_edit_2511_lightning in the picker.
     "qwen_image_edit": {
         "label": "Qwen Image Edit",
         "family": "qwen-image",
         "supportsEdit": True,
-        "steps": 20,
-        "repo": "Qwen/Qwen-Image-Edit",
+        "steps": 40,
+        "guidanceScale": 1.0,
+        "repo": "Qwen/Qwen-Image-Edit-2511",
         "adapter": "qwen_image",
     },
     "qwen_image_edit_2509": {
         "label": "Qwen Image Edit (2509)",
         "family": "qwen-image",
         "supportsEdit": True,
-        # Model-card defaults: 50 steps + true_cfg_scale 4.0 (the variation/CFG knob;
-        # higher = more prompt adherence, lower = closer to the reference). Character
-        # Studio reference goes through QwenImageEditPlusPipeline which accepts a
-        # list of input images for multi-reference subject consistency. Apache-2.0,
-        # ungated. sc-2014.
-        "steps": 50,
-        "repo": "Qwen/Qwen-Image-Edit-2509",
+        "steps": 40,
+        "guidanceScale": 1.0,
+        "repo": "Qwen/Qwen-Image-Edit-2511",
         "adapter": "qwen_image",
+    },
+    "qwen_image_edit_2511": {
+        "label": "Qwen Image Edit (2511)",
+        "family": "qwen-image",
+        "supportsEdit": True,
+        # Model-card defaults: 40 steps + true_cfg_scale 4.0 + guidance_scale 1.0.
+        # Same QwenImageEditPlusPipeline as the 2509 release (multi-image-capable);
+        # 2511 improvements are in the weights, not the API. Apache-2.0, ungated.
+        "steps": 40,
+        "guidanceScale": 1.0,
+        "repo": "Qwen/Qwen-Image-Edit-2511",
+        "adapter": "qwen_image",
+    },
+    "qwen_image_edit_2511_lightning": {
+        "label": "Qwen Image Edit (2511) Lightning",
+        "family": "qwen-image",
+        "supportsEdit": True,
+        # 4-step distill: cfg 1.0 / true_cfg_scale 1.0 / 4 steps (vs base 40).
+        # lightx2v Lightning LoRA fuses into the 2511 base on load; user LoRAs
+        # still stack on top via the normal apply_loras_to_pipeline path.
+        "steps": 4,
+        "guidanceScale": 1.0,
+        "trueCfgScale": 1.0,
+        "repo": "Qwen/Qwen-Image-Edit-2511",
+        "adapter": "qwen_image",
+        "distillLora": {
+            "repo": "lightx2v/Qwen-Image-Edit-2511-Lightning",
+            "file": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+        },
     },
     "lens": {
         "label": "Lens",
@@ -1428,13 +1461,15 @@ class ZImageDiffusersAdapter:
 class QwenImageAdapter:
     id = "qwen_image"
 
-    # qwen_image_edit_2509 routes through the multi-image-capable Edit Plus
-    # pipeline; the original qwen_image_edit uses the single-image Edit pipeline.
-    # Both pipelines accept `image=` + a variation prompt + `true_cfg_scale` —
-    # the diff is the multi-reference subject-consistency improvements baked into
-    # the September model (sc-2014, sc-2013 spike).
+    # sc-2160: all edit IDs route through QwenImageEditPlusPipeline now that the
+    # legacy qwen_image_edit / qwen_image_edit_2509 IDs alias to the 2511 base
+    # (same Plus shape). Both pipelines accept `image=` + true_cfg_scale; the
+    # Plus variant is the multi-image-capable one used by all modern releases.
     _EDIT_PIPELINE_BY_MODEL = {
+        "qwen_image_edit": "QwenImageEditPlusPipeline",
         "qwen_image_edit_2509": "QwenImageEditPlusPipeline",
+        "qwen_image_edit_2511": "QwenImageEditPlusPipeline",
+        "qwen_image_edit_2511_lightning": "QwenImageEditPlusPipeline",
     }
     _DEFAULT_EDIT_PIPELINE = "QwenImageEditPipeline"
 
@@ -1443,6 +1478,10 @@ class QwenImageAdapter:
         self._edit_pipe: Any | None = None
         self._text_repo: str | None = None
         self._edit_repo: str | None = None
+        # sc-2160: distill LoRA fuse state ?? pipeline cache must discriminate
+        # between fused (Lightning) and unfused base loads on the same repo.
+        self._text_distill_key: str | None = None
+        self._edit_distill_key: str | None = None
         self._loaded_model: str | None = None
         self._loaded_lora_states: dict[str, LoraPipelineState] = {}
 
@@ -1470,6 +1509,8 @@ class QwenImageAdapter:
         self._edit_pipe = None
         self._text_repo = None
         self._edit_repo = None
+        self._text_distill_key = None
+        self._edit_distill_key = None
         self._loaded_model = None
         self._loaded_lora_states.clear()
         self._empty_cuda_cache(importlib.import_module("torch"))
@@ -1581,9 +1622,12 @@ class QwenImageAdapter:
         dtype = select_torch_dtype(torch, device, request.advanced.get("dtype"))
         use_edit_pipe = request.mode == "edit_image" or self._use_reference(request)
         cpu_offload = bool(request.advanced.get("cpuOffload", False))
+        distill_lora = self._distill_lora_for(model_target)
+        distill_key = self._distill_key_for(distill_lora)
         cached_pipe = self._edit_pipe if use_edit_pipe else self._text_pipe
         cached_repo = self._edit_repo if use_edit_pipe else self._text_repo
-        if cached_pipe is not None and cached_repo == repo:
+        cached_distill = self._edit_distill_key if use_edit_pipe else self._text_distill_key
+        if cached_pipe is not None and cached_repo == repo and cached_distill == distill_key:
             self._loaded_model = request.model
             progress("loading_model", "loading_model", 0.22, f"Using cached {model_target['label']}.")
             emit_worker_event(
@@ -1601,16 +1645,18 @@ class QwenImageAdapter:
             if use_edit_pipe:
                 self._edit_pipe = None
                 self._edit_repo = None
+                self._edit_distill_key = None
             else:
                 self._text_pipe = None
                 self._text_repo = None
+                self._text_distill_key = None
             self._empty_cuda_cache(torch)
             self._forget_loaded_loras("edit" if use_edit_pipe else "text")
 
         if use_edit_pipe:
-            # Edit-style pipeline class is model-bound: qwen_image_edit_2509 ships
-            # the multi-image Plus variant, the original qwen_image_edit uses the
-            # single-image pipeline. Same `image=` kwarg shape on both.
+            # Edit-style pipeline class is model-bound. As of sc-2160 every edit
+            # ID (incl. legacy aliases) ships the multi-image Plus pipeline; the
+            # original single-image class stays as the default fallback only.
             pipeline_name = self._edit_pipeline_name(request.model)
         else:
             pipeline_name = "QwenImagePipeline"
@@ -1665,12 +1711,16 @@ class QwenImageAdapter:
             gpuMemory=gpu_memory_snapshot(torch, device),
         )
 
+        if distill_lora is not None:
+            self._fuse_distill_lora(pipe, distill_lora, job_id=job_id)
         if use_edit_pipe:
             self._edit_pipe = pipe
             self._edit_repo = repo
+            self._edit_distill_key = distill_key
         else:
             self._text_pipe = pipe
             self._text_repo = repo
+            self._text_distill_key = distill_key
         self._loaded_model = request.model
         return pipe
 
@@ -1708,8 +1758,9 @@ class QwenImageAdapter:
             # QwenImageEditPipeline.__call__ takes `image=` + `true_cfg_scale` (its
             # CFG knob) but NOT a `strength` kwarg — the previous edit path passed
             # one and filter_call_kwargs silently dropped it (sc-2013 spike find).
+            # Default true_cfg_scale per-model (Lightning needs 1.0; base 4.0).
             kwargs["image"] = load_source_image(project_path, request)
-            kwargs["true_cfg_scale"] = float(request.advanced.get("trueCfgScale", 4.0))
+            kwargs["true_cfg_scale"] = self._true_cfg_scale_default(request)
         elif self._use_reference(request):
             # Character Studio reference path: same `image=` kwarg as edit_image but
             # the reference (vs source_asset_id) drives subject identity while the
@@ -1750,22 +1801,71 @@ class QwenImageAdapter:
         return safe_int(request.advanced.get("steps"), model_target["steps"], 1, 80)
 
     def _guidance_scale(self, request: ImageRequest) -> float:
+        # Default differs by target: text-to-image qwen_image uses 4.0; the Edit
+        # / Edit-Plus pipelines (incl. Lightning distill) require 1.0 per the
+        # model card. Per-target default lives in MODEL_TARGETS.guidanceScale.
+        model_target = MODEL_TARGETS.get(request.model, {})
+        default = model_target.get("guidanceScale", 4.0)
         try:
-            return float(request.advanced.get("guidanceScale", 4.0))
+            return float(request.advanced.get("guidanceScale", default))
         except (TypeError, ValueError):
-            return 4.0
+            return float(default)
+
+    @staticmethod
+    def _distill_lora_for(model_target: dict[str, Any]) -> dict[str, Any] | None:
+        distill = model_target.get("distillLora")
+        return distill if isinstance(distill, dict) else None
+
+    @staticmethod
+    def _distill_key_for(distill_lora: dict[str, Any] | None) -> str | None:
+        if distill_lora is None:
+            return None
+        return f"{distill_lora.get('repo', '')}/{distill_lora.get('file', '')}"
+
+    def _fuse_distill_lora(self, pipe: Any, distill_lora: dict[str, Any], *, job_id: str) -> None:
+        repo = str(distill_lora["repo"])
+        file_name = str(distill_lora.get("file") or "")
+        emit_worker_event(
+            "image_distill_lora_fuse_start",
+            jobId=job_id,
+            adapter=self.id,
+            repo=repo,
+            file=file_name,
+        )
+        load_kwargs: dict[str, Any] = {}
+        if file_name:
+            load_kwargs["weight_name"] = file_name
+        # load_lora_weights ?? fuse_lora ?? unload_lora_weights bakes the distill
+        # into the base so user LoRAs can still occupy the adapter slot via the
+        # existing apply_loras_to_pipeline path.
+        pipe.load_lora_weights(repo, **load_kwargs)
+        pipe.fuse_lora()
+        pipe.unload_lora_weights()
+        emit_worker_event(
+            "image_distill_lora_fuse_complete",
+            jobId=job_id,
+            adapter=self.id,
+            repo=repo,
+            file=file_name,
+        )
+
+    def _true_cfg_scale_default(self, request: ImageRequest) -> float:
+        # Per-model default for true_cfg_scale. Base Qwen Edit uses 4.0; Lightning
+        # distill uses 1.0 (CFG disabled). MODEL_TARGETS.trueCfgScale overrides.
+        model_target = MODEL_TARGETS.get(request.model, {})
+        default = model_target.get("trueCfgScale", 4.0)
+        try:
+            return float(request.advanced.get("trueCfgScale", default))
+        except (TypeError, ValueError):
+            return float(default)
 
     def _reference_true_cfg_scale(self, request: ImageRequest) -> float:
-        # Variation knob for the character_image reference path. Model card default
-        # 4.0; higher = more prompt-driven variation, lower = closer to reference.
-        # Clamped [1, 10] — below 1 disables CFG (and Qwen's edit pipeline needs
-        # it >1 with a non-empty negative prompt to function), above 10 collapses
-        # to pure negative-prompt steering.
-        try:
-            scale = float(request.advanced.get("trueCfgScale", 4.0))
-        except (TypeError, ValueError):
-            return 4.0
-        return max(1.0, min(10.0, scale))
+        # Variation knob for the character_image reference path. Defaults per-
+        # model (Lightning fixes at 1.0, base 4.0; higher = more prompt-driven,
+        # lower = closer to reference). Clamped [1, 10] — below 1 disables CFG
+        # (Qwen's edit pipeline needs it >1 with a non-empty negative prompt to
+        # function), above 10 collapses to pure negative-prompt steering.
+        return max(1.0, min(10.0, self._true_cfg_scale_default(request)))
 
 
 class FluxDiffusersAdapter:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -201,30 +201,34 @@
       }
     },
     {
-      "id": "qwen_image_edit",
-      "name": "Qwen Image Edit",
+      "id": "qwen_image_edit_2511",
+      "name": "Qwen Image Edit (2511)",
       "family": "qwen-image",
       "type": "image",
       "adapter": "qwen_image",
-      // character_image: Qwen-Image-Edit's dual-control (Qwen2.5-VL semantic +
-      // VAE appearance) supports subject consistency across new scenes/poses;
-      // reference goes through `image=` on QwenImageEditPipeline (sc-2014 spike).
-      // qwen_image_edit_2509 below has stronger pose/subject decoupling.
+      // Successor to Qwen-Image-Edit (Aug 2025) and Qwen-Image-Edit-2509 (Sep 2025).
+      // Same QwenImageEditPlusPipeline shape as 2509; the 2511 weights bring drift
+      // mitigation, multi-person consistency, integrated popular LoRAs, and
+      // stronger geometric reasoning. The two earlier IDs are aliased to 2511
+      // weights on the worker so existing jobs/presets/characters keep resolving.
       "capabilities": ["edit_image", "character_image"],
       "downloads": [
         {
+          // Apache-2.0, ungated. Comparable size to the 2509 release.
           "provider": "huggingface",
-          "repo": "Qwen/Qwen-Image-Edit",
+          "repo": "Qwen/Qwen-Image-Edit-2511",
           "files": [],
           "estimatedSizeBytes": 57720467613
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Qwen/Qwen-Image-Edit"
+        "model": "${HF_CACHE}/Qwen/Qwen-Image-Edit-2511"
       },
       "defaults": {
+        // Model-card defaults: 40 steps + true_cfg_scale 4.0 + guidance_scale 1.0.
         "resolution": "1024x1024",
-        "steps": 20,
+        "steps": 40,
+        "guidanceScale": 1.0,
         "count": 4,
         "sampler": "default",
         "scheduler": "default"
@@ -240,8 +244,8 @@
         "types": ["style", "enhance", "character"]
       },
       "ui": {
-        "label": "Qwen Image Edit",
-        "description": "Higher-control image edit target backed by Diffusers QwenImageEditPipeline. Dual-control architecture (Qwen2.5-VL for semantic, VAE encoder for appearance) supports both localized edits (background change, object swap) and subject-consistency across new scenes/poses (Character Studio reference). Apache-2.0, ungated. With a character reference, runs the same pipeline with the reference as the `image=` kwarg; `trueCfgScale` (4.0 default) steers prompt adherence — identity stays steady across the range, the knob controls how strictly the model follows the scene/composition described in the prompt vs the reference's own surroundings (sc-2013 spike measured ArcFace cosine Δ0.011 across tc 2→6).",
+        "label": "Qwen Image Edit (2511)",
+        "description": "December 2025 iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2511) on the multi-image `QwenImageEditPlusPipeline`. Mitigates image drift, improves character consistency in multi-person scenes, integrates popular LoRAs into the base, and strengthens geometric reasoning. Apache-2.0, ungated. Recommended 40 steps at trueCfgScale 4.0 / guidanceScale 1.0; bf16 MPS-supported per Qwen. trueCfgScale is the slider lever — identity stays steady across the range, the knob is a prompt-adherence vs reference-surroundings tradeoff (sc-2013 spike on the 2509 release; same Plus pipeline shape).",
         "recommendedFor": ["edit_image", "character_image"],
         // Qwen-Image-Edit's slider is true_cfg_scale (not an IP-Adapter
         // reference-strength scalar): the existing "Reference strength" slider
@@ -259,49 +263,45 @@
           "step": 0.5
         },
         "promptGuide": {
-          "title": "Qwen Image Edit Prompt Guide",
-          "path": "/prompt-guides/qwen-image-edit.md",
+          "title": "Qwen Image Edit (2511) Prompt Guide",
+          "path": "/prompt-guides/qwen-image-edit-2511.md",
           "sources": [
-            { "label": "Qwen Cloud image editing docs", "url": "https://docs.qwencloud.com/developer-guides/image-generation/image-editing" },
-            { "label": "Qwen Cloud image prompt guide", "url": "https://docs.qwencloud.com/developer-guides/accuracy-tuning/image-generation" },
-            { "label": "Qwen Cloud text-to-image docs", "url": "https://docs.qwencloud.com/developer-guides/image-generation/text-to-image" }
+            { "label": "Qwen-Image-Edit-2511 model card", "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511" },
+            { "label": "Qwen-Image-Edit-2511 announcement", "url": "https://qwen.ai/blog?id=qwen-image-edit-2511" },
+            { "label": "Diffusers QwenImageEditPlusPipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/qwenimage" }
           ]
         }
       }
     },
     {
-      "id": "qwen_image_edit_2509",
-      "name": "Qwen Image Edit (2509)",
+      "id": "qwen_image_edit_2511_lightning",
+      "name": "Qwen Image Edit (2511) Lightning",
       "family": "qwen-image",
       "type": "image",
       "adapter": "qwen_image",
-      // QwenImageEditPlusPipeline: multi-image reference + enhanced single-image
-      // subject-consistency (the September 2509 iteration of Qwen-Image-Edit).
-      // Model-card use case: "changing a person's pose while maintaining excellent
-      // identity consistency" — directly Character Studio's wheelhouse (sc-2014).
+      // lightx2v 4-step distill LoRA fused at load over the Qwen-Image-Edit-2511
+      // base weights. ~10× faster than the 40-step base. CFG disabled (1.0)
+      // per the distill recipe; user LoRAs still apply on top of the fused base.
       "capabilities": ["edit_image", "character_image"],
       "downloads": [
         {
-          // Apache-2.0, ungated. Whole-repo download similar in size to qwen_image_edit.
+          // Shares the Qwen-Image-Edit-2511 base; the ~1 GB Lightning LoRA is
+          // fetched on first use and fused in-process.
           "provider": "huggingface",
-          "repo": "Qwen/Qwen-Image-Edit-2509",
+          "repo": "Qwen/Qwen-Image-Edit-2511",
           "files": [],
+          "default": true,
           "estimatedSizeBytes": 57720467613
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Qwen/Qwen-Image-Edit-2509"
+        "model": "${HF_CACHE}/Qwen/Qwen-Image-Edit-2511"
       },
       "defaults": {
-        // Model-card defaults: 50 steps + true_cfg_scale 4.0. The sc-2013
-        // hardware spike measured identity holding steady across the slider
-        // range (ArcFace cosine 0.8125 / 0.8187 / 0.8240 at tc 2 / 4 / 6 on
-        // the studio portrait prompt) — the knob is prompt-adherence vs the
-        // reference's own surroundings, NOT identity-vs-variation. Mac users
-        // wanting sub-10-minute generations should override steps to 20 in
-        // advanced settings (~7 min/image vs ~16 min at 50; minor quality hit).
+        // 4-step distill: cfg 1.0 / true_cfg_scale 1.0 / 4 steps (vs base 40).
         "resolution": "1024x1024",
-        "steps": 50,
+        "steps": 4,
+        "guidanceScale": 1.0,
         "count": 4,
         "sampler": "default",
         "scheduler": "default"
@@ -317,30 +317,29 @@
         "types": ["style", "enhance", "character"]
       },
       "ui": {
-        "label": "Qwen Image Edit (2509)",
-        "description": "September monthly iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2509) backed by the multi-image `QwenImageEditPlusPipeline`. Enhanced subject-consistency for character-in-new-context generation — sc-2013 hardware spike measured ArcFace cosine 0.75 mean vs reference, second only to InstantID across the epic. Apache-2.0, ungated. Recommended ~50 steps at trueCfgScale 4.0; bf16 MPS-supported per Qwen. Slowest engine in the picker on Mac (~16 min/image at 50 steps; drop to 20 steps in advanced settings for ~7 min/image at a small quality cost).",
+        "label": "Qwen Image Edit (2511) Lightning",
+        "description": "4-step distilled Qwen-Image-Edit-2511 — ~10× faster at a small quality trade-off. Shares the Qwen-Image-Edit-2511 base weights; the lightx2v 4-step distill LoRA fuses on first use. CFG is disabled by default (distill drops the guidance signal); the variation knob (trueCfgScale) pins to 1.0. Apache-2.0 base + LoRA.",
         "recommendedFor": ["edit_image", "character_image"],
-        // Same trueCfgScale slider as qwen_image_edit (the picker hides the
-        // no-op IP-Adapter reference-strength slider and surfaces trueCfgScale).
-        // Labeled "Prompt strength" per the sc-2013 measurement — identity is
-        // steady across the slider range; the knob controls how strictly the
-        // model adheres to the prompt's scene/composition vs the reference's
-        // own surroundings.
         "hideReferenceStrength": true,
+        // Distill is trained at cfg 1.0; the variation slider is exposed only as
+        // a narrow safety lever (1.0–2.0) for users willing to trade some
+        // ghosting for stronger prompt adherence. Default stays at 1.0. Labeled
+        // "Prompt strength" to match the sc-2013 naming convention across the
+        // Qwen Edit family.
         "variationStrength": {
           "label": "Prompt strength",
-          "default": 4.0,
+          "default": 1.0,
           "min": 1.0,
-          "max": 10.0,
-          "step": 0.5
+          "max": 2.0,
+          "step": 0.25
         },
         "promptGuide": {
-          "title": "Qwen Image Edit (2509) Prompt Guide",
-          "path": "/prompt-guides/qwen-image-edit-2509.md",
+          "title": "Qwen Image Edit (2511) Lightning Prompt Guide",
+          "path": "/prompt-guides/qwen-image-edit-2511-lightning.md",
           "sources": [
-            { "label": "Qwen-Image-Edit-2509 model card", "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509" },
-            { "label": "Diffusers QwenImageEditPlusPipeline docs", "url": "https://huggingface.co/docs/diffusers/main/en/api/pipelines/qwenimage" },
-            { "label": "Qwen-Image-Edit model card", "url": "https://huggingface.co/Qwen/Qwen-Image-Edit" }
+            { "label": "Qwen-Image-Edit-2511 model card", "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511" },
+            { "label": "lightx2v Qwen-Image-Edit-2511-Lightning", "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning" },
+            { "label": "Qwen-Image-Lightning GitHub", "url": "https://github.com/ModelTC/Qwen-Image-Lightning" }
           ]
         }
       }

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -488,33 +488,102 @@ def test_qwen_loaded_models_track_text_and_edit_repos_independently():
     assert set(adapter.loaded_models()) == {"Qwen/Qwen-Image", "Qwen/Qwen-Image-Edit", "qwen_image_edit"}
 
 
-def test_qwen_image_edit_2509_model_target_defaults():
-    target = MODEL_TARGETS["qwen_image_edit_2509"]
+def test_qwen_image_edit_2511_model_target_defaults():
+    target = MODEL_TARGETS["qwen_image_edit_2511"]
     assert target["adapter"] == "qwen_image"
     assert target["family"] == "qwen-image"
     assert target["supportsEdit"] is True
-    # Model-card recommends 50 steps for the September iteration (vs 20 on
-    # qwen_image_edit) — character_image quality benefits.
-    assert target["steps"] == 50
-    assert target["repo"] == "Qwen/Qwen-Image-Edit-2509"
+    # Model card: 40 steps, guidanceScale 1.0, trueCfgScale 4.0 (default).
+    assert target["steps"] == 40
+    assert target["guidanceScale"] == 1.0
+    assert target["repo"] == "Qwen/Qwen-Image-Edit-2511"
 
 
-def test_create_image_adapter_routes_qwen_image_edit_2509():
-    # The new Plus model rides the same QwenImageAdapter; pipeline-class selection
-    # happens inside _load_pipeline based on the model id (sc-2014).
-    adapter = create_image_adapter({"payload": {"model": "qwen_image_edit_2509"}})
+def test_qwen_image_edit_legacy_ids_alias_to_2511_repo():
+    # sc-2160: the August qwen_image_edit and the September qwen_image_edit_2509
+    # IDs now route to the December 2511 weights so old jobs/presets resolve.
+    legacy = MODEL_TARGETS["qwen_image_edit"]
+    sept = MODEL_TARGETS["qwen_image_edit_2509"]
+    assert legacy["repo"] == "Qwen/Qwen-Image-Edit-2511"
+    assert sept["repo"] == "Qwen/Qwen-Image-Edit-2511"
+    assert legacy["steps"] == 40
+    assert sept["steps"] == 40
+    assert legacy["guidanceScale"] == 1.0
+    assert sept["guidanceScale"] == 1.0
+
+
+def test_qwen_image_edit_2511_lightning_model_target_defaults():
+    target = MODEL_TARGETS["qwen_image_edit_2511_lightning"]
+    assert target["adapter"] == "qwen_image"
+    assert target["family"] == "qwen-image"
+    assert target["supportsEdit"] is True
+    # 4-step distill: cfg 1.0, true_cfg_scale 1.0, shares 2511 base weights.
+    assert target["steps"] == 4
+    assert target["guidanceScale"] == 1.0
+    assert target["trueCfgScale"] == 1.0
+    assert target["repo"] == "Qwen/Qwen-Image-Edit-2511"
+    assert target["distillLora"] == {
+        "repo": "lightx2v/Qwen-Image-Edit-2511-Lightning",
+        "file": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+    }
+
+
+def test_create_image_adapter_routes_qwen_image_edit_2511():
+    # All Qwen Edit IDs ride the same QwenImageAdapter; pipeline-class selection
+    # happens inside _load_pipeline based on the model id.
+    adapter = create_image_adapter({"payload": {"model": "qwen_image_edit_2511"}})
     assert adapter.__class__.__name__ == "QwenImageAdapter"
     assert adapter.id == "qwen_image"
+    lightning = create_image_adapter({"payload": {"model": "qwen_image_edit_2511_lightning"}})
+    assert lightning.__class__.__name__ == "QwenImageAdapter"
 
 
 def test_qwen_edit_pipeline_name_by_model():
-    # qwen_image_edit_2509 -> QwenImageEditPlusPipeline (multi-image reference);
-    # everything else falls back to the single-image QwenImageEditPipeline.
+    # sc-2160: every edit ID (incl. legacy aliases) ships the multi-image Plus
+    # pipeline now that they all run against the 2511 base weights.
+    assert QwenImageAdapter._edit_pipeline_name("qwen_image_edit") == "QwenImageEditPlusPipeline"
     assert QwenImageAdapter._edit_pipeline_name("qwen_image_edit_2509") == "QwenImageEditPlusPipeline"
-    assert QwenImageAdapter._edit_pipeline_name("qwen_image_edit") == "QwenImageEditPipeline"
+    assert QwenImageAdapter._edit_pipeline_name("qwen_image_edit_2511") == "QwenImageEditPlusPipeline"
+    assert QwenImageAdapter._edit_pipeline_name("qwen_image_edit_2511_lightning") == "QwenImageEditPlusPipeline"
     # Defensive: anything else still gets the single-image pipeline, matching
     # the same edit-style API surface.
     assert QwenImageAdapter._edit_pipeline_name("qwen_image") == "QwenImageEditPipeline"
+
+
+def test_qwen_distill_lora_helpers():
+    base_target = MODEL_TARGETS["qwen_image_edit_2511"]
+    lightning_target = MODEL_TARGETS["qwen_image_edit_2511_lightning"]
+    assert QwenImageAdapter._distill_lora_for(base_target) is None
+    assert QwenImageAdapter._distill_key_for(None) is None
+    spec = QwenImageAdapter._distill_lora_for(lightning_target)
+    assert spec is not None
+    key = QwenImageAdapter._distill_key_for(spec)
+    assert key == "lightx2v/Qwen-Image-Edit-2511-Lightning/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors"
+
+
+def test_qwen_guidance_scale_reads_model_target_default():
+    # 2511 family defaults to guidanceScale 1.0 (Plus pipeline requirement).
+    request = SimpleNamespace(model="qwen_image_edit_2511", advanced={})
+    assert QwenImageAdapter()._guidance_scale(request) == 1.0
+    # qwen_image (text-to-image) still defaults to 4.0.
+    request_t2i = SimpleNamespace(model="qwen_image", advanced={})
+    assert QwenImageAdapter()._guidance_scale(request_t2i) == 4.0
+    # User override wins.
+    request_override = SimpleNamespace(model="qwen_image_edit_2511", advanced={"guidanceScale": 3.5})
+    assert QwenImageAdapter()._guidance_scale(request_override) == 3.5
+
+
+def test_qwen_true_cfg_scale_default_per_model():
+    adapter = QwenImageAdapter()
+    # Base family: 4.0 default.
+    request = SimpleNamespace(model="qwen_image_edit_2511", advanced={})
+    assert adapter._true_cfg_scale_default(request) == 4.0
+    # Lightning: distilled at 1.0.
+    lightning_request = SimpleNamespace(model="qwen_image_edit_2511_lightning", advanced={})
+    assert adapter._true_cfg_scale_default(lightning_request) == 1.0
+    # User override wins on either.
+    override = SimpleNamespace(model="qwen_image_edit_2511_lightning", advanced={"trueCfgScale": 2.0})
+    assert adapter._true_cfg_scale_default(override) == 2.0
 
 
 def test_qwen_use_reference_only_for_character_image_with_reference():
@@ -1774,16 +1843,21 @@ def test_qwen_auto_dispatch_skips_mlx_for_edit_image(monkeypatch):
 
 
 def test_qwen_auto_dispatch_skips_mlx_for_qwen_image_edit_model(monkeypatch):
-    # qwen_image_edit / qwen_image_edit_2509 are not in MlxQwenAdapter's
-    # supported set; auto-dispatch must keep them on the torch path.
+    # qwen_image_edit / qwen_image_edit_2509 / qwen_image_edit_2511 / Lightning
+    # are not in MlxQwenAdapter's supported set; auto-dispatch must keep them on
+    # the torch path.
     monkeypatch.delenv("SCENEWORKS_DISABLE_MLX_FLUX", raising=False)
     monkeypatch.delenv("SCENEWORKS_IMAGE_ADAPTER", raising=False)
     monkeypatch.setattr("sys.platform", "darwin")
     monkeypatch.setattr(MlxQwenAdapter, "_sidecar_available", lambda self: True)
-    adapter = create_image_adapter({"payload": {"model": "qwen_image_edit"}})
-    assert adapter.__class__.__name__ == "QwenImageAdapter"
-    adapter = create_image_adapter({"payload": {"model": "qwen_image_edit_2509"}})
-    assert adapter.__class__.__name__ == "QwenImageAdapter"
+    for model in (
+        "qwen_image_edit",
+        "qwen_image_edit_2509",
+        "qwen_image_edit_2511",
+        "qwen_image_edit_2511_lightning",
+    ):
+        adapter = create_image_adapter({"payload": {"model": model}})
+        assert adapter.__class__.__name__ == "QwenImageAdapter", model
 
 
 def test_qwen_auto_dispatch_skips_mlx_when_reference_asset_present(monkeypatch):


### PR DESCRIPTION
## Summary

- Replace `qwen_image_edit` (Aug 2025) + `qwen_image_edit_2509` (Sep 2025) with `Qwen/Qwen-Image-Edit-2511` (Dec 2025) on the same `QwenImageEditPlusPipeline`. Legacy IDs stay in `MODEL_TARGETS` as aliases to the 2511 weights so existing jobs / presets / Character Studio refs keep resolving; the picker only surfaces 2511 + Lightning.
- Add `qwen_image_edit_2511_lightning` (lightx2v 4-step distill LoRA fused at load, ~10x faster, CFG disabled). Pipeline cache key extended by the distill-LoRA signature so the base and the fused variant don't share a cached pipe.
- `_guidance_scale` and `_true_cfg_scale_default` are now `MODEL_TARGETS`-driven (Plus pipeline needs `guidance_scale=1.0`; Lightning needs `true_cfg_scale=1.0`). User overrides still win.

## Why

2511 ships drift mitigation, multi-person identity consistency, integrated popular LoRAs, and stronger geometric reasoning over 2509. The API is unchanged so this is a drop-in repo swap; Lightning gives the same model in 4 steps for fast iteration. LoRA family stays `qwen-image`, so existing Qwen LoRAs apply unchanged.

Shortcut: [sc-2160](https://app.shortcut.com/trefry/story/2160) (under Epic 2003).

## Test plan

- [x] `npm --prefix apps/web run test` — 143/143 vitest tests pass (incl. the Qwen-2511 fixture)
- [x] `cargo test -p sceneworks-core` — 138/138 pass
- [x] `cargo test -p sceneworks-rust-api` — 84/84 pass
- [x] `npm run check` — scaffold consistency clean
- [ ] `pytest tests/test_worker_runtime.py` in the worker container (new tests cover 2511 defaults, Lightning distill spec, legacy aliases, pipeline mapping, guidance / true-CFG per-model defaults)
- [ ] Live Mac (M5 Max) e2e on **Qwen Image Edit (2511)** — confirm wall-clock and quality vs 2509
- [ ] Live Mac (M5 Max) e2e on **Qwen Image Edit (2511) Lightning** — confirm Lightning LoRA fuses cleanly via diffusers `fuse_lora` and ~10x speedup holds
- [ ] First-run download of `lightx2v/Qwen-Image-Edit-2511-Lightning` lands in HF cache as expected

## Notes / out of scope

- The Rust LoRA-validation path rejects unknown model IDs only when LoRAs are attached. Replaying a LoRA-attached job pinned to the legacy `qwen_image_edit` / `qwen_image_edit_2509` IDs will now bad_request "Model ... not found" (manifest no longer carries them). User can retarget the job to `qwen_image_edit_2511`.
- FP8-fused Lightning checkpoint (CUDA-only) — skipped.
- MLX Qwen adapter is untouched (lives in the sc-1972 codepath).

🤖 Generated with [Claude Code](https://claude.com/claude-code)