### PR TITLE
feat(trash): scoped Empty Trash button on every Trashcan view

### DIFF
--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -5,6 +5,30 @@ import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
 import { Modal } from "./Modal.jsx";
 
+// Permanently purge every discarded asset in a single Trashcan view. The caller
+// passes only the assets visible in that view, so per-character and per-filter
+// trashcans empty their own scope and nothing else. Confirms first (guarded so
+// headless/test environments skip the prompt) and purges sequentially.
+export async function emptyTrash(trashedAssets, purgeAsset) {
+  const items = (trashedAssets ?? []).filter((asset) => asset?.status?.trashed);
+  if (!items.length || typeof purgeAsset !== "function") {
+    return;
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.confirm === "function" &&
+    !window.confirm(
+      `Permanently delete ${items.length} discarded item${items.length === 1 ? "" : "s"}? This cannot be undone.`,
+    )
+  ) {
+    return;
+  }
+  for (const asset of items) {
+    // eslint-disable-next-line no-await-in-loop -- sequential keeps state updates predictable
+    await purgeAsset(asset);
+  }
+}
+
 // Reopens a saved interleaved document: the asset's file points to the segments
 // JSON in assets/documents/, fetched here (served like any project file).
 function DocumentReader({ asset }) {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2714,6 +2714,86 @@ describe("SceneWorks app shell", () => {
     expect(purgeAsset).toHaveBeenCalledWith(expect.objectContaining({ id: "img-trashed" }));
   });
 
+  it("Empty Trash purges all discarded images for the character and only in the Trashcan view", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const purgeAsset = vi.fn();
+    const assets = [
+      { id: "img-active", type: "image", displayName: "keep", recipe: { normalizedSettings: { characterId: "char-1" } } },
+      {
+        id: "img-trash-1",
+        type: "image",
+        status: { trashed: true },
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+      },
+      {
+        id: "img-trash-2",
+        type: "image",
+        status: { trashed: true },
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+      },
+      // Belongs to another character — must never be purged by this view.
+      { id: "img-other", type: "image", status: { trashed: true }, recipe: { normalizedSettings: { characterId: "char-2" } } },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference: () => {},
+            archiveCharacter: () => {},
+            assets,
+            attachCharacterLora: () => {},
+            characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: assets,
+            loras: [],
+            setPreviewAsset: () => {},
+            sendCharacterToImage: () => {},
+            sendCharacterToVideo: () => {},
+            purgeAsset,
+            removeCharacterReference: () => {},
+            updateAssetStatus: () => {},
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    const findSection = () =>
+      [...container.querySelectorAll(".character-section")].find((section) =>
+        section.querySelector(".eyebrow")?.textContent === "Character assets",
+      );
+    // No Empty Trash in the active Images view.
+    expect([...findSection().querySelectorAll("button")].some((button) => button.textContent.startsWith("Empty Trash"))).toBe(false);
+
+    await act(async () => {
+      [...findSection().querySelectorAll("button")].find((button) => button.textContent.includes("Trashcan (2)")).click();
+    });
+    const emptyButton = [...findSection().querySelectorAll("button")].find((button) => button.textContent.startsWith("Empty Trash"));
+    expect(emptyButton).toBeTruthy();
+    expect(emptyButton.textContent).toContain("(2)");
+
+    await act(async () => {
+      emptyButton.click();
+    });
+    expect(purgeAsset).toHaveBeenCalledTimes(2);
+    expect(purgeAsset).toHaveBeenCalledWith(expect.objectContaining({ id: "img-trash-1" }));
+    expect(purgeAsset).toHaveBeenCalledWith(expect.objectContaining({ id: "img-trash-2" }));
+    expect(purgeAsset).not.toHaveBeenCalledWith(expect.objectContaining({ id: "img-other" }));
+    confirm.mockRestore();
+  });
+
   it("launches reference-based generation from an approved character reference", async () => {
     const sendCharacterToImage = vi.fn();
     const reference = { assetId: "ref-1", approved: true, asset: { id: "ref-1", type: "image", displayName: "Mira ref" } };
@@ -7870,6 +7950,78 @@ describe("SceneWorks app shell", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Purge").click();
     });
     expect(purgeAsset).toHaveBeenCalledWith(trashed);
+  });
+
+  it("Empty Trash purges every discarded asset in the Library Trashcan view only", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const purgeAsset = vi.fn();
+    const active = {
+      id: "asset-active",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Active Frame",
+      status: { trashed: false },
+    };
+    const trashedA = {
+      id: "trash-a",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Trash A",
+      status: { trashed: true },
+    };
+    const trashedB = {
+      id: "trash-b",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Trash B",
+      status: { trashed: true },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Trash" },
+            assets: [active, trashedA, trashedB],
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset,
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: null,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+            updateAssetTags: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    // Empty Trash only appears in the Trashcan view.
+    expect([...container.querySelectorAll("button")].some((button) => button.textContent.startsWith("Empty Trash"))).toBe(false);
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Trashcan").click();
+    });
+    const emptyButton = [...container.querySelectorAll("button")].find((button) => button.textContent.startsWith("Empty Trash"));
+    expect(emptyButton).toBeTruthy();
+    expect(emptyButton.textContent).toContain("(2)");
+
+    await act(async () => {
+      emptyButton.click();
+    });
+    expect(confirm).toHaveBeenCalled();
+    expect(purgeAsset).toHaveBeenCalledTimes(2);
+    expect(purgeAsset).toHaveBeenCalledWith(trashedA);
+    expect(purgeAsset).toHaveBeenCalledWith(trashedB);
+    expect(purgeAsset).not.toHaveBeenCalledWith(active);
+    confirm.mockRestore();
   });
 
   it("DocumentStudio renders an interleaved document and submits a compose job", async () => {

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
-import { AssetDetail, AssetGrid } from "../components/assetPanels.jsx";
+import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
 import { terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
 
@@ -72,6 +72,17 @@ export function LibraryScreen() {
     }
     return true;
   }));
