### PR TITLE
build(web): split vendor chunk to stay under Vite size warning

### DIFF
--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -6,4 +6,18 @@ export default defineConfig({
       "Cache-Control": "no-store",
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Peel third-party code (React et al.) into a separate, rarely-changing
+        // chunk so the app bundle stays under Vite's size warning and the vendor
+        // chunk caches across app-only deploys.
+        manualChunks(id) {
+          if (id.includes("node_modules")) {
+            return "vendor";
+          }
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
The app built into a single ~499 kB JS chunk; this session's additions nudged it past Vite's 500 kB chunk-size warning. Peel node_modules (React et al.) into a separate `vendor` chunk via manualChunks so the app bundle (~355 kB) and vendor (~142 kB) are both under the limit, and the rarely-changing vendor code caches across app-only deploys.