### PR TITLE
Persist desktop theme + improve fullscreen asset navigation

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -18,6 +18,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             setup::start_setup,
             settings::get_app_settings,
+            settings::save_app_theme,
             settings::get_storage_setup,
             settings::save_storage_setup,
             settings::complete_setup,

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -176,6 +176,12 @@ pub struct AppSettings {
     /// host/label/scheme so the UI can enumerate them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub credentials: Vec<CredentialMeta>,
+    /// Last-used UI theme (`"light"` or `"dark"`). Persisted here because the
+    /// desktop webview's `localStorage` is keyed to the API's per-launch random
+    /// port and so can't be relied on across runs (same reason as the wizard
+    /// state). `None` until the user first toggles the theme.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
 }
 
 fn settings_path() -> PathBuf {
@@ -317,6 +323,29 @@ pub fn save_storage_setup(data_dir: String, hf_home: String) -> Result<AppSettin
 pub fn complete_setup() -> Result<(), String> {
     let mut settings = load_settings();
     settings.setup_completed = true;
+    save_settings(&settings)
+}
+
+/// The valid stored theme for `input`, or `None` if it isn't a theme we
+/// recognize (so a stray value can't wedge the persisted setting).
+fn normalize_theme(input: &str) -> Option<String> {
+    match input.trim() {
+        "light" => Some("light".to_owned()),
+        "dark" => Some("dark".to_owned()),
+        _ => None,
+    }
+}
+
+/// Persist the last-used UI theme so the desktop shell restores it on the next
+/// launch (the webview's `localStorage` is unreliable across runs — see the
+/// wizard-state commands). Unrecognized values are ignored.
+#[tauri::command]
+pub fn save_app_theme(theme: String) -> Result<(), String> {
+    let Some(theme) = normalize_theme(&theme) else {
+        return Ok(());
+    };
+    let mut settings = load_settings();
+    settings.theme = Some(theme);
     save_settings(&settings)
 }
 
@@ -599,6 +628,14 @@ mod tests {
         assert!(settings.credentials.is_empty());
         // Removing a host that isn't recorded is a no-op.
         assert!(!remove_credential_meta(&mut settings, HF_HOST));
+    }
+
+    #[test]
+    fn normalize_theme_accepts_only_known_themes() {
+        assert_eq!(normalize_theme(" light "), Some("light".to_owned()));
+        assert_eq!(normalize_theme("dark"), Some("dark".to_owned()));
+        assert_eq!(normalize_theme("blue"), None);
+        assert_eq!(normalize_theme(""), None);
     }
 
     #[test]

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -410,9 +410,13 @@ export function App() {
   const [jobPrompt, setJobPrompt] = useState("Placeholder generation");
   const [latestGenerationSetId, setLatestGenerationSetId] = useState(null);
   const [previewAsset, setPreviewAsset] = useState(null);
+  // Which way the user last scrolled in the fullscreen preview, so discarding an
+  // asset advances in that same direction.
+  const previewDirectionRef = useRef("next");
   const [studioLaunch, setStudioLaunch] = useState(null);
   const [error, setError] = useState("");
   const [theme, setTheme] = useState(readStoredTheme);
+  const desktopThemeHydrated = useRef(false);
   const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
@@ -535,7 +539,13 @@ export function App() {
     () => assets.find((asset) => asset.id === selectedAssetId) ?? assets[0] ?? null,
     [assets, selectedAssetId],
   );
-  const foldedPreviewAssets = useMemo(() => foldUpscaledAssetVariants(assets), [assets]);
+  // Discarded (trashed) assets are excluded from the fullscreen navigation so
+  // they don't show up while scrolling; purged assets are already dropped from
+  // `assets` entirely.
+  const foldedPreviewAssets = useMemo(
+    () => foldUpscaledAssetVariants(assets.filter((asset) => !asset.status?.trashed)),
+    [assets],
+  );
   const previewedAsset = useMemo(
     () => (previewAsset ? findFoldedAssetById(foldedPreviewAssets, previewAsset.id) ?? previewAsset : null),
     [foldedPreviewAssets, previewAsset],
@@ -671,6 +681,39 @@ export function App() {
     } catch {
       // ignore (private mode etc.)
     }
+  }, [theme]);
+
+  // Desktop: localStorage is keyed to the API's per-launch random port, so it
+  // can't carry the theme across restarts (see isDesktopShell note). Seed from
+  // the durable setting on launch, then persist every change back to it.
+  useEffect(() => {
+    if (!isDesktopShell) {
+      return;
+    }
+    let cancelled = false;
+    tauriInvoke("get_app_settings")
+      .then((settings) => {
+        const stored = settings?.theme;
+        if (!cancelled && (stored === "dark" || stored === "light")) {
+          setTheme(stored);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        desktopThemeHydrated.current = true;
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    // Wait until the stored theme has loaded so the initial render doesn't
+    // overwrite it with the default before we've read it back.
+    if (!isDesktopShell || !desktopThemeHydrated.current) {
+      return;
+    }
+    tauriInvoke("save_app_theme", { theme }).catch(() => {});
   }, [theme]);
 
   useEffect(() => {
@@ -1621,12 +1664,23 @@ export function App() {
         <FullscreenPreview
           asset={previewedAsset}
           deleteAsset={async (asset) => {
+            // Stay in the preview and advance to the neighbour in the direction
+            // the user was scrolling (falling back to the other side, then to
+            // closing once nothing is left).
+            const { previous, next } = previewNavigation;
+            const target =
+              previewDirectionRef.current === "previous" ? previous ?? next : next ?? previous;
             await deleteAsset(asset);
-            setPreviewAsset(null);
+            setPreviewAsset(target ?? null);
           }}
           nextAsset={previewNavigation.next}
           onClose={() => setPreviewAsset(null)}
-          onPreviewAsset={setPreviewAsset}
+          onPreviewAsset={(asset, direction) => {
+            if (direction) {
+              previewDirectionRef.current = direction;
+            }
+            setPreviewAsset(asset);
+          }}
           previousAsset={previewNavigation.previous}
           purgeAsset={async (asset) => {
             await purgeAsset(asset);

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -375,7 +375,7 @@ export function FullscreenPreview({
             aria-label="Previous asset"
             className="preview-nav-button previous"
             disabled={!previousAsset}
-            onClick={() => previousAsset && onPreviewAsset(previousAsset)}
+            onClick={() => previousAsset && onPreviewAsset(previousAsset, "previous")}
             type="button"
           >
             <Icon.ArrowLeft size={18} />
@@ -385,7 +385,7 @@ export function FullscreenPreview({
             aria-label="Next asset"
             className="preview-nav-button next"
             disabled={!nextAsset}
-            onClick={() => nextAsset && onPreviewAsset(nextAsset)}
+            onClick={() => nextAsset && onPreviewAsset(nextAsset, "next")}
             type="button"
           >
             <Icon.ArrowRight size={18} />

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1959,6 +1959,40 @@ describe("SceneWorks app shell", () => {
     expect(container.querySelector(".preview-modal img").getAttribute("src")).toContain("original.png");
   });
 
+  it("reports the scroll direction when navigating the FullscreenPreview", async () => {
+    const noop = () => {};
+    const onPreviewAsset = vi.fn();
+    const asset = { id: "asset-b", displayName: "Plate", type: "image", status: {}, file: { path: "b.png" } };
+    const previous = { id: "asset-a", displayName: "Prev", type: "image", status: {}, file: { path: "a.png" } };
+    const next = { id: "asset-c", displayName: "Next", type: "image", status: {}, file: { path: "c.png" } };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={asset}
+          deleteAsset={noop}
+          nextAsset={next}
+          onClose={noop}
+          onPreviewAsset={onPreviewAsset}
+          previousAsset={previous}
+          purgeAsset={noop}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector(".preview-nav-button.next").click();
+    });
+    expect(onPreviewAsset).toHaveBeenLastCalledWith(next, "next");
+
+    await act(async () => {
+      container.querySelector(".preview-nav-button.previous").click();
+    });
+    expect(onPreviewAsset).toHaveBeenLastCalledWith(previous, "previous");
+  });
+
   it("keeps in-progress picker selection across parent rerenders", async () => {
     const onChange = vi.fn();
     const assets = [


### PR DESCRIPTION
Two small UI tweaks from one session.

## 1. Desktop remembers light/dark mode between runs

**Problem:** The theme was only persisted in `localStorage`. On the desktop (Tauri) shell that doesn't survive a restart — the bundled API binds a *random port each launch*, so the webview origin changes and origin-keyed `localStorage` is effectively wiped. This is the exact reason the first-run wizard state is already persisted via Tauri into `settings.json`.

**Fix:** Give the theme the same durable persistence as the wizard state.
- `AppSettings` gains a `theme: Option<String>` field (returned automatically by `get_app_settings`), plus a `save_app_theme` command that validates `light`/`dark` and writes `settings.json`.
- On the desktop shell only, App.jsx seeds the theme from `settings.json` on launch (guarded so the default render can't clobber the stored value before it loads) and persists every change back. Web/Docker builds are untouched and keep the existing `localStorage` path.

*Minor known limitation:* a dark-mode desktop launch may briefly flash light before the async settings read resolves, since the new origin's `localStorage` is empty. Eliminating it would require blocking first paint on an async IPC read; left out as out of scope.

## 2. Fullscreen asset preview: hide discarded/purged + advance on Discard

**Before:** Discarded (trashed) assets still showed up when scrolling left/right in the fullscreen preview, and clicking **Discard** closed the modal.

**Now:**
- Discarded (trashed) assets are excluded from the preview navigation; purged assets were already dropped from the asset list entirely.
- Clicking **Discard** stays in the preview and advances to the neighbour in the direction you were last scrolling (falling back to the other side, then closing only when nothing is left). A `previewDirectionRef` tracks scroll direction, set by the prev/next buttons which now report `"previous"`/`"next"`.

**Reviewer notes / judgment calls:**
- **Purge** still closes the modal — it only happens from the trashcan view (where every asset is trashed, so there's no non-trashed neighbour to advance to). Easy to change if desired.
- **Rejected** assets are still shown in the preview nav — the request was *discarded and purged*; rejected is a separate state with its own `showRejected` control.
- Opening a preview from the trashcan grid will now show no prev/next neighbours (trashed assets are excluded), consistent with the request.

## Tests
- Desktop crate: compiles, all Rust tests pass incl. new `normalize_theme` test.
- Web: full vitest suite green (247 tests), incl. a new test asserting the fullscreen nav buttons report scroll direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)