### PR TITLE
feat(pose-library): open Poses-tab thumbnails in the shared fullscreen preview

### DIFF
--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { API_BASE_URL, apiFetch, isAbortError } from "../api.js";
-import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
+import { AssetDetail, AssetGrid, FullscreenPreview, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetThumbnail } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { useAppContext } from "../context/AppContext.js";
@@ -329,6 +329,7 @@ export function PoseLibraryScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [selectedId, setSelectedId] = useState(null);
+  const [previewId, setPreviewId] = useState(null);
   const [assetMode, setAssetMode] = useState("assets");
   const [categoryFilter, setCategoryFilter] = useState("all");
 
@@ -408,7 +409,13 @@ export function PoseLibraryScreen() {
   const visible = poses.filter((asset) => inFilter(asset) && inMode(asset));
   const trashedInView = poses.filter((asset) => inFilter(asset) && asset.status?.trashed);
   const selected = poses.find((asset) => asset.id === selectedId) ?? null;
-  const onPreview = (asset) => setSelectedId(asset.id);
+  // Single click selects (side detail); preview opens the shared fullscreen modal —
+  // same larger view as the rest of the asset library. Arrows step the visible set.
+  const onPreview = (asset) => setPreviewId(asset.id);
+  const previewAsset = poses.find((asset) => asset.id === previewId) ?? null;
+  const previewIndex = visible.findIndex((asset) => asset.id === previewId);
+  const previousAsset = previewIndex > 0 ? visible[previewIndex - 1] : null;
+  const nextAsset = previewIndex >= 0 && previewIndex < visible.length - 1 ? visible[previewIndex + 1] : null;
 
   // Group the visible poses by category for the grid (category + tags shown per tile).
   const groups = useMemo(() => {
@@ -541,6 +548,19 @@ export function PoseLibraryScreen() {
           refresh();
         }}
       />
+
+      {previewAsset ? (
+        <FullscreenPreview
+          asset={previewAsset}
+          deleteAsset={deleteAsset}
+          purgeAsset={purgeAsset}
+          updateAssetStatus={updateAssetStatus}
+          onClose={() => setPreviewId(null)}
+          onPreviewAsset={(asset) => setPreviewId(asset.id)}
+          previousAsset={previousAsset}
+          nextAsset={nextAsset}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/screens/PoseLibraryScreen.test.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.test.jsx
@@ -108,6 +108,16 @@ describe("PoseLibraryScreen", () => {
     ).toBe(true);
   });
 
+  it("opens a pose in the shared fullscreen preview on double-click", async () => {
+    poseAssets = [poseAsset()];
+    await render();
+    const tile = [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Arm Raised"));
+    await act(async () => {
+      tile.dispatchEvent(new window.MouseEvent("dblclick", { bubbles: true }));
+    });
+    expect(container.querySelector(".preview-modal")).toBeTruthy();
+  });
+
   it("switches to the Create tab", async () => {
     poseAssets = [poseAsset()];
     await render();


### PR DESCRIPTION
Poses tab tiles only opened the side detail panel. Double-clicking a pose now opens the **same `FullscreenPreview` modal** the rest of the asset library uses (larger view + prev/next across the visible set), wired with the reserved-project mutators (status / delete / purge) so favorite/reject/discard act on the pose project rather than the active one. No Edit button (poses aren't `type:image`).

Test: double-clicking a pose tile opens `.preview-modal`. web suite 274 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)