### PR TITLE
refactor(training): tidy dataset editor toolbar + move Save into the …

### DIFF
--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -679,7 +679,7 @@ function buildJoyCaptionPrompt(settings) {
     .replaceAll("{word_count}", captionLength);
 }
 
-function DatasetHealth({ health }) {
+function DatasetHealth({ health, action }) {
   return (
     <div className="training-health-grid" aria-label="Dataset health">
       <div>
@@ -694,10 +694,7 @@ function DatasetHealth({ health }) {
         <strong>{health.duplicateFilenames}</strong>
         <span>Duplicate filenames</span>
       </div>
-      <div className={health.disabledItems ? "needs-attention" : ""}>
-        <strong>{health.disabledItems}</strong>
-        <span>Disabled items</span>
-      </div>
+      {action ? <div className="training-health-action">{action}</div> : null}
     </div>
   );
 }
@@ -1599,12 +1596,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
                             value={draftName}
                           />
                         </label>
-                        <label>
-                          Modality
-                          <select disabled value="image">
-                            <option value="image">Image</option>
-                          </select>
-                        </label>
                         <button className="primary-action training-add-images" onClick={() => setAddDialogOpen(true)} type="button">
                           <Icon.Plus size={14} />
                           Add images
@@ -1620,7 +1611,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           />
                         </label>
                         <button
-                          className="secondary-action"
+                          className="primary-action"
                           disabled={!activeDataset?.id || renaming || !memberAssets.length}
                           onClick={applyOrderedNames}
                           type="button"
@@ -1629,7 +1620,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           {renaming ? "Renaming…" : "Apply ordered names"}
                         </button>
                         <button
-                          className="secondary-action"
+                          className="primary-action training-caption-all"
                           disabled={!memberAssets.length}
                           onClick={() => setCaptionDialog({ type: "all" })}
                           type="button"
@@ -1638,10 +1629,20 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           Caption all
                         </button>
                       </div>
-                      <DatasetHealth health={health} />
+                      <DatasetHealth
+                        health={health}
+                        action={
+                          <>
+                            <button className="primary-action" disabled={!canSave} onClick={saveDataset} type="button">
+                              {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
+                            </button>
+                            <span>{dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}</span>
+                          </>
+                        }
+                      />
                       <div className="training-validity">
                         <span className={health.valid ? "training-valid-dot valid" : "training-valid-dot"} />
-                        <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets and remove disabled items"}</span>
+                        <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets to build this dataset"}</span>
                       </div>
                       {unavailableAssetIds.length ? (
                         <div className="training-unavailable-list" aria-label="Unavailable dataset items">
@@ -1715,12 +1716,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
                         ) : (
                           <div className="empty-panel compact-panel">No images yet — use “Add images” to build this dataset.</div>
                         )}
-                      </div>
-                      <div className="training-dataset-actions">
-                        <button className="primary-action" disabled={!canSave} onClick={saveDataset} type="button">
-                          {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
-                        </button>
-                        <span>{dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}</span>
                       </div>
                       {addDialogOpen ? (
                         <DatasetAddDialog

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2035,8 +2035,7 @@ label {
 }
 
 .training-health-grid span,
-.training-validity,
-.training-dataset-actions span {
+.training-validity {
   color: var(--text-muted);
   font-size: 12px;
 }
@@ -2044,6 +2043,21 @@ label {
 .training-health-grid .needs-attention {
   border-color: color-mix(in oklch, var(--danger) 42%, var(--border));
   background: color-mix(in oklch, var(--danger) 8%, var(--surface));
+}
+
+/* Save lives in the health row (sc-2025) so a small edit needs no scroll. */
+.training-health-action {
+  gap: 6px !important;
+  justify-items: stretch;
+}
+
+.training-health-action button {
+  width: 100%;
+  justify-content: center;
+}
+
+.training-health-action span {
+  text-align: center;
 }
 
 .training-validity {
@@ -2104,14 +2118,6 @@ label {
   color: color-mix(in oklch, var(--danger) 75%, var(--text));
   font-size: 11px;
   font-weight: 700;
-}
-
-.training-dataset-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  flex-wrap: wrap;
 }
 
 .training-workflow-grid {
@@ -5605,6 +5611,11 @@ label {
   flex-wrap: wrap;
   gap: 10px;
   align-items: flex-end;
+}
+
+/* Push "Caption all" to the far right of the toolbar (sc-2025). */
+.training-caption-all {
+  margin-left: auto;
 }
 
 .training-rename-field {


### PR DESCRIPTION
…header

UI polish on the dataset editor (epic 2019):
- Hide the Modality field (only Image is supported for now).
- Style "Apply ordered names" + "Caption all" as primary buttons matching "Add images"; push "Caption all" to the far right, keep "Apply ordered names" next to the name prefix.
- Drop the "Disabled items" health card (it no longer maps to anything the user acts on; the rejected/trashed guard still gates Save).
- Move "Save dataset" into the health row (where Disabled items was) so saving a small change to a large dataset needs no scroll.

Web (244) + scaffold + build green.