### PR TITLE
fix(pose-library): square-canonical poses + aspect-fit render (no distortion)

### DIFF
--- a/apps/worker/scene_worker/openpose_skeleton.py
+++ b/apps/worker/scene_worker/openpose_skeleton.py
@@ -97,13 +97,25 @@ def normalize_face(raw: object) -> list[Keypoint] | None:
     return normalize_points(raw, 68)
 
 
+def square_fit(canvas_w: int, canvas_h: int) -> tuple[int, int, int]:
+    """Centered-square placement for normalized [0,1] keypoints, returning
+    ``(side, offset_x, offset_y)``. Poses are stored square-canonical (proportions
+    preserved by padding the short axis at capture — epic 2282), so render them into
+    the largest centered square of a (possibly non-square) canvas and letterbox the
+    margins (black = no control signal). A square canvas (w==h) maps 1:1, so square
+    generations are byte-identical to the old full-canvas mapping (no regression)."""
+    side = min(canvas_w, canvas_h)
+    return side, (canvas_w - side) // 2, (canvas_h - side) // 2
+
+
 def draw_bodypose(canvas_w: int, canvas_h: int, keypoints: list[Keypoint], stickwidth: int = 4) -> np.ndarray:
     """Render an OpenPose (COCO-18) skeleton (black background, colored sticks + joints)
     matching the controlnet_aux format. Returns an RGB uint8 array."""
     import cv2
 
     canvas = np.zeros((canvas_h, canvas_w, 3), dtype=np.uint8)
-    pts = [None if p is None else (float(p[0]) * canvas_w, float(p[1]) * canvas_h) for p in keypoints]
+    side, ox, oy = square_fit(canvas_w, canvas_h)
+    pts = [None if p is None else (ox + float(p[0]) * side, oy + float(p[1]) * side) for p in keypoints]
 
     for i, (a, b) in enumerate(LIMB_SEQ):
         if a >= len(pts) or b >= len(pts) or pts[a] is None or pts[b] is None:
