### PR TITLE
Pose Library (epic 2282): DWPose detector + global pose store + screen [WIP]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -424,6 +424,11 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         settings.data_dir.clone(),
         settings.app_version.clone(),
     ));
+    // Reserved global pose library (epic 2282): created up front so its assets
+    // endpoint returns [] (not 404) before any pose is saved. Best-effort.
+    if let Err(error) = project_store.ensure_global_poses_project() {
+        eprintln!("SceneWorks API: could not ensure global pose library project: {error}");
+    }
     let state = AppState {
         settings,
         jobs_store,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -6,6 +6,7 @@ import { StatusDot } from "./components/StatusDot.jsx";
 import { FullscreenPreview } from "./components/assetPanels.jsx";
 import { fallbackModels, terminalStatuses } from "./constants.js";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
+import { PoseLibraryScreen } from "./screens/PoseLibraryScreen.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { DocumentStudio } from "./screens/DocumentStudio.jsx";
@@ -157,6 +158,7 @@ const navSections = [
     items: [
       { id: "Library", label: "Assets", icon: Icon.Library },
       { id: "LibraryDataSets", label: "Data Sets", icon: Icon.Train },
+      { id: "Poses", label: "Pose Library", icon: Icon.Character },
       { id: "Presets", icon: Icon.Preset },
       { id: "Models", icon: Icon.Model },
     ],
@@ -173,6 +175,7 @@ const navSections = [
 const viewTitles = {
   Library: { title: "Assets", blurb: "Browse stills and clips across all your projects." },
   LibraryDataSets: { title: "Data Sets", blurb: "Create and caption training datasets." },
+  Poses: { title: "Pose Library", blurb: "Manage whole-body pose skeletons and create new ones from photos." },
   Image: { title: "Image Studio", blurb: "Describe what you want — we'll render variations side by side." },
   Video: { title: "Video Studio", blurb: "Bring stills to life, or render new clips from scratch." },
   Document: { title: "Document Studio", blurb: "Generate interleaved text-image documents — guides, storyboards, tutorials." },
@@ -1661,6 +1664,10 @@ export function App() {
 
         {activeView === "LibraryDataSets" ? (
           <TrainingDataSetsLibrary />
+        ) : null}
+
+        {activeView === "Poses" ? (
+          <PoseLibraryScreen />
         ) : null}
 
         {activeView === "Image" ? (

--- a/apps/web/src/components/PoseLibraryPicker.jsx
+++ b/apps/web/src/components/PoseLibraryPicker.jsx
@@ -4,8 +4,8 @@ import { usePoseLibrary } from "../poseLibrary.js";
 // Multi-select gallery of OpenPose poses, grouped by category. Controlled: the parent
 // owns `selectedIds` (array) and gets toggles via `onToggle(id)` / `onClear()`. Shared
 // by the Character Studio pose panel and the Image Studio pose section.
-export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear }) {
-  const { poses, categories, loading, error } = usePoseLibrary();
+export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUserPoses }) {
+  const { poses, categories, loading, error } = usePoseLibrary({ loadUserPoses });
   const selected = new Set(selectedIds);
 
   if (loading) {
@@ -51,7 +51,7 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear }) {
                     title={pose.label}
                     type="button"
                   >
-                    <img alt={pose.label} loading="lazy" src={`/${pose.preview}`} />
+                    <img alt={pose.label} loading="lazy" src={pose.previewUrl ?? `/${pose.preview}`} />
                     <span className="pose-thumb-label">{pose.label}</span>
                   </button>
                 );

--- a/apps/web/src/poseLibrary.js
+++ b/apps/web/src/poseLibrary.js
@@ -1,16 +1,19 @@
 import { useEffect, useState } from "react";
 
-// The bundled OpenPose pose library (apps/web/public/poses/index.json): normalized
-// COCO-18 skeletons + preview thumbnails, grouped by category. Loaded once and cached;
-// the selected poses' keypoints ride advanced.poses on a character-image job, where the
-// InstantID adapter renders each skeleton and generates the character in that pose.
-let cachePromise = null;
+// The pose library is the union of two sources:
+//  - BUILT-IN: the bundled OpenPose library (apps/web/public/poses/index.json) —
+//    normalized COCO-18 skeletons + preview thumbnails, shipped read-only, cached.
+//  - USER: type:"pose" assets in the reserved global poses project (epic 2282),
+//    fetched fresh via an injected `loadUserPoses` fetcher (they change as users
+//    create/trash poses). Optional + best-effort: any failure degrades to built-ins.
+// Selected poses' keypoints (+ optional hands/face) ride advanced.poses on a job.
+let builtinCache = null;
 
-export function loadPoseLibrary() {
-  if (!cachePromise) {
+export function loadBuiltinPoses() {
+  if (!builtinCache) {
     // Promise.resolve().then(...) so a missing/throwing fetch becomes a rejection the
     // caller's .catch handles (rather than a synchronous throw at the call site).
-    cachePromise = Promise.resolve()
+    builtinCache = Promise.resolve()
       .then(() => {
         if (typeof fetch !== "function") {
           throw new Error("fetch unavailable");
@@ -25,30 +28,66 @@ export function loadPoseLibrary() {
       })
       .then((data) => {
         const poses = Array.isArray(data?.poses) ? data.poses : [];
-        const categories = Array.isArray(data?.categories)
-          ? data.categories
-          : [...new Set(poses.map((pose) => pose.category))];
-        const byId = Object.fromEntries(poses.map((pose) => [pose.id, pose]));
-        return { poses, categories, byId };
+        return poses.map((pose) => ({
+          ...pose,
+          source: "builtin",
+          previewUrl: `/${pose.preview}`,
+        }));
       })
       .catch((error) => {
-        cachePromise = null; // allow a retry on next mount
+        builtinCache = null; // allow a retry on next mount
         throw error;
       });
   }
-  return cachePromise;
+  return builtinCache;
 }
 
-export function usePoseLibrary() {
+// Map a reserved-project type:"pose" asset into a pose record the picker understands.
+// The asset's `pose` field carries keypoints/hands/face/category; `url` is the rendered
+// skeleton preview. Built by the DWPose detector + Create tab (sc-2285/sc-2287).
+export function poseAssetToRecord(asset) {
+  const pose = asset?.pose ?? {};
+  return {
+    id: asset.id,
+    label: asset.displayName || asset.id,
+    category: pose.category || "my poses",
+    keypoints: pose.keypoints ?? [],
+    hands: pose.hands,
+    face: pose.face,
+    tags: asset.tags ?? [],
+    source: "user",
+    assetId: asset.id,
+    previewUrl: asset.url ?? (asset.file?.path ? `/${asset.file.path}` : undefined),
+  };
+}
+
+export async function loadPoseLibrary({ loadUserPoses } = {}) {
+  const builtin = await loadBuiltinPoses();
+  let user = [];
+  if (typeof loadUserPoses === "function") {
+    try {
+      user = (await loadUserPoses()) || [];
+    } catch {
+      user = []; // best-effort: never let user-pose fetch failures hide the built-ins
+    }
+  }
+  const poses = [...builtin, ...user];
+  const categories = [...new Set(poses.map((pose) => pose.category).filter(Boolean))];
+  const byId = Object.fromEntries(poses.map((pose) => [pose.id, pose]));
+  return { poses, categories, byId };
+}
+
+// `loadUserPoses` should be a memoized (useCallback) async fetcher or undefined.
+export function usePoseLibrary({ loadUserPoses } = {}) {
   const [state, setState] = useState({ poses: [], categories: [], byId: {}, loading: true, error: "" });
   useEffect(() => {
     let active = true;
-    loadPoseLibrary()
+    loadPoseLibrary({ loadUserPoses })
       .then((library) => active && setState({ ...library, loading: false, error: "" }))
       .catch((error) => active && setState({ poses: [], categories: [], byId: {}, loading: false, error: String(error.message ?? error) }));
     return () => {
       active = false;
     };
-  }, []);
+  }, [loadUserPoses]);
   return state;
 }

--- a/apps/web/src/poseLibrary.js
+++ b/apps/web/src/poseLibrary.js
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 
+// The reserved global project that holds user-created pose assets (epic 2282). Mirrors
+// crates/sceneworks-core::GLOBAL_POSES_PROJECT_ID. Hidden from the project switcher;
+// addressed directly by the Pose Library screen + the user-pose picker fetcher.
+export const GLOBAL_POSES_PROJECT_ID = "project_global_poses";
+
 // The pose library is the union of two sources:
 //  - BUILT-IN: the bundled OpenPose library (apps/web/public/poses/index.json) —
 //    normalized COCO-18 skeletons + preview thumbnails, shipped read-only, cached.

--- a/apps/web/src/poseLibrary.test.jsx
+++ b/apps/web/src/poseLibrary.test.jsx
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadBuiltinPoses, loadPoseLibrary, poseAssetToRecord } from "./poseLibrary.js";
+
+const BUILTIN = {
+  version: 1,
+  categories: ["standing"],
+  poses: [{ id: "standing_01", category: "standing", label: "Standing 01", preview: "poses/standing_01.png", keypoints: [[0.5, 0.1]] }],
+};
+
+function mockBuiltinFetch() {
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => BUILTIN })));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("poseLibrary", () => {
+  it("tags built-in poses with source + a usable previewUrl", async () => {
+    mockBuiltinFetch();
+    const builtin = await loadBuiltinPoses();
+    expect(builtin[0].source).toBe("builtin");
+    expect(builtin[0].previewUrl).toBe("/poses/standing_01.png");
+  });
+
+  it("maps a reserved-project pose asset into a pose record", () => {
+    const record = poseAssetToRecord({
+      id: "asset_pose_1",
+      displayName: "Arm Raised",
+      url: "/api/v1/projects/project_global_poses/files/assets/poses/asset_pose_1.png",
+      tags: ["dynamic"],
+      pose: { category: "dance", keypoints: [[0.4, 0.2]], hands: [[], []], face: [] },
+    });
+    expect(record).toMatchObject({
+      id: "asset_pose_1",
+      label: "Arm Raised",
+      category: "dance",
+      source: "user",
+      assetId: "asset_pose_1",
+    });
+    expect(record.keypoints).toEqual([[0.4, 0.2]]);
+    expect(record.previewUrl).toContain("/files/assets/poses/");
+  });
+
+  it("merges built-in + injected user poses (categories + byId)", async () => {
+    mockBuiltinFetch();
+    const userPose = poseAssetToRecord({ id: "asset_u1", displayName: "User Pose", pose: { category: "my poses", keypoints: [[0.1, 0.2]] } });
+    const lib = await loadPoseLibrary({ loadUserPoses: async () => [userPose] });
+    expect(lib.poses).toHaveLength(2);
+    expect(lib.categories).toEqual(expect.arrayContaining(["standing", "my poses"]));
+    expect(lib.byId.asset_u1.source).toBe("user");
+    expect(lib.byId.standing_01.source).toBe("builtin");
+  });
+
+  it("degrades to built-ins when the user-pose fetch fails", async () => {
+    mockBuiltinFetch();
+    const lib = await loadPoseLibrary({
+      loadUserPoses: async () => {
+        throw new Error("network");
+      },
+    });
+    expect(lib.poses).toHaveLength(1);
+    expect(lib.poses[0].id).toBe("standing_01");
+  });
+});

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -1,0 +1,241 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { GLOBAL_POSES_PROJECT_ID } from "../poseLibrary.js";
+
+// The Pose Library screen (epic 2282). Two tabs:
+//  - "Poses": manage the global pose store — user-created type:"pose" assets in the
+//    reserved project, as an image grid + viewer + Trashcan (reusing the shared asset
+//    panels). Built-in poses stay bundled (read-only) and surface in the generation
+//    pose pickers, not here.
+//  - "Create": photo -> DWPose -> categorize -> save (sc-2287; placeholder for now).
+// The reserved project is hidden from the project switcher, so these assets never
+// appear in the Assets/Character views; we address it directly here.
+const TABS = [
+  ["poses", "Poses"],
+  ["create", "Create"],
+];
+
+const UNCATEGORIZED = "uncategorized";
+
+export function PoseLibraryScreen() {
+  const { token } = useAppContext();
+  const [activeTab, setActiveTab] = useState("poses");
+  const [poses, setPoses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [selectedId, setSelectedId] = useState(null);
+  const [assetMode, setAssetMode] = useState("assets");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+
+  const refresh = useCallback(
+    async (signal) => {
+      try {
+        setLoading(true);
+        const items = await apiFetch(
+          `/api/v1/projects/${GLOBAL_POSES_PROJECT_ID}/assets?includeRejected=true&includeTrashed=true`,
+          token,
+          signal ? { signal } : {},
+        );
+        setPoses((Array.isArray(items) ? items : []).filter((asset) => asset.type === "pose"));
+        setError("");
+      } catch (err) {
+        if (isAbortError(err)) return;
+        setError(String(err?.message ?? err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [token],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    refresh(controller.signal);
+    return () => controller.abort();
+  }, [refresh]);
+
+  // Mutations target the reserved project (asset.projectId) and refetch locally — the
+  // app-level asset mutators refresh the *active* project, not this one.
+  const updateAssetStatus = useCallback(
+    async (asset, changes) => {
+      await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/status`, token, {
+        method: "PATCH",
+        body: JSON.stringify(changes),
+      });
+      await refresh();
+    },
+    [token, refresh],
+  );
+  const updateAssetTags = useCallback(
+    async (asset, tags) => {
+      await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/tags`, token, {
+        method: "PATCH",
+        body: JSON.stringify({ tags }),
+      });
+      await refresh();
+    },
+    [token, refresh],
+  );
+  const deleteAsset = useCallback(
+    async (asset) => {
+      await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}`, token, { method: "DELETE" });
+      await refresh();
+    },
+    [token, refresh],
+  );
+  const purgeAsset = useCallback(
+    async (asset) => {
+      await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge`, token, { method: "DELETE" });
+      await refresh();
+    },
+    [token, refresh],
+  );
+
+  const categoryOf = (asset) => asset.pose?.category || UNCATEGORIZED;
+  const categories = useMemo(
+    () => [...new Set(poses.map(categoryOf))].sort(),
+    [poses],
+  );
+  const availableTags = useMemo(
+    () => [...new Set(poses.flatMap((asset) => (Array.isArray(asset.tags) ? asset.tags : [])))].sort(),
+    [poses],
+  );
+
+  const inFilter = (asset) => categoryFilter === "all" || categoryOf(asset) === categoryFilter;
+  const inMode = (asset) => (assetMode === "trashcan" ? Boolean(asset.status?.trashed) : !asset.status?.trashed);
+  const visible = poses.filter((asset) => inFilter(asset) && inMode(asset));
+  const trashedInView = poses.filter((asset) => inFilter(asset) && asset.status?.trashed);
+  const selected = poses.find((asset) => asset.id === selectedId) ?? null;
+  const onPreview = (asset) => setSelectedId(asset.id);
+
+  // Group the visible poses by category for the grid (category + tags shown per tile).
+  const groups = useMemo(() => {
+    const byCategory = new Map();
+    for (const asset of visible) {
+      const key = categoryOf(asset);
+      if (!byCategory.has(key)) byCategory.set(key, []);
+      byCategory.get(key).push(asset);
+    }
+    return [...byCategory.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, [visible]);
+
+  return (
+    <section className="main-surface library-surface pose-library-surface">
+      <div className="surface-header hero">
+        <div className="section-heading">
+          <p className="eyebrow">Pose Library</p>
+          <h2>Poses</h2>
+          <p className="hero-blurb">
+            Manage your whole-body pose skeletons — discard, restore, tag, and categorize. Create new poses from photos in the Create tab.
+          </p>
+        </div>
+        <div className="segmented-control" role="tablist" aria-label="Pose Library sections">
+          {TABS.map(([id, label]) => (
+            <button
+              aria-controls={`pose-library-panel-${id}`}
+              aria-selected={activeTab === id}
+              className={activeTab === id ? "active" : ""}
+              id={`pose-library-tab-${id}`}
+              key={id}
+              onClick={() => setActiveTab(id)}
+              role="tab"
+              type="button"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div
+        aria-labelledby="pose-library-tab-poses"
+        hidden={activeTab !== "poses"}
+        id="pose-library-panel-poses"
+        role="tabpanel"
+      >
+        <div className="toolbar">
+          <select
+            aria-label="Pose category"
+            onChange={(event) => setCategoryFilter(event.target.value)}
+            value={categoryFilter}
+          >
+            <option value="all">All categories</option>
+            {categories.map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))}
+          </select>
+          <div className="segmented-control" role="group" aria-label="Pose collection">
+            <button className={assetMode === "assets" ? "active" : ""} onClick={() => setAssetMode("assets")} type="button">
+              Poses
+            </button>
+            <button className={assetMode === "trashcan" ? "active" : ""} onClick={() => setAssetMode("trashcan")} type="button">
+              Trashcan
+            </button>
+          </div>
+          {assetMode === "trashcan" ? (
+            <button
+              className="danger-action empty-trash-button"
+              disabled={!trashedInView.length}
+              onClick={() => emptyTrash(trashedInView, purgeAsset)}
+              type="button"
+            >
+              Empty Trash ({trashedInView.length})
+            </button>
+          ) : null}
+        </div>
+
+        {error ? <p className="inline-warning">Pose library unavailable: {error}</p> : null}
+
+        <div className="library-layout">
+          <div className="pose-library-grids">
+            {loading && !poses.length ? (
+              <div className="empty-panel">Loading poses…</div>
+            ) : !visible.length ? (
+              <div className="empty-panel">
+                {assetMode === "trashcan"
+                  ? "Trashcan is empty."
+                  : "No saved poses yet — create some from photos in the Create tab."}
+              </div>
+            ) : (
+              groups.map(([category, items]) => (
+                <div className="pose-category" key={category}>
+                  <p className="eyebrow">
+                    {category} <span className="muted">({items.length})</span>
+                  </p>
+                  <AssetGrid
+                    assets={items}
+                    onPreview={onPreview}
+                    selectedAsset={selected}
+                    setSelectedAssetId={setSelectedId}
+                  />
+                </div>
+              ))
+            )}
+          </div>
+          <AssetDetail
+            asset={selected}
+            deleteAsset={deleteAsset}
+            purgeAsset={purgeAsset}
+            onPreview={onPreview}
+            updateAssetStatus={updateAssetStatus}
+            updateAssetTags={updateAssetTags}
+            availableTags={availableTags}
+          />
+        </div>
+      </div>
+
+      <div
+        aria-labelledby="pose-library-tab-create"
+        hidden={activeTab !== "create"}
+        id="pose-library-panel-create"
+        role="tabpanel"
+      >
+        <div className="empty-panel">Pose creation from photos is coming soon.</div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/screens/PoseLibraryScreen.test.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.test.jsx
@@ -1,0 +1,116 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Control the mocked API: GET /assets returns `poseAssets`, mutations resolve and are
+// recorded in `apiCalls`.
+const apiCalls = [];
+let poseAssets = [];
+
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual, // keep API_BASE_URL / eventUrl / isAbortError for assetMedia etc.
+    apiFetch: vi.fn(async (path, _token, options = {}) => {
+      const method = options.method ?? "GET";
+      apiCalls.push({ path, method });
+      if (method === "GET" && path.includes("/assets")) {
+        return poseAssets;
+      }
+      return {};
+    }),
+  };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { PoseLibraryScreen } from "./PoseLibraryScreen.jsx";
+
+function poseAsset(overrides = {}) {
+  return {
+    id: "asset_pose_1",
+    projectId: "project_global_poses",
+    type: "pose",
+    displayName: "Arm Raised",
+    tags: ["dynamic"],
+    file: { path: "assets/poses/asset_pose_1.png", mimeType: "image/png", width: 768, height: 1280 },
+    url: "/api/v1/projects/project_global_poses/files/assets/poses/asset_pose_1.png",
+    status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    pose: { category: "dance", keypoints: [[0.5, 0.1]] },
+    recipe: {},
+    lineage: {},
+    ...overrides,
+  };
+}
+
+async function click(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("PoseLibraryScreen", () => {
+  let container;
+  let root;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    apiCalls.length = 0;
+    poseAssets = [];
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ token: "test-token" }}>
+          <PoseLibraryScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {}); // flush the refresh() effect
+  }
+
+  it("fetches reserved-project poses and groups them by category", async () => {
+    poseAssets = [poseAsset()];
+    await render();
+    expect(apiCalls[0].path).toContain("/api/v1/projects/project_global_poses/assets");
+    expect(container.textContent).toContain("Arm Raised");
+    expect(container.textContent).toContain("dance");
+  });
+
+  it("shows an empty state when there are no saved poses", async () => {
+    poseAssets = [];
+    await render();
+    expect(container.textContent).toContain("No saved poses yet");
+  });
+
+  it("discards a selected pose against the reserved project", async () => {
+    poseAssets = [poseAsset()];
+    await render();
+    const tile = [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Arm Raised"));
+    await click(tile);
+    const discard = [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === "Discard");
+    expect(discard).toBeTruthy();
+    await click(discard);
+    expect(
+      apiCalls.some((c) => c.method === "DELETE" && c.path === "/api/v1/projects/project_global_poses/assets/asset_pose_1"),
+    ).toBe(true);
+  });
+
+  it("switches to the Create tab", async () => {
+    poseAssets = [poseAsset()];
+    await render();
+    const createTab = container.querySelector("#pose-library-tab-create");
+    await click(createTab);
+    expect(container.querySelector("#pose-library-panel-poses").hidden).toBe(true);
+    expect(container.querySelector("#pose-library-panel-create").hidden).toBe(false);
+  });
+});

--- a/apps/worker/requirements-pose.txt
+++ b/apps/worker/requirements-pose.txt
@@ -1,0 +1,14 @@
+# DWPose whole-body keypoint detection for the Pose Library (epic 2282, sc-2285).
+# Install in the GPU worker image; imported lazily by scene_worker/pose_adapters.py,
+# so the worker stays importable without it (the `pose_detect` capability is simply
+# not advertised). Validated on the M5 Max via the sc-2283 spike.
+#
+# rtmlib (Apache-2.0) wraps RTMPose/RTMW whole-body detection on onnxruntime — the
+# same arm64 onnxruntime stack already shipped for InstantID's antelopev2, so no new
+# heavyweight/native dep. `mode=performance` = yolox_m + rtmw-dw-x-l (cocktail14);
+# the onnx weights are fetched on first use (one-time) and cached. Set
+# SCENEWORKS_DWPOSE_DET / SCENEWORKS_DWPOSE_POSE to pinned local onnx paths for a
+# fully offline worker. onnxruntime is already pulled in by requirements-instantid.txt;
+# pinned here too so the pose lane is self-contained.
+rtmlib>=0.0.13
+onnxruntime>=1.20

--- a/apps/worker/scene_worker/pose_adapters.py
+++ b/apps/worker/scene_worker/pose_adapters.py
@@ -1,0 +1,346 @@
+"""DWPose whole-body keypoint detection for the Pose Library (epic 2282, sc-2285).
+
+Photo -> normalized whole-body keypoints (OpenPose-18 body + 21x2 hands + 68 face
++ per-keypoint confidence + per-person bbox) + source aspect, rendered into a
+skeleton preview via the production ``openpose_skeleton.draw_wholebody`` (the same
+control the Z-Image Fun-Controlnet-Union pose head was trained on — sc-2257/PR#376).
+
+Design mirrors ``person_adapters``: the heavy backend (rtmlib / onnxruntime) is
+imported lazily inside the model seam so this module stays importable on a host
+without it (the ``pose_detect`` capability is then simply not advertised). The
+pure keypoint conversion + geometry is plain Python/numpy and unit-testable
+without the onnx weights.
+
+Detector: rtmlib (Apache-2.0) RTMW whole-body on onnxruntime — the same arm64
+onnxruntime stack already shipped for InstantID's antelopev2. ``mode=performance``
+= yolox_m + rtmw-dw-x-l (cocktail14, 384x288). The spike (sc-2283) validated this
+on the M5 Max via CoreML (~33ms/image) and confirmed full DWPose never degrades
+the Z-Image pose lock and fixes the high-scale drift.
+
+The job returns one pose candidate per detected person; persisting candidates into
+the global pose store (asset records) is the Create-tab/store work (sc-2287/2284).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any, Callable
+from uuid import uuid4
+
+ProgressCallback = Callable[[str, str, float, str], None]
+CancelCallback = Callable[[], bool]
+
+# Default per-keypoint confidence floor for rendering. NOTE: rtmlib's RTMW emits
+# SimCC scores that are NOT in [0, 1] (good keypoints observed ~4-8 in the spike),
+# so this is a render/threshold knob, not a probability. Raw scores are preserved
+# in the output so the store can normalize/threshold per detector later (sc-2285
+# spike gotcha).
+DEFAULT_POSE_MIN_CONF = 0.3
+DETECTOR_MODE = os.environ.get("SCENEWORKS_DWPOSE_MODE", "performance")
+
+# COCO-WholeBody-133 (rtmlib raw, to_openpose=False) -> SceneWorks OpenPose-18 body.
+# WholeBody order: 0-16 COCO body, 17-22 feet, 23-90 face(68), 91-111 left hand,
+# 112-132 right hand. COCO body: 0 nose,1 l_eye,2 r_eye,3 l_ear,4 r_ear,5 l_sho,
+# 6 r_sho,7 l_elb,8 r_elb,9 l_wri,10 r_wri,11 l_hip,12 r_hip,13 l_kne,14 r_kne,
+# 15 l_ank,16 r_ank. OpenPose-18 inserts neck(1) = midpoint of shoulders.
+COCO_TO_OPENPOSE = {
+    0: 0, 2: 6, 3: 8, 4: 10, 5: 5, 6: 7, 7: 9, 8: 12, 9: 14, 10: 16,
+    11: 11, 12: 13, 13: 15, 14: 2, 15: 1, 16: 4, 17: 3,
+}
+FACE_SLICE = slice(23, 91)        # 68 points
+LHAND_SLICE = slice(91, 112)      # 21 points
+RHAND_SLICE = slice(112, 133)     # 21 points
+
+
+class PoseDetectError(RuntimeError):
+    """Raised when pose detection cannot proceed (missing backend / no input)."""
+
+
+# ---------------------------------------------------------------------------
+# Backend availability (advertised as a worker capability only when installed)
+# ---------------------------------------------------------------------------
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def pose_detector_backend_available() -> bool:
+    """True when the DWPose backend (rtmlib + onnxruntime) can be imported."""
+    return _module_available("rtmlib") and _module_available("onnxruntime")
+
+
+def _require_pose_extras() -> None:
+    missing = [m for m in ("rtmlib", "onnxruntime") if not _module_available(m)]
+    if missing:
+        raise PoseDetectError(
+            "DWPose detection needs " + " + ".join(missing) + ". Install "
+            "apps/worker/requirements-pose.txt (rtmlib, onnxruntime)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Keypoint conversion (pure; numpy only)
+# ---------------------------------------------------------------------------
+
+
+def _pt(kps, sc, i: int, w: int, h: int) -> list:
+    return [float(kps[i, 0]) / w, float(kps[i, 1]) / h, float(sc[i])]
+
+
+def _seq(kps, sc, sl: slice, w: int, h: int) -> list:
+    return [_pt(kps, sc, i, w, h) for i in range(sl.start, sl.stop)]
+
+
+def wholebody_to_openpose(kps, sc, w: int, h: int) -> dict:
+    """Convert one person's (133,2) keypoints + (133,) scores into the SceneWorks
+    pose record: body18 + hands[left21,right21] + face68, each [x,y,conf] in [0,1]."""
+    body: list = [None] * 18
+    for op_idx, coco_idx in COCO_TO_OPENPOSE.items():
+        body[op_idx] = _pt(kps, sc, coco_idx, w, h)
+    ls, rs = kps[5], kps[6]  # shoulders -> neck
+    body[1] = [
+        float((ls[0] + rs[0]) / 2) / w,
+        float((ls[1] + rs[1]) / 2) / h,
+        float(min(sc[5], sc[6])),
+    ]
+    return {
+        "keypoints": body,
+        "hands": [_seq(kps, sc, LHAND_SLICE, w, h), _seq(kps, sc, RHAND_SLICE, w, h)],
+        "face": _seq(kps, sc, FACE_SLICE, w, h),
+    }
+
+
+def _thresholded(group: list, min_conf: float) -> list:
+    """Render-ready copy: drop (None) points below the confidence floor."""
+    out = []
+    for p in group:
+        out.append(None if (p is None or p[2] < min_conf) else (p[0], p[1]))
+    return out
+
+
+def _bbox(*groups: list, min_conf: float):
+    xs, ys = [], []
+    for g in groups:
+        for p in g:
+            if p is not None and p[2] >= min_conf:
+                xs.append(p[0])
+                ys.append(p[1])
+    if not xs:
+        return None
+    return [min(xs), min(ys), max(xs), max(ys)]
+
+
+def _mean_conf(group: list) -> float:
+    cs = [p[2] for p in group if p is not None]
+    return round(sum(cs) / len(cs), 3) if cs else 0.0
+
+
+def _facing(body: list, min_conf: float) -> str:
+    def ok(i):
+        return body[i] is not None and body[i][2] >= min_conf
+    nose, r_eye, l_eye, r_ear, l_ear = ok(0), ok(14), ok(15), ok(16), ok(17)
+    if not nose and not r_eye and not l_eye:
+        return "back"
+    if r_ear and l_ear:
+        return "front"
+    if r_ear != l_ear:
+        return "profile"
+    return "front"
+
+
+# ---------------------------------------------------------------------------
+# Detector model seam
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PoseDetectorRuntime:
+    model: Any
+    device: str
+    detector_id: str
+
+
+_DETECTOR_CACHE: dict[str, PoseDetectorRuntime] = {}
+
+
+def _onnx_device(settings: Any) -> str:
+    gpu_id = str(getattr(settings, "gpu_id", "") or "").lower()
+    # onnxruntime runs DWPose on CoreML (Apple Silicon) or CPU; never torch-CUDA here.
+    return "cpu" if gpu_id in ("", "cpu") else "mps"
+
+
+def load_pose_detector(settings: Any, *, device: str | None = None) -> PoseDetectorRuntime:
+    """Load (and cache) the rtmlib whole-body detector.
+
+    Tries the requested onnxruntime provider (CoreML for ``mps``) and falls back to
+    CPU if it can't initialise. Weights come from rtmlib's ``performance`` preset;
+    set ``SCENEWORKS_DWPOSE_DET``/``SCENEWORKS_DWPOSE_POSE`` to pinned local onnx
+    paths to run fully offline (no openmmlab fetch)."""
+    _require_pose_extras()
+    from rtmlib import Wholebody
+
+    want = device or _onnx_device(settings)
+    if want in _DETECTOR_CACHE:
+        return _DETECTOR_CACHE[want]
+
+    kwargs: dict[str, Any] = {"mode": DETECTOR_MODE, "backend": "onnxruntime"}
+    det_path = os.environ.get("SCENEWORKS_DWPOSE_DET")
+    pose_path = os.environ.get("SCENEWORKS_DWPOSE_POSE")
+    if det_path and pose_path:
+        # Pinned weights: performance preset input sizes (yolox 640, rtmw 288x384).
+        kwargs = {
+            "det": det_path,
+            "det_input_size": (640, 640),
+            "pose": pose_path,
+            "pose_input_size": (288, 384),
+            "backend": "onnxruntime",
+        }
+
+    try:
+        model = Wholebody(device=want, **kwargs)
+        used = want
+    except Exception:  # noqa: BLE001 - any provider init failure -> CPU
+        model = Wholebody(device="cpu", **kwargs)
+        used = "cpu"
+
+    runtime = PoseDetectorRuntime(
+        model=model, device=used, detector_id=f"rtmlib/wholebody-{DETECTOR_MODE}"
+    )
+    _DETECTOR_CACHE[used] = runtime
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _normalize_sources(payload: dict) -> list[dict]:
+    sources = payload.get("sources")
+    if isinstance(sources, list) and sources:
+        return [s for s in sources if isinstance(s, dict)]
+    # single-source convenience form
+    if payload.get("path"):
+        return [{
+            "path": payload.get("path"),
+            "assetId": payload.get("sourceAssetId"),
+            "displayName": payload.get("displayName"),
+        }]
+    return []
+
+
+def run_pose_detect(
+    settings: Any,
+    job: dict[str, Any],
+    *,
+    progress: ProgressCallback | None = None,
+    cancel_requested: CancelCallback | None = None,
+    detector_factory: Callable[..., PoseDetectorRuntime] = load_pose_detector,
+) -> dict[str, Any]:
+    """Run DWPose on each source image and return whole-body pose candidates.
+
+    payload: ``{"sources": [{"path", "assetId"?, "displayName"?}], "minConf"?}``
+    result:  ``{"sources": [{source meta + poses[]}], "detector", "poseDetectionActive"}``
+    Skeleton previews are written to ``<data_dir>/cache/pose_detect/<job_id>/``.
+    """
+    import cv2
+    import numpy as np  # noqa: F401  (cv2/np used; numpy ensures conversion dtypes)
+
+    from scene_worker.openpose_skeleton import draw_wholebody
+
+    payload = job.get("payload") or {}
+    sources = _normalize_sources(payload)
+    if not sources:
+        raise PoseDetectError("No source images supplied for pose detection.")
+    try:
+        min_conf = float(payload.get("minConf"))
+    except (TypeError, ValueError):
+        min_conf = DEFAULT_POSE_MIN_CONF
+
+    job_id = str(job.get("id") or uuid4().hex)
+    out_dir = Path(getattr(settings, "data_dir", ".")) / "cache" / "pose_detect" / job_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _p(stage: str, value: float, message: str) -> None:
+        if progress is not None:
+            progress("running", stage, value, message)
+
+    _p("downloading", 0.08, "Loading DWPose detector.")
+    runtime = detector_factory(settings)
+
+    out_sources: list[dict] = []
+    total = len(sources)
+    for si, src in enumerate(sources):
+        if cancel_requested is not None and cancel_requested():
+            raise InterruptedError("Pose detection canceled.")
+        path = src.get("path")
+        img = cv2.imread(path) if path else None
+        if img is None:
+            out_sources.append({
+                "sourceAssetId": src.get("assetId"),
+                "sourcePath": path,
+                "error": "unreadable image",
+                "poses": [],
+            })
+            continue
+        h, w = img.shape[:2]
+        keypoints, scores = runtime.model(img)
+        n = 0 if keypoints is None else len(keypoints)
+
+        ordered = []
+        for i in range(n):
+            rec = wholebody_to_openpose(keypoints[i], scores[i], w, h)
+            bbox = _bbox(rec["keypoints"], rec["hands"][0], rec["hands"][1], rec["face"], min_conf=min_conf)
+            area = 0.0 if bbox is None else (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+            ordered.append((area, rec, bbox))
+        ordered.sort(key=lambda t: -t[0])  # largest person first
+
+        stem = Path(path).stem
+        poses = []
+        for person_index, (_area, rec, bbox) in enumerate(ordered):
+            body_t = _thresholded(rec["keypoints"], min_conf)
+            hands_t = [_thresholded(rec["hands"][0], min_conf), _thresholded(rec["hands"][1], min_conf)]
+            face_t = _thresholded(rec["face"], min_conf)
+            stick = max(6, round(min(w, h) * 0.012))
+            skel = draw_wholebody(w, h, body_t, hands_t, face_t, stickwidth=stick)
+            preview = out_dir / f"{stem}_p{person_index}_skel.png"
+            cv2.imwrite(str(preview), cv2.cvtColor(skel, cv2.COLOR_RGB2BGR))
+            poses.append({
+                "personIndex": person_index,
+                "bbox": bbox,
+                "facing": _facing(rec["keypoints"], min_conf),
+                "meanConf": {
+                    "body": _mean_conf(rec["keypoints"]),
+                    "hands": round((_mean_conf(rec["hands"][0]) + _mean_conf(rec["hands"][1])) / 2, 3),
+                    "face": _mean_conf(rec["face"]),
+                },
+                "keypoints": rec["keypoints"],
+                "hands": rec["hands"],
+                "face": rec["face"],
+                "skeletonPreview": str(preview),
+            })
+
+        out_sources.append({
+            "sourceAssetId": src.get("assetId"),
+            "sourcePath": path,
+            "displayName": src.get("displayName") or stem,
+            "sourceWidth": w,
+            "sourceHeight": h,
+            "sourceAspect": round(w / h, 4),
+            "poses": poses,
+        })
+        _p("running", 0.08 + 0.9 * (si + 1) / total,
+           f"Detected {len(poses)} pose(s) in image {si + 1}/{total}.")
+
+    return {
+        "sources": out_sources,
+        "detector": {"id": runtime.detector_id, "device": runtime.device, "minConf": min_conf},
+        "poseDetectionActive": True,
+    }

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -46,6 +46,7 @@ from .person_adapters import (
     segmenter_backend_available,
     tracker_backend_available,
 )
+from .pose_adapters import pose_detector_backend_available, run_pose_detect
 from .prompt_refine import PromptRefineError, PromptRefiner
 from .settings import WorkerSettings
 from .training_adapters import (
@@ -68,6 +69,11 @@ VIDEO_JOB_TYPES = ("video_generate", "video_extend", "video_bridge", "person_rep
 # person_detect_preview / person_track_preview capabilities. Keep in sync with
 # crates/sceneworks-core/src/contracts.rs::WorkerCapability and jobs_store::worker_supports_job.
 PERSON_JOB_TYPES = ("person_detect", "person_track")
+# DWPose whole-body keypoint detection for the Pose Library (epic 2282). onnxruntime
+# (rtmlib) like person_detect — advertised by the Python worker only when the backend
+# is installed; routed via requested_gpu (not in NON_GPU_JOB_TYPES). Keep in sync with
+# crates/sceneworks-core/src/contracts.rs::JobType / WorkerCapability.
+POSE_JOB_TYPES = ("pose_detect",)
 # Keep GPU-required job types in sync with
 # crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
 # apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
@@ -108,6 +114,7 @@ PROMPT_REFINE_JOB_TYPES = ("prompt_refine",)
 ALL_JOB_TYPES = (
     SUPPORTED_JOB_TYPES
     + PERSON_JOB_TYPES
+    + POSE_JOB_TYPES
     + TRAINING_JOB_TYPES
     + CAPTION_JOB_TYPES
     + VQA_JOB_TYPES
@@ -165,6 +172,11 @@ def worker_capabilities(gpu: dict) -> list[str]:
             capabilities.add("person_track")
         if segmenter_backend_available():
             capabilities.add("person_segment")
+        # DWPose whole-body keypoints (Pose Library) — onnxruntime/rtmlib, advertised
+        # only when installed so the queue never routes a pose job to a worker that
+        # can't run it.
+        if pose_detector_backend_available():
+            capabilities.add("pose_detect")
     return sorted(capabilities)
 
 
@@ -1181,6 +1193,61 @@ def run_person_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
             restart_worker_after_oom(settings, job_id)
 
 
+def run_pose_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    """Run a pose_detect job: DWPose whole-body keypoints from one or more photos.
+
+    onnxruntime-backed (rtmlib), so no torch model is loaded — the worker advertises
+    pose_detect only when the backend is installed (worker_capabilities). Returns one
+    pose candidate per detected person plus a rendered skeleton preview per pose.
+    """
+    job_id = job["id"]
+    peaks: dict[str, float] = {}
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        payload = {"status": status, "stage": stage, "progress": value, "message": message}
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(None, settings))
+        update_job(api, job_id, payload)
+
+    try:
+        progress("preparing", "preparing", 0.06, "Preparing pose detection.")
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda cancel: run_pose_detect(
+                settings,
+                job,
+                progress=progress,
+                cancel_requested=cancel,
+            ),
+            loaded_models=lambda: [],
+            peaks=peaks,
+        )
+        update_job(
+            api,
+            job_id,
+            {"status": "completed", "stage": "completed", "progress": 1,
+             "message": "Pose candidates detected.", "result": result},
+        )
+    except InterruptedError as exc:
+        update_job(
+            api,
+            job_id,
+            {"status": "canceled", "stage": "canceled", "progress": 1, "message": str(exc)},
+        )
+    except Exception as exc:
+        message, error = friendly_failure("Pose detection", exc)
+        update_job(
+            api,
+            job_id,
+            {"status": "failed", "stage": "failed", "progress": 1, "message": message, "error": error},
+        )
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def run_lora_train_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     """Run a lora_train job: validate the plan, then either report a dry-run
     summary or execute the real training kernel.
@@ -1511,6 +1578,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
                 run_video_job(api, settings, job)
             elif job["type"] in PERSON_JOB_TYPES:
                 run_person_job(api, settings, job)
+            elif job["type"] in POSE_JOB_TYPES:
+                run_pose_job(api, settings, job)
             elif job["type"] in TRAINING_JOB_TYPES:
                 run_lora_train_job(api, settings, job)
             elif job["type"] in CAPTION_JOB_TYPES:

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -16,6 +16,7 @@ pub(crate) const ASSET_FOLDERS: &[&str] = &[
     "assets/frames",
     "assets/renders",
     "assets/documents",
+    "assets/poses",
     "trash",
 ];
 

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -345,6 +345,10 @@ string_enum! {
         // points to an InterleavedDocument JSON in assets/documents/; the images it
         // references are ordinary `image` assets. See sc-1576.
         Document => "document",
+        // A whole-body DWPose skeleton (Pose Library, epic 2282). The asset's `file`
+        // points to the rendered skeleton preview; keypoints/hands/face + category live
+        // in the sidecar's `pose` field. Stored under a reserved global poses project.
+        Pose => "pose",
     }
 }
 

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -199,6 +199,10 @@ string_enum! {
         PersonDetect => "person_detect",
         PersonTrack => "person_track",
         PersonReplace => "person_replace",
+        // Whole-body DWPose keypoint detection (photo -> body/hands/face) for the
+        // Pose Library (epic 2282). onnxruntime-backed like person_detect; advertised
+        // by the Python worker, routed via requested_gpu (not in NON_GPU_JOB_TYPES).
+        PoseDetect => "pose_detect",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",
@@ -276,6 +280,11 @@ string_enum! {
         PersonDetect => "person_detect",
         PersonTrack => "person_track",
         PersonReplace => "person_replace",
+        // Whole-body DWPose keypoint detection (Pose Library, epic 2282). Advertised
+        // only by the Python worker when the onnxruntime/rtmlib backend is installed
+        // (runtime.py, gated on pose_detector_backend_available); the Rust utility
+        // worker never emits it. See jobs_store::worker_supports_job.
+        PoseDetect => "pose_detect",
         // Procedural detection/tracking previews served by the Rust utility worker.
         // Real, model-backed PersonDetect/PersonTrack jobs are served by the Python
         // GPU worker (YOLO/ByteTrack/SAM2); these preview capabilities keep the CPU

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -41,6 +41,7 @@ pub const PROJECT_FOLDERS: &[&str] = &[
     "assets/frames",
     "assets/renders",
     "assets/documents",
+    "assets/poses",
     "characters",
     "generation-sets",
     "loras",
@@ -52,6 +53,14 @@ pub const PROJECT_FOLDERS: &[&str] = &[
     "trash",
     "cache",
 ];
+
+/// Reserved project that holds the GLOBAL pose library (epic 2282). User-created
+/// poses live here as ordinary `type:"pose"` assets so the existing asset store +
+/// Trashcan work unchanged; it is hidden from `list_projects` so it never appears in
+/// the project switcher. Built-in poses stay bundled in the web app (read-only).
+pub const GLOBAL_POSES_PROJECT_ID: &str = "project_global_poses";
+pub const GLOBAL_POSES_PROJECT_NAME: &str = "Pose Library";
+
 pub type ProjectStoreResult<T> = Result<T, ProjectStoreError>;
 
 #[derive(Debug)]
@@ -234,6 +243,11 @@ impl ProjectStore {
         self.ensure_data_dirs()?;
         let mut projects = Vec::new();
         for item in self.load_registry()? {
+            // The reserved global pose library is addressable by id but hidden from
+            // the project switcher (epic 2282).
+            if item.id.as_deref() == Some(GLOBAL_POSES_PROJECT_ID) {
+                continue;
+            }
             let Some(path) = item.path else {
                 continue;
             };
@@ -270,22 +284,34 @@ impl ProjectStore {
                 .join(format!("{slug}-{suffix}.sceneworks"));
         }
 
-        fs::create_dir_all(&project_path)?;
+        self.provision_project_locked(&project_id, name, &project_path)
+    }
+
+    /// Provision a project directory (folders + project file + db + registry entry)
+    /// for a known id/path. Caller must hold `self.lock`. Shared by `create_project`
+    /// (random id) and `ensure_global_poses_project` (fixed id).
+    fn provision_project_locked(
+        &self,
+        project_id: &str,
+        name: &str,
+        project_path: &Path,
+    ) -> ProjectStoreResult<ProjectSummary> {
+        fs::create_dir_all(project_path)?;
         for folder in PROJECT_FOLDERS {
             fs::create_dir_all(project_path.join(folder))?;
         }
-        write_project_file(&self.app_version, &project_path, &project_id, name)?;
-        apply_project_migrations(&connect_project_db(&project_path)?)?;
+        write_project_file(&self.app_version, project_path, project_id, name)?;
+        apply_project_migrations(&connect_project_db(project_path)?)?;
 
         let mut registry = self
             .load_registry()?
             .into_iter()
-            .filter(|item| item.id.as_deref() != Some(project_id.as_str()))
+            .filter(|item| item.id.as_deref() != Some(project_id))
             .collect::<Vec<_>>();
         registry.insert(
             0,
             RegistryItem {
-                id: Some(project_id),
+                id: Some(project_id.to_owned()),
                 name: Some(name.to_owned()),
                 path: Some(project_path.display().to_string()),
                 extra: Map::new(),
@@ -293,7 +319,23 @@ impl ProjectStore {
         );
         self.save_registry(&registry)?;
 
-        read_project_summary(&project_path)
+        read_project_summary(project_path)
+    }
+
+    /// Ensure the reserved global pose library project exists (idempotent), returning
+    /// its summary. Created lazily on first pose write/list (epic 2282, sc-2284).
+    pub fn ensure_global_poses_project(&self) -> ProjectStoreResult<ProjectSummary> {
+        let _guard = self.lock.lock();
+        self.ensure_data_dirs()?;
+        let project_path = self.projects_dir().join("global-poses.sceneworks");
+        if project_path.exists() {
+            return read_project_summary(&project_path);
+        }
+        self.provision_project_locked(
+            GLOBAL_POSES_PROJECT_ID,
+            GLOBAL_POSES_PROJECT_NAME,
+            &project_path,
+        )
     }
 
     pub fn get_project(&self, project_id: &str) -> ProjectStoreResult<ProjectSummary> {
@@ -2771,7 +2813,7 @@ mod tests {
     use super::{
         build_generated_asset_sidecar, guess_mime_from_filename, is_safe_relative_path,
         normalize_asset_tags, AssetScope, CharacterCreateInput, CharacterLookInput, ProjectStore,
-        PROJECT_FOLDERS,
+        GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS,
     };
     use serde_json::{json, Value};
     use std::sync::Arc;
@@ -3047,6 +3089,41 @@ mod tests {
         assert!(std::path::Path::new(&project.path)
             .join("project.db")
             .exists());
+    }
+
+    #[test]
+    fn ensure_global_poses_project_is_idempotent_and_hidden() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+
+        store
+            .create_project("Visible Project")
+            .expect("project creates");
+
+        let poses = store
+            .ensure_global_poses_project()
+            .expect("poses project ensures");
+        assert_eq!(poses.id, GLOBAL_POSES_PROJECT_ID);
+        assert!(std::path::Path::new(&poses.path)
+            .join("assets/poses")
+            .exists());
+
+        // Idempotent: a second ensure returns the same project path, no duplicate.
+        let again = store
+            .ensure_global_poses_project()
+            .expect("ensure idempotent");
+        assert_eq!(again.path, poses.path);
+
+        // Hidden from the project switcher, but addressable directly by id.
+        let listed = store.list_projects().expect("list");
+        assert!(listed.iter().all(|p| p.id != GLOBAL_POSES_PROJECT_ID));
+        assert_eq!(
+            store
+                .get_project(GLOBAL_POSES_PROJECT_ID)
+                .expect("get reserved")
+                .id,
+            GLOBAL_POSES_PROJECT_ID
+        );
     }
 
     #[test]

--- a/packages/schemas/asset.schema.json
+++ b/packages/schemas/asset.schema.json
@@ -9,7 +9,7 @@
     "id": { "type": "string", "pattern": "^asset_[a-z0-9_]+$" },
     "projectId": { "type": "string", "pattern": "^project_[a-z0-9_]+$" },
     "generationSetId": { "type": ["string", "null"] },
-    "type": { "enum": ["image", "video", "upload", "frame", "render"] },
+    "type": { "enum": ["image", "video", "upload", "frame", "render", "document", "pose"] },
     "displayName": { "type": "string", "minLength": 1 },
     "tags": {
       "type": "array",

--- a/packages/shared/sceneworks_shared/project_db.py
+++ b/packages/shared/sceneworks_shared/project_db.py
@@ -9,7 +9,16 @@ from .utils import read_json
 
 
 ASSET_SIDECAR_PATTERN = "*.sceneworks.json"
-ASSET_FOLDERS = ("assets/images", "assets/videos", "assets/uploads", "assets/frames", "assets/renders", "trash")
+ASSET_FOLDERS = (
+    "assets/images",
+    "assets/videos",
+    "assets/uploads",
+    "assets/frames",
+    "assets/renders",
+    "assets/documents",
+    "assets/poses",
+    "trash",
+)
 
 
 def apply_project_migrations(connection: sqlite3.Connection) -> None:

--- a/scripts/spikes/sc2283_dwpose_detect.py
+++ b/scripts/spikes/sc2283_dwpose_detect.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""sc-2283 spike, step 2 — DWPose whole-body detector (photo -> keypoints).
+
+Runs in the DWPose detection venv (/Users/michael/.dwpose-spike, onnxruntime +
+rtmlib). For each source image: run RTMPose whole-body (DWPose-l: dw-ll_ucoco_384),
+convert COCO-WholeBody-133 -> the SceneWorks OpenPose layout (18 body + 21x2 hands +
+68 face), normalise to [0,1], carry per-keypoint confidence + a per-person bbox +
+source aspect, render a skeleton preview through the PRODUCTION renderer
+(scene_worker.openpose_skeleton.draw_wholebody), and emit one pose record per
+detected person.
+
+This is the *producer* the epic needs; its output drops straight into the
+*consumer* (draw_wholebody, PR #376) the Z-Image Fun-CN pose head was trained on.
+
+rtmlib + RTMPose/DWPose are Apache-2.0; onnxruntime is the same stack already
+shipped/validated for InstantID's antelopev2 (arm64, no source builds).
+
+USAGE (from repo root, in the dwpose venv):
+    /Users/michael/.dwpose-spike/venv/bin/python scripts/spikes/sc2283_dwpose_detect.py \
+        --images "/tmp/sc2283/sources/src_*.png" --out /tmp/sc2283/poses \
+        --device mps --min-conf 0.3
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+# ---- COCO-WholeBody-133 -> SceneWorks OpenPose-18 index map ------------------
+# WholeBody order: 0-16 COCO body, 17-22 feet, 23-90 face(68), 91-111 left hand,
+# 112-132 right hand. COCO body order: 0 nose,1 l_eye,2 r_eye,3 l_ear,4 r_ear,
+# 5 l_sho,6 r_sho,7 l_elb,8 r_elb,9 l_wri,10 r_wri,11 l_hip,12 r_hip,13 l_kne,
+# 14 r_kne,15 l_ank,16 r_ank. OpenPose-18 wants neck(1) = midpoint of shoulders.
+COCO_TO_OPENPOSE = {
+    0: 0,   # nose
+    # 1 neck -> computed
+    2: 6,   # r_sho
+    3: 8,   # r_elb
+    4: 10,  # r_wri
+    5: 5,   # l_sho
+    6: 7,   # l_elb
+    7: 9,   # l_wri
+    8: 12,  # r_hip
+    9: 14,  # r_kne
+    10: 16,  # r_ank
+    11: 11,  # l_hip
+    12: 13,  # l_kne
+    13: 15,  # l_ank
+    14: 2,  # r_eye
+    15: 1,  # l_eye
+    16: 4,  # r_ear
+    17: 3,  # l_ear
+}
+FACE_SLICE = slice(23, 91)        # 68 points
+LHAND_SLICE = slice(91, 112)      # 21 points
+RHAND_SLICE = slice(112, 133)     # 21 points
+
+
+def _pt(kps: np.ndarray, sc: np.ndarray, i: int, w: int, h: int) -> list:
+    """[x_norm, y_norm, conf] for wholebody index i."""
+    return [float(kps[i, 0]) / w, float(kps[i, 1]) / h, float(sc[i])]
+
+
+def _seq(kps: np.ndarray, sc: np.ndarray, sl: slice, w: int, h: int) -> list:
+    return [_pt(kps, sc, i, w, h) for i in range(sl.start, sl.stop)]
+
+
+def wholebody_to_openpose(kps: np.ndarray, sc: np.ndarray, w: int, h: int) -> dict:
+    """Convert one person's (133,2)+(133,) detection into the SceneWorks pose record."""
+    body: list = [None] * 18
+    for op_idx, coco_idx in COCO_TO_OPENPOSE.items():
+        body[op_idx] = _pt(kps, sc, coco_idx, w, h)
+    # neck = midpoint of shoulders (coco 5=l_sho, 6=r_sho); conf = min of the two
+    ls, rs = kps[5], kps[6]
+    body[1] = [float((ls[0] + rs[0]) / 2) / w, float((ls[1] + rs[1]) / 2) / h,
+               float(min(sc[5], sc[6]))]
+    left = _seq(kps, sc, LHAND_SLICE, w, h)
+    right = _seq(kps, sc, RHAND_SLICE, w, h)
+    face = _seq(kps, sc, FACE_SLICE, w, h)
+    return {"keypoints": body, "hands": [left, right], "face": face}
+
+
+def _facing(body: list, min_conf: float) -> str:
+    def ok(i):
+        return body[i] is not None and body[i][2] >= min_conf
+    nose, r_eye, l_eye, r_ear, l_ear = ok(0), ok(14), ok(15), ok(16), ok(17)
+    if not nose and not r_eye and not l_eye:
+        return "back"
+    if r_ear and l_ear:
+        return "front"
+    if r_ear != l_ear:  # only one ear -> turned
+        return "profile"
+    return "front"
+
+
+def _bbox(*groups: list, min_conf: float) -> list | None:
+    xs, ys = [], []
+    for g in groups:
+        for p in g:
+            if p is not None and p[2] >= min_conf:
+                xs.append(p[0]); ys.append(p[1])
+    if not xs:
+        return None
+    return [min(xs), min(ys), max(xs), max(ys)]
+
+
+def _mean_conf(group: list) -> float:
+    cs = [p[2] for p in group if p is not None]
+    return float(np.mean(cs)) if cs else 0.0
+
+
+def _thresholded(group: list, min_conf: float) -> list:
+    """Render-ready copy: zero out conf for sub-threshold points (renderer drops conf<=0)."""
+    out = []
+    for p in group:
+        if p is None or p[2] < min_conf:
+            out.append(None)
+        else:
+            out.append([p[0], p[1], p[2]])
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--images", required=True, help="glob of source images")
+    ap.add_argument("--out", default="/tmp/sc2283/poses")
+    ap.add_argument("--device", default="mps", choices=["mps", "cpu", "cuda"])
+    ap.add_argument("--mode", default="performance", choices=["performance", "balanced", "lightweight"])
+    ap.add_argument("--min-conf", type=float, default=0.3, help="render/threshold conf cutoff")
+    ap.add_argument("--render-size", type=int, default=768, help="skeleton preview width (height scaled to aspect)")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # production renderer (numpy + cv2 only)
+    sys.path.insert(0, str(Path("apps/worker").resolve()))
+    from scene_worker.openpose_skeleton import draw_wholebody
+
+    from rtmlib import Wholebody
+
+    # Build the detector; fall back to CPU if the requested provider is unavailable.
+    device = args.device
+    t0 = time.time()
+    try:
+        model = Wholebody(mode=args.mode, backend="onnxruntime", device=device)
+    except Exception as e:  # noqa: BLE001
+        print(f"[detect] device={device} failed ({e!r}); falling back to cpu", flush=True)
+        device = "cpu"
+        model = Wholebody(mode=args.mode, backend="onnxruntime", device=device)
+    print(f"[detect] Wholebody(mode={args.mode}, device={device}) ready in {time.time() - t0:.1f}s", flush=True)
+
+    paths = sorted(glob.glob(args.images))
+    if not paths:
+        print(f"[detect] no images match {args.images}", flush=True)
+        return 1
+
+    index = []
+    for path in paths:
+        img = cv2.imread(path)  # BGR
+        if img is None:
+            print(f"[detect] SKIP unreadable {path}", flush=True)
+            continue
+        h, w = img.shape[:2]
+        t1 = time.time()
+        keypoints, scores = model(img)  # (N,133,2) px, (N,133)
+        dt = (time.time() - t1) * 1000.0
+        n = 0 if keypoints is None else len(keypoints)
+        print(f"[detect] {Path(path).name}: {n} person(s) in {dt:.0f}ms ({w}x{h})", flush=True)
+
+        poses = []
+        order = []
+        for i in range(n):
+            rec = wholebody_to_openpose(keypoints[i], scores[i], w, h)
+            bbox = _bbox(rec["keypoints"], rec["hands"][0], rec["hands"][1], rec["face"], min_conf=args.min_conf)
+            area = 0.0 if bbox is None else (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+            order.append((area, i, rec, bbox))
+        order.sort(key=lambda t: -t[0])  # largest person first
+
+        stem = Path(path).stem
+        rh = round(args.render_size * h / w)
+        for person_index, (_area, _i, rec, bbox) in enumerate(order):
+            body_t = _thresholded(rec["keypoints"], args.min_conf)
+            hands_t = [_thresholded(rec["hands"][0], args.min_conf), _thresholded(rec["hands"][1], args.min_conf)]
+            face_t = _thresholded(rec["face"], args.min_conf)
+            stick = max(6, round(min(args.render_size, rh) * 0.012))
+            skel = draw_wholebody(args.render_size, rh, body_t, hands_t, face_t, stickwidth=stick)
+            skel_path = out / f"{stem}_p{person_index}_skel.png"
+            cv2.imwrite(str(skel_path), cv2.cvtColor(skel, cv2.COLOR_RGB2BGR))
+            # overlay on source for QA
+            src_rs = cv2.resize(img, (args.render_size, rh))
+            skel_bgr = cv2.cvtColor(skel, cv2.COLOR_RGB2BGR)
+            mask = skel.any(axis=2)
+            overlay = src_rs.copy()
+            overlay[mask] = cv2.addWeighted(src_rs, 0.25, skel_bgr, 0.75, 0)[mask]
+            cv2.imwrite(str(out / f"{stem}_p{person_index}_overlay.png"), overlay)
+
+            poses.append({
+                "personIndex": person_index,
+                "bbox": bbox,
+                "facing": _facing(rec["keypoints"], args.min_conf),
+                "meanConf": {
+                    "body": round(_mean_conf(rec["keypoints"]), 3),
+                    "hands": round((_mean_conf(rec["hands"][0]) + _mean_conf(rec["hands"][1])) / 2, 3),
+                    "face": round(_mean_conf(rec["face"]), 3),
+                },
+                "keypoints": rec["keypoints"],
+                "hands": rec["hands"],
+                "face": rec["face"],
+                "skeletonPreview": str(skel_path),
+            })
+
+        record = {
+            "source": Path(path).name,
+            "sourcePath": str(Path(path).resolve()),
+            "sourceWidth": w,
+            "sourceHeight": h,
+            "sourceAspect": round(w / h, 4),
+            # rtmlib mode->model: performance=RTMW-x(cocktail14,384x288), balanced/lightweight differ.
+            # All emit COCO-WholeBody-133, so the render path is identical regardless.
+            "detector": f"rtmlib/wholebody-{args.mode}",
+            "detectorBackend": "onnxruntime",
+            "device": device,
+            "detectMs": round(dt, 1),
+            "minConf": args.min_conf,
+            "poses": poses,
+        }
+        json_path = out / f"{stem}.json"
+        json_path.write_text(json.dumps(record, indent=2))
+        index.append({"source": record["source"], "json": str(json_path), "nPoses": len(poses),
+                      "meanConf": [p["meanConf"] for p in poses]})
+        print(f"[detect]   -> {json_path}  poses={len(poses)} "
+              + " ".join(f"p{p['personIndex']}={p['facing']}/{p['meanConf']}" for p in poses), flush=True)
+
+    (out / "index.json").write_text(json.dumps(index, indent=2))
+    print(f"[detect] DONE  wrote {len(index)} source record(s) to {out}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spikes/sc2283_lock_ab.py
+++ b/scripts/spikes/sc2283_lock_ab.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""sc-2283 spike, step 3 — the lock A/B (body-only vs full DWPose).
+
+Runs in the mflux SIDECAR venv. For each detected pose (from
+sc2283_dwpose_detect.py), render TWO control images at the source's native aspect:
+  - body-only  : draw_bodypose(...)          (what ships today)
+  - whole-body : draw_wholebody(..., hands, face)  (full DWPose, PR #376 renderer)
+Then generate a NEW generic character into each, at a shared seed/prompt, across a
+scale sweep, so the ONLY variable is whether hands/face are in the control. Probes
+the sc-2257 nonlinearity (lock @0.9-1.0, drift higher) to see if hands/face firm it.
+
+USAGE (repo root, sidecar venv):
+    /Users/michael/mlx-flux-venv/bin/python scripts/spikes/sc2283_lock_ab.py \
+        --cn /path/Fun-Controlnet-Union...safetensors --poses-dir /tmp/sc2283/poses \
+        --out /tmp/sc2283/ab --scales 0.65,0.9,1.3 --steps 8 --seed 1234
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+NEW_SUBJECT = ("a full body studio photograph of a person in a plain white t-shirt and blue jeans, "
+               "plain light grey seamless background, soft studio lighting, sharp focus, photorealistic, 50mm")
+
+
+def _thresh(group, min_conf):
+    out = []
+    for p in group:
+        out.append(None if (p is None or p[2] < min_conf) else (float(p[0]), float(p[1])))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cn", required=True)
+    ap.add_argument("--poses-dir", default="/tmp/sc2283/poses")
+    ap.add_argument("--out", default="/tmp/sc2283/ab")
+    ap.add_argument("--prompt", default=NEW_SUBJECT)
+    ap.add_argument("--scales", default="0.65,0.9,1.3")
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--min-conf", type=float, default=0.3)
+    ap.add_argument("--person", type=int, default=0, help="which detected person (0=largest)")
+    args = ap.parse_args()
+
+    scales = [float(s) for s in args.scales.split(",") if s.strip()]
+    out_root = Path(args.out)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    sys.path.insert(0, str(Path("apps/worker").resolve()))
+    from scene_worker.openpose_skeleton import draw_bodypose, draw_wholebody
+
+    from mflux.models.z_image.variants.z_image_control import ZImageControl
+
+    pose_files = sorted(p for p in Path(args.poses_dir).glob("*.json") if p.name != "index.json")
+    if not pose_files:
+        print(f"[ab] no pose JSONs in {args.poses_dir}", flush=True)
+        return 1
+
+    t0 = time.time()
+    model = ZImageControl(control_weights_path=args.cn)
+    print(f"[ab] ZImageControl loaded in {time.time() - t0:.1f}s (bits={model.bits})", flush=True)
+
+    manifest = []
+    for pf in pose_files:
+        rec = json.loads(pf.read_text())
+        if not rec["poses"]:
+            print(f"[ab] {rec['source']}: no poses, skip", flush=True)
+            continue
+        pose = next((p for p in rec["poses"] if p["personIndex"] == args.person), rec["poses"][0])
+        W, H = rec["sourceWidth"], rec["sourceHeight"]
+        stem = pf.stem
+        d = out_root / stem
+        d.mkdir(parents=True, exist_ok=True)
+
+        body = _thresh(pose["keypoints"], args.min_conf)
+        hands = [_thresh(pose["hands"][0], args.min_conf), _thresh(pose["hands"][1], args.min_conf)]
+        face = _thresh(pose["face"], args.min_conf)
+        stick = max(6, round(min(W, H) * 0.012))
+
+        ctrl_body = draw_bodypose(W, H, body, stickwidth=stick)
+        ctrl_whole = draw_wholebody(W, H, body, hands, face, stickwidth=stick)
+        body_path = d / "control_body.png"
+        whole_path = d / "control_whole.png"
+        Image.fromarray(ctrl_body).save(body_path)
+        Image.fromarray(ctrl_whole).save(whole_path)
+        print(f"[ab] {stem}: {W}x{H} facing={pose['facing']} conf={pose['meanConf']}", flush=True)
+
+        for kind, ctrl_path in (("body", body_path), ("whole", whole_path)):
+            for sc in scales:
+                t1 = time.time()
+                img = model.generate_image(
+                    seed=args.seed,
+                    prompt=args.prompt,
+                    control_image_path=str(ctrl_path),
+                    control_context_scale=sc,
+                    num_inference_steps=args.steps,
+                    height=H,
+                    width=W,
+                )
+                dst = d / f"{kind}_s{sc}.png"
+                getattr(img, "image", img).save(dst)
+                manifest.append({"stem": stem, "kind": kind, "scale": sc, "out": str(dst),
+                                 "control": str(ctrl_path), "W": W, "H": H})
+                print(f"[ab]   {kind:5} scale={sc:<4} -> {dst.name}  ({time.time() - t1:.1f}s)", flush=True)
+
+    (out_root / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"[ab] DONE  {len(manifest)} generations -> {out_root}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spikes/sc2283_score.py
+++ b/scripts/spikes/sc2283_score.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""sc-2283 spike, step 4 — objective adherence scoring + visual contact sheets.
+
+Runs in the DWPose detection venv. Re-detects DWPose on every A/B output and
+measures how well the generated image followed the *intended* pose:
+  - body_err : mean normalized L2 between output body-18 and the intended body-18
+               (same intended body drives both body-only and whole-body controls,
+                so this shows whether adding hands/face HURTS the body lock).
+  - hand_err / face_err : vs the intended hands/face. For body-only the hands are
+               un-controlled (the model invents them) -> expect large/sparse; for
+               whole-body -> expect small. This is the number that justifies (or
+               kills) the epic.
+Also builds a per-source montage [source | body-only sweep | whole-body sweep] for
+human judgement of hand/finger/face fidelity (mangling isn't fully captured by L2).
+
+USAGE (repo root, dwpose venv):
+    /Users/michael/.dwpose-spike/venv/bin/python scripts/spikes/sc2283_score.py \
+        --ab /tmp/sc2283/ab --poses-dir /tmp/sc2283/poses --device mps --min-conf 0.3
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from sc2283_dwpose_detect import wholebody_to_openpose  # noqa: E402
+
+
+def _thresh(group, min_conf):
+    return [None if (p is None or p[2] < min_conf) else (float(p[0]), float(p[1])) for p in group]
+
+
+def _err(a, b):
+    """mean normalized L2 over points present in both; (mean, n_matched)."""
+    ds = []
+    for pa, pb in zip(a, b):
+        if pa is None or pb is None:
+            continue
+        ds.append(((pa[0] - pb[0]) ** 2 + (pa[1] - pb[1]) ** 2) ** 0.5)
+    return (float(np.mean(ds)) if ds else None, len(ds))
+
+
+def detect_one(model, img_bgr, min_conf):
+    h, w = img_bgr.shape[:2]
+    kps, sc = model(img_bgr)
+    if kps is None or len(kps) == 0:
+        return None
+    # largest person by keypoint spread
+    best, best_area = 0, -1.0
+    for i in range(len(kps)):
+        xs, ys = kps[i][:, 0], kps[i][:, 1]
+        area = (xs.max() - xs.min()) * (ys.max() - ys.min())
+        if area > best_area:
+            best, best_area = i, area
+    rec = wholebody_to_openpose(kps[best], sc[best], w, h)
+    return {
+        "body": _thresh(rec["keypoints"], min_conf),
+        "lhand": _thresh(rec["hands"][0], min_conf),
+        "rhand": _thresh(rec["hands"][1], min_conf),
+        "face": _thresh(rec["face"], min_conf),
+    }
+
+
+def _label(img, text, h=28):
+    bar = np.zeros((h, img.shape[1], 3), dtype=np.uint8)
+    cv2.putText(bar, text, (6, 20), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 1, cv2.LINE_AA)
+    return np.vstack([bar, img])
+
+
+def _fit(img, th):
+    w = round(img.shape[1] * th / img.shape[0])
+    return cv2.resize(img, (w, th))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ab", default="/tmp/sc2283/ab")
+    ap.add_argument("--poses-dir", default="/tmp/sc2283/poses")
+    ap.add_argument("--device", default="mps")
+    ap.add_argument("--mode", default="performance")
+    ap.add_argument("--min-conf", type=float, default=0.3)
+    ap.add_argument("--th", type=int, default=384, help="montage thumb height")
+    args = ap.parse_args()
+
+    from rtmlib import Wholebody
+    try:
+        model = Wholebody(mode=args.mode, backend="onnxruntime", device=args.device)
+    except Exception:  # noqa: BLE001
+        model = Wholebody(mode=args.mode, backend="onnxruntime", device="cpu")
+
+    manifest = json.loads((Path(args.ab) / "manifest.json").read_text())
+    # intended pose per stem
+    intended = {}
+    for pf in Path(args.poses_dir).glob("*.json"):
+        if pf.name == "index.json":
+            continue
+        rec = json.loads(pf.read_text())
+        if rec["poses"]:
+            p = rec["poses"][0]
+            intended[pf.stem] = {
+                "body": _thresh(p["keypoints"], args.min_conf),
+                "lhand": _thresh(p["hands"][0], args.min_conf),
+                "rhand": _thresh(p["hands"][1], args.min_conf),
+                "face": _thresh(p["face"], args.min_conf),
+                "src": rec["sourcePath"],
+            }
+
+    rows = []
+    by_stem = {}
+    for m in manifest:
+        stem = m["stem"]
+        out = cv2.imread(m["out"])
+        det = detect_one(model, out, args.min_conf)
+        intd = intended[stem]
+        if det is None:
+            rows.append({**m, "body_err": None, "hand_err": None, "face_err": None,
+                         "n_body": 0, "n_hand": 0, "n_face": 0})
+            by_stem.setdefault(stem, {})[(m["kind"], m["scale"])] = m["out"]
+            continue
+        body_err, n_body = _err(det["body"], intd["body"])
+        lh_err, nlh = _err(det["lhand"], intd["lhand"])
+        rh_err, nrh = _err(det["rhand"], intd["rhand"])
+        face_err, n_face = _err(det["face"], intd["face"])
+        hand_vals = [v for v in (lh_err, rh_err) if v is not None]
+        hand_err = float(np.mean(hand_vals)) if hand_vals else None
+        rows.append({**m, "body_err": body_err, "hand_err": hand_err, "face_err": face_err,
+                     "n_body": n_body, "n_hand": nlh + nrh, "n_face": n_face})
+        by_stem.setdefault(stem, {})[(m["kind"], m["scale"])] = m["out"]
+
+    # ---- table ----
+    scales = sorted({m["scale"] for m in manifest})
+    print("\n=== sc-2283 lock A/B — adherence (mean normalized L2, lower=tighter; n=matched kps) ===")
+    hdr = f"{'source':16} {'ctrl':6} {'scale':6} {'body_err':9} {'hand_err':9} {'face_err':9} {'n_hand':7} {'n_face':7}"
+    print(hdr); print("-" * len(hdr))
+    for stem in sorted(by_stem):
+        for kind in ("body", "whole"):
+            for sc in scales:
+                r = next((x for x in rows if x["stem"] == stem and x["kind"] == kind and x["scale"] == sc), None)
+                if not r:
+                    continue
+                def f(v):
+                    return f"{v:.4f}" if isinstance(v, float) else "  n/a  "
+                print(f"{stem:16} {kind:6} {sc:<6} {f(r['body_err']):9} {f(r['hand_err']):9} "
+                      f"{f(r['face_err']):9} {r['n_hand']:<7} {r['n_face']:<7}")
+        print()
+
+    # ---- per-source montage ----
+    th = args.th
+    for stem, cells in by_stem.items():
+        src = cv2.imread(intended[stem]["src"])
+        cb = cv2.imread(str(Path(args.ab) / stem / "control_body.png"))
+        cw = cv2.imread(str(Path(args.ab) / stem / "control_whole.png"))
+        header = np.hstack([_label(_fit(src, th), "SOURCE"),
+                            _label(_fit(cb, th), "ctrl body-only"),
+                            _label(_fit(cw, th), "ctrl whole-body")])
+        body_row = [_label(_fit(cv2.imread(cells[("body", sc)]), th), f"body s{sc}") for sc in scales if ("body", sc) in cells]
+        whole_row = [_label(_fit(cv2.imread(cells[("whole", sc)]), th), f"whole s{sc}") for sc in scales if ("whole", sc) in cells]
+        body_strip = np.hstack(body_row) if body_row else None
+        whole_strip = np.hstack(whole_row) if whole_row else None
+
+        # pad widths to align
+        widths = [x.shape[1] for x in (header, body_strip, whole_strip) if x is not None]
+        wmax = max(widths)
+        def pad(x):
+            if x is None or x.shape[1] == wmax:
+                return x
+            return np.hstack([x, np.zeros((x.shape[0], wmax - x.shape[1], 3), dtype=np.uint8)])
+        stacked = np.vstack([pad(s) for s in (header, body_strip, whole_strip) if s is not None])
+        mpath = Path(args.ab) / f"{stem}_montage.png"
+        cv2.imwrite(str(mpath), stacked)
+        print(f"[score] montage -> {mpath}")
+
+    (Path(args.ab) / "scores.json").write_text(json.dumps(rows, indent=2))
+    print(f"[score] DONE -> {Path(args.ab) / 'scores.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spikes/sc2283_zimage_sources.py
+++ b/scripts/spikes/sc2283_zimage_sources.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""sc-2283 spike, step 1 — synthesize base Z-Image full-body source photos.
+
+Runs in the mflux SIDECAR venv (/Users/michael/mlx-flux-venv). Generates a few
+diverse full-body person images with **base** Z-Image-Turbo (the Fun-CN loaded but
+``control_context_scale=0.0`` over a black control image == base parity, per the
+sc-2257 validate gate) to use as DWPose detection sources for the lock A/B. No
+external photos needed.
+
+USAGE:
+    /Users/michael/mlx-flux-venv/bin/python scripts/spikes/sc2283_zimage_sources.py \
+        --cn /path/to/Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors \
+        --out /tmp/sc2283/sources --width 768 --height 1280 --steps 8 --seed 7
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+# Full-body prompts chosen to exercise the hand/face lock test:
+#  - arms_crossed: hands partly tucked (hard case)
+#  - sitting:      hands resting on knees (clearly visible, relaxed)
+#  - dance:        one arm raised, open hand (the strongest hand-lock probe)
+PROMPTS = {
+    "arms_crossed": "a full body studio photograph of a young woman standing, arms crossed over chest, "
+                    "looking at the camera, natural hands, plain light grey seamless background, soft studio "
+                    "lighting, sharp focus, photorealistic, 50mm",
+    "sitting": "a full body studio photograph of a man sitting on a simple wooden stool, both hands resting "
+               "on his knees, looking at the camera, plain light grey seamless background, soft studio "
+               "lighting, sharp focus, photorealistic, 50mm",
+    "dance": "a full body studio photograph of a woman in a dynamic dance pose, one arm raised high with an "
+             "open hand, the other arm extended, looking up, plain light grey seamless background, soft studio "
+             "lighting, sharp focus, photorealistic, 50mm",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cn", required=True, help="Fun-Controlnet-Union safetensors path")
+    ap.add_argument("--out", default="/tmp/sc2283/sources")
+    ap.add_argument("--width", type=int, default=768)
+    ap.add_argument("--height", type=int, default=1280)
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    from mflux.models.z_image.variants.z_image_control import ZImageControl
+
+    # A black control image: VAE-encoded then multiplied by control_context_scale=0.0,
+    # so it contributes nothing -> pure base Z-Image-Turbo output.
+    black = out / "_black_control.png"
+    Image.fromarray(np.zeros((args.height, args.width, 3), dtype=np.uint8)).save(black)
+
+    t0 = time.time()
+    model = ZImageControl(control_weights_path=args.cn)
+    print(f"[sources] ZImageControl loaded in {time.time() - t0:.1f}s (bits={model.bits})", flush=True)
+
+    for name, prompt in PROMPTS.items():
+        t1 = time.time()
+        img = model.generate_image(
+            seed=args.seed,
+            prompt=prompt,
+            control_image_path=str(black),
+            control_context_scale=0.0,
+            num_inference_steps=args.steps,
+            height=args.height,
+            width=args.width,
+        )
+        dst = out / f"src_{name}.png"
+        pil = getattr(img, "image", img)
+        pil.save(dst)
+        print(f"[sources] {name:12} -> {dst}  ({time.time() - t1:.1f}s)  {pil.size}", flush=True)
+
+    print("[sources] DONE", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pose_adapters.py
+++ b/tests/test_pose_adapters.py
@@ -1,0 +1,102 @@
+"""Unit tests for the DWPose detector adapter (sc-2285).
+
+Cover the pure COCO-WholeBody-133 -> SceneWorks OpenPose conversion, backend
+availability gating, and the orchestration (run_pose_detect) with a fake detector
+so coverage needs neither the onnx weights nor a GPU.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from scene_worker import pose_adapters as pa
+
+
+def _fake_wholebody(n: int = 1, *, score: float = 5.0):
+    """(keypoints, scores) like rtmlib Wholebody: (N,133,2) px + (N,133)."""
+    kps = np.zeros((n, 133, 2), dtype=np.float32)
+    # place every keypoint at a distinct, in-frame location so conversion is checkable
+    for i in range(133):
+        kps[:, i] = (100 + i, 200 + i)
+    scores = np.full((n, 133), score, dtype=np.float32)
+    return kps, scores
+
+
+def test_wholebody_to_openpose_shapes_and_neck():
+    kps, sc = _fake_wholebody(1)
+    rec = pa.wholebody_to_openpose(kps[0], sc[0], w=1000, h=1000)
+
+    assert len(rec["keypoints"]) == 18
+    assert [len(h) for h in rec["hands"]] == [21, 21]
+    assert len(rec["face"]) == 68
+
+    # nose (openpose 0) == coco 0 ; normalized to [0,1]
+    assert rec["keypoints"][0][0] == pytest.approx(100 / 1000)
+    # neck (openpose 1) == midpoint of shoulders (coco 5 & 6)
+    exp_x = ((100 + 5) + (100 + 6)) / 2 / 1000
+    assert rec["keypoints"][1][0] == pytest.approx(exp_x)
+    # right wrist (openpose 4) maps from coco 10
+    assert rec["keypoints"][4][0] == pytest.approx((100 + 10) / 1000)
+    # confidence carried through
+    assert rec["keypoints"][0][2] == pytest.approx(5.0)
+
+
+def test_pose_detector_backend_available(monkeypatch):
+    monkeypatch.setattr(pa, "_module_available", lambda name: True)
+    assert pa.pose_detector_backend_available() is True
+    monkeypatch.setattr(pa, "_module_available", lambda name: name != "rtmlib")
+    assert pa.pose_detector_backend_available() is False
+
+
+def test_require_pose_extras_raises_clearly(monkeypatch):
+    monkeypatch.setattr(pa, "_module_available", lambda name: False)
+    with pytest.raises(pa.PoseDetectError, match="rtmlib"):
+        pa._require_pose_extras()
+
+
+def test_run_pose_detect_no_sources_raises():
+    with pytest.raises(pa.PoseDetectError, match="No source images"):
+        pa.run_pose_detect(SimpleNamespace(data_dir=".", gpu_id="cpu"), {"id": "j", "payload": {}})
+
+
+def test_run_pose_detect_with_fake_detector(tmp_path):
+    cv2 = pytest.importorskip("cv2")
+    # a real (blank) source image on disk so cv2.imread succeeds
+    src = tmp_path / "src.png"
+    cv2.imwrite(str(src), np.full((480, 320, 3), 30, dtype=np.uint8))
+
+    runtime = pa.PoseDetectorRuntime(
+        model=lambda img: _fake_wholebody(1), device="cpu", detector_id="fake/test"
+    )
+    settings = SimpleNamespace(data_dir=str(tmp_path), gpu_id="cpu")
+    job = {
+        "id": "job_pose_test",
+        "payload": {"sources": [{"path": str(src), "assetId": "asset_1"}], "minConf": 0.3},
+    }
+    events: list = []
+    result = pa.run_pose_detect(
+        settings, job,
+        progress=lambda *a: events.append(a),
+        detector_factory=lambda s: runtime,
+    )
+
+    assert result["poseDetectionActive"] is True
+    assert result["detector"]["device"] == "cpu"
+    assert len(result["sources"]) == 1
+    source = result["sources"][0]
+    assert source["sourceWidth"] == 320 and source["sourceHeight"] == 480
+    assert source["sourceAspect"] == pytest.approx(320 / 480, abs=1e-3)
+    assert source["sourceAssetId"] == "asset_1"
+    assert len(source["poses"]) == 1
+    pose = source["poses"][0]
+    assert len(pose["keypoints"]) == 18
+    assert [len(h) for h in pose["hands"]] == [21, 21]
+    assert len(pose["face"]) == 68
+    assert pose["facing"] in {"front", "back", "profile"}
+    # skeleton preview rendered to the job-scoped staging dir
+    from pathlib import Path
+    assert Path(pose["skeletonPreview"]).exists()
+    assert events  # progress was reported

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -334,6 +334,26 @@ def test_gpu_worker_advertises_real_person_jobs_when_backends_installed(monkeypa
     assert "person_segment" in capabilities
 
 
+def test_gpu_worker_advertises_pose_detect_when_backend_installed(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.pose_detector_backend_available", lambda: True)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    assert "pose_detect" in capabilities
+
+
+def test_gpu_worker_omits_pose_detect_without_backend(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.pose_detector_backend_available", lambda: False)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    assert "pose_detect" not in capabilities
+
+
+def test_cpu_worker_never_advertises_pose_detect(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.pose_detector_backend_available", lambda: True)
+    capabilities = worker_capabilities({"id": "cpu", "name": "CPU", "capabilities": ["placeholder", "cpu"]})
+    assert capabilities == ["cpu"]
+
+
 def test_gpu_worker_omits_person_jobs_without_detector_backend(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
     monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: False)
@@ -5097,6 +5117,7 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.detector_backend_available", lambda: True)
     monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: True)
     monkeypatch.setattr("scene_worker.runtime.segmenter_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.pose_detector_backend_available", lambda: True)
     monkeypatch.setattr(
         "scene_worker.runtime.discover_gpu",
         lambda _gpu_id: {"id": "0", "name": "GPU 0", "capabilities": ["gpu"]},
@@ -5114,6 +5135,7 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         "person_replace",
         "person_detect",
         "person_track",
+        "pose_detect",
         "lora_train",
         "training_caption",
         # sc-1635: VQA + interleave are advertised and dispatched, so the check


### PR DESCRIPTION
Epic [2282](https://app.shortcut.com/trefry/epic/2282) — DWPose whole-body pose assets + photo→skeleton generation. **WIP** (sc-2287/2288/2289 still open); opening early so it can be tested in parallel.

## Included (all verified + committed)

### sc-2283 — spike: DWPose feasibility + lock A/B (Done/GO)
DWPose on Apple Silicon via **rtmlib + onnxruntime CoreML** (~33 ms/img, Apache-2.0). The A/B on the shipped Z-Image Fun-CN proved feeding the **full** whole-body skeleton (body+hands+face) is never worse than today's body-only control and **fixes the sc-2257 high-scale drift**. Scripts under `scripts/spikes/sc2283_*.py`.

### sc-2285 — DWPose detector worker job (In Review)
New `pose_detect` job: photo → OpenPose-18 body + 21×2 hands + 68 face (+confidence, bbox, source aspect) → rendered skeleton preview via the production `draw_wholebody`. `pose_adapters.py` (rtmlib RTMW on onnxruntime, lazy-gated) + `runtime.py` dispatch + `requirements-pose.txt`. Real CoreML smoke run verified.

### sc-2284 — pose asset type + global pose store (In Review)
`AssetType::Pose`; `assets/poses` folders; a **reserved `project_global_poses`** project (hidden from the switcher, addressable) that reuses the asset store/Trashcan as-is. Unified pose-picker read (built-in bundle + reserved-project user poses, best-effort merge).

### sc-2286 — Pose Library screen, "Poses" tab (In Review)
New top-level **Pose Library** screen: category-grouped grid + viewer + Trashcan over the reserved project (Create tab is a placeholder until sc-2287).

## Verified
Rust `cargo test --workspace` (incl. desktop, after staging sidecar artifacts) · Python worker 450 · web 270 · `cargo fmt`. Each slice has tests.

## Not yet in this PR
- **sc-2287** Create tab (multi-source picker → detect → categorize → save) — fully planned on the story, not coded.
- **sc-2288** validate/tune/doc · **sc-2289** extend whole-body rendering to other pose ControlNets (in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)