### PR TITLE
feat(lens): Lens image LoKr — sidecar trainer + inference (sc-2218) + to_out.0 target fix

### DIFF
--- a/apps/worker/scene_worker/lens_runner.py
+++ b/apps/worker/scene_worker/lens_runner.py
@@ -44,24 +44,76 @@ def _log(message: str) -> None:
     sys.stderr.flush()
 
 
+def _adapter_network_type(path: str) -> str:
+    """Return the adapter's recorded ``networkType`` ('lora' default) from its
+    safetensors header. A ``lokr`` stamp routes to PEFT injection because
+    ``load_lora_adapter`` cannot consume LoKr (``lokr_w1``/``lokr_w2``) keys
+    (epic 2193, sc-2218)."""
+    try:
+        from safetensors import safe_open
+
+        with safe_open(path, framework="pt") as handle:
+            meta = handle.metadata() or {}
+        return str(meta.get("networkType") or "lora").strip().lower()
+    except Exception:  # noqa: BLE001 - a missing/plain header reads as a normal LoRA
+        return "lora"
+
+
+def _inject_lokr(transformer, path: str, name: str) -> None:
+    """Rebuild a LoKr adapter's ``LoKrConfig`` from its file metadata and inject +
+    load it onto the transformer — the LoKr equivalent of ``load_lora_adapter``.
+    Mirrors ``lora_adapters.inject_lokr_adapter`` (epic 2193); lives here because the
+    Lens inference sidecar venv is isolated from the main worker module."""
+    import peft
+    from peft.utils import set_peft_model_state_dict
+    from safetensors import safe_open
+    from safetensors.torch import load_file
+
+    with safe_open(path, framework="pt") as handle:
+        meta = handle.metadata() or {}
+    rank = int(meta.get("rank") or 16)
+    target_modules = json.loads(meta.get("targetModules") or "null")
+    config = peft.LoKrConfig(
+        r=rank,
+        alpha=int(meta.get("alpha") or rank),
+        decompose_factor=int(meta.get("decomposeFactor") or -1),
+        target_modules=target_modules,
+        init_weights=True,
+    )
+    peft.inject_adapter_in_model(config, transformer, adapter_name=name)
+    state = load_file(path)
+    reference = next(transformer.parameters(), None)
+    if reference is not None:
+        state = {
+            key: value.to(device=reference.device, dtype=reference.dtype)
+            for key, value in state.items()
+        }
+    set_peft_model_state_dict(transformer, state, adapter_name=name)
+
+
 def _apply_loras(transformer, loras) -> None:
     """Inject + scale trained `lens` LoRAs on the transformer (PeftAdapterMixin).
 
     Each ``loras`` entry is ``{"path", "weight", "name"}``, already resolved to a
-    concrete .safetensors file by the adapter. ``save_lora_adapter`` (training
-    kernel) and ``load_lora_adapter`` are the symmetric PeftAdapterMixin pair; the
-    ``prefix=None`` retry covers builds that saved the adapter without a
-    ``transformer.`` key prefix.
+    concrete .safetensors file by the adapter. For a plain LoRA, ``save_lora_adapter``
+    (training kernel) and ``load_lora_adapter`` are the symmetric PeftAdapterMixin
+    pair; the ``prefix=None`` retry covers builds that saved the adapter without a
+    ``transformer.`` key prefix. A ``networkType=lokr`` adapter (epic 2193, sc-2218)
+    can't load that way, so it's rebuilt + injected via PEFT; either kind then scales
+    through ``set_adapters``.
     """
     names: list[str] = []
     weights: list[float] = []
     for index, lora in enumerate(loras):
         name = str(lora.get("name") or f"lora_{index}")
         path = str(lora["path"])
-        try:
-            transformer.load_lora_adapter(path, adapter_name=name)
-        except Exception:  # noqa: BLE001 - retry with no key prefix before failing
-            transformer.load_lora_adapter(path, adapter_name=name, prefix=None)
+        if _adapter_network_type(path) == "lokr":
+            _inject_lokr(transformer, path, name)
+        else:
+            try:
+                transformer.load_lora_adapter(path, adapter_name=name)
+            except Exception:  # noqa: BLE001 - retry with no key prefix before failing
+                transformer.load_lora_adapter(path, adapter_name=name, prefix=None)
         names.append(name)
         try:
             weights.append(float(lora.get("weight", 1.0)))

