### PR TITLE
fix(worker): diagnosable MLX sidecar OOM/crash failures (sc-2274)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -2630,7 +2630,10 @@ class MlxFluxAdapter:
         # heartbeat thread keeps it alive during the (minutes-long) run. Mirrors
         # LensTurboAdapter._run_sidecar.
         with stdout_log.open("w", encoding="utf-8") as out:
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=None)
+            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
+            # leaves a partial traceback we can surface; result.json stays the
+            # authoritative success channel (_read_result prefers it).
+            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
             while True:
                 try:
                     proc.wait(timeout=2)
@@ -2646,6 +2649,7 @@ class MlxFluxAdapter:
         result = self._read_result(work_dir, stdout_log)
         if proc.returncode != 0 or "error" in result:
             error = result.get("error") or f"MLX FLUX sidecar exited with code {proc.returncode}."
+            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
             emit_worker_event(
                 "mlx_flux_sidecar_failed",
                 jobId=job_id,
@@ -2678,6 +2682,40 @@ class MlxFluxAdapter:
             except ValueError:
                 continue
         return {"error": "MLX FLUX sidecar produced no parseable result."}
+
+
+def _mlx_sidecar_failure_detail(error: str, returncode: int, stdout_log: Path) -> str:
+    """Enrich an opaque MLX-sidecar failure with the OS exit signal + output tail.
+
+    A *negative* return code means the OS killed the sidecar with a signal, which
+    bypasses ``mlx_flux_runner``'s ``try/except`` (so it never gets to write a
+    structured error — which is exactly why the only message is "produced no
+    parseable result"). The signal tells us which failure mode it was:
+
+      - ``-9`` (SIGKILL): macOS memory pressure / jetsam — i.e. out of memory.
+      - ``-6`` (SIGABRT) / ``-11`` (SIGSEGV): a native MLX/Metal abort or fault.
+
+    For the abort/fault cases a partial traceback usually lands in the captured
+    output (stderr is now merged into ``stdout.log``), so we append a short tail.
+    """
+    parts: list[str] = [error] if error else []
+    if returncode < 0:
+        sig = -returncode
+        label = {6: "SIGABRT", 9: "SIGKILL", 11: "SIGSEGV"}.get(sig, f"signal {sig}")
+        if sig == 9:
+            parts.append(
+                f"sidecar killed by {label} — almost certainly out of memory; "
+                "try a lower resolution, Q4 quantization, or fewer LoRAs"
+            )
+        else:
+            parts.append(f"sidecar crashed with {label} (native MLX/Metal fault)")
+    try:
+        tail = "\n".join(stdout_log.read_text(encoding="utf-8").splitlines()[-15:]).strip()
+    except OSError:
+        tail = ""
+    if tail:
+        parts.append(f"last sidecar output:\n{tail}")
+    return " — ".join(parts) if parts else "MLX sidecar failed with no output."
 
 
 class MlxQwenAdapter:
@@ -2935,7 +2973,10 @@ class MlxQwenAdapter:
             f"Running {label} ({total} image(s)).",
         )
         with stdout_log.open("w", encoding="utf-8") as out:
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=None)
+            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
+            # leaves a partial traceback we can surface; result.json stays the
+            # authoritative success channel (_read_result prefers it).
+            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
             while True:
                 try:
                     proc.wait(timeout=2)
@@ -2951,6 +2992,7 @@ class MlxQwenAdapter:
         result = self._read_result(work_dir, stdout_log)
         if proc.returncode != 0 or "error" in result:
             error = result.get("error") or f"MLX Qwen sidecar exited with code {proc.returncode}."
+            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
             emit_worker_event(
                 "mlx_qwen_sidecar_failed",
                 jobId=job_id,
@@ -3233,7 +3275,10 @@ class MlxZImageAdapter:
             f"Running {label} ({total} image(s)).",
         )
         with stdout_log.open("w", encoding="utf-8") as out:
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=None)
+            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
+            # leaves a partial traceback we can surface; result.json stays the
+            # authoritative success channel (_read_result prefers it).
+            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
             while True:
                 try:
                     proc.wait(timeout=2)
