### PR TITLE
feat(character-studio): FLUX.2-klein best-effort pose tier (sc-2262)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -332,8 +332,7 @@ export const fallbackModels = [
       promptGuide: { title: "FLUX.2 [klein] 9B Prompt Guide", path: "/prompt-guides/flux2-klein.md" },
       variationStrength: { label: "Prompt strength", default: 4.0, min: 1.0, max: 10.0, step: 0.5 },
       // Multi-backbone angle set (sc-2003). MlxFlux2Adapter passes the per-
-      // angle augmented prompt through the sidecar runner. Pose library
-      // deferred to a follow-up PR.
+      // angle augmented prompt through the sidecar runner.
       viewAngles: [
         { id: "three_quarter_left", label: "Three-quarter left" },
         { id: "three_quarter_right", label: "Three-quarter right" },
@@ -347,6 +346,11 @@ export const fallbackModels = [
         { id: "down_right", label: "Down · right" },
         { id: "front", label: "Front" },
       ],
+      // Best-effort pose library (sc-2262): worker renders the selected pose as
+      // an OpenPose skeleton and feeds it as a second edit image alongside the
+      // reference through the MLX sidecar (Flux2KleinEdit multi-image). Strict
+      // InstantID pose-lock stays the higher-fidelity option.
+      poseLibrary: true,
     },
   },
   {

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -3723,8 +3723,25 @@ class MlxFlux2Adapter:
         # angles AND uniquely holds portrait framing at 90° profiles where
         # Qwen-Lightning reframes to full-body.
         is_character_image = request.mode == "character_image" and has_reference
-        angle_set = is_character_image and bool(request.advanced.get("angleSet"))
-        if angle_set:
+        # Best-effort pose tier (sc-2262): advanced.poses is a list of {id, keypoints}.
+        # Each pose renders to an OpenPose skeleton paired with the reference as a
+        # [skeleton, reference] multi-image set (Flux2KleinEdit accepts a list of
+        # image_paths) — identity from the reference, pose approximated from the
+        # skeleton + the pose prompt cue. No FLUX.2 pose ControlNet exists (sc-2250).
+        # Pose takes precedence over angleSet.
+        raw_poses = request.advanced.get("poses")
+        pose_entries = [p for p in raw_poses if isinstance(p, dict)] if isinstance(raw_poses, list) else []
+        pose_set = is_character_image and len(pose_entries) > 0
+        angle_set = is_character_image and bool(request.advanced.get("angleSet")) and not pose_set
+        pose_keypoints: list[Any] | None = None
+        if pose_set:
+            total = len(pose_entries)
+            angles = None
+            set_seed = resolve_seed(request.seed, request.prompt, 0, request.seeds)
+            seeds = [set_seed] * total
+            prompts = [augment_prompt_for_pose(request.prompt)] * total
+            pose_keypoints = [normalize_keypoints(p.get("keypoints")) for p in pose_entries]
+        elif angle_set:
             angles = list(CHARACTER_ANGLE_SET_ORDER)
             total = len(angles)
             set_seed = resolve_seed(request.seed, request.prompt, 0, request.seeds)
@@ -3750,6 +3767,20 @@ class MlxFlux2Adapter:
         )
         work_dir = Path(tempfile.mkdtemp(prefix="mlx_flux2_sidecar_"))
         self._scratch_dir = work_dir
+        # Best-effort pose tier: render each pose's skeleton to a PNG in the sidecar
+        # work dir and pair it with the reference as a per-iteration [reference,
+        # skeleton] set. draw_bodypose runs in the main worker venv (cv2 present).
+        image_paths_per_iter: list[list[str]] | None = None
+        if pose_set and pose_keypoints is not None:
+            image_paths_per_iter = []
+            for index, keypoints in enumerate(pose_keypoints):
+                skeleton_path = work_dir / f"pose_skeleton_{index:04d}.png"
+                Image.fromarray(draw_bodypose(request.width, request.height, keypoints)).save(
+                    skeleton_path, "PNG"
+                )
+                # Order [skeleton, reference] mirrors the sc-2003 spike's validated
+                # FLUX.2 multi-image config (image_paths=[skeleton, character]).
+                image_paths_per_iter.append([str(skeleton_path), reference_paths[0]])
         try:
             images = self._run_sidecar(
                 job_id=job["id"],
@@ -3774,6 +3805,9 @@ class MlxFlux2Adapter:
                         for lora in lora_specs
                     ],
                     "imagePaths": reference_paths or None,
