### PR TITLE
Expose all FLUX.2 [klein] variants in Angle + Edit model pickers

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -3687,13 +3687,17 @@ class MlxFlux2Adapter:
                 f"{', '.join(sorted(self._supported_models))}, not {request.model}."
             )
 
-        # Resolve reference image (if any) to a local filesystem path so
-        # mflux's Flux2KleinEdit can read it directly. No PIL round-trip:
-        # find_asset_media_path returns the project-scoped path, and mflux's
-        # image loader handles dtype/resize itself.
+        # Resolve the reference image (if any) to a local filesystem path so
+        # mflux's Flux2KleinEdit can read it directly. Two studios feed the same
+        # single-reference edit path: Character Studio sends it as
+        # referenceAssetId, while the Image Edit studio sends the source image as
+        # sourceAssetId (edit_image mode). No PIL round-trip: find_asset_media_path
+        # returns the project-scoped path and mflux's loader handles dtype/resize.
         reference_paths: list[str] = []
-        if request.reference_asset_id:
-            reference_paths.append(str(find_asset_media_path(project_path, request.reference_asset_id)))
+        edit_source_id = request.source_asset_id if request.mode == "edit_image" else None
+        ref_id = request.reference_asset_id or edit_source_id
+        if ref_id:
+            reference_paths.append(str(find_asset_media_path(project_path, ref_id)))
         has_reference = bool(reference_paths)
 
         validate_lora_compatibility(

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -808,7 +808,7 @@
       "adapter": "mlx_flux2",
       // Unified model: txt2img + edit (single reference image) via mflux's
       // Flux2Klein / Flux2KleinEdit variants.
-      "capabilities": ["text_to_image", "character_image", "style_variations"],
+      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
       "macOnly": true,
       "downloads": [
         {
@@ -915,7 +915,7 @@
       // Without a reference it runs plain text-to-image on par with the base
       // 9B — the cache simply doesn't engage (sc-2173), so the full
       // capability set is exposed rather than gating to character_image only.
-      "capabilities": ["text_to_image", "character_image", "style_variations"],
+      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
       "macOnly": true,
       "downloads": [
         {
@@ -962,6 +962,20 @@
           "max": 10.0,
           "step": 0.5
         },
+        // Shares the base 9B angle set (same mlx_flux2 adapter / flux2 augments).
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",
@@ -984,7 +998,7 @@
       // pipeline — so it is converted at install (mlx.requiresConversion) into a
       // local diffusers dir that borrows the VAE/text-encoder/tokenizer from the
       // base FLUX.2-klein-9B install (mlx.convertBaseRepo). sc-2235.
-      "capabilities": ["text_to_image", "character_image", "style_variations"],
+      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
       "macOnly": true,
       "downloads": [
         {
@@ -1039,6 +1053,20 @@
           "max": 10.0,
           "step": 0.5
         },
+        // Shares the base 9B angle set (same mlx_flux2 adapter / flux2 augments).
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",


### PR DESCRIPTION
## What

Surfaces all three FLUX.2 [klein] variants (`flux2_klein_9b`, `flux2_klein_9b_kv`, `flux2_klein_9b_true_v2`) in **both** the Character Studio **Angle** picker and the Image Studio **Edit** picker. Pose library is intentionally out of scope (separate parallel effort).

## Why

The pickers gate purely on manifest metadata:
- **Angle picker** (`CharacterStudio.jsx`) keeps models with a non-empty `ui.viewAngles`.
- **Edit picker** (`ImageStudio.jsx`) keeps models whose `capabilities` include `edit_image`.

Only the base `flux2_klein_9b` had `ui.viewAngles`, and none of the three advertised `edit_image` — so only one FLUX.2 option showed in the Angle picker, and zero showed in the Edit picker. All three already share the `mlx_flux2` adapter (Flux2KleinEdit for reference edits; per-angle augments resolved by family, not id), so this was a metadata gap, not a capability gap.

## Changes

**`config/manifests/builtin.models.jsonc`**
- Add `edit_image` to `capabilities` on all three flux2_klein variants.
- Add the shared 11-angle `ui.viewAngles` block to `flux2_klein_9b_kv` and `flux2_klein_9b_true_v2` (base already had it; ids match InstantID's canonical pack).

**`apps/worker/scene_worker/image_adapters.py`**
- `MlxFlux2Adapter.generate()` now reads `request.source_asset_id` in `edit_image` mode in addition to `reference_asset_id`. Without this, the Edit gate (`model_supports_edit` → `supportsEdit` is already `True` in `MODEL_TARGETS`) would pass but the uploaded source image — sent by the Image Edit studio as `sourceAssetId` — was silently ignored, so the model generated from the prompt alone.

## Verification

- ✅ Manifest JSON validates — each model reports `edit_image` + 11 `viewAngles`, `poseLibrary` absent.
- ✅ Web `ModelManagerScreen.test.jsx` — 12/12 pass.
- ✅ Edited worker module byte-compiles.
- ✅ Reviewed existing tests: the angle-matrix test only pins `flux2_klein_9b`'s 11 ids (unchanged); no test pins the capabilities array; manifest schema doesn't restrict capability strings.

## Reviewer notes

- The worker pytest suite (`tests/test_worker_runtime.py`) was **not** run in this environment (no worker Python venv available locally). Worth a CI run for `-k "flux2 or supports_edit"`.
- Actual generation still requires installed weights + the mflux sidecar; `true_v2` additionally needs the base `flux2_klein_9b` installed and its install-time conversion.
- Pose library deliberately not enabled for FLUX.2 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)