### PR TITLE
feat(studio): in-dropdown "+ New" item + dataset cover thumbnails (sc…

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -839,6 +839,11 @@ async fn training_dataset_routes_persist_and_validate_project_assets() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(listed[0]["id"], dataset_id);
     assert_eq!(listed[0]["itemCount"], 1);
+    // The summary carries a cover thumbnail path (sc-2025) for the dataset selector.
+    assert_eq!(
+        listed[0]["coverPath"],
+        format!("training/datasets/{dataset_id}/images/item_0001.png")
+    );
 
     let reloaded_app = create_app(settings).expect("app reloads");
     let (status, detail) = request(

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -274,29 +274,6 @@ function ProjectSwitcher({ activeProject, projects, onSelect, onCreate, disabled
 
       {open ? (
         <div className="project-menu" role="listbox">
-          {projects.length === 0 ? (
-            <p className="project-menu-empty">No workspaces yet — create the first one below.</p>
-          ) : (
-            projects.map((project) => (
-              <button
-                aria-selected={project.id === activeProject?.id}
-                className={project.id === activeProject?.id ? "project-menu-item active" : "project-menu-item"}
-                key={project.id}
-                onClick={() => {
-                  onSelect(project);
-                  setOpen(false);
-                  setCreating(false);
-                  setName("");
-                }}
-                role="option"
-                type="button"
-              >
-                <span className="project-menu-thumb" aria-hidden="true" />
-                <span className="project-menu-label">{project.name}</span>
-              </button>
-            ))
-          )}
-
           {creating ? (
             <form className="project-menu-create" onSubmit={submitNew}>
               <input
@@ -328,6 +305,31 @@ function ProjectSwitcher({ activeProject, projects, onSelect, onCreate, disabled
               <Icon.Plus />
               <span className="project-menu-label">New workspace</span>
             </button>
+          )}
+
+          {projects.length ? <div className="project-menu-divider" role="separator" /> : null}
+
+          {projects.length === 0 ? (
+            <p className="project-menu-empty">No workspaces yet — create the first one above.</p>
+          ) : (
+            projects.map((project) => (
+              <button
+                aria-selected={project.id === activeProject?.id}
+                className={project.id === activeProject?.id ? "project-menu-item active" : "project-menu-item"}
+                key={project.id}
+                onClick={() => {
+                  onSelect(project);
+                  setOpen(false);
+                  setCreating(false);
+                  setName("");
+                }}
+                role="option"
+                type="button"
+              >
+                <span className="project-menu-thumb" aria-hidden="true" />
+                <span className="project-menu-label">{project.name}</span>
+              </button>
+            ))
           )}
         </div>
       ) : null}

--- a/apps/web/src/components/CompactSelector.jsx
+++ b/apps/web/src/components/CompactSelector.jsx
@@ -11,6 +11,8 @@ export function CompactSelector({
   items = [],
   selectedId = "",
   onSelect,
+  onCreate,
+  createLabel = "New",
   getThumbAsset = () => null,
   getSubtitle = () => "",
   busyId = "",
@@ -76,8 +78,28 @@ export function CompactSelector({
 
       {open ? (
         <div className="compact-selector-menu" role="listbox">
+          {onCreate ? (
+            <>
+              <button
+                className="compact-selector-item compact-selector-create"
+                onClick={() => {
+                  onCreate();
+                  setOpen(false);
+                }}
+                type="button"
+              >
+                <span className="compact-selector-thumb compact-selector-create-thumb" aria-hidden="true">
+                  <Icon.Plus />
+                </span>
+                <span className="compact-selector-label">
+                  <strong>{createLabel}</strong>
+                </span>
+              </button>
+              {items.length ? <div className="compact-selector-divider" role="separator" /> : null}
+            </>
+          ) : null}
           {items.length === 0 ? (
-            <p className="compact-selector-empty">{emptyLabel}</p>
+            onCreate ? null : <p className="compact-selector-empty">{emptyLabel}</p>
           ) : (
             items.map((item) => (
               <button

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -945,6 +945,39 @@ describe("SceneWorks app shell", () => {
     );
   });
 
+  it("shows a cover thumbnail per dataset and a New dataset item in the selector (sc-2025)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withTrainingDataSetsLibraryContext({
+          activeProject: { id: "project-a", name: "Project A" },
+          assets: [],
+          datasets: [
+            { id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 3, coverPath: "training/datasets/dataset-a/images/item_0001.png" },
+          ],
+        }),
+      );
+    });
+
+    // Pill shows the New-dataset draft placeholder before anything is opened.
+    expect(container.querySelector(".compact-selector-pill").textContent).toContain("New dataset");
+
+    await act(async () => {
+      container.querySelector(".compact-selector-pill").click();
+    });
+
+    // A "New dataset" create item sits at the top of the dropdown.
+    expect(container.querySelector(".compact-selector-create").textContent).toContain("New dataset");
+
+    // Every dataset row renders its server-provided cover thumbnail.
+    const datasetItem = [...container.querySelectorAll(".compact-selector-item")].find((button) =>
+      button.textContent.includes("Portrait Set"),
+    );
+    const cover = datasetItem.querySelector("img");
+    expect(cover).not.toBeNull();
+    expect(cover.getAttribute("src")).toContain("training/datasets/dataset-a/images/item_0001.png");
+  });
+
   it("lets users remove unavailable dataset assets before saving", async () => {
     const loadDataset = vi.fn(async () => ({
       id: "dataset-a",
@@ -2272,6 +2305,61 @@ describe("SceneWorks app shell", () => {
 
     expect(field(container, "Name").value).toBe("Dax");
     expect(container.querySelector(".compact-selector-pill").textContent).toContain("Dax");
+  });
+
+  it("creates a character from the selector's New item (sc-2025)", async () => {
+    const createCharacter = vi.fn(async (payload) => ({
+      id: "char-new",
+      ...payload,
+      references: [],
+      approvedReferences: [],
+      looks: [],
+      loras: [],
+    }));
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      archiveCharacter: () => {},
+      assets: [],
+      attachCharacterLora: () => {},
+      characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+      createCharacter,
+      createCharacterLook: () => {},
+      createCharacterTestJob: () => {},
+      deleteAsset: () => {},
+      deleteCharacterLook: () => {},
+      detachCharacterLora: () => {},
+      imageModels: [],
+      latestImageAssets: [],
+      loras: [],
+      setPreviewAsset: () => {},
+      sendCharacterToImage: () => {},
+      sendCharacterToVideo: () => {},
+      purgeAsset: () => {},
+      removeCharacterReference: () => {},
+      updateAssetStatus: () => {},
+      updateCharacter: () => {},
+      updateCharacterLook: () => {},
+      updateCharacterLora: () => {},
+      updateCharacterReference: () => {},
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+
+    // No inline header create form anymore — creation lives in the dropdown.
+    expect([...container.querySelectorAll("input")].some((input) => input.getAttribute("aria-label") === "Character name")).toBe(false);
+
+    await act(async () => {
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      container.querySelector(".compact-selector-create").click();
+    });
+
+    expect(createCharacter).toHaveBeenCalledWith(expect.objectContaining({ name: "New character", type: "person" }));
   });
 
   it("fires a one-click angle-set batch job from the Character Studio panel", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -61,7 +61,6 @@ export function CharacterStudio() {
   const onSendVideo = sendCharacterToVideo;
   const [selectedCharacterId, setSelectedCharacterId] = useState(characters[0]?.id ?? "");
   const [draft, setDraft] = useState({ name: "", type: "person", description: "" });
-  const [newCharacter, setNewCharacter] = useState({ name: "", type: "person", description: "" });
   const [referenceAssetIds, setReferenceAssetIds] = useState([]);
   const [lookDraft, setLookDraft] = useState({ name: "", description: "" });
   const [selectedReferenceIds, setSelectedReferenceIds] = useState([]);
@@ -156,12 +155,13 @@ export function CharacterStudio() {
     }
   }, [imageModels, testModel]);
 
-  async function submitNewCharacter(event) {
-    event.preventDefault();
-    const created = await createCharacter(newCharacter);
+  // Create a draft character straight from the selector's "+ New character"
+  // item (sc-2025) — name and type are then edited in the detail form, mirroring
+  // the dataset "+ New dataset" flow.
+  async function createDraftCharacter() {
+    const created = await createCharacter({ name: "New character", type: "person", description: "" });
     if (created) {
       setSelectedCharacterId(created.id);
-      setNewCharacter({ name: "", type: "person", description: "" });
     }
   }
 
@@ -285,48 +285,29 @@ export function CharacterStudio() {
           <p className="eyebrow">Character Studio</p>
           <h2>{activeProject ? activeProject.name : "Create a project"}</h2>
         </div>
-        <form className="inline-create" onSubmit={submitNewCharacter}>
-          <input
-            aria-label="Character name"
-            onChange={(event) => setNewCharacter((item) => ({ ...item, name: event.target.value }))}
-            placeholder="New character"
-            value={newCharacter.name}
-          />
-          <select
-            aria-label="Character type"
-            onChange={(event) => setNewCharacter((item) => ({ ...item, type: event.target.value }))}
-            value={newCharacter.type}
-          >
-            {characterTypes.map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-          <button disabled={!activeProject || !newCharacter.name.trim()} type="submit">
-            Create
-          </button>
-        </form>
       </div>
 
-      {!selectedCharacter ? (
-        <div className="empty-panel">No characters yet</div>
-      ) : (
-        <div className="character-layout">
-          <div className="character-selector-bar">
-            <CompactSelector
-              getSubtitle={(character) =>
-                `${typeLabel(character.type)} · ${character.references?.length ?? 0} ref${(character.references?.length ?? 0) === 1 ? "" : "s"}`
-              }
-              getThumbAsset={characterThumbAsset}
-              items={characters}
-              label="Select character"
-              onSelect={(character) => setSelectedCharacterId(character.id)}
-              placeholder="Select a character"
-              selectedId={selectedCharacter.id}
-            />
-          </div>
+      <div className="character-layout">
+        <div className="character-selector-bar">
+          <CompactSelector
+            createLabel="New character"
+            disabled={!activeProject}
+            getSubtitle={(character) =>
+              `${typeLabel(character.type)} · ${character.references?.length ?? 0} ref${(character.references?.length ?? 0) === 1 ? "" : "s"}`
+            }
+            getThumbAsset={characterThumbAsset}
+            items={characters}
+            label="Select character"
+            onCreate={createDraftCharacter}
+            onSelect={(character) => setSelectedCharacterId(character.id)}
+            placeholder="Select a character"
+            selectedId={selectedCharacter?.id ?? ""}
+          />
+        </div>
 
+        {!selectedCharacter ? (
+          <div className="empty-panel">No characters yet — use “New character” to start.</div>
+        ) : (
           <section className="character-detail">
             <form className="character-editor" onSubmit={saveCharacter}>
               <div className="control-grid">
@@ -465,8 +446,8 @@ export function CharacterStudio() {
               updateAssetStatus={updateAssetStatus}
             />
           </section>
-        </div>
-      )}
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -953,14 +953,17 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
     return map;
   }, [activeDataset, importedCaptions]);
-  // Thumbnail for the compact dataset selector (sc-2025): the open dataset's
-  // first member, else a list summary's first item asset if resolvable.
+  // Thumbnail for the compact dataset selector (sc-2025): the list summary's
+  // server-resolved cover image (first item), falling back to the open dataset's
+  // first loaded member.
   const datasetThumbAsset = (dataset) => {
+    if (dataset?.coverPath) {
+      return { projectId: activeProject?.id, type: "image", file: { path: dataset.coverPath } };
+    }
     if (dataset?.id === selectedDatasetId && memberAssets[0]) {
       return memberAssets[0];
     }
-    const firstItemAssetId = (dataset?.items ?? []).find((item) => item.assetId)?.assetId;
-    return firstItemAssetId ? assetsById.get(firstItemAssetId) ?? null : null;
+    return null;
   };
   const health = useMemo(
     () => datasetHealth({ activeDataset, imageAssets, selectedAssetIds }),
@@ -1584,6 +1587,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                     <div className="training-head-actions">
                       <CompactSelector
                         busyId={busyDatasetId}
+                        createLabel="New dataset"
                         getSubtitle={(dataset) => {
                           const count = datasetItemCount(dataset);
                           return `${count} item${count === 1 ? "" : "s"}`;
@@ -1591,6 +1595,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                         getThumbAsset={datasetThumbAsset}
                         items={datasets}
                         label="Select dataset"
+                        onCreate={startNewDataset}
                         onSelect={(dataset) => openDataset(dataset.id)}
                         placeholder={activeDataset ? activeDataset.name : "New dataset"}
                         selectedId={selectedDatasetId}
@@ -1598,10 +1603,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
                       <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
                         <Icon.Search size={14} />
                         {loadingDatasets ? "Refreshing" : "Refresh"}
-                      </button>
-                      <button className="primary-action" onClick={startNewDataset} type="button">
-                        <Icon.Plus size={14} />
-                        New
                       </button>
                     </div>
                   </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -490,12 +490,15 @@ button:focus-visible {
 }
 
 .project-menu-item-new {
-  margin-top: 4px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
   color: var(--accent-strong);
   font-weight: 600;
-  border-radius: 0 0 var(--r-sm) var(--r-sm);
+}
+
+.project-menu-divider,
+.compact-selector-divider {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--border);
 }
 
 [data-theme="dark"] .project-menu-item-new {
@@ -505,9 +508,7 @@ button:focus-visible {
 .project-menu-create {
   display: flex;
   gap: 6px;
-  margin-top: 4px;
-  padding: 8px 6px 6px;
-  border-top: 1px solid var(--border);
+  padding: 6px;
 }
 
 .project-menu-create input {
@@ -670,6 +671,22 @@ button:focus-visible {
 
 [data-theme="dark"] .compact-selector-item.active {
   color: var(--accent);
+}
+
+.compact-selector-create {
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+[data-theme="dark"] .compact-selector-create {
+  color: var(--accent);
+}
+
+.compact-selector-create-thumb {
+  display: grid;
+  place-items: center;
+  background: var(--surface-hover);
+  color: var(--accent-strong);
 }
 
 .project-list {

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -116,6 +116,10 @@ pub struct TrainingDatasetSummary {
     pub item_count: usize,
     pub created_at: String,
     pub updated_at: String,
+    /// Project-relative path to the dataset's first item image, for a list
+    /// thumbnail (sc-2025). `None` when the dataset has no items.
+    #[serde(default)]
+    pub cover_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -942,29 +946,67 @@ fn list_dataset_summaries_from_index(
     let connection = Connection::open(project_path.join("project.db"))?;
     let mut statement = connection.prepare(
         "
-        select id, project_id, name, modality, status, version, item_count, created_at, updated_at
+        select id, project_id, name, modality, status, version, item_count, created_at, updated_at, file_path
           from training_datasets
          where project_id = ?1
          order by updated_at desc, name asc
         ",
     )?;
-    let summaries = statement
+    let rows = statement
         .query_map(params![project_id], |row| {
             let item_count: i64 = row.get(6)?;
-            Ok(TrainingDatasetSummary {
-                id: row.get(0)?,
-                project_id: row.get(1)?,
-                name: row.get(2)?,
-                modality: parse_string_enum(&row.get::<_, String>(3)?),
-                status: parse_string_enum(&row.get::<_, String>(4)?),
-                version: row.get(5)?,
-                item_count: usize::try_from(item_count).unwrap_or(0),
-                created_at: row.get(7)?,
-                updated_at: row.get(8)?,
-            })
+            Ok((
+                TrainingDatasetSummary {
+                    id: row.get(0)?,
+                    project_id: row.get(1)?,
+                    name: row.get(2)?,
+                    modality: parse_string_enum(&row.get::<_, String>(3)?),
+                    status: parse_string_enum(&row.get::<_, String>(4)?),
+                    version: row.get(5)?,
+                    item_count: usize::try_from(item_count).unwrap_or(0),
+                    created_at: row.get(7)?,
+                    updated_at: row.get(8)?,
+                    cover_path: None,
+                },
+                row.get::<_, Option<String>>(9)?,
+            ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
+    let summaries = rows
+        .into_iter()
+        .map(|(mut summary, manifest_rel)| {
+            summary.cover_path = manifest_rel
+                .as_deref()
+                .and_then(|rel| resolve_dataset_cover(project_path, &summary.id, rel));
+            summary
+        })
+        .collect();
     Ok(summaries)
+}
+
+/// Project-relative path to a dataset's first item image, read from its on-disk
+/// manifest. Powers the dataset list thumbnail (sc-2025) without storing a
+/// denormalized column. `None` when the manifest is unreadable or item-less.
+fn resolve_dataset_cover(
+    project_path: &Path,
+    dataset_id: &str,
+    manifest_rel: &str,
+) -> Option<String> {
+    let manifest = read_json(&project_path.join(manifest_rel)).ok()?;
+    let item_path = manifest
+        .get("items")?
+        .as_array()?
+        .first()?
+        .get("path")?
+        .as_str()?;
+    if !is_safe_relative_path(item_path) {
+        return None;
+    }
+    relative_string(
+        project_path,
+        &dataset_root(project_path, dataset_id).join(item_path),
+    )
+    .ok()
 }
 
 fn index_dataset(


### PR DESCRIPTION
…-2025)

Address review feedback on the compact selectors:
- CompactSelector gains an optional "+ New X" item pinned to the TOP of the dropdown, separated from existing items by a divider (matches the Workspace switcher pattern).
- Dataset editor: the standalone "+New" button is gone; "+ New dataset" lives in the selector dropdown and resets to a draft.
- Character Studio: the header inline-create form is gone; "+ New character" lives in the selector dropdown (creates a draft you rename in the editor). The selector now renders even with zero characters so the first one can be created.
- Workspace (ProjectSwitcher): "New workspace" moved to the top of the menu with a divider.
- Dataset cover thumbnails now show for every row, not just the open dataset: TrainingDatasetSummary carries a `coverPath` (first item image, resolved from the manifest in list_datasets); the selector renders it.

Tests: added Character "+ New" create, dataset cover + New-item, and a backend coverPath assertion. Web suite (244) + core/rust-api + scaffold + build green; parity snapshots unchanged.