### PR TITLE
WorkerProgressCard: runtime backend label (mlx / mps / cuda / cpu)

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -159,6 +159,7 @@ pub(crate) async fn update_job_progress(
                 eta_seconds,
                 peak_gpu_memory_pct,
                 peak_gpu_load_pct,
+                backend: payload.backend,
             },
         )
     })

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -155,10 +155,6 @@ function StatusBadge({ status }) {
 
 function HardwarePills({ device, gpuLabel, architecture }) {
   if (!device) return null;
-  // Apple Silicon / MLX runs against Unified Memory — the Mem meter reflects
-  // shared system memory, not dedicated VRAM. Worth surfacing so the meter
-  // number isn't misread as a discrete-VRAM figure.
-  const sharedMem = architecture === "mps" || architecture === "mlx";
   return (
     <div className="worker-progress-card__hw-info">
       <span className="worker-progress-card__pill device">{device}</span>
@@ -166,7 +162,6 @@ function HardwarePills({ device, gpuLabel, architecture }) {
       {architecture ? (
         <span className={`worker-progress-card__pill arch arch-${architecture}`}>{architecture}</span>
       ) : null}
-      {sharedMem ? <span className="worker-progress-card__hw-note">shared mem</span> : null}
     </div>
   );
 }
@@ -364,7 +359,18 @@ export function WorkerProgressCard({
     return findWorkerForJob(job, visibleWorkers ?? []);
   }, [job, workersById, visibleWorkers]);
 
-  const hardware = useMemo(() => deriveWorkerHardware(worker), [worker]);
+  // Architecture pill prefers the job's reported `backend` (the actual runtime
+  // — mlx vs mps vs cuda) when present; falls back to a heuristic on the
+  // worker's gpuName for legacy / pre-backend snapshots. This lets an MLX
+  // adapter run show "mlx" while a Diffusers-on-MPS run on the same worker
+  // shows "mps".
+  const hardware = useMemo(() => {
+    const derived = deriveWorkerHardware(worker);
+    if (job.backend) {
+      return { ...derived, architecture: job.backend };
+    }
+    return derived;
+  }, [worker, job.backend]);
   const meters = useMemo(() => pickMeters(job, worker), [job, worker]);
   const elapsedSeconds = useLiveJobElapsedSeconds(job);
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -213,6 +213,33 @@ def heartbeat(
     )
 
 
+def adapter_backend(adapter: object | None, settings: WorkerSettings) -> str:
+    """Resolve the runtime backend label the WorkerProgressCard's arch pill
+    should display for this job (sc-2086 follow-up).
+
+    The previous arch pill was a heuristic on the worker's gpu_name, which
+    couldn't tell an MLX run from a Diffusers-on-MPS run on the same Apple
+    Silicon worker. This walks the actual adapter that ran the job:
+
+      - Any adapter whose class starts with "Mlx" runs through Apple's MLX
+        runtime — that's mlx.
+      - settings.gpu_id == "mps" → torch on MPS (Diffusers / Wan torch path).
+      - settings.gpu_id == "cpu" → CPU-only path (utility jobs, prompt refine
+        falling back to CPU, etc.).
+      - Everything else (NVIDIA gpu ids like "gpu-0") → cuda.
+
+    Lets the card report what *actually* ran, not what the worker advertised.
+    """
+    if adapter is not None and type(adapter).__name__.startswith("Mlx"):
+        return "mlx"
+    gpu_id = getattr(settings, "gpu_id", "cpu")
+    if gpu_id == "mps":
+        return "mps"
+    if gpu_id == "cpu":
+        return "cpu"
+    return "cuda"
+
+
 def _sample_into_peaks(peaks: dict, settings: WorkerSettings) -> None:
     """Sample current GPU utilization and ratchet the running max into a
     per-job peaks dict (sc-2086).
@@ -242,7 +269,12 @@ def _sample_into_peaks(peaks: dict, settings: WorkerSettings) -> None:
         peaks["load"] = max(peaks.get("load", 0.0), min(100.0, float(load)))
 
 
-def track_job_peaks(payload: dict, peaks: dict, settings: WorkerSettings) -> None:
+def track_job_peaks(
+    payload: dict,
+    peaks: dict,
+    settings: WorkerSettings,
+    backend: str | None = None,
+) -> None:
     """Sample GPU utilization, ratchet the running max into `peaks`, and fold
     the peaks into a progress payload (sc-2086).
 
@@ -252,12 +284,19 @@ def track_job_peaks(payload: dict, peaks: dict, settings: WorkerSettings) -> Non
     run instead of whatever the last sample happened to be. The same dict is
     shared with `keep_job_alive` (via `run_blocking_job_step`) so peaks are
     captured both at progress() boundaries and during blocking work.
+
+    `backend` is the runtime label the WorkerProgressCard's arch pill shows
+    ("mlx" / "mps" / "cuda" / "cpu") — see `adapter_backend()`. Pass once per
+    progress call; the API coalesces first-non-null so subsequent calls are
+    idempotent and the value persists across the run.
     """
     _sample_into_peaks(peaks, settings)
     if peaks.get("memory"):
         payload["peakGpuMemoryPct"] = peaks["memory"]
     if peaks.get("load"):
         payload["peakGpuLoadPct"] = peaks["load"]
+    if backend is not None:
+        payload["backend"] = backend
 
 
 def resolve_loaded_models(source: LoadedModelsSource, *, job_id: str | None = None) -> list[str]:
@@ -740,7 +779,7 @@ def run_image_job(api: ApiClient, settings: WorkerSettings, job: dict, image_ada
         }
         if result is not None:
             payload["result"] = result
-        track_job_peaks(payload, peaks, settings)
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(adapter, settings))
         update_job(api, job_id, payload)
 
     try:
@@ -835,7 +874,7 @@ def run_vqa_job(api: ApiClient, settings: WorkerSettings, job: dict, image_adapt
         payload = {"status": status, "stage": stage, "progress": value, "message": message}
         if result is not None:
             payload["result"] = result
-        track_job_peaks(payload, peaks, settings)
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(adapter, settings))
         update_job(api, job_id, payload)
 
     try:
@@ -902,7 +941,7 @@ def run_interleave_job(api: ApiClient, settings: WorkerSettings, job: dict, imag
         payload = {"status": status, "stage": stage, "progress": value, "message": message}
         if result is not None:
             payload["result"] = result
-        track_job_peaks(payload, peaks, settings)
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(adapter, settings))
         update_job(api, job_id, payload)
 
     try:
@@ -978,7 +1017,7 @@ def run_video_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             "progress": value,
             "message": message,
         }
-        track_job_peaks(payload, peaks, settings)
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(adapter, settings))
         update_job(api, job_id, payload)
 
     try:
@@ -1094,7 +1133,7 @@ def run_person_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     def progress(status: str, stage: str, value: float, message: str) -> None:
         heartbeat(api, settings, "busy", job_id)
         payload = {"status": status, "stage": stage, "progress": value, "message": message}
-        track_job_peaks(payload, peaks, settings)
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(None, settings))
         update_job(api, job_id, payload)
 
     runner = run_person_detect if job_type == "person_detect" else run_person_track
@@ -1166,7 +1205,7 @@ def _run_lora_train_dry_run(api: ApiClient, settings: WorkerSettings, job: dict,
     def progress(status: str, stage: str, value: float, message: str) -> None:
         heartbeat(api, settings, "busy", job_id)
         update_payload = {"status": status, "stage": stage, "progress": value, "message": message}
-        track_job_peaks(update_payload, peaks, settings)
+        track_job_peaks(update_payload, peaks, settings, backend=adapter_backend(None, settings))
         update_job(api, job_id, update_payload)
 
     try:
@@ -1219,7 +1258,7 @@ def _run_lora_train_execution(api: ApiClient, settings: WorkerSettings, job: dic
         update_payload = {"status": status, "stage": stage, "progress": value, "message": message}
         if result is not None:
             update_payload["result"] = result
-        track_job_peaks(update_payload, peaks, settings)
+        track_job_peaks(update_payload, peaks, settings, backend=adapter_backend(trainer_holder["trainer"], settings))
         update_job(api, job_id, update_payload)
 
     try:
@@ -1300,7 +1339,7 @@ def run_training_caption_worker_job(api: ApiClient, settings: WorkerSettings, jo
     def progress(status: str, stage: str, value: float, message: str) -> None:
         heartbeat(api, settings, "busy", job_id)
         payload = {"status": status, "stage": stage, "progress": value, "message": message}
-        track_job_peaks(payload, peaks, settings)
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(None, settings))
         update_job(api, job_id, payload)
 
     try:

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -588,6 +588,13 @@ pub struct ProgressRequest {
     /// running-max treatment as peak_gpu_memory_pct (sc-2086).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peak_gpu_load_pct: Option<ContractNumber>,
+    /// Runtime backend the worker actually executed this job on
+    /// ("mlx" / "mps" / "cuda" / "cpu"). Distinct from the worker's
+    /// device-architecture heuristic — the same Apple-Silicon worker can
+    /// serve both MLX and MPS-Diffusers jobs, and the WorkerProgressCard's
+    /// arch pill should reflect which one ran. First non-null value sticks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }
@@ -631,6 +638,12 @@ pub struct JobSnapshot {
     /// Pair of peak_gpu_memory_pct.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peak_gpu_load_pct: Option<ContractNumber>,
+    /// Runtime backend the worker actually used to execute the job
+    /// ("mlx" / "mps" / "cuda" / "cpu"). Surfaced by the WorkerProgressCard
+    /// arch pill so an MLX run and a Diffusers-on-MPS run on the same worker
+    /// read differently.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
     /// Human-readable job title derived server-side from job type + payload
     /// (sc-2087). The WorkerProgressCard reads `title` first and only falls
     /// back to client-side derivation when this is absent, so queue rows

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -184,6 +184,12 @@ pub struct ProgressUpdate {
     /// Sampled GPU load percentage observed at this progress point (0..100).
     /// Same running-max semantics as peak_gpu_memory_pct.
     pub peak_gpu_load_pct: Option<f64>,
+    /// Runtime backend label the worker reports for this job
+    /// ("mlx" / "mps" / "cuda" / "cpu"). First non-null value sticks — once a
+    /// worker tells us which backend ran the job, subsequent status-only
+    /// progress updates can't accidentally clear it. Drives the
+    /// WorkerProgressCard arch pill.
+    pub backend: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -264,6 +270,10 @@ impl JobsStore {
         // along with progress so a completed row shows the peak the run reached.
         ensure_column(&transaction, "jobs", "peak_gpu_memory_pct", "real")?;
         ensure_column(&transaction, "jobs", "peak_gpu_load_pct", "real")?;
+        // Runtime backend label written by the worker ("mlx" / "mps" / "cuda"
+        // / "cpu"). First-non-null wins so the WorkerProgressCard's arch pill
+        // stays stable across the run.
+        ensure_column(&transaction, "jobs", "backend", "text")?;
         transaction.commit()?;
         Ok(())
     }
@@ -787,8 +797,9 @@ impl JobsStore {
                    peak_gpu_load_pct = case
                        when ?12 is null then peak_gpu_load_pct
                        else max(coalesce(peak_gpu_load_pct, 0), ?12)
-                   end
-             where id = ?13
+                   end,
+                   backend = coalesce(backend, ?13)
+             where id = ?14
             ",
             params![
                 update.status.as_str(),
@@ -803,6 +814,7 @@ impl JobsStore {
                 now,
                 peak_memory,
                 peak_load,
+                update.backend,
                 job_id,
             ],
         )?;
@@ -1012,6 +1024,7 @@ fn row_to_job(row: &Row<'_>) -> rusqlite::Result<JobSnapshot> {
     let eta_seconds: Option<f64> = row.get("eta_seconds")?;
     let peak_memory: Option<f64> = row.get("peak_gpu_memory_pct").ok().flatten();
     let peak_load: Option<f64> = row.get("peak_gpu_load_pct").ok().flatten();
+    let backend: Option<String> = row.get("backend").ok().flatten();
     let created_at: String = row.get("created_at")?;
     let started_at: Option<String> = row.get("started_at")?;
     let completed_at: Option<String> = row.get("completed_at")?;
@@ -1050,6 +1063,7 @@ fn row_to_job(row: &Row<'_>) -> rusqlite::Result<JobSnapshot> {
         last_heartbeat_at: row.get("last_heartbeat_at")?,
         peak_gpu_memory_pct: peak_memory.map(number_from_f64),
         peak_gpu_load_pct: peak_load.map(number_from_f64),
+        backend,
         title,
         extra: Default::default(),
     })

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -84,6 +84,7 @@ fn job_lifecycle_create_claim_complete() {
                 eta_seconds: None,
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
+                backend: None,
             },
         )
         .expect("progress updates");
@@ -119,6 +120,7 @@ fn progress_keeps_running_max_for_peak_gpu_meters() {
             eta_seconds: None,
             peak_gpu_memory_pct: memory,
             peak_gpu_load_pct: load,
+            backend: None,
         }
     }
 
@@ -211,6 +213,7 @@ fn progress_leaves_peaks_null_when_no_samples_arrive() {
         eta_seconds: None,
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
+        backend: None,
     };
     for _ in 0..3 {
         store
@@ -654,6 +657,7 @@ fn training_progress_stages_persist_under_running_and_reject_unknown_status() {
                     eta_seconds: None,
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
+                    backend: None,
                 },
             )
             .expect("running status with a training stage is accepted");
@@ -676,6 +680,7 @@ fn training_progress_stages_persist_under_running_and_reject_unknown_status() {
                 eta_seconds: None,
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
+                backend: None,
             },
         )
         .expect_err("an unknown status is rejected");
@@ -1136,6 +1141,7 @@ fn invalid_progress_numbers_are_rejected() {
                 eta_seconds: None,
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
+                backend: None,
             },
         ),
         Err(JobsStoreError::InvalidNumber(field)) if field == "progress"

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -930,9 +930,11 @@ fn progress_payload(
         eta_seconds,
         // The Rust utility worker doesn't run GPU work, so it never reports
         // per-job peak GPU stats. The Python GPU worker (scene_worker) sets
-        // these (sc-2086).
+        // these (sc-2086). Same for `backend` — utility jobs run on the CPU
+        // worker which never advertises a GPU runtime.
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
+        backend: Some("cpu".to_owned()),
         extra: BTreeMap::new(),
     }
 }


### PR DESCRIPTION
## Summary

Two related WorkerProgressCard tweaks driven by review feedback on the hardware row:

1. **Drop "shared mem"** — the worker's gpuName already reads "Apple GPU (unified)" for Apple Silicon, so the extra label was just noise.
2. **Distinguish MLX from MPS runs** — the arch pill was a string heuristic on `worker.gpuName`, which couldn't tell an MLX adapter run from a Diffusers-on-MPS run on the same Apple Silicon worker. They should read differently.

## What changed

**Frontend**
- `HardwarePills` no longer renders the "shared mem" badge.
- The architecture pill now prefers `job.backend` (what actually ran) over the gpuName heuristic, falling back to the heuristic only when the snapshot has no backend (legacy / pre-feature rows).

**Contract (`crates/sceneworks-core/src/contracts.rs`)**
- Optional `backend: Option<String>` on `ProgressRequest` and `JobSnapshot`. `skip_serializing_if = "Option::is_none"` keeps existing parity fixtures bit-compatible.

**Jobs store**
- `backend` text column added via `ensure_column` migration.
- SQL uses `backend = coalesce(backend, ?incoming)` — first non-null sticks so a later status-only progress update can't clear it.
- `row_to_job` reads the new column.

**Python worker (`apps/worker/scene_worker/runtime.py`)**
- New `adapter_backend(adapter, settings)` resolves the actual runtime:
  - adapter class starts with `Mlx` → `"mlx"`
  - else `settings.gpu_id == "mps"` → `"mps"`
  - `"cpu"` → `"cpu"`
  - everything else → `"cuda"`
- `track_job_peaks` gains an optional `backend=None` kwarg. All 8 per-job `progress()` closures now pass it — for adapter-having ones it's `adapter_backend(adapter, settings)`, for trainer it's `adapter_backend(trainer_holder["trainer"], settings)`, for adapter-less jobs (person, dry-run, caption) it's `adapter_backend(None, settings)` which still picks up mps/cuda/cpu from `gpu_id`.

**Rust utility worker (`crates/sceneworks-worker/src/lib.rs`)**
- `progress_payload` sets `backend: Some("cpu")` — utility jobs always run on the CPU worker.

## Test plan

- [x] `cargo test -p sceneworks-core -p sceneworks-rust-api` — **237 tests, all green** (5 `ProgressUpdate` literals in `jobs_store` integration tests backfilled with `backend: None`).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `npm test` in apps/web — **257/257 green** (no test asserts on the dropped "shared mem" string).
- [x] `pytest tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py` — **464 passed, 9 skipped**, mirroring the CI invocation.
- [ ] Manual: kick off a Z-Image-MLX run on Apple Silicon, confirm arch pill reads `MLX` (not `MPS`).
- [ ] Manual: kick off a Wan-Diffusers run on the same worker, confirm arch pill reads `MPS`.
- [ ] Manual: confirm "shared mem" is gone from every hardware row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)