@@ -3249,6 +3294,7 @@ class MlxZImageAdapter:
         result = self._read_result(work_dir, stdout_log)
         if proc.returncode != 0 or "error" in result:
             error = result.get("error") or f"MLX Z-Image sidecar exited with code {proc.returncode}."
+            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
             emit_worker_event(
                 "mlx_z_image_sidecar_failed",
                 jobId=job_id,
@@ -3937,7 +3983,10 @@ class MlxFlux2Adapter:
             f"Running {label} ({total} image(s)).",
         )
         with stdout_log.open("w", encoding="utf-8") as out:
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=None)
+            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
+            # leaves a partial traceback we can surface; result.json stays the
+            # authoritative success channel (_read_result prefers it).
+            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
             while True:
                 try:
                     proc.wait(timeout=2)
@@ -3953,6 +4002,7 @@ class MlxFlux2Adapter:
         result = MlxFluxAdapter._read_result(work_dir, stdout_log)
         if proc.returncode != 0 or "error" in result:
             error = result.get("error") or f"MLX FLUX.2 sidecar exited with code {proc.returncode}."
+            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
             emit_worker_event(
                 "mlx_flux2_sidecar_failed",
                 jobId=job_id,
@@ -5609,7 +5659,10 @@ class LensTurboAdapter:
         # worker log for diagnostics. Poll so the job stays cancelable; the
         # heartbeat thread keeps it alive during the (minutes-long) run.
         with stdout_log.open("w", encoding="utf-8") as out:
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=None)
+            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
+            # leaves a partial traceback we can surface; result.json stays the
+            # authoritative success channel (_read_result prefers it).
+            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
             while True:
                 try:
                     proc.wait(timeout=2)

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -250,8 +250,20 @@ def main() -> int:
         _log(f"generated image {index + 1}/{len(seeds)} -> {path}")
 
     payload = {"images": images}
+    # Self-report the MLX peak unified-memory high-water mark so the worker can
+    # build a real per-(model, quantize, resolution, #loras) memory profile and
+    # warn before a future run OOMs the sidecar (a hard SIGKILL that bypasses the
+    # try/except below and surfaces only as "produced no parseable result").
+    # Telemetry only — never fail a finished run over it.
+    try:
+        import mlx.core as mx
+
+        payload["peakMemoryBytes"] = int(mx.get_peak_memory())
+    except Exception:  # pragma: no cover - older mlx / probe failure
+        pass
     result_path.write_text(json.dumps(payload), encoding="utf-8")
     print(json.dumps(payload))
+    _log(f"done: {len(images)} image(s); peakMemoryBytes={payload.get('peakMemoryBytes')}")
     return 0
 
 

