### PR TITLE
feat(web): redesign Model Manager — group models by type, LoRAs by family

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -81,6 +81,45 @@ const MODEL_TYPE_OPTIONS = [
   { value: "utility", label: "Utility" },
 ];
 
+// Models render in type-grouped sections. Order is fixed; any model whose `type`
+// isn't listed here falls into a trailing "Other" group so nothing is hidden.
+const MODEL_TYPE_GROUPS = [
+  { type: "image", label: "Image Models" },
+  { type: "video", label: "Video Models" },
+  { type: "utility", label: "Utility Models" },
+];
+
+// Capability descriptors shown as chips on each model card. With models now grouped
+// by `type`, the chips are what tell the user what a card actually does (plain
+// text-to-image vs editing vs character reference, etc.). Unknown keys fall back to
+// a humanized form so a new capability still reads sensibly without a code change.
+const CAPABILITY_LABELS = {
+  text_to_image: "Text to Image",
+  image_to_image: "Image to Image",
+  edit_image: "Image Edit",
+  character_image: "Character",
+  style_variations: "Style Variations",
+  vqa: "Visual Q&A",
+  interleave: "Interleaved",
+  image_to_video: "Image to Video",
+  text_to_video: "Text to Video",
+  first_last_frame: "First / Last Frame",
+  extend_clip: "Extend Clip",
+  video_bridge: "Video Bridge",
+  replace_person: "Replace Person",
+};
+
+function capabilityLabel(capability) {
+  return CAPABILITY_LABELS[capability] ?? String(capability).replaceAll("_", " ");
+}
+
+// Group key for the family-organized LoRA list. A LoRA can list several compatible
+// families; we group under its primary one and bucket family-less entries under a
+// trailing "compatible" group.
+function loraGroupKey(lora) {
+  return lora.family ?? extractFamilies(lora)[0] ?? "";
+}
+
 // Gated models (e.g. FLUX.1 [dev]) need an accepted license + a saved credential
 // before a download can succeed. The catalog flags these with `gated`/
 // `credentialHost`/`licenseUrl` (sc-1898). When the matching credential is already
