### PR TITLE
Add FLUX.2 [klein] 9B True V2 (wikeeyang) via install-time conversion

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -916,6 +916,24 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         "SCENEWORKS_PYTHON",
         venv_python(&venv_dir()).to_string_lossy().to_string(),
     );
+    // FLUX.2-klein single-file fine-tune conversion (sc-2235) runs in the mlx-flux
+    // sidecar venv via the scene_worker converter script — point the in-process
+    // utility worker at both, mirroring how the Python image adapter resolves them.
+    command = command
+        .env(
+            "SCENEWORKS_MLX_FLUX_PYTHON",
+            venv_python(&mlx_flux_venv_dir())
+                .to_string_lossy()
+                .to_string(),
+        )
+        .env(
+            "SCENEWORKS_MLX_FLUX_CONVERT",
+            worker_src_dir(app)
+                .join("scene_worker")
+                .join("mlx_flux_convert.py")
+                .to_string_lossy()
+                .to_string(),
+        );
     let (mut events, child) = command
         .spawn()
         .map_err(|error| format!("spawn api: {error}"))?;

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -204,6 +204,34 @@ pub(crate) async fn create_model_convert_job(
         Value::String(output_dir.display().to_string()),
     );
     job_payload.insert("dtype".to_owned(), Value::String("bfloat16".to_owned()));
+    // Optional converter discriminator + inputs (sc-2235). Default (absent) is the
+    // mlx-video Wan converter. A FLUX.2-klein community fine-tune declares
+    // `mlx.converter` + the single-file source + the base repo whose
+    // VAE/text-encoder/tokenizer are borrowed during assembly.
+    if let Some(converter) = mlx
+        .get("converter")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        job_payload.insert("converter".to_owned(), Value::String(converter.to_owned()));
+    }
+    if let Some(source_file) = mlx
+        .get("convertSourceFile")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        job_payload.insert(
+            "sourceFile".to_owned(),
+            Value::String(source_file.to_owned()),
+        );
+    }
+    if let Some(base_repo) = mlx
+        .get("convertBaseRepo")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        job_payload.insert("baseRepo".to_owned(), Value::String(base_repo.to_owned()));
+    }
     if quantize_only {
         job_payload.insert("quantizeOnly".to_owned(), Value::Bool(true));
     }
