### PR TITLE
Character Studio: 5-tab interface + move to Workspace nav (epic 2293)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -144,6 +144,9 @@ const navSections = [
     items: [
       { id: "Image", icon: Icon.Image },
       { id: "Video", icon: Icon.Video },
+      // Character Studio is a generative studio (sc-2300) — it sits with Image/Video,
+      // below Video and above Training, not in the Library section.
+      { id: "Characters", icon: Icon.Character },
       { id: "Document", icon: Icon.Wand },
       { id: "Train", icon: Icon.Train },
       { id: "Editor", icon: Icon.Editor },
@@ -154,7 +157,6 @@ const navSections = [
     items: [
       { id: "Library", label: "Assets", icon: Icon.Library },
       { id: "LibraryDataSets", label: "Data Sets", icon: Icon.Train },
-      { id: "Characters", icon: Icon.Character },
       { id: "Presets", icon: Icon.Preset },
       { id: "Models", icon: Icon.Model },
     ],
@@ -1694,7 +1696,7 @@ export function App() {
         ) : null}
 
         {activeView === "Characters" ? (
-          <CharacterStudio />
+          <CharacterStudio key={activeProject?.id ?? "default"} />
         ) : null}
         {activeView === "Settings" ? <SettingsScreen /> : null}
           </>

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2129,6 +2129,172 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Beta");
   });
 