--- a/tests/test_mlx_sidecar_failure_detail.py
+++ b/tests/test_mlx_sidecar_failure_detail.py
@@ -1,0 +1,80 @@
+"""Unit tests for ``_mlx_sidecar_failure_detail`` (sc-2274).
+
+The MLX sidecars run out-of-process; when the OS kills one with a signal
+(SIGKILL on memory pressure, SIGABRT/SIGSEGV on a native Metal fault) it
+bypasses ``mlx_flux_runner``'s ``try/except`` and the only structured error
+is the opaque "produced no parseable result". ``_mlx_sidecar_failure_detail``
+turns the (negative) return code + any captured output into an actionable
+message. These tests pin that behavior.
+"""
+
+from __future__ import annotations
+
+from scene_worker.image_adapters import _mlx_sidecar_failure_detail
+
+BASE = "MLX FLUX sidecar produced no parseable result."
+
+
+def test_sigkill_is_reported_as_out_of_memory():
+    msg = _mlx_sidecar_failure_detail(BASE, -9, _missing_log())
+    assert BASE in msg
+    assert "SIGKILL" in msg
+    assert "out of memory" in msg
+    # Actionable levers are surfaced to the user.
+    assert "Q4" in msg
+    assert "resolution" in msg
+    assert "LoRA" in msg
+
+
+def test_sigabrt_is_reported_as_native_fault():
+    msg = _mlx_sidecar_failure_detail(BASE, -6, _missing_log())
+    assert "SIGABRT" in msg
+    assert "native MLX/Metal fault" in msg
+    assert "out of memory" not in msg
+
+
+def test_sigsegv_is_reported_as_native_fault():
+    msg = _mlx_sidecar_failure_detail(BASE, -11, _missing_log())
+    assert "SIGSEGV" in msg
+    assert "native MLX/Metal fault" in msg
+
+
+def test_unknown_signal_uses_generic_label():
+    msg = _mlx_sidecar_failure_detail(BASE, -15, _missing_log())
+    assert "signal 15" in msg
+
+
+def test_clean_nonzero_exit_is_unchanged():
+    # A positive return code means the runner exited normally and already wrote
+    # a structured error; we must not invent a signal explanation.
+    msg = _mlx_sidecar_failure_detail("some structured error", 1, _missing_log())
+    assert msg == "some structured error"
+
+
+def test_captured_output_tail_is_appended(tmp_path):
+    log = tmp_path / "stdout.log"
+    log.write_text("noise\nRuntimeError: kaboom\n", encoding="utf-8")
+    msg = _mlx_sidecar_failure_detail(BASE, -6, log)
+    assert "last sidecar output:" in msg
+    assert "RuntimeError: kaboom" in msg
+
+
+def test_output_tail_is_limited_to_last_15_lines(tmp_path):
+    log = tmp_path / "stdout.log"
+    log.write_text("\n".join(f"line{i}" for i in range(40)) + "\n", encoding="utf-8")
+    msg = _mlx_sidecar_failure_detail(BASE, 1, log)
+    assert "line39" in msg  # newest line kept
+    assert "line25" in msg  # 40 lines -> tail is line25..line39
+    assert "line24" not in msg  # everything older is dropped
+    assert "line0" not in msg
+
+
+def test_no_error_and_no_output_has_a_fallback(tmp_path):
+    msg = _mlx_sidecar_failure_detail("", 0, tmp_path / "missing.log")
+    assert msg == "MLX sidecar failed with no output."
+
+
+def _missing_log():
+    from pathlib import Path
+
+    return Path("/nonexistent/stdout.log")


### PR DESCRIPTION
## What

The MLX image sidecars (FLUX, Qwen, Z-Image, FLUX.2) run out-of-process. When the OS kills one with a signal — **SIGKILL** on memory pressure (jetsam / out-of-memory), or **SIGABRT/SIGSEGV** on a native Metal fault — it bypasses `mlx_flux_runner.py`'s `try/except`, so the only error surfaced was the opaque `MLX FLUX sidecar produced no parseable result.` That made a real OOM (a `flux2_klein_9b_true_v2` Character Studio image with 2 LoRAs) undiagnosable.

## Changes

- New `_mlx_sidecar_failure_detail()` interprets the negative return code: `-9` → out-of-memory with an actionable hint (*lower resolution / Q4 / fewer LoRAs*), `-6`/`-11` → native MLX/Metal fault; appends a 15-line tail of captured output. Wired into the FLUX, Qwen, Z-Image, and FLUX.2 failure branches.
- All 5 sidecar `Popen` calls: `stderr=None` → `stderr=subprocess.STDOUT`, so a native crash's partial traceback is retained in `stdout.log` (`result.json` stays the authoritative success channel).
- `mlx_flux_runner.py` self-reports `peakMemoryBytes` via `mx.get_peak_memory()` (telemetry only; never fails a run) to seed memory profiling.
- New `tests/test_mlx_sidecar_failure_detail.py` — 8 cases (signal mapping, output-tail capture + 15-line truncation, clean-exit passthrough, empty fallback).

## Why

First slice of epic [sc-2273](https://app.shortcut.com/trefry/epic/2273) (GPU/unified-memory preflight + insufficient-hardware warnings). Turns a silent OOM into an actionable message and seeds real peak-memory telemetry the rest of the epic builds on.

## Test

`python -m pytest tests/test_mlx_sidecar_failure_detail.py` green; CI worker subset (`test_worker_runtime`, `test_worker_gpu`, `test_person_adapters`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
