### PR TITLE
Compact Workspace-style character/dataset selector [sc-2025]

### DIFF
--- a/apps/web/src/components/CompactSelector.jsx
+++ b/apps/web/src/components/CompactSelector.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef, useState } from "react";
+import { AssetThumbnail } from "./assetMedia.jsx";
+import { Icon } from "./Icons.jsx";
+
+// Compact Workspace-style switcher (sc-2025): a thumbnail + name pill that opens
+// a dropdown list to switch the active item. Replaces the full-height left-column
+// selectors in Character Studio and the Dataset editor so the real content gets
+// the reclaimed width. Mirrors the ProjectSwitcher pattern (outside-click +
+// Escape to close); item creation stays with each screen's own affordances.
+export function CompactSelector({
+  items = [],
+  selectedId = "",
+  onSelect,
+  getThumbAsset = () => null,
+  getSubtitle = () => "",
+  busyId = "",
+  label = "Select",
+  placeholder = "Select…",
+  emptyLabel = "Nothing to select yet",
+  disabled = false,
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const selected = items.find((item) => item.id === selectedId) ?? null;
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    function onDocMouseDown(event) {
+      if (!containerRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    }
+    function onDocKey(event) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onDocKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onDocKey);
+    };
+  }, [open]);
+
+  function renderThumb(item) {
+    const asset = item ? getThumbAsset(item) : null;
+    return (
+      <span className="compact-selector-thumb" aria-hidden="true">
+        {asset ? <AssetThumbnail asset={asset} /> : null}
+      </span>
+    );
+  }
+
+  return (
+    <div className="compact-selector" ref={containerRef}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={label}
+        className="compact-selector-pill"
+        disabled={disabled}
+        onClick={() => setOpen((value) => !value)}
+        title={selected?.name ?? placeholder}
+        type="button"
+      >
+        {renderThumb(selected)}
+        <span className="compact-selector-meta">
+          <strong>{selected?.name ?? placeholder}</strong>
+          {selected && getSubtitle(selected) ? <span>{getSubtitle(selected)}</span> : null}
+        </span>
+        <Icon.ChevDown className="chev" />
+      </button>
+
+      {open ? (
+        <div className="compact-selector-menu" role="listbox">
+          {items.length === 0 ? (
+            <p className="compact-selector-empty">{emptyLabel}</p>
+          ) : (
+            items.map((item) => (
+              <button
+                aria-selected={item.id === selectedId}
+                className={item.id === selectedId ? "compact-selector-item active" : "compact-selector-item"}
+                disabled={busyId === item.id}
+                key={item.id}
+                onClick={() => {
+                  onSelect(item);
+                  setOpen(false);
+                }}
+                role="option"
+                type="button"
+              >
+                {renderThumb(item)}
+                <span className="compact-selector-label">
+                  <strong>{item.name}</strong>
+                  {getSubtitle(item) ? <span>{busyId === item.id ? "Opening…" : getSubtitle(item)}</span> : null}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -832,7 +832,10 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
     expect(loadDataset).toHaveBeenCalledWith("dataset-a");
@@ -973,7 +976,10 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
 
@@ -1018,7 +1024,10 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
 
@@ -1088,7 +1097,10 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
     await changeField(field(container, "Item ID"), "item_0007");
@@ -1164,7 +1176,10 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
     expect(field(container, "Caption prompt").value).toContain("Write a long detailed description for this image.");
@@ -1245,7 +1260,10 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
     await changeField(field(container, "Method"), "metadata");
@@ -1313,7 +1331,10 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...container.querySelectorAll(".training-dataset-row")].find((button) => button.textContent.includes("Portrait Set")).click();
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
     });
     await settle();
     expect(field(container, "Trigger words").value).toBe("Portrait Set");
@@ -2196,6 +2217,61 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("network hiccup");
     expect(container.querySelectorAll(".asset-preview-chip")).toHaveLength(1);
     expect(container.textContent).toContain("Beta");
+  });
+
+  it("switches the active character via the compact selector (sc-2025)", async () => {
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      archiveCharacter: () => {},
+      assets: [],
+      attachCharacterLora: () => {},
+      characters: [
+        { id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
+        { id: "char-2", name: "Dax", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
+      ],
+      createCharacter: () => {},
+      createCharacterLook: () => {},
+      createCharacterTestJob: () => {},
+      deleteAsset: () => {},
+      deleteCharacterLook: () => {},
+      detachCharacterLora: () => {},
+      imageModels: [],
+      latestImageAssets: [],
+      loras: [],
+      setPreviewAsset: () => {},
+      sendCharacterToImage: () => {},
+      sendCharacterToVideo: () => {},
+      purgeAsset: () => {},
+      removeCharacterReference: () => {},
+      updateAssetStatus: () => {},
+      updateCharacter: () => {},
+      updateCharacterLook: () => {},
+      updateCharacterLora: () => {},
+      updateCharacterReference: () => {},
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+
+    // The full-height character list is replaced by a compact selector pill.
+    expect(container.querySelector(".character-list")).toBeNull();
+    const pill = container.querySelector(".compact-selector-pill");
+    expect(pill.textContent).toContain("Mira");
+    expect(field(container, "Name").value).toBe("Mira");
+
+    // Open the dropdown and switch to the second character.
+    await act(async () => {
+      pill.click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Dax")).click();
+    });
+
+    expect(field(container, "Name").value).toBe("Dax");
+    expect(container.querySelector(".compact-selector-pill").textContent).toContain("Dax");
   });
 
   it("fires a one-click angle-set batch job from the Character Studio panel", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -9,6 +9,7 @@ import {
   CharacterTest,
   editableLora,
 } from "./characterPanels.jsx";
+import { CompactSelector } from "../components/CompactSelector.jsx";
 import { extractFamilies } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
 
@@ -79,6 +80,16 @@ export function CharacterStudio() {
   );
   const selectedCharacter = characters.find((item) => item.id === selectedCharacterId) ?? characters[0] ?? null;
   const approvedReferences = selectedCharacter?.approvedReferences ?? [];
+  // Thumbnail for the compact selector (sc-2025): a character's first approved
+  // reference image, falling back to any reference. Null → placeholder tile.
+  const characterThumbAsset = (character) => {
+    const references = character?.references ?? [];
+    const reference = references.find((item) => item.approved) ?? references[0];
+    if (!reference?.assetId) {
+      return null;
+    }
+    return imageAssets.find((asset) => asset.id === reference.assetId) ?? null;
+  };
   // Multi-backbone model picker for the angle set + pose library (sc-2003).
   // Each backbone declares ui.viewAngles / ui.poseLibrary in the manifest;
   // the worker dispatch handles per-backbone angle / pose loops (InstantID
@@ -302,20 +313,19 @@ export function CharacterStudio() {
         <div className="empty-panel">No characters yet</div>
       ) : (
         <div className="character-layout">
-          <aside className="character-list">
-            {characters.map((character) => (
-              <button
-                className={character.id === selectedCharacter.id ? "character-row active" : "character-row"}
-                key={character.id}
-                onClick={() => setSelectedCharacterId(character.id)}
-                type="button"
-              >
-                <strong>{character.name}</strong>
-                <span>{typeLabel(character.type)}</span>
-                <small>{character.references?.length ?? 0} refs</small>
-              </button>
-            ))}
-          </aside>
+          <div className="character-selector-bar">
+            <CompactSelector
+              getSubtitle={(character) =>
+                `${typeLabel(character.type)} · ${character.references?.length ?? 0} ref${(character.references?.length ?? 0) === 1 ? "" : "s"}`
+              }
+              getThumbAsset={characterThumbAsset}
+              items={characters}
+              label="Select character"
+              onSelect={(character) => setSelectedCharacterId(character.id)}
+              placeholder="Select a character"
+              selectedId={selectedCharacter.id}
+            />
+          </div>
 
           <section className="character-detail">
             <form className="character-editor" onSubmit={saveCharacter}>

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useAppContext } from "../context/AppContext.js";
 import { API_BASE_URL } from "../api.js";
 import { AssetThumbnail, assetCanRenderAsImage } from "../components/assetMedia.jsx";
+import { CompactSelector } from "../components/CompactSelector.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
@@ -193,10 +194,6 @@ const defaultCaptionSettings = {
   captionPrompt: "",
   lowVram: false,
 };
-
-function formatDatasetModality(dataset) {
-  return String(dataset.modality ?? "image").replaceAll("_", " ");
-}
 
 function datasetItemCount(dataset) {
   const value = Number(dataset.itemCount ?? dataset.items?.length ?? 0);
@@ -956,6 +953,15 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
     return map;
   }, [activeDataset, importedCaptions]);
+  // Thumbnail for the compact dataset selector (sc-2025): the open dataset's
+  // first member, else a list summary's first item asset if resolvable.
+  const datasetThumbAsset = (dataset) => {
+    if (dataset?.id === selectedDatasetId && memberAssets[0]) {
+      return memberAssets[0];
+    }
+    const firstItemAssetId = (dataset?.items ?? []).find((item) => item.assetId)?.assetId;
+    return firstItemAssetId ? assetsById.get(firstItemAssetId) ?? null : null;
+  };
   const health = useMemo(
     () => datasetHealth({ activeDataset, imageAssets, selectedAssetIds }),
     [activeDataset, imageAssets, selectedAssetIds],
@@ -1576,6 +1582,19 @@ export function TrainingStudio({ mode = "training" } = {}) {
                       <h3>{active.title}</h3>
                     </div>
                     <div className="training-head-actions">
+                      <CompactSelector
+                        busyId={busyDatasetId}
+                        getSubtitle={(dataset) => {
+                          const count = datasetItemCount(dataset);
+                          return `${count} item${count === 1 ? "" : "s"}`;
+                        }}
+                        getThumbAsset={datasetThumbAsset}
+                        items={datasets}
+                        label="Select dataset"
+                        onSelect={(dataset) => openDataset(dataset.id)}
+                        placeholder={activeDataset ? activeDataset.name : "New dataset"}
+                        selectedId={selectedDatasetId}
+                      />
                       <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
                         <Icon.Search size={14} />
                         {loadingDatasets ? "Refreshing" : "Refresh"}
@@ -1590,30 +1609,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
                   {datasetError ? <p className="inline-warning">{datasetError}</p> : null}
                   {datasetMessage ? <p className="inline-success">{datasetMessage}</p> : null}
                   <div className="training-dataset-workspace">
-                    <aside className="training-dataset-list-panel">
-                      {loadingDatasets ? <div className="empty-panel compact-panel">Loading training datasets</div> : null}
-                      {!loadingDatasets && datasets.length === 0 ? <div className="empty-panel compact-panel">No training datasets yet</div> : null}
-                      {datasets.map((dataset) => {
-                        const itemCount = datasetItemCount(dataset);
-                        return (
-                          <button
-                            aria-pressed={selectedDatasetId === dataset.id}
-                            className={selectedDatasetId === dataset.id ? "training-dataset-row active" : "training-dataset-row"}
-                            disabled={busyDatasetId === dataset.id}
-                            key={dataset.id}
-                            onClick={() => openDataset(dataset.id)}
-                            type="button"
-                          >
-                            <div>
-                              <strong>{dataset.name ?? dataset.id}</strong>
-                              <span>{formatDatasetModality(dataset)} dataset</span>
-                            </div>
-                            <span>{busyDatasetId === dataset.id ? "Opening" : `${itemCount} item${itemCount === 1 ? "" : "s"}`}</span>
-                          </button>
-                        );
-                      })}
-                    </aside>
-
+                    {loadingDatasets ? <div className="empty-panel compact-panel">Loading training datasets</div> : null}
+                    {!loadingDatasets && datasets.length === 0 ? (
+                      <div className="empty-panel compact-panel">No training datasets yet — use “New” to start one.</div>
+                    ) : null}
                     <div className="training-dataset-editor">
                       <div className="training-dataset-form">
                         <label>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -534,6 +534,144 @@ button:focus-visible {
   cursor: not-allowed;
 }
 
+/* Compact Workspace-style selector (sc-2025): character / dataset switcher */
+.compact-selector {
+  position: relative;
+}
+
+.compact-selector-pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: auto;
+  min-width: 200px;
+  max-width: 320px;
+  padding: 6px 10px;
+  border-radius: var(--r-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  text-align: left;
+  color: var(--text);
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+
+.compact-selector-pill:hover:not(:disabled) {
+  border-color: var(--border-strong);
+}
+
+.compact-selector-pill[aria-expanded="true"] {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+}
+
+.compact-selector-thumb {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(45deg, color-mix(in oklch, var(--accent) 24%, transparent) 0 4px, transparent 4px 8px),
+    color-mix(in oklch, var(--warm) 18%, var(--surface));
+}
+
+.compact-selector-thumb img,
+.compact-selector-thumb video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.compact-selector-meta,
+.compact-selector-label {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.compact-selector-meta strong,
+.compact-selector-label strong {
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-selector-meta span,
+.compact-selector-label span {
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-selector-pill .chev {
+  margin-left: auto;
+  opacity: 0.5;
+  flex: 0 0 auto;
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.compact-selector-pill[aria-expanded="true"] .chev {
+  transform: rotate(180deg);
+}
+
+.compact-selector-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 30;
+  display: grid;
+  gap: 2px;
+  min-width: 100%;
+  width: max-content;
+  max-width: 360px;
+  padding: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-lg);
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.compact-selector-empty {
+  margin: 0;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.compact-selector-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  width: 100%;
+  transition: background var(--t-fast);
+}
+
+.compact-selector-item:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.compact-selector-item.active {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+[data-theme="dark"] .compact-selector-item.active {
+  color: var(--accent);
+}
+
 .project-list {
   display: grid;
   gap: 4px;
@@ -1666,9 +1804,7 @@ label {
 .training-empty-state,
 .training-panel,
 .training-live-panel,
-.training-dataset-row,
 .training-step-block,
-.training-dataset-list-panel,
 .training-dataset-editor,
 .training-advanced-panel {
   border: 1px solid var(--border);
@@ -1693,7 +1829,6 @@ label {
 }
 
 .training-metrics span,
-.training-dataset-row span,
 .training-step-block span,
 .training-empty-state span,
 .training-tabs small {
@@ -1831,12 +1966,10 @@ label {
 
 .training-dataset-workspace {
   display: grid;
-  grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
   gap: 14px;
   align-items: start;
 }
 
-.training-dataset-list-panel,
 .training-dataset-editor {
   display: grid;
   gap: 10px;
@@ -1844,35 +1977,10 @@ label {
   padding: 12px;
 }
 
-.training-dataset-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  width: 100%;
-  padding: 12px;
-  text-align: left;
-  background: var(--surface);
-  color: var(--text);
-}
-
-.training-dataset-row:hover:not(:disabled),
-.training-dataset-row.active {
-  border-color: color-mix(in oklch, var(--accent) 55%, var(--border));
-  background: var(--surface-hover);
-}
-
-.training-dataset-row > div,
 .training-step-block {
   display: grid;
   gap: 4px;
   min-width: 0;
-}
-
-.training-dataset-row strong {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .training-dataset-form {
@@ -3066,7 +3174,6 @@ label {
 .preset-list,
 .preset-editor,
 .preset-row,
-.character-list,
 .character-editor,
 .character-section,
 .reference-card,
@@ -3311,16 +3418,21 @@ label {
 }
 
 /* ---------- Characters / presets ---------- */
-.character-layout,
-.preset-layout {
+.character-layout {
   display: grid;
-  grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
   gap: 16px;
   align-items: start;
 }
 
+.character-selector-bar {
+  display: flex;
+}
+
 .preset-layout {
+  display: grid;
   grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
 }
 
 /* Preset create/edit share the same guided flow; edit keeps the selector rail. */
@@ -4150,40 +4262,6 @@ label {
   color: var(--text);
 }
 
-.character-list {
-  display: grid;
-  gap: 8px;
-  padding: 10px;
-}
-
-.character-row {
-  display: grid;
-  gap: 4px;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  border-radius: var(--r-sm);
-  color: var(--text);
-  padding: 10px;
-  text-align: left;
-  transition: border-color var(--t-fast), background var(--t-fast);
-}
-
-.character-row:hover {
-  border-color: var(--border-strong);
-}
-
-.character-row.active {
-  border-color: transparent;
-  background: var(--accent-soft);
-  color: var(--accent-strong);
-}
-
-[data-theme="dark"] .character-row.active {
-  color: var(--text);
-}
-
-.character-row span,
-.character-row small,
 .reference-card span,
 .look-row span,
 .look-row small,


### PR DESCRIPTION
## Summary

Implements **sc-2025** (epic 2019): replaces the full-height left-column selectors in **Character Studio** and the **Dataset editor** with a compact Workspace-style dropdown (thumbnail + name → list to switch). The reclaimed horizontal space goes to the actual content, which now spans a single column.

## Changes

- **New `apps/web/src/components/CompactSelector.jsx`** — reusable switcher built on the existing `ProjectSwitcher` pattern (outside-click + Escape close, thumbnail tile via `AssetThumbnail`, name + subtitle, busy state). Item creation stays with each screen's own affordances.
- **Character Studio** — the `.character-list` aside becomes a `CompactSelector` (thumbnail = the character's first approved/any reference image; subtitle = type + ref count). Single-column layout.
- **Dataset editor** — the `.training-dataset-list-panel` aside becomes a `CompactSelector` in the head actions row next to Refresh/New (opens the dataset, shows an "Opening…" busy state, thumbnail = the open dataset's first member). Single-column editor.
- Removed the now-dead `.character-list`/`.character-row` and `.training-dataset-list-panel`/`.training-dataset-row` CSS and the unused `formatDatasetModality` helper.

## Tests

- The 7 existing dataset tests now open a dataset through the dropdown (`.compact-selector-pill` → `.compact-selector-item`).
- Added a Character Studio test: asserts no `.character-list`, the pill reflects the active character, and switching via the dropdown updates the editor.
- Web suite **242 pass**, scaffold check + production build green.

## Verification note

Reaching these screens in a live browser needs the Rust API plus a project with characters/datasets, which the Vite dev-server preview can't exercise alone. The vitest tests render the real components and drive the actual selector switching + single-column layout assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)