### PR TITLE
Unified dataset image+caption cards + caption dialog (epic 2019)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -309,6 +309,11 @@ pub(crate) struct TrainingCaptionJobRequest {
     pub(crate) requested_gpu: String,
     #[serde(default)]
     pub(crate) options: TrainingCaptionOptions,
+    /// Restrict the job to these dataset item ids (sc-2025 per-image Re-Caption).
+    /// When present, only those items are captioned and they are always recaptioned;
+    /// when absent, the dataset-wide `recaption`/missing-caption rule applies.
+    #[serde(default)]
+    pub(crate) item_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -984,6 +984,22 @@ async fn training_dataset_routes_persist_and_validate_project_assets() {
     assert!(caption_image_path.contains(&dataset_id));
     assert!(caption_image_path.ends_with("item_0001.png"));
 
+    // sc-2025: itemIds targets a single image and recaptions it even though it
+    // already has a caption (recaption:false would otherwise skip it).
+    let (status, single_item_job) = request(
+        reloaded_app.clone(),
+        "POST",
+        &format!("/api/v1/projects/{project_id}/training/datasets/{dataset_id}/caption-jobs"),
+        json!({ "recaption": false, "itemIds": ["item_0001"] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let single_items = single_item_job["payload"]["items"]
+        .as_array()
+        .expect("caption items");
+    assert_eq!(single_items.len(), 1);
+    assert_eq!(single_items[0]["itemId"], "item_0001");
+
     let (status, renamed) = request(
         reloaded_app.clone(),
         "POST",

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -135,10 +135,19 @@ pub(crate) async fn create_training_dataset_caption_job(
             "Training dataset has no items to caption.",
         ));
     }
+    // sc-2025: a per-image Re-Caption targets specific item ids and always
+    // recaptions them; otherwise the dataset-wide recaption/missing rule applies.
+    let target_ids: Option<std::collections::HashSet<&str>> = payload
+        .item_ids
+        .as_ref()
+        .map(|ids| ids.iter().map(String::as_str).collect());
     let items = dataset
         .items
         .iter()
-        .filter(|item| payload.recaption || item.caption.text.trim().is_empty())
+        .filter(|item| match &target_ids {
+            Some(ids) => ids.contains(item.id.as_str()),
+            None => payload.recaption || item.caption.text.trim().is_empty(),
+        })
         .map(|item| {
             json!({
                 "itemId": item.id.clone(),

--- a/apps/web/src/components/DatasetCaptionDialog.jsx
+++ b/apps/web/src/components/DatasetCaptionDialog.jsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { Modal } from "./Modal.jsx";
+
+// Caption settings modal (sc-2025). One dialog drives both "Caption all" and a
+// single image's "Re-Caption" — the dataset editor owns the captioner settings
+// state and the job submission; this component only renders the controls and a
+// Run button scoped to the target.
+export function DatasetCaptionDialog({
+  settings,
+  onChange,
+  gpuOptions = [],
+  captionTypes = [],
+  captionLengths = [],
+  extraOptions = [],
+  promptValue = "",
+  scope,
+  running = false,
+  onRun,
+  onToggleExtra,
+  onClose,
+}) {
+  const single = scope?.type === "item";
+  const title = single ? `Re-caption ${scope.name ?? "image"}` : "Caption images";
+  const runLabel = single ? "Re-caption image" : settings.recaption ? "Re-caption all" : "Caption missing";
+  const joy = settings.captioner === "joy_caption";
+
+  return (
+    <Modal className="dataset-caption-modal" labelledBy="dataset-caption-title" onClose={onClose}>
+      <header className="dataset-caption-head">
+        <div>
+          <p className="eyebrow">Captioner</p>
+          <h2 id="dataset-caption-title">{title}</h2>
+        </div>
+        <button className="modal-close" onClick={onClose} type="button">
+          Close
+        </button>
+      </header>
+
+      <div className="dataset-caption-body">
+        <label>
+          Method
+          <select onChange={(event) => onChange("captioner", event.target.value)} value={settings.captioner}>
+            <option value="joy_caption">Joy Caption</option>
+            <option value="metadata">Metadata fallback</option>
+          </select>
+        </label>
+
+        {joy ? (
+          <>
+            <label>
+              Model
+              <input onChange={(event) => onChange("modelNameOrPath", event.target.value)} value={settings.modelNameOrPath} />
+            </label>
+            <label>
+              GPU
+              <select onChange={(event) => onChange("requestedGpu", event.target.value)} value={settings.requestedGpu}>
+                {gpuOptions.map((gpu) => (
+                  <option key={gpu} value={gpu}>
+                    {gpu}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="dataset-caption-row">
+              <label>
+                Type
+                <select onChange={(event) => onChange("captionType", event.target.value)} value={settings.captionType}>
+                  {captionTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Length
+                <select onChange={(event) => onChange("captionLength", event.target.value)} value={settings.captionLength}>
+                  {captionLengths.map((length) => (
+                    <option key={length} value={length}>
+                      {length}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <label>
+              Character name
+              <input onChange={(event) => onChange("nameInput", event.target.value)} value={settings.nameInput} />
+            </label>
+            <label>
+              Caption prompt
+              <textarea onChange={(event) => onChange("captionPrompt", event.target.value)} rows={6} value={promptValue} />
+            </label>
+            <div className="dataset-caption-row">
+              <label>
+                Temperature
+                <input
+                  max="2"
+                  min="0"
+                  onChange={(event) => onChange("temperature", event.target.value)}
+                  step="0.05"
+                  type="number"
+                  value={settings.temperature}
+                />
+              </label>
+              <label>
+                Top P
+                <input
+                  max="1"
+                  min="0"
+                  onChange={(event) => onChange("topP", event.target.value)}
+                  step="0.05"
+                  type="number"
+                  value={settings.topP}
+                />
+              </label>
+              <label>
+                Max tokens
+                <input
+                  max="1024"
+                  min="1"
+                  onChange={(event) => onChange("maxNewTokens", event.target.value)}
+                  step="1"
+                  type="number"
+                  value={settings.maxNewTokens}
+                />
+              </label>
+            </div>
+            <label className="training-toggle-line">
+              <input checked={settings.lowVram} onChange={(event) => onChange("lowVram", event.target.checked)} type="checkbox" />
+              <span>Low VRAM</span>
+            </label>
+            {single ? null : (
+              <label className="training-toggle-line">
+                <input checked={settings.recaption} onChange={(event) => onChange("recaption", event.target.checked)} type="checkbox" />
+                <span>Re-caption images that already have a caption</span>
+              </label>
+            )}
+            <div className="dataset-caption-options">
+              {extraOptions.map((option) => (
+                <label className="training-toggle-line" key={option.value}>
+                  <input
+                    checked={settings.extraOptions.includes(option.value)}
+                    onChange={() => onToggleExtra(option.value)}
+                    type="checkbox"
+                  />
+                  <span>{option.label}</span>
+                </label>
+              ))}
+            </div>
+          </>
+        ) : null}
+      </div>
+
+      <footer className="dataset-caption-footer">
+        <button onClick={onClose} type="button">
+          Cancel
+        </button>
+        <button className="primary-action" disabled={running} onClick={onRun} type="button">
+          {running ? "Queuing…" : runLabel}
+        </button>
+      </footer>
+    </Modal>
+  );
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -840,8 +840,8 @@ describe("SceneWorks app shell", () => {
     await settle();
     expect(loadDataset).toHaveBeenCalledWith("dataset-a");
     // The editor body shows only the dataset's own member (asset-a), not all assets.
-    expect(container.querySelectorAll(".training-member-card")).toHaveLength(1);
-    expect(container.querySelector(".training-member-grid").textContent).toContain("Mira.png");
+    expect(container.querySelectorAll(".training-caption-card")).toHaveLength(1);
+    expect(container.querySelector(".training-caption-grid").textContent).toContain("Mira.png");
 
     // Add the second asset through the Asset Library tab (current members excluded).
     await act(async () => {
@@ -935,7 +935,7 @@ describe("SceneWorks app shell", () => {
 
     // The editor body is the member grid only — no all-asset picker remains.
     expect(container.querySelector(".training-asset-picker")).toBeNull();
-    expect(container.querySelector(".training-member-grid").textContent).toContain("Kelsie hero.png");
+    expect(container.querySelector(".training-caption-grid").textContent).toContain("Kelsie hero.png");
 
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Create dataset").click();
@@ -1069,22 +1069,19 @@ describe("SceneWorks app shell", () => {
     expect(updateDataset).not.toHaveBeenCalled();
   });
 
-  it("renames dataset items and writes caption sidecars", async () => {
-    const renamedDataset = {
-      id: "dataset-a",
-      name: "Portrait Set",
-      version: 4,
-      items: [
-        {
-          id: "item_0007",
-          assetId: "asset-a",
-          path: "images/mira_0007.png",
-          displayName: "mira_0007.png",
-          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
-        },
-      ],
-    };
-    const loadDataset = vi.fn(async () => ({
+  // Open the lone "Portrait Set" dataset through the compact selector.
+  async function openPortraitSet() {
+    await act(async () => {
+      container.querySelector(".compact-selector-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
+    });
+    await settle();
+  }
+
+  function singleItemDataset() {
+    return {
       id: "dataset-a",
       name: "Portrait Set",
       version: 3,
@@ -1094,26 +1091,111 @@ describe("SceneWorks app shell", () => {
           assetId: "asset-a",
           path: "images/item_0001.png",
           displayName: "item_0001.png",
-          caption: { text: "mira portrait", source: "manual", triggerWords: ["mira"] },
+          caption: { text: "mira portrait", source: "manual", triggerWords: [] },
         },
       ],
-    }));
-    const batchRenameDataset = vi.fn(async () => renamedDataset);
-    const writeCaptionSidecars = vi.fn(async () => ({
-      dataset: {
-        ...renamedDataset,
-        version: 5,
-        items: [
-          {
-            ...renamedDataset.items[0],
-            caption: { text: "mira studio portrait", source: "manual", triggerWords: ["mira", "studio"] },
-          },
-        ],
-      },
-      sidecars: [{ itemId: "item_0007", captionPath: "training/datasets/dataset-a/images/mira_0007.txt" }],
-    }));
-    const createCaptionJob = vi.fn(async () => ({ id: "job-caption-1", type: "training_caption" }));
+    };
+  }
 
+  it("edits a caption inline and saves it with the dataset (sc-2025)", async () => {
+    const updateDataset = vi.fn(async (datasetId, payload) => ({ id: datasetId, name: payload.name, version: 4, items: payload.items }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withTrainingDataSetsLibraryContext({
+          activeProject: { id: "project-a", name: "Project A" },
+          assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
+          datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
+          loadDataset: vi.fn(async () => singleItemDataset()),
+          updateDataset,
+        }),
+      );
+    });
+    await openPortraitSet();
+
+    const caption = container.querySelector(".training-caption-card-text");
+    expect(caption.value).toBe("mira portrait");
+    await changeField(caption, "mira studio portrait");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Save dataset").click();
+    });
+
+    expect(updateDataset).toHaveBeenCalledWith(
+      "dataset-a",
+      expect.objectContaining({
+        items: [expect.objectContaining({ assetId: "asset-a", caption: expect.objectContaining({ text: "mira studio portrait", source: "manual" }) })],
+      }),
+    );
+  });
+
+  it("queues a caption job for all images via the caption dialog (sc-2025)", async () => {
+    const updateDataset = vi.fn(async (datasetId, payload) => ({ id: datasetId, name: payload.name, version: 4, items: singleItemDataset().items }));
+    const createCaptionJob = vi.fn(async () => ({ id: "job-caption-1", type: "training_caption" }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withTrainingDataSetsLibraryContext({
+          activeProject: { id: "project-a", name: "Project A" },
+          assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
+          createCaptionJob,
+          datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
+          loadDataset: vi.fn(async () => singleItemDataset()),
+          updateDataset,
+        }),
+      );
+    });
+    await openPortraitSet();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Caption all").click();
+    });
+    // The dialog prefills the character name from the dataset.
+    expect(field(container, "Character name").value).toBe("Portrait Set");
+    await act(async () => {
+      [...container.querySelectorAll(".dataset-caption-footer button")].find((button) => button.textContent.startsWith("Caption")).click();
+    });
+    await settle();
+
+    expect(createCaptionJob).toHaveBeenCalledWith("dataset-a", expect.objectContaining({ captioner: "joy_caption" }));
+    expect(createCaptionJob.mock.calls[0][1].itemIds).toBeUndefined();
+    expect(container.textContent).toContain("Caption job queued (job-caption-1)");
+  });
+
+  it("re-captions a single image with the itemIds filter (sc-2025)", async () => {
+    const updateDataset = vi.fn(async (datasetId, payload) => ({ id: datasetId, name: payload.name, version: 4, items: singleItemDataset().items }));
+    const createCaptionJob = vi.fn(async () => ({ id: "job-caption-2", type: "training_caption" }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withTrainingDataSetsLibraryContext({
+          activeProject: { id: "project-a", name: "Project A" },
+          assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
+          createCaptionJob,
+          datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
+          loadDataset: vi.fn(async () => singleItemDataset()),
+          updateDataset,
+        }),
+      );
+    });
+    await openPortraitSet();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Re-Caption").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll(".dataset-caption-footer button")].find((button) => button.textContent.startsWith("Re-caption")).click();
+    });
+    await settle();
+
+    expect(createCaptionJob).toHaveBeenCalledWith(
+      "dataset-a",
+      expect.objectContaining({ itemIds: ["item_0001"], recaption: true }),
+    );
+  });
+
+  it("applies ordered names to the dataset from the toolbar (sc-2025)", async () => {
+    const updateDataset = vi.fn(async (datasetId, payload) => ({ id: datasetId, name: payload.name, version: 4, items: singleItemDataset().items }));
+    const batchRenameDataset = vi.fn(async (datasetId) => ({ ...singleItemDataset(), id: datasetId, version: 5 }));
     root = createRoot(container);
     await act(async () => {
       root.render(
@@ -1121,269 +1203,25 @@ describe("SceneWorks app shell", () => {
           activeProject: { id: "project-a", name: "Project A" },
           assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
           batchRenameDataset,
-          createCaptionJob,
           datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
-          loadDataset,
-          writeCaptionSidecars,
+          loadDataset: vi.fn(async () => singleItemDataset()),
+          updateDataset,
         }),
       );
     });
+    await openPortraitSet();
 
     await act(async () => {
-      container.querySelector(".compact-selector-pill").click();
-    });
-    await act(async () => {
-      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
-    });
-    await settle();
-    await changeField(field(container, "Item ID"), "item_0007");
-    await changeField(field(container, "File stem"), "mira_0007");
-    await changeField(field(container, "Display name"), "mira_0007.png");
-    await changeField(field(container, "Caption"), "mira studio portrait");
-    await changeField(field(container, "Trigger words"), "mira, studio");
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Captions").click();
+      [...container.querySelectorAll("button")].find((button) => button.textContent.includes("Apply ordered names")).click();
     });
     await settle();
 
-    expect(batchRenameDataset).toHaveBeenCalledWith("dataset-a", {
-      items: [
-        {
-          itemId: "item_0001",
-          newItemId: "item_0007",
-          fileStem: "mira_0007",
-          displayName: "mira_0007.png",
-        },
-      ],
-    });
-    expect(writeCaptionSidecars).toHaveBeenCalledWith("dataset-a", {
-      items: [
-        {
-          itemId: "item_0007",
-          caption: { text: "mira studio portrait", source: "manual", triggerWords: ["mira", "studio"] },
-        },
-      ],
-    });
-    expect(createCaptionJob).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Captions created (1)");
-  });
-
-  it("queues Joy Caption for missing training captions", async () => {
-    const loadDataset = vi.fn(async () => ({
-      id: "dataset-a",
-      name: "Portrait Set",
-      version: 3,
-      items: [
-        {
-          id: "item_0001",
-          assetId: "asset-a",
-          path: "images/item_0001.png",
-          displayName: "item_0001.png",
-          caption: { text: "", source: "manual", triggerWords: ["miraStyle"] },
-        },
-      ],
-    }));
-    const writeCaptionSidecars = vi.fn(async (datasetId, payload) => ({
-      dataset: {
-        id: datasetId,
-        name: "Portrait Set",
-        version: 4,
-        items: [{ id: "item_0001", assetId: "asset-a", path: "images/item_0001.png", caption: payload.items[0].caption }],
-      },
-      sidecars: [{ itemId: "item_0001", captionPath: "training/datasets/dataset-a/images/item_0001.txt" }],
-    }));
-    const createCaptionJob = vi.fn(async () => ({ id: "job-caption-1", type: "training_caption" }));
-
-    root = createRoot(container);
-    await act(async () => {
-      root.render(
-        withTrainingDataSetsLibraryContext({
-          activeProject: { id: "project-a", name: "Project A" },
-          assets: [{ id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } }],
-          createCaptionJob,
-          datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
-          loadDataset,
-          writeCaptionSidecars,
-        }),
-      );
-    });
-
-    await act(async () => {
-      container.querySelector(".compact-selector-pill").click();
-    });
-    await act(async () => {
-      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
-    });
-    await settle();
-    expect(field(container, "Caption prompt").value).toContain("Write a long detailed description for this image.");
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Captions").click();
-    });
-    await settle();
-
-    expect(writeCaptionSidecars).toHaveBeenCalledWith("dataset-a", {
-      items: [{ itemId: "item_0001", caption: { text: "", source: "manual", triggerWords: ["Portrait Set"] } }],
-    });
-    expect(createCaptionJob).toHaveBeenCalledWith(
+    expect(batchRenameDataset).toHaveBeenCalledWith(
       "dataset-a",
       expect.objectContaining({
-        captioner: "joy_caption",
-        recaption: false,
-        requestedGpu: "auto",
-        options: expect.objectContaining({
-          captionPrompt: "Write a long detailed description for this image.",
-        }),
+        items: [expect.objectContaining({ itemId: "item_0001", newItemId: "portrait_set_0001", fileStem: "portrait_set_0001" })],
       }),
     );
-    expect(container.textContent).toContain("Caption job queued (job-caption-1)");
-  });
-
-  it("uses metadata fallback for missing training captions before writing sidecars", async () => {
-    const loadDataset = vi.fn(async () => ({
-      id: "dataset-a",
-      name: "Portrait Set",
-      version: 3,
-      items: [
-        {
-          id: "item_0001",
-          assetId: "asset-a",
-          path: "images/item_0001.png",
-          displayName: "item_0001.png",
-          caption: { text: "", source: "manual", triggerWords: ["miraStyle"] },
-        },
-      ],
-    }));
-    const writeCaptionSidecars = vi.fn(async (datasetId, payload) => ({
-      dataset: {
-        id: datasetId,
-        name: "Portrait Set",
-        version: 4,
-        items: [
-          {
-            id: "item_0001",
-            assetId: "asset-a",
-            path: "images/item_0001.png",
-            displayName: "item_0001.png",
-            caption: payload.items[0].caption,
-          },
-        ],
-      },
-      sidecars: [{ itemId: "item_0001", captionPath: "training/datasets/dataset-a/images/item_0001.txt" }],
-    }));
-
-    root = createRoot(container);
-    await act(async () => {
-      root.render(
-        withTrainingDataSetsLibraryContext({
-          activeProject: { id: "project-a", name: "Project A" },
-          assets: [
-            {
-              id: "asset-a",
-              type: "image",
-              displayName: "Mira.png",
-              file: { path: "assets/images/Mira.png", mimeType: "image/png" },
-              recipe: { prompt: "studio portrait with soft light" },
-            },
-          ],
-          datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 1 }],
-          loadDataset,
-          writeCaptionSidecars,
-        }),
-      );
-    });
-
-    await act(async () => {
-      container.querySelector(".compact-selector-pill").click();
-    });
-    await act(async () => {
-      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
-    });
-    await settle();
-    await changeField(field(container, "Method"), "metadata");
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Captions").click();
-    });
-    await settle();
-
-    expect(writeCaptionSidecars).toHaveBeenCalledWith("dataset-a", {
-      items: [
-        {
-          itemId: "item_0001",
-          caption: {
-            text: "Portrait Set, studio portrait with soft light",
-            source: "auto",
-            triggerWords: ["Portrait Set"],
-          },
-        },
-      ],
-    });
-    expect(container.textContent).toContain("Portrait Set, studio portrait with soft light");
-  });
-
-  it("prefills caption sidebar defaults from the dataset name", async () => {
-    const loadDataset = vi.fn(async () => ({
-      id: "dataset-a",
-      name: "Portrait Set",
-      version: 3,
-      items: [
-        {
-          id: "item_0001",
-          assetId: "asset-a",
-          path: "images/item_0001.png",
-          displayName: "item_0001.png",
-          caption: { text: "first portrait", source: "manual", triggerWords: ["oldOne"] },
-        },
-        {
-          id: "item_0002",
-          assetId: "asset-b",
-          path: "images/item_0002.png",
-          displayName: "item_0002.png",
-          caption: { text: "second portrait", source: "manual", triggerWords: ["oldTwo"] },
-        },
-      ],
-    }));
-    const writeCaptionSidecars = vi.fn(async (datasetId, payload) => ({
-      dataset: { id: datasetId, name: "Portrait Set", version: 4, items: payload.items },
-      sidecars: payload.items.map((item) => ({ itemId: item.itemId, captionPath: `training/datasets/dataset-a/images/${item.itemId}.txt` })),
-    }));
-
-    root = createRoot(container);
-    await act(async () => {
-      root.render(
-        withTrainingDataSetsLibraryContext({
-          activeProject: { id: "project-a", name: "Project A" },
-          assets: [
-            { id: "asset-a", type: "image", displayName: "Mira.png", file: { path: "assets/images/Mira.png", mimeType: "image/png" } },
-            { id: "asset-b", type: "image", displayName: "Mira 2.png", file: { path: "assets/images/Mira2.png", mimeType: "image/png" } },
-          ],
-          datasets: [{ id: "dataset-a", name: "Portrait Set", modality: "image", itemCount: 2 }],
-          loadDataset,
-          writeCaptionSidecars,
-        }),
-      );
-    });
-
-    await act(async () => {
-      container.querySelector(".compact-selector-pill").click();
-    });
-    await act(async () => {
-      [...container.querySelectorAll(".compact-selector-item")].find((button) => button.textContent.includes("Portrait Set")).click();
-    });
-    await settle();
-    expect(field(container, "Trigger words").value).toBe("Portrait Set");
-    expect(field(container, "Character Name").value).toBe("Portrait Set");
-    await changeField(field(container, "Trigger words"), "miraStyle, portraitSet");
-    await act(async () => {
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Create Captions").click();
-    });
-    await settle();
-
-    expect(writeCaptionSidecars).toHaveBeenCalledWith("dataset-a", {
-      items: [
-        { itemId: "item_0001", caption: { text: "first portrait", source: "manual", triggerWords: ["miraStyle", "portraitSet"] } },
-        { itemId: "item_0002", caption: { text: "second portrait", source: "manual", triggerWords: ["miraStyle", "portraitSet"] } },
-      ],
-    });
   });
 
   it("defaults the training trigger phrase from the selected dataset name until edited", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -4,6 +4,7 @@ import { API_BASE_URL } from "../api.js";
 import { AssetThumbnail, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { CompactSelector } from "../components/CompactSelector.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
+import { DatasetCaptionDialog } from "../components/DatasetCaptionDialog.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
@@ -213,12 +214,6 @@ function captionText(item) {
   return String(item?.caption?.text ?? "").trim();
 }
 
-function itemFileStem(item) {
-  const name = String(item?.path ?? item?.displayName ?? item?.id ?? "item").replaceAll("\\", "/").split("/").pop() || "item";
-  const dotIndex = name.lastIndexOf(".");
-  return dotIndex > 0 ? name.slice(0, dotIndex) : name;
-}
-
 const IMPORT_IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "webp", "bmp", "gif", "tif", "tiff"]);
 
 function uploadFileBaseName(name) {
@@ -247,10 +242,6 @@ function isImageUpload(file) {
   return String(file?.type ?? "").startsWith("image/") || IMPORT_IMAGE_EXTENSIONS.has(uploadFileExtension(file?.name));
 }
 
-function triggerWordsText(caption) {
-  return (caption?.triggerWords ?? caption?.trigger_words ?? []).join(", ");
-}
-
 function parseTriggerWords(value) {
   return String(value ?? "")
     .split(",")
@@ -260,50 +251,6 @@ function parseTriggerWords(value) {
 
 function triggerPhraseFromText(value) {
   return parseTriggerWords(value).join(", ");
-}
-
-function captionSeedFromName(value) {
-  const name = String(value ?? "")
-    .replaceAll("\\", "/")
-    .split("/")
-    .pop()
-    ?.replace(/\.[a-z0-9]+$/i, "")
-    .replace(/#\s*\d+$/u, "")
-    .replace(/[_-]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return name || "";
-}
-
-function captionSeedForItem(item, asset) {
-  const prompt = String(asset?.recipe?.prompt ?? "").trim();
-  if (prompt) {
-    return prompt;
-  }
-  return (
-    captionSeedFromName(item.displayName) ||
-    captionSeedFromName(item.fileStem) ||
-    captionSeedFromName(item.path) ||
-    "training image"
-  );
-}
-
-function captionWithTriggerWords(seed, triggerWords) {
-  const normalizedSeed = String(seed ?? "").trim();
-  const lowerSeed = normalizedSeed.toLowerCase();
-  const missingTriggerWords = triggerWords.filter((word) => !lowerSeed.includes(word.toLowerCase()));
-  return [...missingTriggerWords, normalizedSeed].filter(Boolean).join(", ");
-}
-
-function captionForDraftItem(item, asset, triggerWords) {
-  const text = String(item.captionText ?? "").trim();
-  if (text) {
-    return { source: item.captionSource, text };
-  }
-  return {
-    source: "auto",
-    text: captionWithTriggerWords(captionSeedForItem(item, asset), triggerWords),
-  };
 }
 
 function safeSlug(value, fallback = "item") {
@@ -320,32 +267,43 @@ function orderedName(index, prefix) {
   return `${safeSlug(prefix, "item")}_${String(index + 1).padStart(4, "0")}`;
 }
 
-function renameCaptionDrafts(dataset) {
-  return (dataset?.items ?? []).map((item, index) => ({
-    originalItemId: item.id ?? `item_${String(index + 1).padStart(4, "0")}`,
-    itemId: item.id ?? `item_${String(index + 1).padStart(4, "0")}`,
-    fileStem: itemFileStem(item),
-    displayName: item.displayName ?? imageAssetName(item),
-    captionText: item.caption?.text ?? "",
-    captionSource: item.caption?.source ?? "manual",
-    assetId: datasetItemSelectionKey(dataset, item, index),
-    path: item.path ?? "",
-  }));
+// Human label for the detected caption source (sc-2025) — read-only on the card.
+function captionSourceLabel(source) {
+  if (source === "imported") {
+    return "Imported";
+  }
+  if (source === "auto") {
+    return "Auto";
+  }
+  return "Manual";
 }
 
-function renameFieldsDirty(drafts, dataset) {
-  const items = dataset?.items ?? [];
-  if (drafts.length !== items.length) {
-    return true;
-  }
-  return drafts.some((draft, index) => {
-    const item = items[index] ?? {};
-    return (
-      draft.itemId !== item.id ||
-      draft.fileStem !== itemFileStem(item) ||
-      draft.displayName !== (item.displayName ?? imageAssetName(item))
-    );
+// Caption edit state keyed by selection id (sc-2025): the single source of
+// truth for the unified caption cards, seeded from the saved dataset items and
+// updated as the user edits or imports captions.
+function captionDraftsFromDataset(dataset) {
+  const map = {};
+  (dataset?.items ?? []).forEach((item, index) => {
+    map[datasetItemSelectionKey(dataset, item, index)] = {
+      text: item.caption?.text ?? "",
+      source: item.caption?.source ?? "manual",
+    };
   });
+  return map;
+}
+
+// Map a member to its saved dataset item id so a single-image Re-Caption can
+// target it after a save. The member's id IS its selection key, so match the
+// saved item that resolves to the same key (asset id for library/character
+// items, dataset-item key for owned uploads); fall back to display name.
+function resolveSavedItemId(dataset, member) {
+  const items = dataset?.items ?? [];
+  const byKey = items.find((item, index) => datasetItemSelectionKey(dataset, item, index) === member?.id);
+  if (byKey) {
+    return byKey.id;
+  }
+  const name = member?.displayName ?? imageAssetName(member);
+  return items.find((item) => (item.displayName ?? imageAssetName(item)) === name)?.id ?? null;
 }
 
 function datasetItemSelectionKey(dataset, item, index = 0) {
@@ -424,7 +382,7 @@ function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) {
   };
 }
 
-function datasetPayload({ activeDataset, assetsById, importedCaptions = {}, name, selectedAssetIds }) {
+function datasetPayload({ activeDataset, assetsById, captionDraftById = {}, name, selectedAssetIds }) {
   const itemsByAssetId = new Map(
     (activeDataset?.items ?? []).map((item, index) => [datasetItemSelectionKey(activeDataset, item, index), item]),
   );
@@ -438,14 +396,12 @@ function datasetPayload({ activeDataset, assetsById, importedCaptions = {}, name
           return null;
         }
         const previous = itemsByAssetId.get(selectionId);
-        const imported = importedCaptions[selectionId];
+        const draft = captionDraftById[selectionId];
         let caption;
-        if (imported) {
-          // An imported .txt sidecar takes precedence over a carried-forward
-          // caption so the user can skip the manual captioning step.
+        if (draft && (String(draft.text ?? "").length || draft.source)) {
           caption = {
-            text: imported.text ?? "",
-            source: imported.source ?? "imported",
+            text: draft.text ?? "",
+            source: draft.source ?? "manual",
             triggerWords: previous?.caption?.triggerWords ?? [],
           };
         } else if (previous?.caption) {
@@ -883,14 +839,18 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const [uploadedDatasetAssets, setUploadedDatasetAssets] = useState([]);
   const [savingDataset, setSavingDataset] = useState(false);
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
-  // Captions parsed from .txt sidecars during import, keyed by imported asset id.
-  // Threaded into the dataset payload on save, then cleared once persisted.
-  const [importedCaptions, setImportedCaptions] = useState({});
+  // Single source of truth for caption edits, keyed by selection id (sc-2025):
+  // seeded from the saved dataset items, updated as the user edits an item's
+  // caption or imports a .txt sidecar, and threaded into the dataset payload on
+  // save. Replaces the old importedCaptions + rename-caption draft split.
+  const [captionDraftById, setCaptionDraftById] = useState({});
   const [selectedDatasetId, setSelectedDatasetId] = useState("");
   const [renamePrefix, setRenamePrefix] = useState("");
   const [captionTriggerWords, setCaptionTriggerWords] = useState("");
-  const [renameCaptionDraftItems, setRenameCaptionDraftItems] = useState([]);
-  const [savingRenameCaption, setSavingRenameCaption] = useState(false);
+  // Open caption settings dialog: null | { type: "all" } | { type: "item", member }.
+  const [captionDialog, setCaptionDialog] = useState(null);
+  const [captioning, setCaptioning] = useState(false);
+  const [renaming, setRenaming] = useState(false);
   const [captionSettings, setCaptionSettings] = useState(defaultCaptionSettings);
   const [selectedTargetId, setSelectedTargetId] = useState("");
   const [selectedPresetId, setSelectedPresetId] = useState("");
@@ -942,17 +902,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
     () => selectedAssetIds.map((id) => assetsById.get(id)).filter(Boolean),
     [assetsById, selectedAssetIds],
   );
-  const memberCaptionById = useMemo(() => {
-    const map = new Map(
-      (activeDataset?.items ?? []).map((item, index) => [datasetItemSelectionKey(activeDataset, item, index), captionText(item)]),
-    );
-    for (const [assetId, caption] of Object.entries(importedCaptions)) {
-      if (caption?.text) {
-        map.set(assetId, caption.text);
-      }
-    }
-    return map;
-  }, [activeDataset, importedCaptions]);
   // Thumbnail for the compact dataset selector (sc-2025): the list summary's
   // server-resolved cover image (first item), falling back to the open dataset's
   // first loaded member.
@@ -970,25 +919,29 @@ export function TrainingStudio({ mode = "training" } = {}) {
     [activeDataset, imageAssets, selectedAssetIds],
   );
   const originalAssetIds = useMemo(() => normalizeDatasetAssetIds(activeDataset, assets), [activeDataset, assets]);
+  // Caption edits also make the dataset dirty so the single Save persists them.
+  const captionsDirty = useMemo(
+    () =>
+      Boolean(activeDataset) &&
+      (activeDataset.items ?? []).some((item, index) => {
+        const draft = captionDraftById[datasetItemSelectionKey(activeDataset, item, index)];
+        return draft && (draft.text ?? "") !== (item.caption?.text ?? "");
+      }),
+    [activeDataset, captionDraftById],
+  );
   const dirty =
     Boolean(activeDataset) &&
     (draftName.trim() !== activeDataset.name ||
       selectedAssetIds.length !== originalAssetIds.length ||
-      selectedAssetIds.some((id, index) => id !== originalAssetIds[index]));
+      selectedAssetIds.some((id, index) => id !== originalAssetIds[index]) ||
+      captionsDirty);
   const canSave =
     draftName.trim().length > 0 &&
     selectedAssetIds.length > 0 &&
     health.disabledItems === 0 &&
     !savingDataset &&
     (!activeDataset || dirty);
-  const renameCaptionHasDraft = renameCaptionDraftItems.length > 0;
-  const renameCaptionHasInvalidDraft = renameCaptionDraftItems.some(
-    (item) => !item.itemId.trim() || !item.fileStem.trim() || !item.displayName.trim(),
-  );
-  const missingDraftCaptions = renameCaptionDraftItems.filter((item) => !String(item.captionText ?? "").trim()).length;
   const displayedCaptionPrompt = captionSettings.captionPrompt || buildJoyCaptionPrompt(captionSettings);
-  const canSaveRenameCaption =
-    Boolean(activeDataset?.id) && renameCaptionHasDraft && !renameCaptionHasInvalidDraft && !savingRenameCaption;
   const firstTarget = trainingTargets[0] ?? null;
   const selectedTarget = useMemo(
     () => trainingTargets.find((target) => target.id === selectedTargetId) ?? firstTarget,
@@ -1054,7 +1007,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setSelectedDatasetId("");
     setRenamePrefix("");
     setCaptionTriggerWords("");
-    setRenameCaptionDraftItems([]);
+    setCaptionDraftById({});
     setCaptionSettings(defaultCaptionSettings);
     setSelectedPresetId("");
     setCustomizedConfigFields(new Set());
@@ -1072,13 +1025,12 @@ export function TrainingStudio({ mode = "training" } = {}) {
 
   useEffect(() => {
     const datasetTriggerPhrase = triggerPhraseFromText(activeDataset?.name);
-    setRenameCaptionDraftItems(renameCaptionDrafts(activeDataset));
+    // Seed caption drafts from the (re)loaded dataset; switching datasets or
+    // saving (which swaps activeDataset) resets edits to the persisted state.
+    setCaptionDraftById(captionDraftsFromDataset(activeDataset));
     setRenamePrefix(safeSlug(activeDataset?.name, "item"));
     setCaptionTriggerWords(datasetTriggerPhrase);
     setCaptionSettings((current) => ({ ...current, nameInput: datasetTriggerPhrase }));
-    // Imported captions are persisted into the dataset once saved (which swaps
-    // activeDataset); drop the staging map so switching datasets can't leak them.
-    setImportedCaptions({});
   }, [activeDataset]);
 
   useEffect(() => {
@@ -1207,11 +1159,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setSelectedDatasetId("");
   }
 
-  function updateRenameCaptionDraft(originalItemId, patch) {
+  // Editing a caption marks it as manually authored (sc-2025) — caption source
+  // is detected, never picked by the user.
+  function updateCaption(selectionId, text) {
     setDatasetMessage("");
-    setRenameCaptionDraftItems((current) =>
-      current.map((item) => (item.originalItemId === originalItemId ? { ...item, ...patch } : item)),
-    );
+    setCaptionDraftById((current) => ({
+      ...current,
+      [selectionId]: { text, source: "manual" },
+    }));
   }
 
   function updateCaptionTriggerWords(value) {
@@ -1300,20 +1255,43 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setConfigError("");
   }
 
-  function applyOrderedNames() {
+  // Apply sequential names to the saved dataset's items server-side (sc-2025:
+  // moved out of the per-item rows to a dataset-level action). Persists current
+  // membership/captions first so the rename targets the live item set.
+  async function applyOrderedNames() {
+    if (!activeDataset?.id || renaming) {
+      return;
+    }
+    setRenaming(true);
+    setDatasetError("");
     setDatasetMessage("");
-    setRenameCaptionDraftItems((current) =>
-      current.map((item, index) => {
-        const nextName = orderedName(index, renamePrefix || activeDataset?.name);
-        const extension = String(item.path).split(".").pop() || "png";
+    try {
+      const saved = await persistDataset();
+      if (!saved?.id) {
+        return;
+      }
+      const items = (saved.items ?? []).map((item, index) => {
+        const nextName = orderedName(index, renamePrefix || saved.name);
+        const extension = String(item.path ?? "").split(".").pop() || "png";
         return {
-          ...item,
-          itemId: nextName,
+          itemId: item.id,
+          newItemId: nextName,
           fileStem: nextName,
           displayName: `${nextName}.${extension}`,
         };
-      }),
-    );
+      });
+      const next = await batchRenameDataset(saved.id, { items });
+      if (next) {
+        setActiveDataset(next);
+        setSelectedAssetIds(normalizeDatasetAssetIds(next, assets));
+        setSelectedDatasetId(next.id);
+        setDatasetMessage("Ordered names applied");
+      }
+    } catch (err) {
+      setDatasetError(err.message);
+    } finally {
+      setRenaming(false);
+    }
   }
 
   function addAssets(ids) {
@@ -1366,7 +1344,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       if (imported.length) {
         setSelectedAssetIds((current) => Array.from(new Set([...current, ...imported])));
         if (Object.keys(captionsByAssetId).length) {
-          setImportedCaptions((current) => ({ ...current, ...captionsByAssetId }));
+          setCaptionDraftById((current) => ({ ...current, ...captionsByAssetId }));
         }
         const imageStems = new Set(imageFiles.map((file) => uploadFileStem(file.name)));
         const unmatchedCaptions = captionFiles.filter((file) => !imageStems.has(uploadFileStem(file.name))).length;
@@ -1388,6 +1366,24 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
   }
 
+  // Persist membership + caption edits. Returns the saved dataset (or null) and
+  // re-syncs local state from it. Shared by Save, Apply ordered names, and the
+  // caption dialog so captioning/rename always act on the live persisted items.
+  async function persistDataset() {
+    const payload = datasetPayload({ activeDataset, assetsById, captionDraftById, name: draftName, selectedAssetIds });
+    const dataset = activeDataset
+      ? await updateDataset(activeDataset.id, payload)
+      : await createDataset(payload);
+    if (dataset) {
+      setActiveDataset(dataset);
+      setDraftName(dataset.name ?? draftName.trim());
+      setUploadedDatasetAssets([]);
+      setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
+      setSelectedDatasetId(dataset.id ?? "");
+    }
+    return dataset;
+  }
+
   async function saveDataset() {
     if (!canSave) {
       return;
@@ -1396,16 +1392,11 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setDatasetError("");
     setDatasetMessage("");
     try {
-      const payload = datasetPayload({ activeDataset, assetsById, importedCaptions, name: draftName, selectedAssetIds });
-      const dataset = activeDataset
-        ? await updateDataset(activeDataset.id, payload)
-        : await createDataset(payload);
-      setActiveDataset(dataset);
-      setDraftName(dataset?.name ?? draftName.trim());
-      setUploadedDatasetAssets([]);
-      setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
-      setSelectedDatasetId(dataset?.id ?? "");
-      setDatasetMessage(activeDataset ? "Dataset changes saved" : "Dataset created");
+      const existing = Boolean(activeDataset);
+      const dataset = await persistDataset();
+      if (dataset) {
+        setDatasetMessage(existing ? "Dataset changes saved" : "Dataset created");
+      }
     } catch (err) {
       setDatasetError(err.message);
     } finally {
@@ -1413,58 +1404,42 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
   }
 
-  async function saveRenameCaption() {
-    if (!canSaveRenameCaption) {
+  // Queue a Joy Caption job for the dialog's scope: a single image (Re-Caption)
+  // or every item ("Caption all" / "Re-caption all"). Saves first so the job
+  // sees the live items, then targets them via the itemIds filter.
+  async function runCaptionJob() {
+    if (!captionDialog || captioning) {
       return;
     }
-    setSavingRenameCaption(true);
+    setCaptioning(true);
     setDatasetError("");
     setDatasetMessage("");
     try {
-      let dataset = activeDataset;
-      const renameItems = renameCaptionDraftItems.map((item) => ({
-        itemId: item.originalItemId,
-        newItemId: item.itemId.trim(),
-        fileStem: item.fileStem.trim(),
-        displayName: item.displayName.trim(),
-      }));
-      if (renameFieldsDirty(renameCaptionDraftItems, activeDataset)) {
-        dataset = await batchRenameDataset(activeDataset.id, { items: renameItems });
+      const saved = await persistDataset();
+      if (!saved?.id) {
+        setDatasetError("Save the dataset before captioning.");
+        return;
       }
-      const useJoyCaption = captionSettings.captioner === "joy_caption";
-      const datasetTriggerWords = parseTriggerWords(captionTriggerWords);
-      const captionItems = renameCaptionDraftItems.map((item) => {
-        const asset = assetsById.get(item.assetId);
-        const caption = useJoyCaption
-          ? { source: item.captionSource, text: String(item.captionText ?? "") }
-          : captionForDraftItem(item, asset, datasetTriggerWords);
-        return {
-          itemId: item.itemId.trim(),
-          caption: {
-            text: caption.text,
-            source: caption.source,
-            triggerWords: datasetTriggerWords,
-          },
-        };
-      });
-      const result = await writeCaptionSidecars(activeDataset.id, {
-        items: captionItems,
-      });
-      const nextDataset = result?.dataset ?? dataset;
-      setActiveDataset(nextDataset);
-      setDraftName(nextDataset?.name ?? draftName);
-      setSelectedAssetIds(normalizeDatasetAssetIds(nextDataset, assets));
-      setSelectedDatasetId(nextDataset?.id ?? activeDataset.id);
-      if (useJoyCaption && (captionSettings.recaption || missingDraftCaptions > 0)) {
-        const job = await createCaptionJob(activeDataset.id, trainingCaptionJobPayload(captionSettings));
-        setDatasetMessage(`Caption job queued${job?.id ? ` (${job.id})` : ""}. Track it in the Queue.`);
-      } else {
-        setDatasetMessage(`Captions created${result?.sidecars?.length ? ` (${result.sidecars.length})` : ""}`);
+      let itemIds;
+      if (captionDialog.type === "item") {
+        const id = resolveSavedItemId(saved, captionDialog.member);
+        if (!id) {
+          setDatasetError("Could not resolve that image to re-caption.");
+          return;
+        }
+        itemIds = [id];
       }
+      const payload = {
+        ...trainingCaptionJobPayload(captionSettings),
+        ...(itemIds ? { itemIds, recaption: true } : {}),
+      };
+      const job = await createCaptionJob(saved.id, payload);
+      setDatasetMessage(`Caption job queued${job?.id ? ` (${job.id})` : ""}. Track it in the Queue.`);
+      setCaptionDialog(null);
     } catch (err) {
       setDatasetError(err.message);
     } finally {
-      setSavingRenameCaption(false);
+      setCaptioning(false);
     }
   }
 
@@ -1635,6 +1610,34 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           Add images
                         </button>
                       </div>
+                      <div className="training-dataset-toolbar">
+                        <label className="training-rename-field">
+                          Name prefix
+                          <input
+                            onChange={(event) => setRenamePrefix(event.target.value)}
+                            placeholder="item"
+                            value={renamePrefix}
+                          />
+                        </label>
+                        <button
+                          className="secondary-action"
+                          disabled={!activeDataset?.id || renaming || !memberAssets.length}
+                          onClick={applyOrderedNames}
+                          type="button"
+                        >
+                          <Icon.Sliders size={14} />
+                          {renaming ? "Renaming…" : "Apply ordered names"}
+                        </button>
+                        <button
+                          className="secondary-action"
+                          disabled={!memberAssets.length}
+                          onClick={() => setCaptionDialog({ type: "all" })}
+                          type="button"
+                        >
+                          <Icon.Sliders size={14} />
+                          Caption all
+                        </button>
+                      </div>
                       <DatasetHealth health={health} />
                       <div className="training-validity">
                         <span className={health.valid ? "training-valid-dot valid" : "training-valid-dot"} />
@@ -1655,36 +1658,57 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           ))}
                         </div>
                       ) : null}
-                      <div className="training-member-grid" aria-label="Dataset images">
+                      <div className="training-caption-grid" aria-label="Dataset images and captions">
                         {memberAssets.length ? (
                           memberAssets.map((asset) => {
                             const disabled = asset.status?.rejected || asset.status?.trashed;
-                            const caption = memberCaptionById.get(asset.id);
+                            const draft = captionDraftById[asset.id] ?? {};
+                            const source = draft.source ?? "manual";
+                            const name = asset.displayName ?? imageAssetName(asset);
                             return (
                               <article
-                                className={["training-member-card", disabled ? "disabled" : ""].filter(Boolean).join(" ")}
+                                className={["training-caption-card", disabled ? "disabled" : ""].filter(Boolean).join(" ")}
                                 key={asset.id}
                               >
-                                <button className="training-member-thumb" onClick={() => onPreview(asset)} type="button">
-                                  <AssetThumbnail asset={asset} />
-                                </button>
-                                <div className="training-member-meta">
-                                  <strong>{asset.displayName ?? imageAssetName(asset)}</strong>
-                                  <span className={caption ? "training-member-caption" : "training-member-caption muted"}>
-                                    {caption || "Needs caption"}
-                                  </span>
-                                  {disabled ? (
-                                    <span className="training-asset-badge">{asset.status?.trashed ? "Trashed" : "Rejected"}</span>
-                                  ) : null}
+                                <div className="training-caption-card-head">
+                                  <button className="training-caption-card-thumb" onClick={() => onPreview(asset)} type="button">
+                                    <AssetThumbnail asset={asset} />
+                                  </button>
+                                  <div className="training-caption-card-meta">
+                                    <strong title={name}>{name}</strong>
+                                    <span className={`training-caption-source source-${source}`}>{captionSourceLabel(source)}</span>
+                                    {disabled ? (
+                                      <span className="training-asset-badge">{asset.status?.trashed ? "Trashed" : "Rejected"}</span>
+                                    ) : null}
+                                  </div>
                                 </div>
-                                <button
-                                  aria-label={`Remove ${asset.displayName ?? imageAssetName(asset)}`}
-                                  className="secondary-action training-member-remove"
-                                  onClick={() => removeUnavailableAsset(asset.id)}
-                                  type="button"
-                                >
-                                  Remove
-                                </button>
+                                <textarea
+                                  aria-label={`Caption for ${name}`}
+                                  className="training-caption-card-text"
+                                  onChange={(event) => updateCaption(asset.id, event.target.value)}
+                                  placeholder="Describe this image…"
+                                  rows={3}
+                                  value={draft.text ?? ""}
+                                />
+                                <div className="training-caption-card-actions">
+                                  <button
+                                    aria-label={`Remove ${name}`}
+                                    className="secondary-action"
+                                    onClick={() => removeUnavailableAsset(asset.id)}
+                                    type="button"
+                                  >
+                                    Remove
+                                  </button>
+                                  <button
+                                    aria-label={`Re-caption ${name}`}
+                                    className="secondary-action"
+                                    disabled={captioning}
+                                    onClick={() => setCaptionDialog({ type: "item", member: asset })}
+                                    type="button"
+                                  >
+                                    Re-Caption
+                                  </button>
+                                </div>
                               </article>
                             );
                           })
@@ -1709,282 +1733,31 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           onImport={handleImport}
                         />
                       ) : null}
+                      {captionDialog ? (
+                        <DatasetCaptionDialog
+                          captionLengths={joyCaptionLengths}
+                          captionTypes={joyCaptionTypes}
+                          extraOptions={joyCaptionExtraOptions}
+                          gpuOptions={gpuOptions}
+                          onChange={updateCaptionSetting}
+                          onClose={() => setCaptionDialog(null)}
+                          onRun={runCaptionJob}
+                          onToggleExtra={toggleCaptionExtraOption}
+                          promptValue={displayedCaptionPrompt}
+                          running={captioning}
+                          scope={
+                            captionDialog.type === "item"
+                              ? {
+                                  type: "item",
+                                  name: captionDialog.member.displayName ?? imageAssetName(captionDialog.member),
+                                }
+                              : { type: "all" }
+                          }
+                          settings={captionSettings}
+                        />
+                      ) : null}
                     </div>
                   </div>
-                </>
-              ) : null}
-
-              {datasetLibraryMode || activeTab === "rename-caption" ? (
-                <>
-                  <div className="training-panel-head">
-                    <div>
-                      <p className="eyebrow">Rename & Caption</p>
-                      <h3>{active.title}</h3>
-                    </div>
-                    <span className="training-status-pill">{activeDataset ? `Version ${activeDataset.version}` : "Select dataset"}</span>
-                  </div>
-                  {datasetError ? <p className="inline-warning">{datasetError}</p> : null}
-                  {datasetMessage ? <p className="inline-success">{datasetMessage}</p> : null}
-                  {!activeDataset ? (
-                    <div className="empty-panel compact-panel">Open a saved dataset to edit captions.</div>
-                  ) : (
-                    <div className="training-caption-workspace">
-                      <div className="training-caption-editor">
-                        <div className="training-caption-list" aria-label="Rename and caption dataset items">
-                        {renameCaptionDraftItems.map((item, index) => {
-                          const asset = assetsById.get(item.assetId);
-                          return (
-                            <article className="training-caption-row" key={item.originalItemId}>
-                              <div className="training-caption-preview">
-                                <button disabled={!asset} onClick={() => asset && onPreview(asset)} type="button">
-                                  {asset ? <AssetThumbnail asset={asset} /> : <Icon.Image size={22} />}
-                                </button>
-                                <span>{String(index + 1).padStart(2, "0")}</span>
-                              </div>
-                              <div className="training-caption-fields">
-                                <label>
-                                  Item ID
-                                  <input
-                                    onChange={(event) => updateRenameCaptionDraft(item.originalItemId, { itemId: event.target.value })}
-                                    value={item.itemId}
-                                  />
-                                </label>
-                                <label>
-                                  File stem
-                                  <input
-                                    onChange={(event) => updateRenameCaptionDraft(item.originalItemId, { fileStem: event.target.value })}
-                                    value={item.fileStem}
-                                  />
-                                </label>
-                                <label>
-                                  Display name
-                                  <input
-                                    onChange={(event) =>
-                                      updateRenameCaptionDraft(item.originalItemId, { displayName: event.target.value })
-                                    }
-                                    value={item.displayName}
-                                  />
-                                </label>
-                                <label className="training-caption-text">
-                                  Caption
-                                  <textarea
-                                    onChange={(event) =>
-                                      updateRenameCaptionDraft(item.originalItemId, { captionText: event.target.value })
-                                    }
-                                    rows={3}
-                                    value={item.captionText}
-                                  />
-                                </label>
-                                <label>
-                                  Source
-                                  <select
-                                    onChange={(event) =>
-                                      updateRenameCaptionDraft(item.originalItemId, { captionSource: event.target.value })
-                                    }
-                                    value={item.captionSource}
-                                  >
-                                    <option value="manual">Manual</option>
-                                    <option value="imported">Imported</option>
-                                    <option value="auto">Auto</option>
-                                  </select>
-                                </label>
-                              </div>
-                            </article>
-                          );
-                        })}
-                        </div>
-                      </div>
-                      <aside className="training-caption-sidebar" aria-label="Caption options">
-                        <div className="training-caption-sidebar-section">
-                          <div className="training-sidebar-heading">
-                            <span>Files</span>
-                            <strong>{renameCaptionDraftItems.length}</strong>
-                          </div>
-                          <label>
-                            Rename prefix
-                            <input onChange={(event) => setRenamePrefix(event.target.value)} value={renamePrefix} />
-                          </label>
-                          <label>
-                            Trigger words
-                            <input onChange={(event) => updateCaptionTriggerWords(event.target.value)} value={captionTriggerWords} />
-                          </label>
-                          <button className="secondary-action" onClick={applyOrderedNames} type="button">
-                            <Icon.Sliders size={14} />
-                            Apply ordered names
-                          </button>
-                        </div>
-                        <div className="training-caption-sidebar-section">
-                          <div className="training-sidebar-heading">
-                            <span>Captioner</span>
-                            <strong>{missingDraftCaptions}</strong>
-                          </div>
-                          <label>
-                            Method
-                            <select
-                              onChange={(event) => updateCaptionSetting("captioner", event.target.value)}
-                              value={captionSettings.captioner}
-                            >
-                              <option value="joy_caption">Joy Caption</option>
-                              <option value="metadata">Metadata fallback</option>
-                            </select>
-                          </label>
-                          {captionSettings.captioner === "joy_caption" ? (
-                            <>
-                              <label>
-                                Model
-                                <input
-                                  onChange={(event) => updateCaptionSetting("modelNameOrPath", event.target.value)}
-                                  value={captionSettings.modelNameOrPath}
-                                />
-                              </label>
-                              <label>
-                                GPU
-                                <select
-                                  onChange={(event) => updateCaptionSetting("requestedGpu", event.target.value)}
-                                  value={captionSettings.requestedGpu}
-                                >
-                                  {gpuOptions.map((gpu) => (
-                                    <option key={gpu} value={gpu}>
-                                      {gpu}
-                                    </option>
-                                  ))}
-                                </select>
-                              </label>
-                              <label className="training-toggle-line">
-                                <input
-                                  checked={captionSettings.recaption}
-                                  onChange={(event) => updateCaptionSetting("recaption", event.target.checked)}
-                                  type="checkbox"
-                                />
-                                <span>Recaption existing</span>
-                              </label>
-                              <label className="training-toggle-line">
-                                <input
-                                  checked={captionSettings.lowVram}
-                                  onChange={(event) => updateCaptionSetting("lowVram", event.target.checked)}
-                                  type="checkbox"
-                                />
-                                <span>Low VRAM</span>
-                              </label>
-                            </>
-                          ) : null}
-                        </div>
-                        {captionSettings.captioner === "joy_caption" ? (
-                          <>
-                            <div className="training-caption-sidebar-section">
-                              <div className="training-sidebar-heading">
-                                <span>Prompt</span>
-                              </div>
-                              <label>
-                                Type
-                                <select
-                                  onChange={(event) => updateCaptionSetting("captionType", event.target.value)}
-                                  value={captionSettings.captionType}
-                                >
-                                  {joyCaptionTypes.map((type) => (
-                                    <option key={type} value={type}>
-                                      {type}
-                                    </option>
-                                  ))}
-                                </select>
-                              </label>
-                              <label>
-                                Length
-                                <select
-                                  onChange={(event) => updateCaptionSetting("captionLength", event.target.value)}
-                                  value={captionSettings.captionLength}
-                                >
-                                  {joyCaptionLengths.map((length) => (
-                                    <option key={length} value={length}>
-                                      {length}
-                                    </option>
-                                  ))}
-                                </select>
-                              </label>
-                              <label>
-                                Character Name
-                                <input
-                                  onChange={(event) => updateCaptionSetting("nameInput", event.target.value)}
-                                  value={captionSettings.nameInput}
-                                />
-                              </label>
-                              <label>
-                                Caption prompt
-                                <textarea
-                                  onChange={(event) => updateCaptionSetting("captionPrompt", event.target.value)}
-                                  rows={8}
-                                  value={displayedCaptionPrompt}
-                                />
-                              </label>
-                            </div>
-                            <div className="training-caption-sidebar-section">
-                              <div className="training-sidebar-heading">
-                                <span>Sampling</span>
-                              </div>
-                              <label>
-                                Temperature
-                                <input
-                                  max="2"
-                                  min="0"
-                                  onChange={(event) => updateCaptionSetting("temperature", event.target.value)}
-                                  step="0.05"
-                                  type="number"
-                                  value={captionSettings.temperature}
-                                />
-                              </label>
-                              <label>
-                                Top P
-                                <input
-                                  max="1"
-                                  min="0"
-                                  onChange={(event) => updateCaptionSetting("topP", event.target.value)}
-                                  step="0.05"
-                                  type="number"
-                                  value={captionSettings.topP}
-                                />
-                              </label>
-                              <label>
-                                Max tokens
-                                <input
-                                  max="1024"
-                                  min="1"
-                                  onChange={(event) => updateCaptionSetting("maxNewTokens", event.target.value)}
-                                  step="1"
-                                  type="number"
-                                  value={captionSettings.maxNewTokens}
-                                />
-                              </label>
-                            </div>
-                            <div className="training-caption-sidebar-section">
-                              <div className="training-sidebar-heading">
-                                <span>Options</span>
-                              </div>
-                              <div className="training-caption-option-list">
-                                {joyCaptionExtraOptions.map((option) => (
-                                  <label className="training-toggle-line" key={option.value}>
-                                    <input
-                                      checked={captionSettings.extraOptions.includes(option.value)}
-                                      onChange={() => toggleCaptionExtraOption(option.value)}
-                                      type="checkbox"
-                                    />
-                                    <span>{option.label}</span>
-                                  </label>
-                                ))}
-                              </div>
-                            </div>
-                          </>
-                        ) : null}
-                        <button
-                          className="primary-action training-caption-submit"
-                          disabled={!canSaveRenameCaption}
-                          onClick={saveRenameCaption}
-                          type="button"
-                        >
-                          {savingRenameCaption ? "Creating" : "Create Captions"}
-                        </button>
-                      </aside>
-                      </div>
-                  )}
                 </>
               ) : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1974,9 +1974,7 @@ label {
 .training-config-preview,
 .training-config-form,
 .training-config-grid,
-.training-advanced-grid,
-.training-caption-editor,
-.training-caption-list {
+.training-advanced-grid {
   display: grid;
   gap: 10px;
 }
@@ -2237,155 +2235,18 @@ label {
   line-height: 1.45;
 }
 
-.training-caption-toolbar {
-  display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto auto;
-  gap: 10px;
-  align-items: end;
-}
-
-.training-caption-workspace {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(250px, 320px);
-  gap: 14px;
-  align-items: start;
-}
-
-.training-caption-sidebar {
-  display: grid;
-  gap: 10px;
-  position: sticky;
-  top: 12px;
-  max-height: calc(100vh - 24px);
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  align-self: start;
-  min-width: 0;
-  padding-right: 2px;
-}
-
-.training-caption-sidebar-section {
-  display: grid;
-  gap: 10px;
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--surface);
-}
-
-.training-sidebar-heading {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.training-sidebar-heading strong {
-  color: var(--text);
-  font-size: 14px;
-}
-
-.training-caption-sidebar label,
-.training-caption-toolbar label,
-.training-caption-fields label {
-  display: grid;
-  gap: 7px;
-  min-width: 0;
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
 .training-toggle-line {
+  display: grid;
   grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
   align-items: center;
   color: var(--text);
   font-weight: 600;
+  font-size: 12px;
 }
 
 .training-toggle-line input {
   width: auto;
-}
-
-.training-caption-option-list {
-  display: grid;
-  gap: 8px;
-  max-height: 260px;
-  overflow: auto;
-  padding-right: 2px;
-}
-
-.training-caption-sidebar textarea {
-  resize: vertical;
-  min-height: 168px;
-}
-
-.training-caption-submit {
-  width: 100%;
-  justify-content: center;
-}
-
-.training-caption-row {
-  display: grid;
-  grid-template-columns: 96px minmax(0, 1fr);
-  gap: 12px;
-  min-width: 0;
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--surface);
-}
-
-.training-caption-preview {
-  display: grid;
-  gap: 8px;
-  align-content: start;
-}
-
-.training-caption-preview button {
-  overflow: hidden;
-  width: 96px;
-  aspect-ratio: 1;
-  display: grid;
-  place-items: center;
-  padding: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--surface-2);
-  color: var(--text-muted);
-}
-
-.training-caption-preview img,
-.training-caption-preview video {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.training-caption-preview span {
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.training-caption-fields {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(120px, 1fr));
-  gap: 10px;
-  min-width: 0;
-}
-
-.training-caption-text {
-  grid-column: 1 / -1;
-}
-
-.training-caption-fields textarea {
-  resize: vertical;
-  min-height: 76px;
 }
 
 .preset-rail-head {
@@ -5738,67 +5599,167 @@ label {
 }
 
 /* Dataset member grid (sc-2026): the editor body shows only members + captions */
-.training-member-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+/* Dataset toolbar (sc-2025): rename + caption actions above the card grid */
+.training-dataset-toolbar {
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
+  align-items: flex-end;
 }
 
-.training-member-card {
+.training-rename-field {
   display: grid;
-  grid-template-columns: 56px minmax(0, 1fr) auto;
-  gap: 10px;
-  align-items: center;
-  padding: 8px;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.training-rename-field input {
+  min-width: 160px;
+}
+
+/* Unified image + caption cards (sc-2025): thumbnail + read-only name/source,
+   editable caption underneath, actions at the bottom. Responsive auto-fill. */
+.training-caption-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.training-caption-card {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  padding: 10px;
   border: 1px solid var(--border);
   border-radius: var(--r-md);
   background: var(--surface);
 }
 
-.training-member-card.disabled {
+.training-caption-card.disabled {
   opacity: 0.6;
 }
 
-.training-member-thumb {
+.training-caption-card-head {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.training-caption-card-thumb {
   padding: 0;
   border: none;
   background: none;
   cursor: pointer;
 }
 
-.training-member-thumb img,
-.training-member-thumb video {
-  width: 56px;
-  height: 56px;
+.training-caption-card-thumb img,
+.training-caption-card-thumb video {
+  width: 72px;
+  height: 72px;
   object-fit: cover;
   border-radius: var(--r-sm);
   background: var(--bg-2);
 }
 
-.training-member-meta {
+.training-caption-card-meta {
   display: grid;
-  gap: 2px;
+  gap: 4px;
   min-width: 0;
 }
 
-.training-member-meta strong {
+.training-caption-card-meta strong {
   overflow: hidden;
   font-size: 13px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.training-member-caption {
-  overflow: hidden;
-  font-size: 12px;
-  color: var(--text);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.training-caption-source {
+  justify-self: start;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--surface-hover);
+  color: var(--text-muted);
 }
 
-.training-member-caption.muted {
+.training-caption-source.source-imported {
+  background: color-mix(in oklch, var(--accent) 16%, transparent);
+  color: var(--accent-strong);
+}
+
+.training-caption-source.source-auto {
+  background: color-mix(in oklch, var(--warm) 22%, transparent);
+}
+
+.training-caption-card-text {
+  width: 100%;
+  resize: vertical;
+}
+
+.training-caption-card-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.training-caption-card-actions button {
+  flex: 1;
+}
+
+/* Caption settings dialog (sc-2025) */
+.dataset-caption-modal {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 12px;
+  width: min(620px, 96vw);
+  max-height: 92vh;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.dataset-caption-head,
+.dataset-caption-footer {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dataset-caption-head h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.dataset-caption-body {
+  display: grid;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.dataset-caption-body label {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
   color: var(--text-muted);
-  font-style: italic;
+}
+
+.dataset-caption-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.dataset-caption-options {
+  display: grid;
+  gap: 4px;
 }
 
 /* Asset preview chip (in pickers) */
@@ -6176,10 +6137,6 @@ label {
   .training-config-preview,
   .training-config-grid,
   .training-advanced-grid,
-  .training-caption-workspace,
-  .training-caption-toolbar,
-  .training-caption-row,
-  .training-caption-fields,
   .preset-layout,
   .character-layout,
   .queue-header,


### PR DESCRIPTION
## Summary

Follow-up to the epic-2019 dataset work (sc-2026 add-dialog, sc-2025 selector). Merges the dataset editor's **separate "assets" grid and "Rename & Caption" section into one responsive card grid**, and moves captioning + renaming out of the sidebar.

## Card design

Each image is one card:
- Larger **thumbnail** with the **read-only display name** + a **detected caption-source badge** (Imported / Auto / Manual) beside it.
- **Editable caption** textarea underneath.
- **Remove** + **Re-Caption** actions below that.
- Responsive grid (`auto-fill`) so more cards fit horizontally.

Caption source is **detected, never chosen** (the old Auto|Imported|Manual dropdown is gone) — editing a caption flips it to Manual. Item ID / File stem are no longer surfaced.

## Captioning + renaming

- **Caption settings → dialog** (`DatasetCaptionDialog`), shared by **"Caption all"** and a single image's **"Re-Caption"**. Per-image Re-Caption queues a Joy Caption job scoped via a new backend **`itemIds`** filter on the caption-job request (targets that item and always recaptions it).
- **Renaming** ("Apply ordered names" + name prefix) moved to a **top toolbar**, run server-side via `batchRename`.
- **One "Save dataset"** persists membership + caption edits. A single `captionDraftById` state replaces the old `importedCaptions` + rename-caption-draft split.
- Removed the dead member grid, the rename-caption sidebar, and orphaned helper functions.

## Backend

`TrainingCaptionJobRequest` gains `itemIds: Option<Vec<String>>`; the caption-job handler filters items to those ids (always recaptioning them) when present, else the dataset-wide recaption/missing rule applies.

## Tests

- Rewrote the dataset caption/rename web tests onto the new cards + dialog: inline caption edit + Save, **Caption all** (job, no itemIds), single **Re-Caption** (job with `itemIds` + `recaption`), and **Apply ordered names** (batchRename).
- Added a backend assertion that `itemIds` forces a single item into the job even with `recaption: false`.
- Web **244** + core + rust-api **85** + scaffold + production build green; clippy clean; parity snapshots unchanged.

## Note

The legacy "Metadata fallback" captioner (filename-seeded captions written client-side) was dropped — the new flow is Joy-Caption job-based. Say the word if you want it back.

## Verification

Reaching this editor live needs the Rust backend + a project with a dataset, which the Vite dev-server preview can't exercise alone; the vitest tests render the real components and drive the card edit/save, both dialog scopes, and the rename toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)