### PR TITLE
feat(lokr): Wan2.2 5B video LoKr — trainer + contract + MLX dispatch fallback (sc-2211)

### DIFF
--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -2099,14 +2099,16 @@ class _WanLoraBackend:
             text_encoder.requires_grad_(False)
 
         progress("loading_model", "loading_model", 0.16, "Attaching LoRA adapter to the transformer.")
-        lora_config = peft.LoraConfig(
-            r=config.rank,
-            lora_alpha=config.alpha,
-            init_lora_weights="gaussian",
-            target_modules=list(config.lora_target_modules)
-            if isinstance(config.lora_target_modules, (list, tuple))
-            else config.lora_target_modules,
-        )
+        self._network_type = config.network_type
+        # Stashed for the save path: everything write_lokr_adapter needs to stamp
+        # into the file so inference can rebuild the matching LoKrConfig (epic 2193).
+        self._lokr_save_kwargs = {
+            "rank": config.rank,
+            "alpha": config.alpha,
+            "decompose_factor": config.decompose_factor,
+            "target_modules": config.lora_target_modules,
+        }
+        lora_config = build_peft_network_config(peft, config)
         transformer.add_adapter(lora_config)
         self._activate_lora_adapter(transformer)
         if config.gradient_checkpointing:
@@ -2330,12 +2332,22 @@ class _WanLoraBackend:
 
         os.makedirs(output_dir, exist_ok=True)
         lora_state_dict = get_peft_model_state_dict(self._transformer)