+  it("groups the panels into accessible tabs, preserves working state, and persists the active tab (sc-2294)", async () => {
+    const baseContext = {
+      activeProject: { id: "project-1", name: "Noir" },
+      addCharacterReference: () => {},
+      archiveCharacter: () => {},
+      assets: [],
+      attachCharacterLora: () => {},
+      characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+      createCharacter: () => {},
+      createCharacterLook: () => {},
+      createCharacterTestJob: () => {},
+      deleteAsset: () => {},
+      deleteCharacterLook: () => {},
+      detachCharacterLora: () => {},
+      imageModels: [],
+      latestImageAssets: [],
+      loras: [],
+      setPreviewAsset: () => {},
+      sendCharacterToImage: () => {},
+      sendCharacterToVideo: () => {},
+      purgeAsset: () => {},
+      removeCharacterReference: () => {},
+      updateAssetStatus: () => {},
+      updateCharacter: () => {},
+      updateCharacterLook: () => {},
+      updateCharacterLora: () => {},
+      updateCharacterReference: () => {},
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+
+    // Five accessible tabs, Character selected by default.
+    const tablist = container.querySelector('[role="tablist"]');
+    expect(tablist.getAttribute("aria-label")).toBe("Character workspace");
+    expect([...container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent)).toEqual([
+      "Character",
+      "Assets",
+      "Angles",
+      "Poses",
+      "Test",
+    ]);
+    expect(container.querySelector("#character-tab-character").getAttribute("aria-selected")).toBe("true");
+
+    // The active panel is shown; the others are mounted but hidden so their state survives.
+    expect(container.querySelector("#character-panel-character").hidden).toBe(false);
+    expect(container.querySelector("#character-panel-assets").hidden).toBe(true);
+    expect(container.querySelector("#character-panel-test").hidden).toBe(true);
+
+    // The identity form carries its own section heading (sc-2295) like its siblings.
+    expect([...container.querySelectorAll("#character-panel-character .eyebrow")].map((node) => node.textContent)).toContain(
+      "Identity",
+    );
+
+    // Edit the lifted character draft, switch tabs, and switch back: the draft survives.
+    await changeField(field(container, "Name"), "Mira Vex");
+    await act(async () => {
+      container.querySelector("#character-tab-test").click();
+    });
+    expect(container.querySelector("#character-panel-test").hidden).toBe(false);
+    expect(container.querySelector("#character-panel-character").hidden).toBe(true);
+    expect(container.querySelector("#character-tab-test").getAttribute("aria-selected")).toBe("true");
+    await act(async () => {
+      container.querySelector("#character-tab-character").click();
+    });
+    expect(field(container, "Name").value).toBe("Mira Vex");
+
+    // Keyboard: arrows move between tabs (and wrap), Home/End jump to the ends.
+    await act(async () => {
+      container
+        .querySelector("#character-tab-character")
+        .dispatchEvent(new window.KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    expect(container.querySelector("#character-tab-assets").getAttribute("aria-selected")).toBe("true");
+    await act(async () => {
+      container
+        .querySelector("#character-tab-assets")
+        .dispatchEvent(new window.KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    });
+    expect(container.querySelector("#character-tab-test").getAttribute("aria-selected")).toBe("true");
+    await act(async () => {
+      container
+        .querySelector("#character-tab-test")
+        .dispatchEvent(new window.KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    expect(container.querySelector("#character-tab-character").getAttribute("aria-selected")).toBe("true");
+
+    // The active tab is persisted per workspace and restored on remount.
+    await act(async () => {
+      container.querySelector("#character-tab-poses").click();
+    });
+    expect(window.localStorage.getItem("sceneworks-studio-character-project-1")).toContain('"activeTab":"poses"');
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(baseContext, <CharacterStudio />));
+    });
+    expect(container.querySelector("#character-tab-poses").getAttribute("aria-selected")).toBe("true");
+    expect(container.querySelector("#character-panel-poses").hidden).toBe(false);
+  });
+
+  it("surfaces character videos alongside images in the Assets tab (sc-2296)", async () => {
+    const assets = [
+      { id: "img-1", type: "image", displayName: "Still", projectId: "project-1", recipe: { normalizedSettings: { characterId: "char-1" } } },
+      {
+        id: "vid-1",
+        type: "video",
+        displayName: "Clip",
+        projectId: "project-1",
+        file: { mimeType: "video/mp4", path: "clip.mp4" },
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+      },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference: () => {},
+            archiveCharacter: () => {},
+            assets,
+            attachCharacterLora: () => {},
+            characters: [{ id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] }],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: assets,
+            loras: [],
+            setPreviewAsset: () => {},
+            sendCharacterToImage: () => {},
+            sendCharacterToVideo: () => {},
+            purgeAsset: () => {},
+            removeCharacterReference: () => {},
+            updateAssetStatus: () => {},
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    await act(async () => {
+      container.querySelector("#character-tab-assets").click();
+    });
+    const section = [...container.querySelectorAll(".character-section")].find(
+      (item) => item.querySelector(".eyebrow")?.textContent === "Character assets",
+    );
+    expect(section).toBeTruthy();
+    // Both the still and the clip are listed; the clip renders as a <video>.
+    expect(section.querySelectorAll(".character-asset-thumb").length).toBe(2);
+    expect(section.querySelector("video")).toBeTruthy();
+    expect([...section.querySelectorAll("button")].some((button) => button.textContent.startsWith("Media (2)"))).toBe(true);
+  });
+
   it("switches the active character via the compact selector (sc-2025)", async () => {
     const baseContext = {
       activeProject: { id: "project-1", name: "Noir" },

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CharacterAngleSet,
   CharacterAssets,
@@ -13,6 +13,7 @@ import {
 import { CompactSelector } from "../components/CompactSelector.jsx";
 import { assetMatchesCharacter } from "../components/DatasetAddDialog.jsx";
 import { extractFamilies } from "../presetUtils.js";
+import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { useAppContext } from "../context/AppContext.js";
 
 const characterTypes = [
@@ -20,6 +21,18 @@ const characterTypes = [
   ["creature", "Creature"],
   ["object", "Object"],
 ];
+
+// Tab information architecture (epic 2293): the single stacked column is grouped
+// into five focused workspaces. Order is also the keyboard nav order.
+const CHARACTER_TABS = [
+  ["character", "Character"],
+  ["assets", "Assets"],
+  ["angles", "Angles"],
+  ["poses", "Poses"],
+  ["test", "Test"],
+];
+const CHARACTER_TAB_IDS = CHARACTER_TABS.map(([id]) => id);
+const DEFAULT_CHARACTER_TAB = "character";
 
 function typeLabel(value) {
   return characterTypes.find(([id]) => id === value)?.[1] ?? "Person";
@@ -88,6 +101,40 @@ export function CharacterStudio() {
   const [testCount, setTestCount] = useState(4);
   const [testResolution, setTestResolution] = useState("1024x1024");
   const [creatingDataset, setCreatingDataset] = useState(false);
+
+  // Active tab + per-workspace persistence (epic 2293). The component is keyed by
+  // workspace in App.jsx, so this reads the right snapshot per workspace on mount
+  // and remounts (re-running the initializer) when the workspace changes — no tab
+  // bleed across workspaces. Mirrors the studio-settings localStorage pattern.
+  const savedSettings = useMemo(() => loadStudioSettings("character", activeProject?.id ?? null), [activeProject?.id]);
+  const [activeTab, setActiveTab] = useState(() =>
+    CHARACTER_TAB_IDS.includes(savedSettings.activeTab) ? savedSettings.activeTab : DEFAULT_CHARACTER_TAB,
+  );
+  useStudioSettingsWriter("character", activeProject?.id ?? null, { activeTab });
+  const tabRefs = useRef({});
+  const activeTabIndex = CHARACTER_TABS.findIndex(([id]) => id === activeTab);
+  // Roving-tabindex keyboard nav, matching the TrainingStudio tablist: arrows wrap,
+  // Home/End jump to the ends, and focus follows the selected tab.
+  function focusTab(index) {
+    const [nextId] = CHARACTER_TABS[(index + CHARACTER_TABS.length) % CHARACTER_TABS.length];
+    setActiveTab(nextId);
+    window.requestAnimationFrame(() => tabRefs.current[nextId]?.focus());
+  }
+  function onTabKeyDown(event) {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      focusTab(activeTabIndex + 1);
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusTab(activeTabIndex - 1);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      focusTab(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      focusTab(CHARACTER_TABS.length - 1);
+    }
+  }
 
   const imageAssets = useMemo(
     () => assets.filter((asset) => ["image", "frame", "upload"].includes(asset.type)),
@@ -359,174 +406,250 @@ export function CharacterStudio() {
           <div className="empty-panel">No characters yet — use “New character” to start.</div>
         ) : (
           <section className="character-detail">
-            <form className="character-editor" onSubmit={saveCharacter}>
-              <div className="control-grid">
-                <label>
-                  Name
-                  <input onChange={(event) => setDraft((item) => ({ ...item, name: event.target.value }))} value={draft.name} />
-                </label>
-                <label>
-                  Type
-                  <select onChange={(event) => setDraft((item) => ({ ...item, type: event.target.value }))} value={draft.type}>
-                    {characterTypes.map(([value, label]) => (
-                      <option key={value} value={value}>
-                        {label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-              <label className="prompt-field">
-                Notes
-                <textarea
-                  onChange={(event) => setDraft((item) => ({ ...item, description: event.target.value }))}
-                  value={draft.description}
-                />
-              </label>
-              <div className="detail-actions">
-                <button className="primary-action" type="submit">
-                  Save
-                </button>
-                <button className="secondary-action" onClick={() => archiveCharacter(selectedCharacter.id)} type="button">
-                  Archive
-                </button>
+            <div className="segmented-control character-tabs" role="tablist" aria-label="Character workspace">
+              {CHARACTER_TABS.map(([id, label]) => (
                 <button
-                  className="secondary-action"
-                  onClick={() => onSendImage(selectedCharacter, testLookId || null, approvedReferences[0]?.assetId ?? null)}
+                  aria-controls={activeTab === id ? `character-panel-${id}` : undefined}
+                  aria-selected={activeTab === id}
+                  className={activeTab === id ? "active" : ""}
+                  id={`character-tab-${id}`}
+                  key={id}
+                  onClick={() => setActiveTab(id)}
+                  onKeyDown={onTabKeyDown}
+                  ref={(node) => {
+                    tabRefs.current[id] = node;
+                  }}
+                  role="tab"
+                  tabIndex={activeTab === id ? 0 : -1}
                   type="button"
                 >
-                  Image
+                  {label}
                 </button>
-                <button className="secondary-action" onClick={() => onSendVideo(selectedCharacter, testLookId || null)} type="button">
-                  Video
-                </button>
-              </div>
-            </form>
-            <div className="guidance-strip">
-              <strong>Reference identity</strong>
-              <span>Approve a reference image, then use Generate variations (or the Image button) to create new images that keep this character's appearance with Kolors IP-Adapter. LoRA conditioning activates in a later runtime slice.</span>
+              ))}
             </div>
 
-            <CharacterReferences
-              imageAssets={imageAssets}
-              onGenerateFromReference={(assetId) => onSendImage(selectedCharacter, testLookId || null, assetId)}
-              onPreview={onPreview}
-              referenceMessage={referenceMessage}
-              referenceAssetIds={referenceAssetIds}
-              removeCharacterReference={removeCharacterReference}
-              selectedCharacter={selectedCharacter}
-              setReferenceAssetIds={setReferenceAssetIds}
-              submitReference={submitReference}
-              updateCharacterReference={updateCharacterReference}
-            />
+            {/* Character tab — identity hub: metadata form + references + saved
+                presets (looks) + LoRAs. Every tabpanel stays mounted and is hidden
+                when inactive, so each panel's working state (incl. panel-local
+                state like the angle/pose prompt and selected pose set) survives
+                tab switches. This matches today's all-mounted render cost. */}
+            <div
+              aria-labelledby="character-tab-character"
+              className="character-tabpanel"
+              hidden={activeTab !== "character"}
+              id="character-panel-character"
+              role="tabpanel"
+            >
+              <form className="character-editor" onSubmit={saveCharacter}>
+                <div className="section-heading">
+                  <p className="eyebrow">Identity</p>
+                  <h2>Name, type &amp; notes</h2>
+                </div>
+                <div className="control-grid">
+                  <label>
+                    Name
+                    <input onChange={(event) => setDraft((item) => ({ ...item, name: event.target.value }))} value={draft.name} />
+                  </label>
+                  <label>
+                    Type
+                    <select onChange={(event) => setDraft((item) => ({ ...item, type: event.target.value }))} value={draft.type}>
+                      {characterTypes.map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <label className="prompt-field">
+                  Notes
+                  <textarea
+                    onChange={(event) => setDraft((item) => ({ ...item, description: event.target.value }))}
+                    value={draft.description}
+                  />
+                </label>
+                <div className="detail-actions">
+                  <button className="primary-action" type="submit">
+                    Save
+                  </button>
+                  <button className="secondary-action" onClick={() => archiveCharacter(selectedCharacter.id)} type="button">
+                    Archive
+                  </button>
+                  <button
+                    className="secondary-action"
+                    onClick={() => onSendImage(selectedCharacter, testLookId || null, approvedReferences[0]?.assetId ?? null)}
+                    type="button"
+                  >
+                    Image
+                  </button>
+                  <button className="secondary-action" onClick={() => onSendVideo(selectedCharacter, testLookId || null)} type="button">
+                    Video
+                  </button>
+                </div>
+              </form>
+              <div className="guidance-strip">
+                <strong>Reference identity</strong>
+                <span>Approve a reference image, then use Generate variations (or the Image button) to create new images that keep this character's appearance with Kolors IP-Adapter. LoRA conditioning activates in a later runtime slice.</span>
+              </div>
 
-            <CharacterAssets
-              assets={assets}
-              deleteAsset={deleteAsset}
-              onPreview={onPreview}
-              purgeAsset={purgeAsset}
-              selectedCharacter={selectedCharacter}
-              updateAssetStatus={updateAssetStatus}
-            />
+              <CharacterReferences
+                imageAssets={imageAssets}
+                onGenerateFromReference={(assetId) => onSendImage(selectedCharacter, testLookId || null, assetId)}
+                onPreview={onPreview}
+                referenceMessage={referenceMessage}
+                referenceAssetIds={referenceAssetIds}
+                removeCharacterReference={removeCharacterReference}
+                selectedCharacter={selectedCharacter}
+                setReferenceAssetIds={setReferenceAssetIds}
+                submitReference={submitReference}
+                updateCharacterReference={updateCharacterReference}
+              />
 
-            <CharacterAngleSet
-              addCharacterReference={addCharacterReference}
-              angleModel={angleModel}
-              angleModels={angleModels}
-              approvedReferences={approvedReferences}
-              assets={assets}
-              createImageJob={createImageJob}
-              imageLocalJobs={imageLocalJobs}
-              importAsset={importAsset}
-              latestAssets={latestAssets}
-              loras={loras}
-              onCancel={onCancelCharacterJob}
-              onDuplicate={onDuplicateCharacterJob}
-              onOpenQueue={onOpenCharacterJobQueue}
-              onPreview={onPreview}
-              onRetry={onRetryCharacterJob}
-              rememberLocalGenerationJob={rememberLocalGenerationJob}
-              selectedCharacter={selectedCharacter}
-            />
+              <CharacterLooks
+                approvedReferences={approvedReferences}
+                createCharacterLook={createCharacterLook}
+                deleteCharacterLook={deleteCharacterLook}
+                lookDraft={lookDraft}
+                selectedCharacter={selectedCharacter}
+                selectedReferenceIds={selectedReferenceIds}
+                setLookDraft={setLookDraft}
+                setSelectedReferenceIds={setSelectedReferenceIds}
+                setTestLookId={setTestLookId}
+                submitLook={submitLook}
+                updateCharacterLook={updateCharacterLook}
+              />
 
-            <CharacterPoseLibrary
-              addCharacterReference={addCharacterReference}
-              approvedReferences={approvedReferences}
-              assets={assets}
-              createImageJob={createImageJob}
-              imageLocalJobs={imageLocalJobs}
-              importAsset={importAsset}
-              latestAssets={latestAssets}
-              loras={loras}
-              onCancel={onCancelCharacterJob}
-              onDuplicate={onDuplicateCharacterJob}
-              onOpenQueue={onOpenCharacterJobQueue}
-              onPreview={onPreview}
-              onRetry={onRetryCharacterJob}
-              poseModel={poseModel}
-              poseModels={poseModels}
-              rememberLocalGenerationJob={rememberLocalGenerationJob}
-              selectedCharacter={selectedCharacter}
-            />
+              <CharacterLoras
+                detachCharacterLora={detachCharacterLora}
+                loraEdits={loraEdits}
+                loraId={loraId}
+                loras={loras}
+                saveLora={saveLora}
+                selectedCharacter={selectedCharacter}
+                setLoraEdit={setLoraEdit}
+                setLoraId={setLoraId}
+                submitLora={submitLora}
+              />
+            </div>
 
-            <CharacterLooks
-              approvedReferences={approvedReferences}
-              createCharacterLook={createCharacterLook}
-              deleteCharacterLook={deleteCharacterLook}
-              lookDraft={lookDraft}
-              selectedCharacter={selectedCharacter}
-              selectedReferenceIds={selectedReferenceIds}
-              setLookDraft={setLookDraft}
-              setSelectedReferenceIds={setSelectedReferenceIds}
-              setTestLookId={setTestLookId}
-              submitLook={submitLook}
-              updateCharacterLook={updateCharacterLook}
-            />
+            {/* Assets tab — the character asset library (images + frames) +
+                its training datasets. */}
+            <div
+              aria-labelledby="character-tab-assets"
+              className="character-tabpanel"
+              hidden={activeTab !== "assets"}
+              id="character-panel-assets"
+              role="tabpanel"
+            >
+              <CharacterAssets
+                assets={assets}
+                deleteAsset={deleteAsset}
+                onPreview={onPreview}
+                purgeAsset={purgeAsset}
+                selectedCharacter={selectedCharacter}
+                updateAssetStatus={updateAssetStatus}
+              />
 
-            <CharacterLoras
-              detachCharacterLora={detachCharacterLora}
-              loraEdits={loraEdits}
-              loraId={loraId}
-              loras={loras}
-              saveLora={saveLora}
-              selectedCharacter={selectedCharacter}
-              setLoraEdit={setLoraEdit}
-              setLoraId={setLoraId}
-              submitLora={submitLora}
-            />
+              <CharacterDatasets
+                creating={creatingDataset}
+                datasets={characterDatasets}
+                imageCount={characterImageAssetIds.length}
+                onCreateDataset={createDatasetFromCharacter}
+                onOpenDataset={openDatasetInLibrary}
+                projectId={activeProject?.id}
+                selectedCharacter={selectedCharacter}
+              />
+            </div>
 
-            <CharacterDatasets
-              creating={creatingDataset}
-              datasets={characterDatasets}
-              imageCount={characterImageAssetIds.length}
-              onCreateDataset={createDatasetFromCharacter}
-              onOpenDataset={openDatasetInLibrary}
-              projectId={activeProject?.id}
-              selectedCharacter={selectedCharacter}
-            />
+            {/* Angles tab — Angle Set generation. */}
+            <div
+              aria-labelledby="character-tab-angles"
+              className="character-tabpanel"
+              hidden={activeTab !== "angles"}
+              id="character-panel-angles"
+              role="tabpanel"
+            >
+              <CharacterAngleSet
+                addCharacterReference={addCharacterReference}
+                angleModel={angleModel}
+                angleModels={angleModels}
+                approvedReferences={approvedReferences}
+                assets={assets}
+                createImageJob={createImageJob}
+                imageLocalJobs={imageLocalJobs}
+                importAsset={importAsset}
+                latestAssets={latestAssets}
+                loras={loras}
+                onCancel={onCancelCharacterJob}
+                onDuplicate={onDuplicateCharacterJob}
+                onOpenQueue={onOpenCharacterJobQueue}
+                onPreview={onPreview}
+                onRetry={onRetryCharacterJob}
+                rememberLocalGenerationJob={rememberLocalGenerationJob}
+                selectedCharacter={selectedCharacter}
+              />
+            </div>
 
-            <CharacterTest
-              addCharacterReference={addCharacterReference}
-              createCharacterTestJob={createCharacterTestJob}
-              deleteAsset={deleteAsset}
-              imageModels={imageModels}
-              latestAssets={latestAssets}
-              onPreview={onPreview}
-              purgeAsset={purgeAsset}
-              selectedCharacter={selectedCharacter}
-              setTestCount={setTestCount}
-              setTestLookId={setTestLookId}
-              setTestModel={setTestModel}
-              setTestPrompt={setTestPrompt}
-              setTestResolution={setTestResolution}
-              submitTest={submitTest}
-              testCount={testCount}
-              testLookId={testLookId}
-              testModel={testModel}
-              testPrompt={testPrompt}
-              testResolution={testResolution}
-              updateAssetStatus={updateAssetStatus}
-            />
+            {/* Poses tab — Pose generation. */}
+            <div
+              aria-labelledby="character-tab-poses"
+              className="character-tabpanel"
+              hidden={activeTab !== "poses"}
+              id="character-panel-poses"
+              role="tabpanel"
+            >
+              <CharacterPoseLibrary
+                addCharacterReference={addCharacterReference}
+                approvedReferences={approvedReferences}
+                assets={assets}
+                createImageJob={createImageJob}
+                imageLocalJobs={imageLocalJobs}
+                importAsset={importAsset}
+                latestAssets={latestAssets}
+                loras={loras}
+                onCancel={onCancelCharacterJob}
+                onDuplicate={onDuplicateCharacterJob}
+                onOpenQueue={onOpenCharacterJobQueue}
+                onPreview={onPreview}
+                onRetry={onRetryCharacterJob}
+                poseModel={poseModel}
+                poseModels={poseModels}
+                rememberLocalGenerationJob={rememberLocalGenerationJob}
+                selectedCharacter={selectedCharacter}
+              />
+            </div>
+
+            {/* Test tab — Test Character form. */}
+            <div
+              aria-labelledby="character-tab-test"
+              className="character-tabpanel"
+              hidden={activeTab !== "test"}
+              id="character-panel-test"
+              role="tabpanel"
+            >
+              <CharacterTest
+                addCharacterReference={addCharacterReference}
+                createCharacterTestJob={createCharacterTestJob}
+                deleteAsset={deleteAsset}
+                imageModels={imageModels}
+                latestAssets={latestAssets}
+                onPreview={onPreview}
+                purgeAsset={purgeAsset}
+                selectedCharacter={selectedCharacter}
+                setTestCount={setTestCount}
+                setTestLookId={setTestLookId}
+                setTestModel={setTestModel}
+                setTestPrompt={setTestPrompt}
+                setTestResolution={setTestResolution}
+                submitTest={submitTest}
+                testCount={testCount}
+                testLookId={testLookId}
+                testModel={testModel}
+                testPrompt={testPrompt}
+                testResolution={testResolution}
+                updateAssetStatus={updateAssetStatus}
+              />
+            </div>
           </section>
         )}
       </div>

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -712,7 +712,10 @@ export function CharacterAssets({
   const scopedAssets = (assets ?? [])
     .filter(
       (asset) =>
-        (asset.type === "image" || asset.type === "frame") &&
+        // Images, extracted frames, and generated videos all belong in the
+        // character's asset library (sc-2296) — the Assets tab is the home for
+        // every piece of media made for or referencing this character.
+        (asset.type === "image" || asset.type === "frame" || asset.type === "video") &&
         (asset.recipe?.normalizedSettings?.characterId === characterId ||
           (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === characterId)),
     )
@@ -736,7 +739,7 @@ export function CharacterAssets({
       <div className="trash-controls">
         <div className="segmented-control" role="group" aria-label="Character asset collection">
           <button className={showingTrash ? "" : "active"} onClick={() => setViewMode("active")} type="button">
-            Images ({activeAssets.length})
+            Media ({activeAssets.length})
           </button>
           <button className={showingTrash ? "active" : ""} onClick={() => setViewMode("trashed")} type="button">
             Trashcan ({trashedAssets.length})
@@ -787,8 +790,8 @@ export function CharacterAssets({
       ) : (
         <p className="muted">
           {showingTrash
-            ? "Trashcan is empty — discarded images for this character will appear here."
-            : "No images yet. Angle sets, pose generations, character tests, and any character-image render collect here automatically."}
+            ? "Trashcan is empty — discarded media for this character will appear here."
+            : "No media yet. Angle sets, pose generations, character tests, and any character image or video render collect here automatically."}
         </p>
       )}
     </section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4310,6 +4310,23 @@ label {
   gap: 14px;
 }
 
+/* epic 2293: Character Studio tabbed shell. The tab bar reuses .segmented-control;
+   each tabpanel stacks its sections the way the old single column did. Inactive
+   panels stay mounted (so working state survives switches) but carry [hidden] —
+   which must override .character-tabpanel's own display to actually hide. */
+.character-tabs {
+  align-self: start;
+}
+
+.character-tabpanel {
+  display: grid;
+  gap: 14px;
+}
+
+.character-tabpanel[hidden] {
+  display: none;
+}
+
 .character-editor,
 .character-section,
 .reference-card,


### PR DESCRIPTION
Overhauls **Character Studio** from a single ~8-panel scrolling column into a focused **5-tab interface**, and relocates it among the generative studios. Implements all 7 stories of [epic 2293](https://app.shortcut.com/trefry/epic/2293). UI-only — no Rust/contract/worker changes.

## What changed

**Tab shell — [sc-2294](https://app.shortcut.com/trefry/story/2294)**
- Five tabs: Character / Assets / Angles / Poses / Test, built on the existing `.segmented-control` primitive with `role="tablist"`/`tab` + `aria-selected` + roving-tabindex keyboard nav (arrows wrap, Home/End).
- Last-active tab **persists per workspace** via the `useStudioSettings` localStorage pattern. `App.jsx` now keys `<CharacterStudio>` by `activeProject?.id` (mirrors Image/Video Studio) so the saved tab is per-workspace with no cross-workspace bleed.

**Per-tab content**
- **Character** ([sc-2295](https://app.shortcut.com/trefry/story/2295)): the identity form gets its own section heading to match its sibling cards; order is Identity → References → Saved Presets → LoRAs.
- **Assets** ([sc-2296](https://app.shortcut.com/trefry/story/2296)): `CharacterAssets` now surfaces **videos** alongside images/frames (`AssetMedia` already renders `<video>`+poster); copy updated ("Media" toggle, video-aware empty/trash text).
- **Angles/Poses/Test** ([sc-2297](https://app.shortcut.com/trefry/story/2297)/[2298](https://app.shortcut.com/trefry/story/2298)/[2299](https://app.shortcut.com/trefry/story/2299)): single-panel tabs whose components already provide heading + guidance + empty/loading states; the shell makes each the full focus (no net-new UI).

**Sidebar — [sc-2300](https://app.shortcut.com/trefry/story/2300)**
- Move **Characters** from the Library section to the **Workspace** section, directly below Video and above Train.

## Key design decision — panels stay mounted, hidden via `[hidden]` (not conditionally unmounted)

The scaffold story said "conditionally render," but the Angles/Poses/Test panels hold **panel-local** state that isn't lifted to the parent (angle/pose prompt edits, the **selected pose set**, `faceRestore`, `controlScale`, Test view toggles). Pure `activeTab === x ? <Panel/> : null` would silently drop that on every switch. Keeping all 5 tab panels mounted and toggling the `hidden` attribute instead:
1. Fully satisfies the epic's strongest principle ("working state must survive tab switches") — lifted **and** panel-local state.
2. Is **zero render-cost regression** — today all 8 panels already mount at once, so this is the identical mount graph with visibility control.
3. Is the standard ARIA tabs pattern (inactive `tabpanel`s carry `hidden`).
4. Kept all 8 pre-existing CharacterStudio tests green unchanged (in jsdom, `hidden` elements stay in the DOM and remain programmatically clickable).

CSS note: `.character-tabpanel { display: grid }` overrides the UA `[hidden]` rule, so an explicit `.character-tabpanel[hidden] { display: none }` is required to actually hide inactive panels.

## Testing
- `apps/web` vitest (`--environment jsdom`): **262/262 green**, including two new tests — the tab shell (5 ARIA tabs, default tab, grouping + hidden-toggle visibility, lifted-state survival across a switch, keyboard nav, localStorage persist + restore-on-remount) and the Assets-tab video rendering.
- `vite build` clean.

## Reviewer notes
- The **sidebar move was verified live** in the running app (it renders without a backend). The Character Studio screen itself could not be driven live in this environment (backend API/worker offline → no workspace/character data), so its behavior is verified via the component-level tests that render the real `CharacterStudio`. Worth a quick manual click-through once a backend is up.
- Optional follow-up (not in this PR): a unified visual treatment across the three generation tabs (e.g. promoting each panel's intro `<p>` to a `.guidance-strip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)