+                    # Per-pose [reference, skeleton] sets (sc-2262); overrides
+                    # imagePaths per iteration. None for the plain reference path.
+                    "imagePathsPerIteration": image_paths_per_iter,
                     # Local diffusers dir for converted fine-tunes (sc-2235);
                     # None for built-in mflux repos (loaded from ModelConfig).
                     "modelPath": self._local_model_dir(request.model, settings),
@@ -3811,6 +3845,7 @@ class MlxFlux2Adapter:
                     "kvCacheEnabled": has_reference and request.model in self._kv_cache_models,
                     "realModelInference": True,
                     **({"angleSet": True} if angle_set else {}),
+                    **({"poseLibrary": True} if pose_set else {}),
                 },
                 settings=settings,
                 job_id=job["id"],

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -37,6 +37,10 @@ Spec keys:
     imagePaths: list[str] | None  (FLUX.2 edit mode only — list of reference
         image paths. Triggers Flux2KleinEdit dispatch; for FLUX.2-klein-9b-kv
         the KV cache auto-engages.)
+    imagePathsPerIteration: list[list[str]] | None  (best-effort pose tier,
+        sc-2262 — per-iteration reference sets parallel to ``seeds``; each entry
+        is the [reference, skeleton] list for one pose. Overrides ``imagePaths``
+        per iteration when present.)
     outDir: str (sidecar writes PNGs + result.json here)
 
 Validated 2026-05-28 against mflux 0.17.5 (sc-1969 FLUX spike, sc-1972 Qwen verify).
@@ -155,7 +159,19 @@ def main() -> int:
         quantize = int(quantize)
     loras = spec.get("loras") or []
     image_paths = [str(p) for p in (spec.get("imagePaths") or []) if p]
-    has_reference = bool(image_paths)
+    # Best-effort pose tier (sc-2262): optional per-iteration reference sets parallel
+    # to ``seeds`` — each entry is the [reference, skeleton] list for that pose. When
+    # set it overrides the shared ``imagePaths`` per iteration (mirrors the ``prompts``
+    # override). None / absent → the existing single shared-reference batch path.
+    image_paths_per_iter = spec.get("imagePathsPerIteration") or None
+    if image_paths_per_iter is not None:
+        if len(image_paths_per_iter) != len(seeds):
+            raise RuntimeError(
+                f"mlx_flux_runner: imagePathsPerIteration length ({len(image_paths_per_iter)}) "
+                f"must equal seeds list length ({len(seeds)})."
+            )
+        image_paths_per_iter = [[str(p) for p in (paths or []) if p] for paths in image_paths_per_iter]
+    has_reference = bool(image_paths) or bool(image_paths_per_iter and any(image_paths_per_iter))
     out_dir = Path(spec["outDir"])
     out_dir.mkdir(parents=True, exist_ok=True)
     result_path = out_dir / "result.json"
@@ -223,8 +239,10 @@ def main() -> int:
         }
         if family != "flux2":
             gen_kwargs["negative_prompt"] = negative_prompt
-        if family == "flux2" and has_reference:
-            gen_kwargs["image_paths"] = image_paths
+        # Per-iteration reference set (pose tier) overrides the shared list.
+        iter_image_paths = image_paths_per_iter[index] if image_paths_per_iter is not None else image_paths
+        if family == "flux2" and iter_image_paths:
+            gen_kwargs["image_paths"] = iter_image_paths
         result = model.generate_image(**gen_kwargs)
         path = out_dir / f"{filename_prefix}_{index:04d}.png"
         result.image.save(path, "PNG")

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -889,10 +889,13 @@
           { "id": "down_right", "label": "Down · right" },
           { "id": "front", "label": "Front" }
         ],
-        // NOTE: pose library deferred to a follow-up PR (same reason as
-        // qwen_image_edit_2511_lightning). The sc-2003 hardware spike
-        // validated the multi-image trick (image_paths=[skeleton, character])
-        // at sitting 0.54 / standing 0.36 ArcFace cosine.
+        // Best-effort pose library (sc-2262): no FLUX.2 pose ControlNet exists
+        // (sc-2250 spike), so the worker renders the selected library pose as an
+        // OpenPose skeleton and feeds it as a second edit image alongside the
+        // reference (Flux2KleinEdit image_paths=[reference, skeleton]) through the
+        // MLX sidecar. The sc-2003 hardware spike validated this multi-image trick
+        // at sitting 0.54 / standing 0.36 ArcFace cosine. Best-effort tier.
+        "poseLibrary": true,
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2481,6 +2481,75 @@ def test_mlx_flux2_rejects_unsupported_model():
         raise AssertionError("MlxFlux2Adapter must reject non-FLUX.2 models.")
 
 
