### PR TITLE
feat(character-studio): DWPose whole-body render + 0.9 pose-lock default (sc-2257)

### DIFF
--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -904,9 +904,9 @@ export function CharacterPoseLibrary({
   const [selectedPoseIds, setSelectedPoseIds] = React.useState([]);
   const [faceRestore, setFaceRestore] = React.useState(false);
   // Strict ControlNet pose-lock strength (sc-2257). Only the strict tier
-  // (ui.poseControlScale) honours advanced.controlScale; default 1.0 locks
-  // cleanly, 0.65–1.0 is the model-card range, >~1.2 starts to degrade quality.
-  const [controlScale, setControlScale] = React.useState(1.0);
+  // (ui.poseControlScale) honours advanced.controlScale; default 0.9 matches the
+  // reference pipeline, 0.65–1.0 is the model-card range, >~1.2 degrades quality.
+  const [controlScale, setControlScale] = React.useState(0.9);
   const supportsControlScale = Boolean(activePoseModel?.ui?.poseControlScale);
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
@@ -964,7 +964,14 @@ export function CharacterPoseLibrary({
   }
 
   async function generate() {
-    const poses = selectedPoseIds.map((id) => byId[id]).filter(Boolean).map((pose) => ({ id: pose.id, keypoints: pose.keypoints }));
+    const poses = selectedPoseIds.map((id) => byId[id]).filter(Boolean).map((pose) => ({
+      id: pose.id,
+      keypoints: pose.keypoints,
+      // Forward DWPose hand/face keypoints when a pose carries them (sc-2257) — the
+      // strict Z-Image tier renders them for a firmer, more in-distribution lock.
+      ...(pose.hands ? { hands: pose.hands } : {}),
+      ...(pose.face ? { face: pose.face } : {}),
+    }));
     if (!referenceAssetId || !poses.length || submitting || !activePoseModel) {
       return;
     }
@@ -1073,8 +1080,9 @@ export function CharacterPoseLibrary({
             <span className="lora-weight-value">{controlScale.toFixed(2)}</span>
           </div>
           <p className="field-hint">
-            How hard the ControlNet locks the pose. 1.0 is a clean lock; lower (toward 0.65) loosens it for
-            more natural variation, higher (&gt;1.2) over-constrains and can degrade quality.
+            How hard the ControlNet locks the pose. 0.9 (the reference default) is a clean lock; lower
+            (toward 0.65) loosens it for more natural variation, higher (&gt;1.2) over-constrains and can
+            degrade quality.
           </p>
         </div>
       ) : null}

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -37,7 +37,7 @@ from .character_studio_angles import (
     augment_prompt_for_angle,
     augment_prompt_for_pose,
 )
-from .openpose_skeleton import draw_bodypose, normalize_keypoints
+from .openpose_skeleton import draw_bodypose, draw_wholebody, normalize_face, normalize_hands, normalize_keypoints
 from .sampler_registry import apply_sampler, sampler_selection_from_advanced
 from .hf_cache import huggingface_cache_roots, huggingface_repo_cache_path
 from .lora_adapters import (
@@ -3197,9 +3197,16 @@ class MlxZImageAdapter:
             stick = max(6, round(min(request.width, request.height) * 0.012))
             control_image_paths = []
             for index, keypoints in enumerate(pose_keypoints):
+                # The Fun-Controlnet-Union pose head is trained on full DWPose
+                # (body + hands + face). When a pose entry carries hand/face
+                # keypoints, render them too (more in-distribution → firmer lock);
+                # body-only entries render exactly as before.
+                entry = pose_entries[index]
+                hands = normalize_hands(entry.get("hands"))
+                face = normalize_face(entry.get("face"))
                 skeleton_path = work_dir / f"pose_skeleton_{index:04d}.png"
                 Image.fromarray(
-                    draw_bodypose(request.width, request.height, keypoints, stickwidth=stick)
+                    draw_wholebody(request.width, request.height, keypoints, hands=hands, face=face, stickwidth=stick)
                 ).save(skeleton_path, "PNG")
                 control_image_paths.append(str(skeleton_path))
         try:
@@ -3272,12 +3279,12 @@ class MlxZImageAdapter:
 
     def _control_scale(self, request: ImageRequest) -> float:
         """Pose ControlNet lock strength (sc-2257). Fun-Controlnet-Union recommends
-        0.65–1.0; default 1.0 (clean pose lock, validated). Overridable via
-        advanced.controlScale, clamped to [0, 2]."""
+        0.65–1.0; default 0.9 matches the VideoX-Fun reference's own default and
+        locks cleanly. Overridable via advanced.controlScale, clamped to [0, 2]."""
         try:
-            value = float(request.advanced.get("controlScale", 1.0))
+            value = float(request.advanced.get("controlScale", 0.9))
         except (TypeError, ValueError):
-            return 1.0
+            return 0.9
         return max(0.0, min(2.0, value))
 
     def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:

--- a/apps/worker/scene_worker/openpose_skeleton.py
+++ b/apps/worker/scene_worker/openpose_skeleton.py
@@ -1,4 +1,4 @@
-"""OpenPose (COCO-18) skeleton helpers for the InstantID pose library (sc-2064).
+"""OpenPose / DWPose skeleton helpers for the pose library (sc-2064, sc-2257).
 
 The pose library (apps/web/public/poses/) ships normalized 18-point skeletons; the web
 sends the selected poses' keypoints in the job. This module renders an OpenPose control
@@ -6,6 +6,12 @@ image from those keypoints (matching the controlnet_aux draw_bodypose format the
 SDXL OpenPose ControlNet was trained on — no controlnet_aux dependency) and derives a
 small face box from the head keypoints so InstantID can anchor the face before the
 face-restoration pass.
+
+`draw_wholebody` (sc-2257) extends this to the full DWPose format — body + optional
+hand (21x2) + face (68) landmarks — which the Z-Image Fun-Controlnet-Union pose head
+was trained on. Body-only callers (InstantID / Qwen) keep using `draw_bodypose`; the
+strict Z-Image tier uses `draw_wholebody` and renders hands/face when a pose carries
+them (the bundled poses are body-only today; richer poses come from a DWPose detector).
 
 Keypoint order (COCO-18):
  0 nose 1 neck 2 r_sho 3 r_elb 4 r_wri 5 l_sho 6 l_elb 7 l_wri
@@ -28,12 +34,24 @@ COLORS: tuple[tuple[int, int, int], ...] = (
     (255, 0, 255), (255, 0, 170), (255, 0, 85),
 )
 
+# DWPose / OpenPose hand skeleton (21 keypoints): wrist (0) + 4 joints per finger.
+# Edge order matches controlnet_aux draw_handpose so the per-edge HSV colouring
+# lands the same way the Fun-Controlnet-Union pose head was trained on (sc-2257).
+HAND_EDGES: tuple[tuple[int, int], ...] = (
+    (0, 1), (1, 2), (2, 3), (3, 4),        # thumb
+    (0, 5), (5, 6), (6, 7), (7, 8),        # index
+    (0, 9), (9, 10), (10, 11), (11, 12),   # middle
+    (0, 13), (13, 14), (14, 15), (15, 16),  # ring
+    (0, 17), (17, 18), (18, 19), (19, 20),  # pinky
+)
+
 Keypoint = tuple[float, float] | None
 
 
-def normalize_keypoints(raw: object) -> list[Keypoint]:
-    """Coerce a job-payload keypoint list into exactly 18 normalized (x, y) | None
-    points. Accepts [x, y], [x, y, conf] (conf<=0 -> dropped), or None per entry."""
+def normalize_points(raw: object, count: int) -> list[Keypoint]:
+    """Coerce a job-payload keypoint list into exactly ``count`` normalized
+    (x, y) | None points. Accepts [x, y], [x, y, conf] (conf<=0 -> dropped), or
+    None per entry. Shared by body (18) / hand (21) / face (68) keypoints."""
     points: list[Keypoint] = []
     items = raw if isinstance(raw, (list, tuple)) else []
     for entry in items:
@@ -47,8 +65,36 @@ def normalize_keypoints(raw: object) -> list[Keypoint]:
             points.append((float(entry[0]), float(entry[1])))
         except (TypeError, ValueError):
             points.append(None)
-    points = points[:18] + [None] * max(0, 18 - len(points))
+    points = points[:count] + [None] * max(0, count - len(points))
     return points
+
+
+def normalize_keypoints(raw: object) -> list[Keypoint]:
+    """Coerce a job-payload keypoint list into exactly 18 normalized body points."""
+    return normalize_points(raw, 18)
+
+
+def normalize_hands(raw: object) -> list[list[Keypoint]] | None:
+    """Coerce optional hand keypoints into ``[left21, right21]`` (each a 21-point
+    list). Accepts a [left, right] pair or a flat 42-point list; None / empty -> None."""
+    if not isinstance(raw, (list, tuple)) or not raw:
+        return None
+    # A [left, right] pair (each itself a list of points) vs a flat 42-point list.
+    if isinstance(raw[0], (list, tuple)) and raw[0] and isinstance(raw[0][0], (list, tuple)):
+        hands = [normalize_points(hand, 21) for hand in raw[:2]]
+    else:
+        flat = normalize_points(raw, 42)
+        hands = [flat[:21], flat[21:]]
+    while len(hands) < 2:
+        hands.append([None] * 21)
+    return hands
+
+
+def normalize_face(raw: object) -> list[Keypoint] | None:
+    """Coerce optional face keypoints into 68 normalized points; None/empty -> None."""
+    if not isinstance(raw, (list, tuple)) or not raw:
+        return None
+    return normalize_points(raw, 68)
 
 
 def draw_bodypose(canvas_w: int, canvas_h: int, keypoints: list[Keypoint], stickwidth: int = 4) -> np.ndarray:
@@ -75,6 +121,78 @@ def draw_bodypose(canvas_w: int, canvas_h: int, keypoints: list[Keypoint], stick
             continue
         x, y = pts[i]
         cv2.circle(canvas, (int(x), int(y)), stickwidth, COLORS[i], thickness=-1)
+    return canvas
+
+
+def _hsv_to_rgb(hue: float) -> tuple[int, int, int]:
+    """HSV->RGB at full saturation/value (mirrors controlnet_aux's per-edge hand
+    colouring, which uses matplotlib hsv_to_rgb([h, 1, 1])). No matplotlib dep."""
+    i = int(hue * 6) % 6
+    f = hue * 6 - int(hue * 6)
+    q, t = 1 - f, f
+    r, g, b = ((1, t, 0), (q, 1, 0), (0, 1, t), (0, q, 1), (t, 0, 1), (1, 0, q))[i]
+    return (int(r * 255), int(g * 255), int(b * 255))
+
+
+def draw_handpose(canvas: np.ndarray, hands: list[list[Keypoint]], line_width: int, point_radius: int) -> np.ndarray:
+    """Draw one or both 21-point hand skeletons onto an existing canvas (in place),
+    matching the controlnet_aux/DWPose format: per-edge HSV-coloured finger bones +
+    blue joint dots. ``hands`` is a list of 21-point lists (normalized x,y | None)."""
+    import cv2
+
+    h, w = canvas.shape[:2]
+    for hand in hands:
+        if not hand:
+            continue
+        pts = [None if p is None else (int(p[0] * w), int(p[1] * h)) for p in hand]
+        for index, (a, b) in enumerate(HAND_EDGES):
+            if a >= len(pts) or b >= len(pts) or pts[a] is None or pts[b] is None:
+                continue
+            cv2.line(canvas, pts[a], pts[b], _hsv_to_rgb(index / len(HAND_EDGES)), thickness=line_width)
+        for p in pts:
+            if p is None:
+                continue
+            cv2.circle(canvas, p, point_radius, (0, 0, 255), thickness=-1)
+    return canvas
+
+
+def draw_facepose(canvas: np.ndarray, faces: list[list[Keypoint]], point_radius: int) -> np.ndarray:
+    """Draw face landmark constellations (white dots) onto an existing canvas (in
+    place), matching the DWPose face render. ``faces`` is a list of point lists."""
+    import cv2
+
+    h, w = canvas.shape[:2]
+    for face in faces:
+        if not face:
+            continue
+        for p in face:
+            if p is None:
+                continue
+            cv2.circle(canvas, (int(p[0] * w), int(p[1] * h)), point_radius, (255, 255, 255), thickness=-1)
+    return canvas
+
+
+def draw_wholebody(
+    canvas_w: int,
+    canvas_h: int,
+    keypoints: list[Keypoint],
+    hands: list[list[Keypoint]] | None = None,
+    face: list[Keypoint] | None = None,
+    stickwidth: int = 4,
+) -> np.ndarray:
+    """Render a DWPose whole-body control image: the COCO-18 body skeleton plus
+    optional hand (21x2) + face (68) landmarks, in the format the Z-Image
+    Fun-Controlnet-Union pose head was trained on (sc-2257). Body-only callers can
+    keep using ``draw_bodypose``; this is the strict Z-Image tier's renderer. Hand
+    bones / face dots scale with resolution so they stay visible at 1024²+."""
+    canvas = draw_bodypose(canvas_w, canvas_h, keypoints, stickwidth=stickwidth)
+    scale = min(canvas_w, canvas_h)
+    if hands:
+        line_width = max(2, round(scale * 0.004))
+        point_radius = max(2, round(scale * 0.004))
+        draw_handpose(canvas, hands, line_width=line_width, point_radius=point_radius)
+    if face:
+        draw_facepose(canvas, [face], point_radius=max(2, round(scale * 0.003)))
     return canvas
 
 

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -23,7 +23,10 @@ from scene_worker.instantid_adapter import (
 from scene_worker.lora_adapters import LoraPipelineState
 from scene_worker.openpose_skeleton import (
     draw_bodypose,
+    draw_wholebody,
     face_box_from_keypoints,
+    normalize_face,
+    normalize_hands,
     normalize_keypoints,
 )
 
@@ -236,6 +239,34 @@ def test_draw_bodypose_renders_colored():
     assert skel.any()  # not an all-black canvas
     # An all-empty skeleton stays black.
     assert not draw_bodypose(64, 96, [None] * 18).any()
+
+
+def test_normalize_hands_and_face():
+    # A [left, right] pair is preserved as two 21-point hands.
+    pair = normalize_hands([[[0.1, 0.1]] * 21, [[0.2, 0.2]] * 21])
+    assert pair is not None and len(pair) == 2 and len(pair[0]) == 21 and len(pair[1]) == 21
+    # A flat 42-point list splits into two 21-point hands.
+    flat = normalize_hands([[0.3, 0.3]] * 42)
+    assert flat is not None and len(flat) == 2 and len(flat[0]) == 21 and len(flat[1]) == 21
+    # Empty / None / non-list -> None.
+    assert normalize_hands(None) is None and normalize_hands([]) is None
+    # Face coerces to exactly 68 points (extra trimmed); None -> None.
+    assert len(normalize_face([[0.5, 0.4]] * 70)) == 68
+    assert normalize_face(None) is None and normalize_face([]) is None
+
+
+def test_draw_wholebody_adds_hands_and_face():
+    body = normalize_keypoints(_FRONT_KPS)
+    # Body-only path is byte-identical to draw_bodypose (InstantID/Qwen unaffected).
+    body_only = draw_wholebody(128, 192, body, stickwidth=4)
+    assert (body_only == draw_bodypose(128, 192, body, stickwidth=4)).all()
+    # Hands (off to the sides) + a face cluster (above the head) paint extra marks,
+    # including pure-white face dots that the body/hand palette never produces.
+    hands = [[[0.05, 0.5]] * 21, [[0.95, 0.5]] * 21]
+    face = [[0.5, 0.03]] * 68
+    whole = draw_wholebody(128, 192, body, hands=hands, face=face, stickwidth=4)
+    assert int((whole.sum(2) > 0).sum()) > int((body_only.sum(2) > 0).sum())
+    assert ((whole[:, :, 0] == 255) & (whole[:, :, 1] == 255) & (whole[:, :, 2] == 255)).any()
 
 
 def test_face_box_from_keypoints():

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2580,10 +2580,11 @@ def test_mlx_z_image_pose_set_builds_control_skeleton_specs(tmp_path, monkeypatc
 
     adapter = ia.MlxZImageAdapter()
     monkeypatch.setattr(ia.MlxZImageAdapter, "_sidecar_available", lambda self: True)
-    # draw_bodypose needs cv2 (absent in the CI venv); stub to a tiny array. The
-    # adapter passes a resolution-proportional stickwidth, so accept the kwarg.
+    # draw_wholebody needs cv2 (absent in the CI venv); stub to a tiny array. The
+    # adapter passes hands/face + a resolution-proportional stickwidth, so accept
+    # those kwargs. The real render is covered in test_instantid_adapter.
     monkeypatch.setattr(
-        ia, "draw_bodypose", lambda w, h, kps, stickwidth=4: _np.zeros((h, w, 3), dtype=_np.uint8)
+        ia, "draw_wholebody", lambda w, h, kps, hands=None, face=None, stickwidth=4: _np.zeros((h, w, 3), dtype=_np.uint8)
     )
 
     captured: dict = {}
@@ -2632,7 +2633,7 @@ def test_mlx_z_image_pose_set_builds_control_skeleton_specs(tmp_path, monkeypatc
     assert len(paths) == 2
     for entry in paths:
         assert "pose_skeleton_" in entry and entry.endswith(".png")
-    assert spec["controlScale"] == 1.0  # default lock strength
+    assert spec["controlScale"] == 0.9  # default lock strength (reference default)
     assert captured["raw_settings"].get("poseLibrary") is True
 
 


### PR DESCRIPTION
## sc-2257 follow-up — DWPose whole-body skeleton render + 0.9 default

Follow-up to the merged sc-2257 strict Z-Image pose tier ([#373](https://github.com/michaeltrefry/SceneWorks/pull/373)).

### Why
The `Z-Image-Turbo-Fun-Controlnet-Union` pose head is trained on **full DWPose** — body **+ hands + face**. The model's own reference asset (`VideoX-Fun/asset/pose.jpg`) confirms it: colored finger-bone skeletons on both hands + a 68-point white face-dot constellation. Our body-only render is therefore partly out-of-distribution, which is the most likely cause of the fragile/nonlinear lock (needs a thick skeleton; locks at 0.9–1.0 but drifts higher). This PR makes the renderer capable of the full DWPose format so richer pose data lights it up.

### Changes
- **`openpose_skeleton`**: add `draw_handpose` / `draw_facepose` / `draw_wholebody` (DWPose format — per-edge HSV finger bones + blue joints + white face dots) and `normalize_hands` / `normalize_face`. `draw_bodypose` is **unchanged** (InstantID / Qwen keep using it).
- **`MlxZImageAdapter`**: renders `draw_wholebody`, drawing hand/face landmarks when a pose entry carries them; the web forwards `pose.hands` / `pose.face`. **The bundled poses are body-only today, so this is a no-op until richer pose data exists** — that's the next piece (a DWPose photo→skeleton detector, scoped as a new epic).
- **`controlScale` default → 0.9** (matches the VideoX-Fun reference's own default) across the adapter, the slider, and the hint text.

### Validation
- Visual: a synthetic whole-body render reproduces the reference's DWPose style (colored hand bones + blue joints + white face dots on the body skeleton).
- `draw_wholebody` body-only path is byte-identical to `draw_bodypose`.
- 474 worker + 156 web tests green (new whole-body render + normalizer tests; updated stubs/defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
