### PR TITLE
feat(image-studio): add Edit button to fullscreen image viewer

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1214,6 +1214,52 @@ export function App() {
     setActiveView("Image");
   }
 
+  // Resolve an edit-capable model whose family matches the image's generating model.
+  // Prefers the exact generating model when it can edit, then any same-family
+  // edit-capable model; returns null so Image Studio keeps its default edit model
+  // when nothing matches.
+  function editModelForAsset(asset) {
+    const sourceModelId = asset?.recipe?.model;
+    if (!sourceModelId) {
+      return null;
+    }
+    const canEdit = (item) => {
+      const caps = item?.capabilities ?? [];
+      return caps.includes("edit_image") || caps.includes("image_edit");
+    };
+    const sourceModel = imageModels.find((item) => item.id === sourceModelId);
+    if (sourceModel && canEdit(sourceModel)) {
+      return sourceModel.id;
+    }
+    const families = modelLoraFamilies(sourceModel ?? { family: sourceModelId });
+    if (families.length) {
+      const sibling = imageModels.find(
+        (item) => canEdit(item) && modelLoraFamilies(item).some((family) => families.includes(family)),
+      );
+      if (sibling) {
+        return sibling.id;
+      }
+    }
+    return null;
+  }
+
+  // "Edit" from the fullscreen preview: open Image Studio in edit mode with this
+  // image as the source, preselecting the family-matched edit model when possible.
+  function sendAssetToImageEdit(asset) {
+    if (!asset) {
+      return;
+    }
+    setSelectedAssetId(asset.id);
+    setStudioLaunch({
+      id: crypto.randomUUID(),
+      view: "Image",
+      assetId: asset.id,
+      mode: "edit_image",
+      model: editModelForAsset(asset),
+    });
+    setActiveView("Image");
+  }
+
   function sendAssetToVideo(asset, mode = null) {
     if (!asset) {
       return;
@@ -1670,6 +1716,7 @@ export function App() {
           }}
           nextAsset={previewNavigation.next}
           onClose={() => setPreviewAsset(null)}
+          onEditImage={sendAssetToImageEdit}
           onPreviewAsset={(asset, direction) => {
             if (direction) {
               previewDirectionRef.current = direction;

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -377,6 +377,7 @@ export function FullscreenPreview({
   deleteAsset,
   nextAsset,
   onClose,
+  onEditImage,
   onPreviewAsset,
   previousAsset,
   purgeAsset,
@@ -439,6 +440,11 @@ export function FullscreenPreview({
             </div>
           ) : null}
           <div className="preview-actions">
+            {onEditImage && asset.type === "image" ? (
+              <button onClick={() => onEditImage(asset)} type="button">
+                Edit
+              </button>
+            ) : null}
             <button onClick={() => updateAssetStatus(asset, { favorite: !asset.status?.favorite })} type="button">
               {asset.status?.favorite ? "Saved" : "Favorite"}
             </button>

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -303,6 +303,12 @@ export function ImageStudio() {
       return;
     }
     setMode(launchRequest.mode);
+    // Preselect the family-matched edit model resolved at launch time (App.jsx). It's
+    // edit-capable by construction, so the availableModels snap-to-first effect leaves
+    // it in place; when absent the snap falls back to the default edit model.
+    if (launchRequest.model) {
+      setModel(launchRequest.model);
+    }
     if (launchRequest.mode === "edit_image" && selectedAsset?.id) {
       setSourceAssetId(selectedAsset.id);
     }


### PR DESCRIPTION
## Summary
Adds an **Edit** button to the large/fullscreen image viewer. Clicking it opens Image Studio in **Edit** mode with that image preselected as the source, matching the generating model's family when possible.

## Behavior
- The button appears only for image assets in the fullscreen preview.
- Click → navigate to Image Studio, `mode = "edit_image"`, source image = that image.
- **Model matching:** exact generating model if it's edit-capable → else a same-family edit-capable model → else `null`, in which case Image Studio keeps its default edit model (via the existing "snap to first available edit model" effect).

## Changes
- **`apps/web/src/components/assetPanels.jsx`** — `FullscreenPreview` gains an `onEditImage` prop and an Edit button (image-only).
- **`apps/web/src/App.jsx`** — `editModelForAsset()` resolves the family-matched edit-capable model (via `modelLoraFamilies`); `sendAssetToImageEdit()` dispatches the edit-mode `studioLaunch` packet (now carrying an optional `model`) and navigates; wired onto `<FullscreenPreview>`.
- **`apps/web/src/screens/ImageStudio.jsx`** — the `studioLaunch` consumer effect applies `launchRequest.model` when present.

## Verification
- `vite build` → clean (exit 0)
- `npm test` (vitest + jsdom) → **260/260 passing**

Interactive click-through wasn't run: the fullscreen Edit button is only reachable with the backend API + seeded project assets, which the dev server alone can't exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)