+def test_mlx_flux2_pose_set_builds_per_iteration_skeleton_specs(tmp_path, monkeypatch):
+    """sc-2262: a character_image job with advanced.poses on FLUX.2-klein renders each
+    pose to a skeleton and passes per-iteration [reference, skeleton] image sets to the
+    sidecar (Flux2KleinEdit multi-image), with the pose prompt cue and a shared seed.
+    Pose takes precedence over angleSet (no 11-angle loop runs)."""
+    import numpy as _np
+    from scene_worker import image_adapters as ia
+    from scene_worker.character_studio_angles import POSE_SKELETON_PROMPT
+
+    adapter = ia.MlxFlux2Adapter()
+    monkeypatch.setattr(ia.MlxFlux2Adapter, "_sidecar_available", lambda self: True)
+    monkeypatch.setattr(ia, "find_asset_media_path", lambda project_path, asset_id: tmp_path / "ref.png")
+    # draw_bodypose needs cv2 (absent in the CI venv); stub to a tiny array that
+    # Image.fromarray can save. The real render is covered elsewhere.
+    monkeypatch.setattr(ia, "draw_bodypose", lambda w, h, kps: _np.zeros((h, w, 3), dtype=_np.uint8))
+
+    captured: dict = {}
+
+    def fake_run_sidecar(self, *, job_id, work_dir, label, total, spec, progress, cancel_requested):
+        captured["spec"] = spec
+        return [str(work_dir / f"out_{i}.png") for i in range(total)]
+
+    monkeypatch.setattr(ia.MlxFlux2Adapter, "_run_sidecar", fake_run_sidecar)
+
+    def fake_writer(self, *, image_count, image_at_index, raw_settings, **kwargs):
+        captured["raw_settings"] = raw_settings
+        return {"images": image_count}
+
+    monkeypatch.setattr(ia.ImageAssetWriter, "write_incremental_outputs", fake_writer)
+
+    kp = [[0.5, 0.1 + 0.04 * i] for i in range(18)]
+    job = {
+        "id": "job_flux2_pose",
+        "payload": {
+            "projectId": "p",
+            "mode": "character_image",
+            "model": "flux2_klein_9b",
+            "prompt": "the character",
+            "referenceAssetId": "ref-1",
+            "count": 1,
+            "width": 32,
+            "height": 32,
+            # angleSet also set to prove pose precedence (no angle loop).
+            "advanced": {"poses": [{"id": "sit_01", "keypoints": kp}, {"id": "stand_01", "keypoints": kp}], "angleSet": True},
+        },
+    }
+    adapter.generate(
+        settings=SimpleNamespace(gpu_id="cpu"),
+        job=job,
+        request=image_request_from_job(job),
+        project_path=tmp_path,
+        progress=lambda *a, **k: None,
+        cancel_requested=lambda: False,
+    )
+    spec = captured["spec"]
+    # One sidecar iteration per pose (2), not the 11-angle loop.
+    assert len(spec["seeds"]) == 2
+    assert spec["seeds"][0] == spec["seeds"][1]  # shared seed across the set
+    assert spec["prompts"] == [f"the character, {POSE_SKELETON_PROMPT}"] * 2
+    per_iter = spec["imagePathsPerIteration"]
+    assert len(per_iter) == 2
+    ref = str(tmp_path / "ref.png")
+    for entry in per_iter:
+        # [skeleton, reference] order per the sc-2003 spike's validated config.
+        assert "pose_skeleton_" in entry[0] and entry[0].endswith(".png")  # skeleton (pose)
+        assert entry[1] == ref  # reference (identity)
+    assert captured["raw_settings"].get("poseLibrary") is True
+
+
 def test_mlx_flux2_requires_sidecar_when_missing(monkeypatch):
     # When the sidecar venv is missing, generate() must surface an actionable
     # error rather than silently producing nothing.
@@ -9971,19 +10040,23 @@ def test_prompt_driven_angle_backbones_share_the_instantid_angle_pack():
         )
 
 
