### PR TITLE
Asset Library scoping: exclude Character Studio outputs via persisted origin [sc-2024]

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -6,11 +6,16 @@ pub(crate) async fn list_assets(
     Query(query): Query<AssetsQuery>,
 ) -> Result<Json<Vec<serde_json::Value>>, ApiError> {
     let character_id = query.character_id.clone();
+    let scope = match query.scope.as_deref() {
+        Some("library") => sceneworks_core::project_store::AssetScope::Library,
+        _ => sceneworks_core::project_store::AssetScope::All,
+    };
     let assets = project_call(state, move |store| {
         store.list_assets(
             &project_id,
             query.include_rejected.unwrap_or(false),
             query.include_trashed.unwrap_or(false),
+            scope,
         )
     })
     .await?;

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -29,6 +29,9 @@ pub(crate) struct AssetsQuery {
     /// (recipe.normalizedSettings.characterId) or referencing it
     /// (metadata.characterReferences[].characterId).
     pub(crate) character_id: Option<String>,
+    /// View scope (sc-2024). `library` excludes Character Studio test outputs;
+    /// anything else (the default) returns all assets.
+    pub(crate) scope: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1205,7 +1205,10 @@ async fn asset_library_scope_excludes_character_studio_outputs() {
     // directly as sidecars (no explicit origin → derived on the first reindex,
     // which the initial /assets call triggers because the table is empty).
     let image_dir = project_path.join("assets/images");
-    for (id, mode) in [("img_studio_1", "text_to_image"), ("char_test_1", "character_image")] {
+    for (id, mode) in [
+        ("img_studio_1", "text_to_image"),
+        ("char_test_1", "character_image"),
+    ] {
         std::fs::write(image_dir.join(format!("{id}.png")), b"png-bytes").expect("media");
         std::fs::write(
             image_dir.join(format!("{id}.sceneworks.json")),

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1186,6 +1186,74 @@ async fn training_dataset_uploads_are_dataset_owned_not_assets() {
 }
 
 #[tokio::test]
+async fn asset_library_scope_excludes_character_studio_outputs() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let app = create_app(settings).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Library Scope Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(project["path"].as_str().unwrap());
+
+    // Write a normal Image Studio output and a Character Studio test output
+    // directly as sidecars (no explicit origin → derived on the first reindex,
+    // which the initial /assets call triggers because the table is empty).
+    let image_dir = project_path.join("assets/images");
+    for (id, mode) in [("img_studio_1", "text_to_image"), ("char_test_1", "character_image")] {
+        std::fs::write(image_dir.join(format!("{id}.png")), b"png-bytes").expect("media");
+        std::fs::write(
+            image_dir.join(format!("{id}.sceneworks.json")),
+            serde_json::to_string_pretty(&json!({
+                "id": id,
+                "type": "image",
+                "displayName": id,
+                "createdAt": "2026-05-23T00:00:00Z",
+                "file": {"path": format!("assets/images/{id}.png")},
+                "status": {"favorite": false, "rating": 0, "rejected": false, "trashed": false},
+                "recipe": {"mode": mode},
+            }))
+            .expect("json"),
+        )
+        .expect("sidecar");
+    }
+
+    // Default (all) scope returns both, each tagged with a derived origin.
+    let (status, all) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/assets"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let all = all.as_array().expect("all list");
+    assert_eq!(all.len(), 2);
+    assert!(all
+        .iter()
+        .any(|asset| asset["id"] == "char_test_1" && asset["origin"] == "character_studio"));
+
+    // Library scope drops the Character Studio output.
+    let (status, library) = request(
+        app,
+        "GET",
+        &format!("/api/v1/projects/{project_id}/assets?scope=library"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let library = library.as_array().expect("library list");
+    assert_eq!(library.len(), 1);
+    assert_eq!(library[0]["id"], "img_studio_1");
+    assert_eq!(library[0]["origin"], "image_studio");
+}
+
+#[tokio::test]
 async fn create_training_job_resolves_plan_and_queues_lora_train() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -7266,6 +7266,58 @@ describe("SceneWorks app shell", () => {
     expect(updateAssetTags).toHaveBeenLastCalledWith(portrait, []);
   });
 
+  it("excludes Character Studio outputs from the Asset Library (sc-2024)", async () => {
+    const studioImage = {
+      id: "asset-studio",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Studio Render",
+      origin: "image_studio",
+      recipe: { prompt: "studio render" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const characterImage = {
+      id: "asset-character",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Character Test",
+      origin: "character_studio",
+      recipe: { prompt: "character test" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Scoped" },
+            assets: [studioImage, characterImage],
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: studioImage,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    const tiles = [...container.querySelectorAll(".asset-tile")];
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0].textContent).toContain("Studio Render");
+    expect(container.textContent).not.toContain("Character Test");
+  });
+
   it("folds original and upscaled library variants into one representative tile", async () => {
     const setPreviewAsset = vi.fn();
     const original = {

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -47,7 +47,14 @@ export function LibraryScreen() {
   const [showRejected, setShowRejected] = useState(false);
   const [assetMode, setAssetMode] = useState("assets");
   const [isImporting, setIsImporting] = useState(false);
-  const visibleAssets = foldUpscaledAssetVariants(assets.filter((asset) => {
+  // Asset Library hygiene (sc-2024): show only studio-generated and uploaded
+  // media. Character Studio test outputs (origin "character_studio") live under
+  // the character, not here. The backend also exposes `?scope=library`; we filter
+  // on the authoritative `origin` field client-side to reuse the shared asset
+  // feed instead of loading a second scoped copy. Dataset images never reach the
+  // Library — they are stored outside the indexed asset folders.
+  const libraryAssets = assets.filter((asset) => asset.origin !== "character_studio");
+  const visibleAssets = foldUpscaledAssetVariants(libraryAssets.filter((asset) => {
     if (typeFilter !== "all" && asset.type !== typeFilter) {
       return false;
     }
@@ -77,10 +84,10 @@ export function LibraryScreen() {
     event.target.value = "";
   }
 
-  const imageCount = assets.filter((asset) => asset.type === "image").length;
-  const videoCount = assets.filter((asset) => asset.type === "video").length;
-  const uploadCount = assets.filter((asset) => asset.type === "upload").length;
-  const availableTags = [...new Set(assets.flatMap((asset) => (Array.isArray(asset.tags) ? asset.tags : [])))].sort();
+  const imageCount = libraryAssets.filter((asset) => asset.type === "image").length;
+  const videoCount = libraryAssets.filter((asset) => asset.type === "video").length;
+  const uploadCount = libraryAssets.filter((asset) => asset.type === "upload").length;
+  const availableTags = [...new Set(libraryAssets.flatMap((asset) => (Array.isArray(asset.tags) ? asset.tags : [])))].sort();
 
   return (
     <section className="main-surface library-surface">
@@ -132,7 +139,7 @@ export function LibraryScreen() {
           </div>
           <div className="hero-stat">
             <span className="hero-stat-label">Assets</span>
-            <span className="hero-stat-value">{assets.length} total</span>
+            <span className="hero-stat-value">{libraryAssets.length} total</span>
           </div>
           <div className="hero-stat">
             <span className="hero-stat-label">Images</span>

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -61,12 +61,57 @@ pub(crate) fn collect_sidecars(path: &Path, sidecars: &mut Vec<PathBuf>) -> Proj
     Ok(())
 }
 
+/// The studio / feature an asset originated from. Drives Asset Library hygiene
+/// (sc-2024): the Library shows only studio-generated and uploaded media, never
+/// Character Studio test outputs (those live under the character). Returns an
+/// explicit `origin` when the sidecar carries one, otherwise derives it from the
+/// recipe mode + asset type so legacy sidecars (written before the field existed)
+/// still classify correctly on read and on reindex.
+pub(crate) fn asset_origin(asset: &Value) -> String {
+    if let Some(origin) = asset.get("origin").and_then(Value::as_str) {
+        if !origin.is_empty() {
+            return origin.to_owned();
+        }
+    }
+    let mode = asset
+        .get("recipe")
+        .and_then(|recipe| recipe.get("mode"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let asset_type = asset.get("type").and_then(Value::as_str).unwrap_or_default();
+    derive_origin(mode, asset_type).to_owned()
+}
+
+/// Classify an asset's origin from its generation `mode` and media `type`.
+/// `character_image` (the Character Studio test mode) and `upload` (manual
+/// import) are mode-driven; everything else maps to the studio that produces
+/// that media type.
+pub(crate) fn derive_origin(mode: &str, asset_type: &str) -> &'static str {
+    match mode {
+        "character_image" => "character_studio",
+        "upload" => "upload",
+        _ => match asset_type {
+            "video" => "video_studio",
+            "document" => "document_studio",
+            _ => "image_studio",
+        },
+    }
+}
+
 pub(crate) fn normalize_asset(
     project_id: &str,
     project_path: &Path,
     sidecar_path: &Path,
 ) -> ProjectStoreResult<Value> {
     let mut asset = read_json(sidecar_path)?;
+    // Guarantee every API response carries an `origin`, even for legacy sidecars
+    // written before the field existed (sc-2024).
+    let origin = asset_origin(&asset);
+    if let Some(object) = asset.as_object_mut() {
+        object
+            .entry("origin".to_owned())
+            .or_insert_with(|| Value::String(origin));
+    }
     if let Some(path) = asset.pointer("/file/path").and_then(Value::as_str) {
         let normalized_path = path.replace('\\', "/");
         if let Some(object) = asset.as_object_mut() {
@@ -95,8 +140,8 @@ pub(crate) fn upsert_asset_row(
         "
         insert or replace into assets (
           id, type, display_name, file_path, generation_set_id, created_at,
-          favorite, rating, rejected, trashed, sidecar_path
-        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+          favorite, rating, rejected, trashed, sidecar_path, origin
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
         ",
         params![
             required_str(asset, "id")?,
@@ -115,6 +160,7 @@ pub(crate) fn upsert_asset_row(
             optional_bool(status, "rejected").unwrap_or(false),
             optional_bool(status, "trashed").unwrap_or(false),
             sidecar_rel,
+            asset_origin(asset),
         ],
     )?;
     Ok(())
@@ -123,4 +169,49 @@ pub(crate) fn upsert_asset_row(
 fn required_str<'a>(asset: &'a Value, key: &str) -> ProjectStoreResult<&'a str> {
     optional_str(asset, key)
         .ok_or_else(|| ProjectStoreError::BadRequest(format!("Missing required field: {key}")))
+}
+
+#[cfg(test)]
+mod origin_tests {
+    use super::{asset_origin, derive_origin};
+    use serde_json::json;
+
+    #[test]
+    fn derives_character_studio_from_character_image_mode() {
+        assert_eq!(derive_origin("character_image", "image"), "character_studio");
+        // Mode wins over media type so a character test frame still classifies.
+        assert_eq!(derive_origin("character_image", "video"), "character_studio");
+    }
+
+    #[test]
+    fn derives_upload_from_upload_mode() {
+        assert_eq!(derive_origin("upload", "image"), "upload");
+    }
+
+    #[test]
+    fn derives_studio_origin_by_media_type() {
+        assert_eq!(derive_origin("text_to_image", "image"), "image_studio");
+        assert_eq!(derive_origin("image_to_video", "video"), "video_studio");
+        assert_eq!(derive_origin("interleave", "document"), "document_studio");
+    }
+
+    #[test]
+    fn asset_origin_prefers_explicit_field() {
+        let asset = json!({
+            "type": "image",
+            "origin": "character_studio",
+            "recipe": { "mode": "text_to_image" },
+        });
+        assert_eq!(asset_origin(&asset), "character_studio");
+    }
+
+    #[test]
+    fn asset_origin_derives_when_field_absent_or_empty() {
+        // Legacy sidecar: no origin field, classified by recipe mode.
+        let legacy = json!({ "type": "image", "recipe": { "mode": "character_image" } });
+        assert_eq!(asset_origin(&legacy), "character_studio");
+        // Empty origin falls back to derivation rather than returning "".
+        let empty = json!({ "type": "video", "origin": "", "recipe": { "mode": "image_to_video" } });
+        assert_eq!(asset_origin(&empty), "video_studio");
+    }
 }

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -78,7 +78,10 @@ pub(crate) fn asset_origin(asset: &Value) -> String {
         .and_then(|recipe| recipe.get("mode"))
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let asset_type = asset.get("type").and_then(Value::as_str).unwrap_or_default();
+    let asset_type = asset
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     derive_origin(mode, asset_type).to_owned()
 }
 
@@ -178,9 +181,15 @@ mod origin_tests {
 
     #[test]
     fn derives_character_studio_from_character_image_mode() {
-        assert_eq!(derive_origin("character_image", "image"), "character_studio");
+        assert_eq!(
+            derive_origin("character_image", "image"),
+            "character_studio"
+        );
         // Mode wins over media type so a character test frame still classifies.
-        assert_eq!(derive_origin("character_image", "video"), "character_studio");
+        assert_eq!(
+            derive_origin("character_image", "video"),
+            "character_studio"
+        );
     }
 
     #[test]
@@ -211,7 +220,8 @@ mod origin_tests {
         let legacy = json!({ "type": "image", "recipe": { "mode": "character_image" } });
         assert_eq!(asset_origin(&legacy), "character_studio");
         // Empty origin falls back to derivation rather than returning "".
-        let empty = json!({ "type": "video", "origin": "", "recipe": { "mode": "image_to_video" } });
+        let empty =
+            json!({ "type": "video", "origin": "", "recipe": { "mode": "image_to_video" } });
         assert_eq!(asset_origin(&empty), "video_studio");
     }
 }

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use crate::asset_index::{
-    asset_sidecars, normalize_asset, row_to_asset_record, upsert_asset_row, AssetRecord,
+    asset_origin, asset_sidecars, normalize_asset, row_to_asset_record, upsert_asset_row,
+    AssetRecord,
 };
 use crate::character_store::{
     apply_character_migrations, clear_character_tables, reindex_characters_on_connection,
@@ -143,6 +144,19 @@ pub struct TimelineFileDocument {
 pub struct AssetMutationResult {
     pub id: String,
     pub status: String,
+}
+
+/// Which assets a listing should include (sc-2024). `All` is the historical
+/// behaviour used by Image/Video studios, the Editor, and the per-character
+/// gallery. `Library` is the Asset Library view, which excludes Character Studio
+/// test outputs (`origin = character_studio`) so they live only under the
+/// character. Dataset images are already excluded — they are stored outside the
+/// indexed asset folders and never enter the assets table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AssetScope {
+    #[default]
+    All,
+    Library,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -622,6 +636,7 @@ impl ProjectStore {
         project_id: &str,
         include_rejected: bool,
         include_trashed: bool,
+        scope: AssetScope,
     ) -> ProjectStoreResult<Vec<Value>> {
         let project_path = self.find_project_path(project_id)?;
         ensure_project_db_ready(&project_path)?;
@@ -636,15 +651,23 @@ impl ProjectStore {
         }
 
         let connection = connect_project_db(&project_path)?;
-        let mut statement = connection.prepare(
+        // The Library view hides Character Studio test outputs (sc-2024). Rows
+        // with a null origin (should not occur after the schema-bump reindex)
+        // fail open and stay visible.
+        let origin_filter = match scope {
+            AssetScope::All => "",
+            AssetScope::Library => " and (origin is null or origin != 'character_studio')",
+        };
+        let mut statement = connection.prepare(&format!(
             "
             select sidecar_path, file_path
               from assets
              where (?1 or rejected = 0)
                and (?2 or trashed = 0)
+               {origin_filter}
              order by created_at desc
-            ",
-        )?;
+            "
+        ))?;
         let rows = statement.query_map(params![include_rejected, include_trashed], |row| {
             Ok((
                 row.get::<_, Option<String>>(0)?,
@@ -1067,6 +1090,8 @@ impl ProjectStore {
             "type": media_type_for_mime(&content_type)?,
             "displayName": display_name,
             "createdAt": created_at,
+            // Manual imports are Library media in their own right (sc-2024).
+            "origin": "upload",
             "file": {
                 "path": media_rel,
                 "mimeType": content_type,
@@ -1456,7 +1481,7 @@ struct ReindexCounts {
 /// Bump whenever the project.db schema changes (new table, column, or index).
 /// `apply_project_migrations` only re-runs its DDL when `PRAGMA user_version`
 /// is behind this; forgetting to bump means an existing DB never gets the change.
-const PROJECT_SCHEMA_VERSION: i64 = 1;
+const PROJECT_SCHEMA_VERSION: i64 = 2;
 
 fn project_schema_version(connection: &Connection) -> ProjectStoreResult<i64> {
     Ok(connection.query_row("pragma user_version", [], |row| row.get(0))?)
@@ -1508,6 +1533,10 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
         ",
     )?;
     ensure_column(connection, "assets", "sidecar_path", "text")?;
+    // sc-2024: the originating studio (image_studio / video_studio /
+    // document_studio / character_studio / upload). Existing rows are backfilled
+    // by the reindex that `ensure_project_db_ready` runs on this version bump.
+    ensure_column(connection, "assets", "origin", "text")?;
     apply_character_migrations(connection)?;
     apply_training_dataset_migrations(connection)?;
     // Pragma assignment cannot be parameterized; the version is a trusted const.
@@ -1516,7 +1545,17 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
 }
 
 pub fn ensure_project_db_ready(project_path: &Path) -> ProjectStoreResult<()> {
-    apply_project_migrations(&connect_project_db(project_path)?)
+    let connection = connect_project_db(project_path)?;
+    let version_before = project_schema_version(&connection)?;
+    apply_project_migrations(&connection)?;
+    drop(connection);
+    // A schema bump can add derived columns (e.g. `origin`, sc-2024) that
+    // existing rows lack. Rebuild the index from sidecars once so those columns
+    // are backfilled; subsequent calls are no-ops (version already current).
+    if version_before < PROJECT_SCHEMA_VERSION {
+        reindex_project_path(project_path)?;
+    }
+    Ok(())
 }
 
 fn reindex_project_path(project_path: &Path) -> ProjectStoreResult<ReindexCounts> {
@@ -2218,6 +2257,12 @@ fn build_generated_asset_sidecar(
         "recipe": recipe,
         "lineage": lineage,
     });
+    // Record the originating studio so the Asset Library can exclude Character
+    // Studio test outputs (sc-2024). Derived from recipe mode + media type.
+    let origin = asset_origin(&asset);
+    if let Some(object) = asset.as_object_mut() {
+        object.insert("origin".to_owned(), Value::String(origin));
+    }
     if let Some(extra) = fact.get("extra") {
         if let Some(object) = asset.as_object_mut() {
             object.insert("extra".to_owned(), extra.clone());
@@ -2725,7 +2770,7 @@ fn move_or_copy_file(source: &Path, destination: &Path) -> ProjectStoreResult<()
 mod tests {
     use super::{
         build_generated_asset_sidecar, guess_mime_from_filename, is_safe_relative_path,
-        normalize_asset_tags, CharacterCreateInput, CharacterLookInput, ProjectStore,
+        normalize_asset_tags, AssetScope, CharacterCreateInput, CharacterLookInput, ProjectStore,
         PROJECT_FOLDERS,
     };
     use serde_json::{json, Value};
@@ -3110,11 +3155,72 @@ mod tests {
         assert_eq!(counts.assets, 1);
 
         let assets = store
-            .list_assets(&project.id, false, false)
+            .list_assets(&project.id, false, false, AssetScope::All)
             .expect("assets list");
         assert_eq!(assets.len(), 1);
         assert_eq!(assets[0]["id"], "doc_1");
         assert_eq!(assets[0]["type"], "document");
+        // The document asset carries a derived origin (sc-2024).
+        assert_eq!(assets[0]["origin"], "document_studio");
+    }
+
+    #[test]
+    fn library_scope_excludes_character_studio_outputs() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Scoped").expect("project creates");
+        let project_path = std::path::PathBuf::from(&project.path);
+        let image_dir = project_path.join("assets/images");
+
+        // Two image asset sidecars written WITHOUT an explicit `origin` field, to
+        // exercise the derive-on-reindex backfill: a normal Image Studio output
+        // and a Character Studio test output (recipe.mode == "character_image").
+        let write_sidecar = |id: &str, mode: &str| {
+            std::fs::write(
+                image_dir.join(format!("{id}.png")),
+                b"not-a-real-png".as_slice(),
+            )
+            .expect("media writes");
+            std::fs::write(
+                image_dir.join(format!("{id}.sceneworks.json")),
+                serde_json::to_string_pretty(&json!({
+                    "id": id,
+                    "type": "image",
+                    "displayName": id,
+                    "createdAt": "2026-05-23T00:00:00Z",
+                    "file": {"path": format!("assets/images/{id}.png")},
+                    "status": {"favorite": false, "rating": 0, "rejected": false, "trashed": false},
+                    "recipe": {"mode": mode},
+                }))
+                .expect("json"),
+            )
+            .expect("sidecar writes");
+        };
+        write_sidecar("img_studio_1", "text_to_image");
+        write_sidecar("char_test_1", "character_image");
+
+        store.reindex_project(&project.id).expect("reindex works");
+
+        // All scope returns both, each with a derived origin.
+        let all = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .expect("all list");
+        assert_eq!(all.len(), 2);
+        let origin_of = |id: &str| {
+            all.iter()
+                .find(|asset| asset["id"] == id)
+                .map(|asset| asset["origin"].as_str().unwrap_or_default().to_owned())
+                .unwrap_or_default()
+        };
+        assert_eq!(origin_of("img_studio_1"), "image_studio");
+        assert_eq!(origin_of("char_test_1"), "character_studio");
+
+        // Library scope drops the Character Studio output, keeps the studio image.
+        let library = store
+            .list_assets(&project.id, false, false, AssetScope::Library)
+            .expect("library list");
+        assert_eq!(library.len(), 1);
+        assert_eq!(library[0]["id"], "img_studio_1");
     }
 
     #[test]

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -30,6 +30,7 @@
       "metadata": {
         "characterReferences": []
       },
+      "origin": "upload",
       "projectId": "project_fixture",
       "recipe": {
         "adapter": "api-upload",
@@ -89,6 +90,7 @@
           }
         ]
       },
+      "origin": "upload",
       "projectId": "project_fixture",
       "recipe": {
         "adapter": "api-upload",
@@ -137,6 +139,7 @@
         "sourceAssetId": null,
         "sourceTimestamp": null
       },
+      "origin": "upload",
       "projectId": "project_fixture",
       "recipe": {
         "adapter": "api-upload",
@@ -199,6 +202,7 @@
         }
       ]
     },
+    "origin": "upload",
     "projectId": "project_fixture",
     "recipe": {
       "adapter": "api-upload",
@@ -245,6 +249,7 @@
     "metadata": {
       "characterReferences": []
     },
+    "origin": "upload",
     "projectId": "project_fixture",
     "recipe": {
       "adapter": "api-upload",
@@ -288,6 +293,7 @@
       "sourceAssetId": null,
       "sourceTimestamp": null
     },
+    "origin": "upload",
     "projectId": "project_fixture",
     "recipe": {
       "adapter": "api-upload",
@@ -333,6 +339,7 @@
       "sourceAssetId": null,
       "sourceTimestamp": null
     },
+    "origin": "upload",
     "projectId": "project_fixture",
     "recipe": {
       "adapter": "api-upload",
@@ -2233,6 +2240,7 @@
       "sourceAssetId": null,
       "sourceTimestamp": null
     },
+    "origin": "upload",
     "projectId": "project_fixture",
     "recipe": {
       "adapter": "api-upload",


### PR DESCRIPTION
## Summary

Implements **sc-2024** (epic 2019): the Asset Library now contains only studio-generated and uploaded media — Character Studio test outputs are excluded and live only under the character.

Approach: a persisted **`origin`** field on the asset envelope plus an `AssetScope::Library` backend scope.

## Key finding

Dataset images were **already excluded** — they're stored under `training/datasets/<id>/images`, outside the indexed `ASSET_FOLDERS`, so they never enter the assets table (locked by the existing `training_dataset_uploads_are_dataset_owned_not_assets` test). The only real leak was **Character Studio** test outputs, which are normal `ImageGenerate` jobs (`mode == "character_image"`) written to `assets/images/`.

Note: `recipe.normalizedSettings.characterId` is *not* a safe marker — Image Studio generations that reference a character (epic 2003) also set it but are legitimate Library content. Only the generation `mode` reliably identifies Character-Studio origin.

## Changes

- **core (`sceneworks-core`)**
  - `asset_index.rs`: `asset_origin()` / `derive_origin()` → `image_studio | video_studio | document_studio | character_studio | upload`. `normalize_asset` injects a derived origin for legacy sidecars; `origin` written to the new `assets.origin` column.
  - `project_store.rs`: persist `origin` in `build_generated_asset_sidecar` + `import_asset`; `pub enum AssetScope { All, Library }`; `list_assets(scope)` Library-excludes `origin = 'character_studio'` (fail-open on null). `PROJECT_SCHEMA_VERSION` 1→2 + `ensure_column`; `ensure_project_db_ready` runs a one-time reindex on the bump to backfill existing rows.
- **api (`rust-api`)**: `AssetsQuery.scope`; `?scope=library` → `AssetScope::Library`.
- **web**: Asset Library excludes `origin === "character_studio"` (tiles, counts, tags, total).

## Frontend wiring tradeoff

The global `assets` array is shared across Library, Image Studio recents, Editor, AssetPicker, and the per-character gallery (one fetch). The Library filters client-side on the authoritative `origin` field rather than issuing a second `?scope=library` fetch, to avoid duplicating the feed + its refresh plumbing. The backend scope is implemented and tested as the canonical contract; switching the Library to consume it directly is a one-line follow-up if preferred.

## Tests

- core: 5 origin-derivation units + `library_scope_excludes_character_studio_outputs` (end-to-end via reindex, no explicit origin → exercises backfill).
- rust-api: `asset_library_scope_excludes_character_studio_outputs` (verifies `?scope=library` + derived origin in responses).
- web: "excludes Character Studio outputs from the Asset Library (sc-2024)".
- All suites green: core, rust-api (85), web (235), contract round-trip (7); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)