### PR TITLE
Align Character Studio with the Dataset screen (epic 2019)

### DIFF
--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -285,26 +285,23 @@ export function CharacterStudio() {
           <p className="eyebrow">Character Studio</p>
           <h2>{activeProject ? activeProject.name : "Create a project"}</h2>
         </div>
+        <CompactSelector
+          createLabel="New character"
+          disabled={!activeProject}
+          getSubtitle={(character) =>
+            `${typeLabel(character.type)} · ${character.references?.length ?? 0} ref${(character.references?.length ?? 0) === 1 ? "" : "s"}`
+          }
+          getThumbAsset={characterThumbAsset}
+          items={characters}
+          label="Select character"
+          onCreate={createDraftCharacter}
+          onSelect={(character) => setSelectedCharacterId(character.id)}
+          placeholder="Select a character"
+          selectedId={selectedCharacter?.id ?? ""}
+        />
       </div>
 
       <div className="character-layout">
-        <div className="character-selector-bar">
-          <CompactSelector
-            createLabel="New character"
-            disabled={!activeProject}
-            getSubtitle={(character) =>
-              `${typeLabel(character.type)} · ${character.references?.length ?? 0} ref${(character.references?.length ?? 0) === 1 ? "" : "s"}`
-            }
-            getThumbAsset={characterThumbAsset}
-            items={characters}
-            label="Select character"
-            onCreate={createDraftCharacter}
-            onSelect={(character) => setSelectedCharacterId(character.id)}
-            placeholder="Select a character"
-            selectedId={selectedCharacter?.id ?? ""}
-          />
-        </div>
-
         {!selectedCharacter ? (
           <div className="empty-panel">No characters yet — use “New character” to start.</div>
         ) : (
@@ -334,17 +331,20 @@ export function CharacterStudio() {
                 />
               </label>
               <div className="detail-actions">
-                <button type="submit">Save</button>
-                <button onClick={() => archiveCharacter(selectedCharacter.id)} type="button">
+                <button className="primary-action" type="submit">
+                  Save
+                </button>
+                <button className="secondary-action" onClick={() => archiveCharacter(selectedCharacter.id)} type="button">
                   Archive
                 </button>
                 <button
+                  className="secondary-action"
                   onClick={() => onSendImage(selectedCharacter, testLookId || null, approvedReferences[0]?.assetId ?? null)}
                   type="button"
                 >
                   Image
                 </button>
-                <button onClick={() => onSendVideo(selectedCharacter, testLookId || null)} type="button">
+                <button className="secondary-action" onClick={() => onSendVideo(selectedCharacter, testLookId || null)} type="button">
                   Video
                 </button>
               </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3367,10 +3367,6 @@ label {
   align-items: start;
 }
 
-.character-selector-bar {
-  display: flex;
-}
-
 .preset-layout {
   display: grid;
   grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
@@ -4230,6 +4226,22 @@ label {
 .lora-editor,
 .test-result {
   padding: 14px;
+}
+
+/* Match the Dataset editor's control sizing (sc-2025 parity): larger inputs,
+   44px controls, a green primary Save. */
+.character-editor .control-grid input,
+.character-editor .control-grid select {
+  height: 44px;
+  font-size: 15px;
+}
+
+.character-editor .prompt-field textarea {
+  font-size: 15px;
+}
+
+.character-editor .detail-actions button {
+  height: 44px;
 }
 
 .character-reference-grid {


### PR DESCRIPTION
## Summary

Bring **Character Studio**'s look in line with the redesigned Dataset editor (follow-up polish in epic 2019).

- **Selector moved to the header** — the character compact selector now sits top-right in the header (mirroring the Dataset picker placement) instead of a separate bar below the heading.
- **Matched control sizing** — 44px inputs/select with a larger (15px) font and 44px action buttons, same as the Dataset editor.
- **Button treatment** — **Save** is now a green primary button; **Archive / Image / Video** are secondary, matching the Dataset screen.
- Removed the now-dead `character-selector-bar` style.

## Tests

Web suite (244) + scaffold + production build green. The existing Character Studio tests (selector switch, "+ New character" create) still pass against the relocated selector.

## Verification

Reaching Character Studio live needs the backend + a project with a character, which the Vite dev-server preview can't exercise alone; the vitest tests render the real component and drive the selector + form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)