--- a/apps/worker/scene_worker/lens_train_runner.py
+++ b/apps/worker/scene_worker/lens_train_runner.py
@@ -83,7 +83,11 @@ class _Progress:
 # Report a training tick at most this often (in steps); the final step always
 # reports. Mirrors training_adapters.PROGRESS_STEP_INTERVAL.
 PROGRESS_STEP_INTERVAL = 10
-DEFAULT_LORA_TARGET_MODULES = ["img_qkv", "txt_qkv", "to_out", "to_add_out"]
+# LensTransformer2DModel attention: fused QKV projections (img_qkv/txt_qkv), the
+# joint-attention output (to_add_out, a Linear), and to_out — which is an
+# ``nn.ModuleList([Linear, Identity])``, so the Linear is ``to_out.0``. PEFT
+# (LoRA + LoKr) errors if pointed at the ModuleList, so target ``to_out.0`` (sc-2218).
+DEFAULT_LORA_TARGET_MODULES = ["img_qkv", "txt_qkv", "to_out.0", "to_add_out"]
 
 
 def _read_config(spec: dict[str, Any]) -> dict[str, Any]:
@@ -105,6 +109,56 @@ def _target_modules(config: dict[str, Any]) -> list[str]:
     if isinstance(modules, (list, tuple)) and modules:
         return [str(token) for token in modules]
     return list(DEFAULT_LORA_TARGET_MODULES)
+
+
+def _network_type(config: dict[str, Any]) -> str:
+    """Adapter parameterization: ``lora`` (default) or ``lokr`` (LyCORIS Kronecker,
+    epic 2193). Gated per target by the contract's ``limits.networkTypes``."""
+    raw = _advanced(config).get("networkType") or config.get("network_type") or "lora"
+    return str(raw).strip().lower()
+
+
+def _decompose_factor(config: dict[str, Any]) -> int:
+    """LoKr block-decomposition factor (``-1`` = auto); ignored for plain LoRA."""
+    raw = _advanced(config).get("decomposeFactor")
+    if raw is None:
+        raw = config.get("decompose_factor")
+    try:
+        return int(raw) if raw is not None else -1
+    except (TypeError, ValueError):
+        return -1
+
+
+def _build_network_config(
+    peft: Any,
+    *,
+    network_type: str,
+    rank: int,
+    alpha: int,
+    decompose_factor: int,
+    target_modules: list[str],
+) -> Any:
+    """Build the PEFT adapter config for the requested network type.
+
+    Mirrors ``training_adapters.build_peft_network_config``; duplicated here because
+    the Lens sidecar venv is isolated from the main worker module (epic 2193, sc-2218).
+    The LensTransformer2DModel attaches both via ``add_adapter`` and saves via
+    ``get_peft_model_state_dict`` — only the on-disk key layout + inference loader differ.
+    """
+    if network_type == "lokr":
+        return peft.LoKrConfig(
+            r=rank,
+            alpha=alpha,
+            decompose_factor=decompose_factor,
+            init_weights=True,
+            target_modules=list(target_modules),
+        )
+    return peft.LoraConfig(
+        r=rank,
+        lora_alpha=alpha,
+        init_lora_weights="gaussian",
+        target_modules=list(target_modules),
+    )
 
 
 def _select_dtype(torch: Any, device: str, mixed_precision: Any) -> Any:
