### PR TITLE
fix(character-studio): apply Trashcan to the Character assets grid

### DIFF
--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2621,15 +2621,97 @@ describe("SceneWorks app shell", () => {
     expect(container.querySelectorAll(".review-grid .review-card.trashed").length).toBe(0);
 
     // Switch to the Trashcan view and the discarded image becomes reachable.
-    const trashButton = [...container.querySelectorAll("button")].find((button) =>
+    // Scope to the Sample-outputs panel, since CharacterAssets also has a toggle.
+    const testPanel = container.querySelector(".test-character-panel");
+    const trashButton = [...testPanel.querySelectorAll("button")].find((button) =>
       button.textContent.includes("Trashcan (1)"),
     );
     expect(trashButton).toBeTruthy();
     await act(async () => {
       trashButton.click();
     });
-    expect(container.querySelectorAll(".review-grid .review-card.trashed").length).toBe(1);
-    expect([...container.querySelectorAll(".review-grid button")].some((button) => button.textContent === "Purge")).toBe(true);
+    expect(testPanel.querySelectorAll(".review-grid .review-card.trashed").length).toBe(1);
+    expect([...testPanel.querySelectorAll(".review-grid button")].some((button) => button.textContent === "Purge")).toBe(true);
+  });
+
+  it("hides discarded images from the Character assets grid and exposes Trashcan restore/purge", async () => {
+    const purgeAsset = vi.fn();
+    const updateAssetStatus = vi.fn();
+    const assets = [
+      { id: "img-active", type: "image", displayName: "keep", recipe: { normalizedSettings: { characterId: "char-1" } } },
+      {
+        id: "img-trashed",
+        type: "image",
+        displayName: "discarded",
+        status: { trashed: true },
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+      },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference: () => {},
+            archiveCharacter: () => {},
+            assets,
+            attachCharacterLora: () => {},
+            characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: assets,
+            loras: [],
+            setPreviewAsset: () => {},
+            sendCharacterToImage: () => {},
+            sendCharacterToVideo: () => {},
+            purgeAsset,
+            removeCharacterReference: () => {},
+            updateAssetStatus,
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    // The Character assets section renders thumbnails; the discarded one is hidden.
+    const findSection = () =>
+      [...container.querySelectorAll(".character-section")].find((section) =>
+        section.querySelector(".eyebrow")?.textContent === "Character assets",
+      );
+    const section = findSection();
+    expect(section).toBeTruthy();
+    expect(section.querySelectorAll(".character-asset-thumb").length).toBe(1);
+    // Heading count reflects active images only.
+    expect(section.querySelector("h2").textContent).toContain("(1)");
+
+    // Switch to the Trashcan and the discarded image surfaces with restore/purge.
+    const trashButton = [...section.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("Trashcan (1)"),
+    );
+    expect(trashButton).toBeTruthy();
+    await act(async () => {
+      trashButton.click();
+    });
+    const trashSection = findSection();
+    expect(trashSection.querySelectorAll(".character-asset-thumb").length).toBe(1);
+    const restore = [...trashSection.querySelectorAll("button")].find((button) => button.textContent === "Restore");
+    const purge = [...trashSection.querySelectorAll("button")].find((button) => button.textContent === "Purge");
+    expect(restore).toBeTruthy();
+    expect(purge).toBeTruthy();
+    await act(async () => {
+      purge.click();
+    });
+    expect(purgeAsset).toHaveBeenCalledWith(expect.objectContaining({ id: "img-trashed" }));
   });
 
   it("launches reference-based generation from an approved character reference", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -411,7 +411,14 @@ export function CharacterStudio() {
               updateCharacterReference={updateCharacterReference}
             />
 
-            <CharacterAssets assets={assets} onPreview={onPreview} selectedCharacter={selectedCharacter} />
+            <CharacterAssets
+              assets={assets}
+              deleteAsset={deleteAsset}
+              onPreview={onPreview}
+              purgeAsset={purgeAsset}
+              selectedCharacter={selectedCharacter}
+              updateAssetStatus={updateAssetStatus}
+            />
 
             <CharacterAngleSet
               addCharacterReference={addCharacterReference}

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -635,12 +635,20 @@ export function CharacterAngleSet({
 // character (recipe.normalizedSettings.characterId) or referencing it
 // (metadata.characterReferences). Reads the full project asset list, so character outputs
 // persist beyond the transient "recent generations" window (sc-2076).
-export function CharacterAssets({ selectedCharacter, assets = [], onPreview }) {
+export function CharacterAssets({
+  selectedCharacter,
+  assets = [],
+  onPreview,
+  deleteAsset,
+  purgeAsset,
+  updateAssetStatus,
+}) {
+  const [viewMode, setViewMode] = React.useState("active");
   const characterId = selectedCharacter?.id;
   if (!selectedCharacter) {
     return null;
   }
-  const characterAssets = (assets ?? [])
+  const scopedAssets = (assets ?? [])
     .filter(
       (asset) =>
         (asset.type === "image" || asset.type === "frame") &&
@@ -648,32 +656,66 @@ export function CharacterAssets({ selectedCharacter, assets = [], onPreview }) {
           (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === characterId)),
     )
     .sort((left, right) => new Date(right.createdAt ?? 0) - new Date(left.createdAt ?? 0));
+  // Discarded (status.trashed) images drop out of the main grid so they no
+  // longer hold their slots, but stay reachable through the Trashcan view for
+  // restore or permanent purge.
+  const activeAssets = scopedAssets.filter((asset) => !asset.status?.trashed);
+  const trashedAssets = scopedAssets.filter((asset) => asset.status?.trashed);
+  const showingTrash = viewMode === "trashed";
+  const visibleAssets = showingTrash ? trashedAssets : activeAssets;
   return (
     <section className="character-section">
       <div className="section-heading">
         <p className="eyebrow">Character assets</p>
         <h2>
           Generated for {selectedCharacter.name}
-          {characterAssets.length ? ` (${characterAssets.length})` : ""}
+          {activeAssets.length ? ` (${activeAssets.length})` : ""}
         </h2>
       </div>
-      {characterAssets.length ? (
+      <div className="segmented-control" role="group" aria-label="Character asset collection">
+        <button className={showingTrash ? "" : "active"} onClick={() => setViewMode("active")} type="button">
+          Images ({activeAssets.length})
+        </button>
+        <button className={showingTrash ? "active" : ""} onClick={() => setViewMode("trashed")} type="button">
+          Trashcan ({trashedAssets.length})
+        </button>
+      </div>
+      {visibleAssets.length ? (
         <div className="reference-thumb-row">
-          {characterAssets.map((asset) => (
-            <button
-              aria-label={`Preview ${asset.displayName ?? asset.id}`}
-              className="reference-thumb"
-              key={asset.id}
-              onClick={() => onPreview?.(asset)}
-              type="button"
-            >
-              <AssetMedia asset={asset} controls={false} />
-            </button>
+          {visibleAssets.map((asset) => (
+            <div className="character-asset-thumb" key={asset.id}>
+              <button
+                aria-label={`Preview ${asset.displayName ?? asset.id}`}
+                className="reference-thumb"
+                onClick={() => onPreview?.(asset)}
+                type="button"
+              >
+                <AssetMedia asset={asset} controls={false} />
+              </button>
+              <div className="character-asset-thumb-actions">
+                {showingTrash ? (
+                  <>
+                    <button onClick={() => updateAssetStatus?.(asset, { trashed: false })} type="button">
+                      Restore
+                    </button>
+                    <button onClick={() => purgeAsset?.(asset)} type="button">
+                      Purge
+                    </button>
+                  </>
+                ) : (
+                  <button onClick={() => deleteAsset?.(asset)} type="button">
+                    Discard
+                  </button>
+                )}
+              </div>
+            </div>
           ))}
         </div>
       ) : (
         <p className="muted">
-          No images yet. Angle sets, pose generations, character tests, and any character-image render collect here automatically.
+          {showingTrash
+            ? "Trashcan is empty — discarded images for this character will appear here."
+            : "No images yet. Angle sets, pose generations, character tests, and any character-image render collect here automatically."}
         </p>
       )}
     </section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1652,6 +1652,32 @@ label {
   object-fit: cover;
 }
 
+/* Character assets grid: thumbnail with per-item discard / restore / purge. */
+.character-asset-thumb {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 72px;
+}
+
+.character-asset-thumb-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+}
+
+.character-asset-thumb-actions button {
+  padding: 2px 6px;
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.character-section > .segmented-control {
+  margin-bottom: 12px;
+}
+
 /* Pose library picker (multi-select OpenPose gallery) */
 .pose-library {
   display: flex;


### PR DESCRIPTION
## What

Follow-up to #354. Applies the discard/Trashcan behavior to the prominent **Character assets** thumbnail strip — the section the user actually sees at the top of the studio.

## Why

#354 only fixed the collapsed "Sample outputs" panel (`CharacterTest`). The separate `CharacterAssets` grid ("Generated for {name}") still listed discarded images and had no trash selector, so from the user's perspective the bug was unfixed: discarded assets stayed in view and there was no way to recover/purge them.

## Changes

- **`apps/web/src/screens/characterPanels.jsx`** (`CharacterAssets`)
  - Partition the character-scoped images into active (non-trashed) vs trashed.
  - Render only active images by default, so discarded/purged thumbnails leave the grid immediately; heading count reflects active only.
  - Add an `Images (n)` / `Trashcan (n)` segmented toggle.
  - Each thumbnail gets an inline **Discard** action (active view) or **Restore** / **Purge** actions (Trashcan view).
- **`apps/web/src/screens/CharacterStudio.jsx`** — thread `deleteAsset`, `purgeAsset`, `updateAssetStatus` into `CharacterAssets`.
- **`apps/web/src/styles.css`** — styles for `.character-asset-thumb` / `.character-asset-thumb-actions` and toggle spacing.
- **`apps/web/src/main.test.jsx`** — new regression test (hide-on-discard, Trashcan toggle, purge wiring); existing CharacterTest test scoped to its panel since there are now two toggles.

## Reviewer notes

- No backend change: `deleteAsset` already flips local state to `trashed: true`, so discarding moves the thumbnail straight into the Trashcan tab.
- Web suite: **153 passing** (`vitest run --environment jsdom src/main.test.jsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)