### PR TITLE
fix(lens): repair plain-LoRA inference prefix + declare peft for sidecar venv (sc-2218)

### DIFF
--- a/apps/worker/requirements-lens.txt
+++ b/apps/worker/requirements-lens.txt
@@ -18,6 +18,11 @@ diffusers==0.38.0
 transformers>=5.8,<5.9
 huggingface_hub>=1,<2
 accelerate>=1.11
+# peft is the LoRA/LoKr adapter backend: lens_train_runner imports it directly,
+# lens_runner imports it for LoKr injection, and diffusers' load_lora_adapter
+# needs the PEFT backend present for the plain-LoRA path. Without it the entire
+# Lens LoRA/LoKr train+infer path crashes at import time (sc-2218 real-HW finding).
+peft>=0.19,<0.20
 safetensors>=0.8.0rc0,<0.9
 einops>=0.8,<0.9
 kernels>=0.14,<0.15

--- a/apps/worker/scene_worker/lens_runner.py
+++ b/apps/worker/scene_worker/lens_runner.py
@@ -91,16 +91,38 @@ def _inject_lokr(transformer, path: str, name: str) -> None:
     set_peft_model_state_dict(transformer, state, adapter_name=name)
 
 
+def _load_plain_lora(transformer, path: str, name: str) -> None:
+    """Load a plain LoRA onto the transformer, tolerant of the key-prefix layout.
+
+    The Lens training kernel (``save_lora_adapter``) writes *bare* module keys
+    (``transformer_blocks.0.attn.to_out.0.lora_A.weight``), but
+    ``load_lora_adapter`` defaults to a ``prefix='transformer'`` filter and only
+    *warns* — never raises — when that filter matches zero keys. So a single
+    default call silently registers nothing (``peft_config`` stays empty) and
+    generation falls back to the base model with the LoRA having no effect. Try
+    the bare-key layout first (our trainer's format), then the ``transformer.``
+    prefix for any externally-saved file, and confirm the adapter actually
+    registered each time — failing loudly only if neither layout matches
+    (sc-2218; surfaced by the first real-HW plain-LoRA round-trip)."""
+    for prefix in (None, "transformer"):
+        transformer.load_lora_adapter(path, adapter_name=name, prefix=prefix)
+        if name in (getattr(transformer, "peft_config", None) or {}):
+            return
+    raise ValueError(
+        f"Lens LoRA {path!r} matched no transformer modules under prefix=None or "
+        "'transformer'; the adapter may target a different architecture."
+    )
+
+
 def _apply_loras(transformer, loras) -> None:
     """Inject + scale trained `lens` LoRAs on the transformer (PeftAdapterMixin).
 
     Each ``loras`` entry is ``{"path", "weight", "name"}``, already resolved to a
-    concrete .safetensors file by the adapter. For a plain LoRA, ``save_lora_adapter``
-    (training kernel) and ``load_lora_adapter`` are the symmetric PeftAdapterMixin
-    pair; the ``prefix=None`` retry covers builds that saved the adapter without a
-    ``transformer.`` key prefix. A ``networkType=lokr`` adapter (epic 2193, sc-2218)
-    can't load that way, so it's rebuilt + injected via PEFT; either kind then scales
-    through ``set_adapters``.
+    concrete .safetensors file by the adapter. A plain LoRA loads via
+    ``_load_plain_lora`` (which reconciles the trainer's bare-key layout with
+    ``load_lora_adapter``'s prefix filter). A ``networkType=lokr`` adapter (epic
+    2193, sc-2218) can't load that way, so it's rebuilt + injected via PEFT;
+    either kind then scales through ``set_adapters``.
     """
     names: list[str] = []
     weights: list[float] = []
@@ -110,10 +132,7 @@ def _apply_loras(transformer, loras) -> None:
         if _adapter_network_type(path) == "lokr":
             _inject_lokr(transformer, path, name)
         else:
