### PR TITLE
feat: LoKr (LyCORIS Kronecker) network type for LoRA training (epic 2193)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1122,6 +1122,9 @@ fn serialize_job_lora(lora: &Value, selected_lora: &Value, lora_id: &str) -> Val
         // wan_2_2_t2v_14b). The worker gates Wan 5B-vs-14B on this since both share
         // family `wan-video`. Absent for LoRAs that don't record one.
         "baseModel": preferred_lora_value(selected_lora, lora, "baseModel"),
+        // Adapter network type (epic 2193). Carried into the generation payload so
+        // the worker can route LoKr off the MLX backend without opening the file.
+        "networkType": preferred_lora_value(selected_lora, lora, "networkType"),
         "triggerWords": preferred_lora_array(selected_lora, lora, "triggerWords"),
         "compatibility": preferred_lora_object(selected_lora, lora, "compatibility"),
         "icLora": preferred_lora_value(selected_lora, lora, "icLora"),

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5,8 +5,8 @@ use super::workers::person_readiness_from_workers;
 use super::{
     create_app, huggingface_repo_cache_path, inprocess_worker_gpu_id, lora_artifact_paths,
     merge_model_manifest_entry, mlx_catalog_status, safe_download_dir, safe_repo_dir_name,
-    strip_jsonc_comments, sweep_stale_lora_uploads_before, Settings, WorkerCapability,
-    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
+    serialize_job_lora, strip_jsonc_comments, sweep_stale_lora_uploads_before, Settings,
+    WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
     HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
@@ -16,6 +16,28 @@ use std::sync::atomic::Ordering;
 use std::time::{Duration, SystemTime};
 use tokio_stream::StreamExt;
 use tower::ServiceExt;
+
+#[test]
+fn serialize_job_lora_carries_network_type_to_payload() {
+    // A trained LoKr adapter records networkType (epic 2193); the generation
+    // payload must carry it so the worker can route LoKr off the MLX backend
+    // without opening the file.
+    let lora = json!({
+        "id": "char",
+        "family": "sdxl",
+        "networkType": "lokr",
+        "source": { "provider": "training" },
+    });
+    let payload = serialize_job_lora(&lora, &json!({}), "char");
+    assert_eq!(
+        payload.get("networkType").and_then(Value::as_str),
+        Some("lokr")
+    );
+
+    // A plain LoRA without the field stays absent/null (treated as lora downstream).
+    let plain = serialize_job_lora(&json!({ "id": "x", "family": "sdxl" }), &json!({}), "x");
+    assert!(plain.get("networkType").map(Value::is_null).unwrap_or(true));
+}
 
 fn readiness_worker(
     id: &str,

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -366,6 +366,18 @@ pub(crate) async fn create_training_job(
     let file_name = format!("{}.safetensors", slugify_lora_id(&output_name));
     let job_id = format!("job_{}", Uuid::new_v4().simple());
     let requested_gpu = training_requested_gpu(&payload.config.advanced);
+    // The adapter's network parameterization (epic 2193). Recorded on the trained
+    // LoRA so generation can route LoKr off the MLX backend (which is LoRA-only)
+    // without opening the file — mirrors how `baseModel` gates Wan 5B/14B.
+    let network_type = payload
+        .config
+        .advanced
+        .get("networkType")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_else(|| "lora".to_owned());
 
     // Where the produced adapter is written. The target's default `outputScope`
     // (project) lives in the config's `advanced` bag: project outputs land in the
@@ -447,6 +459,7 @@ pub(crate) async fn create_training_job(
         "scope": output_scope,
         "family": target.family.clone(),
         "baseModel": target.base_model.clone(),
+        "networkType": network_type,
         "triggerWords": plan.output.trigger_words.clone(),
         "source": {
             "provider": "training",

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -29,6 +29,13 @@ const optimizerLabels = {
   prodigyopt: "Prodigy",
   rose: "Rose",
 };
+// Adapter network parameterization. `lora` is the universal default; `lokr`
+// (LyCORIS Kronecker) is offered only on targets whose `limits.networkTypes`
+// advertise it (epic 2193).
+const networkTypeLabels = {
+  lora: "LoRA",
+  lokr: "LoKr (LyCORIS Kronecker)",
+};
 // Versions of the ostris de-distill training adapter (Z-Image-Turbo only). The
 // worker maps these to the matching repo file; legacy "v2-default" normalizes to v2.
 const trainingAdapterVersionOptions = ["v1", "v2"];
@@ -44,6 +51,8 @@ const configFieldLabels = {
   requestedGpu: "Requested GPU",
   rank: "Rank",
   alpha: "Alpha",
+  networkType: "Network type",
+  decomposeFactor: "LoKr factor",
   optimizer: "Optimizer",
   learningRate: "Learning rate",
   weightDecay: "Weight decay",
@@ -478,6 +487,10 @@ function optimizerLabel(value) {
   return optimizerLabels[value] ?? value;
 }
 
+function networkTypeLabel(value) {
+  return networkTypeLabels[value] ?? value;
+}
+
 function optionLabel(value) {
   return String(value ?? "")
     .split("_")
@@ -503,7 +516,7 @@ function defaultPresetForTarget(presets, targetId) {
   return targetPresets.find((preset) => preset.ui?.default) ?? targetPresets[0] ?? null;
 }
 
-function configDraftFromTarget(target, dataset, gpuOptions, triggerPhrase = "", preset = null, previousDraft = {}) {
+export function configDraftFromTarget(target, dataset, gpuOptions, triggerPhrase = "", preset = null, previousDraft = {}) {
   const defaults = preset?.config ?? target?.defaults ?? {};
   const advanced = defaults.advanced ?? {};
   const firstGpu = gpuOptions[0] ?? "";
@@ -517,6 +530,10 @@ function configDraftFromTarget(target, dataset, gpuOptions, triggerPhrase = "", 
     requestedGpu: gpuOptions.includes(requestedGpu) ? requestedGpu : firstGpu,
     rank: numericDraft(defaults.rank),
     alpha: numericDraft(defaults.alpha),
+    networkType: asText(advanced.networkType || "lora"),
+    // LoKr block-decomposition factor; -1 = auto. Only consumed when networkType
+    // is lokr (the worker ignores it otherwise).
+    decomposeFactor: numericDraft(advanced.decomposeFactor ?? -1),
     optimizer: asText(defaults.optimizer),
     learningRate: numericDraft(defaults.learningRate),
     weightDecay: numericDraft(advanced.weightDecay),
@@ -591,10 +608,14 @@ function samplePromptsFromTrigger(triggerWord) {
   ];
 }
 
-function trainingConfigSnapshot({ activeDataset, configDraft, selectedPreset, selectedTarget, dryRun = true }) {
+export function trainingConfigSnapshot({ activeDataset, configDraft, selectedPreset, selectedTarget, dryRun = true }) {
   const defaults = selectedTarget?.defaults ?? {};
+  const networkType = asText(configDraft.networkType).trim() || "lora";
   const advanced = compactObject({
     ...(defaults.advanced ?? {}),
+    networkType,
+    // LoKr factor only matters for lokr; omit it otherwise so lora jobs stay clean.
+    decomposeFactor: networkType === "lokr" ? numberFromDraft(configDraft.decomposeFactor) : undefined,
     weightDecay: numberFromDraft(configDraft.weightDecay),
     lrScheduler: asText(configDraft.lrScheduler).trim() || "constant",
     lrWarmupSteps: numberFromDraft(configDraft.lrWarmupSteps),
@@ -978,6 +999,11 @@ export function TrainingStudio({ mode = "training" } = {}) {
     configDraft.optimizer && !optimizerSelectOptions.includes(configDraft.optimizer)
       ? [...optimizerSelectOptions, configDraft.optimizer]
       : optimizerSelectOptions;
+  // Network type: only render the picker when the target advertises a real choice
+  // (more than just lora). LoKr targets gain the picker + the LoKr factor field.
+  const networkTypeOptions = rangeOptions(selectedTarget?.limits, "networkTypes");
+  const showNetworkType = networkTypeOptions.length > 1;
+  const isLokrNetwork = asText(configDraft.networkType).trim() === "lokr";
   const lrSchedulerLimitOptions = rangeOptions(selectedTarget?.limits, "lrSchedulers");
   const lrSchedulerSelectOptions = lrSchedulerLimitOptions.length ? lrSchedulerLimitOptions : lrSchedulerOptions;
   const visibleLrSchedulerOptions =
@@ -1955,6 +1981,33 @@ export function TrainingStudio({ mode = "training" } = {}) {
                             Alpha
                             <input onChange={(event) => updateConfigDraft("alpha", event.target.value)} type="number" value={configDraft.alpha ?? ""} />
                           </label>
+                          {showNetworkType ? (
+                            <label title="Adapter parameterization. LoRA is the standard low-rank adapter; LoKr (LyCORIS Kronecker) trains a much smaller, often more expressive adapter (torch backends only).">
+                              Network type
+                              <select
+                                onChange={(event) => updateConfigDraft("networkType", event.target.value)}
+                                value={configDraft.networkType ?? "lora"}
+                              >
+                                {networkTypeOptions.map((option) => (
+                                  <option key={option} value={option}>
+                                    {networkTypeLabel(option)}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                          ) : null}
+                          {showNetworkType && isLokrNetwork ? (
+                            <label title="LoKr block-decomposition factor. -1 lets LyCORIS pick the largest factor automatically; larger values trade adapter size for capacity.">
+                              LoKr factor
+                              <input
+                                min="-1"
+                                onChange={(event) => updateConfigDraft("decomposeFactor", event.target.value)}
+                                step="1"
+                                type="number"
+                                value={configDraft.decomposeFactor ?? ""}
+                              />
+                            </label>
+                          ) : null}
                           <label>
                             Optimizer
                             <select onChange={(event) => updateConfigDraft("optimizer", event.target.value)} value={configDraft.optimizer ?? ""}>

--- a/apps/web/src/screens/TrainingStudio.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.test.jsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { configDraftFromTarget, trainingConfigSnapshot } from "./TrainingStudio.jsx";
+
+// Minimal target mirroring a LoKr-capable builtin (sc-2195 gating): networkType
+// lives in defaults.advanced, the choice is gated by limits.networkTypes.
+const lokrTarget = {
+  id: "sdxl_lora",
+  defaults: {
+    rank: 8,
+    alpha: 8,
+    learningRate: 0.0001,
+    steps: 1000,
+    batchSize: 1,
+    gradientAccumulation: 1,
+    resolution: 1024,
+    saveEvery: 0,
+    seed: 42,
+    optimizer: "adamw",
+    advanced: { networkType: "lora" },
+  },
+  limits: { networkTypes: ["lora", "lokr"] },
+};
+
+const dataset = { id: "ds-1", version: 1, name: "Kelsie" };
+
+function snapshot(configDraft) {
+  return trainingConfigSnapshot({
+    activeDataset: dataset,
+    configDraft: { ...configDraft, outputName: "Kelsie LoRA" },
+    selectedTarget: lokrTarget,
+  });
+}
+
+describe("TrainingStudio network type", () => {
+  it("draft defaults to lora with an auto LoKr factor", () => {
+    const draft = configDraftFromTarget(lokrTarget, dataset, []);
+    expect(draft.networkType).toBe("lora");
+    expect(draft.decomposeFactor).toBe("-1");
+  });
+
+  it("draft reflects a lokr default from the target's advanced bag", () => {
+    const lokrDefault = {
+      ...lokrTarget,
+      defaults: { ...lokrTarget.defaults, advanced: { networkType: "lokr", decomposeFactor: 16 } },
+    };
+    const draft = configDraftFromTarget(lokrDefault, dataset, []);
+    expect(draft.networkType).toBe("lokr");
+    expect(draft.decomposeFactor).toBe("16");
+  });
+
+  it("serializes lora without a LoKr factor", () => {
+    const draft = configDraftFromTarget(lokrTarget, dataset, []);
+    const snap = snapshot(draft);
+    expect(snap.config.advanced.networkType).toBe("lora");
+    expect(snap.config.advanced).not.toHaveProperty("decomposeFactor");
+  });
+
+  it("serializes lokr with the chosen factor", () => {
+    const draft = configDraftFromTarget(lokrTarget, dataset, []);
+    const snap = snapshot({ ...draft, networkType: "lokr", decomposeFactor: "16" });
+    expect(snap.config.advanced.networkType).toBe("lokr");
+    expect(snap.config.advanced.decomposeFactor).toBe(16);
+  });
+
+  it("omits a blank LoKr factor so the worker applies its -1 default", () => {
+    const draft = configDraftFromTarget(lokrTarget, dataset, []);
+    const snap = snapshot({ ...draft, networkType: "lokr", decomposeFactor: "" });
+    expect(snap.config.advanced.networkType).toBe("lokr");
+    expect(snap.config.advanced).not.toHaveProperty("decomposeFactor");
+  });
+});

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -43,6 +43,7 @@ from .lora_adapters import (
     apply_loras_to_pipeline,
     normalize_lora_specs,
     reject_loras_if_unsupported,
+    reject_lokr_loras,
     validate_lora_compatibility,
 )
 from .settings import WorkerSettings
@@ -2400,6 +2401,9 @@ class MlxFluxAdapter:
             request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
         )
         lora_specs = normalize_lora_specs(request.loras)
+        # The MLX backend can't apply LoKr (its merge math is LoRA-only); reject
+        # clearly rather than silently ignoring the adapter (epic 2193).
+        reject_lokr_loras(lora_specs, self.id)
 
         if not self._sidecar_available():
             raise RuntimeError(
@@ -2717,6 +2721,9 @@ class MlxQwenAdapter:
             request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
         )
         lora_specs = normalize_lora_specs(request.loras)
+        # The MLX backend can't apply LoKr (its merge math is LoRA-only); reject
+        # clearly rather than silently ignoring the adapter (epic 2193).
+        reject_lokr_loras(lora_specs, self.id)
 
         if not self._sidecar_available():
             raise RuntimeError(
@@ -3010,6 +3017,9 @@ class MlxZImageAdapter:
             request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
         )
         lora_specs = normalize_lora_specs(request.loras)
+        # The MLX backend can't apply LoKr (its merge math is LoRA-only); reject
+        # clearly rather than silently ignoring the adapter (epic 2193).
+        reject_lokr_loras(lora_specs, self.id)
 
         if not self._sidecar_available():
             raise RuntimeError(
@@ -3322,6 +3332,9 @@ class MlxSdxlAdapter:
             request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
         )
         lora_specs = normalize_lora_specs(request.loras)
+        # The MLX backend can't apply LoKr (its merge math is LoRA-only); the SDXL
+        # family can produce LoKr adapters, so reject them clearly here (epic 2193).
+        reject_lokr_loras(lora_specs, self.id)
 
         total = request.count
         steps = self._num_inference_steps(request, model_target)
@@ -3614,6 +3627,9 @@ class MlxFlux2Adapter:
             request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
         )
         lora_specs = normalize_lora_specs(request.loras)
+        # The MLX backend can't apply LoKr (its merge math is LoRA-only); reject
+        # clearly rather than silently ignoring the adapter (epic 2193).
+        reject_lokr_loras(lora_specs, self.id)
 
         if not self._sidecar_available():
             raise RuntimeError(

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -40,7 +40,9 @@ from .sampler_registry import apply_sampler, sampler_selection_from_advanced
 from .hf_cache import huggingface_cache_roots, huggingface_repo_cache_path
 from .lora_adapters import (
     LoraPipelineState,
+    adapter_network_type,
     apply_loras_to_pipeline,
+    lora_path,
     normalize_lora_specs,
     reject_loras_if_unsupported,
     reject_lokr_loras,
@@ -6415,6 +6417,27 @@ def _should_route_flux_to_mlx(payload: dict[str, Any]) -> bool:
     return MlxFluxAdapter()._sidecar_available()
 
 
+def _request_has_lokr_lora(payload: dict[str, Any]) -> bool:
+    """True if any LoRA in the request is a LoKr adapter. LoKr applies only on the
+    torch backends (the MLX merge math is LoRA-only), so the MLX routing gates
+    fall back to torch when this is true (epic 2193) — the same graceful fallback
+    a reference image triggers. Prefers the ``networkType`` recorded on the LoRA
+    (zero I/O) and falls back to reading the adapter's safetensors header."""
+
+    for lora in payload.get("loras") or []:
+        if not isinstance(lora, dict):
+            continue
+        recorded = lora.get("networkType") or (lora.get("compatibility") or {}).get("networkType")
+        network_type = str(recorded or "").strip().lower()
+        if not network_type:
+            resolved = lora_path(lora)
+            if resolved is not None:
+                network_type = adapter_network_type(resolved)
+        if network_type == "lokr":
+            return True
+    return False
+
+
 def _should_route_sdxl_to_mlx(payload: dict[str, Any]) -> bool:
     """Decide whether the SDXL auto-dispatch path should pick MlxSdxlAdapter
     (vendored mlx-examples in-proc) over SdxlDiffusersAdapter (torch). All
@@ -6434,8 +6457,12 @@ def _should_route_sdxl_to_mlx(payload: dict[str, Any]) -> bool:
       5. No referenceAssetId (no IP-Adapter in the MLX path).
       6. The vendored mlx_sd package + mlx itself must import (the
          requirements-mlx.txt install gate).
+      7. No LoKr LoRA in the request — LoKr is torch-only (epic 2193); a LoKr
+         job falls back to the torch path the same way a reference image does.
     """
     if os.getenv("SCENEWORKS_DISABLE_MLX_SDXL", "").strip().lower() in {"1", "true", "yes"}:
+        return False
+    if _request_has_lokr_lora(payload):
         return False
     if sys.platform != "darwin":
         return False
@@ -6477,6 +6504,9 @@ def _should_route_z_image_to_mlx(payload: dict[str, Any]) -> bool:
     if payload.get("mode") == "edit_image":
         return False
     if payload.get("referenceAssetId"):
+        return False
+    # LoKr is torch-only (epic 2193); fall back to the torch path for a LoKr job.
+    if _request_has_lokr_lora(payload):
         return False
     return MlxZImageAdapter()._sidecar_available()
 

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import hashlib
+import importlib
 import json
 import re
 from pathlib import Path
@@ -223,6 +224,97 @@ def wan_moe_low_noise_sibling(primary: Path) -> str | None:
     return str(sibling) if sibling.is_file() else None
 
 
+# --------------------------------------------------------------------------- #
+# LoKr (LyCORIS Kronecker) support (epic 2193).
+#
+# diffusers' ``load_lora_weights`` only understands LoRA-format keys, so a LoKr
+# adapter (``lokr_w1``/``lokr_w2``) must be applied by rebuilding its
+# ``peft.LoKrConfig`` from the safetensors header and injecting it into the
+# pipeline's denoiser module. The trainer (epic 2193 / write_lokr_adapter) stamps
+# everything needed: ``networkType`` to route, plus ``rank``/``alpha``/
+# ``decomposeFactor``/``targetModules`` to reconstruct the network.
+# --------------------------------------------------------------------------- #
+
+
+def read_adapter_metadata(path: str | Path) -> dict[str, str]:
+    """Best-effort read of an adapter's safetensors header metadata."""
+
+    try:
+        from safetensors import safe_open
+
+        with safe_open(str(path), framework="pt") as handle:
+            return dict(handle.metadata() or {})
+    except Exception:
+        return {}
+
+
+def adapter_network_type(path: str | Path) -> str:
+    """``"lokr"`` for a LoKr adapter, else ``"lora"`` (the default for every
+    adapter without explicit ``networkType`` metadata)."""
+
+    return (read_adapter_metadata(path).get("networkType") or "lora").strip().lower()
+
+
+def reject_lokr_loras(specs: list[LoraSpec], adapter_id: str) -> None:
+    """Guard for backends that cannot apply LoKr (e.g. MLX, whose merge math is
+    LoRA-only). Raises a clear error rather than silently mis-applying."""
+
+    for spec in specs:
+        if adapter_network_type(spec.path) == "lokr":
+            raise RuntimeError(
+                f"{adapter_id} cannot apply the LoKr adapter '{spec.id}'. LoKr "
+                "(LyCORIS Kronecker) adapters require the torch generation backend; "
+                "this backend does not support them yet (epic 2193)."
+            )
+
+
+def _denoiser_module(pipe: Any) -> Any:
+    """The pipeline submodule LoKr injects into — the UNet or the DiT transformer."""
+
+    return getattr(pipe, "unet", None) or getattr(pipe, "transformer", None)
+
+
+def inject_lokr_adapter(pipe: Any, spec: LoraSpec, *, adapter_id: str) -> None:
+    """Rebuild ``spec``'s ``LoKrConfig`` from its file metadata and inject it into
+    the denoiser, then load the trained weights — the LoKr equivalent of
+    ``pipe.load_lora_weights`` (which cannot consume LoKr keys)."""
+
+    module = _denoiser_module(pipe)
+    if module is None:
+        raise RuntimeError(
+            f"{adapter_id} cannot apply the LoKr adapter '{spec.id}': the pipeline "
+            "exposes no unet/transformer module to inject into."
+        )
+    try:
+        peft = importlib.import_module("peft")
+        from safetensors.torch import load_file
+    except Exception as exc:
+        raise RuntimeError(peft_backend_message(adapter_id, [spec])) from exc
+
+    meta = read_adapter_metadata(spec.path)
+    rank = int(meta.get("rank") or 16)
+    target_modules = json.loads(meta.get("targetModules") or "null")
+    config = peft.LoKrConfig(
+        r=rank,
+        alpha=int(meta.get("alpha") or rank),
+        decompose_factor=int(meta.get("decomposeFactor") or -1),
+        target_modules=target_modules,
+        init_weights=True,
+    )
+    peft.inject_adapter_in_model(config, module, adapter_name=spec.adapter_name)
+
+    state = load_file(str(spec.path))
+    reference = next(module.parameters(), None)
+    if reference is not None:
+        state = {
+            key: value.to(device=reference.device, dtype=reference.dtype)
+            for key, value in state.items()
+        }
+    from peft import set_peft_model_state_dict
+
+    set_peft_model_state_dict(module, state, adapter_name=spec.adapter_name)
+
+
 def apply_loras_to_pipeline(
     pipe: Any,
     loras: list[dict[str, Any]],
@@ -262,6 +354,11 @@ def apply_loras_to_pipeline(
             raise RuntimeError(f"{adapter_id} cannot clear previously loaded LoRAs between jobs.")
 
     for spec in specs_to_load:
+        # LoKr can't load via load_lora_weights (its lokr_* keys are unrecognized);
+        # rebuild the LoKrConfig from file metadata and inject it instead (epic 2193).
+        if adapter_network_type(spec.path) == "lokr":
+            inject_lokr_adapter(pipe, spec, adapter_id=adapter_id)
+            continue
         try:
             pipe.load_lora_weights(spec.path, adapter_name=spec.adapter_name)
             # Wan A14B MoE: also load the low-noise half into the second expert.
@@ -281,7 +378,14 @@ def apply_loras_to_pipeline(
 
     names = tuple(spec.adapter_name for spec in specs)
     weights = [spec.weight for spec in specs]
-    if hasattr(pipe, "set_adapters"):
+    # Injected LoKr adapters live on the denoiser module but aren't tracked by the
+    # pipeline's lora bookkeeping, so pipe.set_adapters may not see them. When any
+    # adapter is LoKr, set weights on the module (which knows every PEFT adapter).
+    if any(adapter_network_type(spec.path) == "lokr" for spec in specs):
+        set_adapter_weights_on_module(
+            _denoiser_module(pipe), names, weights, adapter_id=adapter_id, specs=specs
+        )
+    elif hasattr(pipe, "set_adapters"):
         set_lora_adapters(pipe, names, weights, adapter_id=adapter_id, specs=specs)
     elif len(names) > 1 or any(weight != 1.0 for weight in weights):
         raise RuntimeError(f"{adapter_id} loaded LoRAs but cannot apply per-LoRA weights.")
@@ -291,13 +395,43 @@ def apply_loras_to_pipeline(
 def clear_loras(pipe: Any, adapter_names: tuple[str, ...], *, adapter_id: str) -> None:
     if not adapter_names:
         return
-    if hasattr(pipe, "unload_lora_weights"):
-        pipe.unload_lora_weights()
-        return
+    # Prefer deleting by name: it removes injected LoKr adapters too, which
+    # unload_lora_weights (LoRA-only) leaves behind and would leak into the next
+    # job (epic 2193). Fall back to unload for pipelines without delete_adapters.
     if hasattr(pipe, "delete_adapters"):
         pipe.delete_adapters(list(adapter_names))
         return
+    if hasattr(pipe, "unload_lora_weights"):
+        pipe.unload_lora_weights()
+        return
     raise RuntimeError(f"{adapter_id} cannot clear previously loaded LoRAs between jobs.")
+
+
+def set_adapter_weights_on_module(
+    module: Any,
+    names: tuple[str, ...],
+    weights: list[float],
+    *,
+    adapter_id: str,
+    specs: list[LoraSpec],
+) -> None:
+    """Activate adapters and apply per-adapter weights on the denoiser module
+    itself — used when LoKr adapters are present (see ``apply_loras_to_pipeline``)."""
+
+    if module is None or not hasattr(module, "set_adapters"):
+        # A single adapter at full weight needs no explicit activation; anything
+        # else genuinely cannot be applied without module-level adapter control.
+        if len(names) > 1 or any(weight != 1.0 for weight in weights):
+            raise RuntimeError(
+                f"{adapter_id} loaded a LoKr adapter but cannot apply per-adapter weights."
+            )
+        return
+    try:
+        module.set_adapters(list(names), weights=list(weights))
+    except Exception as exc:
+        if is_peft_backend_error(exc):
+            raise RuntimeError(peft_backend_message(adapter_id, specs)) from exc
+        raise
 
 
 def lora_path(lora: dict[str, Any]) -> Path | None:

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -746,26 +746,40 @@ def build_peft_network_config(peft: Any, config: TrainingRunConfig) -> Any:
 
 
 def write_lokr_adapter(
-    state_dict: dict[str, Any], output_dir: str, file_name: str, *, decompose_factor: int
+    state_dict: dict[str, Any],
+    output_dir: str,
+    file_name: str,
+    *,
+    rank: int,
+    alpha: int,
+    decompose_factor: int,
+    target_modules: Any,
 ) -> str:
-    """Write a LoKr adapter to safetensors with routing metadata.
+    """Write a LoKr adapter to safetensors with routing + reconstruction metadata.
 
     diffusers' ``save_lora_weights``/``load_lora_weights`` only understand LoRA
     (``lora_A``/``lora_B``) keys — LoKr emits ``lokr_w1``/``lokr_w2``/``lokr_t2``,
-    so the trainer serializes the raw ``get_peft_model_state_dict`` directly and
-    stamps ``networkType``/``decomposeFactor`` into the file metadata. The
-    inference loader (epic 2193) reads that metadata to route through PEFT
-    injection instead of ``load_lora_weights``."""
+    so the trainer serializes the raw ``get_peft_model_state_dict`` directly. The
+    file header carries everything the inference loader (epic 2193) needs to
+    rebuild the matching ``peft.LoKrConfig`` and inject it (``load_lora_weights``
+    cannot consume LoKr): ``networkType`` to route, plus ``rank``/``alpha``/
+    ``decomposeFactor``/``targetModules`` to reconstruct the network. safetensors
+    metadata is ``str``→``str``, so ints are stringified and the module list is
+    JSON-encoded."""
 
     from safetensors.torch import save_file
 
     os.makedirs(output_dir, exist_ok=True)
     path = os.path.join(output_dir, file_name)
     tensors = {key: value.detach().cpu().contiguous() for key, value in state_dict.items()}
+    modules = list(target_modules) if isinstance(target_modules, (list, tuple)) else target_modules
     metadata = {
         "format": "pt",
         "networkType": "lokr",
+        "rank": str(int(rank)),
+        "alpha": str(int(alpha)),
         "decomposeFactor": str(int(decompose_factor)),
+        "targetModules": json.dumps(modules),
     }
     save_file(tensors, path, metadata=metadata)
     return path
@@ -1062,7 +1076,14 @@ class _ZImageLoraBackend:
 
         progress("loading_model", "loading_model", 0.16, "Attaching LoRA adapter to the transformer.")
         self._network_type = config.network_type
-        self._decompose_factor = config.decompose_factor
+        # Stashed for the save path: everything write_lokr_adapter needs to stamp
+        # into the file so inference can rebuild the matching LoKrConfig.
+        self._lokr_save_kwargs = {
+            "rank": config.rank,
+            "alpha": config.alpha,
+            "decompose_factor": config.decompose_factor,
+            "target_modules": config.lora_target_modules,
+        }
         lora_config = build_peft_network_config(peft, config)
         transformer.add_adapter(lora_config)
         self._activate_lora_adapter(transformer)
@@ -1437,7 +1458,7 @@ class _ZImageLoraBackend:
                 lora_state_dict,
                 output_dir,
                 file_name,
-                decompose_factor=getattr(self, "_decompose_factor", -1),
+                **getattr(self, "_lokr_save_kwargs", {}),
             )
         else:
             type(self._pipeline).save_lora_weights(
@@ -1598,7 +1619,14 @@ class _SdxlLoraBackend:
 
         progress("loading_model", "loading_model", 0.16, "Attaching LoRA adapter to the U-Net.")
         self._network_type = config.network_type
-        self._decompose_factor = config.decompose_factor
+        # Stashed for the save path: everything write_lokr_adapter needs to stamp
+        # into the file so inference can rebuild the matching LoKrConfig.
+        self._lokr_save_kwargs = {
+            "rank": config.rank,
+            "alpha": config.alpha,
+            "decompose_factor": config.decompose_factor,
+            "target_modules": config.lora_target_modules,
+        }
         lora_config = build_peft_network_config(peft, config)
         unet.add_adapter(lora_config)
         self._activate_lora_adapter(unet)
@@ -1908,7 +1936,7 @@ class _SdxlLoraBackend:
                 lora_state_dict,
                 output_dir,
                 file_name,
-                decompose_factor=getattr(self, "_decompose_factor", -1),
+                **getattr(self, "_lokr_save_kwargs", {}),
             )
         else:
             type(self._pipeline).save_lora_weights(

--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -186,6 +186,12 @@ class TrainingRunConfig:
     training_adapter_repo: str | None = None
     training_adapter_version: str | None = None
     weight_noise_sigma: float = 0.0
+    # Adapter network parameterization. ``lora`` is the default; ``lokr`` builds a
+    # LyCORIS Kronecker-product adapter (peft.LoKrConfig). ``decompose_factor`` is
+    # the LoKr block-split knob (``-1`` = auto). Both live in the free-form
+    # ``advanced`` bag in the contract (gated per target by ``limits.networkTypes``).
+    network_type: str = "lora"
+    decompose_factor: int = -1
     advanced: dict[str, Any] = field(default_factory=dict)
 
 
@@ -262,6 +268,8 @@ def read_run_config(plan: dict[str, Any]) -> TrainingRunConfig:
         training_adapter_repo=_as_optional_str(advanced.get("trainingAdapterRepo")),
         training_adapter_version=_as_optional_str(advanced.get("trainingAdapterVersion")),
         weight_noise_sigma=max(0.0, _as_float(advanced.get("weightNoiseSigma"), 0.0)),
+        network_type=str(advanced.get("networkType") or "lora").strip().lower(),
+        decompose_factor=_as_int(advanced.get("decomposeFactor"), -1, minimum=-1),
         advanced=advanced,
     )
 
@@ -706,6 +714,63 @@ def build_optimizer(name: str, params: list[Any], learning_rate: float, weight_d
     return torch.optim.AdamW(params, lr=learning_rate, weight_decay=weight_decay)
 
 
+def build_peft_network_config(peft: Any, config: TrainingRunConfig) -> Any:
+    """Build the PEFT adapter config for the requested network type.
+
+    ``lora`` (the default) yields a standard low-rank ``LoraConfig``; ``lokr``
+    yields a LyCORIS Kronecker-product ``LoKrConfig`` (epic 2193). Both attach via
+    the same ``model.add_adapter(...)`` seam and save via ``get_peft_model_state_dict``
+    — only the on-disk key layout and inference loader differ. Per-target gating
+    (which backends accept ``lokr``) lives in the Rust contract's
+    ``limits.networkTypes``; this is the kernel-side constructor."""
+
+    target_modules = (
+        list(config.lora_target_modules)
+        if isinstance(config.lora_target_modules, (list, tuple))
+        else config.lora_target_modules
+    )
+    if (config.network_type or "lora").strip().lower() == "lokr":
+        return peft.LoKrConfig(
+            r=config.rank,
+            alpha=config.alpha,
+            decompose_factor=config.decompose_factor,
+            init_weights=True,
+            target_modules=target_modules,
+        )
+    return peft.LoraConfig(
+        r=config.rank,
+        lora_alpha=config.alpha,
+        init_lora_weights="gaussian",
+        target_modules=target_modules,
+    )
+
+
+def write_lokr_adapter(
+    state_dict: dict[str, Any], output_dir: str, file_name: str, *, decompose_factor: int
+) -> str:
+    """Write a LoKr adapter to safetensors with routing metadata.
+
+    diffusers' ``save_lora_weights``/``load_lora_weights`` only understand LoRA
+    (``lora_A``/``lora_B``) keys — LoKr emits ``lokr_w1``/``lokr_w2``/``lokr_t2``,
+    so the trainer serializes the raw ``get_peft_model_state_dict`` directly and
+    stamps ``networkType``/``decomposeFactor`` into the file metadata. The
+    inference loader (epic 2193) reads that metadata to route through PEFT
+    injection instead of ``load_lora_weights``."""
+
+    from safetensors.torch import save_file
+
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, file_name)
+    tensors = {key: value.detach().cpu().contiguous() for key, value in state_dict.items()}
+    metadata = {
+        "format": "pt",
+        "networkType": "lokr",
+        "decomposeFactor": str(int(decompose_factor)),
+    }
+    save_file(tensors, path, metadata=metadata)
+    return path
+
+
 # Learning-rate schedulers both backends honor. The flow-matching *noise*
 # scheduler (sigmoid/linear/weighted timestep sampling) is a separate concept,
 # configured via ``timestepType``/``timestepBias`` — see ``sample_training_timestep``.
@@ -996,14 +1061,9 @@ class _ZImageLoraBackend:
             text_encoder.requires_grad_(False)
 
         progress("loading_model", "loading_model", 0.16, "Attaching LoRA adapter to the transformer.")
-        lora_config = peft.LoraConfig(
-            r=config.rank,
-            lora_alpha=config.alpha,
-            init_lora_weights="gaussian",
-            target_modules=list(config.lora_target_modules)
-            if isinstance(config.lora_target_modules, (list, tuple))
-            else config.lora_target_modules,
-        )
+        self._network_type = config.network_type
+        self._decompose_factor = config.decompose_factor
+        lora_config = build_peft_network_config(peft, config)
         transformer.add_adapter(lora_config)
         self._activate_lora_adapter(transformer)
         if config.gradient_checkpointing:
@@ -1370,12 +1430,22 @@ class _ZImageLoraBackend:
 
         os.makedirs(output_dir, exist_ok=True)
         lora_state_dict = get_peft_model_state_dict(self._transformer)
-        type(self._pipeline).save_lora_weights(
-            output_dir,
-            transformer_lora_layers=lora_state_dict,
-            weight_name=file_name,
-            safe_serialization=True,
-        )
+        if getattr(self, "_network_type", "lora") == "lokr":
+            # LoKr keys (lokr_w1/lokr_w2) are not save_lora_weights-compatible;
+            # write raw with routing metadata (epic 2193).
+            write_lokr_adapter(
+                lora_state_dict,
+                output_dir,
+                file_name,
+                decompose_factor=getattr(self, "_decompose_factor", -1),
+            )
+        else:
+            type(self._pipeline).save_lora_weights(
+                output_dir,
+                transformer_lora_layers=lora_state_dict,
+                weight_name=file_name,
+                safe_serialization=True,
+            )
         lora_a_norm, lora_b_norm = self._lora_param_norms()
         emit_worker_event(
             "training_lora_weight_norm",
@@ -1527,14 +1597,9 @@ class _SdxlLoraBackend:
         )
 
         progress("loading_model", "loading_model", 0.16, "Attaching LoRA adapter to the U-Net.")
-        lora_config = peft.LoraConfig(
-            r=config.rank,
-            lora_alpha=config.alpha,
-            init_lora_weights="gaussian",
-            target_modules=list(config.lora_target_modules)
-            if isinstance(config.lora_target_modules, (list, tuple))
-            else config.lora_target_modules,
-        )
+        self._network_type = config.network_type
+        self._decompose_factor = config.decompose_factor
+        lora_config = build_peft_network_config(peft, config)
         unet.add_adapter(lora_config)
         self._activate_lora_adapter(unet)
         if config.gradient_checkpointing:
@@ -1836,12 +1901,22 @@ class _SdxlLoraBackend:
 
         os.makedirs(output_dir, exist_ok=True)
         lora_state_dict = get_peft_model_state_dict(self._unet)
-        type(self._pipeline).save_lora_weights(
-            output_dir,
-            unet_lora_layers=lora_state_dict,
-            weight_name=file_name,
-            safe_serialization=True,
-        )
+        if getattr(self, "_network_type", "lora") == "lokr":
+            # LoKr keys (lokr_w1/lokr_w2) are not save_lora_weights-compatible;
+            # write raw with routing metadata (epic 2193).
+            write_lokr_adapter(
+                lora_state_dict,
+                output_dir,
+                file_name,
+                decompose_factor=getattr(self, "_decompose_factor", -1),
+            )
+        else:
+            type(self._pipeline).save_lora_weights(
+                output_dir,
+                unet_lora_layers=lora_state_dict,
+                weight_name=file_name,
+                safe_serialization=True,
+            )
         lora_a_norm, lora_b_norm = self._lora_param_norms()
         emit_worker_event(
             "training_lora_weight_norm",

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -919,6 +919,10 @@ fn z_image_turbo_lora_target() -> TrainingTarget {
             "resolutions": [512, 768, 1024],
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Network parameterization for the adapter. `lora` is the universal
+            // default; `lokr` (LyCORIS Kronecker) is a torch/PEFT-only option
+            // advertised on the validated image backends (epic 2193).
+            "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"]
@@ -1014,6 +1018,9 @@ fn lens_turbo_lora_target() -> TrainingTarget {
             "resolutions": [768, 1024, 1440],
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Lens trains in a separate sidecar venv; LoKr is not validated there
+            // yet (epic 2193 v1 targets Z-Image/SDXL), so only `lora`.
+            "networkTypes": ["lora"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"]
@@ -1084,6 +1091,9 @@ fn ltx_video_lora_target() -> TrainingTarget {
             "steps": [200, 4000],
             "resolutions": [512, 768, 1024],
             "batchSize": [1, 2],
+            // MLX backend: the LoKr inference path (Kronecker merge) is out of
+            // scope for epic 2193 v1, so this target stays `lora`-only.
+            "networkTypes": ["lora"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"],
@@ -1176,6 +1186,9 @@ fn wan_lora_target() -> TrainingTarget {
             "resolutions": [512, 768],
             "batchSize": [1, 2],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Wan is a torch backend, but epic 2193 v1 validates LoKr on the
+            // image backends (Z-Image/SDXL) first; video stays `lora`-only.
+            "networkTypes": ["lora"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"]
@@ -1255,6 +1268,9 @@ fn wan_moe_lora_target(
             "resolutions": [512, 768],
             "batchSize": [1, 2],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Wan is a torch backend, but epic 2193 v1 validates LoKr on the
+            // image backends (Z-Image/SDXL) first; video stays `lora`-only.
+            "networkTypes": ["lora"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"]
@@ -1354,6 +1370,9 @@ fn sdxl_lora_target() -> TrainingTarget {
             "resolutions": [768, 1024],
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // See the Z-Image target: `lokr` (LyCORIS Kronecker) is advertised on
+            // the validated torch/PEFT image backends (epic 2193).
+            "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"]

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -94,6 +94,48 @@ fn builtin_registry_matches_committed_snapshot() {
 }
 
 #[test]
+fn builtin_targets_gate_network_types() {
+    let registry = builtin_training_targets();
+
+    let advertises = |target: &sceneworks_core::training::TrainingTarget, value: &str| {
+        target
+            .limits
+            .get("networkTypes")
+            .and_then(Value::as_array)
+            .is_some_and(|types| types.iter().any(|entry| entry.as_str() == Some(value)))
+    };
+
+    // Every target advertises `lora`; only the spike-validated torch image
+    // backends (epic 2193) advertise `lokr`.
+    let lokr_targets: Vec<&str> = registry
+        .targets
+        .iter()
+        .filter(|target| {
+            assert!(
+                advertises(target, "lora"),
+                "target {} must advertise lora in limits.networkTypes",
+                target.id
+            );
+            advertises(target, "lokr")
+        })
+        .map(|target| target.id.as_str())
+        .collect();
+
+    assert_eq!(lokr_targets, ["z_image_turbo_lora", "sdxl_lora"]);
+}
+
+#[test]
+#[ignore = "regen helper: run with REGEN_FIXTURE=1 to rewrite target-registry.json"]
+fn regen_target_registry_fixture() {
+    if std::env::var("REGEN_FIXTURE").is_err() {
+        return;
+    }
+    let pretty = serde_json::to_string_pretty(&builtin_training_targets())
+        .expect("builtin registry serializes");
+    fs::write(fixture_path("target-registry.json"), pretty + "\n").expect("write fixture");
+}
+
+#[test]
 fn builtin_preset_registry_matches_committed_snapshot() {
     let expected = load_fixture("preset-registry.json");
     let encoded = serde_json::to_value(sceneworks_core::training::builtin_training_presets())

--- a/documents/TRAINING_QUICKSTART.md
+++ b/documents/TRAINING_QUICKSTART.md
@@ -96,6 +96,35 @@ adapter version is a **De-distill adapter** dropdown in the Advanced panel
 (`v1` — stable, smaller; `v2` — experimental, heavier de-distill), so you can A/B
 the two on the same dataset.
 
+## Network type — LoRA vs LoKr
+
+Most targets train a standard **LoRA** (a low-rank `B·A` update). The
+**Z-Image-Turbo** and **SDXL** targets also offer **LoKr** (LyCORIS
+Kronecker-product), selectable as a **Network type** dropdown in the Advanced
+panel on targets that advertise it (`limits.networkTypes`). LoKr parameterizes
+the weight delta as a Kronecker product (`W₁ ⊗ W₂`, with one factor optionally
+low-rank), which produces a **much smaller adapter** — e.g. a rank-16 SDXL LoKr
+is ~2.7 MB vs tens of MB for the LoRA equivalent — at comparable or better
+fidelity. A single **LoKr factor** (`decomposeFactor`, `-1` = auto) controls the
+block split; leave it on auto to start.
+
+Because LoKr changes the saved file, it also changes how inference loads it:
+
+- diffusers' `load_lora_weights` understands only LoRA keys, so a LoKr adapter
+  (`lokr_w1`/`lokr_w2`) is applied by rebuilding its `peft.LoKrConfig` from the
+  file's safetensors metadata and **injecting it** into the UNet/transformer
+  (`peft.inject_adapter_in_model`). The worker does this automatically — the
+  trainer stamps `networkType` / `rank` / `alpha` / `decomposeFactor` /
+  `targetModules` into the file header so generation can reconstruct the network.
+- **Torch backends only.** The MLX image backends apply LoRA via a Kronecker-free
+  merge, so they **reject** a LoKr adapter with a clear error rather than
+  mis-applying it — train LoKr only where you will generate on torch.
+
+Everything else — datasets, presets, dry run, output registration — is identical
+to LoRA. `networkType` / `decomposeFactor` live in the config's free-form
+`advanced` bag (gated per target by `limits.networkTypes`), not as first-class
+config fields.
+
 ## 3. Dry run (validate the plan)
 
 A dry run resolves and validates the full plan — dataset items exist, config is
@@ -348,6 +377,7 @@ messages:
 | *"LoRA adapter attached no trainable parameters…"* (runtime) | `loraTargetModules` matched nothing | For Lens use the fused-QKV names (`img_qkv`, `txt_qkv`, `to_out`, `to_add_out`), not Z-Image's `to_q`/`to_k`/`to_v`. |
 | *"Lens LoRA training requires the isolated Lens sidecar venv…"* (submit) | Worker built without the Lens sidecar | Rebuild with `INCLUDE_LENS=1`, or set `SCENEWORKS_LENS_PYTHON`. |
 | *"… cannot target CPU workers."* (submit) | `requestedGpu` was `cpu` | Training is GPU-only. Use `auto` or a GPU id. |
+| *"… cannot apply the LoKr adapter …"* (runtime) | A LoKr adapter was sent to the MLX generation backend | Generate the LoKr LoRA on a torch backend; MLX supports only standard LoRA (see *Network type*). |
 | *"Not enough free disk space to train…"* (submit) | Output volume low on space | Free space (model weights, checkpoints, cached latents are the largest consumers). |
 | Job stays **queued** | No GPU worker advertises `lora_train_execute` | Start a CUDA-enabled worker. A torch-less worker can claim dry runs only. |
 | *"… GPU ran out of memory."* (runtime) | VRAM exhausted | Lower resolution, batch size, or rank. |

--- a/scripts/e2e_lokr_sdxl.py
+++ b/scripts/e2e_lokr_sdxl.py
@@ -1,0 +1,110 @@
+"""sc-2199 e2e: real SDXL LoKr train -> save -> inference round trip.
+
+Exercises the actual production code paths on real cached SDXL weights:
+  - build_peft_network_config (trainer) attaches a real LoKrConfig to the UNet
+  - write_lokr_adapter (trainer) serializes it with routing metadata
+  - apply_loras_to_pipeline (the exact entrypoint SdxlImageAdapter calls) detects
+    the LoKr file, injects it via PEFT (NOT load_lora_weights), and generates.
+
+Confirms: file routes as lokr, injection applies a real delta to generation,
+and a no-LoRA baseline differs from the LoKr render. Smoke quality only
+(512px / few steps) — this validates plumbing, not aesthetics.
+"""
+
+import os
+import sys
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+sys.path.insert(0, "apps/worker")
+sys.path.insert(0, "packages/shared")
+
+import numpy as np
+import torch
+from diffusers import StableDiffusionXLPipeline
+from peft.utils import get_peft_model_state_dict
+import peft
+
+from scene_worker.training_adapters import build_peft_network_config, write_lokr_adapter, read_run_config
+from scene_worker.lora_adapters import apply_loras_to_pipeline, adapter_network_type
+
+REPO = "stabilityai/stable-diffusion-xl-base-1.0"
+DEVICE = "mps" if torch.backends.mps.is_available() else "cpu"
+DTYPE = torch.bfloat16  # bf16 mandatory on MPS for SDXL (fp16 -> NaN)
+OUT = "/tmp/lokr_sdxl"
+os.makedirs(OUT, exist_ok=True)
+PROMPT = "a photo of a teddy bear riding a skateboard"
+
+
+def load_pipe():
+    pipe = StableDiffusionXLPipeline.from_pretrained(REPO, torch_dtype=DTYPE, variant="fp16", use_safetensors=True)
+    return pipe.to(DEVICE)
+
+
+def gen(pipe, seed=0):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    img = pipe(PROMPT, num_inference_steps=4, guidance_scale=0.0, height=512, width=512, generator=g).images[0]
+    return np.asarray(img).astype(np.float32)
+
+
+print(f"[device={DEVICE} dtype={DTYPE}]  loading SDXL for training...")
+train_pipe = load_pipe()
+unet = train_pipe.unet
+unet.requires_grad_(False)
+
+plan = {"config": {"rank": 16, "alpha": 16, "advanced": {
+    "networkType": "lokr", "decomposeFactor": -1,
+    "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+}}}
+cfg = read_run_config(plan)
+unet.add_adapter(build_peft_network_config(peft, cfg))
+unet.train()
+trainable = [p for p in unet.parameters() if p.requires_grad]
+print(f"  LoKr trainable tensors: {len(trainable)}")
+
+# Tiny fixed-batch overfit so the adapter clearly changes the UNet output.
+torch.manual_seed(0)
+lat = torch.randn(1, 4, 64, 64, device=DEVICE, dtype=DTYPE)
+t = torch.tensor([500], device=DEVICE)
+ehs = torch.randn(1, 77, 2048, device=DEVICE, dtype=DTYPE)
+add_text = torch.randn(1, 1280, device=DEVICE, dtype=DTYPE)
+add_time = torch.tensor([[512, 512, 0, 0, 512, 512]], device=DEVICE, dtype=DTYPE)
+kw = {"added_cond_kwargs": {"text_embeds": add_text, "time_ids": add_time}}
+target = torch.randn_like(unet(lat, t, ehs, **kw).sample)
+opt = torch.optim.AdamW(trainable, lr=1e-3)
+for i in range(25):
+    opt.zero_grad()
+    loss = torch.nn.functional.mse_loss(unet(lat, t, ehs, **kw).sample.float(), target.float())
+    loss.backward(); opt.step()
+    if i in (0, 24):
+        print(f"  step {i:2d} loss={loss.item():.4f}")
+
+sd = get_peft_model_state_dict(unet)
+path = write_lokr_adapter(sd, OUT, "bear_lokr.safetensors", rank=cfg.rank, alpha=cfg.alpha,
+                          decompose_factor=cfg.decompose_factor, target_modules=cfg.lora_target_modules)
+size = os.path.getsize(path)
+print(f"  saved {path}  ({size/1024:.1f} KB, {len(sd)} tensors)  networkType={adapter_network_type(path)}")
+del train_pipe, unet
+import gc; gc.collect()
+if DEVICE == "mps":
+    torch.mps.empty_cache()
+
+print("loading a FRESH SDXL pipeline for inference (no training state)...")
+infer_pipe = load_pipe()
+base_img = gen(infer_pipe, seed=1)
+
+# THE production entrypoint SdxlImageAdapter uses:
+lora = {"id": "bear_lokr", "installedPath": path, "weight": 1.0, "family": "sdxl"}
+state = apply_loras_to_pipeline(infer_pipe, [lora], adapter_id="sdxl", model_family="sdxl")
+print(f"  apply_loras_to_pipeline -> adapter_names={state.adapter_names}")
+assert state.adapter_names, "no adapter applied"
+# Prove it injected as a PEFT adapter on the unet (not via load_lora_weights).
+print(f"  unet.peft_config adapters: {list(getattr(infer_pipe.unet, 'peft_config', {}).keys())}")
+
+lokr_img = gen(infer_pipe, seed=1)
+mad = float(np.abs(lokr_img - base_img).mean())
+from PIL import Image
+Image.fromarray(base_img.astype(np.uint8)).save(f"{OUT}/base.png")
+Image.fromarray(lokr_img.astype(np.uint8)).save(f"{OUT}/lokr.png")
+print(f"  mean abs pixel diff (base vs lokr): {mad:.3f}  -> {'DELTA APPLIED' if mad > 1.0 else 'NO VISIBLE DELTA'}")
+print("E2E OK" if (state.adapter_names and mad > 1.0) else "E2E FAILED")

--- a/scripts/spike_lokr_roundtrip.py
+++ b/scripts/spike_lokr_roundtrip.py
@@ -1,0 +1,140 @@
+"""sc-2194 spike: LoKr round-trip on a real (tiny, config-only) diffusers model.
+
+Retires the model-agnostic risks for epic 2193 without a 20 GB Z-Image download:
+  1. Does peft.LoKrConfig attach to a diffusers transformer via add_adapter?
+  2. Does it actually train (loss drops)?
+  3. What key format / file size does get_peft_model_state_dict produce, vs LoRA?
+  4. Can a LoKr adapter be loaded back for INFERENCE via the PEFT-injection path
+     (inject_adapter_in_model + set_peft_model_state_dict) and reproduce the delta?
+  5. Structurally, why can't diffusers load_lora_weights() consume it?
+"""
+
+import copy
+import io
+
+import torch
+import torch.nn.functional as F
+from diffusers import UNet2DConditionModel
+from peft import LoKrConfig, LoraConfig, get_peft_model_state_dict, set_peft_model_state_dict
+from peft.tuners.tuners_utils import BaseTunerLayer  # noqa: F401  (sanity import)
+from peft import inject_adapter_in_model
+from safetensors.torch import save as st_save
+
+torch.manual_seed(0)
+DEVICE = "cpu"  # deterministic for allclose
+TARGETS = ["to_q", "to_k", "to_v", "to_out.0"]
+RANK = 8
+ALPHA = 8
+
+
+def build_unet():
+    torch.manual_seed(0)
+    return UNet2DConditionModel(
+        sample_size=16,
+        in_channels=4,
+        out_channels=4,
+        layers_per_block=1,
+        block_out_channels=(32, 64),
+        down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+        up_block_types=("UpBlock2D", "CrossAttnUpBlock2D"),
+        cross_attention_dim=32,
+        attention_head_dim=8,
+    ).to(DEVICE)
+
+
+def fixed_batch():
+    g = torch.Generator().manual_seed(42)
+    sample = torch.randn(1, 4, 16, 16, generator=g)
+    ts = torch.tensor([10])
+    ehs = torch.randn(1, 4, 32, generator=g)
+    return sample, ts, ehs
+
+
+def fwd(model, batch):
+    sample, ts, ehs = batch
+    return model(sample, ts, ehs).sample
+
+
+def state_bytes(sd):
+    # mirror how trainers serialize (safetensors); measure on-disk footprint
+    return len(st_save({k: v.contiguous() for k, v in sd.items()}))
+
+
+def param_count(sd):
+    return sum(v.numel() for v in sd.values())
+
+
+def train(model, batch, steps=60):
+    target = torch.randn_like(fwd(model, batch))
+    trainable = [p for p in model.parameters() if p.requires_grad]
+    opt = torch.optim.AdamW(trainable, lr=1e-2)
+    first = last = None
+    for i in range(steps):
+        opt.zero_grad()
+        loss = F.mse_loss(fwd(model, batch), target)
+        loss.backward()
+        opt.step()
+        if i == 0:
+            first = loss.item()
+        last = loss.item()
+    return first, last, len(trainable)
+
+
+def run(kind):
+    print(f"\n===== {kind.upper()} =====")
+    pristine = build_unet()
+    base_batch = fixed_batch()
+    with torch.no_grad():
+        base_out = fwd(pristine, base_batch).clone()
+
+    model = copy.deepcopy(pristine)
+    model.requires_grad_(False)
+    if kind == "lokr":
+        cfg = LoKrConfig(r=RANK, alpha=ALPHA, target_modules=TARGETS, decompose_factor=-1,
+                         init_weights=True)
+    else:
+        cfg = LoraConfig(r=RANK, lora_alpha=ALPHA, target_modules=TARGETS,
+                         init_lora_weights="gaussian")
+    model.add_adapter(cfg)
+
+    first, last, n = train(model, base_batch)
+    print(f"  trainable tensors={n}  loss {first:.4f} -> {last:.4f}  ({'DROPS' if last < first else 'NO DROP'})")
+
+    sd = get_peft_model_state_dict(model)
+    print(f"  saved tensors={len(sd)}  params={param_count(sd):,}  bytes={state_bytes(sd):,}")
+    sample_keys = list(sd.keys())[:4]
+    print(f"  sample keys: {sample_keys}")
+
+    with torch.no_grad():
+        trained_out = fwd(model, base_batch).clone()
+    delta_vs_base = (trained_out - base_out).abs().mean().item()
+
+    # ---- INFERENCE RELOAD via PEFT injection (NOT load_lora_weights) ----
+    fresh = copy.deepcopy(pristine)
+    inject_adapter_in_model(cfg, fresh)
+    missing = set_peft_model_state_dict(fresh, sd)
+    with torch.no_grad():
+        reloaded_out = fwd(fresh, base_batch).clone()
+    reload_match = torch.allclose(trained_out, reloaded_out, atol=1e-5)
+    print(f"  delta vs base (mean abs)={delta_vs_base:.5f}")
+    print(f"  inference reload reproduces delta: {reload_match}  "
+          f"(max diff {(trained_out - reloaded_out).abs().max().item():.2e})")
+    print(f"  set_peft_model_state_dict report: {missing}")
+    return {"bytes": state_bytes(sd), "params": param_count(sd), "keys": sample_keys,
+            "reload_match": reload_match, "delta": delta_vs_base}
+
+
+lokr = run("lokr")
+lora = run("lora")
+
+print("\n===== SUMMARY =====")
+print(f"  LoRA  params={lora['params']:,}  bytes={lora['bytes']:,}")
+print(f"  LoKr  params={lokr['params']:,}  bytes={lokr['bytes']:,}")
+ratio = lora["bytes"] / max(lokr["bytes"], 1)
+print(f"  LoKr is {ratio:.2f}x smaller on disk than LoRA at r={RANK}")
+print(f"  LoKr inference-reload OK: {lokr['reload_match']}   LoRA inference-reload OK: {lora['reload_match']}")
+print("\n  Why load_lora_weights() can't consume LoKr:")
+print(f"    LoRA keys look like:  {lora['keys'][0]}")
+print(f"    LoKr keys look like:  {lokr['keys'][0]}")
+print("    diffusers' converter expects lora_A/lora_B (or kohya lora_down/lora_up);")
+print("    LoKr emits lokr_w1/lokr_w2/lokr_t2 -> unrecognized -> must use PEFT injection.")

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -22,39 +22,79 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "sampleEvery": 250,
-          "sampleSteps": 8,
-          "sampleGuidanceScale": 0.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 0.0,
+          "sampleSteps": 8,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "limits": {
-        "rank": [4, 128],
-        "alpha": [1, 128],
-        "steps": [200, 6000],
-        "resolutions": [512, 768, 1024],
-        "batchSize": [1, 4],
-        "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-        "lrSchedulers": ["constant", "linear", "cosine"],
-        "qualityPresets": ["speed", "balanced", "quality"],
-        "outputScopes": ["project", "global"]
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
       },
       "ui": {
-        "label": "Z-Image-Turbo LoRA",
         "description": "Train an image LoRA for the Z-Image-Turbo base model.",
-        "recommendedFor": ["character", "style"]
+        "label": "Z-Image-Turbo LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
       }
     },
     {
@@ -78,38 +118,82 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 250,
-          "sampleSteps": 30,
-          "sampleGuidanceScale": 7.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
         }
       },
       "limits": {
-        "rank": [4, 128],
-        "alpha": [1, 128],
-        "steps": [200, 6000],
-        "resolutions": [768, 1024],
-        "batchSize": [1, 4],
-        "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-        "lrSchedulers": ["constant", "linear", "cosine"],
-        "qualityPresets": ["speed", "balanced", "quality"],
-        "outputScopes": ["project", "global"]
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
       },
       "ui": {
-        "label": "Stable Diffusion XL LoRA",
         "description": "Train an image LoRA for Stable Diffusion XL. The generic SDXL-UNet trainer and the shared foundation for SDXL-family models.",
-        "recommendedFor": ["character", "style"]
+        "label": "Stable Diffusion XL LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
       }
     },
     {
@@ -133,41 +217,85 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
+          "baseModelRepo": "microsoft/Lens",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
+          "loraTargetModules": [
+            "img_qkv",
+            "txt_qkv",
+            "to_out",
+            "to_add_out"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "loraTargetModules": ["img_qkv", "txt_qkv", "to_out", "to_add_out"],
-          "baseModelRepo": "microsoft/Lens",
-          "sampleEvery": 500,
-          "sampleSteps": 20,
-          "sampleGuidanceScale": 5.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 5.0,
+          "sampleSteps": 20,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "limits": {
-        "rank": [4, 128],
-        "alpha": [1, 128],
-        "steps": [200, 6000],
-        "resolutions": [768, 1024, 1440],
-        "batchSize": [1, 4],
-        "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-        "lrSchedulers": ["constant", "linear", "cosine"],
-        "qualityPresets": ["speed", "balanced", "quality"],
-        "outputScopes": ["project", "global"]
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          768,
+          1024,
+          1440
+        ],
+        "steps": [
+          200,
+          6000
+        ]
       },
       "ui": {
-        "label": "Lens LoRA",
         "description": "Train an image LoRA for Microsoft Lens (gpt-oss text encoder + FLUX.2 VAE). Trains on the non-distilled base and applies to Lens-Turbo.",
-        "recommendedFor": ["character", "style"]
+        "label": "Lens LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
       }
     },
     {
@@ -191,38 +319,76 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
-          "cacheLatents": true,
-          "networkType": "lora",
-          "lrScheduler": "constant",
           "backend": "mlx",
+          "cacheLatents": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out"
+          ],
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out"],
-          "sampleEvery": 250,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250
         }
       },
       "limits": {
-        "rank": [4, 128],
-        "alpha": [1, 128],
-        "steps": [200, 4000],
-        "resolutions": [512, 768, 1024],
-        "batchSize": [1, 2],
-        "lrSchedulers": ["constant", "linear", "cosine"],
-        "qualityPresets": ["speed", "balanced", "quality"],
-        "outputScopes": ["project", "global"],
+        "alpha": [
+          1,
+          128
+        ],
+        "appleSiliconOnly": true,
+        "batchSize": [
+          1,
+          2
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
         "requiresBackend": "mlx",
-        "appleSiliconOnly": true
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          4000
+        ]
       },
       "ui": {
-        "label": "LTX-2.3 Video LoRA",
-        "description": "Train an LTX-2.3 video LoRA from still images. Apple Silicon only (native MLX).",
-        "recommendedFor": ["character", "style"],
         "appleSiliconOnly": true,
         "backend": "mlx",
-        "datasetModality": "image"
+        "datasetModality": "image",
+        "description": "Train an LTX-2.3 video LoRA from still images. Apple Silicon only (native MLX).",
+        "label": "LTX-2.3 Video LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
       }
     },
     {
@@ -246,40 +412,83 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "limits": {
-        "rank": [4, 128],
-        "alpha": [1, 128],
-        "steps": [200, 4000],
-        "resolutions": [512, 768],
-        "batchSize": [1, 2],
-        "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-        "lrSchedulers": ["constant", "linear", "cosine"],
-        "qualityPresets": ["speed", "balanced", "quality"],
-        "outputScopes": ["project", "global"]
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          2
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768
+        ],
+        "steps": [
+          200,
+          4000
+        ]
       },
       "ui": {
-        "label": "Wan2.2 Video LoRA",
+        "datasetModality": "image",
         "description": "Train a Wan2.2 video LoRA from still images (Wan2.2-TI2V-5B). Runs on CUDA and Apple Silicon (MPS).",
-        "recommendedFor": ["character", "style"],
-        "datasetModality": "image"
+        "label": "Wan2.2 Video LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
       }
     },
     {
@@ -303,40 +512,83 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "limits": {
-        "rank": [4, 128],
-        "alpha": [1, 128],
-        "steps": [200, 4000],
-        "resolutions": [512, 768],
-        "batchSize": [1, 2],
-        "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-        "lrSchedulers": ["constant", "linear", "cosine"],
-        "qualityPresets": ["speed", "balanced", "quality"],
-        "outputScopes": ["project", "global"]
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          2
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768
+        ],
+        "steps": [
+          200,
+          4000
+        ]
       },
       "ui": {
-        "label": "Wan2.2 14B T2V Video LoRA",
+        "datasetModality": "image",
         "description": "Train a Wan2.2 14B (A14B MoE, text-to-video) LoRA from still images. Trains both noise experts; GPU-only at bf16 (Q8_0 GGUF base fits smaller hosts).",
-        "recommendedFor": ["character", "style"],
-        "datasetModality": "image"
+        "label": "Wan2.2 14B T2V Video LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
       }
     },
     {
@@ -360,40 +612,83 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "limits": {
-        "rank": [4, 128],
-        "alpha": [1, 128],
-        "steps": [200, 4000],
-        "resolutions": [512, 768],
-        "batchSize": [1, 2],
-        "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-        "lrSchedulers": ["constant", "linear", "cosine"],
-        "qualityPresets": ["speed", "balanced", "quality"],
-        "outputScopes": ["project", "global"]
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          2
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768
+        ],
+        "steps": [
+          200,
+          4000
+        ]
       },
       "ui": {
-        "label": "Wan2.2 14B I2V Video LoRA",
+        "datasetModality": "image",
         "description": "Train a Wan2.2 14B (A14B MoE, image-to-video) LoRA from still images. Trains both noise experts; GPU-only at bf16 (Q8_0 GGUF base fits smaller hosts).",
-        "recommendedFor": ["character", "style"],
-        "datasetModality": "image"
+        "label": "Wan2.2 14B I2V Video LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
       }
     }
   ]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -69,13 +69,18 @@ from scene_worker.upscalers import (
     tile_slices,
 )
 from scene_worker.lora_adapters import (
+    LoraSpec,
+    adapter_network_type,
     apply_loras_to_pipeline,
+    clear_loras,
     first_safetensors_path,
     lora_cache_key,
     lora_weight,
     normalize_lora_specs,
     reject_loras_if_unsupported,
+    reject_lokr_loras,
     resolve_lora_file,
+    set_adapter_weights_on_module,
     validate_lora_compatibility,
 )
 from scene_worker.runtime import (
@@ -190,6 +195,25 @@ class FakeTargetedLoraPipe(FakeLoraPipe):
 
     def delete_adapters(self, names):
         self.deleted.append(names)
+
+
+class FakeDenoiserModule:
+    """Stand-in for a pipeline's unet/transformer that records module-level
+    set_adapters calls (the LoKr weight path)."""
+
+    def __init__(self):
+        self.set_calls = []
+
+    def set_adapters(self, names, weights=None):
+        self.set_calls.append((list(names), list(weights) if weights is not None else None))
+
+
+class FakeLokrPipe(FakeTargetedLoraPipe):
+    """A pipe exposing a denoiser module so LoKr can inject into it."""
+
+    def __init__(self):
+        super().__init__()
+        self.unet = FakeDenoiserModule()
 
 
 class FakeMoeLoraPipe(FakeLoraPipe):
@@ -845,6 +869,76 @@ def test_lora_loader_clears_previous_adapters_between_jobs(tmp_path):
 
     assert pipe.unloaded == 1
     assert pipe.loaded[-1][0] == str(second)
+
+
+def test_adapter_network_type_defaults_to_lora_for_plain_file(tmp_path):
+    plain = tmp_path / "plain.safetensors"
+    plain.write_bytes(b"not a real safetensors header")
+    # Unreadable/absent metadata resolves to lora — every legacy adapter is lora.
+    assert adapter_network_type(plain) == "lora"
+
+
+def test_reject_lokr_loras_raises_only_for_lokr(monkeypatch, tmp_path):
+    lora_file = tmp_path / "a.safetensors"
+    lora_file.write_bytes(b"x")
+    lokr_file = tmp_path / "b.safetensors"
+    lokr_file.write_bytes(b"x")
+    types = {str(lora_file): "lora", str(lokr_file): "lokr"}
+    monkeypatch.setattr(
+        "scene_worker.lora_adapters.adapter_network_type", lambda path: types[str(path)]
+    )
+    lora_spec = LoraSpec(id="a", path=str(lora_file), weight=1.0, adapter_name="a")
+    lokr_spec = LoraSpec(id="b", path=str(lokr_file), weight=1.0, adapter_name="b")
+
+    reject_lokr_loras([lora_spec], "mlx_test")  # all-lora: no raise
+    with pytest.raises(RuntimeError, match="LoKr"):
+        reject_lokr_loras([lora_spec, lokr_spec], "mlx_test")
+
+
+def test_apply_loras_routes_lokr_through_injection(monkeypatch, tmp_path):
+    lokr_file = tmp_path / "char.safetensors"
+    lokr_file.write_bytes(b"x")
+    monkeypatch.setattr("scene_worker.lora_adapters.adapter_network_type", lambda path: "lokr")
+    injected = []
+    monkeypatch.setattr(
+        "scene_worker.lora_adapters.inject_lokr_adapter",
+        lambda pipe, spec, *, adapter_id: injected.append(spec.adapter_name),
+    )
+    pipe = FakeLokrPipe()
+
+    state = apply_loras_to_pipeline(
+        pipe,
+        [{"id": "char", "installedPath": str(lokr_file), "weight": 0.7}],
+        adapter_id="sdxl_test",
+    )
+
+    # LoKr never calls load_lora_weights; it injects, then sets weight on the module.
+    assert pipe.loaded == []
+    assert injected == list(state.adapter_names)
+    assert len(state.adapter_names) == 1
+    assert pipe.unet.set_calls[-1] == (list(state.adapter_names), [0.7])
+
+
+def test_clear_loras_prefers_delete_adapters_so_lokr_is_removed():
+    # delete_adapters removes injected LoKr adapters; unload_lora_weights (LoRA-only)
+    # would leak them into the next job.
+    pipe = FakeTargetedLoraPipe()
+    clear_loras(pipe, ("char",), adapter_id="sdxl_test")
+    assert pipe.deleted == [["char"]]
+    assert pipe.unloaded == 0
+
+
+def test_set_adapter_weights_on_module_applies_and_guards():
+    module = FakeDenoiserModule()
+    spec = LoraSpec(id="c", path="p", weight=0.5, adapter_name="c")
+    set_adapter_weights_on_module(module, ("c",), [0.5], adapter_id="t", specs=[spec])
+    assert module.set_calls == [(["c"], [0.5])]
+
+    # No module support: a single full-weight adapter is already active (fine),
+    # but multiple / non-unity weights cannot be honored.
+    set_adapter_weights_on_module(None, ("c",), [1.0], adapter_id="t", specs=[spec])
+    with pytest.raises(RuntimeError, match="per-adapter weights"):
+        set_adapter_weights_on_module(None, ("c", "d"), [1.0, 0.5], adapter_id="t", specs=[spec])
 
 
 def test_lora_loader_reuses_overlap_when_adapter_can_delete_targeted_loras(tmp_path):
@@ -4782,14 +4876,27 @@ def test_write_lokr_adapter_stamps_metadata_and_serializes_cpu_tensors(monkeypat
             return self
 
     state = {"blk.lokr_w1": FakeTensor(), "blk.lokr_w2": FakeTensor()}
-    path = write_lokr_adapter(state, str(tmp_path), "adapter.safetensors", decompose_factor=8)
+    path = write_lokr_adapter(
+        state,
+        str(tmp_path),
+        "adapter.safetensors",
+        rank=8,
+        alpha=16,
+        decompose_factor=8,
+        target_modules=["to_q", "to_v"],
+    )
 
     assert path == str(tmp_path / "adapter.safetensors")
-    # Routing metadata is what the inference loader (epic 2193) keys off.
+    # Routing + reconstruction metadata: the inference loader (epic 2193) reads
+    # networkType to route and rank/alpha/decomposeFactor/targetModules to rebuild
+    # the matching LoKrConfig for injection.
     assert captured["metadata"] == {
         "format": "pt",
         "networkType": "lokr",
+        "rank": "8",
+        "alpha": "16",
         "decomposeFactor": "8",
+        "targetModules": '["to_q", "to_v"]',
     }
     assert set(captured["tensors"]) == {"blk.lokr_w1", "blk.lokr_w2"}
     assert captured["tensors"]["blk.lokr_w1"].moved == ["detach", "cpu", "contiguous"]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2123,6 +2123,32 @@ def test_should_route_flux2_to_mlx_predicate(monkeypatch):
     assert _should_route_flux2_to_mlx({"model": "flux_dev"}) is False
 
 
+def test_request_has_lokr_lora_detection():
+    from scene_worker.image_adapters import _request_has_lokr_lora
+
+    # Recorded networkType (top-level, mirroring baseModel) or nested in
+    # compatibility — both are read with no file I/O (epic 2193).
+    assert _request_has_lokr_lora({"loras": [{"id": "a", "networkType": "lokr"}]}) is True
+    assert _request_has_lokr_lora({"loras": [{"id": "a", "compatibility": {"networkType": "LoKr"}}]}) is True
+    assert _request_has_lokr_lora({"loras": [{"id": "a", "networkType": "lora"}]}) is False
+    assert _request_has_lokr_lora({"loras": []}) is False
+    assert _request_has_lokr_lora({}) is False
+
+
+def test_should_route_sdxl_to_mlx_falls_back_for_lokr(monkeypatch):
+    from scene_worker.image_adapters import _should_route_sdxl_to_mlx
+
+    monkeypatch.delenv("SCENEWORKS_DISABLE_MLX_SDXL", raising=False)
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(MlxSdxlAdapter, "_mlx_sd_available", lambda: True)
+    model = next(iter(MlxSdxlAdapter._supported_models))
+
+    # A normal LoRA stays on MLX; a LoKr LoRA falls back to the torch path so it
+    # actually applies (MLX can't merge LoKr) instead of erroring.
+    assert _should_route_sdxl_to_mlx({"model": model, "loras": [{"id": "a", "networkType": "lora"}]}) is True
+    assert _should_route_sdxl_to_mlx({"model": model, "loras": [{"id": "a", "networkType": "lokr"}]}) is False
+
+
 def test_mlx_flux2_kv_allows_no_reference_txt2img(monkeypatch):
     # sc-2173: -kv is no longer reference-gated. Without a reference it falls
     # through to the txt2img path (the runner routes it to Flux2Klein) instead

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -120,6 +120,7 @@ from scene_worker.training_adapters import (
     apply_weight_noise,
     build_lr_scheduler,
     build_optimizer,
+    build_peft_network_config,
     bucket_resolution,
     create_training_kernel,
     dry_run_training_summary,
@@ -135,6 +136,7 @@ from scene_worker.training_adapters import (
     seeded_sample,
     training_adapter_weight_name,
     validate_training_plan,
+    write_lokr_adapter,
 )
 from scene_worker.video_adapters import (
     DiffusersVideoAdapter,
@@ -4693,6 +4695,104 @@ def test_build_optimizer_uses_rose(monkeypatch):
         "params": params,
         "kwargs": {"lr": 0.0005, "weight_decay": 0.01, "compute_dtype": "fp32"},
     }
+
+
+def _run_config_for_network(advanced=None):
+    plan = {"config": {"rank": 8, "alpha": 8, "advanced": advanced or {}}}
+    return read_run_config(plan)
+
+
+def test_read_run_config_defaults_network_type_to_lora():
+    config = _run_config_for_network()
+    assert config.network_type == "lora"
+    assert config.decompose_factor == -1
+
+
+def test_read_run_config_parses_lokr_network_and_factor():
+    config = _run_config_for_network({"networkType": "LoKr", "decomposeFactor": 8})
+    # networkType is normalized to lowercase so the trainer's equality check is stable.
+    assert config.network_type == "lokr"
+    assert config.decompose_factor == 8
+
+
+def test_build_peft_network_config_defaults_to_lora():
+    fake_peft = SimpleNamespace(
+        LoraConfig=lambda **kw: ("lora", kw),
+        LoKrConfig=lambda **kw: ("lokr", kw),
+    )
+    config = _run_config_for_network({"loraTargetModules": ["to_q", "to_v"]})
+    kind, kwargs = build_peft_network_config(fake_peft, config)
+    assert kind == "lora"
+    assert kwargs == {
+        "r": config.rank,
+        "lora_alpha": config.alpha,
+        "init_lora_weights": "gaussian",
+        "target_modules": ["to_q", "to_v"],
+    }
+
+
+def test_build_peft_network_config_builds_lokr_with_decompose_factor():
+    fake_peft = SimpleNamespace(
+        LoraConfig=lambda **kw: ("lora", kw),
+        LoKrConfig=lambda **kw: ("lokr", kw),
+    )
+    config = _run_config_for_network(
+        {"networkType": "lokr", "decomposeFactor": 16, "loraTargetModules": ["to_q"]}
+    )
+    kind, kwargs = build_peft_network_config(fake_peft, config)
+    assert kind == "lokr"
+    assert kwargs == {
+        "r": config.rank,
+        "alpha": config.alpha,
+        "decompose_factor": 16,
+        "init_weights": True,
+        "target_modules": ["to_q"],
+    }
+
+
+def test_write_lokr_adapter_stamps_metadata_and_serializes_cpu_tensors(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_save_file(tensors, path, metadata=None):
+        captured["tensors"] = tensors
+        captured["path"] = path
+        captured["metadata"] = metadata
+        Path(path).write_bytes(b"")
+
+    fake_module = SimpleNamespace(save_file=fake_save_file)
+    # Inject the parent package too so the function's `from safetensors.torch
+    # import save_file` never touches the filesystem regardless of install state.
+    monkeypatch.setitem(sys.modules, "safetensors", SimpleNamespace(torch=fake_module))
+    monkeypatch.setitem(sys.modules, "safetensors.torch", fake_module)
+
+    class FakeTensor:
+        def __init__(self):
+            self.moved = []
+
+        def detach(self):
+            self.moved.append("detach")
+            return self
+
+        def cpu(self):
+            self.moved.append("cpu")
+            return self
+
+        def contiguous(self):
+            self.moved.append("contiguous")
+            return self
+
+    state = {"blk.lokr_w1": FakeTensor(), "blk.lokr_w2": FakeTensor()}
+    path = write_lokr_adapter(state, str(tmp_path), "adapter.safetensors", decompose_factor=8)
+
+    assert path == str(tmp_path / "adapter.safetensors")
+    # Routing metadata is what the inference loader (epic 2193) keys off.
+    assert captured["metadata"] == {
+        "format": "pt",
+        "networkType": "lokr",
+        "decomposeFactor": "8",
+    }
+    assert set(captured["tensors"]) == {"blk.lokr_w1", "blk.lokr_w2"}
+    assert captured["tensors"]["blk.lokr_w1"].moved == ["detach", "cpu", "contiguous"]
 
 
 def test_lr_schedule_updates_converts_microsteps_to_optimizer_updates():


### PR DESCRIPTION
Adds **LoKr** (LyCORIS Kronecker-product) as a selectable *network type* alongside the default LoRA in the Training Studio, on the torch image backends (**Z-Image-Turbo** + **SDXL**). LoKr parameterizes the weight delta as a Kronecker product (`W₁ ⊗ W₂`) instead of LoRA's `B·A`, producing much smaller adapters (a rank-16 SDXL LoKr is ~2.7 MB vs many× that for the LoRA equivalent) at comparable fidelity.

Epic: [sc-2193](https://app.shortcut.com/trefry/epic/2193)

## Key design decisions
- **`networkType`/`decomposeFactor` live in the config `advanced` bag, not as first-class `TrainingConfig` fields** — matching the contract's documented "engine-specific knobs go in advanced" design. The contract change is the gating list `limits.networkTypes` (mirrors `limits.optimizers`).
- **Inference is a real fork**: diffusers' `load_lora_weights` can't consume LoKr (`lokr_w1`/`lokr_w2` keys), so a LoKr adapter is applied by rebuilding its `peft.LoKrConfig` from the safetensors header and injecting it (`inject_adapter_in_model` + `set_peft_model_state_dict`). The trainer stamps `rank`/`alpha`/`decomposeFactor`/`targetModules` into the file metadata so the loader can reconstruct the network.
- **MLX backends reject LoKr** with a clear error (their merge math is LoRA-only).

## Stories (per-commit)
| Story | Commit | What |
|---|---|---|
| [sc-2194](https://app.shortcut.com/trefry/story/2194) | `b901b9a` | Spike: validate the PEFT round trip (GO) |
| [sc-2195](https://app.shortcut.com/trefry/story/2195) | `3776031` | Contract: `limits.networkTypes` gating (z-image + SDXL → `["lora","lokr"]`) |
| [sc-2196](https://app.shortcut.com/trefry/story/2196) | `960ccf3` | Trainer: `build_peft_network_config` + `write_lokr_adapter` |
| [sc-2197](https://app.shortcut.com/trefry/story/2197) | `b313e59` | Inference: PEFT-injection load path + MLX rejection |
| [sc-2198](https://app.shortcut.com/trefry/story/2198) | `e77be0a` | Web: Network Type picker + LoKr factor field |
| [sc-2199](https://app.shortcut.com/trefry/story/2199) | `97e35a9` | Docs + real SDXL train→infer e2e |
| [sc-2209](https://app.shortcut.com/trefry/story/2209) | `f5d674c` | MLX dispatch falls back to torch for LoKr + record `networkType` on the trained LoRA |

## Validation
- **Real SDXL e2e** (cached `stabilityai/stable-diffusion-xl-base-1.0`, MPS bf16, `scripts/e2e_lokr_sdxl.py`): LoKr attaches to the real UNet → 2.7 MB adapter (`networkType=lokr`) → the production `apply_loras_to_pipeline` injects it as a PEFT adapter (not `load_lora_weights`) and generates, base-vs-LoKr mean pixel diff 69.4.
- Tests green: **Rust contract 29**, **worker 426** (+2 skipped), **web 251**.

## Out of scope (v1)
- MLX LoKr *inference* (Kronecker merge in the vendored MLX loaders) — deferred. A LoKr job on an MLX-routed model **auto-falls-back to the torch path** (sc-2209), so it renders correctly (just not on MLX).
- LoHa and other LyCORIS algos — same mechanism, cheap follow-on.
- LoKr weights live on the denoiser only; mixed LoKr + text-encoder-LoRA weighting isn't covered.
- Z-Image not e2e'd separately (shares the family-agnostic code path; needs the de-distill fuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
