### PR TITLE
Epic 2221: Apply LoRAs to Character Studio Angle & Pose generation

### DIFF
--- a/apps/web/src/components/LoraPickerField.jsx
+++ b/apps/web/src/components/LoraPickerField.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { loraMatchesModel, loraWeight, serializeLora } from "../presetUtils.js";
+
+// Keep in sync with the worker guard (lora_adapters.MAX_JOB_LORAS) and the Rust
+// recipe-preset normalizer — generation rejects more than this many LoRAs per job.
+const MAX_JOB_LORAS = 3;
+
+// Family-filtered LoRA selection shared by the Character Studio Angle Set + Pose
+// Library panels (sc-2223). Mirrors the Image/Video Studio behaviour without
+// rebuilding the matcher: list only LoRAs whose family matches the active backbone
+// (loraMatchesModel, sc-1927), expose a per-LoRA weight that defaults to the
+// manifest weight, and emit the serialized `loras` array (serializeLora) the
+// character_image payload carries top-level.
+export function useLoraSelection(loras, model) {
+  const compatibleLoras = React.useMemo(
+    () => (Array.isArray(loras) ? loras.filter((lora) => loraMatchesModel(lora, model)) : []),
+    [loras, model],
+  );
+  const compatibleKey = compatibleLoras.map((lora) => lora.id).join("|");
+  const [selectedLoraIds, setSelectedLoraIds] = React.useState([]);
+  const [weights, setWeights] = React.useState({});
+
+  // Drop selections that no longer match when the backbone changes (a stale id from
+  // another family must not ride along into the payload). Mirrors ImageStudio.
+  React.useEffect(() => {
+    setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [compatibleKey]);
+
+  const weightFor = React.useCallback(
+    (lora) => {
+      const override = Number(weights[lora.id]);
+      return Number.isFinite(override) ? override : loraWeight(lora);
+    },
+    [weights],
+  );
+
+  const toggleLora = React.useCallback((lora) => {
+    setSelectedLoraIds((ids) => {
+      if (ids.includes(lora.id)) {
+        return ids.filter((id) => id !== lora.id);
+      }
+      if (ids.length >= MAX_JOB_LORAS) {
+        return ids; // the worker rejects more than MAX_JOB_LORAS per job
+      }
+      return [...ids, lora.id];
+    });
+  }, []);
+
+  const setWeight = React.useCallback((id, value) => {
+    setWeights((current) => ({ ...current, [id]: Number(value) }));
+  }, []);
+
+  const serializedLoras = React.useMemo(
+    () =>
+      selectedLoraIds
+        .map((id) => compatibleLoras.find((lora) => lora.id === id))
+        .filter(Boolean)
+        .map((lora) => serializeLora(lora, { weight: weightFor(lora) })),
+    [selectedLoraIds, compatibleLoras, weightFor],
+  );
+
+  return { compatibleLoras, selectedLoraIds, toggleLora, weightFor, setWeight, serializedLoras };
+}
+
+// Presentational picker driven by a useLoraSelection() result. Renders nothing when
+// the active backbone has no compatible LoRAs (the feature is optional — no clutter).
+export function LoraPickerField({ selection, label = "Style LoRAs (optional)" }) {
+  const { compatibleLoras, selectedLoraIds, toggleLora, weightFor, setWeight } = selection;
+  if (!compatibleLoras.length) {
+    return null;
+  }
+  // Mirrors the ImageStudio picker markup so it reuses the existing LoRA-choice styles.
+  return (
+    <div className="character-lora-picker">
+      <p className="eyebrow">{label}</p>
+      <div className="lora-choice-list">
+        {compatibleLoras.map((lora) => {
+          const checked = selectedLoraIds.includes(lora.id);
+          const weight = weightFor(lora);
+          return (
+            <div className="lora-choice-item" key={lora.id}>
+              <label className={checked ? "lora-choice active" : "lora-choice"}>
+                <input checked={checked} onChange={() => toggleLora(lora)} type="checkbox" />
+                <span>
+                  <strong>{lora.name ?? lora.id}</strong>
+                  <small>
+                    {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
+                  </small>
+                </span>
+              </label>
+              {checked ? (
+                <div className="lora-weight-row">
+                  <span>Weight</span>
+                  <input
+                    aria-label={`${lora.name ?? lora.id} weight`}
+                    max="2"
+                    min="0"
+                    onChange={(event) => setWeight(lora.id, Number(event.target.value))}
+                    step="0.05"
+                    type="range"
+                    value={weight}
+                  />
+                  <span className="lora-weight-value">{weight.toFixed(2)}</span>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2427,6 +2427,146 @@ describe("SceneWorks app shell", () => {
     expect(baseContext.rememberLocalGenerationJob).toHaveBeenCalledWith("image", { id: "job-pose" });
   });
 
+  it("threads a selected LoRA into the angle-set payload (sc-2223)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-angle-lora" }));
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      assets: [],
+      characters: [
+        {
+          id: "char-1",
+          name: "Mira",
+          type: "person",
+          references: [],
+          approvedReferences: [{ assetId: "ref-1", role: "hero", asset: { id: "ref-1", type: "image", displayName: "Mira ref" } }],
+          looks: [],
+          loras: [],
+        },
+      ],
+      createImageJob,
+      importAsset: vi.fn(),
+      imageLocalJobs: [],
+      rememberLocalGenerationJob: vi.fn(),
+      imageModels: [
+        {
+          id: "instantid_realvisxl",
+          name: "InstantID (RealVisXL)",
+          type: "image",
+          family: "sdxl",
+          ui: { viewAngles: [{ id: "front", label: "Front" }] },
+        },
+      ],
+      latestImageAssets: [],
+      // A family-matching LoRA the picker should surface + serialize into the payload.
+      loras: [{ id: "kelsie-lora", name: "Kelsie", families: ["sdxl"], scope: "project" }],
+      setPreviewAsset: () => {},
+      removeCharacterReference: () => {},
+      updateCharacter: () => {},
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+
+    const loraCheckbox = container.querySelector(".character-lora-picker input[type='checkbox']");
+    expect(loraCheckbox).toBeTruthy();
+    await act(async () => {
+      loraCheckbox.click();
+    });
+
+    const generateButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.startsWith("Generate angle set"),
+    );
+    await act(async () => {
+      generateButton.click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        model: "instantid_realvisxl",
+        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 0.8 })],
+      }),
+    );
+  });
+
+  it("threads a selected LoRA into the pose-library payload (sc-2223)", async () => {
+    const poseKeypoints = Array.from({ length: 18 }, (_, i) => [0.5, i / 18]);
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        version: 1,
+        categories: ["standing"],
+        poses: [{ id: "standing_01", category: "standing", label: "Standing 01", preview: "poses/standing_01.png", keypoints: poseKeypoints }],
+      }),
+    }));
+    const createImageJob = vi.fn(async () => ({ id: "job-pose-lora" }));
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      assets: [],
+      characters: [
+        {
+          id: "char-1",
+          name: "Mira",
+          type: "person",
+          references: [],
+          approvedReferences: [{ assetId: "ref-1", role: "hero", asset: { id: "ref-1", type: "image", displayName: "Mira ref" } }],
+          looks: [],
+          loras: [],
+        },
+      ],
+      createImageJob,
+      importAsset: vi.fn(),
+      imageLocalJobs: [],
+      rememberLocalGenerationJob: vi.fn(),
+      imageModels: [
+        { id: "instantid_realvisxl", name: "InstantID (RealVisXL)", type: "image", family: "sdxl", ui: { poseLibrary: true } },
+      ],
+      latestImageAssets: [],
+      loras: [{ id: "kelsie-lora", name: "Kelsie", families: ["sdxl"], scope: "project" }],
+      setPreviewAsset: () => {},
+      removeCharacterReference: () => {},
+      updateCharacter: () => {},
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const poseButton = [...container.querySelectorAll("button")].find((button) =>
+      (button.getAttribute("aria-label") ?? "").includes("pose Standing 01"),
+    );
+    await act(async () => {
+      poseButton.click();
+    });
+    const loraCheckbox = container.querySelector(".character-lora-picker input[type='checkbox']");
+    expect(loraCheckbox).toBeTruthy();
+    await act(async () => {
+      loraCheckbox.click();
+    });
+
+    const generateButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.startsWith("Generate") && button.textContent.includes("pose"),
+    );
+    await act(async () => {
+      generateButton.click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "character_image",
+        model: "instantid_realvisxl",
+        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 0.8 })],
+      }),
+    );
+  });
+
   it("collects all character-associated assets in the Character Studio gallery (sc-2076)", async () => {
     const onPreview = vi.fn();
     const selectedCharacter = { id: "char-1", name: "Mira" };

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -422,6 +422,7 @@ export function CharacterStudio() {
               imageLocalJobs={imageLocalJobs}
               importAsset={importAsset}
               latestAssets={latestAssets}
+              loras={loras}
               onPreview={onPreview}
               rememberLocalGenerationJob={rememberLocalGenerationJob}
               selectedCharacter={selectedCharacter}
@@ -434,6 +435,7 @@ export function CharacterStudio() {
               imageLocalJobs={imageLocalJobs}
               importAsset={importAsset}
               latestAssets={latestAssets}
+              loras={loras}
               onPreview={onPreview}
               poseModel={poseModel}
               poseModels={poseModels}

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -4,6 +4,7 @@ import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
+import { LoraPickerField, useLoraSelection } from "../components/LoraPickerField.jsx";
 import { usePoseLibrary } from "../poseLibrary.js";
 import { extractFamilies } from "../presetUtils.js";
 
@@ -428,6 +429,7 @@ export function CharacterAngleSet({
   addCharacterReference,
   latestAssets = [],
   imageLocalJobs = [],
+  loras = [],
   rememberLocalGenerationJob,
   onPreview,
 }) {
@@ -445,6 +447,9 @@ export function CharacterAngleSet({
     ?? availableModels[0]
     ?? null;
   const angleCount = activeAngleModel?.ui?.viewAngles?.length ?? 0;
+  // Family-filtered LoRA picker (sc-2223): apply an existing LoRA of this character
+  // to its turnaround (the dataset-bootstrapping loop). Filtered to the backbone's family.
+  const loraSelection = useLoraSelection(loras, activeAngleModel);
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
@@ -525,6 +530,7 @@ export function CharacterAngleSet({
         count: 1,
         width: 1024,
         height: 1024,
+        loras: loraSelection.serializedLoras,
         advanced: { angleSet: true, ipAdapterScale: 0.8 },
       });
       if (job?.id) {
@@ -582,6 +588,7 @@ export function CharacterAngleSet({
       ) : (
         <p className="inline-warning">No approved reference yet — upload one below or approve a reference above.</p>
       )}
+      <LoraPickerField selection={loraSelection} />
       <div className="inline-create">
         <button onClick={() => fileInputRef.current?.click()} type="button">
           Upload reference
@@ -762,6 +769,7 @@ export function CharacterPoseLibrary({
   addCharacterReference,
   latestAssets = [],
   imageLocalJobs = [],
+  loras = [],
   rememberLocalGenerationJob,
   onPreview,
 }) {
@@ -778,6 +786,8 @@ export function CharacterPoseLibrary({
     ?? availableModels[0]
     ?? null;
   const { byId } = usePoseLibrary();
+  // Family-filtered LoRA picker (sc-2223), filtered to the active pose backbone's family.
+  const loraSelection = useLoraSelection(loras, activePoseModel);
   const [selectedPoseIds, setSelectedPoseIds] = React.useState([]);
   const [faceRestore, setFaceRestore] = React.useState(true);
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
@@ -858,6 +868,7 @@ export function CharacterPoseLibrary({
         count: 1,
         width: 1024,
         height: 1024,
+        loras: loraSelection.serializedLoras,
         advanced: { poses, ipAdapterScale: 0.8, faceRestore },
       });
       if (job?.id) {
@@ -925,6 +936,7 @@ export function CharacterPoseLibrary({
         <input checked={faceRestore} onChange={(event) => setFaceRestore(event.target.checked)} type="checkbox" />
         Restore face (sharper identity; off keeps the raw render — fewer blend artifacts)
       </label>
+      <LoraPickerField selection={loraSelection} />
       <div className="inline-create">
         <button onClick={() => fileInputRef.current?.click()} type="button">
           Upload reference

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -49,6 +49,7 @@ from .image_adapters import (
     select_torch_device,
     select_torch_dtype,
 )
+from .lora_adapters import LoraPipelineState, apply_loras_to_pipeline
 from .settings import WorkerSettings
 
 _VENDOR = Path(__file__).resolve().parent / "_vendor" / "instantid"
@@ -183,6 +184,10 @@ class InstantIDAdapter:
         # "identity" (IdentityNet only) vs "multi" (IdentityNet + OpenPose). A job that
         # switches between view-angle and full-body-pose modes reloads the pipeline.
         self._loaded_controlnet_mode: str | None = None
+        # SDXL LoRA merge state for the single cached pipe (sc-2224). One field rather
+        # than the dict-keyed cache other adapters use, because this adapter holds at
+        # most one pipe at a time and reloads (clearing this) on repo/mode change.
+        self._loaded_lora_state = LoraPipelineState()
         self._face_app: Any | None = None
 
     def loaded_models(self) -> list[str]:
@@ -195,6 +200,7 @@ class InstantIDAdapter:
         self._loaded_repo = None
         self._loaded_model = None
         self._loaded_controlnet_mode = None
+        self._loaded_lora_state = LoraPipelineState()
         self._empty_cache(importlib.import_module("torch"))
         return True
 
@@ -616,6 +622,19 @@ class InstantIDAdapter:
         progress("loading_model", "loading_model", 0.18, f"Loading {model_target['label']} (InstantID).")
         pipe = self._load_pipeline(
             settings, request, model_target, progress=progress, job_id=job["id"], pose_set=pose_set
+        )
+        # Apply any selected SDXL LoRAs to the (cached) pipe once, before the angle/pose
+        # loop — every image in the set reuses this pipe, and the merge persists across
+        # the per-pose _restore_face pass (validated by the sc-2222 spike). previous_state
+        # tracks the single live pipe (reset on reload via unload());
+        # validate_lora_compatibility (family "sdxl") rejects incompatible LoRAs.
+        self._loaded_lora_state = apply_loras_to_pipeline(
+            pipe,
+            request.loras,
+            adapter_id=self.id,
+            model_family=model_target.get("family"),
+            model_id=request.model,
+            previous_state=self._loaded_lora_state,
         )
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)

--- a/scripts/spikes/instantid_sdxl_lora_spike.py
+++ b/scripts/spikes/instantid_sdxl_lora_spike.py
@@ -1,0 +1,341 @@
+"""sc-2222 spike — InstantID SDXL LoRA stacking on MPS (GO/NO-GO gate for sc-2224).
+
+Question: does the existing SDXL LoRA merge path
+(``lora_adapters.apply_loras_to_pipeline`` -> diffusers ``load_lora_weights``) stack
+cleanly onto the InstantID pipeline — a ``StableDiffusionXLControlNetPipeline``
+(IdentityNet, plus an OpenPose ControlNet in pose mode) with the InstantID
+IP-Adapter loaded — in **bf16 on MPS**, without breaking ControlNet/IP-Adapter
+conditioning or NaN-ing, and does the merge visibly change the output, preserve
+identity, and remove cleanly between jobs?
+
+It drives the REAL adapter code (``InstantIDAdapter._load_pipeline`` / ``_run_pipeline``
+/ ``_run_pose``) and the REAL ``apply_loras_to_pipeline`` — the exact seam sc-2224 will
+wire — so the findings transfer directly. The only monkeypatch is
+``load_reference_image``, swapped to read a face PNG straight off disk (the asset-sidecar
+resolution is orthogonal to what the spike tests).
+
+Probe LoRA: ``latent-consistency/lcm-lora-sdxl`` — a genuine SDXL UNet LoRA whose merge
+produces a large, unambiguous pixel delta at full weight. It is a *sampling-regime* LoRA,
+not a character LoRA, so it is a MECHANICAL probe of the merge path; a real character
+SDXL LoRA belongs in the sc-2226 e2e.
+
+Run with the SceneWorks desktop venv (has torch/diffusers/insightface/peft):
+  "/Users/michael/Library/Application Support/SceneWorks/python/venv/bin/python" \
+      scripts/spikes/instantid_sdxl_lora_spike.py
+
+Outputs PNGs + a JSON summary under --out (default /tmp/sc2222_instantid_lora).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# --- resolve repo paths + defaults BEFORE importing scene_worker -----------------
+_REPO = Path(__file__).resolve().parents[2]
+for _pkg in (_REPO / "apps" / "worker", _REPO / "packages" / "shared"):
+    if str(_pkg) not in sys.path:
+        sys.path.insert(0, str(_pkg))
+
+_DEFAULT_DATA = Path.home() / "Library" / "Application Support" / "SceneWorks" / "data"
+_DEFAULT_REF = (
+    _DEFAULT_DATA
+    / "projects" / "test.sceneworks" / "assets" / "uploads" / "kelsie-0009-5b1ebbc9.png"
+)
+_DEFAULT_LORA = (
+    Path.home()
+    / ".cache" / "huggingface" / "hub" / "models--latent-consistency--lcm-lora-sdxl"
+    / "snapshots" / "a18548dd4956b174ec5b0d78d340c8dae0a129cd"
+    / "pytorch_lora_weights.safetensors"
+)
+_POSE_INDEX = _REPO / "apps" / "web" / "public" / "poses" / "index.json"
+
+os.environ.setdefault("SCENEWORKS_GPU_ID", "mps")
+os.environ.setdefault("SCENEWORKS_DATA_DIR", str(_DEFAULT_DATA))
+
+import numpy as np  # noqa: E402
+from PIL import Image  # noqa: E402
+
+from scene_worker import instantid_adapter as ia  # noqa: E402
+from scene_worker.image_adapters import ImageRequest, MODEL_TARGETS  # noqa: E402
+from scene_worker.instantid_adapter import InstantIDAdapter  # noqa: E402
+from scene_worker.lora_adapters import apply_loras_to_pipeline  # noqa: E402
+from scene_worker.openpose_skeleton import normalize_keypoints  # noqa: E402
+from scene_worker.settings import WorkerSettings  # noqa: E402
+
+import torch  # noqa: E402
+
+MODEL = "instantid_realvisxl"
+ADAPTER_ID = "instantid_sdxl"
+SEED = 12345
+
+
+def _noop_progress(*_args, **_kwargs) -> None:
+    return None
+
+
+def _mps_mem_gb() -> dict[str, float]:
+    try:
+        return {
+            "current_gb": round(torch.mps.current_allocated_memory() / 1e9, 2),
+            "driver_gb": round(torch.mps.driver_allocated_memory() / 1e9, 2),
+        }
+    except Exception:
+        return {}
+
+
+def _img_stats(img: Image.Image) -> dict[str, float]:
+    arr = np.asarray(img.convert("RGB"), dtype=np.float32)
+    return {"mean": round(float(arr.mean()), 2), "min": float(arr.min()), "max": float(arr.max())}
+
+
+def _pixel_delta(a: Image.Image, b: Image.Image) -> float:
+    """Mean absolute pixel difference (0-255 scale) between two same-size RGB images."""
+    aa = np.asarray(a.convert("RGB"), dtype=np.float32)
+    bb = np.asarray(b.convert("RGB").resize(a.size), dtype=np.float32)
+    return round(float(np.abs(aa - bb).mean()), 3)
+
+
+def _build_request(advanced: dict) -> ImageRequest:
+    return ImageRequest(
+        project_id="spike",
+        mode="character_image",
+        prompt="a woman, portrait, natural light, photorealistic",
+        negative_prompt="blurry, lowres, deformed",
+        model=MODEL,
+        count=1,
+        seed=SEED,
+        seeds=[],
+        width=768,
+        height=768,
+        style_preset="cinematic",
+        loras=[],
+        character_id=None,
+        character_look_id=None,
+        source_asset_id=None,
+        reference_asset_id="spike-ref",
+        advanced=advanced,
+        model_manifest_entry={},
+    )
+
+
+def _cosine(u: np.ndarray, v: np.ndarray) -> float:
+    nu, nv = np.linalg.norm(u), np.linalg.norm(v)
+    if nu == 0 or nv == 0:
+        return 0.0
+    return round(float(np.dot(u, v) / (nu * nv)), 4)
+
+
+def _face_embedding(adapter: InstantIDAdapter, img: Image.Image) -> np.ndarray | None:
+    """ArcFace embedding of the largest face in img, or None if no face detected."""
+    import cv2
+
+    bgr = cv2.cvtColor(np.asarray(img.convert("RGB")), cv2.COLOR_RGB2BGR)
+    faces = adapter._face_analysis().get(bgr)
+    if not faces:
+        return None
+    face = sorted(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))[-1]
+    return np.asarray(face["embedding"], dtype=np.float32)
+
+
+def _active_adapters(pipe) -> list[str]:
+    try:
+        active = pipe.get_active_adapters()
+        return list(active) if active else []
+    except Exception:
+        try:
+            return list(getattr(pipe.unet, "active_adapters", lambda: [])() or [])
+        except Exception:
+            return []
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reference", type=Path, default=_DEFAULT_REF)
+    ap.add_argument("--lora", type=Path, default=_DEFAULT_LORA)
+    ap.add_argument("--out", type=Path, default=Path("/tmp/sc2222_instantid_lora"))
+    ap.add_argument("--steps", type=int, default=12)
+    ap.add_argument("--weight", type=float, default=1.0)
+    ap.add_argument("--skip-pose", action="store_true")
+    args = ap.parse_args()
+
+    if not args.reference.exists():
+        print(f"FATAL: reference not found: {args.reference}", file=sys.stderr)
+        return 2
+    if not args.lora.exists():
+        print(f"FATAL: lora not found: {args.lora}", file=sys.stderr)
+        return 2
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    # Monkeypatch reference resolution to read the PNG directly (sidecar lookup is
+    # orthogonal to the merge path this spike exercises).
+    reference_img = Image.open(args.reference).convert("RGB")
+    ia.load_reference_image = lambda *_a, **_k: reference_img  # type: ignore[assignment]
+
+    lora_spec = {
+        "id": "lcm-lora-sdxl",
+        "path": str(args.lora),
+        "weight": args.weight,
+        "families": ["sdxl"],
+    }
+
+    settings = WorkerSettings()
+    adapter = InstantIDAdapter()
+    model_target = MODEL_TARGETS[MODEL]
+    project_path = _DEFAULT_DATA / "projects" / "test.sceneworks"
+    advanced = {"steps": args.steps, "viewAngle": "front", "ipAdapterScale": 0.8}
+    request = _build_request(advanced)
+
+    findings: dict = {
+        "device": "mps",
+        "dtype": "bfloat16",
+        "model": MODEL,
+        "lora": lora_spec["id"],
+        "steps": args.steps,
+        "weight": args.weight,
+        "torch": torch.__version__,
+    }
+
+    # ---- reference identity baseline ------------------------------------------
+    ref_emb = _face_embedding(adapter, reference_img)
+    findings["reference_face_detected"] = ref_emb is not None
+
+    # ============================ PROBE A: identity / angle mode ===============
+    print(">>> PROBE A: identity-mode (IdentityNet + IP-Adapter), angle=front")
+    t0 = time.time()
+    pipe = adapter._load_pipeline(
+        settings, request, model_target, progress=_noop_progress, job_id="spike-a", pose_set=False
+    )
+    findings["load_seconds"] = round(time.time() - t0, 1)
+    findings["mem_after_load"] = _mps_mem_gb()
+
+    a = {}
+    try:
+        t0 = time.time()
+        base_img = adapter._run_pipeline(settings, pipe, request, SEED, project_path, view_angle_override="front")
+        a["baseline_seconds"] = round(time.time() - t0, 1)
+        base_img.save(args.out / "A_baseline.png")
+        a["baseline_stats"] = _img_stats(base_img)
+
+        state = apply_loras_to_pipeline(
+            pipe, [lora_spec], adapter_id=ADAPTER_ID, model_family="sdxl"
+        )
+        a["lora_applied_adapters"] = list(state.adapter_names)
+        a["active_after_apply"] = _active_adapters(pipe)
+        a["mem_after_lora"] = _mps_mem_gb()
+
+        t0 = time.time()
+        lora_img = adapter._run_pipeline(settings, pipe, request, SEED, project_path, view_angle_override="front")
+        a["lora_seconds"] = round(time.time() - t0, 1)
+        lora_img.save(args.out / "A_with_lora.png")
+        a["lora_stats"] = _img_stats(lora_img)
+        a["delta_baseline_vs_lora"] = _pixel_delta(base_img, lora_img)
+
+        # Clean removal: clear LoRA, re-render the same seed -> should match baseline.
+        cleared_state = apply_loras_to_pipeline(
+            pipe, [], adapter_id=ADAPTER_ID, model_family="sdxl", previous_state=state
+        )
+        a["active_after_clear"] = _active_adapters(pipe)
+        cleared_img = adapter._run_pipeline(settings, pipe, request, SEED, project_path, view_angle_override="front")
+        cleared_img.save(args.out / "A_cleared.png")
+        a["delta_baseline_vs_cleared"] = _pixel_delta(base_img, cleared_img)
+
+        # Identity preservation: ArcFace cosine vs the reference for base vs LoRA.
+        if ref_emb is not None:
+            be = _face_embedding(adapter, base_img)
+            le = _face_embedding(adapter, lora_img)
+            a["cosine_baseline_vs_ref"] = _cosine(be, ref_emb) if be is not None else None
+            a["cosine_lora_vs_ref"] = _cosine(le, ref_emb) if le is not None else None
+        a["ok"] = True
+    except Exception as exc:  # noqa: BLE001
+        a["ok"] = False
+        a["error"] = f"{type(exc).__name__}: {exc}"
+        import traceback
+
+        traceback.print_exc()
+    findings["probe_a_identity"] = a
+
+    # ============================ PROBE B: pose / multi-controlnet =============
+    if not args.skip_pose:
+        print(">>> PROBE B: pose-mode (IdentityNet + OpenPose + IP-Adapter) + faceRestore")
+        b = {}
+        try:
+            keypoints = _load_sample_pose()
+            b["pose_keypoints_loaded"] = keypoints is not None
+            pose_advanced = {"steps": args.steps, "ipAdapterScale": 0.8, "faceRestore": True}
+            pose_request = _build_request(pose_advanced)
+            pose_pipe = adapter._load_pipeline(
+                settings, pose_request, model_target, progress=_noop_progress,
+                job_id="spike-b", pose_set=True,
+            )
+            b["mem_after_pose_load"] = _mps_mem_gb()
+            state = apply_loras_to_pipeline(
+                pose_pipe, [lora_spec], adapter_id=ADAPTER_ID, model_family="sdxl"
+            )
+            b["active_before_gen"] = _active_adapters(pose_pipe)
+            t0 = time.time()
+            # faceRestore=True => a SECOND pipe() call (_restore_face); confirms the merged
+            # LoRA persists across calls without re-applying (the sc-2222 _restore_face Q).
+            pose_img = adapter._run_pose(
+                settings, pose_pipe, pose_request, SEED, project_path, normalize_keypoints(keypoints)
+            )
+            b["pose_seconds"] = round(time.time() - t0, 1)
+            pose_img.save(args.out / "B_pose_with_lora.png")
+            b["pose_stats"] = _img_stats(pose_img)
+            b["active_after_gen"] = _active_adapters(pose_pipe)
+            b["lora_persisted_across_restore"] = bool(b["active_after_gen"])
+            b["mem_peak"] = _mps_mem_gb()
+            b["ok"] = True
+        except Exception as exc:  # noqa: BLE001
+            b["ok"] = False
+            b["error"] = f"{type(exc).__name__}: {exc}"
+            import traceback
+
+            traceback.print_exc()
+        findings["probe_b_pose"] = b
+
+    # ---- GO/NO-GO heuristic ----------------------------------------------------
+    a = findings.get("probe_a_identity", {})
+    # NB: compare against explicit values, not `x or default` — a perfectly clean
+    # removal yields delta 0.0, which is falsy and would wrongly fall through to the
+    # default with `or`.
+    delta_lora = a.get("delta_baseline_vs_lora")
+    delta_cleared = a.get("delta_baseline_vs_cleared")
+    base_mean = a.get("baseline_stats", {}).get("mean")
+    lora_mean = a.get("lora_stats", {}).get("mean")
+    go = bool(
+        a.get("ok")
+        and delta_lora is not None and delta_lora > 3.0       # LoRA visibly changed output
+        and base_mean is not None and base_mean > 5.0         # not all-black (no NaN)
+        and lora_mean is not None and lora_mean > 5.0
+        and delta_cleared is not None and delta_cleared < 2.0  # clean removal
+    )
+    findings["verdict"] = "GO" if go else "REVIEW"
+
+    print("\n================ sc-2222 SPIKE SUMMARY ================")
+    print(json.dumps(findings, indent=2))
+    (args.out / "summary.json").write_text(json.dumps(findings, indent=2))
+    print(f"\nImages + summary.json written to: {args.out}")
+    print(f"VERDICT: {findings['verdict']}")
+    return 0
+
+
+def _load_sample_pose():
+    """First library pose with a visible head (so IdentityNet + face-restore engage)."""
+    try:
+        data = json.loads(_POSE_INDEX.read_text())
+    except Exception:
+        return None
+    poses = data.get("poses", []) if isinstance(data, dict) else []
+    for pose in poses:
+        kp = pose.get("keypoints")
+        if isinstance(kp, list) and len(kp) >= 16 and kp[0] is not None:
+            return kp
+    return poses[0].get("keypoints") if poses else None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -19,6 +19,7 @@ from scene_worker.instantid_adapter import (
     _letterbox,
     _view_angle_kps,
 )
+from scene_worker.lora_adapters import LoraPipelineState
 from scene_worker.openpose_skeleton import (
     draw_bodypose,
     face_box_from_keypoints,
@@ -256,3 +257,105 @@ def test_face_restore_enabled_default_and_toggle():
     assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={"faceRestore": True})) is True
     assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={"faceRestore": "false"})) is False
     assert InstantIDAdapter._face_restore_enabled(SimpleNamespace(advanced={"faceRestore": "off"})) is False
+
+
+# ---- SDXL LoRA application (sc-2224) --------------------------------------------
+#
+# The InstantID pipe is a StableDiffusionXLControlNetPipeline; the sc-2222 spike
+# confirmed the existing SDXL LoRA merge path stacks on it (IdentityNet/OpenPose +
+# IP-Adapter, bf16/MPS) and persists across the per-pose _restore_face pass. These
+# tests cover the adapter-level wiring (apply once before the angle/pose loop, state
+# threaded across jobs, reset on unload) with the pipe + merge mocked — the merge
+# math + family gating live in lora_adapters and are exercised via the real
+# apply_loras_to_pipeline in test_lora_family_incompatibility_is_rejected.
+
+
+def _generate_capturing_loras(monkeypatch, adapter, job):
+    """Run generate() with the model load + LoRA merge + asset writer mocked, returning
+    the list of recorded apply_loras_to_pipeline calls."""
+    calls: list[dict] = []
+    applied_state = LoraPipelineState(key="applied", adapter_names=("sw_test",))
+
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: object())  # extras present
+    monkeypatch.setattr(adapter, "_load_pipeline", lambda *a, **k: SimpleNamespace(tag="fakepipe"))
+    monkeypatch.setattr("scene_worker.instantid_adapter.select_torch_device", lambda *a, **k: "cpu")
+    monkeypatch.setattr("scene_worker.instantid_adapter.activate_torch_device", lambda *a, **k: None)
+
+    def _fake_apply(pipe, loras, **kwargs):
+        calls.append({"pipe": pipe, "loras": loras, **kwargs})
+        return applied_state
+
+    monkeypatch.setattr("scene_worker.instantid_adapter.apply_loras_to_pipeline", _fake_apply)
+    monkeypatch.setattr(
+        "scene_worker.instantid_adapter.ImageAssetWriter.write_incremental_outputs",
+        lambda self, **kwargs: {"images": []},
+    )
+    adapter.generate(
+        settings=SimpleNamespace(gpu_id="cpu"),
+        job=job,
+        request=image_request_from_job(job),
+        project_path=None,
+        progress=_NOOP,
+        cancel_requested=lambda: False,
+    )
+    return calls, applied_state
+
+
+def test_generate_applies_request_loras(instantid_model, monkeypatch):
+    loras = [{"id": "kelsie-sdxl", "path": "/loras/kelsie.safetensors", "families": ["sdxl"]}]
+    job = _job(instantid_model, referenceAssetId="ref-x", loras=loras)
+    adapter = InstantIDAdapter()
+    calls, applied_state = _generate_capturing_loras(monkeypatch, adapter, job)
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["loras"] == loras
+    assert call["adapter_id"] == "instantid_sdxl"
+    assert call["model_family"] == "sdxl"
+    assert call["model_id"] == instantid_model
+    # Fresh adapter: the first job threads in the empty starting state.
+    assert call["previous_state"] == LoraPipelineState()
+    # The returned state is stored so the next job can clear/diff against it.
+    assert adapter._loaded_lora_state is applied_state
+
+
+def test_generate_with_no_loras_still_applies_empty(instantid_model, monkeypatch):
+    # A job without loras must still call apply (with []), so a LoRA from a prior job on
+    # the cached pipe is cleared rather than silently carried over.
+    job = _job(instantid_model, referenceAssetId="ref-x")
+    calls, _ = _generate_capturing_loras(monkeypatch, InstantIDAdapter(), job)
+    assert len(calls) == 1 and calls[0]["loras"] == []
+
+
+def test_generate_threads_previous_lora_state_across_jobs(instantid_model, monkeypatch):
+    # The cached pipe persists across jobs, so each apply must receive the prior job's
+    # returned state as previous_state (the diff drives load/clear of adapters).
+    adapter = InstantIDAdapter()
+    job = _job(instantid_model, referenceAssetId="ref-x", loras=[{"id": "a", "path": "/a.safetensors"}])
+    calls1, applied_state = _generate_capturing_loras(monkeypatch, adapter, job)
+    assert calls1[0]["previous_state"] == LoraPipelineState()
+
+    calls2, _ = _generate_capturing_loras(monkeypatch, adapter, job)
+    assert calls2[0]["previous_state"] is applied_state
+
+
+def test_unload_resets_lora_state():
+    adapter = InstantIDAdapter()
+    adapter._pipe = SimpleNamespace(tag="fakepipe")
+    adapter._loaded_lora_state = LoraPipelineState(key="applied", adapter_names=("sw_test",))
+    adapter._empty_cache = lambda *_a, **_k: None  # avoid importing torch
+    assert adapter.unload() is True
+    # The merge belongs to the (now-discarded) pipe; the next pipe must start clean.
+    assert adapter._loaded_lora_state == LoraPipelineState()
+
+
+def test_lora_family_incompatibility_is_rejected():
+    # The InstantID family is "sdxl"; a flux LoRA must be rejected. validate runs before
+    # the pipe is touched, so a bare sentinel pipe is never used.
+    from scene_worker.lora_adapters import apply_loras_to_pipeline
+
+    flux_lora = [{"id": "flux-style", "path": "/loras/flux.safetensors", "families": ["flux"]}]
+    with pytest.raises(RuntimeError, match="not compatible"):
+        apply_loras_to_pipeline(
+            object(), flux_lora, adapter_id="instantid_sdxl", model_family="sdxl"
+        )

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -6,6 +6,7 @@ behavior is validated by the sc-2009 spike + a real worker job, not here.
 """
 from __future__ import annotations
 
+import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -43,6 +44,20 @@ _TEST_TARGET = {
 }
 
 _NOOP = lambda *args, **kwargs: None  # noqa: E731
+
+
+# The worker unit suite runs without torch installed; generate()/unload() do
+# `importlib.import_module("torch")`. Patch it to this stand-in (with gpu_id="cpu",
+# select_torch_device returns early and the cache-empty path is a guarded no-op).
+class _FakeTorch:
+    pass
+
+
+def _patch_torch_import(monkeypatch):
+    monkeypatch.setattr(
+        "scene_worker.instantid_adapter.importlib.import_module",
+        lambda name: _FakeTorch if name == "torch" else importlib.import_module(name),
+    )
 
 
 @pytest.fixture
@@ -277,6 +292,7 @@ def _generate_capturing_loras(monkeypatch, adapter, job):
     applied_state = LoraPipelineState(key="applied", adapter_names=("sw_test",))
 
     monkeypatch.setattr("importlib.util.find_spec", lambda name: object())  # extras present
+    _patch_torch_import(monkeypatch)
     monkeypatch.setattr(adapter, "_load_pipeline", lambda *a, **k: SimpleNamespace(tag="fakepipe"))
     monkeypatch.setattr("scene_worker.instantid_adapter.select_torch_device", lambda *a, **k: "cpu")
     monkeypatch.setattr("scene_worker.instantid_adapter.activate_torch_device", lambda *a, **k: None)
@@ -339,11 +355,12 @@ def test_generate_threads_previous_lora_state_across_jobs(instantid_model, monke
     assert calls2[0]["previous_state"] is applied_state
 
 
-def test_unload_resets_lora_state():
+def test_unload_resets_lora_state(monkeypatch):
+    _patch_torch_import(monkeypatch)  # unload() evaluates importlib.import_module("torch")
     adapter = InstantIDAdapter()
     adapter._pipe = SimpleNamespace(tag="fakepipe")
     adapter._loaded_lora_state = LoraPipelineState(key="applied", adapter_names=("sw_test",))
-    adapter._empty_cache = lambda *_a, **_k: None  # avoid importing torch
+    adapter._empty_cache = lambda *_a, **_k: None  # the cache-empty call itself is a no-op
     assert adapter.unload() is True
     # The merge belongs to the (now-discarded) pipe; the next pipe must start clean.
     assert adapter._loaded_lora_state == LoraPipelineState()

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -12,6 +12,12 @@ from types import SimpleNamespace
 import httpx
 import pytest
 
+from scene_worker.image_adapters import (
+    CHARACTER_ANGLE_SET_ORDER,
+    ImageAssetWriter,
+    MODEL_TARGETS,
+    render_preview_image,
+)
 from scene_worker.runtime import (
     ApiClient,
     heartbeat,
@@ -248,6 +254,168 @@ def test_python_worker_completes_procedural_image_job_against_rust_api_binary(
     written = project_path / asset["file"]["path"]
     assert written.exists()
     assert written.suffix == ".png"
+
+
+class _RecordingImageAdapter:
+    """Records the ImageRequest the worker hands the adapter, then writes weightless
+    preview images so the job completes. Unlike the procedural adapter it does NOT
+    reject loras (that is the point — sc-2226 proves loras survive the API + worker
+    boundary into request.loras for character_image angle/pose sets)."""
+
+    id = "recording-e2e"
+
+    def __init__(self, sink: list[dict]) -> None:
+        self._sink = sink
+
+    def loaded_models(self) -> list[str]:
+        return []
+
+    def generate(self, *, settings, job, request, project_path, progress, cancel_requested):
+        self._sink.append(
+            {"mode": request.mode, "loras": list(request.loras), "advanced": dict(request.advanced)}
+        )
+        model_target = MODEL_TARGETS.get(request.model, MODEL_TARGETS["z_image_turbo"])
+        if request.advanced.get("angleSet"):
+            count = len(CHARACTER_ANGLE_SET_ORDER)
+        elif isinstance(request.advanced.get("poses"), list):
+            count = len(request.advanced["poses"])
+        else:
+            count = request.count
+        return ImageAssetWriter().write_incremental_outputs(
+            request=request,
+            project_path=project_path,
+            image_count=count,
+            image_at_index=lambda index: render_preview_image(request, model_target, index, index),
+            adapter_id=self.id,
+            progress=progress,
+            cancel_requested=cancel_requested,
+            raw_settings={**request.advanced, "recordingE2E": True},
+            settings=settings,
+            job_id=job["id"],
+        )
+
+
+@pytest.mark.e2e
+def test_character_image_angle_and_pose_sets_carry_loras_through_worker(rust_api, tmp_path, monkeypatch):
+    """sc-2226: a character_image angle set AND pose set, each carrying a `loras` array,
+    submitted through the Rust API binary and run by the in-process worker, deliver those
+    loras to the adapter as request.loras (the payload -> catalog-normalized -> worker ->
+    ImageRequest.loras boundary). z_image_turbo stands in as a weightless backbone; the
+    angle/pose LoRA path itself is unit-covered in sc-2224/2225."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+
+    # The Rust API resolves a job's project through its own project store (for project
+    # LoRAs), so create the project via the API and mirror its path into recent-projects
+    # .json (how the in-process worker resolves the same project).
+    created_project = httpx.post(f"{rust_api}/api/v1/projects", json={"name": "Lora E2E"}, timeout=5)
+    created_project.raise_for_status()
+    project = created_project.json()
+    project_id = project["id"]
+    project_path = Path(project["path"])
+    (data_dir / "recent-projects.json").write_text(
+        json.dumps([{"id": project_id, "path": str(project_path)}]), encoding="utf-8"
+    )
+
+    # The Rust API rejects loras not present in the catalog (it hydrates + normalizes
+    # submitted specs against installed LoRAs). Seed one user LoRA whose family matches
+    # the z_image_turbo backbone so the submission validates and reaches the worker.
+    lora_id = "kelsie-zit"
+    lora_dir = data_dir / "loras" / lora_id
+    lora_dir.mkdir(parents=True, exist_ok=True)
+    (lora_dir / "kelsie.safetensors").write_bytes(_minimal_safetensors())
+    manifests = tmp_path / "config" / "manifests"
+    manifests.mkdir(parents=True, exist_ok=True)
+    # The lora compatibility check resolves the model + builtin loras from the catalog,
+    # which reads these manifests; copy the real ones so z_image_turbo (family z-image)
+    # is known. Size estimation is disabled by the rust_api fixture (no network).
+    for manifest_name in ("builtin.models.jsonc", "builtin.loras.jsonc"):
+        shutil.copy(ROOT / "config" / "manifests" / manifest_name, manifests / manifest_name)
+    (manifests / "user.loras.jsonc").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "loras": [
+                    {
+                        "id": lora_id,
+                        "name": "Kelsie ZIT",
+                        "family": "z-image",
+                        "scope": "global",
+                        "files": ["kelsie.safetensors"],
+                        "source": {"path": f"loras/{lora_id}", "provider": "local", "repo": None},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("SCENEWORKS_API_URL", rust_api)
+    monkeypatch.setenv("SCENEWORKS_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("SCENEWORKS_WORKER_ID", "lora-e2e-worker")
+    monkeypatch.setenv("SCENEWORKS_GPU_ID", "gpu-0")
+
+    # Inject a recording adapter (the procedural adapter rejects loras), so the worker's
+    # real dispatch path runs but no model weights are needed.
+    recorded: list[dict] = []
+    monkeypatch.setattr(
+        "scene_worker.runtime.create_image_adapter",
+        lambda job, image_adapters: _RecordingImageAdapter(recorded),
+    )
+
+    settings = WorkerSettings()
+    api = ApiClient(settings)
+    register_worker(
+        api,
+        settings,
+        {"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu", "image_generate"]},
+        loaded_models=[],
+    )
+
+    loras = [{"id": lora_id, "weight": 0.8}]
+    pose_keypoints = [[0.5, index / 18] for index in range(18)]
+    base = {
+        "projectId": project_id,
+        "mode": "character_image",
+        "model": "z_image_turbo",
+        "prompt": "the character",
+        "referenceAssetId": "ref-1",
+        "count": 1,
+        "width": 256,
+        "height": 256,
+        "requestedGpu": "gpu-0",
+        "loras": loras,
+    }
+    jobs = {
+        "angle": {**base, "advanced": {"angleSet": True, "ipAdapterScale": 0.8}},
+        "pose": {
+            **base,
+            "advanced": {"poses": [{"id": "standing_01", "keypoints": pose_keypoints}], "ipAdapterScale": 0.8},
+        },
+    }
+
+    for kind, body in jobs.items():
+        created = httpx.post(f"{rust_api}/api/v1/image/jobs", json=body, timeout=5)
+        assert created.status_code == 201, (kind, created.status_code, created.text)
+        job = created.json()
+
+        claimed = api.post("/api/v1/jobs/claim", {"workerId": settings.worker_id})["job"]
+        assert claimed["id"] == job["id"], kind
+        # The Rust API persisted + served the (normalized) loras on the claimed payload.
+        assert [lora["id"] for lora in claimed["payload"]["loras"]] == [lora_id], kind
+
+        run_image_job(api, settings, claimed, {})
+
+        completed = httpx.get(f"{rust_api}/api/v1/jobs/{job['id']}", timeout=5).json()
+        assert completed["status"] == "completed", (kind, completed)
+
+    # The adapter received request.loras for BOTH the angle set and the pose set.
+    assert len(recorded) == 2
+    assert all([lora["id"] for lora in entry["loras"]] == [lora_id] for entry in recorded)
+    angle_entry = next(entry for entry in recorded if entry["advanced"].get("angleSet"))
+    pose_entry = next(entry for entry in recorded if entry["advanced"].get("poses"))
+    assert angle_entry["loras"][0]["weight"] == 0.8
+    assert pose_entry["loras"][0]["weight"] == 0.8
 
 
 def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(rust_api, tmp_path):

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -756,7 +756,17 @@ def test_qwen_character_image_angle_set_applies_loras_once_then_loops_angles(tmp
         def convert(self, _mode):
             return self
 
+    # The worker unit suite runs without torch installed; generate() does
+    # `importlib.import_module("torch")`, so stand in a fake. With gpu_id="cpu",
+    # select_torch_device returns early and never touches it.
+    class FakeTorch:
+        pass
+
     adapter = QwenImageAdapter()
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.importlib.import_module",
+        lambda name: FakeTorch if name == "torch" else importlib.import_module(name),
+    )
     monkeypatch.setattr("scene_worker.image_adapters.gpu_memory_snapshot", lambda *a, **k: None)
     monkeypatch.setattr(adapter, "_load_pipeline", lambda *a, **k: object())
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -25,6 +25,7 @@ from scene_worker.caption_adapters import (
 from scene_worker.image_adapters import (
     AuraSrUpscaler,
     ChromaDiffusersAdapter,
+    CHARACTER_ANGLE_SET_ORDER,
     FluxDiffusersAdapter,
     ImageAssetWriter,
     KolorsDiffusersAdapter,
@@ -744,6 +745,75 @@ def test_qwen_reference_run_pipeline_passes_image_and_true_cfg(tmp_path, monkeyp
     assert pipe.last_kwargs["negative_prompt"] == " "
     assert pipe.last_kwargs["image"] is not None
     assert result is FakeOutput.images[0]
+
+
+def test_qwen_character_image_angle_set_applies_loras_once_then_loops_angles(tmp_path, monkeypatch):
+    """sc-2225: a character_image + angleSet job on a diffusers backbone (Qwen) must
+    apply request.loras exactly once, BEFORE the per-angle loop, and emit one image per
+    canonical angle. Guards the regression that angle-set mode skips the LoRA merge."""
+
+    class FakeImage:
+        def convert(self, _mode):
+            return self
+
+    adapter = QwenImageAdapter()
+    monkeypatch.setattr("scene_worker.image_adapters.gpu_memory_snapshot", lambda *a, **k: None)
+    monkeypatch.setattr(adapter, "_load_pipeline", lambda *a, **k: object())
+
+    apply_calls: list[list] = []
+    monkeypatch.setattr(adapter, "_apply_loras", lambda pipe, request: apply_calls.append(list(request.loras)))
+
+    run_overrides: list = []
+
+    def fake_run(settings, pipe, request, seed, project_path, *, cancel_requested=None, prompt_override=None):
+        # The LoRA merge must already have happened before any angle is generated.
+        assert apply_calls, "loras must be applied before the angle loop runs"
+        run_overrides.append(prompt_override)
+        return FakeImage()
+
+    monkeypatch.setattr(adapter, "_run_pipeline", fake_run)
+
+    captured: dict = {}
+
+    def fake_writer(self, *, image_count, image_at_index, **kwargs):
+        captured["image_count"] = image_count
+        for index in range(image_count):
+            image_at_index(index)
+        return {"images": [], "count": image_count}
+
+    monkeypatch.setattr(ImageAssetWriter, "write_incremental_outputs", fake_writer)
+
+    loras = [{"id": "kelsie", "path": "/loras/kelsie.safetensors", "families": ["qwen-image"]}]
+    job = {
+        "id": "job-qwen-angle",
+        "payload": {
+            "projectId": "p",
+            "mode": "character_image",
+            "model": "qwen_image_edit_2511",
+            "prompt": "the character",
+            "referenceAssetId": "ref-1",
+            "count": 1,
+            "width": 16,
+            "height": 16,
+            "loras": loras,
+            "advanced": {"angleSet": True},
+        },
+    }
+    adapter.generate(
+        settings=SimpleNamespace(gpu_id="cpu"),
+        job=job,
+        request=image_request_from_job(job),
+        project_path=tmp_path,
+        progress=lambda *a, **k: None,
+        cancel_requested=lambda: False,
+    )
+
+    # Applied exactly once (per pipe, before the loop) with the requested loras.
+    assert apply_calls == [loras]
+    # One image per canonical angle, each with its own per-angle prompt augment.
+    assert captured["image_count"] == len(CHARACTER_ANGLE_SET_ORDER)
+    assert len(run_overrides) == len(CHARACTER_ANGLE_SET_ORDER)
+    assert len(set(run_overrides)) == len(CHARACTER_ANGLE_SET_ORDER)
 
 
 def test_filter_call_kwargs_preserves_none_for_accepted_parameters():


### PR DESCRIPTION
## Epic 2221 — Apply LoRAs to Character Studio Angle & Pose generation

Lets users apply an existing character LoRA to the **Angle Set** and **Pose Library** generators in Character Studio, with a family-filtered picker mirroring Image/Video Studio. This is the "references → dataset → LoRA → generation" bootstrapping loop expressed at the generation step.

Covers all 5 epic stories:

| Story | What |
|---|---|
| [sc-2222](https://app.shortcut.com/trefry/story/2222) | Spike (GO): SDXL LoRA stacks cleanly on the InstantID MultiControlNet + IP-Adapter pipe on MPS/bf16 |
| [sc-2224](https://app.shortcut.com/trefry/story/2224) | Worker: apply `request.loras` in the InstantID adapter (poses + InstantID angles) |
| [sc-2223](https://app.shortcut.com/trefry/story/2223) | Web: family-filtered LoRA picker on the Angle Set + Pose Library panels |
| [sc-2225](https://app.shortcut.com/trefry/story/2225) | Worker: confirm + test LoRA on diffusers-backbone angle sets |
| [sc-2226](https://app.shortcut.com/trefry/story/2226) | E2E (Rust API + worker) + real-Mac validation |

### What changed
- **Worker** (`instantid_adapter.py`): one `LoraPipelineState` field + a single `apply_loras_to_pipeline(...)` call in `generate()` before the angle/pose loop (reset in `unload()`). The merge persists across the per-pose `_restore_face` pass. `_run_pipeline`/`_run_pose`/`_restore_face` unchanged. Family `sdxl` gating + `MAX_JOB_LORAS` come for free from the shared LoRA path.
- **Web**: new shared `LoraPickerField` + `useLoraSelection` hook (reuses `loraMatchesModel`/`serializeLora` — no rebuilt logic), mounted on both Character panels; both `generate()` payloads now carry the top-level `loras` array. No contract change.
- **Tests**: InstantID adapter LoRA wiring (5), Qwen `character_image`+`angleSet` applies-once-then-loops (1), web picker→payload for angle + pose (2), and an `@pytest.mark.e2e` test driving angle + pose `character_image` jobs with loras through the Rust API binary → worker → `request.loras`.

### Verification
- **540 worker tests** + **255 web tests** green. No Rust/contract changes (`loras` was already part of the image-job payload/Recipe).
- **Spike + real-Mac (MPS):** LoRA visibly affects output (pixel delta ~52–54) while InstantID identity holds (ArcFace cosine 0.783→0.785); the no-LoRA path leaves adapter state clean and clears between jobs.

### Notes
- A throwaway spike harness is committed at `scripts/spikes/instantid_sdxl_lora_spike.py` (real-MPS GO/NO-GO).
- Follow-ups filed for the non-InstantID angle backbones (sc-2246 Flux2-klein MLX, sc-2247 SenseNova reject-picker UX, sc-2248 Qwen real-Mac) and a new epic 2249 (pose/angle conditioning beyond InstantID via per-architecture ControlNet flows, incl. LoRA/LoKr on those flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
