### PR TITLE
fix(character-studio): hide discarded images and add Trashcan view

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2560,6 +2560,78 @@ describe("SceneWorks app shell", () => {
     expect(openDatasetInLibrary).toHaveBeenCalledWith("ds-new");
   });
 
+  it("hides discarded character images from the grid and surfaces them in the Trashcan", async () => {
+    const assets = [
+      { id: "img-active", type: "image", displayName: "keep", recipe: { normalizedSettings: { characterId: "char-1" } } },
+      {
+        id: "img-trashed",
+        type: "image",
+        displayName: "discarded",
+        status: { trashed: true },
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+      },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference: () => {},
+            archiveCharacter: () => {},
+            assets,
+            attachCharacterLora: () => {},
+            characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: assets,
+            loras: [],
+            setPreviewAsset: () => {},
+            sendCharacterToImage: () => {},
+            sendCharacterToVideo: () => {},
+            purgeAsset: () => {},
+            removeCharacterReference: () => {},
+            updateAssetStatus: () => {},
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    // The active toggle counts only non-trashed images for this character.
+    const showButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("Show this character's images (1)"),
+    );
+    expect(showButton).toBeTruthy();
+    await act(async () => {
+      showButton.click();
+    });
+
+    // Active grid shows the kept image, not the discarded one.
+    expect(container.querySelectorAll(".review-grid .review-card").length).toBe(1);
+    expect(container.querySelectorAll(".review-grid .review-card.trashed").length).toBe(0);
+
+    // Switch to the Trashcan view and the discarded image becomes reachable.
+    const trashButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("Trashcan (1)"),
+    );
+    expect(trashButton).toBeTruthy();
+    await act(async () => {
+      trashButton.click();
+    });
+    expect(container.querySelectorAll(".review-grid .review-card.trashed").length).toBe(1);
+    expect([...container.querySelectorAll(".review-grid button")].some((button) => button.textContent === "Purge")).toBe(true);
+  });
+
   it("launches reference-based generation from an approved character reference", async () => {
     const sendCharacterToImage = vi.fn();
     const reference = { assetId: "ref-1", approved: true, asset: { id: "ref-1", type: "image", displayName: "Mira ref" } };

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -296,14 +296,21 @@ export function CharacterTest({
   updateAssetStatus,
 }) {
   const [showOutputs, setShowOutputs] = React.useState(false);
+  const [viewMode, setViewMode] = React.useState("active");
   // Scope the outputs grid to THIS character (its generated images + approved
   // references) instead of dumping every recent project image, and keep it
   // collapsed by default so it never turns the studio into an endless scroll.
-  const characterAssets = (latestAssets ?? []).filter(
+  const scopedAssets = (latestAssets ?? []).filter(
     (asset) =>
       asset.recipe?.normalizedSettings?.characterId === selectedCharacter.id ||
       (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === selectedCharacter.id),
   );
+  // Discarded (status.trashed) images leave the active grid so they don't keep
+  // their slots, but stay reachable through the Trashcan view for restore/purge.
+  const activeAssets = scopedAssets.filter((asset) => !asset.status?.trashed);
+  const trashedAssets = scopedAssets.filter((asset) => asset.status?.trashed);
+  const showingTrash = viewMode === "trashed";
+  const characterAssets = showingTrash ? trashedAssets : activeAssets;
   return (
     <section className="character-section test-character-panel">
       <div className="section-heading">
@@ -361,8 +368,18 @@ export function CharacterTest({
       </form>
       <div className="review-panel-head">
         <button className="advanced-toggle" onClick={() => setShowOutputs((value) => !value)} type="button">
-          {showOutputs ? "Hide" : "Show"} this character's images ({characterAssets.length})
+          {showOutputs ? "Hide" : "Show"} this character's images ({activeAssets.length})
         </button>
+        {showOutputs ? (
+          <div className="segmented-control" role="group" aria-label="Character image collection">
+            <button className={showingTrash ? "" : "active"} onClick={() => setViewMode("active")} type="button">
+              Images ({activeAssets.length})
+            </button>
+            <button className={showingTrash ? "active" : ""} onClick={() => setViewMode("trashed")} type="button">
+              Trashcan ({trashedAssets.length})
+            </button>
+          </div>
+        ) : null}
       </div>
       {showOutputs ? (
         <div className="review-grid">
@@ -375,17 +392,21 @@ export function CharacterTest({
                 purgeAsset={purgeAsset}
                 updateAssetStatus={updateAssetStatus}
               />
-              <button
-                onClick={() => addCharacterReference(selectedCharacter.id, { assetId: asset.id, approved: true, role: "test-output" })}
-                type="button"
-              >
-                Approve as Reference
-              </button>
+              {showingTrash ? null : (
+                <button
+                  onClick={() => addCharacterReference(selectedCharacter.id, { assetId: asset.id, approved: true, role: "test-output" })}
+                  type="button"
+                >
+                  Approve as Reference
+                </button>
+              )}
             </div>
           ))}
           {characterAssets.length ? null : (
             <div className="empty-panel compact-panel">
-              No images for this character yet — generate an angle set or a test above.
+              {showingTrash
+                ? "Trashcan is empty — discarded images for this character will appear here."
+                : "No images for this character yet — generate an angle set or a test above."}
             </div>
           )}
         </div>


### PR DESCRIPTION
## What

In Character Studio, discarding an image now removes it from the outputs grid, and a new **Trashcan** view lets you recover (Restore) or permanently delete (Purge) discarded images.

## Why

Discarding an image sets `status.trashed = true` but left the asset in the character outputs grid — there was no `.review-card.trashed` CSS, so the thumbnail kept its slot instead of disappearing. Purge already removed items from the array, but because the view was never partitioned the layout looked frozen. There was also no way to view or recover discarded images within the studio.

## Changes

- **`apps/web/src/screens/characterPanels.jsx`**
  - Partition the character-scoped assets into `activeAssets` (non-trashed) and `trashedAssets`.
  - The main grid renders only active images, so discarded/purged thumbnails leave the grid immediately.
  - Added a segmented `Images (n)` / `Trashcan (n)` control (appears when the outputs grid is expanded), mirroring the Asset Library trashcan pattern. The existing `AssetCard` already exposes **Restore** and **Purge** for trashed items.
  - Hid "Approve as Reference" in the trash view and gave the trashcan its own empty-state copy.
- **`apps/web/src/main.test.jsx`**
  - Regression test: renders the studio with one active + one discarded image, confirms only the active image shows (no `.trashed` card), then switches to Trashcan and confirms the discarded image appears with a Purge action.

## Reviewer notes

- No backend change required: `deleteAsset` already flips local state to `trashed: true`, so a discarded image moves straight into the Trashcan tab without a refetch.
- `.segmented-control` styling already exists globally — no CSS added.
- Web suite: **152 passing** (`vitest run --environment jsdom src/main.test.jsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)