### PR TITLE
Pose Library follow-ups: worker pose-deps provisioning + Create-tab thumbnail bounds

### DIFF
--- a/apps/desktop/scripts/stage-python.mjs
+++ b/apps/desktop/scripts/stage-python.mjs
@@ -31,6 +31,11 @@ for (const file of [
   // insightface/onnxruntime). Installed into the main venv by setup.rs so the
   // pulid_flux adapter runs (sc-2012, epic 2003).
   "requirements-pulid-flux.txt",
+  // DWPose whole-body pose-detection extras (rtmlib + the onnxruntime shared with
+  // InstantID/PuLID). Installed into the main venv by setup.rs so the worker
+  // advertises the `pose_detect` capability — without it the Pose Library Create
+  // tab's detect jobs block ("no active worker supports pose detect"). Epic 2282.
+  "requirements-pose.txt",
 ]) {
   const src = join(workerDir, file);
   if (existsSync(src)) cpSync(src, join(outDir, file));

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -254,6 +254,26 @@ fn requirements_pulid_flux_path(app: &AppHandle) -> PathBuf {
         .join("requirements-pulid-flux.txt")
 }
 
+/// requirements-pose.txt location (DWPose whole-body pose detection: rtmlib + the
+/// onnxruntime shared with InstantID/PuLID): the bundled resource in a packaged
+/// app, or the repo copy during development. Optional — absent in older worker
+/// checkouts, in which case the `pose_detect` worker capability isn't advertised
+/// and the Pose Library Create tab's detect jobs block ("no active worker supports
+/// pose detect"). Installed on all platforms (DWPose uses the CoreML/CPU
+/// onnxruntime provider). Epic 2282 / sc-2285.
+fn requirements_pose_path(app: &AppHandle) -> PathBuf {
+    if let Ok(resources) = app.path().resource_dir() {
+        let bundled = resources.join("python-src").join("requirements-pose.txt");
+        if bundled.exists() {
+            return bundled;
+        }
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("worker")
+        .join("requirements-pose.txt")
+}
+
 /// requirements-lens.txt location (Microsoft Lens sidecar venv deps): the bundled
 /// resource in a packaged app, or the repo copy during development. Optional —
 /// absent in older worker checkouts, in which case Lens is unavailable.
@@ -579,6 +599,12 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     let requirements_pulid_flux = requirements_pulid_flux_path(app);
     let requirements_pulid_flux_body =
         std::fs::read_to_string(&requirements_pulid_flux).unwrap_or_default();
+    // DWPose whole-body pose-detection extras (rtmlib + the onnxruntime shared with
+    // InstantID/PuLID). Optional: absent in older worker checkouts, in which case
+    // the `pose_detect` capability isn't advertised and Pose Library detect jobs
+    // stay blocked. Epic 2282 / sc-2285.
+    let requirements_pose = requirements_pose_path(app);
+    let requirements_pose_body = std::fs::read_to_string(&requirements_pose).unwrap_or_default();
     // Apple Silicon MLX video inference deps — macOS-only; empty body elsewhere so
     // the marker stays stable and the Windows/Linux PyTorch worker is untouched.
     #[cfg(target_os = "macos")]
@@ -589,7 +615,7 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     let requirements_mlx_body = String::new();
     let marker = marker_path();
     let expected = format!(
-        "v{SETUP_VERSION}\n{requirements_body}\n# ltx\n{requirements_ltx_body}\n# mlx\n{requirements_mlx_body}\n# instantid\n{requirements_instantid_body}\n# pulid_flux\n{requirements_pulid_flux_body}"
+        "v{SETUP_VERSION}\n{requirements_body}\n# ltx\n{requirements_ltx_body}\n# mlx\n{requirements_mlx_body}\n# instantid\n{requirements_instantid_body}\n# pulid_flux\n{requirements_pulid_flux_body}\n# pose\n{requirements_pose_body}"
     );
 
     if python.exists() {
@@ -657,6 +683,12 @@ async fn provision_venv(app: &AppHandle) -> Result<(), String> {
     // insightface/einops/onnxruntime pins line up across InstantID + PuLID-FLUX.
     if requirements_pulid_flux.exists() {
         requirement_files.push(requirements_pulid_flux.clone());
+    }
+    // DWPose extras (sc-2285): rtmlib + the shared onnxruntime. Same single uv pass
+    // so the onnxruntime pin stays aligned with InstantID/PuLID. Without these the
+    // worker can't advertise `pose_detect` and Pose Library detect jobs block.
+    if requirements_pose.exists() {
+        requirement_files.push(requirements_pose.clone());
     }
     run_uv(app, pip_install_args(&python, &requirement_files)).await?;
 


### PR DESCRIPTION
Two Pose Library (epic 2282) follow-ups after sc-2287 merged.

### 1. Worker can actually run pose detection
`pose_detect` is a proper queued worker job, but the worker only advertises the `pose_detect` capability when **rtmlib + onnxruntime** import. `requirements-pose.txt` (sc-2285) was never wired into provisioning, so detect jobs sat **"Blocked: no active worker supports pose detect."** Wired it into `stage-python.mjs` + `setup.rs` like the InstantID/PuLID extras (bundled resource, re-provision marker, single uv install pass).

### 2. Create-tab thumbnails were unbounded
Source photos + candidate skeletons rendered through bespoke `pose-source-*`/`pose-candidate-*` classes that had no CSS → full-size images. Refactored onto the shared `.dataset-add-grid` / `.dataset-add-card` + `AssetThumbnail` convention (already bounds images: `width:100%; aspect-ratio:1; object-fit:cover`); kept candidates use the existing `.selected` ring. Only net-new CSS is a small `.pose-create` panel stack.

Verification: web 273, worker suite green, `cargo check -p sceneworks-desktop` clean, build-windows compiles `setup.rs`. Watching CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)