### PR TITLE
fix(desktop): grant Tauri IPC to the local API origin so settings per…

### DIFF
--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -2,5 +2,8 @@
   "identifier": "default",
   "description": "Default capability set for the SceneWorks desktop shell window.",
   "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+  },
   "permissions": ["core:default"]
 }


### PR DESCRIPTION
…sist

Root cause of theme (and setupCompleted) not persisting: after setup, Rust navigates the main window from the tauri:// splash to the embedded React app served by the API at http://127.0.0.1:<port>. The default capability only covered local (tauri://) pages, so every window.__TAURI__ invoke from the React UI — save_app_theme, get_app_settings, complete_setup — was silently rejected and the code fell back to origin-keyed localStorage, which the per-launch random port wipes. Confirmed live: settings.json had no `theme` after a toggle and setupCompleted stayed false, while storageConfigured (written from the splash) did persist.

Add a `remote.urls` grant for http://127.0.0.1:* and http://localhost:* so the main window's IPC works at the API origin. Loopback-only, and the shell already health-checks the API (health_is_sceneworks) before navigating, so it won't expose commands to a foreign service.