### PR TITLE
fix(worker): register MlxFlux2Adapter in the runtime adapter registry (sc-2203)

### DIFF
--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -21,6 +21,7 @@ from .image_adapters import (
     FluxDiffusersAdapter,
     KolorsDiffusersAdapter,
     LensTurboAdapter,
+    MlxFlux2Adapter,
     MlxFluxAdapter,
     MlxQwenAdapter,
     MlxSdxlAdapter,
@@ -1414,6 +1415,11 @@ def run_worker_loop(settings: WorkerSettings) -> None:
         "sensenova_u1": SenseNovaU1Adapter(),
         "flux_diffusers": FluxDiffusersAdapter(),
         "mlx_flux": MlxFluxAdapter(),
+        # FLUX.2-klein family (sc-2164). Registered here so create_image_adapter's
+        # `adapters.get("mlx_flux2")` dispatch resolves in the real runtime; the
+        # earlier omission made every FLUX.2 job crash with "'NoneType' object
+        # has no attribute 'generate'" (sc-2203).
+        "mlx_flux2": MlxFlux2Adapter(),
         "kolors_diffusers": KolorsDiffusersAdapter(),
         "sdxl_diffusers": SdxlDiffusersAdapter(),
         "mlx_sdxl": MlxSdxlAdapter(),

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1994,6 +1994,47 @@ def test_flux2_dispatch_picks_mlx_flux2_for_both_models(monkeypatch):
         assert adapter.__class__.__name__ == "MlxFlux2Adapter", model
 
 
+def test_flux2_dispatch_resolves_via_runtime_registry(monkeypatch):
+    # sc-2203 regression: in the REAL worker, create_image_adapter is called
+    # WITH the runtime's image_adapters dict, so the flux2 dispatch does
+    # `adapters.get("mlx_flux2")`. MlxFlux2Adapter was added to the dispatch +
+    # MODEL_TARGETS in sc-2164 but never registered in that dict, so every
+    # FLUX.2 job resolved to None and crashed with
+    # "'NoneType' object has no attribute 'generate'". The no-dict test above
+    # missed it (it takes the `else MlxFlux2Adapter()` branch). Pass a registry
+    # and assert the lookup resolves.
+    from scene_worker.image_adapters import MlxFlux2Adapter
+
+    monkeypatch.delenv("SCENEWORKS_IMAGE_ADAPTER", raising=False)
+    registry = {"mlx_flux2": MlxFlux2Adapter()}
+    for model in ("flux2_klein_9b", "flux2_klein_9b_kv"):
+        adapter = create_image_adapter({"payload": {"model": model}}, registry)
+        assert adapter is not None, f"{model} dispatched to None — adapter not registered"
+        assert adapter.__class__.__name__ == "MlxFlux2Adapter", model
+
+
+def test_runtime_registry_covers_all_model_target_adapters():
+    # sc-2203 guard: every adapter id a manifest model can dispatch to (the
+    # `adapter` field in MODEL_TARGETS) must be a key in the runtime's
+    # image_adapters registry, or create_image_adapter's `adapters.get(id)`
+    # returns None and the job crashes. Catches "added to dispatch but forgot
+    # to register" for any future adapter, not just FLUX.2.
+    import re
+    from pathlib import Path
+
+    from scene_worker import runtime
+    from scene_worker.image_adapters import MODEL_TARGETS
+
+    src = Path(runtime.__file__).read_text(encoding="utf-8")
+    block = src.split("image_adapters: dict[str, object] = {", 1)[1].split("}", 1)[0]
+    registered = set(re.findall(r'"([a-z0-9_]+)":', block))
+
+    needed = {target["adapter"] for target in MODEL_TARGETS.values() if target.get("adapter")}
+    missing = needed - registered
+    assert not missing, f"adapter ids in MODEL_TARGETS not registered in runtime: {sorted(missing)}"
+    assert "mlx_flux2" in registered  # the specific sc-2203 regression
+
+
 def test_should_route_flux2_to_mlx_predicate(monkeypatch):
     from scene_worker.image_adapters import _should_route_flux2_to_mlx
 


### PR DESCRIPTION
## Summary

**Bug:** generating with any FLUX.2 [klein] model (`flux2_klein_9b`, `flux2_klein_9b_kv`) crashes with:

```
'NoneType' object has no attribute 'generate'
```

The entire FLUX.2-klein family has been non-functional in the production worker since sc-2164 merged.

## Root cause

`MlxFlux2Adapter` was added to `MODEL_TARGETS` and the `create_image_adapter` dispatch in sc-2164, but **never imported or registered** in the `image_adapters` registry in `runtime.py`. The real worker passes that registry to `create_image_adapter`, so the FLUX.2 branch:

```python
if model_target.get("adapter") == MlxFlux2Adapter.id:
    return adapters.get("mlx_flux2") if adapters else MlxFlux2Adapter()
```

resolved `adapters.get("mlx_flux2")` → `None`, and `run_image_job` (`runtime.py:762`) called `.generate()` on it.

## Why it wasn't caught

- sc-2164's e2e was **runner-direct** (drove the adapter / `mlx_flux_runner.py`), not through `run_image_job` → `create_image_adapter` with the real registry.
- `test_flux2_dispatch_picks_mlx_flux2_for_both_models` calls `create_image_adapter` **without** an adapters dict, taking the `else MlxFlux2Adapter()` branch — so it never exercised the failing registry lookup.

## Fix

Import `MlxFlux2Adapter` and add `"mlx_flux2": MlxFlux2Adapter()` to the runtime registry.

## Tests

- `test_flux2_dispatch_resolves_via_runtime_registry` — dispatch *with* a registry resolves to `MlxFlux2Adapter` (not `None`) for both ids (reproduces the real failure mode).
- `test_runtime_registry_covers_all_model_target_adapters` — every `MODEL_TARGETS` adapter id must be a key in the runtime registry; a general guard against "added to dispatch but forgot to register" for any future adapter. Verified it fails without this fix.

✅ 420/420 worker runtime tests pass.

## Notes

- Independent of sc-2173 (PR #342, capability broadening) — predates it and affects `flux2_klein_9b` too. But #342's unlocked txt2img modes are also non-functional until this lands.
- On hosts without the `/opt/mlx-flux-venv` sidecar, this surfaces the next clean error ("requires the isolated mlx-flux sidecar venv") instead of the NoneType crash; the desktop bootstrap provisions that venv on first launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)