### PR TITLE
feat(kolors): Kolors LoRA trainer + LoKr (epic 1929, sc-2217)

### DIFF
--- a/apps/worker/scene_worker/training_adapters.py
+++ b/apps/worker/scene_worker/training_adapters.py
@@ -43,6 +43,7 @@ from sceneworks_shared import utc_now
 from .adapter_utils import filter_call_kwargs
 from .image_adapters import (
     activate_torch_device,
+    empty_torch_cache,
     emit_worker_event,
     gpu_memory_snapshot,
     require_inference_backend_for_gpu_worker,
@@ -1993,6 +1994,96 @@ class SdxlLoraTrainer(ZImageLoraTrainer):
 
 
 # --------------------------------------------------------------------------- #
+# Kolors LoRA backend (epic 1929) — the SDXL-UNet trainer with the Kolors pipeline
+# --------------------------------------------------------------------------- #
+
+
+class _KolorsLoraBackend(_SdxlLoraBackend):
+    """Kolors LoRA training backend — the SDXL-UNet trainer with the Kolors pipeline.
+
+    Kolors (Kwai-Kolors) is an SDXL-architecture U-Net with a **ChatGLM3-6B** text
+    encoder + SDXL VAE and the same epsilon/v-prediction objective, so it reuses
+    every part of :class:`_SdxlLoraBackend` — the U-Net LoRA injection via
+    ``build_peft_network_config`` (so LoKr is inherited for free, epic 2193), the
+    DDPM loop with the SDXL ``added_cond_kwargs``, and the save path — and only
+    swaps the two documented seams: the pipeline class and the prompt encoder
+    (``KolorsPipeline.encode_prompt`` — ChatGLM3, ``max_sequence_length=256``, no
+    second CLIP ``prompt_2``). After caching the prompt embeddings it releases the
+    ~6B-param ChatGLM3 encoder when no live sampling will re-encode prompts,
+    keeping the Mac memory envelope to U-Net + LoRA + VAE.
+    """
+
+    kernel_id = "kolors_lora"
+    pipeline_class_name = "KolorsPipeline"
+    # Kolors-diffusers ships fp16-variant weights only (like the SDXL base).
+    load_variant = "fp16"
+
+    def _encode_prompt(self, pipe: Any, caption: str, device: str) -> tuple[Any, Any]:
+        # Kolors uses a single ChatGLM3 encoder (no SDXL ``prompt_2``) and a GLM
+        # sequence length of 256; the 4-tuple return order matches SDXL.
+        prompt_embeds, _, pooled_prompt_embeds, _ = pipe.encode_prompt(
+            prompt=caption,
+            device=device,
+            num_images_per_prompt=1,
+            do_classifier_free_guidance=False,
+            max_sequence_length=256,
+        )
+        return prompt_embeds, pooled_prompt_embeds
+
+    def prepare_dataset(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        config: TrainingRunConfig,
+        progress: ProgressCallback,
+        cancel_requested: CancelCallback,
+    ) -> dict[str, Any]:
+        result = super().prepare_dataset(
+            items=items, config=config, progress=progress, cancel_requested=cancel_requested
+        )
+        # ChatGLM3-6B (~12 GB fp16) is only used to encode prompts. The embeddings
+        # are now cached and the training loop never touches the encoder, so unless
+        # live sampling will re-encode prompts mid-run, release it to keep the Mac
+        # memory envelope to U-Net + LoRA + VAE (epic 1929).
+        if not config.sample_every:
+            self._release_text_encoder()
+        return result
+
+    def _release_text_encoder(self) -> None:
+        pipe = self._pipeline
+        if pipe is None:
+            return
+        released: list[str] = []
+        for attr in ("text_encoder", "text_encoder_2"):
+            if getattr(pipe, attr, None) is not None:
+                setattr(pipe, attr, None)
+                released.append(attr)
+        if released:
+            empty_torch_cache(self._torch)
+            emit_worker_event(
+                "training_text_encoder_released",
+                kernel=self.kernel_id,
+                released=",".join(released),
+            )
+
+
+class KolorsLoraTrainer(SdxlLoraTrainer):
+    """Kolors LoRA trainer (epic 1929).
+
+    Thin extension of the generic SDXL-UNet trainer: the same staged orchestration
+    and SDXL training loop with the Kolors pipeline + ChatGLM3 prompt encoder via
+    :class:`_KolorsLoraBackend`. Output registers as a ``kolors`` family LoRA the
+    Kolors image adapter loads at generation time; LoKr support is inherited from
+    the shared SDXL backend (epic 2193, sc-2217).
+    """
+
+    kernel_id = "kolors_lora"
+
+    def _create_backend(self) -> _KolorsLoraBackend:
+        return _KolorsLoraBackend()
+
+
+# --------------------------------------------------------------------------- #
 # Real torch/diffusers/peft backend for Wan2.2 video
 # --------------------------------------------------------------------------- #
 
@@ -3863,6 +3954,7 @@ class LensLoraTrainer:
 _TRAINING_KERNELS: dict[str, Callable[[], Any]] = {
     ZImageLoraTrainer.kernel_id: ZImageLoraTrainer,
     SdxlLoraTrainer.kernel_id: SdxlLoraTrainer,
+    KolorsLoraTrainer.kernel_id: KolorsLoraTrainer,
     WanLoraTrainer.kernel_id: WanLoraTrainer,
     WanMoeLoraTrainer.kernel_id: WanMoeLoraTrainer,
     LensLoraTrainer.kernel_id: LensLoraTrainer,

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -405,6 +405,7 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
         targets: vec![
             z_image_turbo_lora_target(),
             sdxl_lora_target(),
+            kolors_lora_target(),
             lens_turbo_lora_target(),
             ltx_video_lora_target(),
             wan_lora_target(),
@@ -419,6 +420,7 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
 pub fn builtin_training_presets() -> TrainingPresetRegistry {
     let target = z_image_turbo_lora_target();
     let sdxl_target = sdxl_lora_target();
+    let kolors_target = kolors_lora_target();
     let wan_target = wan_lora_target();
     let wan_t2v_14b_target = wan_t2v_14b_lora_target();
     let wan_i2v_14b_target = wan_i2v_14b_lora_target();
@@ -603,6 +605,72 @@ pub fn builtin_training_presets() -> TrainingPresetRegistry {
                 },
                 object(json!({
                     "description": "768px preset for tighter-VRAM SDXL training.",
+                    "order": 40
+                })),
+            ),
+            // Kolors reuses the SDXL preset recipe (same U-Net architecture); only
+            // the target (pipeline + ChatGLM3 encoder) and the LoRA family differ.
+            sdxl_preset(
+                &kolors_target,
+                "kolors_lora.character.adamw8bit.balanced",
+                "Character balanced",
+                &["character"],
+                ("adamw8bit", "balanced"),
+                |config| config,
+                object(json!({
+                    "description": "Balanced first run for 12-25 clean character images on Kolors.",
+                    "default": true,
+                    "order": 10
+                })),
+            ),
+            sdxl_preset(
+                &kolors_target,
+                "kolors_lora.character.adamw8bit.conservative",
+                "Character conservative",
+                &["character"],
+                ("adamw8bit", "conservative"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.learning_rate = number(0.00005);
+                    config
+                },
+                object(json!({
+                    "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+                    "order": 20
+                })),
+            ),
+            sdxl_preset(
+                &kolors_target,
+                "kolors_lora.style.adamw8bit.balanced",
+                "Style balanced",
+                &["style"],
+                ("adamw8bit", "balanced"),
+                |mut config| {
+                    config.rank = 32;
+                    config.alpha = 16;
+                    config
+                },
+                object(json!({
+                    "description": "Higher-capacity style LoRA defaults for texture and look transfer.",
+                    "order": 30
+                })),
+            ),
+            sdxl_preset(
+                &kolors_target,
+                "kolors_lora.character.adamw8bit.low_vram",
+                "Low VRAM character",
+                &["character"],
+                ("adamw8bit", "low_vram"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.resolution = 768;
+                    config.steps = 1200;
+                    config
+                },
+                object(json!({
+                    "description": "768px preset for tighter-VRAM Kolors training.",
                     "order": 40
                 })),
             ),
@@ -1382,6 +1450,81 @@ fn sdxl_lora_target() -> TrainingTarget {
         ui: object(json!({
             "label": "Stable Diffusion XL LoRA",
             "description": "Train an image LoRA for Stable Diffusion XL. The generic SDXL-UNet trainer and the shared foundation for SDXL-family models.",
+            "recommendedFor": ["character", "style"]
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Kolors LoRA training target (epic 1929).
+///
+/// Kolors (Kwai-Kolors) is an SDXL-architecture U-Net with a ChatGLM3-6B text
+/// encoder + SDXL VAE and the same epsilon/v-prediction objective, so it reuses
+/// the generic SDXL-UNet trainer wholesale (same DDPM loop, same `added_cond_kwargs`,
+/// same `to_q`/`to_k`/`to_v`/`to_out.0` attention target modules) via a thin
+/// `kolors_lora` kernel that only swaps the pipeline class + the ChatGLM3 prompt
+/// encoder. The output registers as a `kolors` family LoRA the Kolors image
+/// adapter loads at generation time.
+fn kolors_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "kolors_lora".to_owned(),
+        name: "Kolors LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "kolors".to_owned(),
+        base_model: "kolors".to_owned(),
+        base_model_repo: Some("Kwai-Kolors/Kolors-diffusers".to_owned()),
+        kernel: "kolors_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 1500,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                "lrScheduler": "constant",
+                // Kolors shares the SDXL UNet attention module names.
+                "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+                "sampleEvery": 250,
+                "sampleSteps": 30,
+                "sampleGuidanceScale": 7.0,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            "resolutions": [768, 1024],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Kolors is an SDXL-architecture torch/PEFT backend, so it advertises
+            // `lokr` like the SDXL target — inherited from the shared SDXL backend's
+            // LoKr save + PEFT-injection inference path (epic 2193, sc-2217).
+            "networkTypes": ["lora", "lokr"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "qualityPresets": ["speed", "balanced", "quality"],
+            "outputScopes": ["project", "global"]
+        })),
+        ui: object(json!({
+            "label": "Kolors LoRA",
+            "description": "Train an image LoRA for Kolors (Kwai-Kolors). Runs the SDXL-UNet trainer with the Kolors pipeline + ChatGLM3 text encoder, on CUDA and Apple Silicon (MPS).",
             "recommendedFor": ["character", "style"]
         })),
         extra: ExtraFields::new(),

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -106,7 +106,8 @@ fn builtin_targets_gate_network_types() {
     };
 
     // Every target advertises `lora`; only the validated torch/PEFT backends
-    // (epic 2193) advertise `lokr`: the Z-Image/SDXL image backends (v1) plus the
+    // (epic 2193) advertise `lokr`: the Z-Image/SDXL image backends (v1), the
+    // Kolors image backend (SDXL-architecture, epic 1929 / sc-2217), and the
     // Wan2.2 5B video backend (sc-2211). MLX-only and MoE targets stay lora-only.
     let lokr_targets: Vec<&str> = registry
         .targets
@@ -124,7 +125,7 @@ fn builtin_targets_gate_network_types() {
 
     assert_eq!(
         lokr_targets,
-        ["z_image_turbo_lora", "sdxl_lora", "wan_lora"]
+        ["z_image_turbo_lora", "sdxl_lora", "kolors_lora", "wan_lora"]
     );
 }
 
@@ -137,6 +138,18 @@ fn regen_target_registry_fixture() {
     let pretty = serde_json::to_string_pretty(&builtin_training_targets())
         .expect("builtin registry serializes");
     fs::write(fixture_path("target-registry.json"), pretty + "\n").expect("write fixture");
+}
+
+#[test]
+#[ignore = "regen helper: run with REGEN_FIXTURE=1 to rewrite preset-registry.json"]
+fn regen_preset_registry_fixture() {
+    if std::env::var("REGEN_FIXTURE").is_err() {
+        return;
+    }
+    let pretty =
+        serde_json::to_string_pretty(&sceneworks_core::training::builtin_training_presets())
+            .expect("builtin preset registry serializes");
+    fs::write(fixture_path("preset-registry.json"), pretty + "\n").expect("write fixture");
 }
 
 #[test]
@@ -230,6 +243,38 @@ fn builtin_registry_exposes_sdxl_target() {
     assert_eq!(
         target.defaults.advanced.get("loraTargetModules"),
         Some(&serde_json::json!(["to_q", "to_k", "to_v", "to_out.0"]))
+    );
+}
+
+#[test]
+fn builtin_registry_exposes_kolors_target() {
+    // Kolors (epic 1929) is an SDXL-architecture U-Net target served by the
+    // `kolors_lora` kernel; it reuses the SDXL attention modules + LoKr support
+    // (epic 2193 / sc-2217) and resolves the Kolors-diffusers base.
+    let registry = builtin_training_targets();
+    let target = registry
+        .targets
+        .iter()
+        .find(|target| target.id == "kolors_lora")
+        .expect("kolors_lora target present");
+
+    assert_eq!(target.modality, TrainingModality::Image);
+    assert_eq!(target.output_kind, TrainingOutputKind::Lora);
+    assert_eq!(target.family, "kolors");
+    assert_eq!(target.base_model, "kolors");
+    assert_eq!(target.kernel, "kolors_lora");
+    assert_eq!(
+        target.base_model_repo.as_deref(),
+        Some("Kwai-Kolors/Kolors-diffusers")
+    );
+    // SDXL-shared attention modules + LoKr advertised (sc-2217).
+    assert_eq!(
+        target.defaults.advanced.get("loraTargetModules"),
+        Some(&serde_json::json!(["to_q", "to_k", "to_v", "to_out.0"]))
+    );
+    assert_eq!(
+        target.limits.get("networkTypes"),
+        Some(&serde_json::json!(["lora", "lokr"]))
     );
 }
 

--- a/tests/fixtures/rust_migration_contracts/training/preset-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/preset-registry.json
@@ -6,7 +6,9 @@
       "version": 1,
       "targetId": "z_image_turbo_lora",
       "name": "Character balanced",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "balanced",
       "config": {
@@ -21,29 +23,29 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "sampleEvery": 250,
-          "sampleSteps": 8,
-          "sampleGuidanceScale": 0.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
+          "qualityPreset": "balanced",
           "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 0.0,
+          "sampleSteps": 8,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
           "trainingAdapterRepo": "ostris/zimage_turbo_training_adapter",
-          "trainingAdapterVersion": "v2-default"
+          "trainingAdapterVersion": "v2-default",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
-        "description": "Research-backed first run for 12-25 clean character images.",
         "default": true,
+        "description": "Research-backed first run for 12-25 clean character images.",
         "order": 10
       }
     },
@@ -52,7 +54,9 @@
       "version": 1,
       "targetId": "z_image_turbo_lora",
       "name": "Character conservative",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "conservative",
       "config": {
@@ -67,24 +71,24 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "sampleEvery": 250,
-          "sampleSteps": 8,
-          "sampleGuidanceScale": 0.0,
-          "qualityPreset": "conservative",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
+          "qualityPreset": "conservative",
           "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 0.0,
+          "sampleSteps": 8,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
           "trainingAdapterRepo": "ostris/zimage_turbo_training_adapter",
-          "trainingAdapterVersion": "v2-default"
+          "trainingAdapterVersion": "v2-default",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -97,7 +101,9 @@
       "version": 1,
       "targetId": "z_image_turbo_lora",
       "name": "Character balanced (AdamW)",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "balanced",
       "config": {
@@ -112,24 +118,24 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "sampleEvery": 250,
-          "sampleSteps": 8,
-          "sampleGuidanceScale": 0.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
+          "qualityPreset": "balanced",
           "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 0.0,
+          "sampleSteps": 8,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
           "trainingAdapterRepo": "ostris/zimage_turbo_training_adapter",
-          "trainingAdapterVersion": "v2-default"
+          "trainingAdapterVersion": "v2-default",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -142,7 +148,9 @@
       "version": 1,
       "targetId": "z_image_turbo_lora",
       "name": "Prodigy character (experimental)",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "prodigyopt",
       "qualityPreset": "balanced",
       "config": {
@@ -157,25 +165,25 @@
         "seed": 42,
         "optimizer": "prodigyopt",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "sampleEvery": 200,
-          "sampleSteps": 8,
-          "sampleGuidanceScale": 0.0,
-          "qualityPreset": "balanced",
-          "outputScope": "project",
-          "requestedGpu": "auto",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "optimizerDCoef": 1.0,
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 200,
+          "sampleGuidanceScale": 0.0,
+          "sampleSteps": 8,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
           "trainingAdapterRepo": "ostris/zimage_turbo_training_adapter",
-          "trainingAdapterVersion": "v2-default"
+          "trainingAdapterVersion": "v2-default",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -189,7 +197,9 @@
       "version": 1,
       "targetId": "z_image_turbo_lora",
       "name": "Style balanced",
-      "recommendedFor": ["style"],
+      "recommendedFor": [
+        "style"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "balanced",
       "config": {
@@ -204,24 +214,24 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "sampleEvery": 250,
-          "sampleSteps": 8,
-          "sampleGuidanceScale": 0.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
+          "qualityPreset": "balanced",
           "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 0.0,
+          "sampleSteps": 8,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
           "trainingAdapterRepo": "ostris/zimage_turbo_training_adapter",
-          "trainingAdapterVersion": "v2-default"
+          "trainingAdapterVersion": "v2-default",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -234,7 +244,9 @@
       "version": 1,
       "targetId": "z_image_turbo_lora",
       "name": "Low VRAM character",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "low_vram",
       "config": {
@@ -249,24 +261,24 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "high_noise",
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "sampleEvery": 250,
-          "sampleSteps": 8,
-          "sampleGuidanceScale": 0.0,
-          "qualityPreset": "low_vram",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
+          "qualityPreset": "low_vram",
           "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 0.0,
+          "sampleSteps": 8,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
           "trainingAdapterRepo": "ostris/zimage_turbo_training_adapter",
-          "trainingAdapterVersion": "v2-default"
+          "trainingAdapterVersion": "v2-default",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -279,7 +291,9 @@
       "version": 1,
       "targetId": "sdxl_lora",
       "name": "Character balanced",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "balanced",
       "config": {
@@ -294,26 +308,31 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 250,
-          "sampleSteps": 30,
-          "sampleGuidanceScale": 7.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
         }
       },
       "ui": {
-        "description": "Balanced first run for 12-25 clean character images on SDXL.",
         "default": true,
+        "description": "Balanced first run for 12-25 clean character images on SDXL.",
         "order": 10
       }
     },
@@ -322,7 +341,9 @@
       "version": 1,
       "targetId": "sdxl_lora",
       "name": "Character conservative",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "conservative",
       "config": {
@@ -337,21 +358,26 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 250,
-          "sampleSteps": 30,
-          "sampleGuidanceScale": 7.0,
-          "qualityPreset": "conservative",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "conservative",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -364,7 +390,9 @@
       "version": 1,
       "targetId": "sdxl_lora",
       "name": "Style balanced",
-      "recommendedFor": ["style"],
+      "recommendedFor": [
+        "style"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "balanced",
       "config": {
@@ -379,21 +407,26 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 250,
-          "sampleSteps": 30,
-          "sampleGuidanceScale": 7.0,
-          "qualityPreset": "balanced",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -406,7 +439,9 @@
       "version": 1,
       "targetId": "sdxl_lora",
       "name": "Low VRAM character",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw8bit",
       "qualityPreset": "low_vram",
       "config": {
@@ -421,21 +456,26 @@
         "seed": 42,
         "optimizer": "adamw8bit",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 250,
-          "sampleSteps": 30,
-          "sampleGuidanceScale": 7.0,
-          "qualityPreset": "low_vram",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "low_vram",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -444,11 +484,210 @@
       }
     },
     {
+      "id": "kolors_lora.character.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "kolors_lora",
+      "name": "Character balanced",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "default": true,
+        "description": "Balanced first run for 12-25 clean character images on Kolors.",
+        "order": 10
+      }
+    },
+    {
+      "id": "kolors_lora.character.adamw8bit.conservative",
+      "version": 1,
+      "targetId": "kolors_lora",
+      "name": "Character conservative",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "conservative",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.00005,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "conservative",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+        "order": 20
+      }
+    },
+    {
+      "id": "kolors_lora.style.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "kolors_lora",
+      "name": "Style balanced",
+      "recommendedFor": [
+        "style"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 32,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Higher-capacity style LoRA defaults for texture and look transfer.",
+        "order": 30
+      }
+    },
+    {
+      "id": "kolors_lora.character.adamw8bit.low_vram",
+      "version": 1,
+      "targetId": "kolors_lora",
+      "name": "Low VRAM character",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "low_vram",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.0001,
+        "steps": 1200,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 768,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "low_vram",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "768px preset for tighter-VRAM Kolors training.",
+        "order": 40
+      }
+    },
+    {
       "id": "wan_lora.character.adamw.balanced",
       "version": 1,
       "targetId": "wan_lora",
       "name": "Character balanced",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "balanced",
       "config": {
@@ -463,27 +702,32 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
-        "description": "Balanced first run for 12-25 clean character stills on Wan2.2-TI2V-5B.",
         "default": true,
+        "description": "Balanced first run for 12-25 clean character stills on Wan2.2-TI2V-5B.",
         "order": 10
       }
     },
@@ -492,7 +736,9 @@
       "version": 1,
       "targetId": "wan_lora",
       "name": "Character conservative",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "conservative",
       "config": {
@@ -507,22 +753,27 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "conservative",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "conservative",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -535,7 +786,9 @@
       "version": 1,
       "targetId": "wan_lora",
       "name": "Style balanced",
-      "recommendedFor": ["style"],
+      "recommendedFor": [
+        "style"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "balanced",
       "config": {
@@ -550,22 +803,27 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -578,7 +836,9 @@
       "version": 1,
       "targetId": "wan_t2v_14b_lora",
       "name": "Character balanced",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "balanced",
       "config": {
@@ -593,27 +853,32 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
-        "description": "Balanced first run for character stills on Wan2.2 14B T2V (both noise experts).",
         "default": true,
+        "description": "Balanced first run for character stills on Wan2.2 14B T2V (both noise experts).",
         "order": 10
       }
     },
@@ -622,7 +887,9 @@
       "version": 1,
       "targetId": "wan_t2v_14b_lora",
       "name": "Style balanced",
-      "recommendedFor": ["style"],
+      "recommendedFor": [
+        "style"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "balanced",
       "config": {
@@ -637,22 +904,27 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
@@ -665,7 +937,9 @@
       "version": 1,
       "targetId": "wan_i2v_14b_lora",
       "name": "Character balanced",
-      "recommendedFor": ["character"],
+      "recommendedFor": [
+        "character"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "balanced",
       "config": {
@@ -680,27 +954,32 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "ui": {
-        "description": "Balanced first run for character stills on Wan2.2 14B I2V (both noise experts).",
         "default": true,
+        "description": "Balanced first run for character stills on Wan2.2 14B I2V (both noise experts).",
         "order": 10
       }
     },
@@ -709,7 +988,9 @@
       "version": 1,
       "targetId": "wan_i2v_14b_lora",
       "name": "Style balanced",
-      "recommendedFor": ["style"],
+      "recommendedFor": [
+        "style"
+      ],
       "optimizer": "adamw",
       "qualityPreset": "balanced",
       "config": {
@@ -724,22 +1005,27 @@
         "seed": 42,
         "optimizer": "adamw",
         "advanced": {
-          "mixedPrecision": "bf16",
           "cacheLatents": true,
           "cacheTextEmbeddings": true,
           "gradientCheckpointing": true,
-          "networkType": "lora",
-          "timestepType": "sigmoid",
-          "timestepBias": "balanced",
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
           "lossType": "mse",
-          "weightDecay": 0.0001,
           "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
           "numFrames": 1,
-          "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
-          "sampleEvery": 0,
-          "qualityPreset": "balanced",
           "outputScope": "project",
-          "requestedGpu": "auto"
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "balanced",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
         }
       },
       "ui": {

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -197,6 +197,105 @@
       }
     },
     {
+      "id": "kolors_lora",
+      "name": "Kolors LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "kolors",
+      "baseModel": "kolors",
+      "baseModelRepo": "Kwai-Kolors/Kolors-diffusers",
+      "kernel": "kolors_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "qualityPresets": [
+          "speed",
+          "balanced",
+          "quality"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "description": "Train an image LoRA for Kolors (Kwai-Kolors). Runs the SDXL-UNet trainer with the Kolors pipeline + ChatGLM3 text encoder, on CUDA and Apple Silicon (MPS).",
+        "label": "Kolors LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
       "id": "lens_turbo_lora",
       "name": "Lens LoRA",
       "modality": "image",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -113,10 +113,12 @@ from scene_worker.training_adapters import (
     LensLoraTrainer,
     LtxMlxLoraTrainer,
     SdxlLoraTrainer,
+    KolorsLoraTrainer,
     TrainingKernelError,
     WanLoraTrainer,
     WanMoeLoraTrainer,
     ZImageLoraTrainer,
+    _KolorsLoraBackend,
     _SdxlLoraBackend,
     _WanLoraBackend,
     _WanMoeLoraBackend,
@@ -6650,11 +6652,73 @@ def test_z_image_lora_backend_generates_samples_with_turbo_guidance(tmp_path):
 def test_create_training_kernel_resolves_known_and_rejects_unknown():
     assert isinstance(create_training_kernel("z_image_lora"), ZImageLoraTrainer)
     assert isinstance(create_training_kernel("sdxl_lora"), SdxlLoraTrainer)
+    assert isinstance(create_training_kernel("kolors_lora"), KolorsLoraTrainer)
     assert isinstance(create_training_kernel("wan_lora"), WanLoraTrainer)
     assert isinstance(create_training_kernel("wan_moe_lora"), WanMoeLoraTrainer)
     assert isinstance(create_training_kernel("lens_lora"), LensLoraTrainer)
     with pytest.raises(TrainingKernelError, match="No training kernel"):
         create_training_kernel("not_a_kernel")
+
+
+def test_kolors_lora_trainer_reuses_sdxl_backend_with_kolors_seams():
+    # KolorsLoraTrainer (epic 1929) is a thin extension of the generic SDXL-UNet
+    # trainer: same orchestration + SDXL training loop, swapping only the pipeline
+    # class + ChatGLM3 prompt encoder. LoKr is inherited from the SDXL backend.
+    trainer = create_training_kernel("kolors_lora")
+    assert isinstance(trainer, SdxlLoraTrainer)
+    assert trainer.kernel_id == "kolors_lora"
+    backend = trainer._create_backend()
+    assert isinstance(backend, _KolorsLoraBackend)
+    assert isinstance(backend, _SdxlLoraBackend)  # inherits the LoKr-wired save/load
+    assert backend.kernel_id == "kolors_lora"
+    assert backend.pipeline_class_name == "KolorsPipeline"
+
+
+def test_kolors_encode_prompt_uses_chatglm_seam():
+    # The only forward-pass seam: Kolors uses a single ChatGLM3 encoder (no SDXL
+    # prompt_2) at GLM sequence length 256; the 4-tuple return order matches SDXL.
+    captured: dict[str, object] = {}
+
+    def fake_encode_prompt(**kwargs):
+        captured.update(kwargs)
+        return ("PROMPT_EMBEDS", "NEG", "POOLED", "NEG_POOLED")
+
+    pipe = SimpleNamespace(encode_prompt=fake_encode_prompt)
+    backend = _KolorsLoraBackend()
+    prompt_embeds, pooled = backend._encode_prompt(pipe, "a calico cat", "cpu")
+
+    assert prompt_embeds == "PROMPT_EMBEDS"
+    assert pooled == "POOLED"
+    assert captured["prompt"] == "a calico cat"
+    assert captured["max_sequence_length"] == 256
+    assert captured["do_classifier_free_guidance"] is False
+    # Kolors has no second CLIP encoder — the SDXL `prompt_2` arg must be absent.
+    assert "prompt_2" not in captured
+
+
+def test_kolors_backend_releases_chatglm_encoder_when_not_sampling(monkeypatch):
+    # ChatGLM3-6B is only needed to cache prompt embeddings. With no live sampling
+    # the encoder is released after caching (Mac memory envelope, epic 1929); with
+    # sampling on it's retained because generate_samples re-encodes prompts.
+    monkeypatch.setattr(_SdxlLoraBackend, "prepare_dataset", lambda self, **kw: {"itemCount": 0})
+    monkeypatch.setattr("scene_worker.training_adapters.empty_torch_cache", lambda _torch: None)
+
+    def run(sample_every):
+        backend = _KolorsLoraBackend()
+        encoder = object()
+        backend._pipeline = SimpleNamespace(text_encoder=encoder, text_encoder_2=None)
+        backend.prepare_dataset(
+            items=[],
+            config=SimpleNamespace(sample_every=sample_every),
+            progress=lambda *a, **k: None,
+            cancel_requested=lambda: False,
+        )
+        return backend._pipeline.text_encoder, encoder
+
+    released, _ = run(0)
+    assert released is None  # released when not sampling
+    retained, encoder = run(250)
+    assert retained is encoder  # kept for live sampling
 
 
 def test_wan_lora_trainer_reuses_zimage_orchestration_with_wan_backend():


### PR DESCRIPTION
Delivers the **Kolors LoRA training** that [epic 1929](https://app.shortcut.com/trefry/epic/1929) was marked Done for but never actually landed in `main`, and folds in epic-2193 **[sc-2217](https://app.shortcut.com/trefry/story/2217)** (Kolors LoKr) since the shared SDXL backend makes it free.

### Background
Epic 1929 + all 5 stories were marked Done, but `main` had **no `kolors_lora` kernel or training target** — only epic 1787's generic SDXL-UNet trainer (`sdxl_lora`) shipped, with comment seams in `_SdxlLoraBackend` anticipating the Kolors subclass. This implements that subclass for real. Because `_SdxlLoraBackend` already routes adapter construction through `build_peft_network_config` + the LoKr save branch (epic 2193 v1), the Kolors backend **inherits LoKr for free** — closing sc-2217 in the same change.

Stories: sc-1931 (target+presets), sc-1932 (kernel), sc-1933 (inference), sc-1934 (E2E), sc-2217 (LoKr).

### Changes
- **Kernel** (`training_adapters.py`): `_KolorsLoraBackend(_SdxlLoraBackend)` swaps the two documented seams — `pipeline_class_name=KolorsPipeline` and `_encode_prompt` (ChatGLM3, `max_sequence_length=256`, no SDXL `prompt_2`) — and releases the ~6B ChatGLM3 encoder after caching when no live sampling will re-encode prompts (Mac memory envelope). `KolorsLoraTrainer(SdxlLoraTrainer)` registered in `_TRAINING_KERNELS`.
- **Contract** (`training.rs`): `kolors_lora` target (family/base `kolors`, repo `Kwai-Kolors/Kolors-diffusers`, kernel `kolors_lora`, SDXL attention target modules, `networkTypes:["lora","lokr"]` = sc-2217) + character/style/low-vram presets via the shared `sdxl_preset` recipe. Gating test + a new `exposes_kolors_target` test + both registry fixtures regenerated (added a `regen_preset_registry_fixture` helper — the preset fixture also re-sorts to the canonical serde key order it had drifted from, hence the larger reformat there; content is unchanged, all existing presets preserved).
- **Inference**: no change — `KolorsDiffusersAdapter` already routes LoRAs through `apply_loras_to_pipeline` (`load_lora_weights` for LoRA, PEFT injection for LoKr into `pipe.unet`). Kolors has no MLX adapter, so LoKr never needs a torch fallback.
- **Web**: no change — the TrainingStudio picker is data-driven on `limits.networkTypes`, so the Kolors target + its LoKr option surface automatically.

### Tests
- Worker: **489 passed / 9 skipped** (CI trio). New: Kolors kernel dispatch, the SDXL-backend reuse + Kolors seams, the ChatGLM3 `_encode_prompt` seam (256 / no `prompt_2`), and the encoder-release-on-no-sampling path.
- Rust `sceneworks-core`: **30 contract** + lib/integration green; `clippy` + `cargo fmt` clean.

### Real Mac E2E (cached `Kwai-Kolors/Kolors-diffusers`, fp16→bf16/MPS, shipping code)
- **Phase A — plain LoRA**: real `_KolorsLoraBackend` load → prepare_dataset (encoder-release fired) → train_step → save (**22.8 MB**) → `apply_loras_to_pipeline` (`load_lora_weights`) → full `KolorsPipeline` generation differs from base (**1.22** latent mean abs diff).
- **Phase B — LoKr (sc-2217)**: real LoKr train → save (**1.99 MB, ~11× smaller**, `networkType=lokr`) → `inject_lokr_adapter` reproduces the Kronecker delta **exactly (0.0 diff)** on the real Kolors UNet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)