@@ -294,13 +348,68 @@ def _encode_latents(torch, lens_pipeline_cls, pipe: Any, pixel: Any, generator: 
     return latents.contiguous()
 
 
-def _save_lora(transformer: Any, output_dir: str, file_name: str) -> str:
+def _save_lora(
+    transformer: Any,
+    output_dir: str,
+    file_name: str,
+    *,
+    network_type: str = "lora",
+    rank: int = 16,
+    alpha: int = 16,
+    decompose_factor: int = -1,
+    target_modules: list[str] | None = None,
+) -> str:
     os.makedirs(output_dir, exist_ok=True)
+    if network_type == "lokr":
+        return _save_lokr_adapter(
+            transformer,
+            output_dir,
+            file_name,
+            rank=rank,
+            alpha=alpha,
+            decompose_factor=decompose_factor,
+            target_modules=target_modules or [],
+        )
     # LensPipeline has no LoRA loader mixin, but LensTransformer2DModel inherits
     # diffusers' PeftAdapterMixin, so save/load the adapter directly on it. The
     # inference path (sc-1587) loads the same file with ``load_lora_adapter``.
     transformer.save_lora_adapter(output_dir, weight_name=file_name, safe_serialization=True)
     return str(Path(output_dir) / file_name)
+
+
+def _save_lokr_adapter(
+    transformer: Any,
+    output_dir: str,
+    file_name: str,
+    *,
+    rank: int,
+    alpha: int,
+    decompose_factor: int,
+    target_modules: list[str],
+) -> str:
+    """Write a LoKr adapter raw with routing + reconstruction metadata.
+
+    ``save_lora_adapter`` only round-trips LoRA (``lora_A``/``lora_B``) keys — LoKr
+    emits ``lokr_w1``/``lokr_w2`` — so serialize ``get_peft_model_state_dict``
+    directly and stamp the header the inference loader (``lens_runner._apply_loras``)
+    rebuilds the matching ``peft.LoKrConfig`` from. Mirrors
+    ``training_adapters.write_lokr_adapter`` (epic 2193, sc-2218)."""
+    from peft.utils import get_peft_model_state_dict
+    from safetensors.torch import save_file
+
+    state = get_peft_model_state_dict(transformer)
+    tensors = {key: value.detach().cpu().contiguous() for key, value in state.items()}
+    metadata = {
+        "format": "pt",
+        "networkType": "lokr",
+        "rank": str(int(rank)),
+        "alpha": str(int(alpha)),
+        "decomposeFactor": str(int(decompose_factor)),
+        "targetModules": json.dumps(list(target_modules)),
+    }
+    path = str(Path(output_dir) / file_name)
+    save_file(tensors, path, metadata=metadata)
+    return path
 
 
 def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
@@ -351,6 +460,15 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
     lr_warmup_steps = int(advanced.get("lrWarmupSteps") or config.get("lr_warmup_steps") or 0)
     gradient_checkpointing = bool(advanced.get("gradientCheckpointing", config.get("gradient_checkpointing", True)))
     target_modules = _target_modules(config)
+    network_type = _network_type(config)
+    decompose_factor = _decompose_factor(config)
+    save_kwargs = {
+        "network_type": network_type,
+        "rank": rank,
+        "alpha": alpha,
+        "decompose_factor": decompose_factor,
+        "target_modules": target_modules,
+    }
 
     _log(
         f"torch {torch.__version__} transformers {transformers.__version__} device={device} dtype={dtype} "
@@ -411,11 +529,13 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
 
     # ---- Attach the trainable LoRA -----------------------------------------
     progress.emit(event="stage", stage="loading_model", message="Attaching LoRA adapter to the transformer.")
-    lora_config = peft.LoraConfig(
-        r=rank,
-        lora_alpha=alpha,
-        init_lora_weights="gaussian",
-        target_modules=list(target_modules),
+    lora_config = _build_network_config(
+        peft,
+        network_type=network_type,
+        rank=rank,
+        alpha=alpha,
+        decompose_factor=decompose_factor,
+        target_modules=target_modules,
     )
     transformer.add_adapter(lora_config)
     for method_name in ("set_adapter", "enable_adapters"):
@@ -445,7 +565,7 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
         raise RuntimeError(
             "LoRA adapter attached no trainable parameters; the target modules "
             f"{target_modules} matched no LensTransformer2DModel layers. Lens uses fused "
-            "QKV (img_qkv/txt_qkv) plus to_out/to_add_out — adjust advanced.loraTargetModules."
+            "QKV (img_qkv/txt_qkv) plus to_out.0/to_add_out — adjust advanced.loraTargetModules."
         )
     _log(f"trainable LoRA tensors: {len(trainable)}")
 
@@ -510,7 +630,7 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
             stem = Path(file_name).stem or "lora"
             checkpoint_name = f"{stem}-step{step:06d}.safetensors"
             progress.emit(event="stage", stage="checkpointing", step=step, message=f"Saving checkpoint at step {step}.")
-            checkpoint_path = _save_lora(transformer, output_dir, checkpoint_name)
+            checkpoint_path = _save_lora(transformer, output_dir, checkpoint_name, **save_kwargs)
             checkpoints.append({"step": step, "path": checkpoint_path})
 
         if sample_every and sample_prompts and step % sample_every == 0:
@@ -528,7 +648,7 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
 
     # ---- Save final adapter -------------------------------------------------
     progress.emit(event="stage", stage="saving", message="Saving trained LoRA weights.")
-    output_path = _save_lora(transformer, output_dir, file_name)
+    output_path = _save_lora(transformer, output_dir, file_name, **save_kwargs)
     progress.emit(event="saved", path=output_path)
 
     return {
@@ -544,6 +664,7 @@ def train(spec: dict[str, Any], progress: _Progress) -> dict[str, Any]:
         "learningRate": learning_rate,
         "resolution": _bucket_resolution(resolution),
         "loraTargetModules": list(target_modules),
+        "networkType": network_type,
         "baseModelSource": source,
     }
 

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1018,9 +1018,10 @@ fn z_image_turbo_lora_target() -> TrainingTarget {
 /// via `advanced.baseModelRepo` (sc-1584).
 ///
 /// Unlike Z-Image's separate `to_q/to_k/to_v`, Lens uses *fused* QKV attention
-/// (`img_qkv`/`txt_qkv`) plus joint-attention output projections
-/// (`to_out`/`to_add_out`), so the default `loraTargetModules` must name those —
-/// the Z-Image defaults would match nothing and inject no adapter.
+/// (`img_qkv`/`txt_qkv`) plus joint-attention output projections. The image output
+/// `to_out` is an `nn.ModuleList([Linear, Identity])`, so the trainable Linear is
+/// `to_out.0` (PEFT errors if pointed at the ModuleList — sc-2218); `to_add_out` is
+/// a plain Linear. The Z-Image defaults would match nothing and inject no adapter.
 fn lens_turbo_lora_target() -> TrainingTarget {
     TrainingTarget {
         id: "lens_turbo_lora".to_owned(),
@@ -1057,10 +1058,11 @@ fn lens_turbo_lora_target() -> TrainingTarget {
                 // honors `constant`/`linear`/`cosine` with an optional warmup.
                 "lrScheduler": "constant",
                 // Lens uses fused QKV attention plus joint-attention output
-                // projections, NOT Z-Image's separate to_q/to_k/to_v. These
-                // suffixes must match the LensTransformer2DModel module names or
-                // PEFT injects nothing.
-                "loraTargetModules": ["img_qkv", "txt_qkv", "to_out", "to_add_out"],
+                // projections, NOT Z-Image's separate to_q/to_k/to_v. ``to_out`` is
+                // a ModuleList, so its Linear is ``to_out.0`` — PEFT (LoRA + LoKr)
+                // errors on the ModuleList itself (sc-2218). Suffixes must match the
+                // LensTransformer2DModel module names or PEFT injects nothing.
+                "loraTargetModules": ["img_qkv", "txt_qkv", "to_out.0", "to_add_out"],
                 // Non-distilled training base; override with "microsoft/Lens-Base"
                 // to train on the 50-step supervised checkpoint instead (sc-1584).
                 "baseModelRepo": "microsoft/Lens",
@@ -1086,9 +1088,11 @@ fn lens_turbo_lora_target() -> TrainingTarget {
             "resolutions": [768, 1024, 1440],
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-            // Lens trains in a separate sidecar venv; LoKr is not validated there
-            // yet (epic 2193 v1 targets Z-Image/SDXL), so only `lora`.
-            "networkTypes": ["lora"],
+            // Lens trains + infers in a separate sidecar venv; both the trainer
+            // (lens_train_runner) and inference (lens_runner) gained PEFT LoKr
+            // build/save + injection (epic 2193, sc-2218), keyed off the fused-QKV
+            // target modules above.
+            "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "qualityPresets": ["speed", "balanced", "quality"],
             "outputScopes": ["project", "global"]

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -107,8 +107,9 @@ fn builtin_targets_gate_network_types() {
 
     // Every target advertises `lora`; only the validated torch/PEFT backends
     // (epic 2193) advertise `lokr`: the Z-Image/SDXL image backends (v1), the
-    // Kolors image backend (SDXL-architecture, epic 1929 / sc-2217), and the
-    // Wan2.2 5B video backend (sc-2211). MLX-only and MoE targets stay lora-only.
+    // Kolors image backend (SDXL-architecture, epic 1929 / sc-2217), the Lens
+    // sidecar backend (sc-2218), and the Wan2.2 5B video backend (sc-2211).
+    // MLX-only and MoE targets stay lora-only.
     let lokr_targets: Vec<&str> = registry
         .targets
         .iter()
@@ -125,7 +126,13 @@ fn builtin_targets_gate_network_types() {
 
     assert_eq!(
         lokr_targets,
-        ["z_image_turbo_lora", "sdxl_lora", "kolors_lora", "wan_lora"]
+        [
+            "z_image_turbo_lora",
+            "sdxl_lora",
+            "kolors_lora",
+            "lens_turbo_lora",
+            "wan_lora"
+        ]
     );
 }
 

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -323,7 +323,7 @@
           "loraTargetModules": [
             "img_qkv",
             "txt_qkv",
-            "to_out",
+            "to_out.0",
             "to_add_out"
           ],
           "lossType": "mse",
@@ -356,7 +356,8 @@
           "cosine"
         ],
         "networkTypes": [
-          "lora"
+          "lora",
+          "lokr"
         ],
         "optimizers": [
           "adamw8bit",

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1915,6 +1915,171 @@ def test_lens_turbo_requires_sidecar_when_missing(monkeypatch):
         raise AssertionError("Lens generation must fail clearly when the sidecar venv is unavailable.")
 
 
+def test_lens_train_runner_reads_network_type_and_factor():
+    from scene_worker import lens_train_runner as lt
+
+    assert lt._network_type({}) == "lora"
+    assert lt._decompose_factor({}) == -1
+    assert lt._network_type({"advanced": {"networkType": "LoKr"}}) == "lokr"
+    assert lt._decompose_factor({"advanced": {"decomposeFactor": 8}}) == 8
+    # Bad factor falls back to auto (-1).
+    assert lt._decompose_factor({"advanced": {"decomposeFactor": "x"}}) == -1
+    # Default targets point at the Linear `to_out.0`, not the `to_out` ModuleList
+    # (PEFT errors on the ModuleList — sc-2218).
+    assert lt._target_modules({}) == ["img_qkv", "txt_qkv", "to_out.0", "to_add_out"]
+    assert "to_out" not in lt._target_modules({})  # the bare ModuleList name is gone
+
+
+def test_lens_train_runner_build_network_config():
+    from scene_worker import lens_train_runner as lt
+
+    fake_peft = SimpleNamespace(
+        LoraConfig=lambda **kw: ("lora", kw),
+        LoKrConfig=lambda **kw: ("lokr", kw),
+    )
+    kind, _ = lt._build_network_config(
+        fake_peft, network_type="lora", rank=8, alpha=8, decompose_factor=-1,
+        target_modules=["img_qkv", "txt_qkv"],
+    )
+    assert kind == "lora"
+
+    kind, kwargs = lt._build_network_config(
+        fake_peft, network_type="lokr", rank=8, alpha=16, decompose_factor=4,
+        target_modules=["img_qkv", "txt_qkv", "to_out.0", "to_add_out"],
+    )
+    assert kind == "lokr"
+    assert kwargs["r"] == 8 and kwargs["alpha"] == 16
+    assert kwargs["decompose_factor"] == 4
+    assert kwargs["target_modules"] == ["img_qkv", "txt_qkv", "to_out.0", "to_add_out"]
+
+
+def test_lens_save_lora_routes_by_network_type(monkeypatch, tmp_path):
+    from scene_worker import lens_train_runner as lt
+
+    # Plain LoRA: delegates to the transformer's diffusers PeftAdapterMixin saver.
+    saved: dict[str, object] = {}
+
+    class FakeTransformer:
+        def save_lora_adapter(self, output_dir, *, weight_name=None, safe_serialization=None):
+            saved["output_dir"] = output_dir
+            saved["weight_name"] = weight_name
+
+    out = lt._save_lora(FakeTransformer(), str(tmp_path), "lens.safetensors", network_type="lora")
+    assert saved["weight_name"] == "lens.safetensors"
+    assert out == str(tmp_path / "lens.safetensors")
+
+    # LoKr: routes to the raw metadata writer instead (lokr_w1/w2 aren't
+    # save_lora_adapter-compatible), and never calls save_lora_adapter.
+    captured: dict[str, object] = {}
+
+    def fake_save_lokr(transformer, output_dir, file_name, **kwargs):
+        captured["file_name"] = file_name
+        captured["kwargs"] = kwargs
+        return str(tmp_path / file_name)
+
+    monkeypatch.setattr(lt, "_save_lokr_adapter", fake_save_lokr)
+
+    class ExplodingTransformer:
+        def save_lora_adapter(self, *a, **k):
+            raise AssertionError("LoKr must not save via save_lora_adapter")
+
+    out = lt._save_lora(
+        ExplodingTransformer(), str(tmp_path), "lens.safetensors",
+        network_type="lokr", rank=8, alpha=8, decompose_factor=4,
+        target_modules=["img_qkv", "txt_qkv"],
+    )
+    assert captured["file_name"] == "lens.safetensors"
+    assert captured["kwargs"] == {
+        "rank": 8, "alpha": 8, "decompose_factor": 4,
+        "target_modules": ["img_qkv", "txt_qkv"],
+    }
+
+
+def test_lens_save_lokr_adapter_stamps_metadata(monkeypatch, tmp_path):
+    import sys
+    import types as types_module
+
+    from scene_worker import lens_train_runner as lt
+
+    fake_state = {"transformer.x.lokr_w1": "t1", "transformer.x.lokr_w2": "t2"}
+    fake_peft_utils = types_module.ModuleType("peft.utils")
+    fake_peft_utils.get_peft_model_state_dict = lambda _m: fake_state
+    monkeypatch.setitem(sys.modules, "peft.utils", fake_peft_utils)
+
+    written: dict[str, object] = {}
+
+    class FakeTensor:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def contiguous(self):
+            return self
+
+    fake_st_torch = types_module.ModuleType("safetensors.torch")
+
+    def fake_save_file(tensors, path, metadata=None):
+        written["tensors"] = dict(tensors)
+        written["metadata"] = metadata
+
+    fake_st_torch.save_file = fake_save_file
+    monkeypatch.setitem(sys.modules, "safetensors", types_module.ModuleType("safetensors"))
+    monkeypatch.setitem(sys.modules, "safetensors.torch", fake_st_torch)
+
+    # get_peft_model_state_dict returns our fake tensors; patch their .detach chain.
+    monkeypatch.setattr(fake_peft_utils, "get_peft_model_state_dict", lambda _m: {
+        "transformer.x.lokr_w1": FakeTensor(), "transformer.x.lokr_w2": FakeTensor(),
+    })
+
+    out = lt._save_lokr_adapter(
+        object(), str(tmp_path), "lens_lokr.safetensors",
+        rank=8, alpha=16, decompose_factor=4, target_modules=["img_qkv", "txt_qkv"],
+    )
+    assert out == str(tmp_path / "lens_lokr.safetensors")
+    meta = written["metadata"]
+    assert meta["networkType"] == "lokr"
+    assert meta["rank"] == "8" and meta["alpha"] == "16" and meta["decomposeFactor"] == "4"
+    assert json.loads(meta["targetModules"]) == ["img_qkv", "txt_qkv"]
+    assert set(written["tensors"]) == {"transformer.x.lokr_w1", "transformer.x.lokr_w2"}
+
+
+def test_lens_runner_apply_loras_routes_lokr_to_injection(monkeypatch):
+    from scene_worker import lens_runner as lr
+
+    # Classify by recorded networkType (stubbed so the test needs no real files).
+    kinds = {"/lora.safetensors": "lora", "/lokr.safetensors": "lokr"}
+    monkeypatch.setattr(lr, "_adapter_network_type", lambda path: kinds[path])
+
+    injected: list[str] = []
+    monkeypatch.setattr(lr, "_inject_lokr", lambda t, path, name: injected.append(name))
+
+    loaded: list[str] = []
+    set_calls: dict[str, object] = {}
+
+    class FakeTransformer:
+        def load_lora_adapter(self, path, adapter_name=None, prefix="__unset__"):
+            loaded.append(adapter_name)
+
+        def set_adapters(self, names, weights=None):
+            set_calls["names"] = names
+            set_calls["weights"] = weights
+
+    lr._apply_loras(
+        FakeTransformer(),
+        [
+            {"path": "/lora.safetensors", "weight": 0.8, "name": "a"},
+            {"path": "/lokr.safetensors", "weight": 1.0, "name": "b"},
+        ],
+    )
+    # LoKr → PEFT injection; plain LoRA → load_lora_adapter; both then scaled together.
+    assert injected == ["b"]
+    assert loaded == ["a"]
+    assert set_calls["names"] == ["a", "b"]
+    assert set_calls["weights"] == [0.8, 1.0]
+
+
 def test_lens_resolution_for_snaps_to_buckets():
     # Square requests pick the base by area: <1024*1440 px -> 1024, else 1440.
     assert lens_resolution_for(1024, 1024) == (1024, "1:1")
@@ -6918,7 +7083,7 @@ def _lens_train_plan(tmp_path, *, steps=4):
             "optimizer": "adamw8bit",
             "advanced": {
                 "lrScheduler": "constant",
-                "loraTargetModules": ["img_qkv", "txt_qkv", "to_out", "to_add_out"],
+                "loraTargetModules": ["img_qkv", "txt_qkv", "to_out.0", "to_add_out"],
             },
         },
         "output": {


### PR DESCRIPTION
Extends epic 2193 LoKr to the **Lens** image target ([sc-2218](https://app.shortcut.com/trefry/story/2218), `lens_turbo_lora`). Unlike the other LoKr targets, Lens trains *and* infers in **isolated sidecar venvs** (transformers 5.x / gpt-oss), so it can't reuse the main worker's `lora_adapters` — each sidecar got its own PEFT LoKr path.

### Changes
- **Trainer** (`lens_train_runner.py`): `_network_type` / `_decompose_factor` / `_build_network_config` (mirror `build_peft_network_config`) build a `LoKrConfig` when `networkType==lokr`; `_save_lokr_adapter` writes the raw `get_peft_model_state_dict` + safetensors metadata (`networkType`/`rank`/`alpha`/`decomposeFactor`/`targetModules`) since `save_lora_adapter` can't emit `lokr_w1/w2` keys; `networkType` reported in the result.
- **Inference** (`lens_runner.py`): `_apply_loras` reads each adapter's `networkType` header and, for `lokr`, rebuilds the `LoKrConfig` + `inject_adapter_in_model` + `set_peft_model_state_dict` (mirrors `lora_adapters.inject_lokr_adapter`) instead of `load_lora_adapter`; both kinds then scale via `set_adapters`.
- **Contract** (`training.rs`): `lens_turbo_lora` advertises `networkTypes:["lora","lokr"]`; gating test + target fixture updated.

### ⚠️ Pre-existing bug fixed (discovered via the real check — please note)
Lens attention `to_out` is an `nn.ModuleList([Linear, Identity])`, so the trainable Linear is `to_out.0`. The default target modules named `to_out`, which PEFT rejects with `Target module ModuleList not supported` — meaning **the Lens plain-LoRA path could never have attached an adapter either** (it was likely never run on real hardware). I corrected the default to `to_out.0` in the sidecar + contract (+ comments/error message), which repairs both LoRA and LoKr. Flagging because **the Lens plain-LoRA path now warrants its first real-hardware validation**. No backward-compat risk: no valid Lens LoRA could have been produced with the broken `to_out` target.

### Tests
- Worker: **494 passed / 9 skipped** (CI trio). New (all fakes, no torch in CI): `_build_network_config` lora/lokr, `_save_lora` routing, `_save_lokr_adapter` metadata, `lens_runner._apply_loras` lokr-vs-lora routing, and the corrected-default assertion.
- Rust `sceneworks-core`: **30 contract** green; `clippy` + `cargo fmt` clean.

### Real Mac check (cached `microsoft/Lens` transformer, ~15 GB — no gpt-oss encoder needed)
Drove the shipping helpers on the real `LensTransformer2DModel`: `_build_network_config` attaches LoKr to the fused-QKV modules (**576 trainable tensors**), `_save_lokr_adapter` writes **962 KB** (`networkType=lokr`), and `_inject_lokr` reconstructs the Kronecker delta **exactly (0.0 diff)**. A full train→generate needs the Lens sidecar venv (`/opt/lens-venv`) + the ~90 GB gpt-oss stack; the round-trip here covers the Lens-specific risk (LoKr attach + save/load on the real module), and the mechanism is identical to the Wan/Kolors/SDXL E2Es already validated end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)