### PR TITLE
fix: persist UI theme via the API instead of Tauri IPC

### DIFF
--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -2,8 +2,5 @@
   "identifier": "default",
   "description": "Default capability set for the SceneWorks desktop shell window.",
   "windows": ["main"],
-  "remote": {
-    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
-  },
   "permissions": ["core:default"]
 }

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -18,7 +18,6 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             setup::start_setup,
             settings::get_app_settings,
-            settings::save_app_theme,
             settings::get_storage_setup,
             settings::save_storage_setup,
             settings::complete_setup,

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -176,12 +176,6 @@ pub struct AppSettings {
     /// host/label/scheme so the UI can enumerate them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub credentials: Vec<CredentialMeta>,
-    /// Last-used UI theme (`"light"` or `"dark"`). Persisted here because the
-    /// desktop webview's `localStorage` is keyed to the API's per-launch random
-    /// port and so can't be relied on across runs (same reason as the wizard
-    /// state). `None` until the user first toggles the theme.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub theme: Option<String>,
 }
 
 fn settings_path() -> PathBuf {
@@ -323,29 +317,6 @@ pub fn save_storage_setup(data_dir: String, hf_home: String) -> Result<AppSettin
 pub fn complete_setup() -> Result<(), String> {
     let mut settings = load_settings();
     settings.setup_completed = true;
-    save_settings(&settings)
-}
-
-/// The valid stored theme for `input`, or `None` if it isn't a theme we
-/// recognize (so a stray value can't wedge the persisted setting).
-fn normalize_theme(input: &str) -> Option<String> {
-    match input.trim() {
-        "light" => Some("light".to_owned()),
-        "dark" => Some("dark".to_owned()),
-        _ => None,
-    }
-}
-
-/// Persist the last-used UI theme so the desktop shell restores it on the next
-/// launch (the webview's `localStorage` is unreliable across runs — see the
-/// wizard-state commands). Unrecognized values are ignored.
-#[tauri::command]
-pub fn save_app_theme(theme: String) -> Result<(), String> {
-    let Some(theme) = normalize_theme(&theme) else {
-        return Ok(());
-    };
-    let mut settings = load_settings();
-    settings.theme = Some(theme);
     save_settings(&settings)
 }
 
@@ -628,14 +599,6 @@ mod tests {
         assert!(settings.credentials.is_empty());
         // Removing a host that isn't recorded is a no-op.
         assert!(!remove_credential_meta(&mut settings, HF_HOST));
-    }
-
-    #[test]
-    fn normalize_theme_accepts_only_known_themes() {
-        assert_eq!(normalize_theme(" light "), Some("light".to_owned()));
-        assert_eq!(normalize_theme("dark"), Some("dark".to_owned()));
-        assert_eq!(normalize_theme("blue"), None);
-        assert_eq!(normalize_theme(""), None);
     }
 
     #[test]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -96,6 +96,8 @@ mod recipe_presets;
 use recipe_presets::*;
 mod credentials;
 use credentials::*;
+mod preferences;
+use preferences::*;
 mod prompts;
 use prompts::*;
 
@@ -104,6 +106,8 @@ const PUBLIC_PATHS: &[&str] = &[
     "/api/v1/access",
     "/api/v1/auth/verify",
     "/api/v1/jobs/events",
+    // Non-sensitive UI state (theme); loaded before auth to avoid a flash.
+    "/api/v1/ui-preferences",
 ];
 const DEFAULT_CORS_ORIGINS: &str = concat!(
     "http://localhost:5173,http://127.0.0.1:5173,",
@@ -592,6 +596,10 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
             get(list_credentials).put(set_credential),
         )
         .route("/api/v1/credentials/:host", delete(delete_credential))
+        .route(
+            "/api/v1/ui-preferences",
+            get(get_ui_preferences).put(set_ui_preferences),
+        )
         .route("/api/v1/models", get(list_models))
         .route("/api/v1/models/:model_id", delete(delete_model))
         .route(

--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -1,0 +1,85 @@
+//! UI preferences (theme, …) persisted as a small JSON file in the config dir.
+//! Served over plain HTTP because the bundled desktop UI runs at the API's
+//! `http://127.0.0.1:<port>` origin, where both Tauri IPC and origin-keyed
+//! `localStorage` are unreliable across launches (the port — and so the origin —
+//! changes every launch). Routing through the API, the same channel the rest of
+//! the app already uses, makes the choice durable. Non-sensitive, so the routes
+//! are public like `/health`.
+
+use super::*;
+
+use std::path::PathBuf;
+
+const PREFERENCES_FILENAME: &str = "ui-preferences.json";
+
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UiPreferences {
+    /// Last-used UI theme (`"light"` or `"dark"`); absent until first set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    theme: Option<String>,
+}
+
+fn preferences_path(state: &AppState) -> PathBuf {
+    state.settings.config_dir.join(PREFERENCES_FILENAME)
+}
+
+fn load_preferences(state: &AppState) -> UiPreferences {
+    std::fs::read_to_string(preferences_path(state))
+        .ok()
+        .and_then(|body| serde_json::from_str(&body).ok())
+        .unwrap_or_default()
+}
+
+fn save_preferences(state: &AppState, prefs: &UiPreferences) -> std::io::Result<()> {
+    let path = preferences_path(state);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let body = serde_json::to_string_pretty(prefs)?;
+    std::fs::write(path, body)
+}
+
+/// The valid stored theme for `input`, or `None` if it isn't one we recognize.
+fn normalize_theme(input: Option<&str>) -> Option<String> {
+    match input.map(str::trim) {
+        Some("light") => Some("light".to_owned()),
+        Some("dark") => Some("dark".to_owned()),
+        _ => None,
+    }
+}
+
+/// Current UI preferences (empty object on first run).
+pub(crate) async fn get_ui_preferences(
+    State(state): State<AppState>,
+) -> Result<Json<UiPreferences>, ApiError> {
+    Ok(Json(load_preferences(&state)))
+}
+
+/// Merge the supplied preferences in and persist. Only recognized fields/values
+/// are applied, so an unknown theme leaves the stored one untouched.
+pub(crate) async fn set_ui_preferences(
+    State(state): State<AppState>,
+    ApiJson(payload): ApiJson<UiPreferences>,
+) -> Result<Json<UiPreferences>, ApiError> {
+    let mut prefs = load_preferences(&state);
+    if let Some(theme) = normalize_theme(payload.theme.as_deref()) {
+        prefs.theme = Some(theme);
+    }
+    save_preferences(&state, &prefs)
+        .map_err(|error| ApiError::internal(format!("Failed to save UI preferences: {error}")))?;
+    Ok(Json(prefs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_theme;
+
+    #[test]
+    fn normalize_theme_accepts_only_known_themes() {
+        assert_eq!(normalize_theme(Some(" light ")), Some("light".to_owned()));
+        assert_eq!(normalize_theme(Some("dark")), Some("dark".to_owned()));
+        assert_eq!(normalize_theme(Some("blue")), None);
+        assert_eq!(normalize_theme(None), None);
+    }
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -416,14 +416,16 @@ export function App() {
   const [studioLaunch, setStudioLaunch] = useState(null);
   const [error, setError] = useState("");
   const [theme, setTheme] = useState(readStoredTheme);
-  // Apply a theme and, on the desktop shell, persist it durably right away. The
-  // webview's localStorage is keyed to the API's per-launch random port, so it
-  // can't carry the choice across restarts; settings.json can.
+  // Apply a theme and persist it through the API. localStorage gives an instant
+  // initial paint, but on the desktop shell the UI runs at the API's per-launch
+  // http://127.0.0.1:<port> origin, where both localStorage and Tauri IPC are
+  // unreliable across launches — so the durable copy lives server-side.
   const changeTheme = (next) => {
     setTheme(next);
-    if (isDesktopShell) {
-      tauriInvoke("save_app_theme", { theme: next }).catch(() => {});
-    }
+    apiFetch("/api/v1/ui-preferences", "", {
+      method: "PUT",
+      body: JSON.stringify({ theme: next }),
+    }).catch(() => {});
   };
   const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
@@ -691,17 +693,14 @@ export function App() {
     }
   }, [theme]);
 
-  // Desktop: seed the theme from the durable setting on launch (localStorage
-  // can't carry it across restarts — see changeTheme). Each toggle persists
-  // itself, so there's no separate save effect to race with this read.
+  // Seed the theme from the server on launch (the durable copy; localStorage is
+  // only an instant-paint cache). Each toggle persists itself via changeTheme,
+  // so there's no save effect to race with this read.
   useEffect(() => {
-    if (!isDesktopShell) {
-      return;
-    }
     let cancelled = false;
-    tauriInvoke("get_app_settings")
-      .then((settings) => {
-        const stored = settings?.theme;
+    apiFetch("/api/v1/ui-preferences", "")
+      .then((prefs) => {
+        const stored = prefs?.theme;
         if (!cancelled && (stored === "dark" || stored === "light")) {
           setTheme(stored);
         }


### PR DESCRIPTION
The desktop UI runs at the API's per-launch http://127.0.0.1:<port> origin (Rust navigates there after setup). At that origin both origin-keyed localStorage AND Tauri IPC are unreliable: localStorage is wiped when the port changes each launch, and window.__TAURI__ invokes from that remote origin don't reach the shell (proven live — settings.json never gained a `theme` field and setupCompleted stayed false, both written from the React origin, while splash-written storageConfigured persisted; adding a `remote` capability didn't change it).

Stop fighting the IPC/origin problem and persist through the one channel that already works app-wide: HTTP to the API.

- API: new public GET/PUT /api/v1/ui-preferences backed by ui-preferences.json in the (stable, desktop-pinned) config dir.
- Web: changeTheme PUTs the choice; launch reads it back via apiFetch. localStorage stays as an instant-paint cache only.
- Remove the now-dead Tauri theme path (AppSettings.theme, save_app_theme, its registration) and revert the remote-IPC capability grant, which provided no benefit.

Works uniformly on desktop, web, and Docker. rust-api + desktop crates build/clippy clean; 247 web tests green.