### PR TITLE
Pose Library Create-tab fixes: temp File-Upload staging + duplicate flagging

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -102,9 +102,21 @@ pub(crate) async fn import_asset(
 
 pub(crate) async fn write_upload_field_to_temp_file(
     state: &AppState,
-    mut field: axum::extract::multipart::Field<'_>,
+    field: axum::extract::multipart::Field<'_>,
 ) -> Result<PathBuf, ApiError> {
-    let upload_dir = state.settings.data_dir.join("cache").join("uploads");
+    write_upload_field_to_dir(state, field, "uploads").await
+}
+
+/// Stream a multipart field to a unique temp file under `<data_dir>/cache/<subdir>`,
+/// enforcing the upload size cap. Callers own the returned path (move it into place
+/// or delete it). `subdir` lets transient flows isolate their staging area (e.g.
+/// pose-source uploads use `pose-uploads` so they can be swept independently).
+pub(crate) async fn write_upload_field_to_dir(
+    state: &AppState,
+    mut field: axum::extract::multipart::Field<'_>,
+    subdir: &str,
+) -> Result<PathBuf, ApiError> {
+    let upload_dir = state.settings.data_dir.join("cache").join(subdir);
     tokio::fs::create_dir_all(&upload_dir)
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -419,6 +419,7 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         let _ = std::fs::create_dir_all(jobs_db_parent);
     }
     let _ = sweep_stale_lora_uploads(&settings.data_dir);
+    let _ = sweep_stale_pose_uploads(&settings.data_dir);
     let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
     jobs_store.initialize()?;
     let interrupted_jobs_on_startup = jobs_store.mark_interrupted_on_startup()?.len();
@@ -599,6 +600,7 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         .route("/api/v1/video/jobs", post(create_video_job))
         .route("/api/v1/prompts/refine", post(create_prompt_refine_job))
         .route("/api/v1/poses", post(create_poses))
+        .route("/api/v1/poses/sources", post(create_pose_sources))
         .route(
             "/api/v1/poses/preview/:job_id/:file_name",
             get(get_pose_preview),

--- a/apps/rust-api/src/poses.rs
+++ b/apps/rust-api/src/poses.rs
@@ -33,6 +33,73 @@ pub(crate) async fn create_poses(
     Ok((StatusCode::CREATED, Json(created)))
 }
 
+/// Stage File-Upload images for pose detection as TEMPORARY files, NOT workspace
+/// assets (epic 2282). The Create tab uploads photos here, passes the returned
+/// absolute paths to a `pose_detect` job, and the worker deletes them after
+/// detection (`pose-uploads` cache dir); a startup sweep is the backstop. This is
+/// why File-Upload sources don't pollute the asset library. Returns
+/// `{ "sources": [{ "path", "displayName" }] }` in field order.
+pub(crate) async fn create_pose_sources(
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    let mut sources = Vec::new();
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|error| ApiError::bad_request(error.to_string()))?
+    {
+        if field.name() != Some("file") {
+            continue;
+        }
+        let display_name = field.file_name().unwrap_or("image").to_owned();
+        let path = write_upload_field_to_dir(&state, field, "pose-uploads").await?;
+        sources.push(serde_json::json!({
+            "path": path.to_string_lossy(),
+            "displayName": display_name,
+        }));
+    }
+    if sources.is_empty() {
+        return Err(ApiError::bad_request("At least one image file is required"));
+    }
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "sources": sources })),
+    ))
+}
+
+/// Remove stale pose-source temp uploads (`<data_dir>/cache/pose-uploads/upload-*`)
+/// at startup — the backstop for detect jobs that never ran (the worker deletes its
+/// own sources after a successful detect). Mirrors `sweep_stale_lora_uploads`.
+pub(crate) fn sweep_stale_pose_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
+    let cutoff = SystemTime::now() - Duration::from_secs(STALE_LORA_UPLOAD_SECONDS);
+    let upload_root = data_dir.join("cache").join("pose-uploads");
+    let entries = match std::fs::read_dir(upload_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    let mut removed = 0usize;
+    for entry in entries {
+        let entry = entry?;
+        let filename = entry.file_name();
+        if !filename.to_string_lossy().starts_with("upload-") {
+            continue;
+        }
+        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
+        if modified <= cutoff {
+            let path = entry.path();
+            let _ = if entry.file_type()?.is_dir() {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
 /// Stream a worker pose-detect skeleton preview from the cache so the Create tab
 /// can show each candidate before it's saved (the PNG lives server-side, not in
 /// the browser). Same auth class as project files: loadable via a plain `<img>`

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { API_BASE_URL, apiFetch, isAbortError } from "../api.js";
 import { AssetDetail, AssetGrid, FullscreenPreview, emptyTrash } from "../components/assetPanels.jsx";
 import { AssetThumbnail } from "../components/assetMedia.jsx";
@@ -69,15 +69,7 @@ function buildCandidates(job) {
 // The "Create" tab body: pick photos (DatasetAddDialog), run DWPose, then review,
 // categorize, and save one whole-body pose per detected person to the store.
 function PoseCreatePanel({ hidden, categories, onSaved }) {
-  const {
-    token,
-    activeProject,
-    assets = [],
-    characters = [],
-    importAsset,
-    requestedGpu,
-    jobs = [],
-  } = useAppContext();
+  const { token, activeProject, assets = [], characters = [], requestedGpu, jobs = [] } = useAppContext();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [sources, setSources] = useState([]); // selected source asset records
   const [phase, setPhase] = useState("idle"); // idle | detecting | review
@@ -87,27 +79,37 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
   const [saving, setSaving] = useState(false);
   const [importing, setImporting] = useState(false);
 
-  const addSources = useCallback((records) => {
+  // Sources are normalized entries (deduped by `key`): either an asset-backed pick
+  // ({kind:"asset", asset, assetId}) or a transient File-Upload ({kind:"upload",
+  // path, objectUrl}).
+  const mergeSources = useCallback((entries) => {
     setSources((prev) => {
-      const seen = new Set(prev.map((asset) => asset.id));
-      return [...prev, ...records.filter((asset) => asset && !seen.has(asset.id))];
+      const seen = new Set(prev.map((source) => source.key));
+      return [...prev, ...entries.filter((source) => source && !seen.has(source.key))];
     });
   }, []);
 
-  // File tab: import each dropped/selected image into the active project (which
-  // gives the worker an on-disk asset to read), then treat it like any source.
+  // File tab: stage each image to the TRANSIENT pose-source area (NOT a workspace
+  // asset) — the worker reads it by path and deletes it after detection (epic 2282).
   const handleImport = useCallback(
     async (files) => {
-      if (!importAsset) return;
+      const images = Array.from(files).filter((file) => file.type?.startsWith("image/"));
+      if (!images.length) return;
       setImporting(true);
       try {
-        const imported = [];
-        for (const file of Array.from(files)) {
-          if (!file.type?.startsWith("image/")) continue; // pose detection needs images
-          const asset = await importAsset(file, { throwOnError: true });
-          if (asset) imported.push(asset);
-        }
-        addSources(imported);
+        const body = new FormData();
+        for (const file of images) body.append("file", file);
+        const result = await apiFetch("/api/v1/poses/sources", token, { method: "POST", body });
+        const staged = Array.isArray(result?.sources) ? result.sources : [];
+        mergeSources(
+          staged.map((src, index) => ({
+            key: src.path,
+            kind: "upload",
+            path: src.path,
+            displayName: src.displayName ?? images[index]?.name ?? "image",
+            objectUrl: images[index] ? URL.createObjectURL(images[index]) : undefined,
+          })),
+        );
         setError("");
       } catch (err) {
         setError(String(err?.message ?? err));
@@ -115,19 +117,44 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
         setImporting(false);
       }
     },
-    [importAsset, addSources],
+    [token, mergeSources],
   );
 
-  // Library / Character tabs: resolve the picked ids back to asset records.
+  // Library / Character tabs: resolve the picked ids to asset records.
   const handleAdd = useCallback(
     (selectedIds) => {
-      const records = selectedIds.map((id) => assets.find((asset) => asset.id === id)).filter(Boolean);
-      addSources(records);
+      mergeSources(
+        selectedIds
+          .map((id) => assets.find((asset) => asset.id === id))
+          .filter(Boolean)
+          .map((asset) => ({
+            key: asset.id,
+            kind: "asset",
+            asset,
+            assetId: asset.id,
+            displayName: asset.displayName ?? asset.id,
+          })),
+      );
     },
-    [assets, addSources],
+    [assets, mergeSources],
   );
 
-  const removeSource = (id) => setSources((prev) => prev.filter((asset) => asset.id !== id));
+  const removeSource = (key) =>
+    setSources((prev) => {
+      const target = prev.find((source) => source.key === key);
+      if (target?.objectUrl) URL.revokeObjectURL(target.objectUrl);
+      return prev.filter((source) => source.key !== key);
+    });
+
+  // Revoke any object URLs on unmount (latest set via ref).
+  const sourcesRef = useRef(sources);
+  sourcesRef.current = sources;
+  useEffect(
+    () => () => {
+      for (const source of sourcesRef.current) if (source.objectUrl) URL.revokeObjectURL(source.objectUrl);
+    },
+    [],
+  );
 
   const generate = useCallback(async () => {
     if (!activeProject || !sources.length) return;
@@ -143,7 +170,11 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
           requestedGpu,
           payload: {
             projectId: activeProject.id,
-            sources: sources.map((asset) => ({ assetId: asset.id, displayName: asset.displayName })),
+            sources: sources.map((source) =>
+              source.kind === "upload"
+                ? { path: source.path, displayName: source.displayName, temp: true }
+                : { assetId: source.assetId, displayName: source.displayName },
+            ),
           },
         }),
       });
@@ -195,7 +226,10 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
         pose: candidate.pose,
       }));
       await apiFetch("/api/v1/poses", token, { method: "POST", body: JSON.stringify({ poses }) });
-      setSources([]);
+      setSources((prev) => {
+        for (const source of prev) if (source.objectUrl) URL.revokeObjectURL(source.objectUrl);
+        return [];
+      });
       setCandidates([]);
       setPhase("idle");
       onSaved?.();
@@ -232,11 +266,15 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
 
           {sources.length ? (
             <div className="dataset-add-grid">
-              {sources.map((asset) => (
-                <div className="dataset-add-card" key={asset.id}>
-                  <AssetThumbnail asset={asset} />
-                  <span>{asset.displayName ?? asset.id}</span>
-                  <button onClick={() => removeSource(asset.id)} type="button">
+              {sources.map((source) => (
+                <div className="dataset-add-card" key={source.key}>
+                  {source.kind === "upload" ? (
+                    <img alt="" src={source.objectUrl} />
+                  ) : (
+                    <AssetThumbnail asset={source.asset} />
+                  )}
+                  <span>{source.displayName}</span>
+                  <button onClick={() => removeSource(source.key)} type="button">
                     Remove
                   </button>
                 </div>
@@ -310,7 +348,7 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
               assets={assets}
               characters={characters}
               importing={importing}
-              memberIds={sources.map((asset) => asset.id)}
+              memberIds={sources.filter((source) => source.kind === "asset").map((source) => source.assetId)}
               onAdd={handleAdd}
               onClose={() => setDialogOpen(false)}
               onImport={handleImport}

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -66,9 +66,55 @@ function buildCandidates(job) {
   return out;
 }
 
+// Two skeletons from the same photo are near-identical, so flag a new candidate as
+// a likely duplicate of an existing saved pose (or an earlier candidate in the same
+// batch) and start it unkept. Poses are square-canonical, so body keypoints compare
+// directly: mean per-point distance in normalized [0,1] space below DUPLICATE_DISTANCE
+// = "likely the same pose". Catches same-source / near-identical poses (this is not
+// translation/scale-invariant pose-shape matching).
+const DUPLICATE_DISTANCE = 0.03;
+
+function keypointDistance(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return Infinity;
+  let sum = 0;
+  let count = 0;
+  const len = Math.min(a.length, b.length, 18);
+  for (let i = 0; i < len; i += 1) {
+    const pa = a[i];
+    const pb = b[i];
+    if (!pa || !pb || pa[0] == null || pb[0] == null) continue;
+    sum += Math.hypot(pa[0] - pb[0], pa[1] - pb[1]);
+    count += 1;
+  }
+  return count >= 8 ? sum / count : Infinity; // need enough shared points to trust it
+}
+
+// Annotate each built candidate with `duplicateOf` (the label of the closest match
+// within DUPLICATE_DISTANCE among existing saved poses + earlier candidates) and
+// start duplicates unkept so they aren't accidentally re-added.
+function annotateDuplicates(built, existingPoses) {
+  const existing = (existingPoses ?? [])
+    .filter((pose) => !pose.status?.trashed)
+    .map((pose) => ({ keypoints: pose.pose?.keypoints ?? [], label: pose.displayName || pose.id }));
+  return built.map((candidate, index) => {
+    const pool = [
+      ...existing,
+      ...built.slice(0, index).map((c) => ({ keypoints: c.pose.keypoints, label: c.sourceDisplayName })),
+    ];
+    let best = null;
+    for (const other of pool) {
+      const distance = keypointDistance(candidate.pose.keypoints, other.keypoints);
+      if (distance < DUPLICATE_DISTANCE && (!best || distance < best.distance)) {
+        best = { label: other.label, distance };
+      }
+    }
+    return { ...candidate, duplicateOf: best?.label ?? null, keep: !best };
+  });
+}
+
 // The "Create" tab body: pick photos (DatasetAddDialog), run DWPose, then review,
 // categorize, and save one whole-body pose per detected person to the store.
-function PoseCreatePanel({ hidden, categories, onSaved }) {
+function PoseCreatePanel({ hidden, categories, onSaved, existingPoses }) {
   const { token, activeProject, assets = [], characters = [], requestedGpu, jobs = [] } = useAppContext();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [sources, setSources] = useState([]); // selected source asset records
@@ -149,6 +195,10 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
   // Revoke any object URLs on unmount (latest set via ref).
   const sourcesRef = useRef(sources);
   sourcesRef.current = sources;
+  // Snapshot the existing saved poses for duplicate detection without re-running the
+  // job-watch effect (which would reset the user's keep toggles) when they change.
+  const existingPosesRef = useRef(existingPoses);
+  existingPosesRef.current = existingPoses;
   useEffect(
     () => () => {
       for (const source of sourcesRef.current) if (source.objectUrl) URL.revokeObjectURL(source.objectUrl);
@@ -191,7 +241,7 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
     const job = jobs.find((item) => item.id === jobId);
     if (!job || !terminalStatuses.has(job.status)) return;
     if (job.status === "completed") {
-      const built = buildCandidates(job);
+      const built = annotateDuplicates(buildCandidates(job), existingPosesRef.current);
       setCandidates(built);
       setPhase("review");
       if (!built.length) setError("No people were detected in the selected images.");
@@ -317,6 +367,9 @@ function PoseCreatePanel({ hidden, categories, onSaved }) {
                     <span>
                       {candidate.sourceDisplayName} · {candidate.facing}
                     </span>
+                    {candidate.duplicateOf ? (
+                      <span className="inline-warning">Possible duplicate of {candidate.duplicateOf}</span>
+                    ) : null}
                     <label>
                       Category
                       <input
@@ -580,6 +633,7 @@ export function PoseLibraryScreen() {
 
       <PoseCreatePanel
         categories={categories.filter((category) => category !== UNCATEGORIZED)}
+        existingPoses={poses}
         hidden={activeTab !== "create"}
         onSaved={() => {
           setActiveTab("poses");

--- a/apps/web/src/screens/PoseLibraryScreen.test.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.test.jsx
@@ -20,6 +20,9 @@ vi.mock("../api.js", async (importOriginal) => {
       if (method === "POST" && path === "/api/v1/jobs") {
         return { id: "job_pose_1", status: "queued" };
       }
+      if (method === "POST" && path === "/api/v1/poses/sources") {
+        return { sources: [{ path: "/data/cache/pose-uploads/upload-x.png", displayName: "photo.png" }] };
+      }
       return {};
     }),
   };
@@ -278,6 +281,33 @@ describe("PoseLibraryScreen — Create tab", () => {
     expect(body.type).toBe("pose_detect");
     expect(body.projectId).toBe("project_1");
     expect(body.payload.sources).toEqual([{ assetId: "asset_lib_1", displayName: "Photo" }]);
+  });
+
+  it("stages File-Upload sources as temporary uploads, not workspace assets", async () => {
+    window.URL.createObjectURL = () => "blob:test";
+    window.URL.revokeObjectURL = () => {};
+    await render();
+    await click(container.querySelector("#pose-library-tab-create"));
+    await click(byText("Add images"));
+    // File tab is the default; fire a change on its <input type=file> with an image.
+    const fileInput = container.querySelector('input[type="file"]');
+    const file = new File(["x"], "photo.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+    await act(async () => {
+      fileInput.dispatchEvent(new window.Event("change", { bubbles: true }));
+    });
+
+    // Staged via the transient endpoint — NEVER imported as a workspace asset.
+    expect(apiCalls.some((c) => c.method === "POST" && c.path === "/api/v1/poses/sources")).toBe(true);
+    expect(apiCalls.some((c) => c.method === "POST" && c.path.includes("/assets"))).toBe(false);
+
+    // Generate forwards it as a temp path source (not an assetId).
+    await click(byText("Generate poses"));
+    const job = apiCalls.find((c) => c.method === "POST" && c.path === "/api/v1/jobs");
+    expect(JSON.parse(job.body).payload.sources[0]).toMatchObject({
+      path: "/data/cache/pose-uploads/upload-x.png",
+      temp: true,
+    });
   });
 
   it("requires a workspace before creating poses", async () => {

--- a/apps/web/src/screens/PoseLibraryScreen.test.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.test.jsx
@@ -310,6 +310,30 @@ describe("PoseLibraryScreen — Create tab", () => {
     });
   });
 
+  it("flags a candidate that duplicates an existing saved pose and starts it unkept", async () => {
+    const kps = Array.from({ length: 8 }, (_, i) => [0.5, 0.1 + 0.05 * i, 5.0]);
+    // The reserved project already holds a pose with these keypoints…
+    poseAssets = [poseAsset({ id: "asset_pose_existing", displayName: "Existing Pose", pose: { keypoints: kps } })];
+    // …and the detector returns a candidate with the same keypoints (same photo).
+    const source = completedJob.result.sources[0];
+    const job = {
+      ...completedJob,
+      result: { sources: [{ ...source, poses: [{ ...source.poses[0], keypoints: kps }] }] },
+    };
+    await render(makeContext({ jobs: [job] }));
+    await click(container.querySelector("#pose-library-tab-create"));
+    await click(byText("Add images"));
+    await click(byText("Asset Library"));
+    await click(byText("Photo"));
+    await click(exactBtn("Add 1"));
+    await click(exactBtn("Done"));
+    await click(byText("Generate poses"));
+
+    expect(container.textContent).toContain("Possible duplicate of Existing Pose");
+    // Duplicates start unkept → nothing queued to save.
+    expect(byText("Save 0 pose")).toBeTruthy();
+  });
+
   it("requires a workspace before creating poses", async () => {
     await render(makeContext({ activeProject: null }));
     await click(container.querySelector("#pose-library-tab-create"));

--- a/apps/worker/scene_worker/pose_adapters.py
+++ b/apps/worker/scene_worker/pose_adapters.py
@@ -286,6 +286,19 @@ def _resolve_source_path(src: dict, project_path) -> str | None:
     return raw
 
 
+def _cleanup_temp_sources(paths: list[str], uploads_root: Path) -> None:
+    """Delete pose-source temp uploads after detection. File-Upload sources are
+    transient — never workspace assets (epic 2282). Guarded to the pose-uploads
+    cache so a project asset resolved by id can never be removed."""
+    for raw in paths:
+        try:
+            resolved = Path(raw).resolve()
+            if uploads_root in resolved.parents:
+                resolved.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def run_pose_detect(
     settings: Any,
     job: dict[str, Any],
@@ -342,11 +355,15 @@ def run_pose_detect(
     runtime = detector_factory(settings)
 
     out_sources: list[dict] = []
+    uploads_root = (Path(getattr(settings, "data_dir", ".")) / "cache" / "pose-uploads").resolve()
+    temp_sources: list[str] = []
     total = len(sources)
     for si, src in enumerate(sources):
         if cancel_requested is not None and cancel_requested():
             raise InterruptedError("Pose detection canceled.")
         path = _resolve_source_path(src, project_path)
+        if src.get("temp") and path:
+            temp_sources.append(path)
         img = cv2.imread(path) if path else None
         if img is None:
             out_sources.append({
@@ -410,6 +427,10 @@ def run_pose_detect(
         })
         _p("running", 0.08 + 0.9 * (si + 1) / total,
            f"Detected {len(poses)} pose(s) in image {si + 1}/{total}.")
+
+    # File-Upload sources are transient — delete them now detection is done (the
+    # startup sweep backstops canceled/failed jobs). epic 2282.
+    _cleanup_temp_sources(temp_sources, uploads_root)
 
     return {
         "sources": out_sources,

--- a/tests/test_pose_adapters.py
+++ b/tests/test_pose_adapters.py
@@ -158,3 +158,28 @@ def test_run_pose_detect_with_fake_detector(tmp_path):
     prev = cv2.imread(pose["skeletonPreview"])
     assert prev is not None and prev.shape[0] == prev.shape[1]
     assert events  # progress was reported
+
+
+def test_run_pose_detect_deletes_temp_uploads(tmp_path):
+    cv2 = pytest.importorskip("cv2")
+    # A File-Upload source staged under <data_dir>/cache/pose-uploads (transient).
+    uploads = tmp_path / "cache" / "pose-uploads"
+    uploads.mkdir(parents=True)
+    temp_src = uploads / "upload-abc.png"
+    cv2.imwrite(str(temp_src), np.full((480, 320, 3), 30, dtype=np.uint8))
+    # A non-temp source elsewhere must be left untouched.
+    keep = tmp_path / "keep.png"
+    cv2.imwrite(str(keep), np.full((480, 320, 3), 30, dtype=np.uint8))
+
+    runtime = pa.PoseDetectorRuntime(
+        model=lambda img: _fake_wholebody(1), device="cpu", detector_id="fake/test"
+    )
+    settings = SimpleNamespace(data_dir=str(tmp_path), gpu_id="cpu")
+    job = {
+        "id": "job_pose_temp",
+        "payload": {"sources": [{"path": str(temp_src), "temp": True}, {"path": str(keep)}]},
+    }
+    pa.run_pose_detect(settings, job, detector_factory=lambda s: runtime)
+
+    assert not temp_src.exists()  # temp upload removed after detection
+    assert keep.exists()  # non-temp source untouched


### PR DESCRIPTION
Two coupled Create-tab fixes (same file; #394 wasn't merged so they ride together).

### 1. File-Upload sources are temporary, not workspace assets
File-Upload images were imported via the workspace `importAsset` → permanently polluted the asset library. New `POST /api/v1/poses/sources` (multipart) stages them to a `cache/pose-uploads` temp dir (reuses `write_upload_field_to_dir`, returns paths, **no asset**); the Create tab posts there, shows a local objectURL thumbnail, passes `{path, temp:true}` to the detect job. The worker deletes temp sources (guarded to `cache/pose-uploads`) after detection; `sweep_stale_pose_uploads` backstops at startup. Library/Character sources unchanged (assetId).

### 2. Duplicate pose flagging at creation
Re-running detection on the same photo yields a near-identical skeleton. At review, each candidate's body keypoints are compared against existing saved poses + earlier batch candidates (poses are square-canonical → direct compare); within `DUPLICATE_DISTANCE` (0.03 normalized) it's flagged **"Possible duplicate of <name>"** and starts **unkept** (user can still keep it). Catches same-source / near-identical poses.

**Tests:** worker temp-source deletion; web File-Upload → `/poses/sources` not `/assets`; web duplicate candidate flagged + unkept. 503 worker + 10 PoseLibraryScreen (275 web) green; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)