### PR TITLE
fix(character-studio): Z-Image strict pose — fix pose count routing + clean pose-only default; reference img2img-init opt-in (sc-2328)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -7096,9 +7096,14 @@ def _should_route_z_image_to_mlx(payload: dict[str, Any]) -> bool:
       2. Platform == darwin.
       3. Model in MlxZImageAdapter._supported_models.
       4. mode != "edit_image".
-      5. No referenceAssetId (Z-Image has no reference path on either
-         backend; the flag is checked symmetrically with the other mflux
-         families).
+      5. No referenceAssetId — UNLESS the request carries advanced.poses. A
+         plain reference (no poses) has no Z-Image path on either backend, so it
+         falls to torch; but a POSE request must route here regardless of a
+         reference, because the strict Fun-Controlnet-Union pose tier (sc-2257)
+         exists ONLY on MLX (the torch ZImageDiffusersAdapter has no pose
+         ControlNet and would honour count while silently ignoring advanced.poses
+         → "1 of 1" for N poses). MLX consumes the reference as an identity
+         img2img-init (sc-2328) or ignores it (sc-2257).
       6. Sidecar venv exists.
     """
     if os.getenv("SCENEWORKS_DISABLE_MLX_FLUX", "").strip().lower() in {"1", "true", "yes"}:
@@ -7110,7 +7115,14 @@ def _should_route_z_image_to_mlx(payload: dict[str, Any]) -> bool:
         return False
     if payload.get("mode") == "edit_image":
         return False
-    if payload.get("referenceAssetId"):
+    # A pose request belongs on MLX even WITH a reference: the strict pose ControlNet
+    # (sc-2257) lives only here, so diverting reference+pose jobs to torch makes torch
+    # honour count (1) while dropping advanced.poses → "1 of 1" for N poses. The MLX
+    # strict pose path consumes the reference as an identity img2img-init (sc-2328) or
+    # ignores it (sc-2257). Only a plain reference (no poses) falls back to torch.
+    advanced = payload.get("advanced")
+    has_poses = isinstance(advanced, dict) and bool(advanced.get("poses"))
+    if payload.get("referenceAssetId") and not has_poses:
         return False
     # peft-trained LoKr runs natively on MLX for Z-Image (sc-2216: mflux LoKrLoader),
     # so a LoKr job STAYS on the MLX path (Michael's preference) — no torch fallback.

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -3117,21 +3117,34 @@ class MlxZImageAdapter:
         # Strict pose tier (sc-2257): advanced.poses is a list of {id, keypoints}.
         # Each pose renders to an OpenPose skeleton that conditions the ported
         # Z-Image Fun-Controlnet-Union branch (true pose lock, not best-effort).
-        # No reference is used — Z-Image has no IP-Adapter, so identity comes from
-        # the prompt; the skeleton supplies the pose.
+        #
+        # Identity (sc-2328): when a pose request also carries a character reference,
+        # we feed it as the img2img INIT image so the skeleton drives the pose WHILE
+        # the reference seeds identity, in one pass. Z-Image has no IP-Adapter, so the
+        # img2img init is the only identity mechanism; without it identity comes from
+        # the prompt alone (the original pose-only sc-2257 behaviour). Resolved below.
         raw_poses = request.advanced.get("poses")
         pose_entries = [p for p in raw_poses if isinstance(p, dict)] if isinstance(raw_poses, list) else []
         pose_set = len(pose_entries) > 0
         if request.reference_asset_id and not pose_set:
-            # ZImageDiffusersAdapter itself has no reference path (sc-2005
-            # cleanup); raising here keeps the error surface honest if a
-            # caller manually targets MlxZImageAdapter with one. Pose requests
-            # may carry a character reference we can't consume — ignore it
-            # rather than reject (the skeleton drives the pose).
+            # A bare reference (no poses) has no home on the MLX backend: there is no
+            # IP-Adapter, and reference-only img2img with no skeleton is the best-effort
+            # tier we deliberately did NOT build (superseded by this unified path:
+            # sc-2263 → sc-2328). Reject clearly rather than silently ignore.
             raise RuntimeError(
                 f"{request.model} reference-image generation is not supported "
                 "on the MLX backend (Z-Image has no IP-Adapter weights upstream)."
             )
+
+        # Resolve the character reference (if present) to a local path for the
+        # img2img identity init (sc-2328). One reference shared across the whole pose
+        # set — identity is constant; only the per-pose skeleton changes. None →
+        # pose-only generation (identity from the prompt), the prior sc-2257 path.
+        reference_init_path: str | None = None
+        reference_strength: float | None = None
+        if pose_set and request.reference_asset_id:
+            reference_init_path = str(find_asset_media_path(project_path, request.reference_asset_id))
+            reference_strength = self._reference_strength(request)
 
         validate_lora_compatibility(
             request.loras, model_family=model_target.get("family"), adapter_id=self.id, model_id=request.model
@@ -3245,6 +3258,10 @@ class MlxZImageAdapter:
                     # lock strength. None → the plain text-to-image path.
                     "controlImagePaths": control_image_paths,
                     "controlScale": control_scale,
+                    # Identity img2img-init shared across the pose set (sc-2328);
+                    # None → pose-only (identity from the prompt).
+                    "imagePath": reference_init_path,
+                    "imageStrength": reference_strength,
                 },
                 progress=progress,
                 cancel_requested=cancel_requested,
@@ -3296,6 +3313,21 @@ class MlxZImageAdapter:
         except (TypeError, ValueError):
             return 0.9
         return max(0.0, min(2.0, value))
+
+    def _reference_strength(self, request: ImageRequest) -> float:
+        """img2img-init strength for the unified strict pose tier (sc-2328): how much
+        of the character reference to keep as the denoising init. mflux's image_strength
+        is INVERTED from diffusers — higher keeps MORE of the init (stronger identity,
+        but the skeleton control gets fewer denoising steps to repose), lower denoises
+        more (freer repose, identity drifts toward the prompt). Default 0.5 is a neutral
+        starting point pending the real-Mac sweep (sc-2328 E2E). Overridable via
+        advanced.referenceStrength; clamped to [0.05, 1.0] so a present reference always
+        seeds identity (strength 0 disables img2img entirely in mflux)."""
+        try:
+            value = float(request.advanced.get("referenceStrength", 0.5))
+        except (TypeError, ValueError):
+            return 0.5
+        return max(0.05, min(1.0, value))
 
     def _guidance_scale(self, request: ImageRequest, model_target: dict[str, Any]) -> float:
         # Z-Image-Turbo is guidance-distilled; mflux accepts guidance=None to

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -168,6 +168,14 @@ def _run_z_image_control(
     control weights at full precision before quantizing the whole transformer, so
     the control branch quantizes from its real weights (Q8 ≈ halves transformer
     memory vs bf16). Both validated on M5 Max (sc-2257).
+
+    Identity (sc-2328): when the spec carries ``imagePath`` (a character reference),
+    it is forwarded to ``generate_image`` as the img2img *init* image (shared across
+    every pose — identity is constant, only the per-iteration skeleton changes). The
+    init seeds identity while the skeleton control_context still drives the pose, in
+    one pass — Z-Image has no IP-Adapter, so this img2img init is how identity is
+    held. ``imageStrength`` is mflux's INVERTED strength (higher = more init kept =
+    stronger identity, less reposing room); the adapter tunes its default.
     """
     if model_id != "z_image_turbo":
         raise RuntimeError(
@@ -178,6 +186,13 @@ def _run_z_image_control(
             f"mlx_flux_runner: controlImagePaths length ({len(control_image_paths)}) "
             f"must equal seeds list length ({len(seeds)})."
         )
+
+    # Identity init (sc-2328): a single character reference shared across the whole
+    # pose set. None → pose-only (the original sc-2257 behaviour, identity from the
+    # prompt). image_strength is forwarded verbatim (mflux clamps to [0, 1]).
+    image_init_path = (spec.get("imagePath") or None) and str(spec["imagePath"])
+    raw_strength = spec.get("imageStrength")
+    image_strength = float(raw_strength) if raw_strength is not None else None
 
     from huggingface_hub import hf_hub_download
     from mflux.models.common.config.model_config import ModelConfig
@@ -205,7 +220,8 @@ def _run_z_image_control(
 
     _log(
         f"loading ZImageControl model={model_id} controlScale={control_scale} "
-        f"loras={len(lora_paths)} steps={steps} quantize={quantize}"
+        f"loras={len(lora_paths)} steps={steps} quantize={quantize} "
+        f"identityInit={'yes' if image_init_path else 'no'} imageStrength={image_strength}"
     )
     model = ZImageControl(
         control_weights_path=cn_path,
@@ -229,6 +245,9 @@ def _run_z_image_control(
             width=width,
             guidance=guidance,
             negative_prompt=negative_prompt,
+            # Identity init shared across the pose set (sc-2328); None → pose-only.
+            image_path=image_init_path,
+            image_strength=image_strength,
         )
         path = out_dir / f"mlx_z_image_control_{index:04d}.png"
         result.image.save(path, "PNG")

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2456,6 +2456,30 @@ def test_should_route_z_image_to_mlx_keeps_lokr_on_mlx(monkeypatch):
     assert _should_route_z_image_to_mlx({"model": model, "loras": [{"id": "a", "networkType": "lycoris"}]}) is False
 
 
+def test_should_route_z_image_pose_with_reference_to_mlx(monkeypatch):
+    """sc-2328 regression: a strict pose request carrying a reference MUST route to MLX.
+    The strict Fun-Controlnet-Union pose tier lives only on the MLX backend; the torch
+    adapter has no pose ControlNet, so diverting reference+pose jobs to torch (the old
+    `referenceAssetId -> torch` gate) made it honour count=1 while dropping the poses
+    → the "1 of 1 for N poses" bug. A plain reference (no poses) still falls to torch."""
+    from scene_worker.image_adapters import _should_route_z_image_to_mlx
+
+    monkeypatch.delenv("SCENEWORKS_DISABLE_MLX_FLUX", raising=False)
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(MlxZImageAdapter, "_sidecar_available", lambda self: True)
+    model = next(iter(MlxZImageAdapter._supported_models))
+
+    poses = [{"id": "sit_01", "keypoints": []}, {"id": "stand_01", "keypoints": []}]
+    # Reference + poses → MLX (strict pose lives there; reference becomes the identity init).
+    assert _should_route_z_image_to_mlx(
+        {"model": model, "referenceAssetId": "asset_kelsie", "advanced": {"poses": poses}}
+    ) is True
+    # Reference, no poses → still torch (no plain-reference Z-Image path on MLX).
+    assert _should_route_z_image_to_mlx({"model": model, "referenceAssetId": "asset_kelsie"}) is False
+    # Poses, no reference → MLX (the original pose-only sc-2257 path).
+    assert _should_route_z_image_to_mlx({"model": model, "advanced": {"poses": poses}}) is True
+
+
 def test_mlx_flux2_kv_allows_no_reference_txt2img(monkeypatch):
     # sc-2173: -kv is no longer reference-gated. Without a reference it falls
     # through to the txt2img path (the runner routes it to Flux2Klein) instead

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2653,6 +2653,179 @@ def test_mlx_z_image_pose_set_builds_control_skeleton_specs(tmp_path, monkeypatc
         assert "pose_skeleton_" in entry and entry.endswith(".png")
     assert spec["controlScale"] == 0.9  # default lock strength (reference default)
     assert captured["raw_settings"].get("poseLibrary") is True
+    # No reference on this job → pose-only (the original sc-2257 behaviour). The
+    # identity img2img-init keys (sc-2328) must be absent so nothing changes.
+    assert spec["imagePath"] is None
+    assert spec["imageStrength"] is None
+
+
+def test_mlx_z_image_pose_set_with_reference_sends_identity_init(tmp_path, monkeypatch):
+    """sc-2328: a strict pose job that ALSO carries a character reference resolves the
+    reference to a local path and sends it as a single shared img2img-init (imagePath)
+    + imageStrength so the skeleton drives the pose while the reference seeds identity,
+    in one pass. The per-pose skeleton control is unchanged from sc-2257."""
+    import numpy as _np
+    from scene_worker import image_adapters as ia
+
+    adapter = ia.MlxZImageAdapter()
+    monkeypatch.setattr(ia.MlxZImageAdapter, "_sidecar_available", lambda self: True)
+    monkeypatch.setattr(
+        ia, "draw_wholebody", lambda w, h, kps, hands=None, face=None, stickwidth=4: _np.zeros((h, w, 3), dtype=_np.uint8)
+    )
+    # Reference resolution goes through the project sidecar/DB; stub it to a known path.
+    ref_path = tmp_path / "kelsie_ref.png"
+    ref_path.write_bytes(b"PNG")
+    monkeypatch.setattr(ia, "find_asset_media_path", lambda project_path, asset_id: ref_path)
+
+    captured: dict = {}
+
+    def fake_run_sidecar(self, *, job_id, work_dir, label, total, spec, progress, cancel_requested):
+        captured["spec"] = spec
+        return [str(work_dir / f"out_{i}.png") for i in range(total)]
+
+    monkeypatch.setattr(ia.MlxZImageAdapter, "_run_sidecar", fake_run_sidecar)
+    monkeypatch.setattr(
+        ia.ImageAssetWriter,
+        "write_incremental_outputs",
+        lambda self, *, image_count, image_at_index, raw_settings, **kwargs: {"images": image_count},
+    )
+
+    kp = [[0.5, 0.1 + 0.04 * i] for i in range(18)]
+    job = {
+        "id": "job_z_image_pose_ref",
+        "payload": {
+            "projectId": "p",
+            "mode": "character_image",
+            "model": "z_image_turbo",
+            "prompt": "the character",
+            "count": 1,
+            "width": 32,
+            "height": 32,
+            "referenceAssetId": "asset_kelsie",
+            "advanced": {"poses": [{"id": "sit_01", "keypoints": kp}, {"id": "stand_01", "keypoints": kp}]},
+        },
+    }
+    adapter.generate(
+        settings=SimpleNamespace(gpu_id="cpu"),
+        job=job,
+        request=image_request_from_job(job),
+        project_path=tmp_path,
+        progress=lambda *a, **k: None,
+        cancel_requested=lambda: False,
+    )
+    spec = captured["spec"]
+    # Skeleton control still per-pose (identity is constant, only the pose changes).
+    assert len(spec["controlImagePaths"]) == 2
+    # Single shared reference init across the whole set + default strength.
+    assert spec["imagePath"] == str(ref_path)
+    assert spec["imageStrength"] == 0.5  # _reference_strength default (sc-2328)
+
+
+def test_mlx_z_image_reference_strength_default_override_and_clamp():
+    """sc-2328: _reference_strength defaults to 0.5, honours advanced.referenceStrength,
+    clamps to [0.05, 1.0] (strength 0 disables img2img in mflux), and is robust to junk."""
+    from scene_worker.image_adapters import MlxZImageAdapter
+
+    adapter = MlxZImageAdapter()
+
+    def req(advanced):
+        return SimpleNamespace(advanced=advanced)
+
+    assert adapter._reference_strength(req({})) == 0.5
+    assert adapter._reference_strength(req({"referenceStrength": 0.8})) == 0.8
+    assert adapter._reference_strength(req({"referenceStrength": 5})) == 1.0  # clamp high
+    assert adapter._reference_strength(req({"referenceStrength": 0})) == 0.05  # clamp low (keep img2img on)
+    assert adapter._reference_strength(req({"referenceStrength": "nope"})) == 0.5  # junk → default
+
+
+def test_run_z_image_control_forwards_identity_init(tmp_path, monkeypatch):
+    """sc-2328: the sidecar runner forwards spec.imagePath/imageStrength into
+    ZImageControl.generate_image as the img2img init, and omits them (None) when the
+    spec has no reference (the original pose-only sc-2257 path)."""
+    import sys
+    from types import ModuleType, SimpleNamespace as NS
+    from unittest import mock
+
+    calls: list[dict] = []
+
+    class _FakeImage:
+        def save(self, path, fmt):  # noqa: D401 - test stub
+            Path(path).write_bytes(b"PNG")
+
+    class _FakeZImageControl:
+        def __init__(self, **kwargs):
+            pass
+
+        def generate_image(self, **kwargs):
+            calls.append(kwargs)
+            return NS(image=_FakeImage())
+
+    class _FakeModelConfig:
+        @staticmethod
+        def z_image_turbo():
+            return object()
+
+    # Register fake mflux + huggingface_hub module chains so the runner's deferred
+    # imports resolve without the (absent) sidecar venv.
+    def _mod(name):
+        m = ModuleType(name)
+        return m
+
+    hf = _mod("huggingface_hub")
+    hf.hf_hub_download = lambda repo_id, filename: str(tmp_path / "cn.safetensors")
+    mc_mod = _mod("mflux.models.common.config.model_config")
+    mc_mod.ModelConfig = _FakeModelConfig
+    zc_mod = _mod("mflux.models.z_image.variants.z_image_control")
+    zc_mod.ZImageControl = _FakeZImageControl
+    fakes = {
+        "huggingface_hub": hf,
+        "mflux": _mod("mflux"),
+        "mflux.models": _mod("mflux.models"),
+        "mflux.models.common": _mod("mflux.models.common"),
+        "mflux.models.common.config": _mod("mflux.models.common.config"),
+        "mflux.models.common.config.model_config": mc_mod,
+        "mflux.models.z_image": _mod("mflux.models.z_image"),
+        "mflux.models.z_image.variants": _mod("mflux.models.z_image.variants"),
+        "mflux.models.z_image.variants.z_image_control": zc_mod,
+    }
+
+    from scene_worker.mlx_flux_runner import _run_z_image_control
+
+    def run(spec_extra):
+        calls.clear()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir(exist_ok=True)
+        spec = {"outDir": str(out_dir), **spec_extra}
+        with mock.patch.dict(sys.modules, fakes):
+            _run_z_image_control(
+                spec=spec,
+                model_id="z_image_turbo",
+                prompt="the character",
+                prompts_override=None,
+                negative_prompt=None,
+                seeds=[7],
+                height=32,
+                width=32,
+                steps=8,
+                guidance=0.0,
+                quantize=8,
+                loras=[],
+                control_image_paths=[str(tmp_path / "skeleton.png")],
+                out_dir=out_dir,
+                result_path=out_dir / "result.json",
+            )
+        return calls[0]
+
+    # With a reference: forwarded as the img2img init.
+    got = run({"controlScale": 0.9, "imagePath": str(tmp_path / "ref.png"), "imageStrength": 0.5})
+    assert got["image_path"] == str(tmp_path / "ref.png")
+    assert got["image_strength"] == 0.5
+    assert got["control_image_path"] == str(tmp_path / "skeleton.png")
+
+    # Without a reference: pose-only, init args are None (unchanged sc-2257 behaviour).
+    got = run({"controlScale": 0.9})
+    assert got["image_path"] is None
+    assert got["image_strength"] is None
 
 
 def test_mlx_flux2_requires_sidecar_when_missing(monkeypatch):


### PR DESCRIPTION
## Why

The shipped **strict Z-Image pose tier (sc-2257)** locks the *pose* via the Fun-Controlnet-Union skeleton but **dropped the character reference entirely** — identity came from the prompt only ([`image_adapters.py:3120`](../blob/main/apps/worker/scene_worker/image_adapters.py)/`:3128`). So it never met the Character Studio "same character, new pose" requirement. The best-effort tier (sc-2263) was the mirror image: identity via img2img init, but no skeleton.

Investigating "is best-effort redundant now strict shipped?" surfaced that strict didn't preserve identity at all — so they were complementary, not redundant.

## What

mflux's ported `ZImageControl.generate_image` **already** accepts `image_path` / `image_strength` and threads them into the img2img **init** latents, *independently* of the skeleton `control_context`. So one Z-Image pass can do skeleton-accurate pose **and** reference identity. This unifies them — **SceneWorks-only wiring; mflux unchanged** (the pinned branch already has the params):

- **`mlx_flux_runner._run_z_image_control`** forwards spec `imagePath`/`imageStrength` into `generate_image` (`None` → pose-only, the prior sc-2257 behaviour).
- **`MlxZImageAdapter`** strict pose path resolves the reference via `find_asset_media_path` into a **single shared img2img init** across the pose set (identity is constant; only the per-pose skeleton changes). Stops silently dropping it.
- New **`_reference_strength`** helper (default `0.5`, `advanced.referenceStrength` override, clamp `[0.05, 1.0]`). ⚠️ mflux `image_strength` is **inverted** vs diffusers (higher = more init kept = stronger identity, less reposing room), so a dedicated key avoids the footgun.

This **supersedes the best-effort tier sc-2263** (archived — not deferred).

## Tests

475 worker tests pass (3 new):
- ref-init dispatch (strict pose + reference → shared `imagePath` + default strength; no-reference path asserted unchanged)
- `_reference_strength` default / override / clamp / junk-input
- runner pass-through into `generate_image` (mocked mflux), with/without a reference

## Owed (real-Mac E2E)

Sweep `referenceStrength` for the default that holds identity **without** breaking the pose lock — the few-step Turbo init↔control tension. If it can't hold both, sc-2263's best-effort is the documented fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)