@@ -141,10 +153,11 @@ def draw_handpose(canvas: np.ndarray, hands: list[list[Keypoint]], line_width: i
     import cv2
 
     h, w = canvas.shape[:2]
+    side, ox, oy = square_fit(w, h)
     for hand in hands:
         if not hand:
             continue
-        pts = [None if p is None else (int(p[0] * w), int(p[1] * h)) for p in hand]
+        pts = [None if p is None else (int(ox + p[0] * side), int(oy + p[1] * side)) for p in hand]
         for index, (a, b) in enumerate(HAND_EDGES):
             if a >= len(pts) or b >= len(pts) or pts[a] is None or pts[b] is None:
                 continue
@@ -162,13 +175,14 @@ def draw_facepose(canvas: np.ndarray, faces: list[list[Keypoint]], point_radius:
     import cv2
 
     h, w = canvas.shape[:2]
+    side, ox, oy = square_fit(w, h)
     for face in faces:
         if not face:
             continue
         for p in face:
             if p is None:
                 continue
-            cv2.circle(canvas, (int(p[0] * w), int(p[1] * h)), point_radius, (255, 255, 255), thickness=-1)
+            cv2.circle(canvas, (int(ox + p[0] * side), int(oy + p[1] * side)), point_radius, (255, 255, 255), thickness=-1)
     return canvas
 
 

--- a/apps/worker/scene_worker/pose_adapters.py
+++ b/apps/worker/scene_worker/pose_adapters.py
@@ -117,6 +117,28 @@ def wholebody_to_openpose(kps, sc, w: int, h: int) -> dict:
     }
 
 
+def squareify(rec: dict, w: int, h: int) -> dict:
+    """Re-normalize a source-aspect pose into a centered ``max(w, h)`` SQUARE — pad
+    the short axis, never crop — so the stored pose is aspect-canonical. A later
+    square aspect-fit at generation (``openpose_skeleton.square_fit``) then preserves
+    the captured human proportions at any output aspect, instead of stretching x/y
+    independently (epic 2282). Confidence is carried through unchanged. Operates on
+    the body18 + hands[21,21] + face68 ``[x, y, conf]`` record from
+    ``wholebody_to_openpose``."""
+    side = float(max(w, h))
+    ox = (side - w) / 2.0
+    oy = (side - h) / 2.0
+
+    def _sq(p):
+        return None if p is None else [(p[0] * w + ox) / side, (p[1] * h + oy) / side, p[2]]
+
+    return {
+        "keypoints": [_sq(p) for p in rec["keypoints"]],
+        "hands": [[_sq(p) for p in rec["hands"][0]], [_sq(p) for p in rec["hands"][1]]],
+        "face": [_sq(p) for p in rec["face"]],
+    }
+
+
 def _thresholded(group: list, min_conf: float) -> list:
     """Render-ready copy: drop (None) points below the confidence floor."""
     out = []
@@ -341,6 +363,9 @@ def run_pose_detect(
         ordered = []
         for i in range(n):
             rec = wholebody_to_openpose(keypoints[i], scores[i], w, h)
+            # Store square-canonical (pad short axis): proportions then survive a
+            # square aspect-fit at any generation resolution (epic 2282).
+            rec = squareify(rec, w, h)
             bbox = _bbox(rec["keypoints"], rec["hands"][0], rec["hands"][1], rec["face"], min_conf=min_conf)
             area = 0.0 if bbox is None else (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
             ordered.append((area, rec, bbox))
@@ -352,8 +377,11 @@ def run_pose_detect(
             body_t = _thresholded(rec["keypoints"], min_conf)
             hands_t = [_thresholded(rec["hands"][0], min_conf), _thresholded(rec["hands"][1], min_conf)]
             face_t = _thresholded(rec["face"], min_conf)
-            stick = max(6, round(min(w, h) * 0.012))
-            skel = draw_wholebody(w, h, body_t, hands_t, face_t, stickwidth=stick)
+            # Render the (already square-canonical) skeleton on a SQUARE canvas so
+            # the stored preview/thumbnail is square; square_fit maps it 1:1.
+            side = max(w, h)
+            stick = max(6, round(side * 0.012))
+            skel = draw_wholebody(side, side, body_t, hands_t, face_t, stickwidth=stick)
             preview = out_dir / f"{stem}_p{person_index}_skel.png"
             cv2.imwrite(str(preview), cv2.cvtColor(skel, cv2.COLOR_RGB2BGR))
             poses.append({

--- a/tests/test_pose_adapters.py
+++ b/tests/test_pose_adapters.py
@@ -44,6 +44,34 @@ def test_wholebody_to_openpose_shapes_and_neck():
     assert rec["keypoints"][0][2] == pytest.approx(5.0)
 
 
+def test_square_fit_centers_into_largest_square():
+    from scene_worker.openpose_skeleton import square_fit
+
+    assert square_fit(100, 100) == (100, 0, 0)  # square: unchanged (no regression)
+    assert square_fit(200, 100) == (100, 50, 0)  # wide: centered horizontally
+    assert square_fit(100, 200) == (100, 0, 50)  # tall: centered vertically
+
+
+def test_squareify_pads_short_axis_preserving_proportions():
+    rec = {
+        "keypoints": [[0.5, 0.5, 1.0], [0.0, 0.0, 1.0], [1.0, 1.0, 1.0]],
+        "hands": [[None], [None]],
+        "face": [[0.5, 0.5, 0.9]],
+    }
+    # Portrait 320x480 -> square side 480, x padded by (480-320)/2 = 80, y unchanged.
+    out = pa.squareify(rec, 320, 480)
+    assert out["keypoints"][0] == pytest.approx([0.5, 0.5, 1.0])  # center stays center
+    assert out["keypoints"][1][0] == pytest.approx(80 / 480)  # left edge moves toward center
+    assert out["keypoints"][1][1] == pytest.approx(0.0)  # y keeps full range
+    assert out["keypoints"][2][0] == pytest.approx((320 + 80) / 480)
+    assert out["keypoints"][2][1] == pytest.approx(1.0)
+    # The x-span equals the source width fraction (320/480) — proportions preserved,
+    # NOT stretched to fill the square.
+    assert out["keypoints"][2][0] - out["keypoints"][1][0] == pytest.approx(320 / 480)
+    assert out["face"][0] == pytest.approx([0.5, 0.5, 0.9])
+    assert out["hands"][0][0] is None  # None carried through
+
+
 def test_pose_detector_backend_available(monkeypatch):
     monkeypatch.setattr(pa, "_module_available", lambda name: True)
     assert pa.pose_detector_backend_available() is True
@@ -126,4 +154,7 @@ def test_run_pose_detect_with_fake_detector(tmp_path):
     # skeleton preview rendered to the job-scoped staging dir
     from pathlib import Path
     assert Path(pose["skeletonPreview"]).exists()
+    # Preview is rendered SQUARE — poses are stored square-canonical (epic 2282).
+    prev = cv2.imread(pose["skeletonPreview"])
+    assert prev is not None and prev.shape[0] == prev.shape[1]
     assert events  # progress was reported


### PR DESCRIPTION
**Problem.** Pose keypoints are normalized to the source photo's aspect, but every adapter renders them with `draw_*(request.width, request.height, kp)` mapping `x·w, y·h` **independently** — so a portrait pose **stretches** when you generate square/landscape. The pose's aspect wasn't even forwarded to the worker.

**Fix (Michael's call — square-by-padding, then aspect-fit), two non-lossy steps:**
1. **Capture** (`squareify`, `pose_adapters`): re-normalize each detected pose into a centered `max(w,h)` **square by padding the short axis** (never cropping); render the preview on a square canvas. Stored keypoints + thumbnail are now aspect-canonical (uniform square thumbnails on the Poses tab too).
2. **Render** (`square_fit`, `openpose_skeleton`): `draw_bodypose/handpose/facepose` map the unit square into the **largest centered square** of the target canvas, letterboxing the margins (black = no control). **Square generations are byte-identical** (no regression); non-square ones place the figure centered at correct proportions instead of stretched. Applies uniformly to built-in (already unit-square) + user poses.

No payload/frontend change (the worker owns aspect; keypoints flow as before). InstantID (fixed 1024²) is unaffected.

**Tests:** `square_fit` centering, `squareify` padding + proportion preservation, square preview. 496 worker tests green locally (cv2 venv). Note: CI's worker step stubs the draw fns + the CI venv has no cv2, so `test_pose_adapters`/`test_instantid_adapter` (the real mapping) run locally, not in CI — flagging that.

**Note:** existing built-in poses now letterbox (centered) at non-square output instead of stretching — intended (aspect-fit). No saved user poses predate this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)