### PR TITLE
fix(lora): support FLUX.2 [klein] LoRA family detection and import

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
 import { hasPresentCredential, loadCredentials } from "../credentials.js";
-import { extractFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
+import { extractFamilies, modelLoraFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
 
 // Wan A14B is a two-expert mixture; its LoRAs come as a high/low-noise pair. These
@@ -210,7 +210,12 @@ export function ModelManagerScreen() {
   const onImportLora = createLoraImportJob;
   const onImportModel = createModelImportJob;
   const onOpenQueue = () => setActiveView("Queue");
-  const families = Array.from(new Set(models.map((model) => model.family).filter(Boolean))).sort();
+  // LoRA families come from each model's LoRA-compatibility set — NOT its model
+  // `family` identity. They usually coincide, but distilled variants differ: e.g.
+  // FLUX.2 [klein] has family "flux2-klein" yet accepts "flux2" LoRAs. The import
+  // validator + generation-time matcher both key off loraCompatibility.families,
+  // so the dropdown must too, or the user picks a family the backend rejects.
+  const families = Array.from(new Set(models.flatMap((model) => modelLoraFamilies(model)).filter(Boolean))).sort();
   const familiesKey = families.join("|");
   const [familyFilter, setFamilyFilter] = useState("all");
   const [importingLora, setImportingLora] = useState(false);

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -271,6 +271,50 @@ describe("ModelManagerScreen Wan A14B MoE LoRA import (sc-1991)", () => {
     expect(payload.family).toBe("wan-video");
     expect(payload.baseModel).toBe("wan_2_2_t2v_14b");
   });
+
+  // Distilled variants whose model `family` differs from their LoRA-compatibility
+  // set (FLUX.2 [klein]: family "flux2-klein" but accepts "flux2" LoRAs) must offer
+  // the compatibility family in the dropdown — the import validator + generation
+  // matcher both key off loraCompatibility.families, so offering "flux2-klein"
+  // would let the user pick a family the backend rejects ("Unsupported LoRA family").
+  it("offers the LoRA-compatibility family, not the model identity, for distilled variants", async () => {
+    const value = {
+      activeProject: null,
+      jobs: [],
+      loras: [],
+      models: [
+        {
+          id: "flux2_klein_9b",
+          name: "FLUX.2 [klein] 9B",
+          type: "image",
+          family: "flux2-klein",
+          loraCompatibility: { families: ["flux2"] },
+          installState: "ready",
+          ui: { description: "Distilled FLUX.2 variant." },
+        },
+      ],
+      presets: [],
+      jobAction: () => {},
+      setActiveView: () => {},
+      deleteLora: () => {},
+      deleteModel: () => {},
+      createModelDownloadJob: () => {},
+      createModelConvertJob: () => {},
+      createLoraImportJob,
+      createModelImportJob: () => {},
+    };
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+    const familyOptions = [...labelStartingWith("Family").querySelectorAll("option")].map((option) => option.value);
+    expect(familyOptions).toContain("flux2");
+    expect(familyOptions).not.toContain("flux2-klein");
+  });
 });
 
 describe("ModelManagerScreen type-grouped layout", () => {

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -321,6 +321,7 @@ pub fn detect_lora_family(header: &Value) -> Option<String> {
     match bucket {
         Bucket::WanVideo => Some("wan-video".to_owned()),
         Bucket::Flux => Some("flux".to_owned()),
+        Bucket::Flux2 => Some("flux2".to_owned()),
         Bucket::LtxVideo => Some("ltx-video".to_owned()),
         Bucket::Sdxl => Some("sdxl".to_owned()),
         Bucket::Sd15 => Some("sd1.5".to_owned()),
@@ -332,6 +333,7 @@ pub fn detect_lora_family(header: &Value) -> Option<String> {
 enum Bucket {
     WanVideo,
     Flux,
+    Flux2,
     LtxVideo,
     MmDit,
     Sdxl,
@@ -387,6 +389,28 @@ const SIGNATURES: &[BucketSignature] = &[
         ],
         disqualifiers: &["single_transformer_blocks.", "single_blocks_"],
         markers: &["double_blocks.", "processor.", "qkv_lora", "proj_lora"],
+    },
+    BucketSignature {
+        bucket: Bucket::Flux2,
+        // FLUX.2 [klein] native/ComfyUI LoRAs share the FLUX.1 `diffusion_model.`
+        // prefix and the same double_blocks/single_blocks split, but FLUX.2 shares
+        // modulation ACROSS all blocks via top-level `double_stream_modulation_img`
+        // / `double_stream_modulation_txt` / `single_stream_modulation` tensors,
+        // whereas FLUX.1 keeps per-block `img_mod`/`txt_mod`/`modulation` inside
+        // each block index. Those shared-modulation keys are unique to FLUX.2 and
+        // never appear in a FLUX.1 LoRA, so requiring one cleanly separates the two
+        // (the primary Flux signature can't fire here anyway — FLUX.2 uses
+        // `single_blocks.` with a dot, not the `single_blocks_` underscore form).
+        require_all_of: &[&["double_stream_modulation_", "single_stream_modulation."]],
+        disqualifiers: &["single_transformer_blocks."],
+        markers: &[
+            "double_stream_modulation_",
+            "single_stream_modulation.",
+            "double_blocks.",
+            "single_blocks.",
+            ".img_attn.",
+            ".txt_attn.",
+        ],
     },
     BucketSignature {
         bucket: Bucket::WanVideo,
@@ -647,6 +671,17 @@ fn metadata_value_to_family(value: &str) -> Option<String> {
     // transformer blocks), so the key-based detector classifies it as `flux`.
     if normalized.contains("chroma") {
         return Some("chroma".to_owned());
+    }
+    // Check flux2 before flux: FLUX.2 architecture strings ("flux2", "flux-2",
+    // "flux.2", "flux_2") all contain the "flux" substring, so the generic flux
+    // match below would otherwise swallow them. FLUX.2 is a distinct family with
+    // its own MLX adapter — a FLUX.1 ("flux") LoRA is not interchangeable with it.
+    if normalized.contains("flux2")
+        || normalized.contains("flux-2")
+        || normalized.contains("flux.2")
+        || normalized.contains("flux_2")
+    {
+        return Some("flux2".to_owned());
     }
     if normalized.contains("flux") {
         return Some("flux".to_owned());
@@ -948,6 +983,131 @@ mod tests {
         let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
 
         assert_eq!(detect_lora_family(&header).as_deref(), Some("flux"));
+    }
+
+    fn flux2_klein_native_keys() -> Vec<String> {
+        // Mirrors the real klein_9B_Turbo_r128.safetensors layout: native/ComfyUI
+        // `diffusion_model.` prefix, 8 double blocks + 24 single blocks, and FLUX.2's
+        // shared (per-stream, not per-block) modulation tensors.
+        let mut keys = Vec::new();
+        for block in 0..8 {
+            for module in [
+                "img_attn.proj",
+                "img_attn.qkv",
+                "txt_attn.proj",
+                "txt_attn.qkv",
+            ] {
+                keys.push(format!(
+                    "diffusion_model.double_blocks.{block}.{module}.lora_down.weight"
+                ));
+                keys.push(format!(
+                    "diffusion_model.double_blocks.{block}.{module}.lora_up.weight"
+                ));
+            }
+            for module in ["img_mlp.0", "img_mlp.2", "txt_mlp.0", "txt_mlp.2"] {
+                keys.push(format!(
+                    "diffusion_model.double_blocks.{block}.{module}.lora_down.weight"
+                ));
+                keys.push(format!(
+                    "diffusion_model.double_blocks.{block}.{module}.lora_up.weight"
+                ));
+            }
+        }
+        for block in 0..24 {
+            for module in ["linear1", "linear2"] {
+                keys.push(format!(
+                    "diffusion_model.single_blocks.{block}.{module}.lora_down.weight"
+                ));
+                keys.push(format!(
+                    "diffusion_model.single_blocks.{block}.{module}.lora_up.weight"
+                ));
+            }
+        }
+        for module in [
+            "double_stream_modulation_img.lin",
+            "double_stream_modulation_txt.lin",
+            "single_stream_modulation.lin",
+            "img_in",
+            "txt_in",
+        ] {
+            keys.push(format!("diffusion_model.{module}.lora_down.weight"));
+            keys.push(format!("diffusion_model.{module}.lora_up.weight"));
+        }
+        keys
+    }
+
+    #[test]
+    fn detects_flux2_klein_native() {
+        let keys = flux2_klein_native_keys();
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("flux2"));
+    }
+
+    #[test]
+    fn flux1_native_keys_do_not_detect_as_flux2() {
+        // A FLUX.1 native LoRA shares the double_blocks/single_blocks split but keeps
+        // PER-BLOCK modulation (`img_mod`/`txt_mod`/`modulation`) and has none of the
+        // shared `*_stream_modulation` tensors, so it must not be misread as FLUX.2.
+        let mut keys = Vec::new();
+        for block in 0..19 {
+            for module in ["img_attn.qkv", "txt_attn.qkv", "img_mod.lin", "txt_mod.lin"] {
+                keys.push(format!(
+                    "diffusion_model.double_blocks.{block}.{module}.lora_down.weight"
+                ));
+                keys.push(format!(
+                    "diffusion_model.double_blocks.{block}.{module}.lora_up.weight"
+                ));
+            }
+        }
+        for block in 0..38 {
+            for module in ["linear1", "modulation.lin"] {
+                keys.push(format!(
+                    "diffusion_model.single_blocks.{block}.{module}.lora_down.weight"
+                ));
+                keys.push(format!(
+                    "diffusion_model.single_blocks.{block}.{module}.lora_up.weight"
+                ));
+            }
+        }
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_ne!(detect_lora_family(&header).as_deref(), Some("flux2"));
+    }
+
+    #[test]
+    fn flux2_metadata_wins_over_generic_flux_substring() {
+        // FLUX.2 architecture strings contain "flux"; the flux2 metadata branch must
+        // claim them before the generic flux match (mirrors chroma-before-flux).
+        for arch in ["flux2", "flux-2", "flux.2-klein", "FLUX_2/lora"] {
+            let mut header = header_from_keys(&[
+                "lora_unet_double_blocks_0_img_mlp_0.lora_down.weight",
+                "lora_unet_double_blocks_0_img_mlp_0.lora_up.weight",
+            ]);
+            header["__metadata__"] = json!({ "modelspec.architecture": arch });
+            assert_eq!(
+                detect_lora_family(&header).as_deref(),
+                Some("flux2"),
+                "architecture {arch} should map to flux2"
+            );
+        }
+    }
+
+    #[test]
+    fn ai_toolkit_flux2_klein_base_model_version_detects_flux2() {
+        // Real ai-toolkit klein LoRAs (e.g. V3_flux_klein.safetensors) train only
+        // attn/mlp/linear — no `*_stream_modulation` tensors — so the key signature
+        // can't fire, but they carry `ss_base_model_version: "flux2_klein_9b"`. That
+        // value contains "flux", so the generic flux branch used to swallow it; the
+        // flux2 branch must claim it first.
+        let mut header = header_from_keys(&[
+            "diffusion_model.double_blocks.0.img_attn.qkv.lora_A.weight",
+            "diffusion_model.double_blocks.0.img_attn.qkv.lora_B.weight",
+            "diffusion_model.single_blocks.0.linear1.lora_A.weight",
+        ]);
+        header["__metadata__"] = json!({ "ss_base_model_version": "flux2_klein_9b" });
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("flux2"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Importing **and generating with** a LoRA for **FLUX.2 [klein]** failed at three different layers. Root cause is a deliberate-but-unhandled split: klein models declare `family: "flux2-klein"` (model identity) but accept `flux2` LoRAs (`loraCompatibility.families: ["flux2"]`). Klein is a distilled variant — its LoRAs are `flux2` LoRAs. Three layers didn't account for this.

## Fixes

**1. Model Manager dropdown offered a family the backend rejects** (`Unsupported LoRA family: flux2-klein`)
The LoRA-family dropdown was built from `model.family` (`flux2-klein`), but the import validator + generation matcher key off `loraCompatibility.families` (`flux2`). Now derives the list from `modelLoraFamilies()`. (Side effect: Chroma correctly offers both `chroma` and `flux`.)

**2. `detect_lora_family` had no `flux2` path** (auto-detect blank or mislabeled `flux`)
- **Native/ComfyUI klein LoRAs** matched no signature → inconclusive. Added a `Bucket::Flux2` signature keyed on FLUX.2's **shared** per-stream modulation tensors (`double_stream_modulation_*`, `single_stream_modulation`) — FLUX.1 uses per-block modulation, so they never collide.
- **ai-toolkit klein LoRAs** carry `ss_base_model_version: "flux2_klein_9b"` (contains `"flux"`), so the generic flux match swallowed them. Added a `flux2`-before-`flux` metadata branch, mirroring chroma-before-flux.

**3. Worker rejected flux2 LoRAs at generation** (`LoRA portrait_engine is not compatible with model family flux2-klein for mlx_flux2`)
The worker's `validate_lora_compatibility` keyed accepted families off the model `family` string (`flux2-klein`) instead of `loraCompatibility`. The Rust submission guard already keys off `loraCompatibility.families` and passed correctly — only the worker used the identity string. Added a one-directional `flux2-klein → {flux2}` entry to `EXTRA_COMPATIBLE_LORA_FAMILIES`, mirroring `chroma → {flux}`.

All three layers now agree: Rust submit guard, detection, and worker all resolve klein LoRAs to `flux2`.

## Verification

Detector run against the **real uploaded files**:
| File | Format | Signal | Result |
|------|--------|--------|--------|
| `klein_9B_Turbo_r128` | native/ComfyUI | modulation key signature | `flux2` |
| `V3_flux_klein` | ai-toolkit | `ss_base_model_version` metadata | `flux2` |

Worker compatibility logic exercised directly: `flux2` LoRA accepted on `flux2-klein` model; one-directional reject holds; chroma→flux regression intact.

- 5 new Rust tests, 1 new web test, 1 new worker test.
- Green: `sceneworks-core` (75), `rust-api` LoRA (16), web ModelManager (12), worker compatibility logic (direct).
- No API response shapes changed → no contract-snapshot regen.

## Notes

- A klein LoRA with **neither** modulation tensors **nor** flux2 metadata is structurally indistinguishable from a FLUX.1 attn/mlp-only LoRA → returns inconclusive (manual `flux2` pick works). A block-count heuristic was deliberately avoided (false-positives on sparse FLUX.1 LoRAs). Both real-world klein formats are covered.
- Mild architectural smell: the worker keys LoRA compatibility off `model.family` while the Rust guard keys off `loraCompatibility.families`. Fixed here via the established extras-map pattern; threading `loraCompatibility` through the worker would be a larger, separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)