-        type(self._pipeline).save_lora_weights(
-            output_dir,
-            transformer_lora_layers=lora_state_dict,
-            weight_name=file_name,
-            safe_serialization=True,
-        )
+        if getattr(self, "_network_type", "lora") == "lokr":
+            # LoKr keys (lokr_w1/lokr_w2) are not save_lora_weights-compatible;
+            # write raw with routing metadata (epic 2193).
+            write_lokr_adapter(
+                lora_state_dict,
+                output_dir,
+                file_name,
+                **getattr(self, "_lokr_save_kwargs", {}),
+            )
+        else:
+            type(self._pipeline).save_lora_weights(
+                output_dir,
+                transformer_lora_layers=lora_state_dict,
+                weight_name=file_name,
+                safe_serialization=True,
+            )
         lora_a_norm, lora_b_norm = self._lora_param_norms()
         emit_worker_event(
             "training_lora_weight_norm",

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -33,7 +33,7 @@ from sceneworks_shared import (
 from .adapter_utils import cancel_step_callback, filter_call_kwargs
 from .sampler_registry import apply_sampler, sampler_selection_from_advanced
 from .hf_cache import huggingface_cache_root, huggingface_cache_roots, huggingface_repo_cache_path_for_root
-from .image_adapters import emit_worker_event, empty_torch_cache, gpu_memory_snapshot, require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
+from .image_adapters import _request_has_lokr_lora, emit_worker_event, empty_torch_cache, gpu_memory_snapshot, require_inference_backend_for_gpu_worker, select_torch_device, select_torch_dtype, write_json
 from .lora_adapters import (
     LoraPipelineState,
     LoraSpec,
@@ -41,6 +41,7 @@ from .lora_adapters import (
     lora_cache_key_for_specs,
     lora_looks_like_ic_lora,
     normalize_lora_specs,
+    reject_lokr_loras,
     reject_loras_if_unsupported,
     validate_lora_compatibility,
 )
@@ -2211,7 +2212,13 @@ class MlxVideoAdapter(VideoGenerationAdapter):
         high: list[tuple[str, float]] = []
         low: list[tuple[str, float]] = []
         shared: list[tuple[str, float]] = []
-        for spec in normalize_lora_specs(request.loras):
+        specs = normalize_lora_specs(request.loras)
+        # Backstop (sc-2211): the mlx-video loader can't merge LoKr/LyCORIS keys.
+        # create_video_adapter already diverts LoKr jobs to the torch path, but guard
+        # the env-override route (SCENEWORKS_VIDEO_ADAPTER=mlx_video) so a LoKr fails
+        # loudly here rather than silently mis-applying as a plain LoRA.
+        reject_lokr_loras(specs, self.id)
+        for spec in specs:
             if spec.secondary_path:
                 high.append((spec.path, spec.weight))
                 low.append((spec.secondary_path, spec.weight))
@@ -2879,6 +2886,14 @@ def create_video_adapter(job: dict[str, Any] | None = None) -> VideoGenerationAd
             and model in MlxVideoAdapter._supported_models
             and mode in MlxVideoAdapter._supported_modes
         )
+        # epic 2193 (sc-2211), video companion to sc-2209: the mlx-video LoRA loader
+        # merges plain B@A deltas and can't apply a LoKr (Kronecker) adapter, so a job
+        # carrying one must run on the torch path that loads LoKr via PEFT injection
+        # (apply_loras_to_pipeline). Only the diffusers backend (Wan family) has that
+        # loader — the LTX torch path doesn't — so scope the fallback to it; LTX LoKr
+        # is native-MLX-only (sc-2214) and stays on MLX here.
+        if mlx_eligible and target["adapter"] != "ltx_video" and _request_has_lokr_lora(payload):
+            mlx_eligible = False
         if mlx_eligible:
             return MlxVideoAdapter()
         if target["adapter"] == "ltx_video":

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1186,9 +1186,11 @@ fn wan_lora_target() -> TrainingTarget {
             "resolutions": [512, 768],
             "batchSize": [1, 2],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-            // Wan is a torch backend, but epic 2193 v1 validates LoKr on the
-            // image backends (Z-Image/SDXL) first; video stays `lora`-only.
-            "networkTypes": ["lora"],
+            // Wan2.2 TI2V-5B is a torch/diffusers backend: the PEFT LoKr trainer
+            // (sc-2196) applies and the diffusers video inference loads it via PEFT
+            // injection (sc-2197/2211). MLX video has no Kronecker merge yet, so a
+            // LoKr Wan job falls back to the torch path (sc-2211; native MLX is sc-2213).
+            "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"]

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -105,8 +105,9 @@ fn builtin_targets_gate_network_types() {
             .is_some_and(|types| types.iter().any(|entry| entry.as_str() == Some(value)))
     };
 
-    // Every target advertises `lora`; only the spike-validated torch image
-    // backends (epic 2193) advertise `lokr`.
+    // Every target advertises `lora`; only the validated torch/PEFT backends
+    // (epic 2193) advertise `lokr`: the Z-Image/SDXL image backends (v1) plus the
+    // Wan2.2 5B video backend (sc-2211). MLX-only and MoE targets stay lora-only.
     let lokr_targets: Vec<&str> = registry
         .targets
         .iter()
@@ -121,7 +122,10 @@ fn builtin_targets_gate_network_types() {
         .map(|target| target.id.as_str())
         .collect();
 
-    assert_eq!(lokr_targets, ["z_image_turbo_lora", "sdxl_lora"]);
+    assert_eq!(
+        lokr_targets,
+        ["z_image_turbo_lora", "sdxl_lora", "wan_lora"]
+    );
 }
 
 #[test]

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -450,7 +450,8 @@
           "cosine"
         ],
         "networkTypes": [
-          "lora"
+          "lora",
+          "lokr"
         ],
         "optimizers": [
           "adamw8bit",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -4639,6 +4639,90 @@ def test_sdxl_backend_save_lora_writes_unet_diffusers_format(tmp_path, monkeypat
     assert output_path == str(tmp_path / "aurora_style.safetensors")
 
 
+def test_wan_backend_save_lora_writes_transformer_diffusers_format(tmp_path, monkeypatch):
+    # Default (lora) network: the Wan trainer saves via WanPipeline.save_lora_weights
+    # (transformer_lora_layers=...), the diffusers format the video loader round-trips.
+    # Torch-free: fake peft + pipeline (sc-2211).
+    import sys
+    import types as types_module
+
+    fake_state = {"transformer.blocks.0.attn1.to_q.lora_A.weight": "tensor"}
+    fake_peft_utils = types_module.ModuleType("peft.utils")
+    fake_peft_utils.get_peft_model_state_dict = lambda _module: fake_state
+    monkeypatch.setitem(sys.modules, "peft.utils", fake_peft_utils)
+
+    saved: dict[str, object] = {}
+
+    class FakeWanPipeline:
+        @staticmethod
+        def save_lora_weights(
+            output_dir, *, transformer_lora_layers=None, weight_name=None, safe_serialization=None, **_kwargs
+        ):
+            saved["transformer_lora_layers"] = transformer_lora_layers
+            saved["weight_name"] = weight_name
+            saved["safe_serialization"] = safe_serialization
+
+    backend = _WanLoraBackend()
+    backend._transformer = object()
+    backend._pipeline = FakeWanPipeline()
+    output_path = backend._save_lora(output_dir=str(tmp_path), file_name="motion.safetensors")
+
+    assert saved["transformer_lora_layers"] is fake_state
+    assert saved["weight_name"] == "motion.safetensors"
+    assert saved["safe_serialization"] is True
+    assert output_path == str(tmp_path / "motion.safetensors")
+
+
+def test_wan_backend_save_lora_lokr_routes_to_write_lokr_adapter(tmp_path, monkeypatch):
+    # LoKr network (sc-2211): LoKr keys (lokr_w1/lokr_w2) aren't save_lora_weights-
+    # compatible, so the Wan trainer serializes raw via write_lokr_adapter with the
+    # routing metadata the video inference loader (PEFT injection) needs — exactly
+    # like the SDXL/Z-Image backends. save_lora_weights must NOT be called.
+    import sys
+    import types as types_module
+
+    fake_state = {"transformer.blocks.0.attn1.to_q.lokr_w1": "tensor"}
+    fake_peft_utils = types_module.ModuleType("peft.utils")
+    fake_peft_utils.get_peft_model_state_dict = lambda _module: fake_state
+    monkeypatch.setitem(sys.modules, "peft.utils", fake_peft_utils)
+
+    captured: dict[str, object] = {}
+
+    def fake_write_lokr_adapter(state_dict, output_dir, file_name, **kwargs):
+        captured["state_dict"] = state_dict
+        captured["file_name"] = file_name
+        captured["kwargs"] = kwargs
+        return str(Path(output_dir) / file_name)
+
+    monkeypatch.setattr(
+        "scene_worker.training_adapters.write_lokr_adapter", fake_write_lokr_adapter
+    )
+
+    class FakeWanPipeline:
+        @staticmethod
+        def save_lora_weights(*_args, **_kwargs):
+            raise AssertionError("LoKr must not save via save_lora_weights")
+
+    backend = _WanLoraBackend()
+    backend._transformer = object()
+    backend._pipeline = FakeWanPipeline()
+    backend._network_type = "lokr"
+    save_kwargs = {
+        "rank": 16,
+        "alpha": 16,
+        "decompose_factor": -1,
+        "target_modules": ["to_q", "to_k", "to_v", "to_out.0"],
+    }
+    backend._lokr_save_kwargs = save_kwargs
+
+    output_path = backend._save_lora(output_dir=str(tmp_path), file_name="motion.safetensors")
+
+    assert captured["state_dict"] is fake_state
+    assert captured["file_name"] == "motion.safetensors"
+    assert captured["kwargs"] == save_kwargs
+    assert output_path == str(tmp_path / "motion.safetensors")
+
+
 def test_create_image_adapter_routes_sensenova_u1():
     adapter = create_image_adapter({"payload": {"model": "sensenova_u1_8b"}})
     assert adapter.__class__.__name__ == "SenseNovaU1Adapter"
@@ -7937,6 +8021,30 @@ def test_mlx_routing_is_mode_aware_on_mps(monkeypatch):
     assert adapter("ltx_2_3", "video_bridge") == "LtxPipelinesVideoAdapter"
     assert adapter("wan_2_2", "video_bridge") == "DiffusersVideoAdapter"
     assert adapter("wan_2_2", "replace_person") == "DiffusersVideoAdapter"
+
+
+def test_wan_lokr_lora_falls_back_off_mlx_to_torch(monkeypatch):
+    # sc-2211 (video companion to sc-2209): the mlx-video LoRA loader merges plain
+    # B@A deltas and can't apply a LoKr (Kronecker) adapter, so a Wan job carrying one
+    # falls back to the diffusers torch path (which loads LoKr via PEFT injection). A
+    # plain LoRA stays on MLX. networkType is read with no file I/O (top-level or
+    # nested in compatibility), mirroring the image dispatch gate.
+    monkeypatch.delenv("SCENEWORKS_VIDEO_ADAPTER", raising=False)
+    monkeypatch.setattr("scene_worker.video_adapters._mps_available", lambda: True)
+
+    def adapter(model, loras):
+        job = {"payload": {"model": model, "mode": "image_to_video", "loras": loras}}
+        return create_video_adapter(job).__class__.__name__
+
+    # Plain LoRA (or none) stays on MLX; a LoKr LoRA diverts to the torch path.
+    assert adapter("wan_2_2", []) == "MlxVideoAdapter"
+    assert adapter("wan_2_2", [{"id": "a", "networkType": "lora"}]) == "MlxVideoAdapter"
+    assert adapter("wan_2_2", [{"id": "a", "networkType": "lokr"}]) == "DiffusersVideoAdapter"
+    assert adapter("wan_2_2", [{"id": "a", "compatibility": {"networkType": "lokr"}}]) == "DiffusersVideoAdapter"
+
+    # Scoped to the diffusers torch path: an LTX LoKr stays on MLX (the LTX torch path
+    # has no LoKr loader; native-MLX LoKr for LTX is sc-2214).
+    assert adapter("ltx_2_3", [{"id": "a", "networkType": "lokr"}]) == "MlxVideoAdapter"
 
 
 def test_video_pipeline_evicts_previous_pipeline_and_loaded_models():


### PR DESCRIPTION
Extends epic 2193 (LoKr / LyCORIS Kronecker network type) to the **Wan2.2 TI2V-5B** video target (`wan_lora`). Builds on the v1 foundation in [#352](https://github.com/michaeltrefry/SceneWorks/pull/352) (merged): `build_peft_network_config` + `write_lokr_adapter` (sc-2196) and the PEFT-injection inference loader used by the diffusers video path (sc-2197). mflux-free — torch/diffusers only.

Story: [sc-2211](https://app.shortcut.com/trefry/story/2211). Unblocks sc-2212 (A14B MoE).

## Changes
- **Trainer** (`apps/worker/scene_worker/training_adapters.py`): `_WanLoraBackend.load()` stashes `_network_type` + `_lokr_save_kwargs` and builds the adapter via `build_peft_network_config(peft, config)` (was a hardcoded `LoraConfig`); `_save_lora()` gains the LoKr branch (`write_lokr_adapter`), mirroring the SDXL/Z-Image backends. **`_WanMoeLoraBackend` (A14B) is untouched** — it overrides `load`/`save_both` and stays `lora`-only, deferred to sc-2212.
- **Contract** (`crates/sceneworks-core/src/training.rs`): `wan_lora` `limits.networkTypes` → `["lora","lokr"]`. Gating test expected list → `["z_image_turbo_lora","sdxl_lora","wan_lora"]`; `target-registry.json` regenerated. MoE + MLX-only targets stay `lora`-only.
- **Video dispatch** (`apps/worker/scene_worker/video_adapters.py`, companion to sc-2209 on the video side): `create_video_adapter()` diverts a LoKr-carrying job off the mlx-video loader (which has no Kronecker merge) to the diffusers torch path (`DiffusersVideoAdapter`, which applies LoKr via `apply_loras_to_pipeline` PEFT injection). Scoped to the diffusers backend (`target["adapter"] != "ltx_video"`) — an LTX LoKr stays on MLX (native-MLX LoKr for LTX is sc-2214). Defensive `reject_lokr_loras` backstop added in `MlxVideoAdapter._wan_user_loras` for the `SCENEWORKS_VIDEO_ADAPTER=mlx_video` override route.
- **Web**: no change — the TrainingStudio network-type picker is data-driven on `limits.networkTypes` (sc-2198), so the LoKr option + decompose-factor field now appear for Wan automatically.

## Tests
- Worker (CI trio): **486 passed, 9 skipped**. 3 new: Wan `_save_lora` lora branch, Wan `_save_lora` lokr branch → `write_lokr_adapter`, and the Wan-LoKr MLX→torch dispatch fallback (+ LTX-stays-on-MLX scoping).
- Rust `sceneworks-core`: **29 passed**; `sceneworks-worker`: 42 passed; `clippy` + `cargo fmt` clean.

## Real Mac E2E (cached `Wan-AI/Wan2.2-TI2V-5B-Diffusers`, fp32/MPS)
Drove the shipping code end-to-end:
- **Train** (`_WanLoraBackend` load → prepare_dataset → train_step, 6 steps on 2 images) → **save** via `_save_lora` lokr branch: **3.1 MB**, header `networkType=lokr`.
- **Inference-load** via `apply_loras_to_pipeline` → `inject_lokr_adapter`: reconstructed Kronecker delta == trained delta **exactly (max abs diff 0.0)** on real Wan weights.
- **Generate** (full `WanPipeline.__call__` with the injected LoKr): output latents differ from base (**0.093** mean abs diff), no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)