### PR TITLE
fix(worker): accept flux2 LoRAs on flux2-klein models

### DIFF
--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -68,8 +68,15 @@ def normalize_lora_family(family: Any) -> str:
 # Flux LoRAs load on Chroma — and Chroma LoRAs that carry no chroma metadata are
 # classified as `flux` by the key-based detector (the keys are identical). The
 # relationship is one-directional: a Flux model does not accept chroma LoRAs.
+#
+# FLUX.2 [klein] is a distilled variant whose model family ("flux2-klein") differs
+# from its LoRA-compatible family ("flux2"): klein LoRAs are flux2 LoRAs and are
+# detected/declared as such (see lora_family.rs Bucket::Flux2). The klein models'
+# manifest loraCompatibility.families is ["flux2"], so a klein model must accept
+# flux2 LoRAs even though its own family string is "flux2-klein".
 EXTRA_COMPATIBLE_LORA_FAMILIES: dict[str, set[str]] = {
     "chroma": {"flux"},
+    "flux2-klein": {"flux2"},
 }
 
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1426,6 +1426,25 @@ def test_lora_compatibility_chroma_accepts_flux_but_not_vice_versa():
         )
 
 
+def test_lora_compatibility_flux2_klein_accepts_flux2_lora():
+    # FLUX.2 [klein] models have family "flux2-klein" but accept "flux2" LoRAs
+    # (loraCompatibility.families = ["flux2"]). The validate guard keys off the
+    # model `family` string, so the klein->flux2 relationship must be declared.
+    validate_lora_compatibility(
+        [{"id": "portrait_engine", "compatibility": {"families": ["flux2"]}}],
+        model_family="flux2-klein",
+        adapter_id="mlx_flux2",
+    )
+    # The relationship is one-directional: a plain flux2 model would reject a
+    # flux2-klein-tagged LoRA (no such model ships today, but keep the gate tight).
+    with pytest.raises(RuntimeError, match="not compatible with model family flux2"):
+        validate_lora_compatibility(
+            [{"id": "klein_only", "compatibility": {"families": ["flux2-klein"]}}],
+            model_family="flux2",
+            adapter_id="mlx_flux2",
+        )
+
+
 def test_lora_weight_defaults_on_unparseable_values():
     assert lora_weight({"weight": "not-a-number"}) == 0.8
 


### PR DESCRIPTION
The worker's validate_lora_compatibility keys accepted LoRA families off the model manifest `family` string ("flux2-klein"), but klein models accept "flux2" LoRAs (loraCompatibility.families = ["flux2"]). Generation failed with "LoRA portrait_engine is not compatible with model family flux2-klein for mlx_flux2."

The Rust submission guard already keys off loraCompatibility.families and passed correctly; only the worker used the model identity string. Add a flux2-klein -> {flux2} entry to EXTRA_COMPATIBLE_LORA_FAMILIES, mirroring the existing one-directional chroma -> {flux} relationship.