-def test_qwen_lightning_declares_pose_library_capability():
-    """sc-2256: Qwen-Lightning is the best-effort pose tier — its manifest must
-    advertise ui.poseLibrary so the Character Studio pose picker (poseModels
-    filter) includes it alongside the strict InstantID backbone."""
+def test_best_effort_backbones_declare_pose_library_capability():
+    """sc-2256 / sc-2262: the best-effort pose backbones must advertise
+    ui.poseLibrary so the Character Studio pose picker (poseModels filter)
+    includes them alongside the strict InstantID backbone."""
     manifest = _load_builtin_models_manifest()
     manifest_by_id = {model["id"]: model for model in manifest.get("models", [])}
     instantid = manifest_by_id.get("instantid_realvisxl", {})
     assert instantid.get("ui", {}).get("poseLibrary") is True, "Baseline pose backbone drifted."
-    qwen = manifest_by_id.get("qwen_image_edit_2511_lightning", {})
-    assert qwen.get("ui", {}).get("poseLibrary") is True, (
-        "qwen_image_edit_2511_lightning must declare ui.poseLibrary so the pose "
-        "picker offers the best-effort Qwen tier (sc-2256)."
-    )
+    for model_id, story in (
+        ("qwen_image_edit_2511_lightning", "sc-2256"),
+        ("flux2_klein_9b", "sc-2262"),
+    ):
+        entry = manifest_by_id.get(model_id, {})
+        assert entry.get("ui", {}).get("poseLibrary") is True, (
+            f"{model_id} must declare ui.poseLibrary so the pose picker offers its "
+            f"best-effort tier ({story})."
+        )
 
 
 def test_qwen_image_adapter_angleset_loop_uses_augmented_prompts(monkeypatch):


### PR DESCRIPTION
## What & why

Extends the Character Studio **pose library** to the **FLUX.2-klein** backbone (`flux2_klein_9b`), following the Qwen best-effort tier just merged in #362 (epic [2249](https://app.shortcut.com/trefry/epic/2249), story [sc-2262](https://app.shortcut.com/trefry/story/2262)).

No FLUX.2 pose ControlNet exists (sc-2250 spike), so this uses the model's **multi-image edit** path: each selected library pose is rendered as an OpenPose skeleton and fed to `Flux2KleinEdit` as a `[skeleton, reference]` image set — pose approximated from the skeleton, identity held by the reference. Best-effort tier (no strength control); strict InstantID pose-lock remains the higher-fidelity option.

## Changes

**Sidecar runner** (`mlx_flux_runner.py`)
- New optional `imagePathsPerIteration` spec field — per-iteration reference sets parallel to `seeds` (mirrors the existing `prompts` override). When present it overrides the shared `imagePaths` per iteration, so each pose gets its own `[skeleton, reference]` set; `has_reference` accounts for it so dispatch resolves to `Flux2KleinEdit`.

**Worker** (`MlxFlux2Adapter.generate`)
- Detect `advanced.poses` (character_image + reference, **precedence over `angleSet`**), render each skeleton via `openpose_skeleton.draw_bodypose` into the sidecar work dir, build per-iteration `[skeleton, reference]` sets, shared seed (continuity), `augment_prompt_for_pose` cue.
- Image order `[skeleton, reference]` matches the sc-2003 hardware spike's validated FLUX.2 config (`image_paths=[skeleton, character]`, sitting 0.54 / standing 0.36 ArcFace).

**Manifest**: `ui.poseLibrary: true` on `flux2_klein_9b` in `builtin.models.jsonc` + `constants.js`. Frontend needs no change (multi-backbone pose picker already gates on the flag).

## Reviewer notes
- The `draw_bodypose` render runs in the **main worker venv** (cv2 present for InstantID), not the sidecar — only the rendered PNG path crosses into the sidecar.
- **No Rust change** — `ui` is untyped passthrough; `imagePathsPerIteration` rides in the existing sidecar JSON spec.
- **Tests**: 432 worker + 154 web pass. New: adapter builds per-iteration `[skeleton, reference]` specs with pose-over-angle precedence; manifest declares `poseLibrary` for both best-effort backbones. (Sidecar/mflux isn't exercised in CI — mocked like the angle-set tests.)
- **Still owed (sc-2262):** real M-series E2E to judge pose adherence. Same try-and-prune shape as Qwen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)