### PR TITLE
Character Studio: WorkerProgressCard parity (buttons, persistence, stacking, streaming)

### DIFF
--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -46,7 +46,9 @@ export function CharacterStudio() {
     createImageJob,
     importAsset,
     imageLocalJobs,
+    jobAction,
     rememberLocalGenerationJob,
+    setActiveView,
     deleteAsset,
     purgeAsset,
     imageModels,
@@ -63,6 +65,13 @@ export function CharacterStudio() {
   } = useAppContext();
   const latestAssets = latestImageAssets;
   const onPreview = setPreviewAsset;
+  // Job callbacks for character generation cards (Angle Set / Pose Library).
+  // jobAction may be missing in test contexts that wrap CharacterStudio with a
+  // stub provider; guard so the buttons just no-op there.
+  const onCancelCharacterJob = jobAction ? (job) => jobAction(job, "cancel") : undefined;
+  const onRetryCharacterJob = jobAction ? (job) => jobAction(job, "retry") : undefined;
+  const onDuplicateCharacterJob = jobAction ? (job) => jobAction(job, "duplicate") : undefined;
+  const onOpenCharacterJobQueue = setActiveView ? () => setActiveView("Queue") : undefined;
   const onSendImage = sendCharacterToImage;
   const onSendVideo = sendCharacterToVideo;
   const [selectedCharacterId, setSelectedCharacterId] = useState(characters[0]?.id ?? "");
@@ -425,12 +434,17 @@ export function CharacterStudio() {
               angleModel={angleModel}
               angleModels={angleModels}
               approvedReferences={approvedReferences}
+              assets={assets}
               createImageJob={createImageJob}
               imageLocalJobs={imageLocalJobs}
               importAsset={importAsset}
               latestAssets={latestAssets}
               loras={loras}
+              onCancel={onCancelCharacterJob}
+              onDuplicate={onDuplicateCharacterJob}
+              onOpenQueue={onOpenCharacterJobQueue}
               onPreview={onPreview}
+              onRetry={onRetryCharacterJob}
               rememberLocalGenerationJob={rememberLocalGenerationJob}
               selectedCharacter={selectedCharacter}
             />
@@ -438,12 +452,17 @@ export function CharacterStudio() {
             <CharacterPoseLibrary
               addCharacterReference={addCharacterReference}
               approvedReferences={approvedReferences}
+              assets={assets}
               createImageJob={createImageJob}
               imageLocalJobs={imageLocalJobs}
               importAsset={importAsset}
               latestAssets={latestAssets}
               loras={loras}
+              onCancel={onCancelCharacterJob}
+              onDuplicate={onDuplicateCharacterJob}
+              onOpenQueue={onOpenCharacterJobQueue}
               onPreview={onPreview}
+              onRetry={onRetryCharacterJob}
               poseModel={poseModel}
               poseModels={poseModels}
               rememberLocalGenerationJob={rememberLocalGenerationJob}

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -3,14 +3,17 @@ import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
+import { terminalStatuses } from "../jobTypes.js";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
 import { LoraPickerField, useLoraSelection } from "../components/LoraPickerField.jsx";
 import { usePoseLibrary } from "../poseLibrary.js";
 import { extractFamilies } from "../presetUtils.js";
 
-// Resolve a character generation job's produced images from the surrounding
-// latestAssets list. The component is propped from above (no AppContext here)
-// so this stays a small local helper instead of pulling in a shared util.
+// Resolve a character generation job's produced images from the full asset
+// catalog. Using the catalog (not just latestAssets, which is the single most
+// recent generation set) is what lets pose / angle previews stream in as each
+// image is saved — otherwise a parallel job's newer generation set hides this
+// job's partial outputs from latestAssets and nothing surfaces in the card.
 function jobImageAssets(job, assets) {
   if (!job?.result || !Array.isArray(assets)) return [];
   const byId = new Map(assets.map((asset) => [asset.id, asset]));
@@ -20,6 +23,33 @@ function jobImageAssets(job, assets) {
     return assets.filter((asset) => asset?.type === "image" && asset.generationSetId === job.result.generationSetId);
   }
   return [];
+}
+
+// True when the job was started from the Angle Set form (advanced.angleSet)
+// rather than the Pose Library (advanced.poses). Keeps the two cards from
+// stealing each other's jobs when both are visible for the same character.
+function isAngleSetJob(job) {
+  return job?.payload?.advanced?.angleSet === true;
+}
+
+function isPoseLibraryJob(job) {
+  return Array.isArray(job?.payload?.advanced?.poses) && job.payload.advanced.poses.length > 0;
+}
+
+// Active jobs for a given character + form-kind predicate, with terminal jobs
+// filtered out. Stack order: oldest-first (running run on top, queued runs
+// follow in execution order), mirroring buildLocalJobStack in App.jsx so the
+// Character Studio matches Image/Video Studio behavior.
+function characterFormJobs(imageLocalJobs, characterId, predicate) {
+  if (!characterId) return [];
+  return (imageLocalJobs ?? [])
+    .filter(
+      (job) =>
+        job?.payload?.characterId === characterId &&
+        predicate(job) &&
+        !terminalStatuses.has(job.status),
+    )
+    .sort((left, right) => (left.createdAt ?? "").localeCompare(right.createdAt ?? ""));
 }
 
 export function editableLora(link) {
@@ -424,6 +454,7 @@ export function CharacterAngleSet({
   angleModel,
   angleModels,
   approvedReferences,
+  assets = [],
   createImageJob,
   importAsset,
   addCharacterReference,
@@ -431,7 +462,11 @@ export function CharacterAngleSet({
   imageLocalJobs = [],
   loras = [],
   rememberLocalGenerationJob,
+  onCancel,
+  onDuplicate,
+  onOpenQueue,
   onPreview,
+  onRetry,
 }) {
   // sc-2003: multi-backbone picker. angleModels is the full list of viewAngles-
   // capable backbones (manifest order: InstantID first, then prompt-driven
@@ -454,7 +489,6 @@ export function CharacterAngleSet({
   const [prompt, setPrompt] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
   const [status, setStatus] = React.useState("");
-  const [jobId, setJobId] = React.useState(null);
   const fileInputRef = React.useRef(null);
   const characterId = selectedCharacter?.id;
 
@@ -483,9 +517,11 @@ export function CharacterAngleSet({
     return null;
   }
 
-  // The just-launched batch job (live progress while it runs) + this character's
-  // images (they stream in as the worker writes each angle).
-  const activeJob = imageLocalJobs.find((job) => job.id === jobId);
+  // Active jobs for this character's angle-set form, derived from the
+  // App-level imageLocalJobs so they persist across navigation and stack
+  // when multiple runs are in flight (sc-2092 follow-up). The local jobId
+  // state is gone — there's nothing to remember per mount.
+  const activeJobs = characterFormJobs(imageLocalJobs, characterId, isAngleSetJob);
   const characterImages = (latestAssets ?? []).filter(
     (asset) =>
       asset.recipe?.normalizedSettings?.characterId === characterId ||
@@ -535,7 +571,6 @@ export function CharacterAngleSet({
       });
       if (job?.id) {
         rememberLocalGenerationJob?.("image", job);
-        setJobId(job.id);
         setStatus("");
       } else {
         setStatus("Could not start the job — check the error banner.");
@@ -602,23 +637,32 @@ export function CharacterAngleSet({
         Prompt
         <textarea onChange={(event) => setPrompt(event.target.value)} rows={2} value={prompt} />
       </label>
-      {activeJob ? (
-        <WorkerProgressCard
-          job={{
-            ...activeJob,
-            payload: {
-              ...activeJob.payload,
-              characterId: selectedCharacter?.id,
-              characterName: selectedCharacter?.name,
-            },
-          }}
-          thumbnailsVariant="image-grid"
-          thumbnailAssets={jobImageAssets(activeJob, latestAssets)}
-          expectedThumbnailCount={angleCount}
-          onThumbnailClick={onPreview}
-        />
+      {activeJobs.length ? (
+        <div className="worker-progress-card-stack local-job-stack">
+          {activeJobs.map((job) => (
+            <WorkerProgressCard
+              key={job.id}
+              job={{
+                ...job,
+                payload: {
+                  ...job.payload,
+                  characterId: selectedCharacter?.id,
+                  characterName: selectedCharacter?.name,
+                },
+              }}
+              thumbnailsVariant="image-grid"
+              thumbnailAssets={jobImageAssets(job, assets)}
+              expectedThumbnailCount={angleCount}
+              onThumbnailClick={onPreview}
+              onCancel={onCancel}
+              onRetry={onRetry}
+              onDuplicate={onDuplicate}
+              onOpenQueue={onOpenQueue}
+            />
+          ))}
+        </div>
       ) : null}
-      {!activeJob && status ? <p className="inline-warning">{status}</p> : null}
+      {!activeJobs.length && status ? <p className="inline-warning">{status}</p> : null}
       {characterImages.length ? (
         <div className="reference-thumb-row">
           {characterImages.map((asset) => (
@@ -806,6 +850,7 @@ export function CharacterPoseLibrary({
   poseModel,
   poseModels,
   approvedReferences,
+  assets = [],
   createImageJob,
   importAsset,
   addCharacterReference,
@@ -813,7 +858,11 @@ export function CharacterPoseLibrary({
   imageLocalJobs = [],
   loras = [],
   rememberLocalGenerationJob,
+  onCancel,
+  onDuplicate,
+  onOpenQueue,
   onPreview,
+  onRetry,
 }) {
   // sc-2003: multi-backbone picker. poseModels is the full list of poseLibrary-
   // capable backbones (manifest order: InstantID strict tier first, then the
@@ -836,7 +885,6 @@ export function CharacterPoseLibrary({
   const [prompt, setPrompt] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
   const [status, setStatus] = React.useState("");
-  const [jobId, setJobId] = React.useState(null);
   const fileInputRef = React.useRef(null);
   const characterId = selectedCharacter?.id;
 
@@ -860,7 +908,7 @@ export function CharacterPoseLibrary({
     return null;
   }
 
-  const activeJob = imageLocalJobs.find((job) => job.id === jobId);
+  const activeJobs = characterFormJobs(imageLocalJobs, characterId, isPoseLibraryJob);
   const characterImages = (latestAssets ?? []).filter(
     (asset) =>
       asset.recipe?.normalizedSettings?.characterId === characterId ||
@@ -915,7 +963,6 @@ export function CharacterPoseLibrary({
       });
       if (job?.id) {
         rememberLocalGenerationJob?.("image", job);
-        setJobId(job.id);
         setStatus("");
       } else {
         setStatus("Could not start the job — check the error banner.");
@@ -994,23 +1041,34 @@ export function CharacterPoseLibrary({
         Prompt
         <textarea onChange={(event) => setPrompt(event.target.value)} rows={2} value={prompt} />
       </label>
-      {activeJob ? (
-        <WorkerProgressCard
-          job={{
-            ...activeJob,
-            payload: {
-              ...activeJob.payload,
-              characterId: selectedCharacter?.id,
-              characterName: selectedCharacter?.name,
-            },
-          }}
-          thumbnailsVariant="image-grid"
-          thumbnailAssets={jobImageAssets(activeJob, latestAssets)}
-          expectedThumbnailCount={selectedPoseIds.length}
-          onThumbnailClick={onPreview}
-        />
+      {activeJobs.length ? (
+        <div className="worker-progress-card-stack local-job-stack">
+          {activeJobs.map((job) => (
+            <WorkerProgressCard
+              key={job.id}
+              job={{
+                ...job,
+                payload: {
+                  ...job.payload,
+                  characterId: selectedCharacter?.id,
+                  characterName: selectedCharacter?.name,
+                },
+              }}
+              thumbnailsVariant="image-grid"
+              thumbnailAssets={jobImageAssets(job, assets)}
+              expectedThumbnailCount={
+                Array.isArray(job.payload?.advanced?.poses) ? job.payload.advanced.poses.length : selectedPoseIds.length
+              }
+              onThumbnailClick={onPreview}
+              onCancel={onCancel}
+              onRetry={onRetry}
+              onDuplicate={onDuplicate}
+              onOpenQueue={onOpenQueue}
+            />
+          ))}
+        </div>
       ) : null}
-      {!activeJob && status ? <p className="inline-warning">{status}</p> : null}
+      {!activeJobs.length && status ? <p className="inline-warning">{status}</p> : null}
       {characterImages.length ? (
         <div className="reference-thumb-row">
           {characterImages.map((asset) => (


### PR DESCRIPTION
## Summary

User-reported gaps in the Character Studio's Angle Set + Pose Library cards. All four trace back to my sc-2092 wiring, which tracked one local `jobId` in component state instead of deriving from the App-level `imageLocalJobs` list the way Image and Video Studio do.

## Fixes

1. **Cancel / Retry / View in Queue buttons** were missing. `CharacterStudio` now reads `jobAction` + `setActiveView` from `AppContext`, derives the four standard callbacks (guarded so test contexts that stub `jobAction` no-op cleanly), and passes them to both forms; both forms forward them to `WorkerProgressCard`.

2. **Worker disappears on navigation.** Each form held `const [jobId, setJobId] = useState(null)` which reset on remount, so the card vanished when the user left and returned even though the job itself is persisted in `imageLocalJobs` (App.jsx remembers it via `rememberLocalGenerationJob`). Dropped the local state; derive the active list from `imageLocalJobs` filtered by `characterId` + form-kind predicate. The card now reappears on return for as long as the job is still in flight.

3. **Multiple in-flight runs didn't stack.** `imageLocalJobs.find(...)` returned exactly one job; the second was invisible. Switched to `.filter(...)` and render a stack of `WorkerProgressCard`s in `.worker-progress-card-stack` — matches the Image Studio layout. Jobs sort oldest-first.

4. **Pose Library card wasn't streaming partial images.** `jobImageAssets(job, latestAssets)` was reading from `latestAssets` — the single most recent generation set — so a parallel Image Studio batch's newer generation set hid the pose job's partial outputs entirely. Switched to the full `assets` catalog (matching the Image Studio wiring) so `job.result.assetIds` resolves as each image is saved.

## Form disambiguation

So the Angle and Pose cards don't steal each other's jobs when both are visible:

- `isAngleSetJob` — `payload.advanced.angleSet === true`
- `isPoseLibraryJob` — `Array.isArray(payload.advanced.poses) && length > 0`

Terminal jobs filter out so the card auto-collapses on completion; the produced images then appear in the existing character-images strip below — matches the stated spec ("when the current worker completes its assets are added to recent assets, the worker disappears").

## Test plan

- [x] `npm test` in apps/web — **257/257 green**
- [x] `npx vite build --mode production` — clean
- [ ] Manual: start a pose-library run, watch each pose's image fill the corresponding slot as it's saved (was empty before)
- [ ] Manual: navigate away from Character Studio mid-run, come back, confirm the card is still showing the in-flight job
- [ ] Manual: kick off two angle-set runs back-to-back for the same character, confirm they stack
- [ ] Manual: cancel from the new Cancel button, confirm it routes to the queue's cancel action

🤖 Generated with [Claude Code](https://claude.com/claude-code)