### PR TITLE
feat(pose-library): render whole-body DWPose for Kolors pose ControlN…

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -4194,6 +4194,8 @@ class KolorsDiffusersAdapter:
             try:
                 image = self._run_pose(
                     settings, pipe, request, set_seed, project_path, pose_keypoints[index],
+                    hands=normalize_hands(pose_entries[index].get("hands")),
+                    face=normalize_face(pose_entries[index].get("face")),
                     cancel_requested=cancel_requested,
                 )
             except Exception as exc:
@@ -4353,18 +4355,25 @@ class KolorsDiffusersAdapter:
         seed: int,
         project_path: Path,
         keypoints: list[Any],
+        hands: list[Any] | None = None,
+        face: list[Any] | None = None,
         cancel_requested: CancelCallback | None = None,
     ) -> Image.Image:
-        """Render the character in one library pose: OpenPose skeleton drives the pose
-        ControlNet, the reference drives identity via IP-Adapter. img2img init is the
-        reference (at full strength it only seeds latent dimensions)."""
+        """Render the character in one library pose: a DWPose whole-body skeleton drives
+        the pose ControlNet, the reference drives identity via IP-Adapter. img2img init is
+        the reference (at full strength it only seeds latent dimensions).
+
+        Kolors-ControlNet-Pose is DWPose-trained (sc-2264), so when a pose carries hand
+        (21x2) / face (68) keypoints we render them too (sc-2289) — more in-distribution.
+        Body-only poses render identically to the previous draw_bodypose path
+        (``draw_wholebody`` with no hands/face == ``draw_bodypose``)."""
         torch = importlib.import_module("torch")
         device = select_torch_device(torch, settings.gpu_id)
         activate_torch_device(torch, device)
         generator = torch.Generator(device if device.startswith("cuda") else "cpu").manual_seed(seed)
         model_target = MODEL_TARGETS[request.model]
         width, height = request.width, request.height
-        skeleton = Image.fromarray(draw_bodypose(width, height, keypoints))
+        skeleton = Image.fromarray(draw_wholebody(width, height, keypoints, hands=hands, face=face))
         reference = load_reference_image(project_path, request.reference_asset_id)
         if hasattr(pipe, "set_ip_adapter_scale"):
             pipe.set_ip_adapter_scale(self._ip_adapter_scale(request))

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -3781,7 +3781,13 @@ def test_kolors_run_pose_composes_skeleton_controlnet_and_ip_adapter(tmp_path, m
     )
     skeleton_sentinel = FakeImage()
     reference_sentinel = FakeImage()
-    monkeypatch.setattr(ia, "draw_bodypose", lambda w, h, kps: _np.zeros((h, w, 3), dtype=_np.uint8))
+    # Kolors _run_pose renders the DWPose whole-body skeleton (sc-2289); draw_wholebody
+    # needs cv2 (absent in the CI venv), so stub it (real render covered elsewhere).
+    monkeypatch.setattr(
+        ia,
+        "draw_wholebody",
+        lambda w, h, kps, hands=None, face=None, stickwidth=4: _np.zeros((h, w, 3), dtype=_np.uint8),
+    )
     monkeypatch.setattr("scene_worker.image_adapters.Image", SimpleNamespace(fromarray=lambda arr: skeleton_sentinel))
     monkeypatch.setattr(ia, "load_reference_image", lambda project_path, asset_id: reference_sentinel)
 
@@ -3815,9 +3821,9 @@ def test_kolors_pose_set_loops_poses_with_shared_seed(tmp_path, monkeypatch):
 
     calls: list[dict] = []
 
-    def fake_run_pose(self, settings, pipe, request, seed, project_path, keypoints, cancel_requested=None):
+    def fake_run_pose(self, settings, pipe, request, seed, project_path, keypoints, hands=None, face=None, cancel_requested=None):
         from PIL import Image as _Image
-        calls.append({"seed": seed, "keypoints": keypoints})
+        calls.append({"seed": seed, "keypoints": keypoints, "hands": hands, "face": face})
         return _Image.new("RGB", (8, 8))
 
     monkeypatch.setattr(ia.KolorsDiffusersAdapter, "_run_pose", fake_run_pose)
@@ -3835,10 +3841,15 @@ def test_kolors_pose_set_loops_poses_with_shared_seed(tmp_path, monkeypatch):
     monkeypatch.setattr(ia, "ImageAssetWriter", _FakeWriter)
 
     kp = [[0.5, 0.1 + 0.04 * i] for i in range(18)]
+    hands = [[[0.4, 0.4]] * 21, [[0.6, 0.4]] * 21]
+    face = [[0.5, 0.3]] * 68
     job = {"id": "job_kolors_pose", "payload": {
         "projectId": "p", "mode": "character_image", "model": "kolors", "prompt": "the character",
         "referenceAssetId": "ref-1", "count": 1, "width": 64, "height": 64,
-        "advanced": {"poses": [{"id": "sit_01", "keypoints": kp}, {"id": "stand_01", "keypoints": kp}]},
+        "advanced": {"poses": [
+            {"id": "sit_01", "keypoints": kp},  # body-only
+            {"id": "dance_01", "keypoints": kp, "hands": hands, "face": face},  # whole-body
+        ]},
     }}
     KolorsDiffusersAdapter().generate(
         settings=SimpleNamespace(gpu_id="cpu"), job=job, request=image_request_from_job(job),
@@ -3847,6 +3858,10 @@ def test_kolors_pose_set_loops_poses_with_shared_seed(tmp_path, monkeypatch):
     assert captured["image_count"] == 2  # one per pose, not request.count
     assert len(calls) == 2
     assert calls[0]["seed"] == calls[1]["seed"]  # shared seed across the set
+    # sc-2289: whole-body hands/face thread through to the DWPose-trained Kolors CN;
+    # body-only poses pass None (rendered identically to the old body-only path).
+    assert calls[0]["hands"] is None and calls[0]["face"] is None
+    assert calls[1]["hands"] is not None and len(calls[1]["face"]) == 68
     assert captured["raw_settings"].get("poseLibrary") is True
     assert captured["raw_settings"].get("controlNetPose") == "Kwai-Kolors/Kolors-ControlNet-Pose"
 


### PR DESCRIPTION
…et (sc-2289)

Kolors-ControlNet-Pose is DWPose-trained (sc-2264) but KolorsDiffusersAdapter._run_pose still rendered body-only draw_bodypose. Swap to draw_wholebody and thread the pose entry's hand (21x2) / face (68) keypoints through _generate_pose_set -> _run_pose, so whole-body user poses (sc-2285+) get the hands/face the CN was trained on.

Zero-risk for today's body-only bundled poses: draw_wholebody with no hands/face is byte-identical to draw_bodypose (verified). Updated the Kolors pose tests (stub draw_wholebody; assert hands/face thread through for whole-body, None for body-only). 482 worker tests green.

InstantID (xinsir OpenPose) + Qwen/FLUX.2 best-effort whole-body remain "evaluate before wiring" per the story — they need real-HW A/Bs (separate spikes).