-            try:
-                transformer.load_lora_adapter(path, adapter_name=name)
-            except Exception:  # noqa: BLE001 - retry with no key prefix before failing
-                transformer.load_lora_adapter(path, adapter_name=name, prefix=None)
+            _load_plain_lora(transformer, path, name)
         names.append(name)
         try:
             weights.append(float(lora.get("weight", 1.0)))

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2059,8 +2059,14 @@ def test_lens_runner_apply_loras_routes_lokr_to_injection(monkeypatch):
     set_calls: dict[str, object] = {}
 
     class FakeTransformer:
+        def __init__(self):
+            self.peft_config: dict = {}
+
         def load_lora_adapter(self, path, adapter_name=None, prefix="__unset__"):
             loaded.append(adapter_name)
+            # Real PeftAdapterMixin registers the adapter once a prefix matches
+            # keys; _load_plain_lora confirms registration before moving on.
+            self.peft_config[adapter_name] = object()
 
         def set_adapters(self, names, weights=None):
             set_calls["names"] = names
@@ -2078,6 +2084,87 @@ def test_lens_runner_apply_loras_routes_lokr_to_injection(monkeypatch):
     assert loaded == ["a"]
     assert set_calls["names"] == ["a", "b"]
     assert set_calls["weights"] == [0.8, 1.0]
+
+
+def test_lens_runner_loads_plain_lora_with_bare_key_prefix(monkeypatch):
+    """The Lens trainer (``save_lora_adapter``) writes *bare* module keys, but
+    ``load_lora_adapter`` defaults to a ``prefix='transformer'`` filter that
+    matches zero of them and only *warns* — so a naive single call silently loads
+    nothing and generation falls back to the base model. ``_load_plain_lora`` must
+    try ``prefix=None`` (the trainer's layout) and confirm the adapter actually
+    registered (sc-2218; surfaced by the first real-HW plain-LoRA round-trip)."""
+    from scene_worker import lens_runner as lr
+
+    monkeypatch.setattr(lr, "_adapter_network_type", lambda path: "lora")
+
+    class FakeTransformer:
+        def __init__(self):
+            self.peft_config: dict = {}
+            self.load_calls: list = []
+            self.set_calls: dict = {}
+
+        def load_lora_adapter(self, path, adapter_name=None, prefix="__unset__"):
+            self.load_calls.append(prefix)
+            if prefix is None:  # bare-key layout the Lens trainer writes
+                self.peft_config[adapter_name] = object()
+
+        def set_adapters(self, names, weights=None):
+            self.set_calls = {"names": names, "weights": weights}
+
+    ft = FakeTransformer()
+    lr._apply_loras(ft, [{"path": "/lora.safetensors", "weight": 0.7, "name": "a"}])
+    assert ft.load_calls == [None]  # one call, prefix=None — no silent prefix miss
+    assert "a" in ft.peft_config  # adapter actually registered
+    assert ft.set_calls == {"names": ["a"], "weights": [0.7]}
+
+
+def test_lens_runner_plain_lora_falls_back_to_transformer_prefix(monkeypatch):
+    """An externally-saved adapter keyed under ``transformer.`` still loads: the
+    ``prefix=None`` attempt registers nothing, so ``_load_plain_lora`` retries with
+    the ``transformer`` prefix before giving up."""
+    from scene_worker import lens_runner as lr
+
+    monkeypatch.setattr(lr, "_adapter_network_type", lambda path: "lora")
+
+    class FakeTransformer:
+        def __init__(self):
+            self.peft_config: dict = {}
+            self.load_calls: list = []
+
+        def load_lora_adapter(self, path, adapter_name=None, prefix="__unset__"):
+            self.load_calls.append(prefix)
+            if prefix == "transformer":  # only the prefixed layout matches
+                self.peft_config[adapter_name] = object()
+
+        def set_adapters(self, names, weights=None):
+            pass
+
+    ft = FakeTransformer()
+    lr._apply_loras(ft, [{"path": "/lora.safetensors", "weight": 1.0, "name": "a"}])
+    assert ft.load_calls == [None, "transformer"]
+    assert "a" in ft.peft_config
+
+
+def test_lens_runner_plain_lora_raises_when_no_prefix_matches(monkeypatch):
+    """If neither key layout registers the adapter, fail loudly instead of
+    silently generating from the base model (the pre-fix failure mode)."""
+    from scene_worker import lens_runner as lr
+
+    monkeypatch.setattr(lr, "_adapter_network_type", lambda path: "lora")
+
+    class FakeTransformer:
+        peft_config: dict = {}
+
+        def load_lora_adapter(self, path, adapter_name=None, prefix="__unset__"):
+            pass  # never registers under any prefix
+
+        def set_adapters(self, names, weights=None):
+            pass
+
+    with pytest.raises(ValueError, match="matched no transformer modules"):
+        lr._apply_loras(
+            FakeTransformer(), [{"path": "/lora.safetensors", "name": "a"}]
+        )
 
 
 def test_lens_resolution_for_snaps_to_buckets():


