### PR TITLE
refactor(training): align dataset header into one 4-column grid

### DIFF
--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1557,6 +1557,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
                       <h3>{active.title}</h3>
                     </div>
                     <div className="training-head-actions">
+                      <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
+                        <Icon.Search size={14} />
+                        {loadingDatasets ? "Refreshing" : "Refresh"}
+                      </button>
                       <CompactSelector
                         busyId={busyDatasetId}
                         createLabel="New dataset"
@@ -1572,10 +1576,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
                         placeholder={activeDataset ? activeDataset.name : "New dataset"}
                         selectedId={selectedDatasetId}
                       />
-                      <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
-                        <Icon.Search size={14} />
-                        {loadingDatasets ? "Refreshing" : "Refresh"}
-                      </button>
                     </div>
                   </div>
                   {datasetsError ? <p className="inline-warning">{datasetsError}</p> : null}
@@ -1587,8 +1587,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
                       <div className="empty-panel compact-panel">No training datasets yet — use “New” to start one.</div>
                     ) : null}
                     <div className="training-dataset-editor">
-                      <div className="training-dataset-form">
-                        <label>
+                      <div className="training-dataset-fields">
+                        <label className="field-name">
                           Dataset name
                           <input
                             onChange={(event) => setDraftName(event.target.value)}
@@ -1596,13 +1596,15 @@ export function TrainingStudio({ mode = "training" } = {}) {
                             value={draftName}
                           />
                         </label>
-                        <button className="primary-action training-add-images" onClick={() => setAddDialogOpen(true)} type="button">
+                        <span className="field-version">
+                          {dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}
+                        </span>
+                        <button className="primary-action field-add" onClick={() => setAddDialogOpen(true)} type="button">
                           <Icon.Plus size={14} />
                           Add images
                         </button>
-                      </div>
-                      <div className="training-dataset-toolbar">
-                        <label className="training-rename-field">
+
+                        <label className="field-prefix">
                           Name prefix
                           <input
                             onChange={(event) => setRenamePrefix(event.target.value)}
@@ -1611,7 +1613,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           />
                         </label>
                         <button
-                          className="primary-action"
+                          className="primary-action field-apply"
                           disabled={!activeDataset?.id || renaming || !memberAssets.length}
                           onClick={applyOrderedNames}
                           type="button"
@@ -1620,7 +1622,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                           {renaming ? "Renaming…" : "Apply ordered names"}
                         </button>
                         <button
-                          className="primary-action training-caption-all"
+                          className="primary-action field-caption"
                           disabled={!memberAssets.length}
                           onClick={() => setCaptionDialog({ type: "all" })}
                           type="button"
@@ -1632,12 +1634,9 @@ export function TrainingStudio({ mode = "training" } = {}) {
                       <DatasetHealth
                         health={health}
                         action={
-                          <>
-                            <button className="primary-action" disabled={!canSave} onClick={saveDataset} type="button">
-                              {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
-                            </button>
-                            <span>{dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}</span>
-                          </>
+                          <button className="primary-action" disabled={!canSave} onClick={saveDataset} type="button">
+                            {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
+                          </button>
                         }
                       />
                       <div className="training-validity">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1998,19 +1998,77 @@ label {
   min-width: 0;
 }
 
-.training-dataset-form {
+/* Dataset header fields aligned to the 4 health columns (sc-2025 polish):
+   row 1 = name | version | Add images, row 2 = prefix | Apply names | Caption all;
+   the health grid below (row 3) shares the same 4-column geometry. */
+.training-dataset-fields {
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) minmax(120px, 160px) auto;
-  gap: 10px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
   align-items: end;
 }
 
-.training-dataset-form label:not(.file-upload-button) {
+.field-name,
+.field-prefix {
   display: grid;
   gap: 7px;
+  grid-column: 1 / span 2;
   font-size: 12px;
   font-weight: 700;
   color: var(--text-muted);
+}
+
+.field-name {
+  grid-row: 1;
+}
+
+.field-prefix {
+  grid-row: 2;
+}
+
+.field-version {
+  grid-row: 1;
+  grid-column: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.field-add {
+  grid-row: 1;
+  grid-column: 4;
+}
+
+.field-apply {
+  grid-row: 2;
+  grid-column: 3;
+}
+
+.field-caption {
+  grid-row: 2;
+  grid-column: 4;
+}
+
+/* Split the difference: inputs grow a touch (larger font), buttons shrink, both
+   land on a shared 44px control height. */
+.training-dataset-fields input {
+  height: 44px;
+  font-size: 15px;
+}
+
+.training-dataset-fields .primary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 44px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .training-health-grid {
@@ -2046,18 +2104,19 @@ label {
 }
 
 /* Save lives in the health row (sc-2025) so a small edit needs no scroll. */
+/* Save sits in the health row's 4th column (sc-2025): no card chrome, button
+   bottom-aligned with the stat cards, same size as Add images / Caption all. */
 .training-health-action {
-  gap: 6px !important;
-  justify-items: stretch;
+  border: none !important;
+  background: none !important;
+  padding: 0 !important;
+  align-content: end !important;
 }
 
 .training-health-action button {
   width: 100%;
+  height: 44px;
   justify-content: center;
-}
-
-.training-health-action span {
-  text-align: center;
 }
 
 .training-validity {
@@ -5604,31 +5663,6 @@ label {
   white-space: nowrap;
 }
 
-/* Dataset member grid (sc-2026): the editor body shows only members + captions */
-/* Dataset toolbar (sc-2025): rename + caption actions above the card grid */
-.training-dataset-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: flex-end;
-}
-
-/* Push "Caption all" to the far right of the toolbar (sc-2025). */
-.training-caption-all {
-  margin-left: auto;
-}
-
-.training-rename-field {
-  display: grid;
-  gap: 4px;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.training-rename-field input {
-  min-width: 160px;
-}
-
 /* Unified image + caption cards (sc-2025): thumbnail + read-only name/source,
    editable caption underneath, actions at the bottom. Responsive auto-fill. */
 .training-caption-grid {
@@ -6142,7 +6176,7 @@ label {
   .training-tabs,
   .training-metrics,
   .training-dataset-workspace,
-  .training-dataset-form,
+  .training-dataset-fields,
   .training-health-grid,
   .training-workflow-grid,
   .training-config-preview,


### PR DESCRIPTION
Tidy the dataset editor header so every row lines up (epic 2019):
- Swap the panel-head order: Refresh on the left, dataset picker on the right.
- Unify the name/prefix/action rows into a 4-column grid sharing the health grid's columns: row1 = Dataset name (cols 1-2) | Version | Add images, row2 = Name prefix (cols 1-2) | Apply ordered names | Caption all, row3 = Items | Missing captions | Duplicate filenames | Save.
- Inputs and buttons share a 44px control height (inputs a bit taller + larger font, buttons a bit shorter); Add images / Caption all / Save are identical.
- Name prefix now spans the Items + Missing-captions columns.
- Move the Version indicator up beside the Dataset name; Save loses its card chrome and bottom-aligns with the stat cards.

Web (244) + scaffold + build green.