### PR TITLE
feat(worker): FLUX.2 [klein] 9B + 9B-KV via mflux (MLX-only, sc-2164)

### DIFF
--- a/apps/web/public/prompt-guides/flux2-klein.md
+++ b/apps/web/public/prompt-guides/flux2-klein.md
@@ -1,0 +1,69 @@
+# FLUX.2 [klein] 9B Prompt Guide
+
+## Best For
+
+A 9B-parameter Black Forest Labs FLUX.2 [klein] checkpoint, 4-step distilled — fast, high-quality text-to-image AND reference-driven editing in a single model. Apple Silicon only (MLX backend); ships in two variants:
+
+- **FLUX.2 [klein] 9B** — text-to-image and reference editing.
+- **FLUX.2 [klein] 9B-KV** — reference editing with KV-cache acceleration, ~2.4× faster than the base 9B edit path. Reference image required (cache is meaningless without one).
+
+> **License:** FLUX Non-Commercial License — gated Hugging Face download. Accept the license at the model card and add a Hugging Face token under Settings → Service credentials before downloading. Generations are for non-commercial use only.
+
+> **Hardware:** ~36 GB bf16 peak at 1024² on M5 Max. Q8 quantization (default) trades minor quality for ~25 % memory reduction. macOS only.
+
+## Prompt Shape
+
+FLUX.2 uses an 8B Qwen3 text embedder, so write a fluent natural-language description rather than tag lists:
+
+`subject + setting + visual details + style + composition + lighting + any text`
+
+There is no negative prompt — FLUX.2 disallows it. Keep everything in the positive prompt and describe what you DO want.
+
+## Build The Prompt
+
+### Subject
+
+Describe the subject as if captioning a finished photo. Include type, action, position, and distinguishing features.
+
+Good: `a marine biologist examining a glowing jellyfish in a research lab tank`
+
+### Details
+
+Add material, texture, and atmosphere:
+
+- `brushed copper helmet`
+- `wet kelp glinting under fluorescents`
+- `late-afternoon golden light through high windows`
+
+### Style + Composition
+
+Pick concrete style cues (photo, illustration, render) and a composition (medium shot, low angle, etc.). The model handles photoreal and stylized equally well, but doesn't infer them — say what you want.
+
+### Text
+
+FLUX.2 [klein] renders short legible text well. Wrap exact strings in double quotes:
+
+`a vintage tea-tin labeled "Earl Grey No. 3"`
+
+## Reference Editing
+
+When you attach a reference image, the model switches to `Flux2KleinEdit` and conditions on the reference at every step (or on cached reference KV for the -kv variant). Write the prompt as a description of the *target* image, not as an instruction:
+
+Good: `a portrait of a black cat wearing a tall purple wizard hat with gold stars, sitting on a stack of vintage books, photoreal`
+
+Avoid: `add a wizard hat to the cat`
+
+The 4-step distillation means the cache-on -kv variant produces results in ~13 s on M5 Max, ~2.4× faster than the base 9B at the same prompt and reference.
+
+## Defaults
+
+- Resolution: 1024×1024 (also 768×768, 1280×720, 720×1280)
+- Steps: 4 (the distillation target; longer runs don't help and aren't supported on -kv)
+- Guidance: 1.0 (must stay at 1.0 on distilled klein variants)
+- Quantization: Q8 (sweet spot — bf16 speed, lower memory)
+
+## Sources
+
+- [FLUX.2 [klein] 9B model card](https://huggingface.co/black-forest-labs/FLUX.2-klein-9B)
+- [FLUX.2 [klein] 9B-KV model card](https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv)
+- [FLUX.2 blog post](https://bfl.ai/blog/flux2-klein-towards-interactive-visual-intelligence)

--- a/apps/worker/requirements-mlx-flux.txt
+++ b/apps/worker/requirements-mlx-flux.txt
@@ -24,4 +24,9 @@
 # Adapter: `MlxFluxAdapter` in apps/worker/scene_worker/image_adapters.py
 # mflux pulls its own torch, transformers, huggingface_hub, mlx, etc. — pin
 # only mflux here and let it resolve the rest.
-mflux>=0.17.5,<0.18
+#
+# Temporarily pinned at michaeltrefry/mflux@claude/flux2-kv-cache (sc-2163,
+# upstream PR filipstrand/mflux#426) so MlxFlux2Adapter (sc-2164) can use the
+# FLUX.2-klein-9b-kv KV-cache optimisation (~2.4x faster multi-ref edit). Flip
+# back to a PyPI mflux>=0.18 pin once the upstream PR lands.
+mflux @ git+https://github.com/michaeltrefry/mflux.git@claude/flux2-kv-cache

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -377,6 +377,33 @@ MODEL_TARGETS = {
             "imageEncoderRepo": "openai/clip-vit-large-patch14",
         },
     },
+    "flux2_klein_9b": {
+        "label": "FLUX.2 [klein] 9B",
+        "family": "flux2-klein",
+        # Unified model: txt2img via Flux2Klein, edit via Flux2KleinEdit (reference
+        # image conditioning). Both paths go through the same MLX-only adapter.
+        "supportsEdit": True,
+        # 4-step distilled (mflux's default for klein-9b); guidance 1.0 mandatory
+        # on distilled variants — the mflux CLI errors on any other value.
+        "steps": 4,
+        "guidanceScale": 1.0,
+        "repo": "black-forest-labs/FLUX.2-klein-9B",
+        "adapter": "mlx_flux2",
+    },
+    "flux2_klein_9b_kv": {
+        "label": "FLUX.2 [klein] 9B-KV",
+        "family": "flux2-klein",
+        # Edit-only (KV cache requires a reference image to be meaningful);
+        # MlxFlux2Adapter rejects this model id in txt2img mode. Cache
+        # auto-engages on the supports_kv_cache ModelConfig flag set in
+        # the pinned mflux fork (sc-2163, upstream PR filipstrand/mflux#426).
+        "supportsEdit": True,
+        "supportsTxt2Img": False,
+        "steps": 4,
+        "guidanceScale": 1.0,
+        "repo": "black-forest-labs/FLUX.2-klein-9b-kv",
+        "adapter": "mlx_flux2",
+    },
     "kolors": {
         "label": "Kolors",
         "family": "kolors",
@@ -3447,6 +3474,300 @@ class MlxSdxlAdapter:
             return float(default)
 
 
+class MlxFlux2Adapter:
+    """FLUX.2-klein-9b (txt2img + edit) via mflux (Apple MLX), run OUT-OF-PROCESS.
+
+    The first MLX-only image-generation family in SceneWorks — there is no
+    diffusers torch fallback for FLUX.2 today, so the model's manifest entry
+    points directly at this adapter rather than redirecting from a torch
+    adapter. On non-Mac hosts the dispatch falls through to nothing and the
+    job fails with a clear error; the frontend hides the model on those
+    platforms via the existing host-capability filter.
+
+    Shares the mflux sidecar venv (`/opt/mlx-flux-venv`) and runner
+    (`scene_worker/mlx_flux_runner.py`) with `MlxFluxAdapter` /
+    `MlxQwenAdapter` / `MlxZImageAdapter` — runner dispatches on
+    `spec["model"]` to `Flux2Klein` (txt2img) or `Flux2KleinEdit` (reference).
+
+    Two model ids:
+      - ``flux2_klein_9b`` — txt2img + edit. Edit mode passes a single
+        reference image through `image_paths` and runs the standard
+        denoise loop.
+      - ``flux2_klein_9b_kv`` — edit-only. The KV-cache distilled variant
+        from BFL (FLUX.2-klein-9b-kv) caches reference-image K/V on step
+        0 and reuses it on steps 1-3, ~2.4× faster than the un-cached
+        edit path on M5 Max. Cache auto-engages via the mflux
+        ModelConfig flag (sc-2163, upstream PR filipstrand/mflux#426).
+        Reference is required.
+
+    Dispatch gate: `_should_route_flux2_to_mlx`. The shared mflux escape
+    hatch ``SCENEWORKS_DISABLE_MLX_FLUX`` opts out of this adapter too.
+
+    Validation (M5 Max 128GB, 1024², 4 steps):
+      - flux2_klein_9b txt2img: ~26 s gen, ~36 GB peak
+      - flux2_klein_9b edit (no cache): ~33 s gen
+      - flux2_klein_9b_kv edit (cache on): ~13.5 s gen — 2.4× speedup
+      (numbers measured against the mflux fork's editable install during
+       sc-2163; sidecar venv post-provision should match).
+    """
+
+    id = "mlx_flux2"
+    _supported_models = {"flux2_klein_9b", "flux2_klein_9b_kv"}
+    _kv_only_models = {"flux2_klein_9b_kv"}  # require a reference image
+
+    def __init__(self) -> None:
+        self._scratch_dir: Path | None = None
+
+    def discard_temp_outputs(self, job_id: str | None = None) -> None:
+        work_dir = self._scratch_dir
+        if work_dir is not None:
+            shutil.rmtree(work_dir, ignore_errors=True)
+            self._scratch_dir = None
+
+    def loaded_models(self) -> list[str]:
+        # The sidecar process loads + frees the model per job; nothing stays
+        # resident in this (main-venv) process. Mirrors MlxFluxAdapter.
+        return []
+
+    @staticmethod
+    def _sidecar_python() -> str:
+        return os.getenv("SCENEWORKS_MLX_FLUX_PYTHON", "/opt/mlx-flux-venv/bin/python")
+
+    @staticmethod
+    def _runner_path() -> Path:
+        return Path(__file__).resolve().parent / "mlx_flux_runner.py"
+
+    def _sidecar_available(self) -> bool:
+        return Path(self._sidecar_python()).exists() and self._runner_path().exists()
+
+    def generate(
+        self,
+        *,
+        settings: WorkerSettings,
+        job: dict[str, Any],
+        request: ImageRequest,
+        project_path: Path,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        model_target = MODEL_TARGETS.get(request.model, {})
+        if model_target.get("adapter") != self.id:
+            raise RuntimeError(f"{request.model} is not a FLUX.2 target.")
+        if request.model not in self._supported_models:
+            raise RuntimeError(
+                f"MlxFlux2Adapter supports "
+                f"{', '.join(sorted(self._supported_models))}, not {request.model}."
+            )
+
+        # Resolve reference image (if any) to a local filesystem path so
+        # mflux's Flux2KleinEdit can read it directly. No PIL round-trip:
+        # find_asset_media_path returns the project-scoped path, and mflux's
+        # image loader handles dtype/resize itself.
+        reference_paths: list[str] = []
+        if request.reference_asset_id:
+            reference_paths.append(str(find_asset_media_path(project_path, request.reference_asset_id)))
+        has_reference = bool(reference_paths)
+
+        if request.model in self._kv_only_models and not has_reference:
+            raise RuntimeError(
+                f"{request.model} requires a reference image (the KV cache is "
+                "meaningless without one). Use flux2_klein_9b for text-to-image."
+            )
+
+        validate_lora_compatibility(
+            request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
+        )
+        lora_specs = normalize_lora_specs(request.loras)
+
+        if not self._sidecar_available():
+            raise RuntimeError(
+                "MLX FLUX.2 generation requires the isolated mlx-flux sidecar venv. The desktop "
+                "bootstrap installs it on first launch (apps/desktop/src/setup.rs "
+                "provision_mlx_flux_venv); rebuild without SCENEWORKS_DISABLE_MLX_FLUX=1, or set "
+                "SCENEWORKS_MLX_FLUX_PYTHON to a Python interpreter that has mflux installed "
+                f"(looked for {self._sidecar_python()})."
+            )
+
+        total = request.count
+        steps = self._num_inference_steps(request, model_target)
+        guidance = self._guidance_scale(request, model_target)
+        quantize = self._resolve_quantize(request)
+        seeds = [resolve_seed(request.seed, request.prompt, index, request.seeds) for index in range(total)]
+
+        progress(
+            "loading_model",
+            "loading_model",
+            0.18,
+            f"Loading {model_target['label']} (MLX sidecar venv).",
+        )
+        work_dir = Path(tempfile.mkdtemp(prefix="mlx_flux2_sidecar_"))
+        self._scratch_dir = work_dir
+        try:
+            images = self._run_sidecar(
+                job_id=job["id"],
+                work_dir=work_dir,
+                label=model_target["label"],
+                total=total,
+                spec={
+                    "model": request.model,
+                    "prompt": request.prompt,
+                    "negativePrompt": None,  # Flux2 disallows negatives; runner skips it anyway
+                    "seeds": seeds,
+                    "height": request.height,
+                    "width": request.width,
+                    "numInferenceSteps": steps,
+                    "guidance": guidance,
+                    "quantize": quantize,
+                    "loras": [
+                        {"path": lora.path, "weight": lora.weight, "name": lora.adapter_name}
+                        for lora in lora_specs
+                    ],
+                    "imagePaths": reference_paths or None,
+                },
+                progress=progress,
+                cancel_requested=cancel_requested,
+            )
+
+            def image_at_index(index: int) -> Image.Image:
+                progress(
+                    "running",
+                    "generating",
+                    image_batch_progress(index, total),
+                    format_batch_running_message(model_target["label"], index, total),
+                )
+                with Image.open(images[index]) as handle:
+                    return handle.convert("RGB")
+
+            return ImageAssetWriter().write_incremental_outputs(
+                request=request,
+                project_path=project_path,
+                image_count=total,
+                image_at_index=image_at_index,
+                adapter_id=self.id,
+                progress=progress,
+                cancel_requested=cancel_requested,
+                raw_settings={
+                    **request.advanced,
+                    "repo": model_target["repo"],
+                    "numInferenceSteps": steps,
+                    "guidanceScale": guidance,
+                    "mlxQuantize": quantize,
+                    "sidecarVenv": self._sidecar_python(),
+                    "hasReference": has_reference,
+                    "kvCacheEnabled": has_reference and request.model in self._kv_only_models,
+                    "realModelInference": True,
+                },
+                settings=settings,
+                job_id=job["id"],
+            )
+        finally:
+            self.discard_temp_outputs(job["id"])
+
+    def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
+        # FLUX.2-klein distilled variants are 4-step; cap at 40 because the
+        # ModelConfig has supports_guidance=True so power users CAN crank
+        # steps if they really want.
+        return safe_int(request.advanced.get("steps"), model_target.get("steps", 4), 1, 40)
+
+    def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:
+        # Distilled FLUX.2 wants guidance=1.0 (the mflux CLI even errors if
+        # not 1.0 on distilled variants). Leave room for manifest override
+        # in case a future base variant needs a different default.
+        default = model_target.get("guidanceScale", 1.0)
+        try:
+            return float(request.advanced.get("guidanceScale", default))
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _resolve_quantize(self, request: ImageRequest) -> int | None:
+        """Pick the mflux quantize level. Same algorithm as MlxFluxAdapter:
+        advanced override > manifest mlx.quantize > Q8 default.
+
+        FLUX.2-klein-9b at bf16 is ~36GB peak on M5 Max; Q8 cuts that
+        substantially with no visible quality drift on the spike runs.
+        """
+        override = request.advanced.get("mlxQuantize")
+        if override is not None and not isinstance(override, bool):
+            try:
+                parsed = int(override)
+                return parsed if parsed > 0 else None
+            except (TypeError, ValueError):
+                pass
+        mlx_entry = request.model_manifest_entry.get("mlx") if request.model_manifest_entry else None
+        if isinstance(mlx_entry, dict):
+            manifest_q = mlx_entry.get("quantize")
+            if manifest_q is not None:
+                try:
+                    parsed = int(manifest_q)
+                    return parsed if parsed > 0 else None
+                except (TypeError, ValueError):
+                    pass
+        return 8
+
+    def _run_sidecar(
+        self,
+        *,
+        job_id: str,
+        work_dir: Path,
+        label: str,
+        total: int,
+        spec: dict[str, Any],
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> list[str]:
+        spec = {**spec, "outDir": str(work_dir)}
+        spec_path = work_dir / "spec.json"
+        spec_path.write_text(json.dumps(spec), encoding="utf-8")
+        stdout_log = work_dir / "stdout.log"
+        cmd = [self._sidecar_python(), str(self._runner_path()), str(spec_path)]
+        emit_worker_event(
+            "mlx_flux2_sidecar_start",
+            jobId=job_id,
+            adapter=self.id,
+            model=spec["model"],
+            imageCount=total,
+            quantize=spec.get("quantize"),
+            sidecar=self._sidecar_python(),
+            hasReference=bool(spec.get("imagePaths")),
+        )
+        progress(
+            "running",
+            "generating",
+            image_batch_progress(0, total),
+            f"Running {label} ({total} image(s)).",
+        )
+        with stdout_log.open("w", encoding="utf-8") as out:
+            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=None)
+            while True:
+                try:
+                    proc.wait(timeout=2)
+                    break
+                except subprocess.TimeoutExpired:
+                    if cancel_requested():
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=10)
+                        except subprocess.TimeoutExpired:
+                            proc.kill()
+                        raise InterruptedError("Image generation canceled by user.")
+        result = MlxFluxAdapter._read_result(work_dir, stdout_log)
+        if proc.returncode != 0 or "error" in result:
+            error = result.get("error") or f"MLX FLUX.2 sidecar exited with code {proc.returncode}."
+            emit_worker_event(
+                "mlx_flux2_sidecar_failed",
+                jobId=job_id,
+                adapter=self.id,
+                error=error,
+                returnCode=proc.returncode,
+            )
+            raise RuntimeError(f"MLX FLUX.2 generation failed in the sidecar venv: {error}")
+        images = [str(path) for path in result.get("images", [])]
+        if len(images) != total:
+            raise RuntimeError(f"MLX FLUX.2 sidecar produced {len(images)} image(s); expected {total}.")
+        emit_worker_event("mlx_flux2_sidecar_complete", jobId=job_id, adapter=self.id, imageCount=len(images))
+        return images
+
+
 class KolorsDiffusersAdapter:
     """Kwai-Kolors Kolors text-to-image via diffusers.KolorsPipeline.
 
@@ -5845,6 +6166,7 @@ def create_image_adapter(
     | SenseNovaU1Adapter
     | FluxDiffusersAdapter
     | MlxFluxAdapter
+    | MlxFlux2Adapter
     | KolorsDiffusersAdapter
     | SdxlDiffusersAdapter
     | MlxSdxlAdapter
@@ -5869,6 +6191,7 @@ def create_image_adapter(
         SenseNovaU1Adapter.id,
         FluxDiffusersAdapter.id,
         MlxFluxAdapter.id,
+        MlxFlux2Adapter.id,
         KolorsDiffusersAdapter.id,
         SdxlDiffusersAdapter.id,
         MlxSdxlAdapter.id,
@@ -5893,6 +6216,8 @@ def create_image_adapter(
         return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
     if requested == MlxFluxAdapter.id:
         return adapters.get("mlx_flux") if adapters else MlxFluxAdapter()
+    if requested == MlxFlux2Adapter.id:
+        return adapters.get("mlx_flux2") if adapters else MlxFlux2Adapter()
     if requested == KolorsDiffusersAdapter.id:
         return adapters.get("kolors_diffusers") if adapters else KolorsDiffusersAdapter()
     if requested == SdxlDiffusersAdapter.id:
@@ -5939,6 +6264,14 @@ def create_image_adapter(
         return adapters.get("flux_diffusers") if adapters else FluxDiffusersAdapter()
     if model_target.get("adapter") == KolorsDiffusersAdapter.id:
         return adapters.get("kolors_diffusers") if adapters else KolorsDiffusersAdapter()
+    if model_target.get("adapter") == MlxFlux2Adapter.id:
+        # FLUX.2-klein has no torch fallback today — MlxFlux2Adapter is the
+        # only adapter for the family. The frontend hides the model on
+        # non-Mac hosts via the manifest `macOnly` flag; on any host the
+        # adapter's own preflight (platform, sidecar venv, -kv requires
+        # reference) raises a clear error if something is wrong, rather
+        # than silently rendering the procedural placeholder. sc-2164.
+        return adapters.get("mlx_flux2") if adapters else MlxFlux2Adapter()
     if model_target.get("adapter") == SdxlDiffusersAdapter.id:
         # SDXL auto-dispatch: prefer MlxSdxlAdapter on macOS when the vendored
         # mlx-examples is importable AND the model is supported AND the job
@@ -6051,6 +6384,41 @@ def _should_route_z_image_to_mlx(payload: dict[str, Any]) -> bool:
     if payload.get("referenceAssetId"):
         return False
     return MlxZImageAdapter()._sidecar_available()
+
+
+def _should_route_flux2_to_mlx(payload: dict[str, Any]) -> bool:
+    """Decide whether MlxFlux2Adapter can handle a FLUX.2-klein job.
+
+    Unlike the other ``_should_route_*_to_mlx`` predicates, this is NOT an
+    "MLX vs torch" choice — FLUX.2-klein has no torch backend in SceneWorks
+    today, so MlxFlux2Adapter is the only adapter for the family. If this
+    predicate returns False on a flux2-klein job, the dispatch hands it to
+    the procedural preview placeholder and the frontend should have already
+    hidden the model on the host (manifest macOnly flag).
+
+    Gates:
+      1. SCENEWORKS_DISABLE_MLX_FLUX unset (shared opt-out with the other
+         mflux family — one env var per sidecar venv, not per family).
+      2. Platform == darwin (mflux/MLX is Apple-only).
+      3. Model in MlxFlux2Adapter._supported_models.
+      4. flux2_klein_9b_kv requires a reference image: KV cache only kicks in
+         when image_paths is populated, so a -kv request without a reference
+         is a misuse and must fail loudly rather than silently fall back to a
+         non-cached run (which wouldn't even produce the model's intended
+         distilled-at-4-steps output without the cache).
+      5. Sidecar venv exists.
+    sc-2164.
+    """
+    if os.getenv("SCENEWORKS_DISABLE_MLX_FLUX", "").strip().lower() in {"1", "true", "yes"}:
+        return False
+    if sys.platform != "darwin":
+        return False
+    model = payload.get("model")
+    if model not in MlxFlux2Adapter._supported_models:
+        return False
+    if model in MlxFlux2Adapter._kv_only_models and not payload.get("referenceAssetId"):
+        return False
+    return MlxFlux2Adapter()._sidecar_available()
 
 
 def _should_route_qwen_to_mlx(payload: dict[str, Any]) -> bool:

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -22,9 +22,11 @@ Progress and diagnostics go to stderr (captured into the worker log). A non-zero
 exit code with an "error" JSON on stdout signals failure to the adapter.
 
 Spec keys:
-    model: e.g. "flux_schnell" | "flux_dev" | "qwen_image"
+    model: e.g. "flux_schnell" | "flux_dev" | "qwen_image" | "flux2_klein_9b"
+        | "flux2_klein_9b_kv"
     prompt: str
-    negativePrompt: str | None
+    negativePrompt: str | None  (ignored by FLUX.2 — Flux2 disallows negatives;
+        focus on describing what you want.)
     seeds: list[int]
     height: int
     width: int
@@ -32,9 +34,15 @@ Spec keys:
     guidance: float
     quantize: int | None (None, 3, 4, 5, 6, 8)
     loras: list[{"path": str, "weight": float, "name": str}]
+    imagePaths: list[str] | None  (FLUX.2 edit mode only — list of reference
+        image paths. Triggers Flux2KleinEdit dispatch; for FLUX.2-klein-9b-kv
+        the KV cache auto-engages.)
     outDir: str (sidecar writes PNGs + result.json here)
 
 Validated 2026-05-28 against mflux 0.17.5 (sc-1969 FLUX spike, sc-1972 Qwen verify).
+sc-2164 extends with FLUX.2-klein-9b / -kv via Flux2Klein / Flux2KleinEdit, pinned
+to michaeltrefry/mflux@claude/flux2-kv-cache for the upstream KV-cache patch
+(filipstrand/mflux#426).
 """
 from __future__ import annotations
 
@@ -48,29 +56,33 @@ def _log(message: str) -> None:
     sys.stderr.flush()
 
 
-def _resolve_model_handle(model_id: str) -> tuple[type, object, str]:
-    """Map a SceneWorks model id onto an mflux (class, ModelConfig, filename_prefix).
+def _resolve_model_handle(model_id: str, has_reference: bool) -> tuple[type, object, str, str]:
+    """Map a SceneWorks model id + edit-vs-t2i hint onto an mflux
+    (class, ModelConfig, filename_prefix, family) tuple.
 
-    Each branch instantiates an mflux txt2img class for one model family and
+    Each branch instantiates an mflux generation class for one model family and
     returns it alongside a `ModelConfig` factory and the per-image filename
-    prefix used in `outDir`. Both classes expose the same
-    `(quantize, model_config, lora_paths, lora_scales)` constructor and the
-    same `generate_image(seed, prompt, num_inference_steps, height, width,
-    guidance, negative_prompt, ...)` keyword interface (mflux 0.17.5), so the
-    main loop is family-agnostic. Keep this map in sync with the
-    `_supported_models` sets in the corresponding adapters.
+    prefix used in `outDir`. The fourth tuple element is the family tag
+    (``"flux1" | "qwen" | "z_image" | "flux2"``) the main loop uses to skip
+    family-incompatible kwargs (e.g. ``negative_prompt`` is disallowed by
+    Flux2). Keep this map in sync with the `_supported_models` sets in the
+    corresponding adapters.
+
+    ``has_reference`` selects the edit variant for families that have one
+    (FLUX.2 → Flux2Klein vs Flux2KleinEdit). Families without an edit path
+    ignore the flag.
     """
     from mflux.models.common.config.model_config import ModelConfig
 
     if model_id == "flux_schnell":
         from mflux.models.flux.variants.txt2img.flux import Flux1
-        return Flux1, ModelConfig.schnell(), "mlx_flux"
+        return Flux1, ModelConfig.schnell(), "mlx_flux", "flux1"
     if model_id == "flux_dev":
         from mflux.models.flux.variants.txt2img.flux import Flux1
-        return Flux1, ModelConfig.dev(), "mlx_flux"
+        return Flux1, ModelConfig.dev(), "mlx_flux", "flux1"
     if model_id == "qwen_image":
         from mflux.models.qwen.variants.txt2img.qwen_image import QwenImage
-        return QwenImage, ModelConfig.qwen_image(), "mlx_qwen"
+        return QwenImage, ModelConfig.qwen_image(), "mlx_qwen", "qwen"
     if model_id == "z_image_turbo":
         # NOTE: the ZImage import path is `variants.z_image`, not
         # `variants.txt2img.z_image` (mflux 0.17.5 — Z-Image hasn't been
@@ -78,7 +90,24 @@ def _resolve_model_handle(model_id: str) -> tuple[type, object, str]:
         # GeneratedImage return shape matches even though the type annotation
         # claims PIL.Image.Image — main() drops `.image` either way.
         from mflux.models.z_image.variants.z_image import ZImage
-        return ZImage, ModelConfig.z_image_turbo(), "mlx_z_image"
+        return ZImage, ModelConfig.z_image_turbo(), "mlx_z_image", "z_image"
+    if model_id == "flux2_klein_9b":
+        if has_reference:
+            from mflux.models.flux2.variants.edit.flux2_klein_edit import Flux2KleinEdit
+            return Flux2KleinEdit, ModelConfig.flux2_klein_9b(), "mlx_flux2_klein", "flux2"
+        from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+        return Flux2Klein, ModelConfig.flux2_klein_9b(), "mlx_flux2_klein", "flux2"
+    if model_id == "flux2_klein_9b_kv":
+        # The -kv variant only makes sense with a reference image (cache is
+        # meaningless otherwise). MlxFlux2Adapter gates this in the main venv
+        # so we get here only when has_reference is True.
+        if not has_reference:
+            raise RuntimeError(
+                "mlx_flux_runner: flux2_klein_9b_kv requires a reference image; "
+                "use flux2_klein_9b for text-to-image."
+            )
+        from mflux.models.flux2.variants.edit.flux2_klein_edit import Flux2KleinEdit
+        return Flux2KleinEdit, ModelConfig.flux2_klein_9b_kv(), "mlx_flux2_klein_kv", "flux2"
     raise RuntimeError(f"mlx_flux_runner: unsupported model id {model_id!r}.")
 
 
@@ -101,13 +130,15 @@ def main() -> int:
     if quantize is not None:
         quantize = int(quantize)
     loras = spec.get("loras") or []
+    image_paths = [str(p) for p in (spec.get("imagePaths") or []) if p]
+    has_reference = bool(image_paths)
     out_dir = Path(spec["outDir"])
     out_dir.mkdir(parents=True, exist_ok=True)
     result_path = out_dir / "result.json"
 
     # Heavy imports deferred until the spec is valid: a bad spec fails cleanly
     # before mflux loads MLX + the multi-GB transformer.
-    model_cls, model_config, filename_prefix = _resolve_model_handle(model_id)
+    model_cls, model_config, filename_prefix, family = _resolve_model_handle(model_id, has_reference)
 
     lora_paths: list[str] = []
     lora_scales: list[float] = []
@@ -138,16 +169,27 @@ def main() -> int:
     for index, seed in enumerate(seeds):
         # mflux 0.17.5 generate_image() takes per-call kwargs; older 0.12.x
         # took a Config object. Pin in requirements-mlx-flux.txt anchors us
-        # to the kwargs form.
-        result = model.generate_image(
-            seed=int(seed),
-            prompt=prompt,
-            num_inference_steps=steps,
-            height=height,
-            width=width,
-            guidance=guidance,
-            negative_prompt=negative_prompt,
-        )
+        # to the kwargs form. Per-family signature differences:
+        #   - Flux2 (txt2img + edit) disallows negative_prompt entirely
+        #     ("focus on describing what you want") and uses `image_paths` for
+        #     reference list (not `image_path`).
+        #   - Flux2Klein (txt2img) accepts a single optional `image_path`
+        #     instead of a list; the runner only dispatches to it when there
+        #     is no reference (image_paths is empty), so we don't pass it.
+        #   - Other families (Flux1, Qwen, Z-Image) still take negative_prompt.
+        gen_kwargs: dict[str, object] = {
+            "seed": int(seed),
+            "prompt": prompt,
+            "num_inference_steps": steps,
+            "height": height,
+            "width": width,
+            "guidance": guidance,
+        }
+        if family != "flux2":
+            gen_kwargs["negative_prompt"] = negative_prompt
+        if family == "flux2" and has_reference:
+            gen_kwargs["image_paths"] = image_paths
+        result = model.generate_image(**gen_kwargs)
         path = out_dir / f"{filename_prefix}_{index:04d}.png"
         result.image.save(path, "PNG")
         images.append(str(path))

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -738,6 +738,157 @@
       }
     },
     {
+      "id": "flux2_klein_9b",
+      "name": "FLUX.2 [klein] 9B",
+      "family": "flux2-klein",
+      "type": "image",
+      // First MLX-only image-generation model family in SceneWorks. There is
+      // no diffusers torch backend for FLUX.2 today, so the adapter field
+      // points directly at mlx_flux2 (sc-2164). Non-Mac hosts hide the model
+      // via the macOnly flag below; on Mac the adapter requires the shared
+      // mflux sidecar venv (/opt/mlx-flux-venv).
+      "adapter": "mlx_flux2",
+      // Unified model: txt2img + edit (single reference image) via mflux's
+      // Flux2Klein / Flux2KleinEdit variants.
+      "capabilities": ["text_to_image", "character_image", "style_variations"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Gated repo (FLUX Non-Commercial License). Whole-repo download (~49 GiB
+          // — Qwen3 text embedder + Flux2 transformer + VAE).
+          "provider": "huggingface",
+          "repo": "black-forest-labs/FLUX.2-klein-9B",
+          "files": [],
+          "estimatedSizeBytes": 52613349376
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/black-forest-labs/FLUX.2-klein-9B"
+      },
+      "defaults": {
+        // Step-distilled to 4 steps; guidance MUST be 1.0 on distilled klein
+        // variants (mflux CLI errors on any other value).
+        "resolution": "1024x1024",
+        "steps": 4,
+        "guidanceScale": 1.0,
+        "count": 1
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        "families": ["flux2"],
+        "types": ["style", "enhance", "character"]
+      },
+      // Q8 sweet spot on M-series: same per-step speed as bf16, ~25% peak
+      // memory reduction. minMemoryGb tracks bf16 peak ~36 GB measured at
+      // 1024² 4-step on M5 Max; 64 GB Macs are well in range.
+      "mlx": {
+        "minMemoryGb": 42,
+        "quantize": 8
+      },
+      // Gated FLUX Non-Commercial License (same posture as flux_dev: accept
+      // license + add HF token before downloading). Generations are
+      // non-commercial use only — matches SceneWorks's overall non-commercial
+      // posture, so no new app-level guardrail beyond the existing one.
+      "gated": true,
+      "credentialHost": "huggingface.co",
+      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
+      "ui": {
+        "label": "FLUX.2 [klein] 9B",
+        "description": "Black Forest Labs FLUX.2 [klein] 9B — 4-step distilled text-to-image + reference editing, MLX-only (Apple Silicon). 9B flow transformer + 8B Qwen3 text embedder; ~36 GB bf16 peak at 1024². Distributed under the FLUX Non-Commercial License (gated): accept the license at huggingface.co/black-forest-labs/FLUX.2-klein-9B and add a Hugging Face token under Settings → Service credentials before downloading. For faster reference editing on the same architecture, see FLUX.2 [klein] 9B-KV.",
+        "recommendedFor": ["text_to_image", "character_image", "style_variations"],
+        // Edit-style backbone (Flux2KleinEdit handles reference natively; no
+        // IP-Adapter, no face-ID). The variation knob maps to image_strength
+        // — surfaced as "Prompt strength" because the cache-distilled model
+        // adapts the reference primarily via the prompt at 4 steps.
+        "variationStrength": {
+          "label": "Prompt strength",
+          "default": 4.0,
+          "min": 1.0,
+          "max": 10.0,
+          "step": 0.5
+        },
+        "promptGuide": {
+          "title": "FLUX.2 [klein] 9B Prompt Guide",
+          "path": "/prompt-guides/flux2-klein.md",
+          "sources": [
+            { "label": "FLUX.2 [klein] 9B model card", "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B" },
+            { "label": "FLUX.2 blog post", "url": "https://bfl.ai/blog/flux2-klein-towards-interactive-visual-intelligence" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "flux2_klein_9b_kv",
+      "name": "FLUX.2 [klein] 9B-KV",
+      "family": "flux2-klein",
+      "type": "image",
+      "adapter": "mlx_flux2",
+      // Reference-only: the KV cache caches reference-image K/V on step 0
+      // and reuses on steps 1-3, ~2.4× faster than the un-cached edit path
+      // on M5 Max (sc-2163, upstream PR filipstrand/mflux#426). Cache is
+      // meaningless without a reference image, so the model id is gated to
+      // character_image / edit modes only.
+      "capabilities": ["character_image"],
+      "macOnly": true,
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "black-forest-labs/FLUX.2-klein-9b-kv",
+          "files": [],
+          "estimatedSizeBytes": 52613349376
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/black-forest-labs/FLUX.2-klein-9b-kv"
+      },
+      "defaults": {
+        "resolution": "1024x1024",
+        "steps": 4,
+        "guidanceScale": 1.0,
+        "count": 1
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        "families": ["flux2"],
+        "types": ["style", "enhance", "character"]
+      },
+      "mlx": {
+        "minMemoryGb": 42,
+        "quantize": 8
+      },
+      "gated": true,
+      "credentialHost": "huggingface.co",
+      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
+      "ui": {
+        "label": "FLUX.2 [klein] 9B-KV",
+        "description": "FLUX.2 [klein] 9B with KV-cache acceleration for reference editing — ~2.4× faster than the base 9B edit path on Apple Silicon (validated M5 Max 128 GB, sc-2163). Reference image required; for plain text-to-image use FLUX.2 [klein] 9B. Distributed under the FLUX Non-Commercial License (gated). Same ~36 GB bf16 peak at 1024² as the base 9B.",
+        "recommendedFor": ["character_image"],
+        // Same edit-style knob as the base 9B (Flux2KleinEdit). The cache
+        // doesn't change the variation behavior, just the per-step compute.
+        "variationStrength": {
+          "label": "Prompt strength",
+          "default": 4.0,
+          "min": 1.0,
+          "max": 10.0,
+          "step": 0.5
+        },
+        "promptGuide": {
+          "title": "FLUX.2 [klein] 9B Prompt Guide",
+          "path": "/prompt-guides/flux2-klein.md",
+          "sources": [
+            { "label": "FLUX.2 [klein] 9B-KV model card", "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv" },
+            { "label": "FLUX.2 blog post", "url": "https://bfl.ai/blog/flux2-klein-towards-interactive-visual-intelligence" }
+          ]
+        }
+      }
+    },
+    {
       "id": "chroma1_hd",
       "name": "Chroma1-HD",
       "family": "chroma",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -29,6 +29,7 @@ from scene_worker.image_adapters import (
     ImageAssetWriter,
     KolorsDiffusersAdapter,
     LensTurboAdapter,
+    MlxFlux2Adapter,
     MlxFluxAdapter,
     MlxQwenAdapter,
     MlxSdxlAdapter,
@@ -1970,6 +1971,189 @@ def test_mlx_qwen_rejects_reference_asset():
         assert "character" in str(exc).lower() or "reference-image" in str(exc).lower()
     else:
         raise AssertionError("MlxQwenAdapter must reject reference-image jobs (deferred follow-up).")
+
+
+# --- sc-2164: FLUX.2 [klein] MLX-only adapter ---
+
+
+def test_image_adapter_env_override_selects_mlx_flux2(monkeypatch):
+    # Explicit env override picks MlxFlux2Adapter regardless of platform/sidecar.
+    monkeypatch.setenv("SCENEWORKS_IMAGE_ADAPTER", "mlx_flux2")
+    adapter = create_image_adapter({"payload": {"model": "flux2_klein_9b"}})
+    assert adapter.__class__.__name__ == "MlxFlux2Adapter"
+    assert adapter.id == "mlx_flux2"
+
+
+def test_flux2_dispatch_picks_mlx_flux2_for_both_models(monkeypatch):
+    # FLUX.2-klein has no torch fallback in SceneWorks, so the dispatch
+    # ALWAYS returns MlxFlux2Adapter regardless of platform / sidecar. The
+    # adapter's own preflight raises a clean error on misconfigured hosts.
+    monkeypatch.delenv("SCENEWORKS_IMAGE_ADAPTER", raising=False)
+    for model in ("flux2_klein_9b", "flux2_klein_9b_kv"):
+        adapter = create_image_adapter({"payload": {"model": model}})
+        assert adapter.__class__.__name__ == "MlxFlux2Adapter", model
+
+
+def test_should_route_flux2_to_mlx_predicate(monkeypatch):
+    from scene_worker.image_adapters import _should_route_flux2_to_mlx
+
+    monkeypatch.delenv("SCENEWORKS_DISABLE_MLX_FLUX", raising=False)
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(MlxFlux2Adapter, "_sidecar_available", lambda self: True)
+
+    # Happy paths.
+    assert _should_route_flux2_to_mlx({"model": "flux2_klein_9b"}) is True
+    assert _should_route_flux2_to_mlx(
+        {"model": "flux2_klein_9b", "referenceAssetId": "asset_ref"}
+    ) is True
+    # -kv requires a reference asset; without one the gate must fail so the
+    # adapter raises a clear error instead of running un-cached on -kv weights.
+    assert _should_route_flux2_to_mlx({"model": "flux2_klein_9b_kv"}) is False
+    assert _should_route_flux2_to_mlx(
+        {"model": "flux2_klein_9b_kv", "referenceAssetId": "asset_ref"}
+    ) is True
+    # Non-Mac and disable env both close the gate.
+    monkeypatch.setattr("sys.platform", "linux")
+    assert _should_route_flux2_to_mlx({"model": "flux2_klein_9b"}) is False
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setenv("SCENEWORKS_DISABLE_MLX_FLUX", "1")
+    assert _should_route_flux2_to_mlx({"model": "flux2_klein_9b"}) is False
+    monkeypatch.delenv("SCENEWORKS_DISABLE_MLX_FLUX", raising=False)
+    # Missing sidecar closes the gate even on darwin.
+    monkeypatch.setattr(MlxFlux2Adapter, "_sidecar_available", lambda self: False)
+    assert _should_route_flux2_to_mlx({"model": "flux2_klein_9b"}) is False
+    # Unsupported model never matches.
+    assert _should_route_flux2_to_mlx({"model": "flux_dev"}) is False
+
+
+def test_mlx_flux2_kv_rejects_no_reference():
+    # -kv without a reference is misuse: the cache is meaningless and the
+    # 4-step distilled output drifts without it. Adapter must fail loudly.
+    job = {
+        "id": "job_mlx_flux2_kv_norefs",
+        "payload": {
+            "projectId": "p",
+            "mode": "text_to_image",
+            "model": "flux2_klein_9b_kv",
+            "prompt": "a cat",
+        },
+    }
+    noop = lambda *args, **kwargs: None  # noqa: E731
+    try:
+        MlxFlux2Adapter().generate(
+            settings=None,
+            job=job,
+            request=image_request_from_job(job),
+            project_path=None,
+            progress=noop,
+            cancel_requested=lambda: False,
+        )
+    except RuntimeError as exc:
+        assert "reference image" in str(exc).lower()
+    else:
+        raise AssertionError(
+            "MlxFlux2Adapter must reject flux2_klein_9b_kv jobs without a reference image."
+        )
+
+
+def test_mlx_flux2_rejects_unsupported_model():
+    # Wrong model_target.adapter (e.g. routing a flux_schnell job through
+    # MlxFlux2Adapter by mistake) must fail clearly.
+    job = {
+        "id": "job_mlx_flux2_wrong_model",
+        "payload": {
+            "projectId": "p",
+            "mode": "text_to_image",
+            "model": "flux_schnell",
+            "prompt": "x",
+        },
+    }
+    noop = lambda *args, **kwargs: None  # noqa: E731
+    try:
+        MlxFlux2Adapter().generate(
+            settings=None,
+            job=job,
+            request=image_request_from_job(job),
+            project_path=None,
+            progress=noop,
+            cancel_requested=lambda: False,
+        )
+    except RuntimeError as exc:
+        assert "FLUX.2 target" in str(exc) or "MlxFlux2Adapter supports" in str(exc)
+    else:
+        raise AssertionError("MlxFlux2Adapter must reject non-FLUX.2 models.")
+
+
+def test_mlx_flux2_requires_sidecar_when_missing(monkeypatch):
+    # When the sidecar venv is missing, generate() must surface an actionable
+    # error rather than silently producing nothing.
+    monkeypatch.setenv("SCENEWORKS_MLX_FLUX_PYTHON", "/nonexistent/mlx-flux-venv/bin/python")
+    job = {
+        "id": "job_mlx_flux2_no_sidecar",
+        "payload": {
+            "projectId": "p",
+            "mode": "text_to_image",
+            "model": "flux2_klein_9b",
+            "prompt": "a cat",
+        },
+    }
+    noop = lambda *args, **kwargs: None  # noqa: E731
+    try:
+        MlxFlux2Adapter().generate(
+            settings=None,
+            job=job,
+            request=image_request_from_job(job),
+            project_path=None,
+            progress=noop,
+            cancel_requested=lambda: False,
+        )
+    except RuntimeError as exc:
+        assert "sidecar" in str(exc).lower()
+    else:
+        raise AssertionError("MlxFlux2Adapter must fail when sidecar venv is unavailable.")
+
+
+def test_mlx_flux2_resolve_quantize_order():
+    # Same advanced > manifest > Q8 default algorithm as the other MLX adapters.
+    adapter = MlxFlux2Adapter()
+    request = SimpleNamespace(advanced={}, model_manifest_entry={})
+    assert adapter._resolve_quantize(request) == 8
+    request = SimpleNamespace(advanced={}, model_manifest_entry={"mlx": {"quantize": 4}})
+    assert adapter._resolve_quantize(request) == 4
+    request = SimpleNamespace(
+        advanced={"mlxQuantize": 3}, model_manifest_entry={"mlx": {"quantize": 8}}
+    )
+    assert adapter._resolve_quantize(request) == 3
+    request = SimpleNamespace(advanced={"mlxQuantize": 0}, model_manifest_entry={})
+    assert adapter._resolve_quantize(request) is None
+
+
+def test_flux2_klein_manifest_entries_present():
+    # Both flux2_klein_9b and flux2_klein_9b_kv must be present in the
+    # builtin manifest with the expected adapter + family + mlx block.
+    import re
+
+    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
+    for model_id, expect_kv_only in (
+        ("flux2_klein_9b", False),
+        ("flux2_klein_9b_kv", True),
+    ):
+        block = find_entry_block(model_id)
+        assert '"adapter": "mlx_flux2"' in block, model_id
+        assert '"family": "flux2-klein"' in block, model_id
+        assert '"macOnly": true' in block, model_id
+        assert '"gated": true' in block, model_id
+        mlx_block = find_mlx_block(block)
+        quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
+        assert quant_match is not None, f"{model_id}: mlx.quantize missing"
+        assert int(quant_match.group(1)) == 8, f"{model_id}: quantize should be 8 (sweet spot)"
+        if expect_kv_only:
+            # -kv carries character_image only — the KV cache is meaningless
+            # without a reference image.
+            assert '"capabilities": ["character_image"]' in block.replace("\n", " "), model_id
+        else:
+            assert '"text_to_image"' in block, model_id
+            assert '"character_image"' in block, model_id
 
 
 # --- sc-2145: Z-Image MLX adapter ---


### PR DESCRIPTION
## Summary

First MLX-only image-generation family in SceneWorks: **FLUX.2 [klein] 9B** (txt2img + reference editing) and **FLUX.2 [klein] 9B-KV** (KV-cache distilled, ~2.4× faster reference editing). FLUX.2 has no torch backend in SceneWorks today, so the manifest entries point directly at the new `MlxFlux2Adapter` rather than the auto-route-from-torch pattern of the other MLX adapters (sc-1970 / sc-1972 / sc-2145).

The KV-cache mechanism itself ships in the pinned mflux fork ([upstream PR #426](https://github.com/filipstrand/mflux/pull/426), sc-2163). Once that PR merges, the `requirements-mlx-flux.txt` pin in this PR flips back to a PyPI `mflux>=0.18` pin.

## Validation (M5 Max 128GB, 1024², 4 steps, runner-direct e2e)

| Variant | Mode | Cache | Total | Per-step |
|---|---|---|---|---|
| flux2_klein_9b | txt2img | n/a | 27.5 s | ~6.9 s |
| flux2_klein_9b_kv | edit | **on** | **21.6 s wall** | **step 0 11.3 s, cached 1-3 ~4 s avg** |

Both outputs visually coherent, identity preserved across the cache-on edit.

## Changes

- **requirements-mlx-flux.txt** — pin to user fork until upstream merges
- **mlx_flux_runner.py** — dispatch `Flux2Klein` (txt2img) / `Flux2KleinEdit` (reference) on `flux2_klein_9b` / `flux2_klein_9b_kv`; plumb `imagePaths` through spec; skip `negative_prompt` for the Flux2 family (Flux2 disallows negatives)
- **image_adapters.py**
  - new `MlxFlux2Adapter` mirroring `MlxFluxAdapter` (shared `/opt/mlx-flux-venv` sidecar)
  - `_supported_models = {flux2_klein_9b, flux2_klein_9b_kv}`; `flux2_klein_9b_kv` rejects no-reference jobs (cache is meaningless without a reference, and the 4-step distillation drifts un-cached)
  - `MODEL_TARGETS` entries with new `flux2-klein` family
  - `_should_route_flux2_to_mlx` predicate
  - dispatch routes the family unconditionally to `MlxFlux2Adapter` (no torch fallback); adapter raises clear preflight errors on misconfigured hosts
- **builtin.models.jsonc** — `flux2_klein_9b` and `flux2_klein_9b_kv` entries with `macOnly`, `gated` (FLUX Non-Commercial), `mlx` block (`minMemoryGb 42`, Q8 default), `variationStrength` UI hint
- **test_worker_runtime.py** — 8 new tests covering dispatch, predicate, -kv reference requirement, quantize resolution, manifest shape
- **flux2-klein.md prompt guide** — covers both variants and the edit/cache flow

## Checks

- Worker tests: **406 passed, 9 skipped** (full `tests/test_worker_runtime.py`)
- Rust contracts: **28 passed** (`cargo test -p sceneworks-core`)
- Scaffold check: clean (`node scripts/check-scaffold.mjs`)

## License posture

FLUX Non-Commercial License — same as the already-shipped `flux_dev`. Gated HF download; the manifest entries declare `gated`, `credentialHost`, `licenseUrl` so the Models screen routes the user through Service credentials before download (sc-1898 pattern).

## Test plan

- [x] Verify worker test suite passes locally
- [x] Verify Rust contracts pass locally
- [x] E2E run `flux2_klein_9b` txt2img through `mlx_flux_runner.py`
- [x] E2E run `flux2_klein_9b_kv` edit-with-reference through `mlx_flux_runner.py`; confirm cache-on per-step pattern (step 0 slow, 1-3 fast)
- [ ] After upstream mflux PR #426 merges: flip `requirements-mlx-flux.txt` pin back to PyPI release and re-provision `/opt/mlx-flux-venv` in CI
- [ ] Manual on a fresh Mac: select FLUX.2 [klein] 9B in Image Studio, generate a txt2img output
- [ ] Manual on a fresh Mac: select FLUX.2 [klein] 9B-KV in Image Studio with a character reference, confirm cache speedup visible in worker logs

## Follow-ups (separate stories)

- Frontend `macOnly` host-capability filter — manifest already carries the flag; UI hiding is a separate change once consumers start reading it
- Multi-reference edit mode (`Flux2KleinEdit` supports multiple `image_paths` natively)
- Flip mflux pin to PyPI release after #426 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)