### PR DESCRIPTION
## Summary

First **real-hardware validation** of the corrected Lens plain-LoRA train→infer path (epic 2193 / sc-2218 `to_out.0` fix) on an M5 Max. The training fix is correct, but the end-to-end run surfaced **two pre-existing defects** that left the path silently non-functional — both fixed here.

### ✅ Training (`to_out.0` fix) confirmed correct
16-step MPS run (512px, 68.5s, loss 1.22→0.53) attached **384 trainable LoRA tensors** — 96 each for `img_qkv`/`txt_qkv`/`to_out.0`/`to_add_out` (48 blocks × A+B). Saved keys are well-formed (`transformer_blocks.0.attn.to_out.0.lora_A.weight`), **zero** target the bare `to_out` `ModuleList`, and `lora_B` actually trained (`to_out.0` mean norm ~0.98). Pre-fix, PEFT rejected the `to_out` `ModuleList`.

### 🐞 Bug 1 — plain-LoRA inference was a silent no-op
`lens_runner._apply_loras` loaded plain LoRAs with diffusers' default `prefix="transformer"`. `save_lora_adapter` writes **bare** module keys, so the filter matched **zero** keys and only *warned* (never raised) — so the `try/except → prefix=None` fallback was dead code. The adapter never registered (`peft_config == []`) and generation silently used the base model. **Proof:** base-vs-LoRA output was byte-identical (mean diff `0.0`).

**Fix:** `_load_plain_lora` tries `prefix=None` (the trainer's bare-key layout) then `"transformer"`, and confirms the adapter registered each time, raising only if neither matches. **After the fix:** mean abs pixel diff **27/255, 97.5% of pixels changed**, coherent same-seed output — the LoRA is now reflected end-to-end.

### 🐞 Bug 2 — `peft` missing from the Lens sidecar venv
Both runners `import peft` and diffusers' `load_lora_adapter` needs the PEFT backend, but `requirements-lens.txt` shipped no `peft`. The Docker worker image (`worker.Dockerfile`) and the desktop provisioner (`setup.rs`) install **only** that file, so the production Lens LoRA/LoKr path crashed at `import peft` (empirically confirmed: the prod app-support venv lacks peft). Added `peft>=0.19,<0.20` (validated against 0.19.1).

## Changes
- `apps/worker/scene_worker/lens_runner.py` — `_load_plain_lora` prefix-tolerant loader replaces the dead try/except.
- `tests/test_worker_runtime.py` — 3 regression tests (bare-key load, prefix fallback, raise-when-no-match); updated the LoKr-routing fake to register adapters like real diffusers.
- `apps/worker/requirements-lens.txt` — declare `peft>=0.19,<0.20`.

## Testing
- Full `tests/test_worker_runtime.py`: **473 passed, 2 skipped**.
- Real M5 Max E2E via the actual runners on the cached `microsoft/Lens` base + `microsoft/Lens-Turbo` (peft-equipped `.lens-spike` venv, identical to the prod stack).

## Reviewer notes
- **LoKr inference is unaffected** (separate `_inject_lokr` path, no `load_lora_adapter`), but it's worth re-validating the LoKr path on the prod venv now that `peft` is declared.
- The desktop staged copy of `lens_runner.py` is generated by `stage-python.mjs`, not tracked — a build regenerates it.
- The `requirements-lens.txt` change re-triggers desktop venv provisioning (marker) and a Docker lens-venv layer rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)