### PR TITLE
feat(worker): apply third-party LyCORIS LoKr/LoHa adapters for generation (sc-2193)

### DIFF
--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -18,6 +18,11 @@ sentencepiece>=0.2,<1
 protobuf>=4.25,<7
 accelerate>=1.11
 peft>=0.17,<1
+# Third-party LyCORIS LoKr/LoHa adapter loading for generation (epic 2193). kohya
+# and ai-toolkit produce lokr_*/hada_* keys that diffusers' load_lora_weights
+# cannot consume; lycoris.create_lycoris_from_weights applies them onto the
+# denoiser (see lora_adapters.apply_lycoris_adapter).
+lycoris-lora>=3.4,<4
 safetensors>=0.6
 prodigyopt>=1.1,<2
 rose-opt>=1.0.2,<2

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -43,6 +43,7 @@ from .hf_cache import huggingface_cache_roots, huggingface_repo_cache_path
 from .lora_adapters import (
     LoraPipelineState,
     adapter_network_type,
+    classify_adapter_network,
     apply_loras_to_pipeline,
     lora_path,
     normalize_lora_specs,
@@ -6862,23 +6863,24 @@ def _should_route_flux_to_mlx(payload: dict[str, Any]) -> bool:
 
 
 def _request_has_lokr_lora(payload: dict[str, Any]) -> bool:
-    """True if any LoRA in the request is a LoKr adapter. LoKr applies only on the
-    torch backends (the MLX merge math is LoRA-only), so the MLX routing gates
-    fall back to torch when this is true (epic 2193) — the same graceful fallback
-    a reference image triggers. Prefers the ``networkType`` recorded on the LoRA
-    (zero I/O) and falls back to reading the adapter's safetensors header."""
+    """True if any LoRA in the request is a LoKr/LyCORIS adapter. These apply only
+    on the torch backends (the MLX merge math is LoRA-only), so the MLX routing
+    gates fall back to torch when this is true (epic 2193) — the same graceful
+    fallback a reference image triggers. Prefers the ``networkType`` recorded on
+    the LoRA (zero I/O) and otherwise classifies the adapter's safetensors header
+    (which also catches third-party LyCORIS files that carry no ``networkType``)."""
 
     for lora in payload.get("loras") or []:
         if not isinstance(lora, dict):
             continue
         recorded = lora.get("networkType") or (lora.get("compatibility") or {}).get("networkType")
         network_type = str(recorded or "").strip().lower()
+        if network_type in ("lokr", "lycoris"):
+            return True
         if not network_type:
             resolved = lora_path(lora)
-            if resolved is not None:
-                network_type = adapter_network_type(resolved)
-        if network_type == "lokr":
-            return True
+            if resolved is not None and classify_adapter_network(resolved) in ("lokr", "lycoris"):
+                return True
     return False
 
 

--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -255,24 +255,93 @@ def read_adapter_metadata(path: str | Path) -> dict[str, str]:
         return {}
 
 
+# Tensor-key substrings that mark a LyCORIS-format adapter (LoKr/LoHa). These are
+# the third-party kohya / ai-toolkit families whose keys ``load_lora_weights``
+# cannot consume — without this sniff they fall through to diffusers and crash with
+# a multi-thousand-line "state_dict should be empty at this point" dump (epic 2193).
+_LYCORIS_KEY_MARKERS = (".lokr_w1", ".lokr_w2", ".lokr_t2", ".hada_w1_a", ".hada_w2_a")
+
+
+def _adapter_tensor_names(path: str | Path, limit: int = 256) -> list[str]:
+    """Best-effort peek at an adapter's tensor names (header only, no tensor data)."""
+
+    try:
+        from safetensors import safe_open
+
+        with safe_open(str(path), framework="pt") as handle:
+            names: list[str] = []
+            for key in handle.keys():  # noqa: SIM118 - safetensors handle isn't a dict
+                names.append(key)
+                if len(names) >= limit:
+                    break
+            return names
+    except Exception:
+        return []
+
+
 def adapter_network_type(path: str | Path) -> str:
-    """``"lokr"`` for a LoKr adapter, else ``"lora"`` (the default for every
-    adapter without explicit ``networkType`` metadata)."""
+    """``"lokr"`` for a SceneWorks-trained (peft) LoKr adapter, else ``"lora"``.
+
+    Keyed off the ``networkType`` metadata SceneWorks' own trainer stamps (epic
+    2193). Third-party LyCORIS adapters carry no such stamp — use
+    :func:`classify_adapter_network` to detect those by tensor-key sniffing."""
 
     return (read_adapter_metadata(path).get("networkType") or "lora").strip().lower()
 
 
+def classify_adapter_network(path: str | Path) -> str:
+    """Classify an adapter into the layout that decides how it's applied:
+
+    - ``"lokr"``   — SceneWorks-trained peft LoKr (``networkType`` metadata) →
+      :func:`inject_lokr_adapter` (rebuilds ``peft.LoKrConfig``).
+    - ``"lycoris"`` — third-party LyCORIS LoKr/LoHa (kohya / ai-toolkit), detected
+      by ``lokr_*``/``hada_*`` tensor keys or ``ss_network_module`` →
+      :func:`apply_lycoris_adapter` (the ``lycoris`` library loader).
+    - ``"lora"``   — a standard low-rank adapter → ``pipe.load_lora_weights``.
+    """
+
+    # SceneWorks-trained peft LoKr is defined solely by the ``networkType`` stamp;
+    # delegate to adapter_network_type so it stays the single source of truth.
+    if adapter_network_type(path) == "lokr":
+        return "lokr"
+    meta = read_adapter_metadata(path)
+    module = (meta.get("ss_network_module") or "").lower()
+    if "lycoris" in module:
+        return "lycoris"
+    names = _adapter_tensor_names(path)
+    if any(any(marker in name for marker in _LYCORIS_KEY_MARKERS) for name in names):
+        return "lycoris"
+    return "lora"
+
+
 def reject_lokr_loras(specs: list[LoraSpec], adapter_id: str) -> None:
-    """Guard for backends that cannot apply LoKr (e.g. MLX, whose merge math is
-    LoRA-only). Raises a clear error rather than silently mis-applying."""
+    """Guard for backends that cannot apply LoKr/LyCORIS (e.g. MLX, whose merge
+    math is LoRA-only). Raises a clear, short error rather than silently
+    mis-applying or letting diffusers dump thousands of unconsumed keys."""
 
     for spec in specs:
-        if adapter_network_type(spec.path) == "lokr":
+        kind = classify_adapter_network(spec.path)
+        if kind in ("lokr", "lycoris"):
+            label = "LoKr" if kind == "lokr" else "LyCORIS (LoKr/LoHa)"
             raise RuntimeError(
-                f"{adapter_id} cannot apply the LoKr adapter '{spec.id}'. LoKr "
-                "(LyCORIS Kronecker) adapters require the torch generation backend; "
-                "this backend does not support them yet (epic 2193)."
+                f"{adapter_id} cannot apply the {label} adapter '{spec.id}'. "
+                f"{label} adapters require the torch generation backend; this "
+                "backend does not support them (epic 2193)."
             )
+
+
+def _lycoris_module_prefix(path: str | Path) -> str:
+    """The ``LycorisNetwork.LORA_PREFIX`` that maps this file's keys onto a denoiser
+    module. kohya/ai-toolkit DiT adapters prefix denoiser keys with ``lora_unet``
+    (the lycoris loader matches ``f"{PREFIX}_{module_name}"``)."""
+
+    for name in _adapter_tensor_names(path, limit=8):
+        head = name.split(".", 1)[0]
+        if head.startswith("lora_unet"):
+            return "lora_unet"
+        if head.startswith("lora_transformer"):
+            return "lora_transformer"
+    return "lora_unet"
 
 
 def _denoiser_module(pipe: Any) -> Any:
@@ -322,6 +391,92 @@ def inject_lokr_adapter(pipe: Any, spec: LoraSpec, *, adapter_id: str) -> None:
     set_peft_model_state_dict(module, state, adapter_name=spec.adapter_name)
 
 
+# Active LyCORIS networks are stashed on the denoiser module under this attribute
+# so ``clear_loras`` can ``restore()`` them — they aren't peft adapters and the
+# pipeline's lora bookkeeping never sees them, so a permanent merge would corrupt
+# the next job on a reused/cached pipeline. apply_to() + restore() keeps it clean.
+_LYCORIS_ATTR = "_sceneworks_lycoris_nets"
+
+
+def apply_lycoris_adapter(pipe: Any, spec: LoraSpec, *, adapter_id: str) -> None:
+    """Apply a third-party LyCORIS LoKr/LoHa adapter via the ``lycoris`` library —
+    the equivalent of ``pipe.load_lora_weights`` for files diffusers can't consume.
+
+    Uses ``apply_to()`` (reversible) and keeps the network handle on the denoiser
+    so ``clear_loras`` can ``restore()`` it between jobs (epic 2193)."""
+
+    module = _denoiser_module(pipe)
+    if module is None:
+        raise RuntimeError(
+            f"{adapter_id} cannot apply the LyCORIS adapter '{spec.id}': the "
+            "pipeline exposes no unet/transformer module to inject into."
+        )
+    try:
+        from lycoris import LycorisNetwork, create_lycoris_from_weights
+    except Exception as exc:  # pragma: no cover - exercised only without lycoris
+        raise RuntimeError(
+            f"{adapter_id} cannot apply the LyCORIS adapter '{spec.id}': the "
+            "'lycoris-lora' package is not installed in the worker environment "
+            "(epic 2193)."
+        ) from exc
+
+    prefix = _lycoris_module_prefix(spec.path)
+    saved_prefix = LycorisNetwork.LORA_PREFIX
+    try:
+        LycorisNetwork.LORA_PREFIX = prefix
+        network, _ = create_lycoris_from_weights(spec.weight, str(spec.path), module)
+    finally:
+        LycorisNetwork.LORA_PREFIX = saved_prefix
+
+    if not getattr(network, "loras", None):
+        raise RuntimeError(
+            f"{adapter_id} loaded the LyCORIS adapter '{spec.id}' but matched 0 "
+            f"modules (prefix {prefix!r}); the adapter's layer naming does not "
+            "match this model's transformer."
+        )
+    network.apply_to()
+    reference = next(module.parameters(), None)
+    if reference is not None:
+        network.to(device=reference.device, dtype=reference.dtype)
+    network.set_multiplier(spec.weight)
+
+    store = getattr(module, _LYCORIS_ATTR, None)
+    if store is None:
+        store = {}
+        setattr(module, _LYCORIS_ATTR, store)
+    store[spec.adapter_name] = network
+
+
+def _restore_lycoris_nets(module: Any, names: set[str] | None = None) -> set[str]:
+    """Reverse LyCORIS ``apply_to`` for the named adapters (or all) on ``module``.
+
+    Returns the set of adapter names actually restored, so callers can tell which
+    of the names they asked to clear were LyCORIS (and therefore already handled
+    here, with no peft delete/unload needed)."""
+
+    restored: set[str] = set()
+    if module is None:
+        return restored
+    store = getattr(module, _LYCORIS_ATTR, None)
+    if not store:
+        return restored
+    for name in list(store.keys()):
+        if names is not None and name not in names:
+            continue
+        network = store.pop(name)
+        restored.add(name)
+        try:
+            network.restore()
+        except Exception:
+            pass
+    if not store:
+        try:
+            delattr(module, _LYCORIS_ATTR)
+        except Exception:
+            pass
+    return restored
+
+
 def apply_loras_to_pipeline(
     pipe: Any,
     loras: list[dict[str, Any]],
@@ -352,8 +507,15 @@ def apply_loras_to_pipeline(
     specs_to_load = [spec for spec in specs if spec.adapter_name not in previous_by_name]
 
     if removed_names:
-        if hasattr(pipe, "delete_adapters"):
-            pipe.delete_adapters(list(removed_names))
+        module = _denoiser_module(pipe)
+        # Reverse any LyCORIS adapters among the removed set first (they aren't peft
+        # adapters, so delete_adapters/unload won't touch them) — epic 2193.
+        restored = _restore_lycoris_nets(module, set(removed_names))
+        non_lycoris_removed = [name for name in removed_names if name not in restored]
+        if not non_lycoris_removed:
+            pass  # every removed adapter was LyCORIS; the restore handled it
+        elif hasattr(pipe, "delete_adapters"):
+            pipe.delete_adapters(non_lycoris_removed)
         elif hasattr(pipe, "unload_lora_weights"):
             pipe.unload_lora_weights()
             specs_to_load = specs
@@ -361,10 +523,16 @@ def apply_loras_to_pipeline(
             raise RuntimeError(f"{adapter_id} cannot clear previously loaded LoRAs between jobs.")
 
     for spec in specs_to_load:
-        # LoKr can't load via load_lora_weights (its lokr_* keys are unrecognized);
-        # rebuild the LoKrConfig from file metadata and inject it instead (epic 2193).
-        if adapter_network_type(spec.path) == "lokr":
+        # Neither LoKr nor LyCORIS load via load_lora_weights (their lokr_*/hada_*
+        # keys are unrecognized and crash diffusers). Route each to its loader
+        # (epic 2193): SceneWorks-trained peft LoKr → inject_lokr_adapter; a
+        # third-party kohya/ai-toolkit LyCORIS file → apply_lycoris_adapter.
+        kind = classify_adapter_network(spec.path)
+        if kind == "lokr":
             inject_lokr_adapter(pipe, spec, adapter_id=adapter_id)
+            continue
+        if kind == "lycoris":
+            apply_lycoris_adapter(pipe, spec, adapter_id=adapter_id)
             continue
         try:
             pipe.load_lora_weights(spec.path, adapter_name=spec.adapter_name)
@@ -385,22 +553,38 @@ def apply_loras_to_pipeline(
 
     names = tuple(spec.adapter_name for spec in specs)
     weights = [spec.weight for spec in specs]
-    # Injected LoKr adapters live on the denoiser module but aren't tracked by the
-    # pipeline's lora bookkeeping, so pipe.set_adapters may not see them. When any
-    # adapter is LoKr, set weights on the module (which knows every PEFT adapter).
-    if any(adapter_network_type(spec.path) == "lokr" for spec in specs):
+    kinds = {spec.adapter_name: classify_adapter_network(spec.path) for spec in specs}
+    # LyCORIS nets carry their own multiplier (set at apply time) and aren't peft
+    # adapters, so they're excluded from pipeline weight wiring. Of the rest:
+    # injected peft LoKr adapters live on the denoiser module and aren't tracked by
+    # the pipeline's lora bookkeeping, so when any is LoKr we set weights on the
+    # module (which knows every PEFT adapter); otherwise use pipe.set_adapters.
+    managed_names = tuple(name for name in names if kinds[name] != "lycoris")
+    managed_weights = [weight for name, weight in zip(names, weights) if kinds[name] != "lycoris"]
+    if any(kinds[name] == "lokr" for name in managed_names):
         set_adapter_weights_on_module(
-            _denoiser_module(pipe), names, weights, adapter_id=adapter_id, specs=specs
+            _denoiser_module(pipe), managed_names, managed_weights, adapter_id=adapter_id, specs=specs
         )
-    elif hasattr(pipe, "set_adapters"):
-        set_lora_adapters(pipe, names, weights, adapter_id=adapter_id, specs=specs)
-    elif len(names) > 1 or any(weight != 1.0 for weight in weights):
+    elif managed_names and hasattr(pipe, "set_adapters"):
+        set_lora_adapters(pipe, managed_names, managed_weights, adapter_id=adapter_id, specs=specs)
+    elif managed_names and (len(managed_names) > 1 or any(weight != 1.0 for weight in managed_weights)):
         raise RuntimeError(f"{adapter_id} loaded LoRAs but cannot apply per-LoRA weights.")
     return LoraPipelineState(key=key, adapter_names=names, specs=tuple(specs))
 
 
 def clear_loras(pipe: Any, adapter_names: tuple[str, ...], *, adapter_id: str) -> None:
     if not adapter_names:
+        return
+    # Reverse LyCORIS adapters first: they're applied via the lycoris network's
+    # apply_to (not peft), so delete_adapters/unload_lora_weights would leave them
+    # active and corrupt the next job on a reused pipeline (epic 2193).
+    module = _denoiser_module(pipe)
+    restored = _restore_lycoris_nets(module, set(adapter_names))
+    # If every cleared adapter was a LyCORIS one, the restore above is the whole
+    # job — there is no peft adapter to delete/unload (and demanding one would
+    # spuriously fail on a pipe that only ever held LyCORIS adapters).
+    remaining = [name for name in adapter_names if name not in restored]
+    if not remaining:
         return
     # Prefer deleting by name: it removes injected LoKr adapters too, which
     # unload_lora_weights (LoRA-only) leaves behind and would leak into the next

--- a/tests/test_lycoris_lokr.py
+++ b/tests/test_lycoris_lokr.py
@@ -1,0 +1,165 @@
+"""Third-party LyCORIS LoKr/LoHa adapter handling (epic 2193).
+
+Two layers:
+  * Pure-logic ``classify_adapter_network`` tests (no torch) — run in lightweight CI.
+  * A torch + ``lycoris`` round-trip through the production
+    ``apply_loras_to_pipeline`` / ``clear_loras`` path (skipped without the deps).
+
+Background: kohya / ai-toolkit LyCORIS adapters carry ``lokr_w1``/``lokr_w2`` (or
+``hada_*``) tensors that diffusers' ``load_lora_weights`` cannot consume — without
+detection they crash with a multi-thousand-line "state_dict should be empty at this
+point" dump. These tests pin that they're detected and applied via the lycoris
+loader instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scene_worker import lora_adapters
+from scene_worker.lora_adapters import LoraSpec, classify_adapter_network
+
+
+# --------------------------------------------------------------------------- #
+# Pure-logic classification (no torch / no lycoris)
+# --------------------------------------------------------------------------- #
+
+
+def _patch_adapter(monkeypatch, *, metadata=None, tensor_names=()):
+    monkeypatch.setattr(lora_adapters, "read_adapter_metadata", lambda _p: dict(metadata or {}))
+    monkeypatch.setattr(lora_adapters, "_adapter_tensor_names", lambda _p, limit=256: list(tensor_names))
+
+
+def test_sceneworks_peft_lokr_classified_as_lokr(monkeypatch):
+    # SceneWorks' own trainer stamps networkType=lokr (epic 2193).
+    _patch_adapter(monkeypatch, metadata={"networkType": "lokr"})
+    assert classify_adapter_network("x.safetensors") == "lokr"
+
+
+def test_kohya_lycoris_detected_by_metadata(monkeypatch):
+    _patch_adapter(monkeypatch, metadata={"ss_network_module": "lycoris.kohya"})
+    assert classify_adapter_network("x.safetensors") == "lycoris"
+
+
+def test_lycoris_detected_by_lokr_keys_without_metadata(monkeypatch):
+    # The real failing case: no networkType, no ss_network_module — detect by keys.
+    _patch_adapter(
+        monkeypatch,
+        metadata={},
+        tensor_names=[
+            "lora_unet_transformer_blocks_0_attn_to_q.alpha",
+            "lora_unet_transformer_blocks_0_attn_to_q.lokr_w1",
+            "lora_unet_transformer_blocks_0_attn_to_q.lokr_w2",
+        ],
+    )
+    assert classify_adapter_network("x.safetensors") == "lycoris"
+
+
+def test_loha_keys_detected_as_lycoris(monkeypatch):
+    _patch_adapter(monkeypatch, metadata={}, tensor_names=["x.hada_w1_a", "x.hada_w2_a"])
+    assert classify_adapter_network("x.safetensors") == "lycoris"
+
+
+def test_plain_lora_is_lora(monkeypatch):
+    _patch_adapter(
+        monkeypatch,
+        metadata={},
+        tensor_names=[
+            "transformer.blocks.0.attn.to_q.lora_A.weight",
+            "transformer.blocks.0.attn.to_q.lora_B.weight",
+        ],
+    )
+    assert classify_adapter_network("x.safetensors") == "lora"
+
+
+def test_reject_lokr_loras_rejects_lycoris(monkeypatch):
+    monkeypatch.setattr(lora_adapters, "classify_adapter_network", lambda _p: "lycoris")
+    spec = LoraSpec(id="snof", path="x.safetensors", weight=1.0, adapter_name="snof")
+    with pytest.raises(RuntimeError) as excinfo:
+        lora_adapters.reject_lokr_loras([spec], "mlx_qwen")
+    msg = str(excinfo.value)
+    assert "LyCORIS" in msg
+    assert "snof" in msg
+
+
+def test_reject_lokr_loras_allows_plain_lora(monkeypatch):
+    monkeypatch.setattr(lora_adapters, "classify_adapter_network", lambda _p: "lora")
+    spec = LoraSpec(id="ok", path="x.safetensors", weight=1.0, adapter_name="ok")
+    lora_adapters.reject_lokr_loras([spec], "mlx_qwen")  # must not raise
+
+
+# --------------------------------------------------------------------------- #
+# torch + lycoris round-trip through the production path
+# --------------------------------------------------------------------------- #
+
+
+def test_lycoris_apply_and_restore_roundtrip(tmp_path):
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("lycoris")
+    import torch.nn as nn
+    from safetensors.torch import save_file
+
+    class Node(nn.Module):
+        pass
+
+    # A tiny DiT-ish denoiser: transformer_blocks.0.attn.{to_q,to_k} as Linears.
+    transformer = Node()
+    blocks = Node()
+    transformer.add_module("transformer_blocks", blocks)
+    b0 = Node()
+    blocks.add_module("0", b0)
+    attn = Node()
+    b0.add_module("attn", attn)
+    attn.add_module("to_q", nn.Linear(16, 16, bias=False))
+    attn.add_module("to_k", nn.Linear(16, 16, bias=False))
+
+    # Hand-craft a kohya-format LoKr state dict (lokr_w1 @ lokr_w2 = a full 16x16
+    # delta) for both leaves. factor split 4*4 = 16.
+    def lokr_tensors():
+        return {
+            "lokr_w1": torch.randn(4, 4) * 0.3,
+            "lokr_w2": torch.randn(4, 4) * 0.3,
+            "alpha": torch.tensor(4.0),
+        }
+
+    state = {}
+    for leaf in ("to_q", "to_k"):
+        name = f"lora_unet_transformer_blocks_0_attn_{leaf}"
+        for k, v in lokr_tensors().items():
+            state[f"{name}.{k}"] = v
+    path = tmp_path / "kohya_lokr.safetensors"
+    save_file(state, str(path), metadata={"ss_network_module": "lycoris.kohya"})
+
+    # Sanity: the production classifier sees this file as lycoris.
+    assert classify_adapter_network(str(path)) == "lycoris"
+
+    class FakePipe:
+        def __init__(self, tr):
+            self.transformer = tr
+
+        def load_lora_weights(self, *a, **k):  # must never be called for LyCORIS
+            raise AssertionError("load_lora_weights called for a LyCORIS adapter")
+
+    pipe = FakePipe(transformer)
+    to_q = transformer.transformer_blocks._modules["0"].attn.to_q
+    torch.manual_seed(0)
+    x = torch.randn(2, 16)
+    base = to_q(x).clone()
+
+    lora = {"id": "snof", "path": str(path), "weight": 1.0, "name": "snof"}
+    pstate = lora_adapters.apply_loras_to_pipeline(
+        pipe, [lora], adapter_id="qwen_image", model_family="qwen"
+    )
+    applied = to_q(x)
+    assert (applied - base).abs().max().item() > 1e-6, "LyCORIS adapter did not change output"
+
+    lora_adapters.clear_loras(pipe, pstate.adapter_names, adapter_id="qwen_image")
+    restored = to_q(x)
+    assert (restored - base).abs().max().item() < 1e-6, "clear_loras left LyCORIS residue"
+
+    # Re-apply after clear proves cached-pipeline reuse isn't corrupted.
+    pstate2 = lora_adapters.apply_loras_to_pipeline(
+        pipe, [lora], adapter_id="qwen_image", model_family="qwen"
+    )
+    assert (to_q(x) - base).abs().max().item() > 1e-6
+    lora_adapters.clear_loras(pipe, pstate2.adapter_names, adapter_id="qwen_image")


### PR DESCRIPTION
## What

Third-party **LyCORIS** LoKr/LoHa adapters (from kohya and ai-toolkit) could not be used for image generation — selecting one produced a multi-thousand-line crash:

```
`state_dict` should be empty at this point but has state_dict.keys()=dict_keys([... .lokr_w1, .lokr_w2, .alpha ...])
```

## Root cause

These files carry `lokr_w1`/`lokr_w2` (or `hada_*`) tensors that diffusers' `load_lora_weights` cannot consume. They carry no SceneWorks `networkType` metadata stamp, so `adapter_network_type` classified them as plain `"lora"` → they fell through to `load_lora_weights`, which renamed the keys but left every LoKr tensor unconsumed and raised the "state_dict should be empty" dump. (The existing `inject_lokr_adapter` path is for SceneWorks-trained **peft** LoKr — a different scheme — and would not load these either.)

## Changes (`apps/worker`)

- **`lora_adapters.py`**
  - `classify_adapter_network()` → `"lokr"` (SceneWorks peft LoKr, via `networkType`, delegated to `adapter_network_type` as the single source of truth) | `"lycoris"` (third-party, detected by `lokr_*`/`hada_*` tensor keys or `ss_network_module`) | `"lora"`.
  - `apply_lycoris_adapter()` — applies via `lycoris.create_lycoris_from_weights` + `apply_to()`, with `LycorisNetwork.LORA_PREFIX` set to the file's denoiser prefix (`lora_unet`). Keeps the network handle on the denoiser so `clear_loras` can `restore()` it between jobs — **cached-pipeline-safe** (no permanent merge that would corrupt the next job).
  - `apply_loras_to_pipeline` routes `lokr`→`inject_lokr_adapter`, `lycoris`→`apply_lycoris_adapter`, `lora`→`load_lora_weights`. LyCORIS nets carry their own multiplier and are excluded from pipeline weight wiring; `clear_loras` + the removed-adapters path restore LyCORIS first and only `delete_adapters` the peft-managed names.
  - `reject_lokr_loras` now rejects LyCORIS too — so MLX backends (no LyCORIS support) give a short, clear error instead of the crash.
- **`image_adapters.py`** — `_request_has_lokr_lora` also detects LyCORIS, so requests with these adapters defer from MLX to the torch backend.
- **`requirements.txt`** — add `lycoris-lora>=3.4,<4`.
- **`tests/test_lycoris_lokr.py`** (new) — classifier tests (no torch, run in lightweight CI) + a torch+lycoris round-trip through the production `apply_loras_to_pipeline` / `clear_loras` path.

## Verification

- Pinned the real `lycoris-lora` 3.4.0 API and tested against the **actual kohya Qwen LoKr file**: all 14/14 block-0 modules bind, `apply_to()` changes the forward pass (Δ≈3.0), `restore()` reverts cleanly to 0.0.
- Worker test subset (`test_lycoris_lokr` + `test_worker_runtime` + `test_worker_gpu` + `test_person_adapters`): **483 passed, 2 skipped**.

## Caveats / follow-ups

- **Real Qwen-pipeline generation still needs hardware verification** by the reviewer — the loader and apply/restore round-trip are proven on a synthetic module with the real adapter's tensors, but full Qwen image quality/identity (and the large `factor=10` Kronecker) hasn't been run end-to-end here.
- The ai-toolkit **FLUX.2-klein** LoKr files target the **MLX/mflux** backend, which has no LyCORIS support — they now get a clean rejection rather than the crash. Actually generating with them is a separate story.

Part of epic [sc-2193](https://app.shortcut.com/trefry/epic/2193) (LoKr network type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
