### PR TITLE
feat(worker): broaden FLUX.2 [klein] 9B-KV beyond character_image (sc-2173)

### DIFF
--- a/apps/web/public/prompt-guides/flux2-klein.md
+++ b/apps/web/public/prompt-guides/flux2-klein.md
@@ -5,7 +5,7 @@
 A 9B-parameter Black Forest Labs FLUX.2 [klein] checkpoint, 4-step distilled — fast, high-quality text-to-image AND reference-driven editing in a single model. Apple Silicon only (MLX backend); ships in two variants:
 
 - **FLUX.2 [klein] 9B** — text-to-image and reference editing.
-- **FLUX.2 [klein] 9B-KV** — reference editing with KV-cache acceleration, ~2.4× faster than the base 9B edit path. Reference image required (cache is meaningless without one).
+- **FLUX.2 [klein] 9B-KV** — text-to-image and reference editing, plus KV-cache acceleration that makes editing ~2.4× faster than the base 9B edit path. The cache engages automatically when you attach a reference; without one it runs plain text-to-image on par with the base 9B.
 
 > **License:** FLUX Non-Commercial License — gated Hugging Face download. Accept the license at the model card and add a Hugging Face token under Settings → Service credentials before downloading. Generations are for non-commercial use only.
 

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -393,12 +393,13 @@ MODEL_TARGETS = {
     "flux2_klein_9b_kv": {
         "label": "FLUX.2 [klein] 9B-KV",
         "family": "flux2-klein",
-        # Edit-only (KV cache requires a reference image to be meaningful);
-        # MlxFlux2Adapter rejects this model id in txt2img mode. Cache
-        # auto-engages on the supports_kv_cache ModelConfig flag set in
-        # the pinned mflux fork (sc-2163, upstream PR filipstrand/mflux#426).
+        # Full txt2img + edit, same as the base 9B (sc-2173 validated the
+        # -kv distill renders plain text-to-image + non-character edit with
+        # no artifacts). The KV cache auto-engages only on the edit path when
+        # a reference is present, via the supports_kv_cache ModelConfig flag
+        # in the pinned mflux fork (sc-2163, upstream PR filipstrand/mflux#426).
         "supportsEdit": True,
-        "supportsTxt2Img": False,
+        "supportsTxt2Img": True,
         "steps": 4,
         "guidanceScale": 1.0,
         "repo": "black-forest-labs/FLUX.2-klein-9b-kv",
@@ -3497,8 +3498,10 @@ class MlxFlux2Adapter:
         from BFL (FLUX.2-klein-9b-kv) caches reference-image K/V on step
         0 and reuses it on steps 1-3, ~2.4× faster than the un-cached
         edit path on M5 Max. Cache auto-engages via the mflux
-        ModelConfig flag (sc-2163, upstream PR filipstrand/mflux#426).
-        Reference is required.
+        ModelConfig flag (sc-2163, upstream PR filipstrand/mflux#426). The
+        cache only engages on the edit path when a reference is present;
+        without one the id runs plain txt2img through ``Flux2Klein`` just
+        like the base 9B (sc-2173).
 
     Dispatch gate: `_should_route_flux2_to_mlx`. The shared mflux escape
     hatch ``SCENEWORKS_DISABLE_MLX_FLUX`` opts out of this adapter too.
@@ -3507,13 +3510,17 @@ class MlxFlux2Adapter:
       - flux2_klein_9b txt2img: ~26 s gen, ~36 GB peak
       - flux2_klein_9b edit (no cache): ~33 s gen
       - flux2_klein_9b_kv edit (cache on): ~13.5 s gen — 2.4× speedup
+      - flux2_klein_9b_kv txt2img: parity with base 9B, no cache artifacts
+        (sc-2173)
       (numbers measured against the mflux fork's editable install during
-       sc-2163; sidecar venv post-provision should match).
+       sc-2163/sc-2173; sidecar venv post-provision should match).
     """
 
     id = "mlx_flux2"
     _supported_models = {"flux2_klein_9b", "flux2_klein_9b_kv"}
-    _kv_only_models = {"flux2_klein_9b_kv"}  # require a reference image
+    # Models whose edit path uses the KV cache (engages only with a reference);
+    # they still run plain txt2img without one (sc-2173).
+    _kv_cache_models = {"flux2_klein_9b_kv"}
 
     def __init__(self) -> None:
         self._scratch_dir: Path | None = None
@@ -3567,12 +3574,6 @@ class MlxFlux2Adapter:
         if request.reference_asset_id:
             reference_paths.append(str(find_asset_media_path(project_path, request.reference_asset_id)))
         has_reference = bool(reference_paths)
-
-        if request.model in self._kv_only_models and not has_reference:
-            raise RuntimeError(
-                f"{request.model} requires a reference image (the KV cache is "
-                "meaningless without one). Use flux2_klein_9b for text-to-image."
-            )
 
         validate_lora_compatibility(
             request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
@@ -3654,7 +3655,7 @@ class MlxFlux2Adapter:
                     "mlxQuantize": quantize,
                     "sidecarVenv": self._sidecar_python(),
                     "hasReference": has_reference,
-                    "kvCacheEnabled": has_reference and request.model in self._kv_only_models,
+                    "kvCacheEnabled": has_reference and request.model in self._kv_cache_models,
                     "realModelInference": True,
                 },
                 settings=settings,
@@ -6401,13 +6402,10 @@ def _should_route_flux2_to_mlx(payload: dict[str, Any]) -> bool:
          mflux family — one env var per sidecar venv, not per family).
       2. Platform == darwin (mflux/MLX is Apple-only).
       3. Model in MlxFlux2Adapter._supported_models.
-      4. flux2_klein_9b_kv requires a reference image: KV cache only kicks in
-         when image_paths is populated, so a -kv request without a reference
-         is a misuse and must fail loudly rather than silently fall back to a
-         non-cached run (which wouldn't even produce the model's intended
-         distilled-at-4-steps output without the cache).
-      5. Sidecar venv exists.
-    sc-2164.
+      4. Sidecar venv exists.
+    Both ids route by reference presence inside the runner (txt2img vs edit);
+    -kv no longer requires a reference — its txt2img path is on par with the
+    base 9B (sc-2164, sc-2173).
     """
     if os.getenv("SCENEWORKS_DISABLE_MLX_FLUX", "").strip().lower() in {"1", "true", "yes"}:
         return False
@@ -6415,8 +6413,6 @@ def _should_route_flux2_to_mlx(payload: dict[str, Any]) -> bool:
         return False
     model = payload.get("model")
     if model not in MlxFlux2Adapter._supported_models:
-        return False
-    if model in MlxFlux2Adapter._kv_only_models and not payload.get("referenceAssetId"):
         return False
     return MlxFlux2Adapter()._sidecar_available()
 

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -98,16 +98,16 @@ def _resolve_model_handle(model_id: str, has_reference: bool) -> tuple[type, obj
         from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
         return Flux2Klein, ModelConfig.flux2_klein_9b(), "mlx_flux2_klein", "flux2"
     if model_id == "flux2_klein_9b_kv":
-        # The -kv variant only makes sense with a reference image (cache is
-        # meaningless otherwise). MlxFlux2Adapter gates this in the main venv
-        # so we get here only when has_reference is True.
-        if not has_reference:
-            raise RuntimeError(
-                "mlx_flux_runner: flux2_klein_9b_kv requires a reference image; "
-                "use flux2_klein_9b for text-to-image."
-            )
-        from mflux.models.flux2.variants.edit.flux2_klein_edit import Flux2KleinEdit
-        return Flux2KleinEdit, ModelConfig.flux2_klein_9b_kv(), "mlx_flux2_klein_kv", "flux2"
+        # Same FLUX.2 [klein] 9B architecture as flux2_klein_9b with the KV
+        # cache enabled (a separate distill — sc-2173). The cache machinery
+        # lives entirely in Flux2KleinEdit and only engages when a reference
+        # is present, so txt2img + non-character edit run fine on these
+        # weights. Route by reference presence, exactly like flux2_klein_9b.
+        if has_reference:
+            from mflux.models.flux2.variants.edit.flux2_klein_edit import Flux2KleinEdit
+            return Flux2KleinEdit, ModelConfig.flux2_klein_9b_kv(), "mlx_flux2_klein_kv", "flux2"
+        from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+        return Flux2Klein, ModelConfig.flux2_klein_9b_kv(), "mlx_flux2_klein_kv", "flux2"
     raise RuntimeError(f"mlx_flux_runner: unsupported model id {model_id!r}.")
 
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -826,12 +826,13 @@
       "family": "flux2-klein",
       "type": "image",
       "adapter": "mlx_flux2",
-      // Reference-only: the KV cache caches reference-image K/V on step 0
-      // and reuses on steps 1-3, ~2.4× faster than the un-cached edit path
-      // on M5 Max (sc-2163, upstream PR filipstrand/mflux#426). Cache is
-      // meaningless without a reference image, so the model id is gated to
-      // character_image / edit modes only.
-      "capabilities": ["character_image"],
+      // KV-optimized distill of the same FLUX.2 [klein] 9B family. With a
+      // reference image the KV cache caches reference K/V on step 0 and reuses
+      // it on steps 1-3 (faster edit; sc-2163, PR filipstrand/mflux#426).
+      // Without a reference it runs plain text-to-image on par with the base
+      // 9B — the cache simply doesn't engage (sc-2173), so the full
+      // capability set is exposed rather than gating to character_image only.
+      "capabilities": ["text_to_image", "character_image", "style_variations"],
       "macOnly": true,
       "downloads": [
         {
@@ -867,7 +868,7 @@
       "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
       "ui": {
         "label": "FLUX.2 [klein] 9B-KV",
-        "description": "FLUX.2 [klein] 9B with KV-cache acceleration for reference editing — ~2.4× faster than the base 9B edit path on Apple Silicon (validated M5 Max 128 GB, sc-2163). Reference image required; for plain text-to-image use FLUX.2 [klein] 9B. Distributed under the FLUX Non-Commercial License (gated). Same ~36 GB bf16 peak at 1024² as the base 9B.",
+        "description": "A KV-optimized distill of FLUX.2 [klein] 9B: text-to-image, reference editing, and style variations, plus KV-cache acceleration that makes reference editing ~2.4× faster than the base 9B edit path on Apple Silicon (validated M5 Max 128 GB, sc-2163). The cache engages automatically when you attach a reference; without one it runs plain text-to-image on par with the base 9B (sc-2173). Distributed under the FLUX Non-Commercial License (gated). Same ~36 GB bf16 peak at 1024² as the base 9B.",
         "recommendedFor": ["character_image"],
         // Same edit-style knob as the base 9B (Flux2KleinEdit). The cache
         // doesn't change the variation behavior, just the per-step compute.

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2006,9 +2006,10 @@ def test_should_route_flux2_to_mlx_predicate(monkeypatch):
     assert _should_route_flux2_to_mlx(
         {"model": "flux2_klein_9b", "referenceAssetId": "asset_ref"}
     ) is True
-    # -kv requires a reference asset; without one the gate must fail so the
-    # adapter raises a clear error instead of running un-cached on -kv weights.
-    assert _should_route_flux2_to_mlx({"model": "flux2_klein_9b_kv"}) is False
+    # -kv routes to MLX with or without a reference (sc-2173): no reference
+    # runs txt2img through Flux2Klein, a reference engages the KV-cache edit
+    # path. FLUX.2 has no torch fallback, so both must route here.
+    assert _should_route_flux2_to_mlx({"model": "flux2_klein_9b_kv"}) is True
     assert _should_route_flux2_to_mlx(
         {"model": "flux2_klein_9b_kv", "referenceAssetId": "asset_ref"}
     ) is True
@@ -2026,9 +2027,13 @@ def test_should_route_flux2_to_mlx_predicate(monkeypatch):
     assert _should_route_flux2_to_mlx({"model": "flux_dev"}) is False
 
 
-def test_mlx_flux2_kv_rejects_no_reference():
-    # -kv without a reference is misuse: the cache is meaningless and the
-    # 4-step distilled output drifts without it. Adapter must fail loudly.
+def test_mlx_flux2_kv_allows_no_reference_txt2img(monkeypatch):
+    # sc-2173: -kv is no longer reference-gated. Without a reference it falls
+    # through to the txt2img path (the runner routes it to Flux2Klein) instead
+    # of raising. With the sidecar absent, generate() surfaces the *sidecar*
+    # error — the point is that it is NOT a "reference image" rejection, which
+    # proves the old gate is gone.
+    monkeypatch.setenv("SCENEWORKS_MLX_FLUX_PYTHON", "/nonexistent/mlx-flux-venv/bin/python")
     job = {
         "id": "job_mlx_flux2_kv_norefs",
         "payload": {
@@ -2049,11 +2054,11 @@ def test_mlx_flux2_kv_rejects_no_reference():
             cancel_requested=lambda: False,
         )
     except RuntimeError as exc:
-        assert "reference image" in str(exc).lower()
+        message = str(exc).lower()
+        assert "reference image" not in message, "-kv must no longer require a reference"
+        assert "sidecar" in message
     else:
-        raise AssertionError(
-            "MlxFlux2Adapter must reject flux2_klein_9b_kv jobs without a reference image."
-        )
+        raise AssertionError("MlxFlux2Adapter must still fail when the sidecar venv is unavailable.")
 
 
 def test_mlx_flux2_rejects_unsupported_model():
@@ -2134,10 +2139,10 @@ def test_flux2_klein_manifest_entries_present():
     import re
 
     _, find_entry_block, find_mlx_block = _manifest_brace_walker()
-    for model_id, expect_kv_only in (
-        ("flux2_klein_9b", False),
-        ("flux2_klein_9b_kv", True),
-    ):
+    # Both ids expose the same capability set: -kv is no longer gated to
+    # character_image only — it runs plain txt2img on par with the base 9B,
+    # the cache just doesn't engage without a reference (sc-2173).
+    for model_id in ("flux2_klein_9b", "flux2_klein_9b_kv"):
         block = find_entry_block(model_id)
         assert '"adapter": "mlx_flux2"' in block, model_id
         assert '"family": "flux2-klein"' in block, model_id
@@ -2147,13 +2152,8 @@ def test_flux2_klein_manifest_entries_present():
         quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
         assert quant_match is not None, f"{model_id}: mlx.quantize missing"
         assert int(quant_match.group(1)) == 8, f"{model_id}: quantize should be 8 (sweet spot)"
-        if expect_kv_only:
-            # -kv carries character_image only — the KV cache is meaningless
-            # without a reference image.
-            assert '"capabilities": ["character_image"]' in block.replace("\n", " "), model_id
-        else:
-            assert '"text_to_image"' in block, model_id
-            assert '"character_image"' in block, model_id
+        assert '"text_to_image"' in block, model_id
+        assert '"character_image"' in block, model_id
 
 
 # --- sc-2145: Z-Image MLX adapter ---


### PR DESCRIPTION
## Summary

`flux2_klein_9b_kv` was gated to `capabilities: ["character_image"]` on the assumption that the KV cache is "meaningless without a reference image." **sc-2173** validated on M5 Max 128GB (1024² / 4-step / guidance 1.0 / bf16) that the gate is **conservative, not architectural** — the model does plain text-to-image and non-character edit perfectly well. This broadens it to mirror the base 9B.

## Findings (full detail on [sc-2173](https://app.shortcut.com/trefry/story/2173))

| # | Question | Answer |
|---|----------|--------|
| Q1 | Same weights as `flux2_klein_9b`? | **No — separate distill.** Identical arch, but same-seed txt2img differs `mean_abs=32.5` / 1.8% identical pixels (bit-identical if weights matched). |
| Q2 | `-kv` through `Flux2Klein` (txt2img)? | **Yes, no artifacts.** `supports_kv_cache` is read only in `Flux2KleinEdit`; the txt2img class never constructs the cache. 7.8s vs base 8.5s. |
| Q3 | txt2img quality/speed parity? | **Yes** — both photoreal, no cache-path artifacts. |
| Q4 | Plain (non-character) edit + speedup? | **Yes** — cache gates on "reference present", not "character". 11.4s cache-on vs 19.7s off (**1.73×** this run; sc-2163 saw 2.4×). |

## Changes (5 files)

- **Runner** — `_resolve_model_handle` routes `-kv` by reference presence (txt2img → `Flux2Klein`, edit → `Flux2KleinEdit`), mirroring `flux2_klein_9b`; removed the no-reference `RuntimeError`.
- **Adapter** — removed the reference-required guard and route-gate #4 in `_should_route_flux2_to_mlx`; renamed `_kv_only_models` → `_kv_cache_models` (still drives `kvCacheEnabled`); `supportsTxt2Img: True`.
- **Manifest** — `capabilities` → `["text_to_image", "character_image", "style_variations"]` (mirrors base 9B; edit reached via the reference/character flow, so no separate `edit_image` chip). Description reframed as "KV-optimized distill"; `recommendedFor` kept at `["character_image"]` (the cache only helps in edit mode). Model Manager renders chips from `capabilities`, so the unlocked modes surface automatically.
- **Prompt guide** — corrected the "reference required" line.
- **Tests** — route predicate, `rejects`→`allows-txt2img`, and manifest-entry capabilities.

## Verification

- ✅ 415/415 worker runtime tests
- ✅ scaffold check
- ✅ Rust contract unaffected (no klein references in Rust tests/snapshots; no new capability enum values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)