### PR TITLE
Character Studio multi-backbone angle picker [epic-2003]

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -83,13 +83,31 @@ export const fallbackModels = [
     type: "image",
     capabilities: ["edit_image", "character_image"],
     ui: {
-      description: "4-step distilled Qwen-Image-Edit-2511 (lightx2v Lightning LoRA fused at load). ~10x faster at a small quality trade-off; CFG disabled.",
+      description: "4-step distilled Qwen-Image-Edit-2511 (lightx2v Lightning LoRA fused at load). ~10x faster at a small quality trade-off; CFG disabled. In Character Studio's angle set + pose library, the prompt-driven fast tier (sc-2003 spike: mean ArcFace 0.62 across 5 angles, second-best identity after InstantID; pose-library multi-image best-effort, sitting 0.68 / standing 0.45). Caveat: profile prompts reframe to full-body (Qwen's framing-expansion personality).",
       promptGuide: { title: "Qwen Image Edit (2511) Lightning Prompt Guide", path: "/prompt-guides/qwen-image-edit-2511-lightning.md" },
       hideReferenceStrength: true,
       // Distill is trained at cfg 1.0; the lever is exposed only as a narrow
       // safety range (1.0–2.0) for users willing to trade ghosting for stronger
       // prompt adherence. Default stays at 1.0.
       variationStrength: { label: "Prompt strength", default: 1.0, min: 1.0, max: 2.0, step: 0.25 },
+      // Multi-backbone angle set (sc-2003): same 11 canonical angles as the
+      // InstantID baseline, driven by prompt rather than landmark pack (worker
+      // resolves via character_studio_angles.ANGLE_PROMPT_AUGMENTS). Pose
+      // library deferred to a follow-up PR; the spike validated the multi-
+      // image trick at sitting 0.68 / standing 0.45 ArcFace cosine.
+      viewAngles: [
+        { id: "three_quarter_left", label: "Three-quarter left" },
+        { id: "three_quarter_right", label: "Three-quarter right" },
+        { id: "left_profile", label: "Left profile" },
+        { id: "right_profile", label: "Right profile" },
+        { id: "up", label: "Looking up" },
+        { id: "down", label: "Looking down" },
+        { id: "up_left", label: "Up · left" },
+        { id: "up_right", label: "Up · right" },
+        { id: "down_left", label: "Down · left" },
+        { id: "down_right", label: "Down · right" },
+        { id: "front", label: "Front" },
+      ],
     },
   },
   {
@@ -123,11 +141,30 @@ export const fallbackModels = [
     capabilities: ["text_to_image", "edit_image", "character_image", "vqa", "interleave"],
     limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
     ui: {
-      description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. In Character Studio, drives a wardrobe-preserving reference flow — outfit + accessories + tattoos + hair color carry through to new scenes, but face geometry may drift. Pick InstantID or PuLID-FLUX for face-locked identity. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
+      description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. In Character Studio, drives a wardrobe-preserving reference flow — outfit + accessories + tattoos + hair color carry through to new scenes, but face geometry may drift. Pick InstantID or PuLID-FLUX for face-locked identity. Available in the angle-set picker (sc-2003) as the wardrobe-continuity tier — lowest pure-face ArcFace cosine (mean 0.29) but the most faithful preservation of tank + tattoo + accessories. NOT shown in the pose library — it2i_generate is single-image only. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
       promptGuide: { title: "SenseNova-U1 8B Prompt Guide", path: "/prompt-guides/sensenova-u1-8b.md" },
       // Edit-style variation knob (imageGuidanceScale): higher = closer to the
       // reference, lower = more prompt-driven variation. Drives advanced.imageGuidanceScale.
       variationStrength: { label: "Reference strength", default: 1.5, min: 0.5, max: 4.0, step: 0.1 },
+      // Multi-backbone angle set (sc-2003): SenseNova rotates the head per
+      // prompt and uniquely preserves wardrobe + tattoos + accessories at the
+      // cost of face-geometry fidelity. Worker resolves the augment via
+      // SenseNovaU1Adapter._ANGLE_PROMPT_AUGMENTS. NOT pose-library-capable
+      // (it2i_generate is single-image only; side-by-side concat is rendered
+      // literally rather than interpreted as a pose instruction).
+      viewAngles: [
+        { id: "three_quarter_left", label: "Three-quarter left" },
+        { id: "three_quarter_right", label: "Three-quarter right" },
+        { id: "left_profile", label: "Left profile" },
+        { id: "right_profile", label: "Right profile" },
+        { id: "up", label: "Looking up" },
+        { id: "down", label: "Looking down" },
+        { id: "up_left", label: "Up · left" },
+        { id: "up_right", label: "Up · right" },
+        { id: "down_left", label: "Down · left" },
+        { id: "down_right", label: "Down · right" },
+        { id: "front", label: "Front" },
+      ],
     },
   },
   {
@@ -267,7 +304,7 @@ export const fallbackModels = [
     // Reference-driven only — appears solely in the "With character" picker.
     capabilities: ["character_image"],
     ui: {
-      description: "Identity-preserving FLUX character generation — holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. FLUX.1-dev + PuLID IDFormer cross-attention; the sc-2012 spike measured 0.8016 ArcFace cosine vs reference at id_weight=1.0 / start-cfg=4 (above InstantID-SDXL no-restore; no face-restoration pass needed). Pick a character with an approved reference, then raise Variations. ~30 steps at guidance 4.0, ~85 GB peak unified memory. License: FLUX.1 [dev] non-commercial (gated).",
+      description: "Identity-preserving FLUX character generation — holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. FLUX.1-dev + PuLID IDFormer cross-attention; the sc-2012 spike measured 0.8016 ArcFace cosine vs reference at id_weight=1.0 / start-cfg=4 (above InstantID-SDXL no-restore; no face-restoration pass needed). Pick a character with an approved reference, then raise Variations. ~30 steps at guidance 4.0, ~85 GB peak unified memory. License: FLUX.1 [dev] non-commercial (gated). NOT shown in the angle-set or pose-library pickers (sc-2003 spike: identity injection over-anchors the head to the reference's frontal pose; prompt direction is treated as decorative — left/right outputs are visually identical).",
       promptGuide: { title: "PuLID-FLUX Prompt Guide", path: "/prompt-guides/pulid-flux.md" },
       // Identity tuning: reference strength drives idWeight (PuLID's identity-strength
       // analog of InstantID's ip_adapter_scale); identityStructure adds a second slider
@@ -275,6 +312,36 @@ export const fallbackModels = [
       // editability but weaker identity; PuLID photoreal recommendation is 4).
       referenceStrengthDefault: 1.0,
       identityStructure: { label: "Identity start step", default: 4, min: 0, max: 8, step: 1 },
+    },
+  },
+  {
+    id: "flux2_klein_9b",
+    name: "FLUX.2 [klein] 9B",
+    type: "image",
+    // FLUX.2 [klein] — Apple Silicon MLX-only image-edit backbone. The
+    // adapter advertises text_to_image (txt2img) and character_image (reference
+    // editing through Flux2KleinEdit + image_paths).
+    capabilities: ["text_to_image", "character_image", "style_variations"],
+    ui: {
+      description: "Black Forest Labs FLUX.2 [klein] 9B — 4-step distilled text-to-image + reference editing, MLX-only (Apple Silicon). Distributed under the FLUX Non-Commercial License (gated). In Character Studio's angle set + pose library, the FLUX.2-aesthetic tier (sc-2003 spike: mean ArcFace 0.52 across 5 angles — third-best identity hold, BUT the only prompt-driven backbone that holds portrait framing at 90° profiles where Qwen and InstantID both reframe). Pose library runs the multi-image trick (skeleton + character) at compact ~22 GB memory.",
+      promptGuide: { title: "FLUX.2 [klein] 9B Prompt Guide", path: "/prompt-guides/flux2-klein.md" },
+      variationStrength: { label: "Prompt strength", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
+      // Multi-backbone angle set (sc-2003). MlxFlux2Adapter passes the per-
+      // angle augmented prompt through the sidecar runner. Pose library
+      // deferred to a follow-up PR.
+      viewAngles: [
+        { id: "three_quarter_left", label: "Three-quarter left" },
+        { id: "three_quarter_right", label: "Three-quarter right" },
+        { id: "left_profile", label: "Left profile" },
+        { id: "right_profile", label: "Right profile" },
+        { id: "up", label: "Looking up" },
+        { id: "down", label: "Looking down" },
+        { id: "up_left", label: "Up · left" },
+        { id: "up_right", label: "Up · right" },
+        { id: "down_left", label: "Down · left" },
+        { id: "down_right", label: "Down · right" },
+        { id: "front", label: "Front" },
+      ],
     },
   },
   {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -79,16 +79,38 @@ export function CharacterStudio() {
   );
   const selectedCharacter = characters.find((item) => item.id === selectedCharacterId) ?? characters[0] ?? null;
   const approvedReferences = selectedCharacter?.approvedReferences ?? [];
-  // The InstantID-style model that can render a one-click angle set (declares view angles).
-  const angleModel = useMemo(
-    () => imageModels.find((item) => Array.isArray(item.ui?.viewAngles) && item.ui.viewAngles.length > 0) ?? null,
+  // Multi-backbone model picker for the angle set + pose library (sc-2003).
+  // Each backbone declares ui.viewAngles / ui.poseLibrary in the manifest;
+  // the worker dispatch handles per-backbone angle / pose loops (InstantID
+  // landmark pack + OpenPose ControlNet for the strict tier; prompt-driven
+  // augments + multi-image references for the prompt-driven tiers).
+  //
+  // Spike-validated angle backbones (sc-2003 follow-up, mean ArcFace cosine):
+  //   instantid_realvisxl                 — landmark deterministic, highest
+  //   qwen_image_edit_2511_lightning      — 0.62, prompt-driven fast tier
+  //   flux2_klein_9b                      — 0.52, holds portrait at profiles
+  //   sensenova_u1_8b                     — 0.29, wardrobe-continuity tier
+  //
+  // Spike-validated pose backbones:
+  //   instantid_realvisxl                 — OpenPose ControlNet strict
+  //   qwen_image_edit_2511_lightning      — multi-image best-effort
+  //   flux2_klein_9b                      — multi-image best-effort
+  //
+  // SenseNova-U1 is gated out of the pose picker because it2i_generate is
+  // single-image only (side-by-side concat is rendered literally, not
+  // interpreted as a pose instruction).
+  const angleModels = useMemo(
+    () => imageModels.filter((item) => Array.isArray(item.ui?.viewAngles) && item.ui.viewAngles.length > 0),
     [imageModels],
   );
-  // The InstantID-style model that supports the pose library (OpenPose-driven poses).
-  const poseModel = useMemo(
-    () => imageModels.find((item) => item.ui?.poseLibrary) ?? null,
+  const poseModels = useMemo(
+    () => imageModels.filter((item) => item.ui?.poseLibrary),
     [imageModels],
   );
+  // Default selection: the first registered backbone (manifest order keeps
+  // InstantID first so the existing strict tier remains the default).
+  const angleModel = angleModels[0] ?? null;
+  const poseModel = poseModels[0] ?? null;
 
   useEffect(() => {
     if (!selectedCharacter && characters[0]?.id) {
@@ -359,6 +381,7 @@ export function CharacterStudio() {
             <CharacterAngleSet
               addCharacterReference={addCharacterReference}
               angleModel={angleModel}
+              angleModels={angleModels}
               approvedReferences={approvedReferences}
               createImageJob={createImageJob}
               imageLocalJobs={imageLocalJobs}
@@ -378,6 +401,7 @@ export function CharacterStudio() {
               latestAssets={latestAssets}
               onPreview={onPreview}
               poseModel={poseModel}
+              poseModels={poseModels}
               rememberLocalGenerationJob={rememberLocalGenerationJob}
               selectedCharacter={selectedCharacter}
             />

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -400,6 +400,7 @@ export function CharacterTest({
 export function CharacterAngleSet({
   selectedCharacter,
   angleModel,
+  angleModels,
   approvedReferences,
   createImageJob,
   importAsset,
@@ -409,7 +410,20 @@ export function CharacterAngleSet({
   rememberLocalGenerationJob,
   onPreview,
 }) {
-  const angleCount = angleModel?.ui?.viewAngles?.length ?? 0;
+  // sc-2003: multi-backbone picker. angleModels is the full list of viewAngles-
+  // capable backbones (manifest order: InstantID first, then prompt-driven
+  // tiers). angleModel is the resolved default (kept for back-compat with the
+  // pre-picker callers); the local state below tracks the user's pick.
+  const availableModels = Array.isArray(angleModels) && angleModels.length > 0
+    ? angleModels
+    : (angleModel ? [angleModel] : []);
+  const [selectedAngleModelId, setSelectedAngleModelId] = React.useState(
+    angleModel?.id ?? availableModels[0]?.id ?? "",
+  );
+  const activeAngleModel = availableModels.find((item) => item.id === selectedAngleModelId)
+    ?? availableModels[0]
+    ?? null;
+  const angleCount = activeAngleModel?.ui?.viewAngles?.length ?? 0;
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
@@ -422,16 +436,24 @@ export function CharacterAngleSet({
     setReferenceAssetId(approvedReferences[0]?.assetId ?? "");
   }, [characterId, approvedReferences]);
   React.useEffect(() => {
-    // Seed with the character's appearance notes (InstantID preserves the face but NOT
-    // hair/wardrobe, so describe them here for a consistent turnaround) + tight framing.
+    // Seed with the character's appearance notes (face-identity engines preserve
+    // face but not hair/wardrobe, so describe them here for a consistent
+    // turnaround) + tight framing.
     const appearance = (selectedCharacter?.description ?? "").trim() || selectedCharacter?.name || "the character";
     setPrompt(
       `${appearance}, head and shoulders, neutral expression, consistent outfit, plain grey background, face clearly visible, sharp focus, photorealistic`,
     );
     setStatus("");
   }, [characterId, selectedCharacter?.name, selectedCharacter?.description]);
+  // Reset the picker selection when the available models change (e.g. a new
+  // manifest load) so a stale id doesn't lock the panel.
+  React.useEffect(() => {
+    if (!availableModels.find((item) => item.id === selectedAngleModelId)) {
+      setSelectedAngleModelId(availableModels[0]?.id ?? "");
+    }
+  }, [availableModels, selectedAngleModelId]);
 
-  if (!angleModel || !selectedCharacter) {
+  if (!activeAngleModel || !selectedCharacter) {
     return null;
   }
 
@@ -462,7 +484,7 @@ export function CharacterAngleSet({
   }
 
   async function generate() {
-    if (!referenceAssetId || submitting) {
+    if (!referenceAssetId || submitting || !activeAngleModel) {
       return;
     }
     setSubmitting(true);
@@ -470,7 +492,7 @@ export function CharacterAngleSet({
     try {
       const job = await createImageJob({
         mode: "character_image",
-        model: angleModel.id,
+        model: activeAngleModel.id,
         characterId,
         referenceAssetId,
         prompt: prompt.trim(),
@@ -500,12 +522,27 @@ export function CharacterAngleSet({
     <section className="character-section">
       <div className="section-heading">
         <p className="eyebrow">Angle set</p>
-        <h2>{angleModel.name} turnaround</h2>
+        <h2>{activeAngleModel.name} turnaround</h2>
       </div>
       <p>
         Generate {angleCount} consistent views of this character (front, three-quarters, profiles, up/down and the
         diagonals) from one reference, in a single job. A good starting set for curating a character LoRA.
       </p>
+      {availableModels.length > 1 ? (
+        <label>
+          Backbone
+          <select
+            onChange={(event) => setSelectedAngleModelId(event.target.value)}
+            value={selectedAngleModelId}
+          >
+            {availableModels.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
       {approvedReferences.length ? (
         <div className="reference-thumb-row">
           {approvedReferences.map((reference) => (
@@ -630,6 +667,7 @@ export function CharacterAssets({ selectedCharacter, assets = [], onPreview }) {
 export function CharacterPoseLibrary({
   selectedCharacter,
   poseModel,
+  poseModels,
   approvedReferences,
   createImageJob,
   importAsset,
@@ -639,6 +677,18 @@ export function CharacterPoseLibrary({
   rememberLocalGenerationJob,
   onPreview,
 }) {
+  // sc-2003: multi-backbone picker. poseModels is the full list of poseLibrary-
+  // capable backbones (manifest order: InstantID strict tier first, then the
+  // multi-image best-effort tiers).
+  const availableModels = Array.isArray(poseModels) && poseModels.length > 0
+    ? poseModels
+    : (poseModel ? [poseModel] : []);
+  const [selectedPoseModelId, setSelectedPoseModelId] = React.useState(
+    poseModel?.id ?? availableModels[0]?.id ?? "",
+  );
+  const activePoseModel = availableModels.find((item) => item.id === selectedPoseModelId)
+    ?? availableModels[0]
+    ?? null;
   const { byId } = usePoseLibrary();
   const [selectedPoseIds, setSelectedPoseIds] = React.useState([]);
   const [faceRestore, setFaceRestore] = React.useState(true);
@@ -655,13 +705,18 @@ export function CharacterPoseLibrary({
   }, [characterId, approvedReferences]);
   React.useEffect(() => {
     // Pose-neutral prompt: the skeleton sets the stance, so describe only appearance +
-    // outfit/shoes (InstantID preserves the face but NOT hair/wardrobe).
+    // outfit/shoes (face-identity engines preserve the face but NOT hair/wardrobe).
     const appearance = (selectedCharacter?.description ?? "").trim() || selectedCharacter?.name || "the character";
     setPrompt(`${appearance}, consistent outfit and shoes, plain grey background, soft even lighting, sharp focus, photorealistic`);
     setStatus("");
   }, [characterId, selectedCharacter?.name, selectedCharacter?.description]);
+  React.useEffect(() => {
+    if (!availableModels.find((item) => item.id === selectedPoseModelId)) {
+      setSelectedPoseModelId(availableModels[0]?.id ?? "");
+    }
+  }, [availableModels, selectedPoseModelId]);
 
-  if (!poseModel || !selectedCharacter) {
+  if (!activePoseModel || !selectedCharacter) {
     return null;
   }
 
@@ -695,7 +750,7 @@ export function CharacterPoseLibrary({
 
   async function generate() {
     const poses = selectedPoseIds.map((id) => byId[id]).filter(Boolean).map((pose) => ({ id: pose.id, keypoints: pose.keypoints }));
-    if (!referenceAssetId || !poses.length || submitting) {
+    if (!referenceAssetId || !poses.length || submitting || !activePoseModel) {
       return;
     }
     setSubmitting(true);
@@ -703,7 +758,7 @@ export function CharacterPoseLibrary({
     try {
       const job = await createImageJob({
         mode: "character_image",
-        model: poseModel.id,
+        model: activePoseModel.id,
         characterId,
         referenceAssetId,
         prompt: prompt.trim(),
@@ -736,10 +791,25 @@ export function CharacterPoseLibrary({
         <h2>Generate {selectedCharacter.name} in a pose</h2>
       </div>
       <p>
-        Pick one or more poses and generate this character in each, in a single job. An OpenPose ControlNet drives the
-        pose; each image adds a face-restoration pass so identity holds at full-body size, so larger selections take a
-        while.
+        Pick one or more poses and generate this character in each, in a single job. The strict tier (InstantID) uses an
+        OpenPose ControlNet to enforce the pose and a face-restoration pass to anchor identity; the best-effort tiers
+        (Qwen-Lightning, FLUX.2-klein) approximate the pose via multi-image reference.
       </p>
+      {availableModels.length > 1 ? (
+        <label>
+          Backbone
+          <select
+            onChange={(event) => setSelectedPoseModelId(event.target.value)}
+            value={selectedPoseModelId}
+          >
+            {availableModels.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
       {approvedReferences.length ? (
         <div className="reference-thumb-row">
           {approvedReferences.map((reference) => (

--- a/apps/worker/scene_worker/character_studio_angles.py
+++ b/apps/worker/scene_worker/character_studio_angles.py
@@ -1,0 +1,77 @@
+"""Shared canonical-angle definitions for multi-backbone Character Studio (sc-2003).
+
+InstantID owns the strict tier via landmark packs (`VIEW_ANGLE_KPS` in
+``instantid_adapter``). Prompt-driven backbones (Qwen-Image-Edit, FLUX.2-klein,
+SenseNova-U1) consume the same 11-angle list but augment the user's prompt
+with the per-angle description below — the worker spike (sc-2003 hardware run)
+verified that this is the only viable cross-backbone interface today, because
+each backbone uses a different identity-conditioning mechanism (cross-attention
+adapter / dual-control / it2i / KV-cached flow) and they don't share landmark
+or ControlNet inputs.
+
+Augments are phrased as continuation clauses (no leading punctuation) so they
+append cleanly to whatever prompt the user typed. Per-backbone prompt shape
+differences (Qwen edit instructions vs FLUX descriptive vs SenseNova edit)
+are handled at the call site — each adapter chooses to prepend "Re-render the
+same woman as a …" or to append " — …" around this base augment.
+"""
+
+from __future__ import annotations
+
+# Same order as instantid_adapter.ANGLE_SET_ORDER (kept in sync so the angle
+# count and per-index angle match across backbones for users comparing outputs).
+# Importable as a sibling so callers can pick this up without pulling the
+# InstantID-only landmark pack along with it.
+ANGLE_SET_ORDER: tuple[str, ...] = (
+    "front",
+    "three_quarter_left",
+    "three_quarter_right",
+    "left_profile",
+    "right_profile",
+    "up",
+    "down",
+    "up_left",
+    "up_right",
+    "down_left",
+    "down_right",
+)
+
+
+# Continuation clauses appended to the user's prompt for each canonical angle.
+# Wording mirrors what the sc-2003 hardware spike used to validate angle
+# compliance across Qwen-Lightning + FLUX.2-klein + SenseNova-U1. The strongest
+# discriminator across the spike runs was including BOTH the descriptive name
+# ("three-quarter left profile") AND the directional instruction ("head turned
+# slightly to the left") — backbones followed the directional cue when present
+# and ignored the name otherwise.
+ANGLE_PROMPT_AUGMENTS: dict[str, str] = {
+    "front": "frontal portrait, looking directly at the camera, head and shoulders, neutral expression",
+    "three_quarter_left": "three-quarter left profile, head turned slightly to the left, three-quarter view",
+    "three_quarter_right": "three-quarter right profile, head turned slightly to the right, three-quarter view",
+    "left_profile": "full left profile, head turned 90 degrees to the left, side view of the head",
+    "right_profile": "full right profile, head turned 90 degrees to the right, side view of the head",
+    "up": "looking up, head tilted slightly upward toward the sky",
+    "down": "looking down, head tilted slightly downward toward the floor",
+    "up_left": "looking up and to the left, head tilted slightly upward and turned slightly to the left",
+    "up_right": "looking up and to the right, head tilted slightly upward and turned slightly to the right",
+    "down_left": "looking down and to the left, head tilted slightly downward and turned slightly to the left",
+    "down_right": "looking down and to the right, head tilted slightly downward and turned slightly to the right",
+}
+
+
+def augment_prompt_for_angle(base_prompt: str, angle: str) -> str:
+    """Append the per-angle continuation clause to the user's base prompt.
+
+    Empty base + unknown angle → empty string (caller usually validates the
+    angle is in ``ANGLE_SET_ORDER`` first, but be lenient here so a forward-
+    compatible manifest with a new angle id doesn't crash the worker; the user
+    still gets their base prompt).
+    """
+    augment = ANGLE_PROMPT_AUGMENTS.get(angle, "")
+    base = (base_prompt or "").strip().rstrip(",.;")
+    if base and augment:
+        return f"{base}, {augment}"
+    return augment or base
+
+
+__all__ = ["ANGLE_SET_ORDER", "ANGLE_PROMPT_AUGMENTS", "augment_prompt_for_angle"]

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -31,6 +31,11 @@ from sceneworks_shared import (
 )
 
 from .adapter_utils import cancel_step_callback, filter_call_kwargs
+from .character_studio_angles import (
+    ANGLE_PROMPT_AUGMENTS,
+    ANGLE_SET_ORDER as CHARACTER_ANGLE_SET_ORDER,
+    augment_prompt_for_angle,
+)
 from .sampler_registry import apply_sampler, sampler_selection_from_advanced
 from .hf_cache import huggingface_cache_roots, huggingface_repo_cache_path
 from .lora_adapters import (
@@ -1572,14 +1577,29 @@ class QwenImageAdapter:
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)
         label = "Qwen Image"
+        # sc-2003 multi-backbone angle set: when advanced.angleSet is set on a
+        # character_image request, loop the 11 canonical angles in one job — one
+        # image per pack angle, each driven by the per-angle augmented prompt.
+        # Mirrors the InstantID angle-set shape (sc-2050) but uses a prompt
+        # augment rather than a landmark pack, since Qwen has no landmark
+        # ControlNet (the spike-validated prompt-driven path, mean ArcFace
+        # cosine 0.62 on Kelsie). All angles share one seed for noise-derived
+        # attribute continuity (hair / wardrobe / lighting) — same trick the
+        # InstantID angle set uses.
+        angle_set = self._use_reference(request) and bool(request.advanced.get("angleSet"))
+        angles = list(CHARACTER_ANGLE_SET_ORDER) if angle_set else []
+        total = len(angles) if angle_set else request.count
+        set_seed = resolve_seed(request.seed, request.prompt, 0, request.seeds)
 
         def image_at_index(index: int) -> Image.Image:
-            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            seed = set_seed if angle_set else resolve_seed(request.seed, request.prompt, index, request.seeds)
+            angle = angles[index] if angle_set else None
+            prompt_override = augment_prompt_for_angle(request.prompt, angle) if angle else None
             progress(
                 "running",
                 "generating",
-                image_batch_progress(index, request.count),
-                format_batch_running_message(label, index, request.count),
+                image_batch_progress(index, total),
+                format_batch_running_message(label, index, total),
             )
             emit_worker_event(
                 "image_inference_start",
@@ -1587,12 +1607,21 @@ class QwenImageAdapter:
                 adapter=self.id,
                 model=request.model,
                 imageIndex=index,
-                imageCount=request.count,
+                imageCount=total,
+                viewAngle=angle,
                 device=device,
                 gpuMemory=gpu_memory_snapshot(torch, device),
             )
             try:
-                image = self._run_pipeline(settings, pipe, request, seed, project_path, cancel_requested=cancel_requested)
+                image = self._run_pipeline(
+                    settings,
+                    pipe,
+                    request,
+                    seed,
+                    project_path,
+                    cancel_requested=cancel_requested,
+                    prompt_override=prompt_override,
+                )
             except Exception as exc:
                 emit_worker_event(
                     "image_inference_failed",
@@ -1615,7 +1644,7 @@ class QwenImageAdapter:
         return ImageAssetWriter().write_incremental_outputs(
             request=request,
             project_path=project_path,
-            image_count=request.count,
+            image_count=total,
             image_at_index=image_at_index,
             adapter_id=self.id,
             progress=progress,
@@ -1626,6 +1655,7 @@ class QwenImageAdapter:
                 "numInferenceSteps": self._num_inference_steps(request, model_target),
                 "guidanceScale": self._guidance_scale(request),
                 "realModelInference": True,
+                **({"angleSet": True} if angle_set else {}),
             },
             settings=settings,
             job_id=job["id"],
@@ -1764,6 +1794,7 @@ class QwenImageAdapter:
         seed: int,
         project_path: Path,
         cancel_requested: CancelCallback | None = None,
+        prompt_override: str | None = None,
     ) -> Image.Image:
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)
@@ -1771,8 +1802,12 @@ class QwenImageAdapter:
         generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
         sampler_key, scheduler_key, shift_value = sampler_selection_from_advanced(request.advanced)
         apply_sampler(pipe, sampler_key, scheduler_key, shift_value, adapter=self.id)
+        # sc-2003 angleSet: each angle in the loop calls _run_pipeline with the
+        # per-angle augmented prompt as `prompt_override`; falls back to the
+        # request's prompt for single-image generation.
+        effective_prompt = prompt_override if prompt_override else request.prompt
         kwargs = {
-            "prompt": request.prompt,
+            "prompt": effective_prompt,
             "height": request.height,
             "width": request.width,
             "num_inference_steps": self._num_inference_steps(request, MODEL_TARGETS[request.model]),
@@ -3588,11 +3623,34 @@ class MlxFlux2Adapter:
                 f"(looked for {self._sidecar_python()})."
             )
 
-        total = request.count
+        # sc-2003 multi-backbone angle set: when advanced.angleSet is set on a
+        # character_image request with a reference, loop the 11 canonical
+        # angles in one job — same shape as InstantID's angle set (sc-2050),
+        # but the per-angle prompt augment comes from
+        # character_studio_angles.ANGLE_PROMPT_AUGMENTS (Flux2 has no landmark
+        # ControlNet; the angle comes from prompt-driven editing of the
+        # reference). Spike-validated: FLUX.2-klein mean ArcFace 0.52 across
+        # angles AND uniquely holds portrait framing at 90° profiles where
+        # Qwen-Lightning reframes to full-body.
+        is_character_image = request.mode == "character_image" and has_reference
+        angle_set = is_character_image and bool(request.advanced.get("angleSet"))
+        if angle_set:
+            angles = list(CHARACTER_ANGLE_SET_ORDER)
+            total = len(angles)
+            set_seed = resolve_seed(request.seed, request.prompt, 0, request.seeds)
+            # Shared seed across the set so noise-derived attributes (hair,
+            # lighting) stay consistent across angles — only the head pose
+            # changes. Mirrors the sc-2050 InstantID angle-set seed strategy.
+            seeds = [set_seed] * total
+            prompts = [augment_prompt_for_angle(request.prompt, angle) for angle in angles]
+        else:
+            total = request.count
+            angles = None
+            seeds = [resolve_seed(request.seed, request.prompt, index, request.seeds) for index in range(total)]
+            prompts = None
         steps = self._num_inference_steps(request, model_target)
         guidance = self._guidance_scale(request, model_target)
         quantize = self._resolve_quantize(request)
-        seeds = [resolve_seed(request.seed, request.prompt, index, request.seeds) for index in range(total)]
 
         progress(
             "loading_model",
@@ -3613,6 +3671,9 @@ class MlxFlux2Adapter:
                     "prompt": request.prompt,
                     "negativePrompt": None,  # Flux2 disallows negatives; runner skips it anyway
                     "seeds": seeds,
+                    # Per-iteration prompt overrides — runner zips with seeds.
+                    # None / absent → all iterations use the top-level "prompt".
+                    "prompts": prompts,
                     "height": request.height,
                     "width": request.width,
                     "numInferenceSteps": steps,
@@ -3656,6 +3717,7 @@ class MlxFlux2Adapter:
                     "hasReference": has_reference,
                     "kvCacheEnabled": has_reference and request.model in self._kv_only_models,
                     "realModelInference": True,
+                    **({"angleSet": True} if angle_set else {}),
                 },
                 settings=settings,
                 job_id=job["id"],
@@ -5471,14 +5533,28 @@ class SenseNovaU1Adapter:
         model, tokenizer = self._load_model(torch, repo, device, dtype, distill_lora=distill_lora, job_id=job["id"])
         self._loaded_model = request.model
         label = model_target["label"]
+        # sc-2003 multi-backbone angle set: loop the 11 canonical angles when
+        # advanced.angleSet is set on a character_image request, augmenting the
+        # user's prompt per-angle. SenseNova-U1 has no landmark or face-ID
+        # conditioning — the angle comes entirely from the prompt augment.
+        # Spike-validated: mean ArcFace 0.29 across angles (lowest of the 4
+        # angle-capable backbones for pure face fidelity, but uniquely
+        # preserves the reference's wardrobe + accessories — the "character
+        # continuity" tier in the picker).
+        angle_set = is_character_image and bool(request.advanced.get("angleSet"))
+        angles = list(CHARACTER_ANGLE_SET_ORDER) if angle_set else []
+        total = len(angles) if angle_set else request.count
+        set_seed = resolve_seed(request.seed, request.prompt, 0, request.seeds)
 
         def image_at_index(index: int) -> Image.Image:
-            seed = resolve_seed(request.seed, request.prompt, index, request.seeds)
+            seed = set_seed if angle_set else resolve_seed(request.seed, request.prompt, index, request.seeds)
+            angle = angles[index] if angle_set else None
+            effective_prompt = augment_prompt_for_angle(request.prompt, angle) if angle else request.prompt
             progress(
                 "running",
                 "generating",
-                image_batch_progress(index, request.count),
-                format_batch_running_message(label, index, request.count),
+                image_batch_progress(index, total),
+                format_batch_running_message(label, index, total),
             )
             emit_worker_event(
                 "image_inference_start",
@@ -5486,7 +5562,8 @@ class SenseNovaU1Adapter:
                 adapter=self.id,
                 model=request.model,
                 imageIndex=index,
-                imageCount=request.count,
+                imageCount=total,
+                viewAngle=angle,
                 device=device,
                 resolution=f"{width}x{height}",
                 gpuMemory=gpu_memory_snapshot(torch, device),
@@ -5496,12 +5573,12 @@ class SenseNovaU1Adapter:
                     # Both modes route through it2i_generate; the difference is
                     # which asset the source_image points at (source vs reference).
                     image = self._run_edit_inference(
-                        torch, model, tokenizer, request.prompt, source_image,
+                        torch, model, tokenizer, effective_prompt, source_image,
                         width, height, steps, guidance_scale, img_guidance_scale, timestep_shift, seed,
                     )
                 else:
                     image = self._run_inference(
-                        torch, model, tokenizer, request.prompt,
+                        torch, model, tokenizer, effective_prompt,
                         width, height, steps, guidance_scale, timestep_shift, seed,
                     )
             except Exception as exc:
@@ -5526,7 +5603,7 @@ class SenseNovaU1Adapter:
         return ImageAssetWriter().write_incremental_outputs(
             request=request,
             project_path=project_path,
-            image_count=request.count,
+            image_count=total,
             image_at_index=image_at_index,
             adapter_id=self.id,
             progress=progress,
@@ -5542,6 +5619,7 @@ class SenseNovaU1Adapter:
                 "timestepShift": timestep_shift,
                 "resolution": f"{width}x{height}",
                 "realModelInference": True,
+                **({"angleSet": True} if angle_set else {}),
             },
             settings=settings,
             job_id=job["id"],

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -122,6 +122,18 @@ def main() -> int:
     prompt = str(spec.get("prompt") or "")
     negative_prompt = spec.get("negativePrompt") or None
     seeds = [int(seed) for seed in spec.get("seeds") or []] or [0]
+    # sc-2003 multi-backbone angle set: optional per-iteration prompt overrides
+    # parallel to ``seeds``. None / absent / empty → all iterations use the
+    # top-level ``prompt`` (the existing single-prompt batch path). When set,
+    # the runner zips one prompt per seed and ignores the top-level ``prompt``
+    # for that iteration. Adapter side (MlxFlux2Adapter) computes the augmented
+    # prompts via character_studio_angles.augment_prompt_for_angle.
+    prompts_override = spec.get("prompts") or None
+    if prompts_override is not None and len(prompts_override) != len(seeds):
+        raise RuntimeError(
+            f"mlx_flux_runner: prompts list length ({len(prompts_override)}) "
+            f"must equal seeds list length ({len(seeds)})."
+        )
     height = int(spec.get("height") or 1024)
     width = int(spec.get("width") or 1024)
     steps = int(spec.get("numInferenceSteps") or 4)
@@ -177,9 +189,12 @@ def main() -> int:
         #     instead of a list; the runner only dispatches to it when there
         #     is no reference (image_paths is empty), so we don't pass it.
         #   - Other families (Flux1, Qwen, Z-Image) still take negative_prompt.
+        # Per-iteration prompt override (sc-2003 angle set); falls back to the
+        # top-level prompt when prompts_override isn't set.
+        iter_prompt = prompts_override[index] if prompts_override else prompt
         gen_kwargs: dict[str, object] = {
             "seed": int(seed),
-            "prompt": prompt,
+            "prompt": iter_prompt,
             "num_inference_steps": steps,
             "height": height,
             "width": width,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -333,6 +333,34 @@
           "max": 2.0,
           "step": 0.25
         },
+        // Multi-backbone angle set (sc-2003): the picker exposes Qwen-Lightning
+        // as a prompt-driven alternative to InstantID's landmark-pack precision.
+        // Hardware spike (sc-2003 follow-up): mean ArcFace 0.62 across the 5
+        // measured angles — 2nd-best identity hold among prompt-driven backbones,
+        // far above PuLID-FLUX (which doesn't rotate the head at all). The 11
+        // canonical angles ride the same shared ANGLE_SET_ORDER as InstantID;
+        // the worker resolves the per-angle prompt augment from
+        // QwenImageAdapter._ANGLE_PROMPT_AUGMENTS. Caveat: profile prompts
+        // reframe to full-body (Qwen's "leaning at railing" interpretation
+        // bug, sc-2013).
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
+        // NOTE: pose library deferred to a follow-up PR. The sc-2003 hardware
+        // spike validated Qwen-Lightning's multi-image trick (image=[skeleton,
+        // character]) at sitting 0.68 / standing 0.45 ArcFace cosine, but the
+        // worker dispatch + adapter plumbing for it ships separately so this PR
+        // focuses on shipping the angle picker for all four backbones.
         "promptGuide": {
           "title": "Qwen Image Edit (2511) Lightning Prompt Guide",
           "path": "/prompt-guides/qwen-image-edit-2511-lightning.md",
@@ -520,6 +548,33 @@
         // (the adapter raises the default vs the 1.0 edit baseline so the
         // reference subject pulls harder by default).
         "variationStrength": { "label": "Reference strength", "default": 1.5, "min": 0.5, "max": 4.0, "step": 0.1 },
+        // Multi-backbone angle set (sc-2003): SenseNova-U1 rotates the head per
+        // prompt and preserves the reference's wardrobe + tattoos + accessories
+        // most faithfully of any backbone in the picker. Hardware spike: mean
+        // ArcFace 0.29 across the 5 measured angles (vs Qwen-Lightning 0.62 and
+        // FLUX.2-klein 0.52) — pure-face cosine is lowest of the 4 angle-capable
+        // backbones, but the *overall character* (face + outfit + props) often
+        // reads as more consistent to a human. Best pick when wardrobe
+        // continuity matters more than strict face-geometry identity.
+        //
+        // NOT shipped for the pose library: it2i_generate is single-image only,
+        // and the side-by-side concat trick (which works on the multi-image-
+        // capable Qwen + FLUX.2-klein backbones) is rendered literally rather
+        // than interpreted as a pose instruction (ArcFace 0.06–0.22 in the
+        // hardware spike — sc-2003 follow-up).
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
         "promptGuide": {
           "title": "SenseNova-U1 8B Prompt Guide",
           "path": "/prompt-guides/sensenova-u1-8b.md",
@@ -810,6 +865,31 @@
           "max": 10.0,
           "step": 0.5
         },
+        // Multi-backbone angle set (sc-2003): FLUX.2-klein rotates the head per
+        // prompt AND keeps portrait framing at 90° profiles — the only prompt-
+        // driven backbone in the picker that doesn't reframe to full-body on
+        // profile prompts. Hardware spike: mean ArcFace 0.52 across the 5
+        // angles (front 0.68 / 3/4-L 0.54 / 3/4-R 0.57 / L-profile 0.38 /
+        // R-profile 0.43). Sits between Qwen-Lightning (0.62) and SenseNova
+        // (0.29) on identity, but uniquely strong on profile framing. Compact
+        // MLX memory (~22 GB) + FLUX.2 photoreal aesthetic.
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
+        // NOTE: pose library deferred to a follow-up PR (same reason as
+        // qwen_image_edit_2511_lightning). The sc-2003 hardware spike
+        // validated the multi-image trick (image_paths=[skeleton, character])
+        // at sitting 0.54 / standing 0.36 ArcFace cosine.
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -9473,8 +9473,21 @@ def test_qwen_image_adapter_angleset_loop_uses_augmented_prompts(monkeypatch):
     QwenImageAdapter loops the 11 canonical angles and routes each to
     _run_pipeline with the per-angle prompt_override — NOT the original
     user prompt. Sanity-check this without loading torch / diffusers."""
+    import sys as _sys
+    from types import ModuleType, SimpleNamespace as _SimpleNamespace
+
     from scene_worker.character_studio_angles import ANGLE_PROMPT_AUGMENTS, ANGLE_SET_ORDER
     from scene_worker.image_adapters import QwenImageAdapter
+
+    # CI (sceneworks-core-pytest) installs requirements-dev.txt only — torch
+    # isn't there. Stub the few attrs the generate() path touches so the test
+    # runs against the pure-Python dispatch logic without pulling torch.
+    if "torch" not in _sys.modules:
+        torch_stub = ModuleType("torch")
+        torch_stub.cuda = _SimpleNamespace(is_available=lambda: False, empty_cache=lambda: None)
+        torch_stub.backends = _SimpleNamespace(mps=_SimpleNamespace(is_available=lambda: False))
+        torch_stub.mps = _SimpleNamespace(empty_cache=lambda: None)
+        monkeypatch.setitem(_sys.modules, "torch", torch_stub)
 
     captured: list[str] = []
 
@@ -9497,6 +9510,13 @@ def test_qwen_image_adapter_angleset_loop_uses_augmented_prompts(monkeypatch):
             return {"images": image_count}
 
     monkeypatch.setattr(ia, "ImageAssetWriter", _FakeWriter)
+    # Bypass the GPU-backend-required check and the device-activation step:
+    # both poke at torch internals the stub above doesn't fully model, and the
+    # dispatch logic we're verifying doesn't depend on the answer.
+    monkeypatch.setattr(ia, "require_inference_backend_for_gpu_worker", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ia, "activate_torch_device", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ia, "select_torch_device", lambda *args, **kwargs: "cpu")
+    monkeypatch.setattr(ia, "gpu_memory_snapshot", lambda *args, **kwargs: None)
 
     request = ia.ImageRequest(
         project_id="p",
@@ -9518,10 +9538,6 @@ def test_qwen_image_adapter_angleset_loop_uses_augmented_prompts(monkeypatch):
         advanced={"angleSet": True},
         model_manifest_entry={},
     )
-    # select_torch_device reads settings.gpu_id; "cpu" forces the cpu branch
-    # which doesn't touch torch.cuda / torch.backends.mps.
-    from types import SimpleNamespace as _SimpleNamespace
-
     fake_settings = _SimpleNamespace(gpu_id="cpu")
     QwenImageAdapter().generate(
         settings=fake_settings,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -9411,3 +9411,131 @@ def test_hide_reference_strength_models_declare_a_variation_knob():
         f"with NO identity tuning control. Add `variationStrength` or drop "
         f"`hideReferenceStrength`."
     )
+
+
+# ---- sc-2003: multi-backbone angle-set picker ----
+
+
+def test_character_studio_angle_prompt_augments_cover_full_pack():
+    """Every angle in the canonical ANGLE_SET_ORDER must have a matching
+    prompt-augment string. Backbones that consume the shared list (Qwen, FLUX2,
+    SenseNova) won't render correctly for an angle without an augment — the
+    user would get an unaugmented prompt repeated for that index."""
+    from scene_worker.character_studio_angles import (
+        ANGLE_PROMPT_AUGMENTS,
+        ANGLE_SET_ORDER,
+        augment_prompt_for_angle,
+    )
+
+    missing = [angle for angle in ANGLE_SET_ORDER if not ANGLE_PROMPT_AUGMENTS.get(angle)]
+    assert not missing, f"Angles missing prompt augments: {missing}"
+    # Augment helper appends the per-angle clause to the user's base prompt.
+    augmented = augment_prompt_for_angle("a portrait of the woman", "three_quarter_left")
+    assert "three-quarter left profile" in augmented
+    assert augmented.startswith("a portrait of the woman,")
+    # Unknown angle is a no-op (caller passes the base through unchanged).
+    assert augment_prompt_for_angle("hello", "unknown_angle_id") == "hello"
+
+
+def test_prompt_driven_angle_backbones_share_the_instantid_angle_pack():
+    """Each prompt-driven backbone (Qwen-Lightning, FLUX.2-klein, SenseNova) in
+    the multi-backbone angle-set picker (sc-2003) MUST advertise the same 11
+    canonical angles as the InstantID baseline. The picker depends on every
+    backbone exposing the same angle ids so the dropdown shows identical
+    angle options regardless of which backbone is selected.
+    """
+    manifest = _load_builtin_models_manifest()
+    manifest_by_id = {model["id"]: model for model in manifest.get("models", [])}
+    instantid_angles = (
+        manifest_by_id.get("instantid_realvisxl", {}).get("ui", {}).get("viewAngles") or []
+    )
+    instantid_ids = {entry["id"] for entry in instantid_angles}
+    assert len(instantid_ids) == 11, "Baseline angle pack drifted from 11 canonical angles."
+    # The four prompt-driven backbones we shipped in the picker matrix:
+    for model_id in (
+        "qwen_image_edit_2511_lightning",
+        "flux2_klein_9b",
+        "sensenova_u1_8b",
+    ):
+        backbone = manifest_by_id.get(model_id) or {}
+        view_angles = backbone.get("ui", {}).get("viewAngles") or []
+        ids = {entry["id"] for entry in view_angles}
+        assert ids == instantid_ids, (
+            f"{model_id} advertises viewAngles that don't match InstantID's pack: "
+            f"missing={instantid_ids - ids}, extra={ids - instantid_ids}. "
+            f"The Character Studio angle dropdown depends on all four backbones "
+            f"exposing the same 11 angle ids."
+        )
+
+
+def test_qwen_image_adapter_angleset_loop_uses_augmented_prompts(monkeypatch):
+    """When advanced.angleSet is set on a character_image request, the
+    QwenImageAdapter loops the 11 canonical angles and routes each to
+    _run_pipeline with the per-angle prompt_override — NOT the original
+    user prompt. Sanity-check this without loading torch / diffusers."""
+    from scene_worker.character_studio_angles import ANGLE_PROMPT_AUGMENTS, ANGLE_SET_ORDER
+    from scene_worker.image_adapters import QwenImageAdapter
+
+    captured: list[str] = []
+
+    def fake_run_pipeline(self, settings, pipe, request, seed, project_path, *, cancel_requested=None, prompt_override=None):
+        from PIL import Image as _Image
+        captured.append(prompt_override or request.prompt)
+        return _Image.new("RGB", (8, 8))
+
+    # Stub out the heavy load + LoRA paths.
+    monkeypatch.setattr(QwenImageAdapter, "_run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(QwenImageAdapter, "_load_pipeline", lambda self, *args, **kwargs: object())
+    monkeypatch.setattr(QwenImageAdapter, "_apply_loras", lambda self, *args, **kwargs: None)
+    # Don't actually write asset files in the test — short-circuit the writer.
+    from scene_worker import image_adapters as ia
+
+    class _FakeWriter:
+        def write_incremental_outputs(self, *, image_count, image_at_index, **_kwargs):
+            for index in range(image_count):
+                image_at_index(index)
+            return {"images": image_count}
+
+    monkeypatch.setattr(ia, "ImageAssetWriter", _FakeWriter)
+
+    request = ia.ImageRequest(
+        project_id="p",
+        mode="character_image",
+        prompt="a photo of the character",
+        negative_prompt="",
+        model="qwen_image_edit_2511_lightning",
+        count=1,
+        seed=42,
+        seeds=[],
+        width=1024,
+        height=1024,
+        style_preset="",
+        loras=[],
+        character_id=None,
+        character_look_id=None,
+        source_asset_id=None,
+        reference_asset_id="ref-asset-id",
+        advanced={"angleSet": True},
+        model_manifest_entry={},
+    )
+    # select_torch_device reads settings.gpu_id; "cpu" forces the cpu branch
+    # which doesn't touch torch.cuda / torch.backends.mps.
+    from types import SimpleNamespace as _SimpleNamespace
+
+    fake_settings = _SimpleNamespace(gpu_id="cpu")
+    QwenImageAdapter().generate(
+        settings=fake_settings,
+        job={"id": "job_x", "payload": {}},
+        request=request,
+        project_path=None,
+        progress=lambda *args, **kwargs: None,
+        cancel_requested=lambda: False,
+    )
+    assert len(captured) == len(ANGLE_SET_ORDER) == 11
+    # Each captured prompt should contain the corresponding angle's augment.
+    for prompt, angle in zip(captured, ANGLE_SET_ORDER):
+        augment = ANGLE_PROMPT_AUGMENTS[angle]
+        assert augment in prompt, (
+            f"angle '{angle}' didn't reach _run_pipeline as an augmented prompt: "
+            f"expected snippet {augment!r} in {prompt!r}"
+        )


### PR DESCRIPTION
## Summary

Ships the Character Studio model picker for the angle set, with four spike-validated backbones. Pose library extension deferred to a follow-up PR.

## Picker matrix (sc-2003 hardware spike, ArcFace cosine vs Kelsie reference)

| # | Backbone | Rotates head? | Mean cosine | Unique value |
|---|---|---|---|---|
| 1 | `instantid_realvisxl` | ✅ landmark deterministic | ~0.85 | Best face identity, strict tier |
| 2 | `qwen_image_edit_2511_lightning` | ✅ prompt-driven | 0.62 | Fast (~32s/angle), 2nd-best identity |
| 3 | `flux2_klein_9b` | ✅ prompt-driven | 0.52 | **Holds portrait framing at 90° profiles** where Qwen reframes to full-body |
| 4 | `sensenova_u1_8b` | ✅ prompt-driven | 0.29 | Wardrobe + tattoo + accessory continuity (lowest face cosine but most consistent overall character feel) |

**PuLID-FLUX dropped:** the spike found its identity injection over-anchors the head to the reference's frontal pose — left/right prompts produce visually identical outputs (head locked frontal). PuLID stays available for single-image character_image generation, just not the angle batch.

## How it works

The 11 canonical angles ride the same `ANGLE_SET_ORDER` as the existing InstantID strict tier. The new shared module `apps/worker/scene_worker/character_studio_angles.py` adds `ANGLE_PROMPT_AUGMENTS` — continuation clauses appended to the user's prompt per-angle (e.g. *"three-quarter left profile, head turned slightly to the left, three-quarter view"*). Each prompt-driven backbone reuses the same augments, so the picker dropdown behaves consistently regardless of selection.

- **Qwen, SenseNova**: in-process adapters take a new `prompt_override` kwarg into their existing pipeline / `it2i_generate` calls and loop the angles.
- **MLX FLUX.2-klein**: extends the sidecar runner spec with an optional `prompts` list (parallel to `seeds`); when set, each iteration uses the per-index prompt. None → all iterations use the top-level `prompt` (existing batch path unchanged).
- **All backbones**: share one seed across the angle set so noise-derived attributes (hair, lighting) stay consistent — only the head pose changes. Mirrors sc-2050's InstantID angle-set seed strategy.

Honest UI copy in each manifest description names the trade-off the spike measured.

## Pose-library deferred

Manifest + `constants.js` for the three new backbones intentionally do **not** yet declare `ui.poseLibrary`, so the pose picker stays InstantID-only. The spike validated multi-image dispatch for Qwen + FLUX.2-klein (sitting 0.68 / standing 0.45 on Qwen; sitting 0.54 / standing 0.36 on FLUX.2-klein) — that ships in a follow-up PR once the worker pose-loop wiring lands. SenseNova is intentionally never added to the pose picker (`it2i_generate` is single-image only; the multi-image trick can't be approximated cleanly there).

## Test plan

- [x] **pytest** 517 (3 new sc-2003 tests in `tests/test_worker_runtime.py`)
- [x] **vitest** 234
- [x] **scaffold** `node scripts/check-scaffold.mjs` green
- [x] **rustfmt** clean (no Rust changes in this PR)
- [ ] Live Mac angle-set run via each new backbone — deferred to the follow-up review since the hardware spike already validated the per-backbone behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)