+  // All discarded assets within the current type/tag filters — the exact scope
+  // the "Empty Trash" button purges (unfolded, so folded variants go too).
+  const trashedInView = libraryAssets.filter((asset) => {
+    if (typeFilter !== "all" && asset.type !== typeFilter) {
+      return false;
+    }
+    if (tagFilter !== "all" && !(asset.tags ?? []).includes(tagFilter)) {
+      return false;
+    }
+    return Boolean(asset.status?.trashed);
+  });
 
   async function handleImport(event) {
     const [file] = event.target.files;
@@ -131,6 +142,16 @@ export function LibraryScreen() {
               Trashcan
             </button>
           </div>
+          {assetMode === "trashcan" ? (
+            <button
+              className="danger-action empty-trash-button"
+              disabled={!trashedInView.length}
+              onClick={() => emptyTrash(trashedInView, purgeAsset)}
+              type="button"
+            >
+              Empty Trash ({trashedInView.length})
+            </button>
+          ) : null}
         </div>
         <div className="hero-stats">
           <div className="hero-stat">

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
-import { AssetCard } from "../components/assetPanels.jsx";
+import { AssetCard, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
@@ -380,6 +380,16 @@ export function CharacterTest({
             </button>
           </div>
         ) : null}
+        {showOutputs && showingTrash ? (
+          <button
+            className="danger-action empty-trash-button"
+            disabled={!trashedAssets.length}
+            onClick={() => emptyTrash(trashedAssets, purgeAsset)}
+            type="button"
+          >
+            Empty Trash ({trashedAssets.length})
+          </button>
+        ) : null}
       </div>
       {showOutputs ? (
         <div className="review-grid">
@@ -672,13 +682,25 @@ export function CharacterAssets({
           {activeAssets.length ? ` (${activeAssets.length})` : ""}
         </h2>
       </div>
-      <div className="segmented-control" role="group" aria-label="Character asset collection">
-        <button className={showingTrash ? "" : "active"} onClick={() => setViewMode("active")} type="button">
-          Images ({activeAssets.length})
-        </button>
-        <button className={showingTrash ? "active" : ""} onClick={() => setViewMode("trashed")} type="button">
-          Trashcan ({trashedAssets.length})
-        </button>
+      <div className="trash-controls">
+        <div className="segmented-control" role="group" aria-label="Character asset collection">
+          <button className={showingTrash ? "" : "active"} onClick={() => setViewMode("active")} type="button">
+            Images ({activeAssets.length})
+          </button>
+          <button className={showingTrash ? "active" : ""} onClick={() => setViewMode("trashed")} type="button">
+            Trashcan ({trashedAssets.length})
+          </button>
+        </div>
+        {showingTrash ? (
+          <button
+            className="danger-action empty-trash-button"
+            disabled={!trashedAssets.length}
+            onClick={() => emptyTrash(trashedAssets, purgeAsset)}
+            type="button"
+          >
+            Empty Trash ({trashedAssets.length})
+          </button>
+        ) : null}
       </div>
       {visibleAssets.length ? (
         <div className="reference-thumb-row">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1678,6 +1678,19 @@ label {
   margin-bottom: 12px;
 }
 
+/* Trashcan toggle + Empty Trash, kept on one row above the grid. */
+.trash-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.empty-trash-button {
+  font-size: 12px;
+}
+
 /* Pose library picker (multi-select OpenPose gallery) */
 .pose-library {
   display: flex;


### PR DESCRIPTION
## What

Adds an **Empty Trash** button next to the Trashcan toggle in every view that has one. It appears only while the Trashcan is selected (hidden in the Assets/Images view) and permanently purges all discarded assets **in that view only**.

Applies to all three Trashcan views:
- Asset Library (`LibraryScreen`)
- Character assets grid (`CharacterAssets`)
- Character Studio Sample-outputs panel (`CharacterTest`)

## Why

Restoring/purging discarded items one at a time is tedious. Each Trashcan now has a single action to clear it — scoped so it never reaches beyond what that view shows.

## Scope semantics ("only in that view")

- **Library:** purges discarded assets matching the current type/tag filters (unfolded, so folded upscale variants go too) — not items hidden by an active filter.
- **Character views:** purge only the discarded images belonging to the selected character; another character's trash is never touched.

## Changes

- **`apps/web/src/components/assetPanels.jsx`** — new shared `emptyTrash(trashedAssets, purgeAsset)` helper: confirms via `window.confirm` (guarded so headless/test envs skip the prompt), then purges sequentially. Operates only on the list it's handed.
- **`apps/web/src/screens/LibraryScreen.jsx`** — compute `trashedInView` (respects type/tag filters); render `Empty Trash (n)` only in Trashcan mode.
- **`apps/web/src/screens/characterPanels.jsx`** — `Empty Trash (n)` in both `CharacterTest` and `CharacterAssets`, shown only in the Trashcan view.
- **`apps/web/src/styles.css`** — `.trash-controls` row + `.empty-trash-button`; reuses the existing `danger-action` style.
- **`apps/web/src/main.test.jsx`** — regression tests for the Library and Character assets views: button hidden in active view, confirm fires, count correct, and only in-view trashed items are purged (cross-character/other items untouched).

## Reviewer notes

- Destructive, so it confirms first; the button is disabled when the view's trash is empty.
- No backend change — reuses the existing per-asset `purgeAsset`.
- Web suite: **155 passing** (`vitest run --environment jsdom src/main.test.jsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)