@@ -1071,7 +1099,12 @@ pub(crate) fn mlx_catalog_status(
     {
         let model_id = model.get("id").and_then(Value::as_str).unwrap_or_default();
         let converted_dir = data_dir.join("models").join("mlx").join(model_id);
-        if converted_dir.join("config.json").is_file() {
+        // mlx-video converters write a top-level config.json; the FLUX.2-klein
+        // diffusers converter (sc-2235) writes a diffusers model_index.json. Either
+        // marks a finished local MLX artifact.
+        if converted_dir.join("config.json").is_file()
+            || converted_dir.join("model_index.json").is_file()
+        {
             return Some(MlxCatalogStatus {
                 install_state: "installed",
                 conversion_state: "converted",

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -413,6 +413,27 @@ MODEL_TARGETS = {
         "repo": "black-forest-labs/FLUX.2-klein-9b-kv",
         "adapter": "mlx_flux2",
     },
+    "flux2_klein_9b_true_v2": {
+        "label": "FLUX.2 [klein] 9B True V2",
+        "family": "flux2-klein",
+        # Community full fine-tune of FLUX.2-klein-9B (wikeeyang) — improved
+        # realism + prompt adherence (sc-2220). Same 9B architecture; weights
+        # ship as a transformer-only single-file checkpoint converted at install
+        # into a local diffusers dir (sc-2235) and loaded via the runner's
+        # modelPath seam. This is the UNDISTILLED line, so unlike the 4-step
+        # distill it wants ~24 steps at guidance 1.0 (sc-2220 / V1 model card).
+        "supportsEdit": True,
+        "supportsTxt2Img": True,
+        "steps": 24,
+        "guidanceScale": 1.0,
+        # The wikeeyang source repo; the install-time convert job pulls the bf16
+        # single-file from here. The runtime weights load from the assembled
+        # local dir (see MlxFlux2Adapter._local_model_dir), not this repo.
+        "repo": "wikeeyang/Flux2-Klein-9B-True-V2",
+        "adapter": "mlx_flux2",
+        # Borrowed VAE/text-encoder/tokenizer come from this base klein install.
+        "componentBaseRepo": "black-forest-labs/FLUX.2-klein-9B",
+    },
     "kolors": {
         "label": "Kolors",
         "family": "kolors",
@@ -3567,13 +3588,28 @@ class MlxFlux2Adapter:
     """
 
     id = "mlx_flux2"
-    _supported_models = {"flux2_klein_9b", "flux2_klein_9b_kv"}
+    _supported_models = {"flux2_klein_9b", "flux2_klein_9b_kv", "flux2_klein_9b_true_v2"}
+    # Models whose weights load from a locally-assembled diffusers dir (produced
+    # by the install-time conversion job, sc-2235) rather than an mflux built-in
+    # repo. The adapter resolves the dir and threads it to the runner as modelPath.
+    _local_dir_models = {"flux2_klein_9b_true_v2"}
     # Models whose edit path uses the KV cache (engages only with a reference);
     # they still run plain txt2img without one (sc-2173).
     _kv_cache_models = {"flux2_klein_9b_kv"}
 
     def __init__(self) -> None:
         self._scratch_dir: Path | None = None
+
+    @classmethod
+    def _local_model_dir(cls, model_id: str, settings: WorkerSettings) -> str | None:
+        """Local assembled diffusers dir for converted fine-tunes (sc-2235), or
+        None for built-in mflux repos. Convention mirrors the model_convert job's
+        output dir (``<data_dir>/models/mlx/<model_id>``). Returns None if not yet
+        converted so the runner surfaces a clear missing-weights error."""
+        if model_id not in cls._local_dir_models:
+            return None
+        candidate = Path(settings.data_dir) / "models" / "mlx" / model_id
+        return str(candidate) if (candidate / "transformer").is_dir() else None
 
     def discard_temp_outputs(self, job_id: str | None = None) -> None:
         work_dir = self._scratch_dir
@@ -3703,6 +3739,9 @@ class MlxFlux2Adapter:
                         for lora in lora_specs
                     ],
                     "imagePaths": reference_paths or None,
+                    # Local diffusers dir for converted fine-tunes (sc-2235);
+                    # None for built-in mflux repos (loaded from ModelConfig).
+                    "modelPath": self._local_model_dir(request.model, settings),
                 },
                 progress=progress,
                 cancel_requested=cancel_requested,

--- a/apps/worker/scene_worker/mlx_flux_convert.py
+++ b/apps/worker/scene_worker/mlx_flux_convert.py
@@ -1,0 +1,228 @@
+"""Convert a FLUX.2-klein *original/single-file* transformer checkpoint into the
+diffusers `transformer/` layout that mflux's `Flux2KleinWeightDefinition` loads,
+then assemble a complete local diffusers model dir by borrowing the VAE / text
+encoder / tokenizer / scheduler from an already-installed base FLUX.2-klein-9B.
+
+Motivation (sc-2220 / sc-2235): community FLUX.2-klein fine-tunes such as
+``wikeeyang/Flux2-Klein-9B-True-V2`` ship ONLY a transformer, as a single flat
+safetensors file in the original (ComfyUI/BFL) key convention — no diffusers
+subfolders, no text-encoder/VAE. mflux needs a full diffusers dir, and its
+`Flux2WeightMapping.get_transformer_mapping` is a pure 1:1 rename (no permutes),
+so the on-disk tensors must already match BFL's *diffusers* convention. This
+module reproduces the exact transforms diffusers' own
+``convert_flux2_transformer_checkpoint_to_diffusers`` applies:
+
+  * key renames (img_in -> x_embedder, *.lin -> *.linear, ...)
+  * double-block fused qkv [3*d, d] row-split into to_q/to_k/to_v (img stream)
+    and add_q_proj/add_k_proj/add_v_proj (txt stream)
+  * single-block linear1/linear2 -> to_qkv_mlp_proj/to_out (1:1; diffusers also
+    keeps the single block fused)
+  * ``final_layer.adaLN_modulation.1`` -> ``norm_out.linear`` WITH a scale/shift
+    SWAP: BFL packs (shift, scale); diffusers/mflux expect (scale, shift). This
+    one swap is load-bearing — that tensor modulates every output patch, so
+    getting it wrong corrupts the whole image with a periodic weave (sc-2220).
+
+The transformer math (`build_target_state_dict`) is framework-agnostic — it
+takes tensor-op callables — so it is unit-testable with numpy in the main worker
+venv. The mlx load/save + dir assembly live in `convert_and_assemble`, which
+imports mlx lazily (only available in the mlx-flux sidecar venv).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import struct
+import sys
+from pathlib import Path
+from typing import Callable
+
+# Borrowed-from-base components: a transformer-only fine-tune does not touch
+# these, so taking them from the installed base klein-9B is correct.
+BORROWED_SUBDIRS = ("vae", "text_encoder", "tokenizer", "scheduler")
+BORROWED_FILES = ("model_index.json",)
+
+# Top-level (non-block) direct renames: original -> diffusers.
+_TOP_RENAMES = {
+    "img_in.weight": "x_embedder.weight",
+    "txt_in.weight": "context_embedder.weight",
+    "time_in.in_layer.weight": "time_guidance_embed.timestep_embedder.linear_1.weight",
+    "time_in.out_layer.weight": "time_guidance_embed.timestep_embedder.linear_2.weight",
+    "double_stream_modulation_img.lin.weight": "double_stream_modulation_img.linear.weight",
+    "double_stream_modulation_txt.lin.weight": "double_stream_modulation_txt.linear.weight",
+    "single_stream_modulation.lin.weight": "single_stream_modulation.linear.weight",
+    "final_layer.linear.weight": "proj_out.weight",
+}
+# Handled separately (scale/shift swap): final_layer.adaLN_modulation.1 -> norm_out.linear.
+_ADALN_SOURCE = "final_layer.adaLN_modulation.1.weight"
+_ADALN_TARGET = "norm_out.linear.weight"
+
+# Per-double-block renames (original suffix -> diffusers suffix), excluding the
+# fused qkv tensors which are row-split below.
+_DOUBLE_RENAMES = {
+    "img_attn.norm.query_norm.weight": "attn.norm_q.weight",
+    "img_attn.norm.key_norm.weight": "attn.norm_k.weight",
+    "img_attn.proj.weight": "attn.to_out.0.weight",
+    "img_mlp.0.weight": "ff.linear_in.weight",
+    "img_mlp.2.weight": "ff.linear_out.weight",
+    "txt_attn.norm.query_norm.weight": "attn.norm_added_q.weight",
+    "txt_attn.norm.key_norm.weight": "attn.norm_added_k.weight",
+    "txt_attn.proj.weight": "attn.to_add_out.weight",
+    "txt_mlp.0.weight": "ff_context.linear_in.weight",
+    "txt_mlp.2.weight": "ff_context.linear_out.weight",
+}
+# fused qkv -> (q, k, v) target suffixes, per stream.
+_DOUBLE_QKV = {
+    "img_attn.qkv.weight": ("attn.to_q.weight", "attn.to_k.weight", "attn.to_v.weight"),
+    "txt_attn.qkv.weight": ("attn.add_q_proj.weight", "attn.add_k_proj.weight", "attn.add_v_proj.weight"),
+}
+# Per-single-block renames (1:1; diffusers keeps the fused single block).
+_SINGLE_RENAMES = {
+    "linear1.weight": "attn.to_qkv_mlp_proj.weight",
+    "linear2.weight": "attn.to_out.weight",
+    "norm.query_norm.weight": "attn.norm_q.weight",
+    "norm.key_norm.weight": "attn.norm_k.weight",
+}
+
+
+def _count_blocks(keys, prefix: str) -> int:
+    idxs = [int(m.group(1)) for k in keys for m in [re.match(rf"{prefix}\.(\d+)\.", k)] if m]
+    return max(idxs) + 1 if idxs else 0
+
+
+def build_target_state_dict(
+    src: dict,
+    *,
+    chunk3: Callable[[object], tuple[object, object, object]],
+    swap_halves: Callable[[object], object],
+) -> dict:
+    """Map an original-format FLUX.2-klein transformer state dict onto diffusers
+    keys. ``chunk3`` row-splits a [3*d, ...] tensor into three; ``swap_halves``
+    splits a [2*d, ...] tensor and swaps the halves (shift,scale -> scale,shift).
+    Pure: no framework import, so numpy ops drive the unit test.
+    """
+    out: dict = {}
+    for s, d in _TOP_RENAMES.items():
+        out[d] = src[s]
+    out[_ADALN_TARGET] = swap_halves(src[_ADALN_SOURCE])
+
+    n_double = _count_blocks(src, "double_blocks")
+    for i in range(n_double):
+        s, d = f"double_blocks.{i}", f"transformer_blocks.{i}"
+        for src_suffix, (q, k, v) in _DOUBLE_QKV.items():
+            tq, tk, tv = chunk3(src[f"{s}.{src_suffix}"])
+            out[f"{d}.{q}"], out[f"{d}.{k}"], out[f"{d}.{v}"] = tq, tk, tv
+        for src_suffix, dst_suffix in _DOUBLE_RENAMES.items():
+            out[f"{d}.{dst_suffix}"] = src[f"{s}.{src_suffix}"]
+
+    n_single = _count_blocks(src, "single_blocks")
+    for i in range(n_single):
+        s, d = f"single_blocks.{i}", f"single_transformer_blocks.{i}"
+        for src_suffix, dst_suffix in _SINGLE_RENAMES.items():
+            out[f"{d}.{dst_suffix}"] = src[f"{s}.{src_suffix}"]
+
+    return out
+
+
+def _safetensors_header_keys(path: Path) -> set[str]:
+    """Read safetensors tensor names + shapes from the header alone (no weights)."""
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(n))
+    return {k: tuple(v["shape"]) for k, v in header.items() if k != "__metadata__"}
+
+
+def _validate_against_base(produced: dict, base_transformer_dir: Path) -> None:
+    """Hard guard: the produced key set + shapes must exactly match the base
+    klein diffusers transformer (the ground-truth diffusers layout mflux loads).
+    """
+    base: dict = {}
+    for shard in sorted(base_transformer_dir.glob("*.safetensors")):
+        base.update(_safetensors_header_keys(shard))
+    if not base:
+        raise RuntimeError(f"No base transformer safetensors in {base_transformer_dir}")
+    prod_keys, base_keys = set(produced), set(base)
+    missing, extra = base_keys - prod_keys, prod_keys - base_keys
+    bad_shape = [k for k in prod_keys & base_keys if tuple(produced[k].shape) != base[k]]
+    if missing or extra or bad_shape:
+        raise RuntimeError(
+            f"Conversion validation FAILED vs base transformer: "
+            f"{len(missing)} missing, {len(extra)} extra, {len(bad_shape)} shape mismatch. "
+            f"missing={sorted(missing)[:5]} extra={sorted(extra)[:5]} shape={bad_shape[:5]}"
+        )
+
+
+def convert_and_assemble(source_file: str, base_dir: str, out_dir: str) -> str:
+    """Convert ``source_file`` (original single-file transformer) into ``out_dir``
+    as a complete diffusers model dir, borrowing components from ``base_dir`` (an
+    installed base FLUX.2-klein-9B diffusers snapshot). Returns ``out_dir``.
+    Imports mlx lazily — only runnable inside the mlx-flux sidecar venv.
+    """
+    import mlx.core as mx
+
+    source = Path(source_file)
+    base = Path(base_dir)
+    out = Path(out_dir)
+    base_transformer = base / "transformer"
+    if not source.is_file():
+        raise FileNotFoundError(f"source transformer file not found: {source}")
+    if not base_transformer.is_dir():
+        raise FileNotFoundError(f"base transformer dir not found: {base_transformer}")
+
+    def chunk3(t):
+        return tuple(mx.split(t, 3, axis=0))
+
+    def swap_halves(t):
+        shift, scale = mx.split(t, 2, axis=0)
+        return mx.concatenate([scale, shift], axis=0)
+
+    src = mx.load(str(source))
+    produced = build_target_state_dict(src, chunk3=chunk3, swap_halves=swap_halves)
+    _validate_against_base(produced, base_transformer)
+
+    out_transformer = out / "transformer"
+    out_transformer.mkdir(parents=True, exist_ok=True)
+    mx.eval(list(produced.values()))
+    mx.save_safetensors(str(out_transformer / "diffusion_pytorch_model.safetensors"), produced)
+    shutil.copyfile(base_transformer / "config.json", out_transformer / "config.json")
+
+    # Borrow the untouched components from the base klein snapshot. Symlink with
+    # absolute targets so they survive the worker's temp->final atomic rename and
+    # avoid duplicating multi-GB encoder/VAE weights on disk.
+    for name in BORROWED_FILES:
+        src_path = (base / name).resolve()
+        dst = out / name
+        if dst.exists() or dst.is_symlink():
+            dst.unlink()
+        shutil.copyfile(src_path, dst)
+    for name in BORROWED_SUBDIRS:
+        src_path = (base / name).resolve()
+        if not src_path.exists():
+            raise FileNotFoundError(f"base component missing: {src_path}")
+        dst = out / name
+        if dst.is_symlink() or dst.exists():
+            dst.unlink() if dst.is_symlink() else shutil.rmtree(dst)
+        os.symlink(src_path, dst)
+    return str(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert a FLUX.2-klein single-file transformer to a diffusers model dir.")
+    parser.add_argument("--source-file", required=True, help="Original single-file transformer safetensors (bf16).")
+    parser.add_argument("--base-dir", required=True, help="Installed base FLUX.2-klein-9B diffusers snapshot dir.")
+    parser.add_argument("--out-dir", required=True, help="Output diffusers model dir to assemble.")
+    args = parser.parse_args(argv)
+    try:
+        path = convert_and_assemble(args.source_file, args.base_dir, args.out_dir)
+    except Exception as exc:  # surface a single-line error for the worker log
+        sys.stderr.write(f"[mlx_flux_convert] ERROR: {exc}\n")
+        return 1
+    sys.stderr.write(f"[mlx_flux_convert] assembled diffusers model dir at {path}\n")
+    print(json.dumps({"path": path}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -56,7 +56,7 @@ def _log(message: str) -> None:
     sys.stderr.flush()
 
 
-def _resolve_model_handle(model_id: str, has_reference: bool) -> tuple[type, object, str, str]:
+def _resolve_model_handle(model_id: str, has_reference: bool) -> tuple[type, object, str, str]:  # noqa: C901
     """Map a SceneWorks model id + edit-vs-t2i hint onto an mflux
     (class, ModelConfig, filename_prefix, family) tuple.
 
@@ -108,6 +108,18 @@ def _resolve_model_handle(model_id: str, has_reference: bool) -> tuple[type, obj
             return Flux2KleinEdit, ModelConfig.flux2_klein_9b_kv(), "mlx_flux2_klein_kv", "flux2"
         from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
         return Flux2Klein, ModelConfig.flux2_klein_9b_kv(), "mlx_flux2_klein_kv", "flux2"
+    if model_id == "flux2_klein_9b_true_v2":
+        # Community full fine-tune of FLUX.2-klein-9B (wikeeyang). Same 9B
+        # architecture, so it reuses ModelConfig.flux2_klein_9b() for the arch
+        # overrides — but the WEIGHTS live in a locally-assembled diffusers dir
+        # produced by the install-time conversion job (sc-2235), threaded in via
+        # spec["modelPath"]. Undistilled line: caller sets steps ~24 / guidance
+        # 1.0 (vs the 4-step distill). Routes edit-vs-t2i exactly like the base.
+        if has_reference:
+            from mflux.models.flux2.variants.edit.flux2_klein_edit import Flux2KleinEdit
+            return Flux2KleinEdit, ModelConfig.flux2_klein_9b(), "mlx_flux2_klein_true_v2", "flux2"
+        from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+        return Flux2Klein, ModelConfig.flux2_klein_9b(), "mlx_flux2_klein_true_v2", "flux2"
     raise RuntimeError(f"mlx_flux_runner: unsupported model id {model_id!r}.")
 
 
@@ -169,8 +181,17 @@ def main() -> int:
         f"loading {model_cls.__name__} model={model_id} quantize={quantize} "
         f"loras={len(lora_paths)} steps={steps} guidance={guidance}"
     )
+    # Optional locally-assembled diffusers model dir (sc-2235). When present the
+    # weights load from this path instead of the mflux built-in repo for the
+    # ModelConfig — used by converted community fine-tunes (flux2_klein_9b_true_v2)
+    # whose weights aren't a built-in mflux repo. Absent for the built-in klein
+    # models, which resolve from ModelConfig.model_name as before.
+    model_path = spec.get("modelPath") or None
+    if model_path is not None:
+        _log(f"using local model_path={model_path}")
     model = model_cls(
         quantize=quantize,
+        model_path=model_path,
         lora_paths=lora_paths or None,
         lora_scales=lora_scales or None,
         model_config=model_config,

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -970,6 +970,83 @@
       }
     },
     {
+      "id": "flux2_klein_9b_true_v2",
+      "name": "FLUX.2 [klein] 9B True V2",
+      "family": "flux2-klein",
+      "type": "image",
+      "adapter": "mlx_flux2",
+      // Community full fine-tune of FLUX.2 [klein] 9B (wikeeyang) tuned for
+      // realism + prompt adherence (sc-2220). Ships transformer-only as a single
+      // safetensors file in the original BFL key convention — NOT a diffusers
+      // pipeline — so it is converted at install (mlx.requiresConversion) into a
+      // local diffusers dir that borrows the VAE/text-encoder/tokenizer from the
+      // base FLUX.2-klein-9B install (mlx.convertBaseRepo). sc-2235.
+      "capabilities": ["text_to_image", "character_image", "style_variations"],
+      "macOnly": true,
+      "downloads": [
+        {
+          // Only the bf16 single-file transformer (the convert source). The repo
+          // also hosts GGUF/fp8/fp4 quants we don't use — pulling just this file
+          // avoids a ~73 GB whole-repo download.
+          "provider": "huggingface",
+          "repo": "wikeeyang/Flux2-Klein-9B-True-V2",
+          "files": ["Flux2-Klein-9B-True-v2-bf16.safetensors"],
+          "estimatedSizeBytes": 18253611008
+        }
+      ],
+      "defaults": {
+        // Undistilled line: ~24 steps at CFG 1.0 (Euler), unlike the 4-step
+        // distilled flux2_klein_9b. Turbo/Distill LoRAs can drop this to 4-8.
+        "resolution": "1024x1024",
+        "steps": 24,
+        "guidanceScale": 1.0,
+        "count": 1
+      },
+      "limits": {
+        "resolutions": ["768x768", "1024x1024", "1280x720", "720x1280"],
+        "count": [1, 2, 4]
+      },
+      "loraCompatibility": {
+        "families": ["flux2"],
+        "types": ["style", "enhance", "character"]
+      },
+      "mlx": {
+        "minMemoryGb": 42,
+        "quantize": 8,
+        // Install-time conversion: pull the bf16 single-file from convertSourceRepo,
+        // run the FLUX.2-klein diffusers converter (sc-2235), and assemble a local
+        // diffusers dir under <data>/models/mlx/flux2_klein_9b_true_v2 by borrowing
+        // components from the installed base klein-9B (convertBaseRepo). The base
+        // model must be installed first; the convert job fails clearly if it isn't.
+        "requiresConversion": true,
+        "converter": "flux2_klein_diffusers",
+        "convertSourceRepo": "wikeeyang/Flux2-Klein-9B-True-V2",
+        "convertSourceFile": "Flux2-Klein-9B-True-v2-bf16.safetensors",
+        "convertBaseRepo": "black-forest-labs/FLUX.2-klein-9B"
+      },
+      "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B/blob/main/LICENSE.md",
+      "ui": {
+        "label": "FLUX.2 [klein] 9B True V2",
+        "description": "Community full fine-tune of FLUX.2 [klein] 9B (wikeeyang) tuned for stronger realism, texture, and prompt adherence, with cleaner reference editing. Runs on Apple Silicon via the same MLX path as the base klein. This is the undistilled line, so it uses ~24 steps at guidance 1.0 (slower than the 4-step distill, ~50 s/image at 1024² on an M5 Max). Requires the base FLUX.2 [klein] 9B to be installed (its VAE/text-encoder/tokenizer are reused) and is converted locally at install. Distributed under the FLUX Non-Commercial License.",
+        "recommendedFor": ["text_to_image", "character_image", "style_variations"],
+        "variationStrength": {
+          "label": "Prompt strength",
+          "default": 4.0,
+          "min": 1.0,
+          "max": 10.0,
+          "step": 0.5
+        },
+        "promptGuide": {
+          "title": "FLUX.2 [klein] 9B Prompt Guide",
+          "path": "/prompt-guides/flux2-klein.md",
+          "sources": [
+            { "label": "Flux2-Klein-9B-True-V2 model card", "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2" },
+            { "label": "FLUX.2 [klein] 9B model card", "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B" }
+          ]
+        }
+      }
+    },
+    {
       "id": "chroma1_hd",
       "name": "Chroma1-HD",
       "family": "chroma",

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -240,11 +240,72 @@ pub(crate) async fn run_model_convert_job(
         return Ok(());
     };
 
-    let python = std::env::var("SCENEWORKS_PYTHON")
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "python3".to_owned());
+    // Converter discriminator (sc-2235). Absent => the default mlx-video Wan
+    // converter (existing behavior). "flux2_klein_diffusers" => convert a
+    // FLUX.2-klein single-file fine-tune into a diffusers dir via the mlx-flux
+    // sidecar venv, borrowing VAE/text-encoder/tokenizer from an installed base.
+    let converter = optional_payload_string(&job.payload, "converter")
+        .map(str::to_owned)
+        .unwrap_or_default();
+    let is_flux2_klein = converter == "flux2_klein_diffusers";
+
+    let (python, flux2_source_file, flux2_base_dir, flux2_script) = if is_flux2_klein {
+        let source_file_name = required_payload_string(&job.payload, "sourceFile")?.to_owned();
+        let base_repo = required_payload_string(&job.payload, "baseRepo")?.to_owned();
+        let source_file = checkpoint_dir.join(&source_file_name);
+        if !source_file.is_file() {
+            fail_job(
+                api,
+                &job.id,
+                "Converted-model source file is missing.",
+                Some(format!("Expected {source_file_name} in {source_repo}.")),
+            )
+            .await?;
+            return Ok(());
+        }
+        let Some(base_dir) = huggingface_snapshot_dir(&settings.data_dir, &base_repo) else {
+            fail_job(
+                api,
+                &job.id,
+                "Base FLUX.2-klein model is not installed.",
+                Some(format!(
+                    "Install {base_repo} before converting {model_id} — its VAE, text encoder, \
+                     and tokenizer are reused."
+                )),
+            )
+            .await?;
+            return Ok(());
+        };
+        let py = std::env::var("SCENEWORKS_MLX_FLUX_PYTHON")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(
+                    "SCENEWORKS_MLX_FLUX_PYTHON is not set; the mlx-flux sidecar venv is required \
+                     to convert FLUX.2-klein fine-tunes."
+                        .to_owned(),
+                )
+            })?;
+        let script = std::env::var("SCENEWORKS_MLX_FLUX_CONVERT")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(
+                    "SCENEWORKS_MLX_FLUX_CONVERT is not set; cannot locate mlx_flux_convert.py."
+                        .to_owned(),
+                )
+            })?;
+        (py, Some(source_file), Some(base_dir), Some(script))
+    } else {
+        let py = std::env::var("SCENEWORKS_PYTHON")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "python3".to_owned());
+        (py, None, None, None)
+    };
 
     // Convert into a unique temp sibling and only promote it on success, so a
     // canceled/failed conversion never leaves a partial directory that the catalog
@@ -285,27 +346,42 @@ pub(crate) async fn run_model_convert_job(
     .await?;
 
     let mut command = Command::new(&python);
-    command
-        .arg("-m")
-        .arg("mlx_video.convert_wan")
-        .arg("--checkpoint-dir")
-        .arg(&checkpoint_dir)
-        .arg("--output-dir")
-        .arg(&temp_dir)
-        .arg("--dtype")
-        .arg(&dtype)
-        .arg("--model-version")
-        .arg("auto");
-    if quantize_only {
-        command.arg("--quantize-only");
-    } else if quantize_bits.is_some() {
-        command.arg("--quantize");
-    }
-    if let Some(bits) = quantize_bits {
-        command.arg("--bits").arg(bits.to_string());
-    }
-    if let Some(group_size) = quantize_group_size {
-        command.arg("--group-size").arg(group_size.to_string());
+    if is_flux2_klein {
+        // Self-contained converter script in the scene_worker package, run by the
+        // mlx-flux sidecar python: --source-file <single-file> --base-dir <base
+        // klein snapshot> --out-dir <temp>. It validates the converted transformer
+        // against the base diffusers layout and assembles the borrowed components.
+        command
+            .arg(flux2_script.as_ref().expect("flux2 script resolved"))
+            .arg("--source-file")
+            .arg(flux2_source_file.as_ref().expect("flux2 source resolved"))
+            .arg("--base-dir")
+            .arg(flux2_base_dir.as_ref().expect("flux2 base resolved"))
+            .arg("--out-dir")
+            .arg(&temp_dir);
+    } else {
+        command
+            .arg("-m")
+            .arg("mlx_video.convert_wan")
+            .arg("--checkpoint-dir")
+            .arg(&checkpoint_dir)
+            .arg("--output-dir")
+            .arg(&temp_dir)
+            .arg("--dtype")
+            .arg(&dtype)
+            .arg("--model-version")
+            .arg("auto");
+        if quantize_only {
+            command.arg("--quantize-only");
+        } else if quantize_bits.is_some() {
+            command.arg("--quantize");
+        }
+        if let Some(bits) = quantize_bits {
+            command.arg("--bits").arg(bits.to_string());
+        }
+        if let Some(group_size) = quantize_group_size {
+            command.arg("--group-size").arg(group_size.to_string());
+        }
     }
     let mut child = command
         .stdout(Stdio::null())

--- a/tests/test_mlx_flux_convert.py
+++ b/tests/test_mlx_flux_convert.py
@@ -1,0 +1,108 @@
+"""Unit tests for the FLUX.2-klein single-file -> diffusers transformer converter
+(sc-2235). Exercises the framework-agnostic key plan with numpy, so it runs in
+the main worker venv without mlx. The real tensor conversion was validated on
+hardware in sc-2220; these tests are regression guards on the mapping, the
+double-block qkv row-split, and the load-bearing norm_out scale/shift swap.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from scene_worker.mlx_flux_convert import build_target_state_dict
+
+N_DOUBLE = 8
+N_SINGLE = 24
+D = 8  # tiny stand-in hidden dim
+
+
+def _np_chunk3(t):
+    return tuple(np.split(t, 3, axis=0))
+
+
+def _np_swap_halves(t):
+    shift, scale = np.split(t, 2, axis=0)
+    return np.concatenate([scale, shift], axis=0)
+
+
+def _synthetic_original_state_dict() -> dict:
+    """All original (BFL/ComfyUI-convention) FLUX.2-klein transformer keys with
+    plausible-but-tiny shapes."""
+    sd: dict = {}
+    sd["img_in.weight"] = np.random.rand(D, 4).astype(np.float32)
+    sd["txt_in.weight"] = np.random.rand(D, 3 * D).astype(np.float32)
+    sd["time_in.in_layer.weight"] = np.random.rand(D, 4).astype(np.float32)
+    sd["time_in.out_layer.weight"] = np.random.rand(D, D).astype(np.float32)
+    sd["double_stream_modulation_img.lin.weight"] = np.random.rand(6 * D, D).astype(np.float32)
+    sd["double_stream_modulation_txt.lin.weight"] = np.random.rand(6 * D, D).astype(np.float32)
+    sd["single_stream_modulation.lin.weight"] = np.random.rand(3 * D, D).astype(np.float32)
+    sd["final_layer.linear.weight"] = np.random.rand(4, D).astype(np.float32)
+    sd["final_layer.adaLN_modulation.1.weight"] = np.random.rand(2 * D, D).astype(np.float32)
+    for i in range(N_DOUBLE):
+        s = f"double_blocks.{i}"
+        for stream in ("img", "txt"):
+            sd[f"{s}.{stream}_attn.qkv.weight"] = np.random.rand(3 * D, D).astype(np.float32)
+            sd[f"{s}.{stream}_attn.proj.weight"] = np.random.rand(D, D).astype(np.float32)
+            sd[f"{s}.{stream}_attn.norm.query_norm.weight"] = np.random.rand(D).astype(np.float32)
+            sd[f"{s}.{stream}_attn.norm.key_norm.weight"] = np.random.rand(D).astype(np.float32)
+            sd[f"{s}.{stream}_mlp.0.weight"] = np.random.rand(3 * D, D).astype(np.float32)
+            sd[f"{s}.{stream}_mlp.2.weight"] = np.random.rand(D, 3 * D).astype(np.float32)
+    for i in range(N_SINGLE):
+        s = f"single_blocks.{i}"
+        sd[f"{s}.linear1.weight"] = np.random.rand(9 * D, D).astype(np.float32)
+        sd[f"{s}.linear2.weight"] = np.random.rand(D, 4 * D).astype(np.float32)
+        sd[f"{s}.norm.query_norm.weight"] = np.random.rand(D).astype(np.float32)
+        sd[f"{s}.norm.key_norm.weight"] = np.random.rand(D).astype(np.float32)
+    return sd
+
+
+def test_key_plan_matches_diffusers_klein_9b_cardinality():
+    src = _synthetic_original_state_dict()
+    out = build_target_state_dict(src, chunk3=_np_chunk3, swap_halves=_np_swap_halves)
+    # 9 top-level + 16 per double block (6 qkv splits + 10 renames) + 4 per single block.
+    assert len(out) == 9 + 16 * N_DOUBLE + 4 * N_SINGLE == 233
+    assert len(set(out)) == len(out)  # no collisions
+
+
+def test_top_level_and_block_keys_present():
+    src = _synthetic_original_state_dict()
+    out = build_target_state_dict(src, chunk3=_np_chunk3, swap_halves=_np_swap_halves)
+    for key in (
+        "x_embedder.weight",
+        "context_embedder.weight",
+        "time_guidance_embed.timestep_embedder.linear_1.weight",
+        "norm_out.linear.weight",
+        "proj_out.weight",
+        "transformer_blocks.0.attn.to_q.weight",
+        "transformer_blocks.7.attn.add_v_proj.weight",
+        "transformer_blocks.3.attn.to_out.0.weight",
+        "transformer_blocks.3.ff_context.linear_out.weight",
+        "single_transformer_blocks.0.attn.to_qkv_mlp_proj.weight",
+        "single_transformer_blocks.23.attn.norm_k.weight",
+    ):
+        assert key in out, key
+    # original-convention keys must NOT leak through
+    assert not any(k.startswith(("double_blocks.", "single_blocks.", "img_in", "txt_in")) for k in out)
+
+
+def test_double_block_qkv_row_split_order():
+    src = _synthetic_original_state_dict()
+    out = build_target_state_dict(src, chunk3=_np_chunk3, swap_halves=_np_swap_halves)
+    qkv = src["double_blocks.0.img_attn.qkv.weight"]
+    np.testing.assert_array_equal(out["transformer_blocks.0.attn.to_q.weight"], qkv[:D])
+    np.testing.assert_array_equal(out["transformer_blocks.0.attn.to_k.weight"], qkv[D : 2 * D])
+    np.testing.assert_array_equal(out["transformer_blocks.0.attn.to_v.weight"], qkv[2 * D :])
+    txt = src["double_blocks.0.txt_attn.qkv.weight"]
+    np.testing.assert_array_equal(out["transformer_blocks.0.attn.add_q_proj.weight"], txt[:D])
+    np.testing.assert_array_equal(out["transformer_blocks.0.attn.add_v_proj.weight"], txt[2 * D :])
+
+
+def test_norm_out_scale_shift_swap():
+    """The load-bearing transform: BFL (shift, scale) -> diffusers (scale, shift)."""
+    src = _synthetic_original_state_dict()
+    out = build_target_state_dict(src, chunk3=_np_chunk3, swap_halves=_np_swap_halves)
+    adaln = src["final_layer.adaLN_modulation.1.weight"]
+    shift, scale = adaln[:D], adaln[D:]
+    result = out["norm_out.linear.weight"]
+    np.testing.assert_array_equal(result[:D], scale)  # scale now first
+    np.testing.assert_array_equal(result[D:], shift)  # shift now second
+    assert not np.array_equal(result, adaln)  # genuinely reordered

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2109,6 +2109,66 @@ def test_flux2_dispatch_resolves_via_runtime_registry(monkeypatch):
         assert adapter.__class__.__name__ == "MlxFlux2Adapter", model
 
 
+def test_flux2_true_v2_targets_and_dispatch(monkeypatch):
+    # sc-2232: the converted community fine-tune rides MlxFlux2Adapter with
+    # undistilled defaults (24 steps / CFG 1.0) and a local-dir weight source.
+    from scene_worker.image_adapters import MlxFlux2Adapter
+
+    monkeypatch.delenv("SCENEWORKS_IMAGE_ADAPTER", raising=False)
+    target = MODEL_TARGETS["flux2_klein_9b_true_v2"]
+    assert target["adapter"] == "mlx_flux2"
+    assert target["family"] == "flux2-klein"
+    assert target["steps"] == 24 and target["guidanceScale"] == 1.0
+    assert target["supportsEdit"] and target["supportsTxt2Img"]
+    assert target["componentBaseRepo"] == "black-forest-labs/FLUX.2-klein-9B"
+    assert "flux2_klein_9b_true_v2" in MlxFlux2Adapter._supported_models
+    assert "flux2_klein_9b_true_v2" in MlxFlux2Adapter._local_dir_models
+
+    registry = {"mlx_flux2": MlxFlux2Adapter()}
+    adapter = create_image_adapter({"payload": {"model": "flux2_klein_9b_true_v2"}}, registry)
+    assert adapter is not None and adapter.__class__.__name__ == "MlxFlux2Adapter"
+
+
+def test_flux2_true_v2_local_model_dir_resolution(tmp_path):
+    # Local weights live at <data>/models/mlx/<id> (the model_convert output dir);
+    # None until the transformer is assembled so the runner errors clearly, and
+    # always None for the built-in repos (they load from ModelConfig).
+    from types import SimpleNamespace
+
+    from scene_worker.image_adapters import MlxFlux2Adapter
+
+    settings = SimpleNamespace(data_dir=tmp_path)
+    assert MlxFlux2Adapter._local_model_dir("flux2_klein_9b_true_v2", settings) is None
+    assert MlxFlux2Adapter._local_model_dir("flux2_klein_9b", settings) is None
+
+    converted = tmp_path / "models" / "mlx" / "flux2_klein_9b_true_v2"
+    (converted / "transformer").mkdir(parents=True)
+    resolved = MlxFlux2Adapter._local_model_dir("flux2_klein_9b_true_v2", settings)
+    assert resolved == str(converted)
+
+
+def test_flux2_true_v2_manifest_install_time_conversion():
+    # sc-2235: the entry must declare the install-time conversion contract the
+    # Rust convert job + adapter rely on.
+    import re
+
+    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
+    block = find_entry_block("flux2_klein_9b_true_v2")
+    assert '"macOnly": true' in block
+    assert '"adapter": "mlx_flux2"' in block
+    # Only the bf16 single-file is pulled (not the whole 73 GB repo).
+    assert "Flux2-Klein-9B-True-v2-bf16.safetensors" in block
+    # Undistilled defaults differ from the 4-step distill.
+    assert re.search(r'"steps"\s*:\s*24', block)
+
+    mlx_block = find_mlx_block(block)
+    assert '"requiresConversion": true' in mlx_block
+    assert '"converter": "flux2_klein_diffusers"' in mlx_block
+    assert '"convertSourceRepo": "wikeeyang/Flux2-Klein-9B-True-V2"' in mlx_block
+    assert '"convertBaseRepo": "black-forest-labs/FLUX.2-klein-9B"' in mlx_block
+    assert re.search(r'"quantize"\s*:\s*8', mlx_block)
+
+
 def test_runtime_registry_covers_all_model_target_adapters():
     # sc-2203 guard: every adapter id a manifest model can dispatch to (the
     # `adapter` field in MODEL_TARGETS) must be a key in the runtime's


### PR DESCRIPTION
## What

Adds the community full fine-tune **`wikeeyang/Flux2-Klein-9B-True-V2`** as a selectable MLX image model on Apple Silicon (improved realism + prompt adherence + cleaner editing over base FLUX.2 [klein] 9B). Covers **T2I, image edit, and character**. Model id: `flux2_klein_9b_true_v2`.

Stories: **sc-2220** (spike, GO) + **sc-2235 / sc-2232 / sc-2233 / sc-2234** (epic 1968).

## Why it's more than a clean-sibling wiring job

This fine-tune ships **transformer-only as a single-file checkpoint** in the original BFL key convention — no diffusers layout, no text-encoder/VAE. mflux requires a full diffusers dir and applies a pure 1:1 weight rename, so the tensors must already match BFL's *diffusers* convention. That means a conversion + assembly step the existing klein models don't need.

## How

- **`mlx_flux_convert.py`** (new): convert the single-file transformer to the diffusers layout mflux expects — key renames + double-block qkv 1→3 row-split + single-block 1:1 + the load-bearing **`norm_out` scale/shift swap** (BFL packs `(shift, scale)`; diffusers/mflux expect `(scale, shift)` — mirrors diffusers' `convert_flux2_transformer_checkpoint_to_diffusers`). Validates produced keys/shapes against the base klein transformer (233-tensor hard guard), then assembles a local diffusers dir borrowing `vae`/`text_encoder`/`tokenizer`/`scheduler` from the installed base FLUX.2 [klein] 9B.
- **`mlx_flux_runner.py`**: `flux2_klein_9b_true_v2` dispatch arm + `modelPath` threading (backward-compatible across all mflux families).
- **`image_adapters.py`**: MODEL_TARGETS entry (undistilled **24-step / CFG 1.0** defaults), `_supported_models`/`_local_dir_models`, `_local_model_dir` resolver (`<data>/models/mlx/<id>`), `modelPath` in the sidecar spec.
- **`model_jobs.rs`**: `run_model_convert_job` gains a `converter` discriminator — `flux2_klein_diffusers` runs the converter in the mlx-flux **sidecar venv** with the bf16 single-file + base klein snapshot, failing clearly if the base model isn't installed. Default mlx-video Wan path is unchanged.
- **`models.rs`**: `create_model_convert_job` forwards `converter`/`sourceFile`/`baseRepo` from the manifest `mlx` block; `mlx_catalog_status` accepts a diffusers `model_index.json` as a converted-dir marker.
- **`setup.rs`**: desktop exports `SCENEWORKS_MLX_FLUX_PYTHON` + `SCENEWORKS_MLX_FLUX_CONVERT` to the in-process utility worker.
- **`builtin.models.jsonc`**: `flux2_klein_9b_true_v2` entry (macOnly, FLUX Non-Commercial license, `requiresConversion` + converter/source/base, downloads **only the 18 GB bf16 file**, 24-step/CFG1 defaults, `flux2` LoRA family).
- **Frontend**: none — the Model Manager drives `model_convert` generically, so V2 rides the existing download→Convert→generate flow.

## Testing

- 4 converter unit tests (`tests/test_mlx_flux_convert.py`) + 3 dispatch/manifest tests (`tests/test_worker_runtime.py`).
- **436 Python worker tests**, **42 Rust tests**, scaffold check, and **12 contract snapshots** all green. `cargo fmt` clean; `cargo check` clean for `sceneworks-worker` + `sceneworks-rust-api`.
- **Real M5 Max E2E via the production scripts** (`mlx_flux_convert.py` → `mlx_flux_runner.py`): convert → assemble → render produced clean photoreal output with legible in-image text; prompt adherence beats base klein.

## Reviewer notes / caveats

- **Depends on base FLUX.2 [klein] 9B being installed** (its VAE/text-encoder/tokenizer are reused). Enforced by a clear convert-job error; a dependency-aware install prompt is a possible follow-up.
- Storage: ~18 GB bf16 source + ~18 GB converted transformer per machine.
- License: **FLUX Non-Commercial** — same as the klein base already shipped. Converts locally; no redistribution of weights.
- **`cargo check -p sceneworks-desktop` is blocked by a pre-existing prerequisite** (tauri build script needs the bundled `binaries/sceneworks-api-aarch64-apple-darwin` sidecar staged) — unrelated to this change; the `setup.rs` edit is a small additive `.env(...)` using existing helpers.
- Packaged-app click-through (Download→Convert→generate in Image Studio) not run; validated at the code level via the production scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)