### PR TITLE
fix(character-studio): default pose "Restore face" toggle off

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2420,7 +2420,7 @@ describe("SceneWorks app shell", () => {
         advanced: expect.objectContaining({
           ipAdapterScale: 0.8,
           poses: [{ id: "standing_01", keypoints: poseKeypoints }],
-          faceRestore: true,
+          faceRestore: false,
         }),
       }),
     );

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -247,7 +247,7 @@ export function ImageStudio() {
   // clear the override.
   const [stepsOverride, setStepsOverride] = useState(saved.steps ?? "");
   const [guidanceOverride, setGuidanceOverride] = useState(saved.guidanceScale ?? "");
-  const [faceRestore, setFaceRestore] = useState(true);
+  const [faceRestore, setFaceRestore] = useState(false);
   const { byId: poseById } = usePoseLibrary();
   const [upscaleEnabled, setUpscaleEnabled] = useState(saved.upscaleEnabled ?? false);
   const [upscaleFactor, setUpscaleFactor] = useState(saved.upscaleFactor ?? 2);

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -758,7 +758,7 @@ export function CharacterPoseLibrary({
     ?? null;
   const { byId } = usePoseLibrary();
   const [selectedPoseIds, setSelectedPoseIds] = React.useState([]);
-  const [faceRestore, setFaceRestore] = React.useState(true);
+  const [faceRestore, setFaceRestore] = React.useState(false);
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -352,9 +352,9 @@ class InstantIDAdapter:
     @staticmethod
     def _face_restore_enabled(request: ImageRequest) -> bool:
         """Whether the full-body face-restoration pass runs (advanced.faceRestore,
-        default on). Off = the OpenPose+InstantID base image is used as-is (cleaner
+        default off). Off = the OpenPose+InstantID base image is used as-is (cleaner
         blend, but weaker identity at the small full-body face size)."""
-        value = request.advanced.get("faceRestore", True)
+        value = request.advanced.get("faceRestore", False)
         if isinstance(value, str):
             return value.strip().lower() not in ("false", "0", "no", "off", "")
         return bool(value)

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -250,8 +250,8 @@ def test_openpose_scale_default_and_override():
 
 
 def test_face_restore_enabled_default_and_toggle():
-    # Defaults on; explicit booleans + string forms toggle the full-body restoration pass.
-    assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={})) is True
+    # Defaults off; explicit booleans + string forms toggle the full-body restoration pass.
+    assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={})) is False
     assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={"faceRestore": False})) is False
     assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={"faceRestore": True})) is True
     assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={"faceRestore": "false"})) is False


### PR DESCRIPTION
## What

Defaults the pose **"Restore face"** toggle to **off** in both Image Studio and Character Studio, and flips the worker fallback to match.

## Why

The toggle gates `_restore_face` in the InstantID adapter — an ADetailer-style identity pass: it detects the small face in the rendered pose, crops + upscales it to 1024², re-runs the full InstantID pipeline on the crop, then **pastes the result back over the body through a feathered elliptical mask**. That paste-back step leaves visible seams and lighting/skin mismatches. The default-on behavior produced consistently poor blends, so the cleaner raw InstantID+OpenPose render is now the default; users can still opt in.

Scope note: `_restore_face` is **pose-only** — the angle-set path never invokes it.

## Changes

- `ImageStudio.jsx` / `characterPanels.jsx`: `faceRestore` `useState` default → `false`
- `instantid_adapter._face_restore_enabled`: `advanced.faceRestore` fallback → `False` (+ docstring)
- Updated the pose-payload web test and the worker default assertion

## Tests

- Web pose suite (vitest, jsdom): 6 passing, incl. the payload now asserting `faceRestore: false`
- Worker `test_face_restore_enabled_default_and_toggle` updated (default-off); not executed locally (no Python env in this worktree) — pure default flip, no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)