### PR TITLE
feat(character-studio): Z-Image strict pose ControlNet tier (sc-2257)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -41,6 +41,9 @@ export const fallbackModels = [
       // ported Z-Image Fun-Controlnet-Union branch on it (true pose lock). The
       // pose picker gates on this flag alone — no character_image needed.
       poseLibrary: true,
+      // Strict ControlNet → expose a pose-lock-strength slider (advanced.controlScale).
+      // Best-effort tiers (Qwen/Flux2) have no strength control, so they omit this.
+      poseControlScale: true,
     },
   },
   {

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -36,6 +36,11 @@ export const fallbackModels = [
     ui: {
       description: "Fast local text-to-image target.",
       promptGuide: { title: "Z-Image-Turbo Prompt Guide", path: "/prompt-guides/z-image-turbo.md" },
+      // Strict pose tier (sc-2257): on the macOS MLX backend the worker renders
+      // the selected library pose to an OpenPose skeleton and conditions the
+      // ported Z-Image Fun-Controlnet-Union branch on it (true pose lock). The
+      // pose picker gates on this flag alone — no character_image needed.
+      poseLibrary: true,
     },
   },
   {

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2427,6 +2427,114 @@ describe("SceneWorks app shell", () => {
     expect(baseContext.rememberLocalGenerationJob).toHaveBeenCalledWith("image", { id: "job-pose" });
   });
 
+  it("exposes a pose-lock-strength slider for the strict Z-Image tier and threads controlScale (sc-2257)", async () => {
+    const poseKeypoints = Array.from({ length: 18 }, (_, i) => [0.5, i / 18]);
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        version: 1,
+        categories: ["standing"],
+        poses: [
+          { id: "standing_01", category: "standing", label: "Standing 01", preview: "poses/standing_01.png", keypoints: poseKeypoints },
+        ],
+      }),
+    }));
+    const createImageJob = vi.fn(async () => ({ id: "job-zpose" }));
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      archiveCharacter: () => {},
+      assets: [],
+      attachCharacterLora: () => {},
+      characters: [
+        {
+          id: "char-1",
+          name: "Mira",
+          type: "person",
+          references: [],
+          approvedReferences: [{ assetId: "ref-1", role: "hero", asset: { id: "ref-1", type: "image", displayName: "Mira ref" } }],
+          looks: [],
+          loras: [],
+        },
+      ],
+      createCharacter: () => {},
+      createCharacterLook: () => {},
+      createCharacterTestJob: () => {},
+      createImageJob,
+      importAsset: vi.fn(),
+      imageLocalJobs: [],
+      rememberLocalGenerationJob: vi.fn(),
+      deleteAsset: () => {},
+      deleteCharacterLook: () => {},
+      detachCharacterLora: () => {},
+      imageModels: [
+        {
+          id: "z_image_turbo",
+          name: "Z-Image-Turbo",
+          type: "image",
+          ui: { poseLibrary: true, poseControlScale: true },
+        },
+      ],
+      latestImageAssets: [],
+      loras: [],
+      setPreviewAsset: () => {},
+      sendCharacterToImage: () => {},
+      sendCharacterToVideo: () => {},
+      purgeAsset: () => {},
+      removeCharacterReference: () => {},
+      updateAssetStatus: () => {},
+      updateCharacter: () => {},
+      updateCharacterLook: () => {},
+      updateCharacterLora: () => {},
+      updateCharacterReference: () => {},
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const poseButton = [...container.querySelectorAll("button")].find((button) =>
+      (button.getAttribute("aria-label") ?? "").includes("pose Standing 01"),
+    );
+    expect(poseButton).toBeTruthy();
+    await act(async () => {
+      poseButton.click();
+    });
+
+    // Strict tier exposes the pose-lock-strength slider (best-effort tiers don't).
+    const slider = container.querySelector('input[aria-label="Pose lock strength"]');
+    expect(slider).toBeTruthy();
+
+    // Move it off the 1.0 default; the value must thread into advanced.controlScale.
+    const valueSetter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(slider), "value").set;
+    await act(async () => {
+      valueSetter.call(slider, "0.75");
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const generateButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.startsWith("Generate") && button.textContent.includes("pose"),
+    );
+    expect(generateButton).toBeTruthy();
+    await act(async () => {
+      generateButton.click();
+    });
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "z_image_turbo",
+        advanced: expect.objectContaining({
+          poses: [{ id: "standing_01", keypoints: poseKeypoints }],
+          controlScale: 0.75,
+        }),
+      }),
+    );
+  });
+
   it("threads a selected LoRA into the angle-set payload (sc-2223)", async () => {
     const createImageJob = vi.fn(async () => ({ id: "job-angle-lora" }));
     const baseContext = {

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -881,6 +881,11 @@ export function CharacterPoseLibrary({
   const loraSelection = useLoraSelection(loras, activePoseModel);
   const [selectedPoseIds, setSelectedPoseIds] = React.useState([]);
   const [faceRestore, setFaceRestore] = React.useState(false);
+  // Strict ControlNet pose-lock strength (sc-2257). Only the strict tier
+  // (ui.poseControlScale) honours advanced.controlScale; default 1.0 locks
+  // cleanly, 0.65–1.0 is the model-card range, >~1.2 starts to degrade quality.
+  const [controlScale, setControlScale] = React.useState(1.0);
+  const supportsControlScale = Boolean(activePoseModel?.ui?.poseControlScale);
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
@@ -959,7 +964,12 @@ export function CharacterPoseLibrary({
         width: 1024,
         height: 1024,
         loras: loraSelection.serializedLoras,
-        advanced: { poses, ipAdapterScale: 0.8, faceRestore },
+        advanced: {
+          poses,
+          ipAdapterScale: 0.8,
+          faceRestore,
+          ...(supportsControlScale ? { controlScale } : {}),
+        },
       });
       if (job?.id) {
         rememberLocalGenerationJob?.("image", job);
@@ -1025,6 +1035,27 @@ export function CharacterPoseLibrary({
         <input checked={faceRestore} onChange={(event) => setFaceRestore(event.target.checked)} type="checkbox" />
         Restore face (sharper identity; off keeps the raw render — fewer blend artifacts)
       </label>
+      {supportsControlScale ? (
+        <div className="control-scale-field">
+          <div className="lora-weight-row">
+            <span>Pose lock strength</span>
+            <input
+              aria-label="Pose lock strength"
+              max="1.5"
+              min="0.5"
+              onChange={(event) => setControlScale(Number(event.target.value))}
+              step="0.05"
+              type="range"
+              value={controlScale}
+            />
+            <span className="lora-weight-value">{controlScale.toFixed(2)}</span>
+          </div>
+          <p className="field-hint">
+            How hard the ControlNet locks the pose. 1.0 is a clean lock; lower (toward 0.65) loosens it for
+            more natural variation, higher (&gt;1.2) over-constrains and can degrade quality.
+          </p>
+        </div>
+      ) : null}
       <LoraPickerField selection={loraSelection} />
       <div className="inline-create">
         <button onClick={() => fileInputRef.current?.click()} type="button">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4679,6 +4679,18 @@ label {
   font-variant-numeric: tabular-nums;
 }
 
+/* Z-Image strict pose-lock strength slider (sc-2257) */
+.control-scale-field {
+  margin-top: 8px;
+}
+
+.control-scale-field .field-hint {
+  margin: 6px 10px 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .editable-lora-choice {
   display: grid;
   grid-template-columns: minmax(0, 1fr) max-content;

--- a/apps/worker/requirements-mlx-flux.txt
+++ b/apps/worker/requirements-mlx-flux.txt
@@ -25,8 +25,12 @@
 # mflux pulls its own torch, transformers, huggingface_hub, mlx, etc. — pin
 # only mflux here and let it resolve the rest.
 #
-# Temporarily pinned at michaeltrefry/mflux@claude/flux2-kv-cache (sc-2163,
-# upstream PR filipstrand/mflux#426) so MlxFlux2Adapter (sc-2164) can use the
-# FLUX.2-klein-9b-kv KV-cache optimisation (~2.4x faster multi-ref edit). Flip
-# back to a PyPI mflux>=0.18 pin once the upstream PR lands.
-mflux @ git+https://github.com/michaeltrefry/mflux.git@claude/flux2-kv-cache
+# Pinned at michaeltrefry/mflux@claude/sc2257-z-image-controlnet, which branches
+# from claude/flux2-kv-cache (sc-2163, upstream PR filipstrand/mflux#426 — keeps
+# the FLUX.2-klein-9b-kv KV-cache optimisation MlxFlux2Adapter (sc-2164) relies
+# on, ~2.4x faster multi-ref edit) and adds the VACE-style Z-Image
+# Fun-Controlnet-Union pose ControlNet port (sc-2257): ZImageControl /
+# ZImageControlTransformer, used by mlx_flux_runner's controlImagePaths path for
+# the strict Z-Image pose tier. Flip back to a PyPI mflux>=0.18 pin once both the
+# KV-cache PR and a Z-Image ControlNet land upstream.
+mflux @ git+https://github.com/michaeltrefry/mflux.git@claude/sc2257-z-image-controlnet

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -3068,10 +3068,20 @@ class MlxZImageAdapter:
                 f"{request.model} MLX adapter is text-to-image only. "
                 "Use SCENEWORKS_IMAGE_ADAPTER=z_image_diffusers for the torch path."
             )
-        if request.reference_asset_id:
+        # Strict pose tier (sc-2257): advanced.poses is a list of {id, keypoints}.
+        # Each pose renders to an OpenPose skeleton that conditions the ported
+        # Z-Image Fun-Controlnet-Union branch (true pose lock, not best-effort).
+        # No reference is used — Z-Image has no IP-Adapter, so identity comes from
+        # the prompt; the skeleton supplies the pose.
+        raw_poses = request.advanced.get("poses")
+        pose_entries = [p for p in raw_poses if isinstance(p, dict)] if isinstance(raw_poses, list) else []
+        pose_set = len(pose_entries) > 0
+        if request.reference_asset_id and not pose_set:
             # ZImageDiffusersAdapter itself has no reference path (sc-2005
             # cleanup); raising here keeps the error surface honest if a
-            # caller manually targets MlxZImageAdapter with one.
+            # caller manually targets MlxZImageAdapter with one. Pose requests
+            # may carry a character reference we can't consume — ignore it
+            # rather than reject (the skeleton drives the pose).
             raise RuntimeError(
                 f"{request.model} reference-image generation is not supported "
                 "on the MLX backend (Z-Image has no IP-Adapter weights upstream)."
@@ -3095,11 +3105,30 @@ class MlxZImageAdapter:
                 f"mflux installed (looked for {self._sidecar_python()})."
             )
 
-        total = request.count
         steps = self._num_inference_steps(request, model_target)
         guidance = self._guidance_scale(request, model_target)
         quantize = self._resolve_quantize(request)
-        seeds = [resolve_seed(request.seed, request.prompt, index, request.seeds) for index in range(total)]
+        if pose_set:
+            # One image per pose, sharing a seed so noise-derived attributes stay
+            # consistent across the set (mirrors the InstantID / Flux2 pose tiers);
+            # only the conditioned body pose changes.
+            #
+            # Strict ControlNet tier: the skeleton conditions the pose DIRECTLY, so
+            # the prompt must stay the plain character prompt. The
+            # augment_prompt_for_pose cue ("matching the OpenPose skeleton reference
+            # image") is for the best-effort multi-image tier (sc-2256, where the
+            # skeleton is a second prompt image) — adding it here makes Z-Image
+            # literally draw a skeleton in the scene and fights the pose lock.
+            total = len(pose_entries)
+            set_seed = resolve_seed(request.seed, request.prompt, 0, request.seeds)
+            seeds = [set_seed] * total
+            prompts = None
+            pose_keypoints = [normalize_keypoints(p.get("keypoints")) for p in pose_entries]
+        else:
+            total = request.count
+            seeds = [resolve_seed(request.seed, request.prompt, index, request.seeds) for index in range(total)]
+            prompts = None
+            pose_keypoints = None
 
         progress(
             "loading_model",
@@ -3109,6 +3138,28 @@ class MlxZImageAdapter:
         )
         work_dir = Path(tempfile.mkdtemp(prefix="mlx_z_image_sidecar_"))
         self._scratch_dir = work_dir
+        # Strict pose tier: render each pose's COCO-18 skeleton to a PNG in the
+        # sidecar work dir; the runner conditions ZImageControl on it. draw_bodypose
+        # runs in the main worker venv (cv2 present).
+        control_image_paths: list[str] | None = None
+        control_scale: float | None = None
+        if pose_set and pose_keypoints is not None:
+            control_scale = self._control_scale(request)
+            # The Fun-Controlnet-Union pose head is DWPose-trained; a hair-thin
+            # skeleton (the default stickwidth=4) at 1024² is a weak, partly
+            # out-of-distribution control signal that only steers under a vague
+            # prompt. A resolution-proportional stickwidth (~12px at 1024²) gives
+            # a strong in-distribution signal that locks the pose cleanly at
+            # controlScale 1.0 even under detailed character prompts (sc-2257
+            # validation: thin→arms-down, thick→clean T-pose lock).
+            stick = max(6, round(min(request.width, request.height) * 0.012))
+            control_image_paths = []
+            for index, keypoints in enumerate(pose_keypoints):
+                skeleton_path = work_dir / f"pose_skeleton_{index:04d}.png"
+                Image.fromarray(
+                    draw_bodypose(request.width, request.height, keypoints, stickwidth=stick)
+                ).save(skeleton_path, "PNG")
+                control_image_paths.append(str(skeleton_path))
         try:
             images = self._run_sidecar(
                 job_id=job["id"],
@@ -3120,6 +3171,8 @@ class MlxZImageAdapter:
                     "prompt": request.prompt,
                     "negativePrompt": request.negative_prompt or None,
                     "seeds": seeds,
+                    # Per-iteration pose-augmented prompts (None → top-level prompt).
+                    "prompts": prompts,
                     "height": request.height,
                     "width": request.width,
                     "numInferenceSteps": steps,
@@ -3129,6 +3182,10 @@ class MlxZImageAdapter:
                         {"path": lora.path, "weight": lora.weight, "name": lora.adapter_name}
                         for lora in lora_specs
                     ],
+                    # Strict pose ControlNet (sc-2257): per-iteration skeletons +
+                    # lock strength. None → the plain text-to-image path.
+                    "controlImagePaths": control_image_paths,
+                    "controlScale": control_scale,
                 },
                 progress=progress,
                 cancel_requested=cancel_requested,
@@ -3160,6 +3217,7 @@ class MlxZImageAdapter:
                     "mlxQuantize": quantize,
                     "sidecarVenv": self._sidecar_python(),
                     "realModelInference": True,
+                    **({"poseLibrary": True} if pose_set else {}),
                 },
                 settings=settings,
                 job_id=job["id"],
@@ -3169,6 +3227,16 @@ class MlxZImageAdapter:
 
     def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
         return safe_int(request.advanced.get("steps"), model_target["steps"], 1, 80)
+
+    def _control_scale(self, request: ImageRequest) -> float:
+        """Pose ControlNet lock strength (sc-2257). Fun-Controlnet-Union recommends
+        0.65–1.0; default 1.0 (clean pose lock, validated). Overridable via
+        advanced.controlScale, clamped to [0, 2]."""
+        try:
+            value = float(request.advanced.get("controlScale", 1.0))
+        except (TypeError, ValueError):
+            return 1.0
+        return max(0.0, min(2.0, value))
 
     def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:
         # Z-Image-Turbo is guidance-distilled; mflux accepts guidance=None to

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -154,6 +154,7 @@ def _run_z_image_control(
     width: int,
     steps: int,
     guidance: float,
+    quantize: int | None,
     loras: list,
     control_image_paths: list[str],
     out_dir: Path,
@@ -163,10 +164,10 @@ def _run_z_image_control(
 
     Loads the ported ``ZImageControl`` (base Z-Image-Turbo + Fun-Controlnet-Union)
     and renders one image per iteration, each conditioned on its rendered skeleton.
-    Runs bf16 (quantize forced None): the control branch is added to the transformer
-    after base quantization, so a quantized control branch would not accept the raw
-    bf16 Fun-Controlnet weights — Q8 control is a follow-up. bf16 peak fits the M5
-    Max envelope (validated sc-2257).
+    Honours ``quantize`` (None / 8 / …): ZImageControlInitializer applies the base +
+    control weights at full precision before quantizing the whole transformer, so
+    the control branch quantizes from its real weights (Q8 ≈ halves transformer
+    memory vs bf16). Both validated on M5 Max (sc-2257).
     """
     if model_id != "z_image_turbo":
         raise RuntimeError(
@@ -204,11 +205,11 @@ def _run_z_image_control(
 
     _log(
         f"loading ZImageControl model={model_id} controlScale={control_scale} "
-        f"loras={len(lora_paths)} steps={steps} (bf16)"
+        f"loras={len(lora_paths)} steps={steps} quantize={quantize}"
     )
     model = ZImageControl(
         control_weights_path=cn_path,
-        quantize=None,
+        quantize=quantize,
         lora_paths=lora_paths or None,
         lora_scales=lora_scales or None,
         model_config=ModelConfig.z_image_turbo(),
@@ -305,6 +306,7 @@ def main() -> int:
             width=width,
             steps=steps,
             guidance=guidance,
+            quantize=quantize,
             loras=loras,
             control_image_paths=control_image_paths,
             out_dir=out_dir,

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -41,6 +41,14 @@ Spec keys:
         sc-2262 — per-iteration reference sets parallel to ``seeds``; each entry
         is the [reference, skeleton] list for one pose. Overrides ``imagePaths``
         per iteration when present.)
+    controlImagePaths: list[str] | None  (Z-Image strict pose ControlNet, sc-2257
+        — per-iteration rendered-skeleton paths parallel to ``seeds``. When present
+        (z_image_turbo only) the runner loads the ported ``ZImageControl`` variant
+        and conditions each image on its skeleton via the Fun-Controlnet-Union
+        branch. controlScale sets the lock strength (0.65–1.0).)
+    controlScale: float | None  (Z-Image ControlNet control_context_scale; default 1.0)
+    controlWeights: {"repo": str, "filename": str} | None  (HF repo + file for the
+        Fun-Controlnet-Union safetensors; the runner hf_hub_downloads + caches it)
     outDir: str (sidecar writes PNGs + result.json here)
 
 Validated 2026-05-28 against mflux 0.17.5 (sc-1969 FLUX spike, sc-1972 Qwen verify).
@@ -127,6 +135,111 @@ def _resolve_model_handle(model_id: str, has_reference: bool) -> tuple[type, obj
     raise RuntimeError(f"mlx_flux_runner: unsupported model id {model_id!r}.")
 
 
+# Z-Image Fun-Controlnet-Union (strict pose tier, sc-2257). Apache-2.0. The 8-step
+# distill matches Z-Image-Turbo's NFE budget. Used as the default when the spec
+# omits an explicit controlWeights block.
+_Z_IMAGE_CONTROL_REPO = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1"
+_Z_IMAGE_CONTROL_FILE = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors"
+
+
+def _run_z_image_control(
+    *,
+    spec: dict,
+    model_id: str,
+    prompt: str,
+    prompts_override: list | None,
+    negative_prompt: str | None,
+    seeds: list[int],
+    height: int,
+    width: int,
+    steps: int,
+    guidance: float,
+    loras: list,
+    control_image_paths: list[str],
+    out_dir: Path,
+    result_path: Path,
+) -> int:
+    """Z-Image strict pose ControlNet generation (sc-2257).
+
+    Loads the ported ``ZImageControl`` (base Z-Image-Turbo + Fun-Controlnet-Union)
+    and renders one image per iteration, each conditioned on its rendered skeleton.
+    Runs bf16 (quantize forced None): the control branch is added to the transformer
+    after base quantization, so a quantized control branch would not accept the raw
+    bf16 Fun-Controlnet weights — Q8 control is a follow-up. bf16 peak fits the M5
+    Max envelope (validated sc-2257).
+    """
+    if model_id != "z_image_turbo":
+        raise RuntimeError(
+            f"mlx_flux_runner: controlImagePaths is only supported for z_image_turbo, not {model_id!r}."
+        )
+    if len(control_image_paths) != len(seeds):
+        raise RuntimeError(
+            f"mlx_flux_runner: controlImagePaths length ({len(control_image_paths)}) "
+            f"must equal seeds list length ({len(seeds)})."
+        )
+
+    from huggingface_hub import hf_hub_download
+    from mflux.models.common.config.model_config import ModelConfig
+    from mflux.models.z_image.variants.z_image_control import ZImageControl
+
+    control_scale = float(spec.get("controlScale") or 1.0)
+    control_weights = spec.get("controlWeights") or {}
+    repo = str(control_weights.get("repo") or _Z_IMAGE_CONTROL_REPO)
+    filename = str(control_weights.get("filename") or _Z_IMAGE_CONTROL_FILE)
+    _log(f"resolving Z-Image ControlNet weights {repo}/{filename}")
+    cn_path = hf_hub_download(repo_id=repo, filename=filename)
+
+    lora_paths: list[str] = []
+    lora_scales: list[float] = []
+    for index, lora in enumerate(loras):
+        path = str(lora.get("path") or "")
+        if not path:
+            raise RuntimeError(f"mlx_flux_runner: LoRA #{index + 1} has no path.")
+        try:
+            scale = float(lora.get("weight", 1.0))
+        except (TypeError, ValueError):
+            scale = 1.0
+        lora_paths.append(path)
+        lora_scales.append(scale)
+
+    _log(
+        f"loading ZImageControl model={model_id} controlScale={control_scale} "
+        f"loras={len(lora_paths)} steps={steps} (bf16)"
+    )
+    model = ZImageControl(
+        control_weights_path=cn_path,
+        quantize=None,
+        lora_paths=lora_paths or None,
+        lora_scales=lora_scales or None,
+        model_config=ModelConfig.z_image_turbo(),
+    )
+    _log("ZImageControl loaded; entering control generation loop")
+
+    images: list[str] = []
+    for index, seed in enumerate(seeds):
+        iter_prompt = prompts_override[index] if prompts_override else prompt
+        result = model.generate_image(
+            seed=int(seed),
+            prompt=iter_prompt,
+            control_image_path=control_image_paths[index],
+            control_context_scale=control_scale,
+            num_inference_steps=steps,
+            height=height,
+            width=width,
+            guidance=guidance,
+            negative_prompt=negative_prompt,
+        )
+        path = out_dir / f"mlx_z_image_control_{index:04d}.png"
+        result.image.save(path, "PNG")
+        images.append(str(path))
+        _log(f"generated control image {index + 1}/{len(seeds)} -> {path}")
+
+    payload = {"images": images}
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+    print(json.dumps(payload))
+    return 0
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         print(json.dumps({"error": "mlx_flux_runner expects exactly one argument: the spec JSON path"}))
@@ -175,6 +288,28 @@ def main() -> int:
     out_dir = Path(spec["outDir"])
     out_dir.mkdir(parents=True, exist_ok=True)
     result_path = out_dir / "result.json"
+
+    # Z-Image strict pose ControlNet (sc-2257): per-iteration rendered skeletons
+    # condition the ported ZImageControl variant. Distinct dispatch from the
+    # generic loop below (different class + generate signature).
+    control_image_paths = [str(p) for p in (spec.get("controlImagePaths") or []) if p]
+    if control_image_paths:
+        return _run_z_image_control(
+            spec=spec,
+            model_id=model_id,
+            prompt=prompt,
+            prompts_override=prompts_override,
+            negative_prompt=negative_prompt,
+            seeds=seeds,
+            height=height,
+            width=width,
+            steps=steps,
+            guidance=guidance,
+            loras=loras,
+            control_image_paths=control_image_paths,
+            out_dir=out_dir,
+            result_path=result_path,
+        )
 
     # Heavy imports deferred until the spec is valid: a bad spec fails cleanly
     # before mflux loads MLX + the multi-GB transformer.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -84,7 +84,11 @@
         // the best-effort tier). Surfaces Z-Image in the Character Studio pose
         // picker. character_image capability is NOT required — poseLibrary alone
         // gates the picker; the worker dispatches by model id.
-        "poseLibrary": true
+        "poseLibrary": true,
+        // Strict ControlNet → expose the pose-lock-strength slider
+        // (advanced.controlScale, read by MlxZImageAdapter._control_scale). The
+        // best-effort tiers have no strength control, so they omit this flag.
+        "poseControlScale": true
       }
     },
     {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -77,7 +77,14 @@
             { "label": "Tongyi-MAI prompting discussion", "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo/discussions/8" },
             { "label": "Z-Image prompt enhancer template", "url": "https://huggingface.co/spaces/Tongyi-MAI/Z-Image-Turbo/blob/main/pe.py" }
           ]
-        }
+        },
+        // Strict pose tier (sc-2257): on the macOS MLX backend the worker renders
+        // the selected library pose to an OpenPose skeleton and conditions the
+        // ported Z-Image Fun-Controlnet-Union branch on it (true pose lock, not
+        // the best-effort tier). Surfaces Z-Image in the Character Studio pose
+        // picker. character_image capability is NOT required — poseLibrary alone
+        // gates the picker; the worker dispatches by model id.
+        "poseLibrary": true
       }
     },
     {

--- a/scripts/spikes/z_image_controlnet_validate.py
+++ b/scripts/spikes/z_image_controlnet_validate.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""sc-2257 — real-weights validation of the Z-Image strict pose ControlNet port.
+
+Runs in the mflux SIDECAR venv (the one with the ported mflux fork +
+Fun-Controlnet-Union weights). Renders a bundled COCO-18 pose skeleton, loads the
+ported ``ZImageControl`` (base Z-Image-Turbo + Fun-Controlnet-Union-2.1-8steps),
+and generates two images at a shared seed/prompt:
+
+  - ``control_context_scale = 0.0`` — must reproduce base Z-Image (parity gate;
+    the control hints are multiplied by 0).
+  - ``control_context_scale = <scale>`` — pose-locked output that should follow
+    the rendered skeleton.
+
+USAGE (on the Mac, sidecar venv):
+    python scripts/spikes/z_image_controlnet_validate.py \
+        --cn /path/to/Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors \
+        --poses apps/web/public/poses/index.json \
+        --category tpose --steps 8 --scale 1.0 --out /tmp/sc2257_out
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+
+def _load_pose_keypoints(poses_index: Path, category: str) -> tuple[str, list]:
+    data = json.loads(poses_index.read_text())
+    poses = data.get("poses", [])
+    for p in poses:
+        if p.get("category") == category:
+            return p.get("id"), p.get("keypoints")
+    # fall back to the first pose
+    return poses[0].get("id"), poses[0].get("keypoints")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cn", required=True, help="Fun-Controlnet-Union safetensors path")
+    ap.add_argument("--poses", default="apps/web/public/poses/index.json")
+    ap.add_argument("--category", default="tpose")
+    ap.add_argument("--prompt", default="a full body studio photograph of a person, plain grey background, sharp focus")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--scale", type=float, default=1.0)
+    ap.add_argument("--size", type=int, default=1024)
+    ap.add_argument("--out", default="/tmp/sc2257_out")
+    args = ap.parse_args()
+
+    import mlx.core as mx
+    import numpy as np
+    from PIL import Image
+
+    # SceneWorks skeleton renderer (worker module on sys.path via repo root)
+    sys.path.insert(0, str(Path("apps/worker").resolve()))
+    from scene_worker.openpose_skeleton import draw_bodypose, normalize_keypoints
+
+    from mflux.models.z_image.variants.z_image_control import ZImageControl
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    pose_id, raw_kp = _load_pose_keypoints(Path(args.poses), args.category)
+    keypoints = normalize_keypoints(raw_kp)
+    skel = draw_bodypose(args.size, args.size, keypoints)
+    skel_path = out / f"skeleton_{pose_id}.png"
+    Image.fromarray(skel).save(skel_path)
+    print(f"[validate] pose={pose_id} skeleton -> {skel_path}", flush=True)
+
+    t0 = time.time()
+    model = ZImageControl(control_weights_path=args.cn)
+    print(f"[validate] ZImageControl loaded in {time.time() - t0:.1f}s (bits={model.bits})", flush=True)
+
+    common = dict(
+        seed=args.seed,
+        prompt=args.prompt,
+        control_image_path=str(skel_path),
+        num_inference_steps=args.steps,
+        height=args.size,
+        width=args.size,
+    )
+
+    t1 = time.time()
+    img0 = model.generate_image(control_context_scale=0.0, **common)
+    p0 = out / f"scale0_{pose_id}.png"
+    img0.save(p0)
+    print(f"[validate] scale=0.0 -> {p0}  ({time.time() - t1:.1f}s)", flush=True)
+
+    t2 = time.time()
+    img1 = model.generate_image(control_context_scale=args.scale, **common)
+    p1 = out / f"scale{args.scale}_{pose_id}.png"
+    img1.save(p1)
+    print(f"[validate] scale={args.scale} -> {p1}  ({time.time() - t2:.1f}s)", flush=True)
+
+    # mflux generate_image returns a GeneratedImage wrapper; .image is the PIL image
+    a0 = np.asarray(getattr(img0, "image", img0), dtype=np.float32)
+    a1 = np.asarray(getattr(img1, "image", img1), dtype=np.float32)
+    diff = float(np.abs(a0 - a1).mean())
+    print(f"[validate] mean|scale0 - scale{args.scale}| = {diff:.3f} (0-255 scale); "
+          f"expect >0 (control steers). Inspect {p1} vs skeleton for pose lock.", flush=True)
+    print("[validate] DONE", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2569,6 +2569,73 @@ def test_mlx_flux2_pose_set_builds_per_iteration_skeleton_specs(tmp_path, monkey
     assert captured["raw_settings"].get("poseLibrary") is True
 
 
+def test_mlx_z_image_pose_set_builds_control_skeleton_specs(tmp_path, monkeypatch):
+    """sc-2257: a job with advanced.poses on z_image_turbo (MLX) renders each pose to a
+    skeleton and passes it as a per-iteration controlImagePaths entry + controlScale to
+    the sidecar (strict Fun-Controlnet-Union tier). Unlike the best-effort Qwen/Flux2
+    tiers, the prompt stays plain (the ControlNet drives the pose — the skeleton cue
+    would make Z-Image draw a skeleton), and no reference is used."""
+    import numpy as _np
+    from scene_worker import image_adapters as ia
+
+    adapter = ia.MlxZImageAdapter()
+    monkeypatch.setattr(ia.MlxZImageAdapter, "_sidecar_available", lambda self: True)
+    # draw_bodypose needs cv2 (absent in the CI venv); stub to a tiny array. The
+    # adapter passes a resolution-proportional stickwidth, so accept the kwarg.
+    monkeypatch.setattr(
+        ia, "draw_bodypose", lambda w, h, kps, stickwidth=4: _np.zeros((h, w, 3), dtype=_np.uint8)
+    )
+
+    captured: dict = {}
+
+    def fake_run_sidecar(self, *, job_id, work_dir, label, total, spec, progress, cancel_requested):
+        captured["spec"] = spec
+        return [str(work_dir / f"out_{i}.png") for i in range(total)]
+
+    monkeypatch.setattr(ia.MlxZImageAdapter, "_run_sidecar", fake_run_sidecar)
+
+    def fake_writer(self, *, image_count, image_at_index, raw_settings, **kwargs):
+        captured["raw_settings"] = raw_settings
+        return {"images": image_count}
+
+    monkeypatch.setattr(ia.ImageAssetWriter, "write_incremental_outputs", fake_writer)
+
+    kp = [[0.5, 0.1 + 0.04 * i] for i in range(18)]
+    job = {
+        "id": "job_z_image_pose",
+        "payload": {
+            "projectId": "p",
+            "mode": "character_image",
+            "model": "z_image_turbo",
+            "prompt": "the character",
+            "count": 1,
+            "width": 32,
+            "height": 32,
+            "advanced": {"poses": [{"id": "sit_01", "keypoints": kp}, {"id": "stand_01", "keypoints": kp}]},
+        },
+    }
+    adapter.generate(
+        settings=SimpleNamespace(gpu_id="cpu"),
+        job=job,
+        request=image_request_from_job(job),
+        project_path=tmp_path,
+        progress=lambda *a, **k: None,
+        cancel_requested=lambda: False,
+    )
+    spec = captured["spec"]
+    # One sidecar iteration per pose (2), shared seed across the set.
+    assert len(spec["seeds"]) == 2
+    assert spec["seeds"][0] == spec["seeds"][1]
+    # Strict tier: plain prompt (no skeleton cue), the ControlNet drives the pose.
+    assert spec["prompts"] is None
+    paths = spec["controlImagePaths"]
+    assert len(paths) == 2
+    for entry in paths:
+        assert "pose_skeleton_" in entry and entry.endswith(".png")
+    assert spec["controlScale"] == 1.0  # default lock strength
+    assert captured["raw_settings"].get("poseLibrary") is True
+
+
 def test_mlx_flux2_requires_sidecar_when_missing(monkeypatch):
     # When the sidecar venv is missing, generate() must surface an actionable
     # error rather than silently producing nothing.


### PR DESCRIPTION
## sc-2257 — Z-Image strict pose ControlNet tier

Adds a **strict (true pose-lock) pose tier for Z-Image-Turbo** on the macOS MLX backend, by porting `alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` (Apache-2.0) into the mflux Z-Image stack and wiring it through the worker. Epic [2249](https://app.shortcut.com/trefry/epic/2249) — the only native, license-clean pose ControlNet among the new backbones.

### The port (mflux fork)
The CN is a **VACE-style** mechanism, not the simple FLUX zero-init-Linear template: 15 control transformer blocks (base places 0,2,…,28) + 2 control noise-refiners + a 33-ch VAE-encoded control context, dual-injecting per-block hints into the base `noise_refiner` and main loop. Implemented in `michaeltrefry/mflux@claude/sc2257-z-image-controlnet` (branches from `claude/flux2-kv-cache`, so the FLUX.2 KV-cache work is preserved):
- `ZImageControlTransformerBlock`, `ZImageControlTransformer`, `ZImageControl` variant + initializer.
- Reuses the image RoPE/padding for the control branch, so `control_context=None` / `control_context_scale=0` reproduce base Z-Image **bit-for-bit**.

`requirements-mlx-flux.txt` is repinned to that branch.

### Worker wiring (this PR)
- **`mlx_flux_runner`**: new `controlImagePaths` / `controlScale` / `controlWeights` spec keys route `z_image_turbo` to `ZImageControl` (`hf_hub_download`s the 8-step Union weights; bf16).
- **`MlxZImageAdapter`**: `advanced.poses` renders each pose to a resolution-proportional COCO-18 skeleton and conditions the ControlNet on it. No reference needed (Z-Image has no IP-Adapter); identity comes from the prompt.
- **Manifest + constants**: `ui.poseLibrary` on `z_image_turbo` surfaces it in the Character Studio pose picker (frontend unchanged; worker dispatches by model id).

### Two findings baked in
1. **Strict tier uses the plain prompt.** The best-effort `augment_prompt_for_pose` cue ("…OpenPose skeleton reference image") made Z-Image literally *draw a skeleton* in the scene. The ControlNet drives the pose.
2. **Skeleton stick width scales with resolution.** The default 4px at 1024² is a weak, partly out-of-distribution signal for the DWPose-trained head (arms-down even at scale 2.0, which also destroys quality). ~12px@1024 locks cleanly at scale 1.0.

### Validation (M5 Max, bf16, 1024² 8-step, ~3.4 s/step)
- `scale=0` ≡ base Z-Image (bit-exact — resolves the spike's padding/RoPE-alignment risk).
- `scale=1.0` + a detailed clothed prompt → clean, pixel-aligned pose lock.
- Full `runner → ZImageControl → image` path green across poses.
- Numerical parity vs the torch VideoX-Fun reference was not run (heavy second env); covered by the bit-exact scale-0 gate + the visual lock.

### Tests
447 worker (new `test_mlx_z_image_pose_set_builds_control_skeleton_specs`) + 155 web green. Validation script at `scripts/spikes/z_image_controlnet_validate.py`.

### Follow-ups
Q8 control quantization (the control branch is added after base quantization, so it's bf16 for now); optional DWPose-format render (hands/face) for an even firmer lock; control-scale slider in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