@@ -433,6 +472,169 @@ export function ModelManagerScreen() {
     (importForm.scope === "project" && !activeProject) ||
     (isFileImport ? !importForm.file : !importForm.sourceUrl.trim());
 
+  // Models grouped by type for the sectioned layout. Known types keep their fixed
+  // order; anything else lands in a trailing "Other" group. Empty groups drop out.
+  const knownModelTypes = new Set(MODEL_TYPE_GROUPS.map((group) => group.type));
+  const modelGroups = [
+    ...MODEL_TYPE_GROUPS.map((group) => ({ ...group, items: models.filter((model) => model.type === group.type) })),
+    { type: "other", label: "Other Models", items: models.filter((model) => !knownModelTypes.has(model.type)) },
+  ].filter((group) => group.items.length > 0);
+
+  // Visible LoRAs grouped by family for the family-organized list. The family
+  // dropdown still narrows `visibleLoras` upstream; when a specific family is
+  // selected this collapses to a single group.
+  const loraGroupMap = new Map();
+  visibleLoras.forEach((lora) => {
+    const key = loraGroupKey(lora) || "compatible";
+    if (!loraGroupMap.has(key)) {
+      loraGroupMap.set(key, []);
+    }
+    loraGroupMap.get(key).push(lora);
+  });
+  const loraGroups = [...loraGroupMap.entries()]
+    .sort(([a], [b]) => (a === "compatible" ? 1 : b === "compatible" ? -1 : a.localeCompare(b)))
+    .map(([family, items]) => ({ family, items }));
+
+  function renderModelCard(model) {
+    const downloadJobs = downloadJobsFor(model);
+    const downloadJob = downloadJobs.find((job) => !terminalStatuses.has(job.status));
+    const installed = model.installState === "installed";
+    const localDownloadJob = installed ? null : downloadJobs.find((job) => job.status !== "completed");
+    const failedDownload = localDownloadJob && terminalStatuses.has(localDownloadJob.status);
+    const downloadSize = downloadSizeText(model);
+    const unassociated = !model.family;
+    const capabilities = Array.isArray(model.capabilities) ? model.capabilities : [];
+    const deleteKey = `model:${model.id}`;
+    const canDelete = Boolean(onDeleteModel) && model.removable !== false;
+    // MLX (macOS) variant: only present when the catalog computed mlxConversionState.
+    const mlxState = model.mlxConversionState;
+    const mlxMinGb = model.mlx?.minMemoryGb ?? null;
+    const mlxEnoughMemory = unifiedMemoryGb == null || mlxMinGb == null || unifiedMemoryGb >= mlxMinGb;
+    const convertJobs = convertJobsFor(model);
+    const convertJob = convertJobs.find((job) => !terminalStatuses.has(job.status));
+    const failedConvert = convertJobs.find((job) => terminalStatuses.has(job.status) && job.status !== "completed");
+    const showConvertButton = mlxState === "needs_conversion" || mlxState === "converted";
+    const gated = Boolean(model.gated);
+    const credentialPresent = gated && hasPresentCredential(credentials, model.credentialHost);
+    return (
+      <article className="model-card" key={model.id}>
+        <div>
+          <p className="eyebrow">{model.family ?? "unassociated"}</p>
+          <h3>{model.name}</h3>
+        </div>
+        <span className={installed ? "status-badge installed" : "status-badge"}>{installed ? "installed" : "missing"}</span>
+        {unassociated ? (
+          <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
+            needs family
+          </span>
+        ) : null}
+        {capabilities.length ? (
+          <ul className="model-capabilities">
+            {capabilities.map((capability) => (
+              <li className="chip" key={capability}>
+                {capabilityLabel(capability)}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        <p>{model.ui?.description ?? model.family ?? model.id}</p>
+        {gated && !installed ? (
+          <GatedModelNotice
+            host={model.credentialHost}
+            licenseUrl={model.licenseUrl}
+            present={credentialPresent}
+            onOpenSettings={() => setActiveView("Settings")}
+          />
+        ) : null}
+        <dl>
+          <div>
+            <dt>Repo</dt>
+            <dd>{model.downloads?.[0]?.repo ?? "none"}</dd>
+          </div>
+          <div>
+            <dt>Download size</dt>
+            <dd>{downloadSize}</dd>
+          </div>
+        </dl>
+        {localDownloadJob ? (
+          <WorkerProgressCard job={localDownloadJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+        ) : null}
+        {mlxState ? (
+          <div className="mlx-status">
+            <div className="mlx-status-badges">
+              <span className="status-badge">MLX</span>
+              {mlxMinGb != null ? (
+                <span className={mlxEnoughMemory ? "status-badge" : "status-badge warning"}>needs ≥ {mlxMinGb} GB</span>
+              ) : null}
+            </div>
+            <p>{mlxStatusText(model)}</p>
+            {!mlxEnoughMemory ? (
+              <p className="inline-warning">
+                Needs ≥ {mlxMinGb} GB unified memory; this Mac has ~{Math.round(unifiedMemoryGb)} GB. It may run out of memory.
+              </p>
+            ) : null}
+            {convertJob ? <WorkerProgressCard job={convertJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} /> : null}
+            {showConvertButton ? (
+              <button
+                disabled={mlxState === "converted" || Boolean(convertJob) || !mlxEnoughMemory}
+                onClick={() => onConvertModel?.(model)}
+                type="button"
+              >
+                {convertJob
+                  ? convertJob.status
+                  : mlxState === "converted"
+                    ? "MLX ready"
+                    : failedConvert
+                      ? "Retry MLX Conversion"
+                      : "Convert to MLX"}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="model-card-actions">
+          <button disabled={installed || !model.downloadable || Boolean(downloadJob)} onClick={() => onDownloadModel(model)} type="button">
+            {downloadJob
+              ? downloadJob.status
+              : installed
+                ? "Ready"
+                : failedDownload
+                  ? "Retry Download"
+                  : model.downloadSizeLabel
+                    ? `Download ${downloadSize}`
+                    : "Download"}
+          </button>
+          <button className="danger-action" disabled={!canDelete || deletingItem === deleteKey} onClick={() => deleteModel(model)} type="button">
+            {model.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
+          </button>
+        </div>
+      </article>
+    );
+  }
+
+  function renderLoraRow(lora) {
+    const installed = lora.installState === "installed";
+    const missing = lora.installState === "missing";
+    const statusText = missing ? "unavailable" : installed ? "installed" : "pending";
+    const deleteKey = `lora:${lora.scope ?? "global"}:${lora.id}`;
+    return (
+      <article className={missing ? "lora-row warning" : "lora-row"} key={lora.id ?? lora.name}>
+        <span>
+          <strong>{lora.name ?? lora.id}</strong>
+          <small>{[lora.scope, lora.family ?? "compatible"].filter(Boolean).join(" | ")}</small>
+        </span>
+        <span className={installed ? "status-badge installed" : "status-badge"}>{statusText}</span>
+        <button
+          className="danger-action"
+          disabled={!onDeleteLora || lora.removable === false || deletingItem === deleteKey}
+          onClick={() => deleteLora(lora)}
+          type="button"
+        >
+          {lora.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
+        </button>
+      </article>
+    );
+  }
+
   return (
     <section className="main-surface models-surface">
       <div className="surface-header">
@@ -453,124 +655,15 @@ export function ModelManagerScreen() {
         </label>
       </div>
 
-      <div className="model-grid">
-        {models.map((model) => {
-          const downloadJobs = downloadJobsFor(model);
-          const downloadJob = downloadJobs.find((job) => !terminalStatuses.has(job.status));
-          const installed = model.installState === "installed";
-          const localDownloadJob = installed ? null : downloadJobs.find((job) => job.status !== "completed");
-          const failedDownload = localDownloadJob && terminalStatuses.has(localDownloadJob.status);
-          const downloadSize = downloadSizeText(model);
-          const unassociated = !model.family;
-          const deleteKey = `model:${model.id}`;
-          const canDelete = Boolean(onDeleteModel) && model.removable !== false;
-          // MLX (macOS) variant: only present when the catalog computed mlxConversionState.
-          const mlxState = model.mlxConversionState;
-          const mlxMinGb = model.mlx?.minMemoryGb ?? null;
-          const mlxEnoughMemory =
-            unifiedMemoryGb == null || mlxMinGb == null || unifiedMemoryGb >= mlxMinGb;
-          const convertJobs = convertJobsFor(model);
-          const convertJob = convertJobs.find((job) => !terminalStatuses.has(job.status));
-          const failedConvert = convertJobs.find(
-            (job) => terminalStatuses.has(job.status) && job.status !== "completed",
-          );
-          const showConvertButton = mlxState === "needs_conversion" || mlxState === "converted";
-          const gated = Boolean(model.gated);
-          const credentialPresent = gated && hasPresentCredential(credentials, model.credentialHost);
-          return (
-            <article className="model-card" key={model.id}>
-              <div>
-                <p className="eyebrow">{model.type}</p>
-                <h3>{model.name}</h3>
-              </div>
-              <span className={installed ? "status-badge installed" : "status-badge"}>{installed ? "installed" : "missing"}</span>
-              {unassociated ? (
-                <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
-                  needs family
-                </span>
-              ) : null}
-              <p>{model.ui?.description ?? model.family ?? model.id}</p>
-              {gated && !installed ? (
-                <GatedModelNotice
-                  host={model.credentialHost}
-                  licenseUrl={model.licenseUrl}
-                  present={credentialPresent}
-                  onOpenSettings={() => setActiveView("Settings")}
-                />
-              ) : null}
-              <dl>
-                <div>
-                  <dt>Family</dt>
-                  <dd>{model.family ?? "unassociated"}</dd>
-                </div>
-                <div>
-                  <dt>Repo</dt>
-                  <dd>{model.downloads?.[0]?.repo ?? "none"}</dd>
-                </div>
-                <div>
-                  <dt>Download size</dt>
-                  <dd>{downloadSize}</dd>
-                </div>
-              </dl>
-              {localDownloadJob ? (
-                <WorkerProgressCard job={localDownloadJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
-              ) : null}
-              {mlxState ? (
-                <div className="mlx-status">
-                  <div className="mlx-status-badges">
-                    <span className="status-badge">MLX</span>
-                    {mlxMinGb != null ? (
-                      <span className={mlxEnoughMemory ? "status-badge" : "status-badge warning"}>
-                        needs ≥ {mlxMinGb} GB
-                      </span>
-                    ) : null}
-                  </div>
-                  <p>{mlxStatusText(model)}</p>
-                  {!mlxEnoughMemory ? (
-                    <p className="inline-warning">
-                      Needs ≥ {mlxMinGb} GB unified memory; this Mac has ~{Math.round(unifiedMemoryGb)} GB. It may run out of memory.
-                    </p>
-                  ) : null}
-                  {convertJob ? (
-                    <WorkerProgressCard job={convertJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
-                  ) : null}
-                  {showConvertButton ? (
-                    <button
-                      disabled={mlxState === "converted" || Boolean(convertJob) || !mlxEnoughMemory}
-                      onClick={() => onConvertModel?.(model)}
-                      type="button"
-                    >
-                      {convertJob
-                        ? convertJob.status
-                        : mlxState === "converted"
-                          ? "MLX ready"
-                          : failedConvert
-                            ? "Retry MLX Conversion"
-                            : "Convert to MLX"}
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
-              <div className="model-card-actions">
-                <button disabled={installed || !model.downloadable || Boolean(downloadJob)} onClick={() => onDownloadModel(model)} type="button">
-                  {downloadJob
-                    ? downloadJob.status
-                    : installed
-                      ? "Ready"
-                      : failedDownload
-                        ? "Retry Download"
-                        : model.downloadSizeLabel
-                          ? `Download ${downloadSize}`
-                          : "Download"}
-                </button>
-                <button className="danger-action" disabled={!canDelete || deletingItem === deleteKey} onClick={() => deleteModel(model)} type="button">
-                  {model.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
-                </button>
-              </div>
-            </article>
-          );
-        })}
-      </div>
+      {modelGroups.map((group) => (
+        <section className="model-type-group" key={group.type}>
+          <div className="model-type-group-heading">
+            <h3>{group.label}</h3>
+            <span>{group.items.length}</span>
+          </div>
+          <div className="model-grid">{group.items.map((model) => renderModelCard(model))}</div>
+        </section>
+      ))}
       {deleteMessage.text ? <p className={deleteMessage.tone === "success" ? "inline-success" : "inline-warning"}>{deleteMessage.text}</p> : null}
 
       <section className="model-import-panel-section">
@@ -859,29 +952,16 @@ export function ModelManagerScreen() {
         ) : null}
         {hiddenImportCount ? <p className="helper-copy">{hiddenImportCount} LoRA import{hiddenImportCount === 1 ? " is" : "s are"} hidden by this family filter.</p> : null}
         {visibleLoras.length ? (
-          <div className="lora-list">
-            {visibleLoras.map((lora) => {
-              const installed = lora.installState === "installed";
-              const missing = lora.installState === "missing";
-              const statusText = missing ? "unavailable" : installed ? "installed" : "pending";
-              return (
-                <article className={missing ? "lora-row warning" : "lora-row"} key={lora.id ?? lora.name}>
-                  <span>
-                    <strong>{lora.name ?? lora.id}</strong>
-                    <small>{[lora.scope, lora.family ?? "compatible"].filter(Boolean).join(" | ")}</small>
-                  </span>
-                  <span className={installed ? "status-badge installed" : "status-badge"}>{statusText}</span>
-                  <button
-                    className="danger-action"
-                    disabled={!onDeleteLora || lora.removable === false || deletingItem === `lora:${lora.scope ?? "global"}:${lora.id}`}
-                    onClick={() => deleteLora(lora)}
-                    type="button"
-                  >
-                    {lora.removable === false ? "Protected" : deletingItem === `lora:${lora.scope ?? "global"}:${lora.id}` ? "Deleting" : "Delete"}
-                  </button>
-                </article>
-              );
-            })}
+          <div className="lora-family-groups">
+            {loraGroups.map((group) => (
+              <div className="lora-family-group" key={group.family}>
+                <div className="lora-family-group-heading">
+                  <h3>{group.family === "compatible" ? "Other / compatible" : group.family}</h3>
+                  <span>{group.items.length}</span>
+                </div>
+                <div className="lora-list">{group.items.map((lora) => renderLoraRow(lora))}</div>
+              </div>
+            ))}
           </div>
         ) : localLoraImportJobs.length ? null : loras.length && familyFilter !== "all" ? (
           <div className="empty-panel compact-panel">No LoRAs match {familyFilter}</div>

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -272,3 +272,117 @@ describe("ModelManagerScreen Wan A14B MoE LoRA import (sc-1991)", () => {
     expect(payload.baseModel).toBe("wan_2_2_t2v_14b");
   });
 });
+
+describe("ModelManagerScreen type-grouped layout", () => {
+  let container;
+  let root;
+  let ModelManagerScreen;
+  let AppContext;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.__TAURI__ = { core: { invoke: vi.fn(async () => null) } };
+    vi.resetModules();
+    ({ AppContext } = await import("../context/AppContext.js"));
+    ({ ModelManagerScreen } = await import("./ModelManagerScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render({ models = [], loras = [] } = {}) {
+    const value = {
+      activeProject: null,
+      jobs: [],
+      loras,
+      models,
+      presets: [],
+      jobAction: () => {},
+      setActiveView: () => {},
+      deleteLora: () => {},
+      deleteModel: () => {},
+      createModelDownloadJob: () => {},
+      createModelConvertJob: () => {},
+      createLoraImportJob: () => {},
+      createModelImportJob: () => {},
+    };
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const MODELS = [
+    { id: "z_image_turbo", name: "Z-Image-Turbo", type: "image", family: "z-image", capabilities: ["text_to_image", "style_variations"], installState: "missing" },
+    { id: "wan_t2v", name: "Wan T2V", type: "video", family: "wan-video", capabilities: ["text_to_video"], installState: "missing" },
+    { id: "real_esrgan", name: "Real-ESRGAN", type: "utility", family: "real-esrgan", capabilities: [], installState: "missing" },
+  ];
+
+  function groupHeadings() {
+    return [...container.querySelectorAll(".model-type-group-heading h3")].map((h) => h.textContent);
+  }
+
+  it("renders one section per populated model type, in fixed order", async () => {
+    await render({ models: MODELS });
+    expect(groupHeadings()).toEqual(["Image Models", "Video Models", "Utility Models"]);
+    // Each group holds exactly its own type's card.
+    const groups = container.querySelectorAll(".model-type-group");
+    expect(groups.length).toBe(3);
+    expect(groups[0].querySelectorAll(".model-card").length).toBe(1);
+    expect(groups[0].textContent).toContain("Z-Image-Turbo");
+    expect(groups[1].textContent).toContain("Wan T2V");
+    expect(groups[2].textContent).toContain("Real-ESRGAN");
+  });
+
+  it("omits a type section when no model has that type", async () => {
+    await render({ models: [MODELS[0]] });
+    expect(groupHeadings()).toEqual(["Image Models"]);
+  });
+
+  it("describes each model's capabilities as chips on the card", async () => {
+    await render({ models: [MODELS[0]] });
+    const chips = [...container.querySelectorAll(".model-capabilities .chip")].map((c) => c.textContent);
+    expect(chips).toEqual(["Text to Image", "Style Variations"]);
+  });
+
+  it("groups LoRAs by family with a heading per family", async () => {
+    await render({
+      models: MODELS,
+      loras: [
+        { id: "a", name: "Flux A", family: "flux", installState: "installed" },
+        { id: "b", name: "Flux B", family: "flux", installState: "installed" },
+        { id: "c", name: "Wan C", family: "wan-video", installState: "installed" },
+      ],
+    });
+    const families = [...container.querySelectorAll(".lora-family-group-heading h3")].map((h) => h.textContent);
+    expect(families).toEqual(["flux", "wan-video"]);
+    const groups = container.querySelectorAll(".lora-family-group");
+    expect(groups[0].querySelectorAll(".lora-row").length).toBe(2);
+    expect(groups[1].querySelectorAll(".lora-row").length).toBe(1);
+  });
+
+  it("buckets family-less LoRAs under a trailing 'Other / compatible' group", async () => {
+    await render({
+      models: MODELS,
+      loras: [
+        { id: "a", name: "Flux A", family: "flux", installState: "installed" },
+        { id: "x", name: "Loose", installState: "installed" },
+      ],
+    });
+    const families = [...container.querySelectorAll(".lora-family-group-heading h3")].map((h) => h.textContent);
+    expect(families).toEqual(["flux", "Other / compatible"]);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3057,6 +3057,71 @@ label {
   gap: var(--gap-3);
 }
 
+/* Type-grouped model sections (Image / Video / Utility) + family-grouped LoRAs. */
+.model-type-group {
+  display: grid;
+  gap: 12px;
+}
+
+.model-type-group + .model-type-group {
+  margin-top: var(--gap-3);
+}
+
+.model-type-group-heading,
+.lora-family-group-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.model-type-group-heading h3,
+.lora-family-group-heading h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.model-type-group-heading > span,
+.lora-family-group-heading > span {
+  font-size: 12px;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.model-capabilities {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.model-capabilities .chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  font-size: 11.5px;
+  font-weight: 500;
+  background: var(--surface-2);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.lora-family-groups {
+  display: grid;
+  gap: var(--gap-3);
+}
+
+.lora-family-group {
+  display: grid;
+  gap: 10px;
+}
+
 .model-card,
 .lora-panel,
 .lora-row,


### PR DESCRIPTION
## Summary

Redesigns the Model Manager screen so the growing catalog is organized rather than rendered as one flat grid.

- **Models grouped by type** — `Image Models` → `Video Models` → `Utility Models`, fixed order, empty groups omitted. Any model whose `type` isn't one of these falls into a trailing **Other Models** group so nothing is ever hidden (e.g. the upscalers now have a home under Utility).
- **Capabilities shown as chips** on each card (`Text to Image`, `Image Edit`, `Character`, etc.) so the type-grouped layout still communicates what each model actually does. Unknown capability keys humanize gracefully.
- **LoRAs grouped by model family** — per-family sections with a heading + count, while the existing family **dropdown filter is retained** for narrowing. Family-less LoRAs bucket under `Other / compatible`.
- Extracts `renderModelCard` / `renderLoraRow` helpers (no behavior change to download / convert / gated-notice / MoE-import flows).

> Earlier the design briefly considered a separate "Image Edit" bucket, but too many models are dual-capable for a clean split — grouping by `type` + describing capabilities on the card was the chosen approach.

## Tests

- Adds 5 tests asserting the new grouped DOM: section order, empty-group omission, capability chips, family grouping, and the family-less bucket.
- Full web suite green (**240 passed**); parity suite green (**12 passed**) after merging `origin/main` (PR #339, the sc-2024 asset `origin` snapshot refresh).
- `vite build` clean.

## Follow-up

- [sc-2173](https://app.shortcut.com/trefry/story/2173) — spike to determine why **FLUX.2 [klein] 9B-KV** is gated to `character_image` only. Its capabilities currently render as a single chip here; if the spike confirms it also handles text-to-image / plain edit, broadening the manifest will surface those modes automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)