### PR TITLE
feat(character): associate training datasets with a character (sc-2022)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1116,6 +1116,117 @@ async fn training_dataset_routes_persist_and_validate_project_assets() {
     assert_eq!(listed_after_delete, json!([]));
 }
 
+// sc-2022: a dataset can be associated with a character at create time or via a
+// later PATCH, and the association surfaces on the detail body and list summary
+// so the Character Studio can scope its dataset list client-side. General
+// datasets leave `characterId` null.
+#[tokio::test]
+async fn training_datasets_associate_with_a_character() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let app = create_app(settings.clone()).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Character Datasets" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    let (status, asset) = request_multipart_upload(
+        app.clone(),
+        &format!("/api/v1/projects/{project_id}/assets"),
+        "Portrait.PNG",
+        "image/png",
+        b"png-bytes",
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+
+    // Created with an explicit character association (the "create from a
+    // character's images" path).
+    let (status, scoped) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/projects/{project_id}/training/datasets"),
+        json!({
+            "name": "Mira identity set",
+            "characterId": "character_mira",
+            "items": [{ "assetId": asset_id }]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(scoped["characterId"], "character_mira");
+    let scoped_id = scoped["id"].as_str().expect("dataset id").to_owned();
+
+    // A general dataset leaves the association null.
+    let (status, general) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/projects/{project_id}/training/datasets"),
+        json!({ "name": "Style set", "items": [{ "assetId": asset_id }] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(general["characterId"], Value::Null);
+    let general_id = general["id"].as_str().expect("dataset id").to_owned();
+
+    // The association round-trips through a reload and the list summary.
+    let reloaded_app = create_app(settings).expect("app reloads");
+    let (status, listed) = request(
+        reloaded_app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/training/datasets"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let by_id = |id: &str| -> Value {
+        listed
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["id"] == id)
+            .cloned()
+            .expect("dataset present in list")
+    };
+    assert_eq!(by_id(&scoped_id)["characterId"], "character_mira");
+    assert_eq!(by_id(&general_id)["characterId"], Value::Null);
+
+    // PATCHing a general dataset associates it (the import-from-character path,
+    // which always saves a full item set alongside the new association).
+    let (status, associated) = request(
+        reloaded_app.clone(),
+        "PATCH",
+        &format!("/api/v1/projects/{project_id}/training/datasets/{general_id}"),
+        json!({ "characterId": "character_kelsie", "items": [{ "assetId": asset_id }] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(associated["characterId"], "character_kelsie");
+
+    let (status, relisted) = request(
+        reloaded_app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/training/datasets"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let associated_summary = relisted
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["id"] == general_id)
+        .cloned()
+        .expect("associated dataset present");
+    assert_eq!(associated_summary["characterId"], "character_kelsie");
+}
+
 #[tokio::test]
 async fn training_dataset_uploads_are_dataset_owned_not_assets() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1210,6 +1210,16 @@ export function App() {
     setActiveView("Video");
   }
 
+  // sc-2022: open a specific dataset in the Dataset editor (Character Studio's
+  // "Open" action on an associated dataset). The editor consumes studioLaunch.
+  function openDatasetInLibrary(datasetId) {
+    if (!datasetId) {
+      return;
+    }
+    setStudioLaunch({ id: crypto.randomUUID(), view: "LibraryDataSets", datasetId });
+    setActiveView("LibraryDataSets");
+  }
+
   async function updateAssetStatus(asset, changes) {
     try {
       const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/status`, token, {
@@ -1437,6 +1447,7 @@ export function App() {
     createCharacterTestJob,
     sendCharacterToImage,
     sendCharacterToVideo,
+    openDatasetInLibrary,
   };
 
   return (

--- a/apps/web/src/components/DatasetAddDialog.jsx
+++ b/apps/web/src/components/DatasetAddDialog.jsx
@@ -93,7 +93,9 @@ export function DatasetAddDialog({ assets = [], memberIds = [], characters = [],
 
   function commit() {
     if (selectedIds.length) {
-      onAdd(selectedIds);
+      // sc-2022: adding from the Character tab associates the dataset with that
+      // character on the next save; other sources pass no character.
+      onAdd(selectedIds, tab === "character" ? characterId : null);
       setSelectedIds([]);
     }
   }

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -8,7 +8,7 @@ import { liveElapsedSeconds } from "./formatting.js";
 import { foldUpscaledAssetVariants } from "./assetVariants.js";
 import { extractFamilies } from "./presetUtils.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
-import { CharacterAssets } from "./screens/characterPanels.jsx";
+import { CharacterAssets, CharacterDatasets } from "./screens/characterPanels.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { DocumentStudio } from "./screens/DocumentStudio.jsx";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
@@ -940,8 +940,13 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Create dataset").click();
     });
+    // Importing from the Character tab associates the dataset with that
+    // character (sc-2022).
     expect(createDataset).toHaveBeenCalledWith(
-      expect.objectContaining({ items: [expect.objectContaining({ assetId: "asset-char" })] }),
+      expect.objectContaining({
+        characterId: "char-1",
+        items: [expect.objectContaining({ assetId: "asset-char" })],
+      }),
     );
   });
 
@@ -2413,6 +2418,112 @@ describe("SceneWorks app shell", () => {
       previewButtons[0].click();
     });
     expect(onPreview).toHaveBeenCalled();
+  });
+
+  it("lists a character's associated datasets and opens one (sc-2022)", async () => {
+    const onOpenDataset = vi.fn();
+    const onCreateDataset = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <CharacterDatasets
+          datasets={[
+            { id: "ds-1", name: "Mira identity set", itemCount: 12, status: "ready", characterId: "char-1" },
+          ]}
+          imageCount={5}
+          onCreateDataset={onCreateDataset}
+          onOpenDataset={onOpenDataset}
+          projectId="project-1"
+          selectedCharacter={{ id: "char-1", name: "Mira" }}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("For Mira (1)");
+    const row = container.querySelector(".character-dataset-row");
+    expect(row.textContent).toContain("Mira identity set");
+    expect(row.textContent).toContain("12 images · ready");
+
+    await act(async () => {
+      [...row.querySelectorAll("button")].find((button) => button.textContent === "Open").click();
+    });
+    expect(onOpenDataset).toHaveBeenCalledWith("ds-1");
+
+    // The create button reflects how many of the character's images would seed it.
+    const createButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("Create dataset from 5 images"),
+    );
+    await act(async () => {
+      createButton.click();
+    });
+    expect(onCreateDataset).toHaveBeenCalled();
+  });
+
+  it("creates a dataset from a character's images and opens it (sc-2022)", async () => {
+    const createTrainingDataset = vi.fn(async () => ({ id: "ds-new" }));
+    const openDatasetInLibrary = vi.fn();
+    const assets = [
+      { id: "img-1", type: "image", displayName: "hero", recipe: { normalizedSettings: { characterId: "char-1" } } },
+      { id: "img-2", type: "image", displayName: "ref", metadata: { characterReferences: [{ characterId: "char-1" }] } },
+      { id: "img-3", type: "image", displayName: "other", recipe: { normalizedSettings: { characterId: "char-2" } } },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference: () => {},
+            archiveCharacter: () => {},
+            assets,
+            attachCharacterLora: () => {},
+            characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            createTrainingDataset,
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: [],
+            loras: [],
+            openDatasetInLibrary,
+            setPreviewAsset: () => {},
+            sendCharacterToImage: () => {},
+            sendCharacterToVideo: () => {},
+            purgeAsset: () => {},
+            removeCharacterReference: () => {},
+            trainingDatasets: [],
+            trainingDatasetsProjectId: "project-1",
+            updateAssetStatus: () => {},
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    // Two of three images belong to this character.
+    const createButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("Create dataset from 2 images"),
+    );
+    expect(createButton).toBeTruthy();
+    await act(async () => {
+      createButton.click();
+    });
+
+    expect(createTrainingDataset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        characterId: "char-1",
+        name: "Mira dataset",
+        items: [{ assetId: "img-1" }, { assetId: "img-2" }],
+      }),
+    );
+    expect(openDatasetInLibrary).toHaveBeenCalledWith("ds-new");
   });
 
   it("launches reference-based generation from an approved character reference", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   CharacterAngleSet,
   CharacterAssets,
+  CharacterDatasets,
   CharacterLoras,
   CharacterLooks,
   CharacterPoseLibrary,
@@ -10,6 +11,7 @@ import {
   editableLora,
 } from "./characterPanels.jsx";
 import { CompactSelector } from "../components/CompactSelector.jsx";
+import { assetMatchesCharacter } from "../components/DatasetAddDialog.jsx";
 import { extractFamilies } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
 
@@ -54,6 +56,10 @@ export function CharacterStudio() {
     sendCharacterToImage,
     sendCharacterToVideo,
     updateAssetStatus,
+    trainingDatasets = [],
+    trainingDatasetsProjectId,
+    createTrainingDataset,
+    openDatasetInLibrary,
   } = useAppContext();
   const latestAssets = latestImageAssets;
   const onPreview = setPreviewAsset;
@@ -72,6 +78,7 @@ export function CharacterStudio() {
   const [testLookId, setTestLookId] = useState("");
   const [testCount, setTestCount] = useState(4);
   const [testResolution, setTestResolution] = useState("1024x1024");
+  const [creatingDataset, setCreatingDataset] = useState(false);
 
   const imageAssets = useMemo(
     () => assets.filter((asset) => ["image", "frame", "upload"].includes(asset.type)),
@@ -79,6 +86,21 @@ export function CharacterStudio() {
   );
   const selectedCharacter = characters.find((item) => item.id === selectedCharacterId) ?? characters[0] ?? null;
   const approvedReferences = selectedCharacter?.approvedReferences ?? [];
+  // sc-2022: datasets the dataset backend reports as owned by this character,
+  // and the character's own images (same match the Dataset editor's Character
+  // tab uses) that a new dataset would be seeded from.
+  const datasetsForProject = trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [];
+  const characterDatasets = useMemo(
+    () => datasetsForProject.filter((dataset) => dataset.characterId === selectedCharacter?.id),
+    [datasetsForProject, selectedCharacter?.id],
+  );
+  const characterImageAssetIds = useMemo(
+    () =>
+      selectedCharacter
+        ? imageAssets.filter((asset) => assetMatchesCharacter(asset, selectedCharacter.id)).map((asset) => asset.id)
+        : [],
+    [imageAssets, selectedCharacter?.id],
+  );
   // Thumbnail for the compact selector (sc-2025): a character's first approved
   // reference image, falling back to any reference. Null → placeholder tile.
   const characterThumbAsset = (character) => {
@@ -169,6 +191,28 @@ export function CharacterStudio() {
     event.preventDefault();
     if (selectedCharacter) {
       await updateCharacter(selectedCharacter.id, draft);
+    }
+  }
+
+  // sc-2022: seed a new dataset (associated with this character) from its images
+  // and jump into the Dataset editor to caption and train, reusing the shared
+  // TrainingDataset engine.
+  async function createDatasetFromCharacter() {
+    if (!selectedCharacter || !characterImageAssetIds.length || creatingDataset) {
+      return;
+    }
+    setCreatingDataset(true);
+    try {
+      const created = await createTrainingDataset({
+        name: `${selectedCharacter.name} dataset`,
+        characterId: selectedCharacter.id,
+        items: characterImageAssetIds.map((assetId) => ({ assetId })),
+      });
+      if (created?.id) {
+        openDatasetInLibrary(created.id);
+      }
+    } finally {
+      setCreatingDataset(false);
     }
   }
 
@@ -421,6 +465,16 @@ export function CharacterStudio() {
               setLoraEdit={setLoraEdit}
               setLoraId={setLoraId}
               submitLora={submitLora}
+            />
+
+            <CharacterDatasets
+              creating={creatingDataset}
+              datasets={characterDatasets}
+              imageCount={characterImageAssetIds.length}
+              onCreateDataset={createDatasetFromCharacter}
+              onOpenDataset={openDatasetInLibrary}
+              projectId={activeProject?.id}
+              selectedCharacter={selectedCharacter}
             />
 
             <CharacterTest

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -382,13 +382,16 @@ function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) {
   };
 }
 
-function datasetPayload({ activeDataset, assetsById, captionDraftById = {}, name, selectedAssetIds }) {
+function datasetPayload({ activeDataset, assetsById, associatedCharacterId, captionDraftById = {}, name, selectedAssetIds }) {
   const itemsByAssetId = new Map(
     (activeDataset?.items ?? []).map((item, index) => [datasetItemSelectionKey(activeDataset, item, index), item]),
   );
   return {
     name: name.trim(),
     modality: "image",
+    // sc-2022: associate the dataset with a character when one is set (created
+    // from a character's images, or images imported from the Character tab).
+    ...(associatedCharacterId ? { characterId: associatedCharacterId } : {}),
     items: selectedAssetIds
       .map((selectionId) => {
         const asset = assetsById.get(selectionId);
@@ -809,6 +812,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     trainingTargets: trainingTargetsCatalog,
     trainingTargetsError = "",
     setActiveView,
+    studioLaunch,
   } = useAppContext();
   const datasets = trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [];
   const datasetsError = trainingDatasetsError;
@@ -836,6 +840,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const [uploadedDatasetAssets, setUploadedDatasetAssets] = useState([]);
   const [savingDataset, setSavingDataset] = useState(false);
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
+  // Owning character for this dataset (sc-2022). Seeded from the loaded dataset,
+  // set when images are imported from the Character tab, threaded into the save
+  // payload. "" = a general (unassociated) dataset.
+  const [associatedCharacterId, setAssociatedCharacterId] = useState("");
   // Single source of truth for caption edits, keyed by selection id (sc-2025):
   // seeded from the saved dataset items, updated as the user edits an item's
   // caption or imports a .txt sidecar, and threaded into the dataset payload on
@@ -929,6 +937,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const dirty =
     Boolean(activeDataset) &&
     (draftName.trim() !== activeDataset.name ||
+      associatedCharacterId !== (activeDataset.characterId ?? "") ||
       selectedAssetIds.length !== originalAssetIds.length ||
       selectedAssetIds.some((id, index) => id !== originalAssetIds[index]) ||
       captionsDirty);
@@ -1019,6 +1028,18 @@ export function TrainingStudio({ mode = "training" } = {}) {
   useEffect(() => {
     setActiveTab(datasetLibraryMode ? "dataset" : "configure");
   }, [datasetLibraryMode]);
+
+  // sc-2022: open a dataset requested from elsewhere (Character Studio's
+  // "Open" action hands off via studioLaunch). Keyed on the launch id so a
+  // repeat request for the same dataset re-opens it.
+  useEffect(() => {
+    if (!datasetLibraryMode || studioLaunch?.view !== "LibraryDataSets" || !studioLaunch?.datasetId) {
+      return;
+    }
+    if (studioLaunch.datasetId !== selectedDatasetId) {
+      openDataset(studioLaunch.datasetId);
+    }
+  }, [datasetLibraryMode, studioLaunch?.id]);
 
   useEffect(() => {
     const datasetTriggerPhrase = triggerPhraseFromText(activeDataset?.name);
@@ -1121,6 +1142,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setActiveDataset(null);
       setDraftName("");
       setSelectedAssetIds([]);
+      setAssociatedCharacterId("");
       setSelectedDatasetId("");
       return;
     }
@@ -1132,6 +1154,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setActiveDataset(dataset);
       setDraftName(dataset?.name ?? "");
       setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
+      setAssociatedCharacterId(dataset?.characterId ?? "");
       setSelectedDatasetId(dataset?.id ?? datasetId);
     } catch (err) {
       setDatasetError(err.message);
@@ -1152,6 +1175,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setDatasetMessage("");
     setDraftName("");
     setSelectedAssetIds([]);
+    setAssociatedCharacterId("");
     setUploadedDatasetAssets([]);
     setSelectedDatasetId("");
   }
@@ -1291,13 +1315,17 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
   }
 
-  function addAssets(ids) {
+  function addAssets(ids, characterId = null) {
     const additions = (ids ?? []).filter(Boolean);
     if (!additions.length) {
       return;
     }
     setDatasetMessage("");
     setSelectedAssetIds((current) => Array.from(new Set([...current, ...additions])));
+    // sc-2022: importing a character's images associates the dataset with it.
+    if (characterId) {
+      setAssociatedCharacterId(characterId);
+    }
   }
 
   // Accepts a FileList from either the dialog's file input or a drag/drop, so
@@ -1367,7 +1395,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // re-syncs local state from it. Shared by Save, Apply ordered names, and the
   // caption dialog so captioning/rename always act on the live persisted items.
   async function persistDataset() {
-    const payload = datasetPayload({ activeDataset, assetsById, captionDraftById, name: draftName, selectedAssetIds });
+    const payload = datasetPayload({
+      activeDataset,
+      assetsById,
+      associatedCharacterId,
+      captionDraftById,
+      name: draftName,
+      selectedAssetIds,
+    });
     const dataset = activeDataset
       ? await updateDataset(activeDataset.id, payload)
       : await createDataset(payload);
@@ -1376,6 +1411,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setDraftName(dataset.name ?? draftName.trim());
       setUploadedDatasetAssets([]);
       setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
+      setAssociatedCharacterId(dataset.characterId ?? "");
       setSelectedDatasetId(dataset.id ?? "");
     }
     return dataset;

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -659,6 +659,73 @@ export function CharacterAssets({ selectedCharacter, assets = [], onPreview }) {
   );
 }
 
+// Training datasets associated with this character (sc-2022). The character is
+// the hub for its references, looks, LoRAs, and — here — its LoRA training data.
+// This is UI grouping over the shared TrainingDataset backend: "Open" deep-links
+// into the Dataset editor, and "Create from images" seeds a new associated
+// dataset from the character's generated images. No dataset logic is duplicated.
+export function CharacterDatasets({
+  selectedCharacter,
+  projectId,
+  datasets = [],
+  imageCount = 0,
+  onOpenDataset,
+  onCreateDataset,
+  creating = false,
+}) {
+  if (!selectedCharacter) {
+    return null;
+  }
+  const coverAsset = (dataset) =>
+    dataset?.coverPath ? { projectId, type: "image", file: { path: dataset.coverPath } } : null;
+  return (
+    <section className="character-section character-datasets">
+      <div className="section-heading">
+        <p className="eyebrow">Training datasets</p>
+        <h2>
+          For {selectedCharacter.name}
+          {datasets.length ? ` (${datasets.length})` : ""}
+        </h2>
+      </div>
+      {datasets.length ? (
+        <ul className="character-dataset-list">
+          {datasets.map((dataset) => {
+            const cover = coverAsset(dataset);
+            return (
+              <li className="character-dataset-row" key={dataset.id}>
+                <span className="character-dataset-cover">
+                  {cover ? <AssetMedia asset={cover} controls={false} /> : <span className="thumb-placeholder" />}
+                </span>
+                <span className="character-dataset-meta">
+                  <strong>{dataset.name}</strong>
+                  <span className="muted">
+                    {dataset.itemCount ?? 0} image{(dataset.itemCount ?? 0) === 1 ? "" : "s"} · {dataset.status ?? "draft"}
+                  </span>
+                </span>
+                <button className="secondary-action" onClick={() => onOpenDataset?.(dataset.id)} type="button">
+                  Open
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="muted">No datasets yet for this character. Create one from its images to start a LoRA.</p>
+      )}
+      <div className="detail-actions">
+        <button
+          className="primary-action"
+          disabled={creating || imageCount === 0}
+          onClick={() => onCreateDataset?.()}
+          type="button"
+        >
+          {creating ? "Creating…" : `Create dataset from ${imageCount} image${imageCount === 1 ? "" : "s"}`}
+        </button>
+      </div>
+    </section>
+  );
+}
+
 // Pose library: pick one or more poses from the bundled OpenPose gallery and generate
 // the character in each, in a single batch job (advanced.poses) sharing one seed for
 // wardrobe/hair consistency. An OpenPose ControlNet drives the pose; a face-restoration

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3128,6 +3128,58 @@ label {
   border-radius: var(--r-md);
 }
 
+/* Character-scoped training datasets panel (sc-2022) */
+.character-dataset-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.character-dataset-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+}
+
+.character-dataset-cover {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  background: var(--bg-1);
+  border-radius: var(--r-sm);
+}
+
+.character-dataset-cover img,
+.character-dataset-cover video,
+.character-dataset-cover .thumb-placeholder {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.character-dataset-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.character-dataset-meta strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .model-card {
   display: grid;
   gap: 12px;

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -90,6 +90,11 @@ pub struct TrainingDataset {
     /// Owning project, when the dataset is project-scoped. `None` means global.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_id: Option<String>,
+    /// Owning character, when the dataset is scoped to one (sc-2022). `None` for
+    /// general (style / standalone) datasets. Set when images are imported from a
+    /// character or the dataset is created from a character's images.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub character_id: Option<String>,
     pub name: String,
     pub modality: TrainingModality,
     pub status: TrainingDatasetStatus,

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -26,6 +26,9 @@ pub struct TrainingDatasetCreateInput {
     pub modality: Option<TrainingModality>,
     #[serde(default)]
     pub status: Option<TrainingDatasetStatus>,
+    /// Optional owning character (sc-2022). `None` creates a general dataset.
+    #[serde(default)]
+    pub character_id: Option<String>,
     #[serde(default)]
     pub items: Vec<TrainingDatasetItemInput>,
 }
@@ -37,6 +40,10 @@ pub struct TrainingDatasetUpdateInput {
     pub name: Option<String>,
     #[serde(default)]
     pub status: Option<TrainingDatasetStatus>,
+    /// Associate the dataset with a character (sc-2022) when present. `Some`
+    /// sets/changes the owning character; absent leaves it unchanged.
+    #[serde(default)]
+    pub character_id: Option<String>,
     /// Full replacement for the dataset's ordered item set when present.
     #[serde(default)]
     pub items: Option<Vec<TrainingDatasetItemInput>>,
@@ -120,6 +127,10 @@ pub struct TrainingDatasetSummary {
     /// thumbnail (sc-2025). `None` when the dataset has no items.
     #[serde(default)]
     pub cover_path: Option<String>,
+    /// Owning character id (sc-2022), or `None` for a general dataset. Lets the
+    /// Character Studio filter the list to one character's datasets client-side.
+    #[serde(default)]
+    pub character_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -196,6 +207,7 @@ impl TrainingDatasetStore {
             id: dataset_id,
             version: 1,
             project_id: Some(project_id.to_owned()),
+            character_id: input.character_id,
             name,
             modality,
             status: input.status.unwrap_or(TrainingDatasetStatus::Draft),
@@ -234,6 +246,11 @@ impl TrainingDatasetStore {
         }
         if let Some(status) = input.status {
             dataset.status = status;
+        }
+        // sc-2022: a present `character_id` (sets/changes the owning character);
+        // applied before either save path below so both persist it.
+        if let Some(character_id) = input.character_id {
+            dataset.character_id = Some(character_id);
         }
         if let Some(items) = input.items {
             let dataset_root = dataset_root(&self.project_path, &dataset.id);
@@ -927,6 +944,7 @@ pub fn apply_training_dataset_migrations(connection: &Connection) -> ProjectStor
           status text not null,
           version integer not null,
           item_count integer not null default 0,
+          character_id text,
           file_path text not null,
           created_at text not null,
           updated_at text not null
@@ -936,6 +954,7 @@ pub fn apply_training_dataset_migrations(connection: &Connection) -> ProjectStor
         ",
     )?;
     ensure_training_dataset_column(connection, "item_count", "integer not null default 0")?;
+    ensure_training_dataset_column(connection, "character_id", "text")?;
     Ok(())
 }
 
@@ -946,7 +965,7 @@ fn list_dataset_summaries_from_index(
     let connection = Connection::open(project_path.join("project.db"))?;
     let mut statement = connection.prepare(
         "
-        select id, project_id, name, modality, status, version, item_count, created_at, updated_at, file_path
+        select id, project_id, name, modality, status, version, item_count, created_at, updated_at, file_path, character_id
           from training_datasets
          where project_id = ?1
          order by updated_at desc, name asc
@@ -967,6 +986,7 @@ fn list_dataset_summaries_from_index(
                     created_at: row.get(7)?,
                     updated_at: row.get(8)?,
                     cover_path: None,
+                    character_id: row.get::<_, Option<String>>(10)?,
                 },
                 row.get::<_, Option<String>>(9)?,
             ))
@@ -1020,8 +1040,8 @@ fn index_dataset(
     connection.execute(
         "
         insert or replace into training_datasets (
-          id, project_id, name, modality, status, version, item_count, file_path, created_at, updated_at
-        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+          id, project_id, name, modality, status, version, item_count, character_id, file_path, created_at, updated_at
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
         ",
         params![
             dataset.id,
@@ -1031,6 +1051,7 @@ fn index_dataset(
             dataset.status.as_str(),
             dataset.version,
             i64::try_from(dataset.items.len()).unwrap_or(i64::MAX),
+            dataset.character_id,
             rel_path,
             dataset.created_at,
             dataset.updated_at,


### PR DESCRIPTION
## sc-2022 — Backend + UI: character ↔ TrainingDataset association

Associates a training dataset with a character. General datasets leave the association null and are unaffected. **No dataset logic is duplicated** — uploads, captioning, sidecars, batch rename, and training stay the single shared engine.

> Scope refined with the user: 2021 → Done, 2023 (full references→LoRA loop) → Backlog. This story now also pulls a thin UI slice forward (the character-screen datasets area).

### Backend (`sceneworks-core` + `rust-api`)
- `characterId` on `TrainingDataset` + create/update inputs + list summary.
- `training_datasets` gains a `character_id` column (migration via `ensure_training_dataset_column`), indexed on write, returned in the summary.
- `create` sets it from input; `update` applies a present `characterId` before both save paths.
- New API test: create-with-character, general dataset (null), reload, and `PATCH`-to-associate — all round-tripping through the list summary.

### Web
- **Dataset editor add dialog:** importing from the **Character** tab associates the dataset with that character on the next save (threaded `addAssets → associatedCharacterId → datasetPayload`; counted as dirty; reseeded on load/save).
- **Character Studio — "Training datasets" panel:** lists the selected character's associated datasets (cover + count + status) with an **Open** action that deep-links into the Dataset editor (via `openDatasetInLibrary` → `studioLaunch` handoff), plus **"Create dataset from this character's images"** which seeds a new associated dataset and opens it.

Filtering by character / "general" is done client-side off the returned `characterId` (no new endpoint).

### Verification
- `cargo test` (workspace) green; `cargo fmt --all` clean.
- Web: `vite build` clean; **246 tests pass** (2 new: character datasets panel + create-from-images flow; extended the Character-tab dialog test to assert auto-association).
- Scaffold check passed. Parity snapshots don't cover training-dataset endpoints, so no snapshot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)