### PR TITLE
Dataset editor: add-images dialog + member-only view [sc-2026]

### DIFF
--- a/apps/web/src/components/DatasetAddDialog.jsx
+++ b/apps/web/src/components/DatasetAddDialog.jsx
@@ -1,0 +1,215 @@
+import React, { useMemo, useState } from "react";
+import { AssetThumbnail, assetCanRenderAsImage } from "./assetMedia.jsx";
+import { Modal } from "./Modal.jsx";
+
+// An asset belongs to a character when it was generated in association with it
+// (recipe.normalizedSettings.characterId) or generated referencing it
+// (metadata.characterReferences[].characterId). Mirrors the per-character
+// gallery filter so the Character tab surfaces the same images.
+export function assetMatchesCharacter(asset, characterId) {
+  if (!characterId) {
+    return false;
+  }
+  if (asset?.recipe?.normalizedSettings?.characterId === characterId) {
+    return true;
+  }
+  return (asset?.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId);
+}
+
+function assetTitle(asset) {
+  return asset?.displayName ?? asset?.title ?? asset?.name ?? asset?.id ?? "Untitled asset";
+}
+
+const TABS = [
+  ["file", "File"],
+  ["library", "Asset Library"],
+  ["character", "Character"],
+];
+
+// Multi-select grid shared by the Library and Character tabs. Selection is
+// local to the dialog; nothing is added to the dataset until "Add" is pressed.
+function CandidateGrid({ assets, selectedIds, onToggle, emptyLabel }) {
+  if (!assets.length) {
+    return <div className="empty-panel compact-panel">{emptyLabel}</div>;
+  }
+  return (
+    <div aria-multiselectable className="dataset-add-grid" role="listbox">
+      {assets.map((asset) => {
+        const selected = selectedIds.includes(asset.id);
+        return (
+          <button
+            aria-selected={selected}
+            className={selected ? "dataset-add-card selected" : "dataset-add-card"}
+            key={asset.id}
+            onClick={() => onToggle(asset.id)}
+            role="option"
+            type="button"
+          >
+            <AssetThumbnail asset={asset} />
+            <span>{assetTitle(asset)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Add-to-dataset modal with three sources (sc-2026): drag/upload files, pick
+// from the (scoped) Asset Library, or pull a character's images. The dataset
+// editor owns membership + import; this dialog only collects a selection or
+// hands files back via onImport.
+export function DatasetAddDialog({ assets = [], memberIds = [], characters = [], importing = false, onImport, onAdd, onClose }) {
+  const [tab, setTab] = useState("file");
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [characterId, setCharacterId] = useState(characters[0]?.id ?? "");
+  const [dragActive, setDragActive] = useState(false);
+
+  const memberSet = useMemo(() => new Set(memberIds), [memberIds]);
+
+  // Library tab: studio + uploaded media only — never Character Studio test
+  // outputs (origin gating from sc-2024) — and nothing already in the dataset.
+  const libraryCandidates = useMemo(
+    () =>
+      assets.filter(
+        (asset) =>
+          assetCanRenderAsImage(asset) &&
+          asset.origin !== "character_studio" &&
+          !memberSet.has(asset.id) &&
+          !asset.status?.trashed,
+      ),
+    [assets, memberSet],
+  );
+
+  // Character tab: this character's images (including its Character Studio
+  // outputs, which the Library tab hides), minus current members.
+  const characterCandidates = useMemo(
+    () => assets.filter((asset) => assetMatchesCharacter(asset, characterId) && !memberSet.has(asset.id)),
+    [assets, characterId, memberSet],
+  );
+
+  function toggle(id) {
+    setSelectedIds((ids) => (ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id]));
+  }
+
+  function commit() {
+    if (selectedIds.length) {
+      onAdd(selectedIds);
+      setSelectedIds([]);
+    }
+  }
+
+  function switchTab(next) {
+    setTab(next);
+    setSelectedIds([]);
+  }
+
+  function handleDrop(event) {
+    event.preventDefault();
+    setDragActive(false);
+    const files = event.dataTransfer?.files;
+    if (files?.length) {
+      onImport(files);
+    }
+  }
+
+  return (
+    <Modal className="dataset-add-modal" labelledBy="dataset-add-title" onClose={onClose}>
+      <header className="dataset-add-head">
+        <div>
+          <p className="eyebrow">Add images</p>
+          <h2 id="dataset-add-title">Add images to dataset</h2>
+        </div>
+        <button className="modal-close" onClick={onClose} type="button">
+          Close
+        </button>
+      </header>
+
+      <div className="segmented-control compact-segment" role="tablist" aria-label="Add source">
+        {TABS.map(([key, label]) => (
+          <button
+            aria-selected={tab === key}
+            className={tab === key ? "active" : ""}
+            key={key}
+            onClick={() => switchTab(key)}
+            role="tab"
+            type="button"
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "file" ? (
+        <div
+          className={dragActive ? "dataset-add-dropzone active" : "dataset-add-dropzone"}
+          onDragLeave={() => setDragActive(false)}
+          onDragOver={(event) => {
+            event.preventDefault();
+            setDragActive(true);
+          }}
+          onDrop={handleDrop}
+        >
+          <p>Drag images and caption .txt files here, or</p>
+          <label className="file-upload-button">
+            <input
+              accept="image/*,.txt,text/plain"
+              disabled={importing}
+              multiple
+              onChange={(event) => {
+                onImport(event.target.files);
+                event.target.value = "";
+              }}
+              type="file"
+            />
+            {importing ? "Importing" : "Browse files"}
+          </label>
+        </div>
+      ) : null}
+
+      {tab === "library" ? (
+        <CandidateGrid
+          assets={libraryCandidates}
+          emptyLabel="No library images to add"
+          onToggle={toggle}
+          selectedIds={selectedIds}
+        />
+      ) : null}
+
+      {tab === "character" ? (
+        <div className="dataset-add-character">
+          <label>
+            Character
+            <select aria-label="Character" onChange={(event) => setCharacterId(event.target.value)} value={characterId}>
+              {characters.length ? null : <option value="">No characters yet</option>}
+              {characters.map((character) => (
+                <option key={character.id} value={character.id}>
+                  {character.name ?? character.id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <CandidateGrid
+            assets={characterCandidates}
+            emptyLabel={characterId ? "No images for this character yet" : "Select a character"}
+            onToggle={toggle}
+            selectedIds={selectedIds}
+          />
+        </div>
+      ) : null}
+
+      {tab === "file" ? null : (
+        <footer className="dataset-add-footer">
+          <span>{selectedIds.length ? `${selectedIds.length} selected` : "No selection"}</span>
+          <div className="detail-actions">
+            <button onClick={onClose} type="button">
+              Done
+            </button>
+            <button className="primary-action" disabled={!selectedIds.length} onClick={commit} type="button">
+              Add {selectedIds.length || ""}
+            </button>
+          </div>
+        </footer>
+      )}
+    </Modal>
+  );
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -131,6 +131,7 @@ function withTrainingDataSetsLibraryContext(p) {
       activeProject: p.activeProject,
       authenticated: p.authenticated,
       assets: p.assets,
+      characters: p.characters,
       gpuOptions: p.gpuOptions,
       jobs: p.jobs,
       setPreviewAsset: p.onPreview ?? (() => {}),
@@ -707,8 +708,18 @@ describe("SceneWorks app shell", () => {
     });
 
     await changeField(field(container, "Dataset name"), "Mira Set");
+    // Add the image via the Asset Library tab of the add dialog.
     await act(async () => {
-      container.querySelector(".training-asset-card input").click();
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add images").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent === "Asset Library").click();
+    });
+    await act(async () => {
+      container.querySelector(".dataset-add-card").click();
+    });
+    await act(async () => {
+      container.querySelector(".dataset-add-footer button.primary-action").click();
     });
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Create dataset").click();
@@ -753,7 +764,11 @@ describe("SceneWorks app shell", () => {
 
     const imageFile = new File([new Uint8Array([1, 2, 3])], "mira.png", { type: "image/png" });
     const captionFile = new File(["a portrait of mira"], "mira.txt", { type: "text/plain" });
-    const fileInput = container.querySelector(".training-import-button input[type=file]");
+    // Import via the File tab of the add dialog (default tab).
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add images").click();
+    });
+    const fileInput = container.querySelector(".dataset-add-dropzone input[type=file]");
     await act(async () => {
       Object.defineProperty(fileInput, "files", { configurable: true, value: [imageFile, captionFile] });
       fileInput.dispatchEvent(new window.Event("change", { bubbles: true }));
@@ -764,6 +779,9 @@ describe("SceneWorks app shell", () => {
     expect(uploadDatasetItem).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Imported 1 image with 1 caption");
 
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Close").click();
+    });
     await changeField(field(container, "Dataset name"), "Mira Set");
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Create dataset").click();
@@ -818,10 +836,22 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
     expect(loadDataset).toHaveBeenCalledWith("dataset-a");
-    expect(container.querySelectorAll(".training-asset-card input")[0].checked).toBe(true);
+    // The editor body shows only the dataset's own member (asset-a), not all assets.
+    expect(container.querySelectorAll(".training-member-card")).toHaveLength(1);
+    expect(container.querySelector(".training-member-grid").textContent).toContain("Mira.png");
 
+    // Add the second asset through the Asset Library tab (current members excluded).
     await act(async () => {
-      container.querySelectorAll(".training-asset-card input")[1].click();
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add images").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent === "Asset Library").click();
+    });
+    await act(async () => {
+      container.querySelector(".dataset-add-card").click();
+    });
+    await act(async () => {
+      container.querySelector(".dataset-add-footer button.primary-action").click();
     });
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Save dataset").click();
@@ -838,6 +868,78 @@ describe("SceneWorks app shell", () => {
       }),
     );
     expect(container.textContent).toContain("Dataset changes saved");
+  });
+
+  it("scopes the add dialog: Library excludes Character Studio outputs, Character tab pulls them in (sc-2026)", async () => {
+    const createDataset = vi.fn(async (payload) => ({ id: "dataset-new", name: payload.name, version: 1, items: payload.items }));
+    const assets = [
+      {
+        id: "asset-lib",
+        type: "image",
+        displayName: "Studio render.png",
+        origin: "image_studio",
+        file: { path: "assets/images/studio.png", mimeType: "image/png" },
+      },
+      {
+        id: "asset-char",
+        type: "image",
+        displayName: "Kelsie hero.png",
+        origin: "character_studio",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        file: { path: "assets/images/kelsie.png", mimeType: "image/png" },
+      },
+    ];
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withTrainingDataSetsLibraryContext({
+          activeProject: { id: "project-a", name: "Project A" },
+          assets,
+          characters: [{ id: "char-1", name: "Kelsie" }],
+          createDataset,
+          datasets: [],
+        }),
+      );
+    });
+
+    await changeField(field(container, "Dataset name"), "Kelsie Set");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Add images").click();
+    });
+
+    // Asset Library tab is scoped: the Character Studio output is hidden.
+    await act(async () => {
+      [...container.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent === "Asset Library").click();
+    });
+    const libraryCards = [...container.querySelectorAll(".dataset-add-card")];
+    expect(libraryCards).toHaveLength(1);
+    expect(libraryCards[0].textContent).toContain("Studio render.png");
+
+    // Character tab intentionally surfaces the character's image (its character_studio output).
+    await act(async () => {
+      [...container.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent === "Character").click();
+    });
+    const characterCards = [...container.querySelectorAll(".dataset-add-card")];
+    expect(characterCards).toHaveLength(1);
+    expect(characterCards[0].textContent).toContain("Kelsie hero.png");
+    await act(async () => {
+      characterCards[0].click();
+    });
+    await act(async () => {
+      container.querySelector(".dataset-add-footer button.primary-action").click();
+    });
+
+    // The editor body is the member grid only — no all-asset picker remains.
+    expect(container.querySelector(".training-asset-picker")).toBeNull();
+    expect(container.querySelector(".training-member-grid").textContent).toContain("Kelsie hero.png");
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Create dataset").click();
+    });
+    expect(createDataset).toHaveBeenCalledWith(
+      expect.objectContaining({ items: [expect.objectContaining({ assetId: "asset-char" })] }),
+    );
   });
 
   it("lets users remove unavailable dataset assets before saving", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useAppContext } from "../context/AppContext.js";
 import { API_BASE_URL } from "../api.js";
 import { AssetThumbnail, assetCanRenderAsImage } from "../components/assetMedia.jsx";
+import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
@@ -835,6 +836,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     activeProject,
     authenticated = true,
     assets = [],
+    characters = [],
     gpuOptions = defaultGpuOptions,
     jobs = [],
     setPreviewAsset,
@@ -880,6 +882,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const [draftName, setDraftName] = useState("");
   const [busyDatasetId, setBusyDatasetId] = useState("");
   const [importingAssets, setImportingAssets] = useState(false);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [uploadedDatasetAssets, setUploadedDatasetAssets] = useState([]);
   const [savingDataset, setSavingDataset] = useState(false);
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
@@ -935,6 +938,24 @@ export function TrainingStudio({ mode = "training" } = {}) {
     () => selectedAssetIds.filter((assetId) => !assetsById.has(assetId)),
     [assetsById, selectedAssetIds],
   );
+  // Members shown in the editor body: the dataset's own items (available
+  // assets), in selection order. Captions come from the saved dataset items or
+  // freshly imported .txt sidecars, keyed by selection id.
+  const memberAssets = useMemo(
+    () => selectedAssetIds.map((id) => assetsById.get(id)).filter(Boolean),
+    [assetsById, selectedAssetIds],
+  );
+  const memberCaptionById = useMemo(() => {
+    const map = new Map(
+      (activeDataset?.items ?? []).map((item, index) => [datasetItemSelectionKey(activeDataset, item, index), captionText(item)]),
+    );
+    for (const [assetId, caption] of Object.entries(importedCaptions)) {
+      if (caption?.text) {
+        map.set(assetId, caption.text);
+      }
+    }
+    return map;
+  }, [activeDataset, importedCaptions]);
   const health = useMemo(
     () => datasetHealth({ activeDataset, imageAssets, selectedAssetIds }),
     [activeDataset, imageAssets, selectedAssetIds],
@@ -1161,13 +1182,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
   }
 
-  function toggleAsset(assetId) {
-    setDatasetMessage("");
-    setSelectedAssetIds((current) =>
-      current.includes(assetId) ? current.filter((id) => id !== assetId) : [...current, assetId],
-    );
-  }
-
+  // Drops a member (or an unavailable/orphaned id) from the dataset selection.
   function removeUnavailableAsset(assetId) {
     setDatasetMessage("");
     setSelectedAssetIds((current) => current.filter((id) => id !== assetId));
@@ -1292,8 +1307,19 @@ export function TrainingStudio({ mode = "training" } = {}) {
     );
   }
 
-  async function handleImport(event) {
-    const files = Array.from(event.target.files ?? []);
+  function addAssets(ids) {
+    const additions = (ids ?? []).filter(Boolean);
+    if (!additions.length) {
+      return;
+    }
+    setDatasetMessage("");
+    setSelectedAssetIds((current) => Array.from(new Set([...current, ...additions])));
+  }
+
+  // Accepts a FileList from either the dialog's file input or a drag/drop, so
+  // both entry points share the import + caption-pairing path.
+  async function handleImport(fileList) {
+    const files = Array.from(fileList ?? []);
     if (!files.length) {
       return;
     }
@@ -1350,7 +1376,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setDatasetError(err.message);
     } finally {
       setImportingAssets(false);
-      event.target.value = "";
     }
   }
 
@@ -1605,10 +1630,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
                             <option value="image">Image</option>
                           </select>
                         </label>
-                        <label className="file-upload-button training-import-button">
-                          <input accept="image/*,.txt,text/plain" disabled={importingAssets} multiple onChange={handleImport} type="file" />
-                          {importingAssets ? "Importing" : "Import images & captions"}
-                        </label>
+                        <button className="primary-action training-add-images" onClick={() => setAddDialogOpen(true)} type="button">
+                          <Icon.Plus size={14} />
+                          Add images
+                        </button>
                       </div>
                       <DatasetHealth health={health} />
                       <div className="training-validity">
@@ -1630,37 +1655,41 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           ))}
                         </div>
                       ) : null}
-                      <div className="training-asset-picker" aria-label="Training dataset image assets">
-                        {imageAssets.length ? (
-                          imageAssets.map((asset) => {
-                            const selected = selectedAssetIds.includes(asset.id);
+                      <div className="training-member-grid" aria-label="Dataset images">
+                        {memberAssets.length ? (
+                          memberAssets.map((asset) => {
                             const disabled = asset.status?.rejected || asset.status?.trashed;
+                            const caption = memberCaptionById.get(asset.id);
                             return (
                               <article
-                                className={[
-                                  "training-asset-card",
-                                  selected ? "selected" : "",
-                                  disabled ? "disabled" : "",
-                                ]
-                                  .filter(Boolean)
-                                  .join(" ")}
+                                className={["training-member-card", disabled ? "disabled" : ""].filter(Boolean).join(" ")}
                                 key={asset.id}
                               >
-                                <button onClick={() => onPreview(asset)} type="button">
+                                <button className="training-member-thumb" onClick={() => onPreview(asset)} type="button">
                                   <AssetThumbnail asset={asset} />
                                 </button>
-                                <label>
-                                  <input checked={selected} onChange={() => toggleAsset(asset.id)} type="checkbox" />
-                                  <span>{asset.displayName ?? imageAssetName(asset)}</span>
-                                </label>
-                                {disabled ? (
-                                  <span className="training-asset-badge">{asset.status?.trashed ? "Trashed" : "Rejected"}</span>
-                                ) : null}
+                                <div className="training-member-meta">
+                                  <strong>{asset.displayName ?? imageAssetName(asset)}</strong>
+                                  <span className={caption ? "training-member-caption" : "training-member-caption muted"}>
+                                    {caption || "Needs caption"}
+                                  </span>
+                                  {disabled ? (
+                                    <span className="training-asset-badge">{asset.status?.trashed ? "Trashed" : "Rejected"}</span>
+                                  ) : null}
+                                </div>
+                                <button
+                                  aria-label={`Remove ${asset.displayName ?? imageAssetName(asset)}`}
+                                  className="secondary-action training-member-remove"
+                                  onClick={() => removeUnavailableAsset(asset.id)}
+                                  type="button"
+                                >
+                                  Remove
+                                </button>
                               </article>
                             );
                           })
                         ) : (
-                          <div className="empty-panel compact-panel">Import or create project images before building a dataset</div>
+                          <div className="empty-panel compact-panel">No images yet — use “Add images” to build this dataset.</div>
                         )}
                       </div>
                       <div className="training-dataset-actions">
@@ -1669,6 +1698,17 @@ export function TrainingStudio({ mode = "training" } = {}) {
                         </button>
                         <span>{dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}</span>
                       </div>
+                      {addDialogOpen ? (
+                        <DatasetAddDialog
+                          assets={imageAssets}
+                          characters={characters}
+                          importing={importingAssets}
+                          memberIds={selectedAssetIds}
+                          onAdd={addAssets}
+                          onClose={() => setAddDialogOpen(false)}
+                          onImport={handleImport}
+                        />
+                      ) : null}
                     </div>
                   </div>
                 </>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1670,8 +1670,7 @@ label {
 .training-step-block,
 .training-dataset-list-panel,
 .training-dataset-editor,
-.training-advanced-panel,
-.training-asset-card {
+.training-advanced-panel {
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface-2);
@@ -1891,10 +1890,6 @@ label {
   color: var(--text-muted);
 }
 
-.training-import-button {
-  min-height: 40px;
-}
-
 .training-health-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -1976,63 +1971,6 @@ label {
 .training-unavailable-item span {
   color: var(--text-muted);
   font-size: 12px;
-}
-
-.training-asset-picker {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 10px;
-}
-
-.training-asset-card {
-  display: grid;
-  gap: 8px;
-  min-width: 0;
-  padding: 8px;
-  background: var(--surface);
-}
-
-.training-asset-card.selected {
-  border-color: color-mix(in oklch, var(--accent) 58%, var(--border));
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent) 34%, transparent);
-}
-
-.training-asset-card.disabled {
-  border-color: color-mix(in oklch, var(--danger) 42%, var(--border));
-  background: color-mix(in oklch, var(--danger) 7%, var(--surface));
-}
-
-.training-asset-card > button {
-  overflow: hidden;
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  padding: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--surface-2);
-}
-
-.training-asset-card img,
-.training-asset-card video {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.training-asset-card label {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 8px;
-  align-items: center;
-  min-height: 24px;
-  font-size: 12px;
-}
-
-.training-asset-card label span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .training-asset-badge {
@@ -5526,6 +5464,181 @@ label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Dataset add dialog (sc-2026): three-tab add-to-dataset modal */
+.dataset-add-modal {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 12px;
+  width: min(960px, 96vw);
+  max-height: 92vh;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.dataset-add-head,
+.dataset-add-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dataset-add-head h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.dataset-add-footer {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.dataset-add-dropzone {
+  display: grid;
+  gap: 12px;
+  place-items: center;
+  padding: 40px 16px;
+  border: 2px dashed var(--border-strong);
+  border-radius: var(--r-md);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.dataset-add-dropzone.active {
+  border-color: var(--accent);
+  background: color-mix(in oklch, var(--accent) 8%, transparent);
+}
+
+.dataset-add-character {
+  display: grid;
+  gap: 12px;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+}
+
+.dataset-add-character > label {
+  display: grid;
+  gap: 4px;
+  max-width: 320px;
+}
+
+.dataset-add-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 10px;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.dataset-add-card {
+  display: grid;
+  gap: 6px;
+  align-content: start;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--r-md);
+  color: var(--text);
+  padding: 6px;
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--t-fast), border-color var(--t-fast), box-shadow var(--t-fast);
+}
+
+.dataset-add-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-strong);
+}
+
+.dataset-add-card.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 22%, transparent);
+}
+
+.dataset-add-card img,
+.dataset-add-card video {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  background: var(--bg-2);
+  border-radius: var(--r-sm);
+}
+
+.dataset-add-card span {
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Dataset member grid (sc-2026): the editor body shows only members + captions */
+.training-member-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.training-member-card {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.training-member-card.disabled {
+  opacity: 0.6;
+}
+
+.training-member-thumb {
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.training-member-thumb img,
+.training-member-thumb video {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+}
+
+.training-member-meta {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.training-member-meta strong {
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.training-member-caption {
+  overflow: hidden;
+  font-size: 12px;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.training-member-caption.muted {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 /* Asset preview chip (in pickers) */


### PR DESCRIPTION
## Summary

Implements **sc-2026** (epic 2019): fixes the Data Sets editor, which stacked an all-project-images checkbox picker on top of the member list (two colliding lists). Now the editor body shows **only the dataset's members** (thumbnail + caption preview + remove), and adding images is a single **"Add images" dialog** with three sources.

## The dialog (one modal, three tabs)

1. **File** — drag/drop or browse images + caption `.txt` sidecars (reuses the existing import + caption-pairing path).
2. **Asset Library** — a scoped grid that excludes Character Studio outputs (`origin === "character_studio"`, from sc-2024) and images already in the dataset; multi-select → Add.
3. **Character** — pick a character, add its associated images (`recipe.normalizedSettings.characterId` / `metadata.characterReferences`). This intentionally surfaces the very character_studio images the Library tab hides, completing the references→dataset→LoRA loop the epic calls out.

## Changes

- New `apps/web/src/components/DatasetAddDialog.jsx` (built on the shared `Modal` primitive).
- `TrainingStudio.jsx`: members-only grid + "Add images" button + dialog; `handleImport` now takes a `FileList` (shared by the dialog input and drag/drop); removed the all-images picker and the dead `toggleAsset`.
- `styles.css`: dialog + member-grid styles; removed the now-dead `.training-asset-picker` / `.training-asset-card` / `.training-import-button` rules.
- No backend changes — reuses the existing `selectedAssetIds` / import / caption machinery. The detailed Rename & Caption editor is untouched.

## Tests

- Reworked the 3 dataset tests that drove the old `.training-asset-card` checkboxes onto the new dialog flow (create-from-library, import-captions, open-and-save-membership — the last now asserts a member-only body).
- Added a test covering the **Character tab** + **Library scoping** (Character Studio output hidden in Library, present in Character) + **member-only listing** (no `.training-asset-picker`).
- Full web suite (236) + scaffold check + production build all green.

## Verification note

Reaching this dialog in a live browser needs the Rust API plus a project with datasets/characters/assets, which the Vite dev-server preview alone can't exercise. The new/updated vitest tests render the real components and drive the actual open-dialog → three-tab → add/remove → member-grid flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)