### PR TITLE
FLUX.2 [klein] pose variants + incremental MLX sidecar image streaming

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import warnings
 from pathlib import Path
 from textwrap import wrap
@@ -2785,8 +2786,9 @@ class MlxFluxAdapter:
         )
         work_dir = Path(tempfile.mkdtemp(prefix="mlx_flux_sidecar_"))
         self._scratch_dir = work_dir
+        stream: _MlxSidecarStream | None = None
         try:
-            images = self._run_sidecar(
+            stream = self._run_sidecar(
                 job_id=job["id"],
                 work_dir=work_dir,
                 label=model_target["label"],
@@ -2817,10 +2819,13 @@ class MlxFluxAdapter:
                     image_batch_progress(index, total),
                     format_batch_running_message(model_target["label"], index, total),
                 )
-                with Image.open(images[index]) as handle:
+                # Blocks only until image `index` lands (sc-2412) so the writer
+                # streams each asset as the sidecar produces it, instead of all
+                # appearing at once when the process exits.
+                with Image.open(stream.wait_for_image(index)) as handle:
                     return handle.convert("RGB")
 
-            return ImageAssetWriter().write_incremental_outputs(
+            outputs = ImageAssetWriter().write_incremental_outputs(
                 request=request,
                 project_path=project_path,
                 image_count=total,
@@ -2840,7 +2845,11 @@ class MlxFluxAdapter:
                 settings=settings,
                 job_id=job["id"],
             )
+            stream.finish()
+            return outputs
         finally:
+            if stream is not None:
+                stream.shutdown()
             # The writer has read every PNG into the project by now; drop the
             # sidecar's scratch dir regardless of success/failure (also clears
             # the force-cancel registry).
@@ -2897,7 +2906,7 @@ class MlxFluxAdapter:
         spec: dict[str, Any],
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
-    ) -> list[str]:
+    ) -> _MlxSidecarStream:
         spec = {**spec, "outDir": str(work_dir)}
         spec_path = work_dir / "spec.json"
         spec_path.write_text(json.dumps(spec), encoding="utf-8")
@@ -2918,44 +2927,24 @@ class MlxFluxAdapter:
             image_batch_progress(0, total),
             f"Running {label} ({total} image(s)).",
         )
-        # stdout -> file (avoids any pipe-fill deadlock); stderr inherits to the
-        # worker log for diagnostics. Poll so the job stays cancelable; the
-        # heartbeat thread keeps it alive during the (minutes-long) run. Mirrors
-        # LensTurboAdapter._run_sidecar.
-        with stdout_log.open("w", encoding="utf-8") as out:
-            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
-            # leaves a partial traceback we can surface; result.json stays the
-            # authoritative success channel (_read_result prefers it).
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
-            while True:
-                try:
-                    proc.wait(timeout=2)
-                    break
-                except subprocess.TimeoutExpired:
-                    if cancel_requested():
-                        proc.terminate()
-                        try:
-                            proc.wait(timeout=10)
-                        except subprocess.TimeoutExpired:
-                            proc.kill()
-                        raise InterruptedError("Image generation canceled by user.")
-        result = self._read_result(work_dir, stdout_log)
-        if proc.returncode != 0 or "error" in result:
-            error = result.get("error") or f"MLX FLUX sidecar exited with code {proc.returncode}."
-            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
-            emit_worker_event(
-                "mlx_flux_sidecar_failed",
-                jobId=job_id,
-                adapter=self.id,
-                error=error,
-                returnCode=proc.returncode,
-            )
-            raise RuntimeError(f"MLX FLUX generation failed in the sidecar venv: {error}")
-        images = [str(path) for path in result.get("images", [])]
-        if len(images) != total:
-            raise RuntimeError(f"MLX FLUX sidecar produced {len(images)} image(s); expected {total}.")
-        emit_worker_event("mlx_flux_sidecar_complete", jobId=job_id, adapter=self.id, imageCount=len(images))
-        return images
+        # Stream images as the sidecar writes them (sc-2412) rather than blocking
+        # until it exits. A daemon reader thread drains stdout (no pipe-fill
+        # deadlock), mirrors it into stdout.log so a native crash still leaves a
+        # partial traceback, and parses per-image markers; result.json stays the
+        # authoritative success channel.
+        return _MlxSidecarStream(
+            cmd=cmd,
+            job_id=job_id,
+            adapter_id=self.id,
+            work_dir=work_dir,
+            stdout_log=stdout_log,
+            total=total,
+            cancel_requested=cancel_requested,
+            read_result=self._read_result,
+            complete_event="mlx_flux_sidecar_complete",
+            failed_event="mlx_flux_sidecar_failed",
+            fail_label="MLX FLUX",
+        ).start()
 
     @staticmethod
     def _read_result(work_dir: Path, stdout_log: Path) -> dict[str, Any]:
@@ -3009,6 +2998,222 @@ def _mlx_sidecar_failure_detail(error: str, returncode: int, stdout_log: Path) -
     if tail:
         parts.append(f"last sidecar output:\n{tail}")
     return " — ".join(parts) if parts else "MLX sidecar failed with no output."
+
+
+class _MlxSidecarStream:
+    """Streams images out of a running mflux sidecar as they're produced (sc-2412).
+
+    Shared by every mflux sidecar adapter (FLUX.1, Qwen-Image, Z-Image, FLUX.2).
+    The former ``_run_sidecar`` blocked on ``proc.wait()`` until the process
+    exited and then handed back ALL image paths at once, so a multi-image batch
+    only appeared in the UI in one burst at job end. This class instead launches
+    the sidecar with a piped stdout and a daemon reader thread that:
+
+      * mirrors every line to ``stdout.log`` (so a native crash — SIGABRT /
+        SIGSEGV / SIGKILL — still leaves a partial traceback for
+        ``_mlx_sidecar_failure_detail``), and
+      * parses the runner's per-image markers
+        (``{"event":"image","index":i,"path":...}``) into a thread-safe map.
+
+    ``wait_for_image(index)`` then blocks only until *that* image lands, so the
+    pull-based ``ImageAssetWriter.write_incremental_outputs`` loop writes + reports
+    each asset the instant it's ready — identical streaming to the in-process torch
+    adapters, with no change to the writer.
+
+    Degrades gracefully: if the runner emits no markers (older runner, or a future
+    path that forgets them) ``wait_for_image`` falls back to the authoritative
+    ``result.json`` image list once the process exits — i.e. the old all-at-once
+    behavior — so correctness never depends on the markers. Continuously draining
+    the pipe on the reader thread also removes the pipe-fill deadlock risk that
+    motivated the original stdout-to-file approach.
+    """
+
+    def __init__(
+        self,
+        *,
+        cmd: list[str],
+        job_id: str,
+        adapter_id: str,
+        work_dir: Path,
+        stdout_log: Path,
+        total: int,
+        cancel_requested: CancelCallback,
+        read_result: Callable[[Path, Path], dict[str, Any]],
+        complete_event: str,
+        failed_event: str,
+        fail_label: str,
+    ) -> None:
+        self._cmd = cmd
+        self._job_id = job_id
+        self._adapter_id = adapter_id
+        self._work_dir = work_dir
+        self._stdout_log = stdout_log
+        self._total = total
+        self._cancel_requested = cancel_requested
+        self._read_result = read_result
+        self._complete_event = complete_event
+        self._failed_event = failed_event
+        self._fail_label = fail_label
+        self._proc: subprocess.Popen[str] | None = None
+        self._reader: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._images: dict[int, str] = {}
+        self._tick = threading.Event()
+        self._finished = False
+
+    def start(self) -> "_MlxSidecarStream":
+        self._proc = subprocess.Popen(
+            self._cmd,
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        self._reader = threading.Thread(
+            target=self._pump_stdout, name="mlx-sidecar-reader", daemon=True
+        )
+        self._reader.start()
+        return self
+
+    def _pump_stdout(self) -> None:
+        proc = self._proc
+        assert proc is not None and proc.stdout is not None
+        try:
+            with self._stdout_log.open("w", encoding="utf-8") as out:
+                for raw in proc.stdout:
+                    out.write(raw)
+                    out.flush()
+                    line = raw.strip()
+                    if not line or '"event"' not in line:
+                        continue
+                    try:
+                        msg = json.loads(line)
+                    except ValueError:
+                        continue
+                    if not isinstance(msg, dict) or msg.get("event") != "image":
+                        continue
+                    try:
+                        idx = int(msg["index"])
+                        path = str(msg["path"])
+                    except (KeyError, TypeError, ValueError):
+                        continue
+                    with self._lock:
+                        self._images[idx] = path
+                    self._tick.set()
+        finally:
+            # Wake any waiter that's parked past EOF / process exit.
+            self._tick.set()
+
+    def wait_for_image(self, index: int) -> str:
+        """Block until image ``index`` is available, returning its PNG path.
+
+        Raises ``InterruptedError`` on cancel and ``RuntimeError`` if the sidecar
+        failed before producing it. Falls back to ``result.json`` ordering when
+        the run finished without per-image markers.
+        """
+        while True:
+            with self._lock:
+                if index in self._images:
+                    return self._images[index]
+            if self._cancel_requested():
+                self._terminate()
+                raise InterruptedError("Image generation canceled by user.")
+            proc = self._proc
+            if proc is not None and proc.poll() is not None:
+                # Process exited. Drain the reader, re-check markers, then fall
+                # back to the authoritative result.json ordering.
+                if self._reader is not None:
+                    self._reader.join(timeout=10)
+                with self._lock:
+                    if index in self._images:
+                        return self._images[index]
+                self._raise_if_failed(proc.returncode)
+                images = [
+                    str(p)
+                    for p in self._read_result(self._work_dir, self._stdout_log).get("images", [])
+                ]
+                if index < len(images):
+                    return images[index]
+                raise RuntimeError(
+                    f"{self._fail_label} sidecar produced {len(images)} image(s); "
+                    f"expected at least {index + 1}."
+                )
+            # Park until the reader signals a new image or the process exits.
+            self._tick.wait(timeout=1.0)
+            self._tick.clear()
+
+    def _raise_if_failed(self, returncode: int | None) -> None:
+        result = self._read_result(self._work_dir, self._stdout_log)
+        if (returncode == 0) and "error" not in result:
+            return
+        code = returncode if returncode is not None else -1
+        error = result.get("error") or f"{self._fail_label} sidecar exited with code {code}."
+        error = _mlx_sidecar_failure_detail(error, code, self._stdout_log)
+        emit_worker_event(
+            self._failed_event,
+            jobId=self._job_id,
+            adapter=self._adapter_id,
+            error=error,
+            returnCode=code,
+        )
+        raise RuntimeError(f"{self._fail_label} generation failed in the sidecar venv: {error}")
+
+    def _terminate(self) -> None:
+        proc = self._proc
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        if self._reader is not None:
+            self._reader.join(timeout=10)
+
+    def finish(self) -> None:
+        """Success-path finalize: confirm a clean exit, validate the image count,
+        and emit the completion event. Raises ``RuntimeError`` on sidecar failure.
+        """
+        proc = self._proc
+        if proc is None:
+            return
+        # Poll so the job stays cancelable in the brief window between the last
+        # image and the sidecar writing result.json + exiting (parity with the
+        # former blocking wait loop).
+        while True:
+            try:
+                proc.wait(timeout=2)
+                break
+            except subprocess.TimeoutExpired:
+                if self._cancel_requested():
+                    self._terminate()
+                    raise InterruptedError("Image generation canceled by user.")
+        if self._reader is not None:
+            self._reader.join(timeout=10)
+        self._raise_if_failed(proc.returncode)
+        images = [
+            str(p) for p in self._read_result(self._work_dir, self._stdout_log).get("images", [])
+        ]
+        if len(images) != self._total:
+            raise RuntimeError(
+                f"{self._fail_label} sidecar produced {len(images)} image(s); expected {self._total}."
+            )
+        self._finished = True
+        emit_worker_event(
+            self._complete_event,
+            jobId=self._job_id,
+            adapter=self._adapter_id,
+            imageCount=len(images),
+        )
+
+    def shutdown(self) -> None:
+        """Idempotent cleanup for a ``finally`` block — never raises. Ensures the
+        sidecar process is gone and the reader thread joined, even if the consumer
+        bailed early (error / cancel) before reading every image."""
+        try:
+            self._terminate()
+        except Exception:  # noqa: BLE001 - cleanup must not mask the real error
+            pass
 
 
 class MlxQwenAdapter:
@@ -3145,8 +3350,9 @@ class MlxQwenAdapter:
         )
         work_dir = Path(tempfile.mkdtemp(prefix="mlx_qwen_sidecar_"))
         self._scratch_dir = work_dir
+        stream: _MlxSidecarStream | None = None
         try:
-            images = self._run_sidecar(
+            stream = self._run_sidecar(
                 job_id=job["id"],
                 work_dir=work_dir,
                 label=model_target["label"],
@@ -3177,10 +3383,13 @@ class MlxQwenAdapter:
                     image_batch_progress(index, total),
                     format_batch_running_message(model_target["label"], index, total),
                 )
-                with Image.open(images[index]) as handle:
+                # Blocks only until image `index` lands (sc-2412) so the writer
+                # streams each asset as the sidecar produces it, instead of all
+                # appearing at once when the process exits.
+                with Image.open(stream.wait_for_image(index)) as handle:
                     return handle.convert("RGB")
 
-            return ImageAssetWriter().write_incremental_outputs(
+            outputs = ImageAssetWriter().write_incremental_outputs(
                 request=request,
                 project_path=project_path,
                 image_count=total,
@@ -3200,7 +3409,11 @@ class MlxQwenAdapter:
                 settings=settings,
                 job_id=job["id"],
             )
+            stream.finish()
+            return outputs
         finally:
+            if stream is not None:
+                stream.shutdown()
             self.discard_temp_outputs(job["id"])
 
     def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
@@ -3245,7 +3458,7 @@ class MlxQwenAdapter:
         spec: dict[str, Any],
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
-    ) -> list[str]:
+    ) -> _MlxSidecarStream:
         spec = {**spec, "outDir": str(work_dir)}
         spec_path = work_dir / "spec.json"
         spec_path.write_text(json.dumps(spec), encoding="utf-8")
@@ -3266,40 +3479,20 @@ class MlxQwenAdapter:
             image_batch_progress(0, total),
             f"Running {label} ({total} image(s)).",
         )
-        with stdout_log.open("w", encoding="utf-8") as out:
-            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
-            # leaves a partial traceback we can surface; result.json stays the
-            # authoritative success channel (_read_result prefers it).
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
-            while True:
-                try:
-                    proc.wait(timeout=2)
-                    break
-                except subprocess.TimeoutExpired:
-                    if cancel_requested():
-                        proc.terminate()
-                        try:
-                            proc.wait(timeout=10)
-                        except subprocess.TimeoutExpired:
-                            proc.kill()
-                        raise InterruptedError("Image generation canceled by user.")
-        result = self._read_result(work_dir, stdout_log)
-        if proc.returncode != 0 or "error" in result:
-            error = result.get("error") or f"MLX Qwen sidecar exited with code {proc.returncode}."
-            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
-            emit_worker_event(
-                "mlx_qwen_sidecar_failed",
-                jobId=job_id,
-                adapter=self.id,
-                error=error,
-                returnCode=proc.returncode,
-            )
-            raise RuntimeError(f"MLX Qwen generation failed in the sidecar venv: {error}")
-        images = [str(path) for path in result.get("images", [])]
-        if len(images) != total:
-            raise RuntimeError(f"MLX Qwen sidecar produced {len(images)} image(s); expected {total}.")
-        emit_worker_event("mlx_qwen_sidecar_complete", jobId=job_id, adapter=self.id, imageCount=len(images))
-        return images
+        # Stream images as the sidecar writes them (sc-2412); see MlxFluxAdapter.
+        return _MlxSidecarStream(
+            cmd=cmd,
+            job_id=job_id,
+            adapter_id=self.id,
+            work_dir=work_dir,
+            stdout_log=stdout_log,
+            total=total,
+            cancel_requested=cancel_requested,
+            read_result=self._read_result,
+            complete_event="mlx_qwen_sidecar_complete",
+            failed_event="mlx_qwen_sidecar_failed",
+            fail_label="MLX Qwen",
+        ).start()
 
     @staticmethod
     def _read_result(work_dir: Path, stdout_log: Path) -> dict[str, Any]:
@@ -3526,8 +3719,9 @@ class MlxZImageAdapter:
                     draw_wholebody(request.width, request.height, keypoints, hands=hands, face=face, stickwidth=stick)
                 ).save(skeleton_path, "PNG")
                 control_image_paths.append(str(skeleton_path))
+        stream: _MlxSidecarStream | None = None
         try:
-            images = self._run_sidecar(
+            stream = self._run_sidecar(
                 job_id=job["id"],
                 work_dir=work_dir,
                 label=model_target["label"],
@@ -3568,10 +3762,13 @@ class MlxZImageAdapter:
                     image_batch_progress(index, total),
                     format_batch_running_message(model_target["label"], index, total),
                 )
-                with Image.open(images[index]) as handle:
+                # Blocks only until image `index` lands (sc-2412) so the writer
+                # streams each asset as the sidecar produces it, instead of all
+                # appearing at once when the process exits.
+                with Image.open(stream.wait_for_image(index)) as handle:
                     return handle.convert("RGB")
 
-            return ImageAssetWriter().write_incremental_outputs(
+            outputs = ImageAssetWriter().write_incremental_outputs(
                 request=request,
                 project_path=project_path,
                 image_count=total,
@@ -3592,7 +3789,11 @@ class MlxZImageAdapter:
                 settings=settings,
                 job_id=job["id"],
             )
+            stream.finish()
+            return outputs
         finally:
+            if stream is not None:
+                stream.shutdown()
             self.discard_temp_outputs(job["id"])
 
     def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
@@ -3675,7 +3876,7 @@ class MlxZImageAdapter:
         spec: dict[str, Any],
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
-    ) -> list[str]:
+    ) -> _MlxSidecarStream:
         spec = {**spec, "outDir": str(work_dir)}
         spec_path = work_dir / "spec.json"
         spec_path.write_text(json.dumps(spec), encoding="utf-8")
@@ -3696,40 +3897,20 @@ class MlxZImageAdapter:
             image_batch_progress(0, total),
             f"Running {label} ({total} image(s)).",
         )
-        with stdout_log.open("w", encoding="utf-8") as out:
-            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
-            # leaves a partial traceback we can surface; result.json stays the
-            # authoritative success channel (_read_result prefers it).
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
-            while True:
-                try:
-                    proc.wait(timeout=2)
-                    break
-                except subprocess.TimeoutExpired:
-                    if cancel_requested():
-                        proc.terminate()
-                        try:
-                            proc.wait(timeout=10)
-                        except subprocess.TimeoutExpired:
-                            proc.kill()
-                        raise InterruptedError("Image generation canceled by user.")
-        result = self._read_result(work_dir, stdout_log)
-        if proc.returncode != 0 or "error" in result:
-            error = result.get("error") or f"MLX Z-Image sidecar exited with code {proc.returncode}."
-            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
-            emit_worker_event(
-                "mlx_z_image_sidecar_failed",
-                jobId=job_id,
-                adapter=self.id,
-                error=error,
-                returnCode=proc.returncode,
-            )
-            raise RuntimeError(f"MLX Z-Image generation failed in the sidecar venv: {error}")
-        images = [str(path) for path in result.get("images", [])]
-        if len(images) != total:
-            raise RuntimeError(f"MLX Z-Image sidecar produced {len(images)} image(s); expected {total}.")
-        emit_worker_event("mlx_z_image_sidecar_complete", jobId=job_id, adapter=self.id, imageCount=len(images))
-        return images
+        # Stream images as the sidecar writes them (sc-2412); see MlxFluxAdapter.
+        return _MlxSidecarStream(
+            cmd=cmd,
+            job_id=job_id,
+            adapter_id=self.id,
+            work_dir=work_dir,
+            stdout_log=stdout_log,
+            total=total,
+            cancel_requested=cancel_requested,
+            read_result=self._read_result,
+            complete_event="mlx_z_image_sidecar_complete",
+            failed_event="mlx_z_image_sidecar_failed",
+            fail_label="MLX Z-Image",
+        ).start()
 
     @staticmethod
     def _read_result(work_dir: Path, stdout_log: Path) -> dict[str, Any]:
@@ -4261,8 +4442,9 @@ class MlxFlux2Adapter:
                 # Order [skeleton, reference] mirrors the sc-2003 spike's validated
                 # FLUX.2 multi-image config (image_paths=[skeleton, character]).
                 image_paths_per_iter.append([str(skeleton_path), reference_paths[0]])
+        stream: _MlxSidecarStream | None = None
         try:
-            images = self._run_sidecar(
+            stream = self._run_sidecar(
                 job_id=job["id"],
                 work_dir=work_dir,
                 label=model_target["label"],
@@ -4303,10 +4485,13 @@ class MlxFlux2Adapter:
                     image_batch_progress(index, total),
                     format_batch_running_message(model_target["label"], index, total),
                 )
-                with Image.open(images[index]) as handle:
+                # Blocks only until image `index` lands (sc-2412) so the writer
+                # streams each asset as the sidecar produces it, instead of all
+                # appearing at once when the process exits.
+                with Image.open(stream.wait_for_image(index)) as handle:
                     return handle.convert("RGB")
 
-            return ImageAssetWriter().write_incremental_outputs(
+            outputs = ImageAssetWriter().write_incremental_outputs(
                 request=request,
                 project_path=project_path,
                 image_count=total,
@@ -4330,7 +4515,11 @@ class MlxFlux2Adapter:
                 settings=settings,
                 job_id=job["id"],
             )
+            stream.finish()
+            return outputs
         finally:
+            if stream is not None:
+                stream.shutdown()
             self.discard_temp_outputs(job["id"])
 
     def _num_inference_steps(self, request: ImageRequest, model_target: dict[str, Any]) -> int:
@@ -4384,7 +4573,7 @@ class MlxFlux2Adapter:
         spec: dict[str, Any],
         progress: ProgressCallback,
         cancel_requested: CancelCallback,
-    ) -> list[str]:
+    ) -> _MlxSidecarStream:
         spec = {**spec, "outDir": str(work_dir)}
         spec_path = work_dir / "spec.json"
         spec_path.write_text(json.dumps(spec), encoding="utf-8")
@@ -4406,40 +4595,21 @@ class MlxFlux2Adapter:
             image_batch_progress(0, total),
             f"Running {label} ({total} image(s)).",
         )
-        with stdout_log.open("w", encoding="utf-8") as out:
-            # stderr merged into stdout.log so a native crash (SIGABRT/SIGSEGV)
-            # leaves a partial traceback we can surface; result.json stays the
-            # authoritative success channel (_read_result prefers it).
-            proc = subprocess.Popen(cmd, env=os.environ.copy(), stdout=out, stderr=subprocess.STDOUT)
-            while True:
-                try:
-                    proc.wait(timeout=2)
-                    break
-                except subprocess.TimeoutExpired:
-                    if cancel_requested():
-                        proc.terminate()
-                        try:
-                            proc.wait(timeout=10)
-                        except subprocess.TimeoutExpired:
-                            proc.kill()
-                        raise InterruptedError("Image generation canceled by user.")
-        result = MlxFluxAdapter._read_result(work_dir, stdout_log)
-        if proc.returncode != 0 or "error" in result:
-            error = result.get("error") or f"MLX FLUX.2 sidecar exited with code {proc.returncode}."
-            error = _mlx_sidecar_failure_detail(error, proc.returncode, stdout_log)
-            emit_worker_event(
-                "mlx_flux2_sidecar_failed",
-                jobId=job_id,
-                adapter=self.id,
-                error=error,
-                returnCode=proc.returncode,
-            )
-            raise RuntimeError(f"MLX FLUX.2 generation failed in the sidecar venv: {error}")
-        images = [str(path) for path in result.get("images", [])]
-        if len(images) != total:
-            raise RuntimeError(f"MLX FLUX.2 sidecar produced {len(images)} image(s); expected {total}.")
-        emit_worker_event("mlx_flux2_sidecar_complete", jobId=job_id, adapter=self.id, imageCount=len(images))
-        return images
+        # Stream images as the sidecar writes them (sc-2412); see MlxFluxAdapter.
+        # FLUX.2 shares MlxFluxAdapter's result reader.
+        return _MlxSidecarStream(
+            cmd=cmd,
+            job_id=job_id,
+            adapter_id=self.id,
+            work_dir=work_dir,
+            stdout_log=stdout_log,
+            total=total,
+            cancel_requested=cancel_requested,
+            read_result=MlxFluxAdapter._read_result,
+            complete_event="mlx_flux2_sidecar_complete",
+            failed_event="mlx_flux2_sidecar_failed",
+            fail_label="MLX FLUX.2",
+        ).start()
 
 
 class KolorsDiffusersAdapter:

--- a/apps/worker/scene_worker/mlx_flux_runner.py
+++ b/apps/worker/scene_worker/mlx_flux_runner.py
@@ -18,8 +18,14 @@ template). Adding a new mflux family is a one-arm extension to
 Contract: argv[1] is a path to a JSON spec; the runner writes one PNG per seed
 into spec["outDir"] and prints a single result JSON object to stdout:
     {"images": ["<outDir>/mlx_<family>_0000.png", ...]}
-Progress and diagnostics go to stderr (captured into the worker log). A non-zero
-exit code with an "error" JSON on stdout signals failure to the adapter.
+Additionally, as each PNG is written the runner prints a per-image stream marker
+on its own stdout line (sc-2412) so the adapter can surface images one-by-one
+instead of all at job end:
+    {"event": "image", "index": 0, "path": "<outDir>/mlx_<family>_0000.png"}
+These markers are advisory — result.json / the final {"images": [...]} line stay
+the authoritative success channel, and the adapter degrades to that ordered list
+if markers are missing. Progress and diagnostics go to stderr (captured into the
+worker log). A non-zero exit code with an "error" JSON on stdout signals failure.
 
 Spec keys:
     model: e.g. "flux_schnell" | "flux_dev" | "qwen_image" | "flux2_klein_9b"
@@ -66,6 +72,21 @@ from pathlib import Path
 def _log(message: str) -> None:
     sys.stderr.write(f"[mlx_flux_runner] {message}\n")
     sys.stderr.flush()
+
+
+def _emit_image(index: int, path: Path) -> None:
+    """Per-image stream marker on stdout (sc-2412).
+
+    The orchestrating adapter (`scene_worker.image_adapters`) tails the sidecar's
+    stdout and parses these markers so each finished image streams into the UI
+    immediately, instead of all appearing at once when the process exits. This is
+    advisory only: ``result.json`` (and the final ``{"images": [...]}`` line) stay
+    the authoritative success channel, and the adapter degrades to that ordered
+    list when markers are absent. One JSON object per line, flushed so the parent
+    sees it the instant the PNG is written.
+    """
+    sys.stdout.write(json.dumps({"event": "image", "index": int(index), "path": str(path)}) + "\n")
+    sys.stdout.flush()
 
 
 def _resolve_model_handle(model_id: str, has_reference: bool) -> tuple[type, object, str, str]:  # noqa: C901
@@ -252,6 +273,7 @@ def _run_z_image_control(
         path = out_dir / f"mlx_z_image_control_{index:04d}.png"
         result.image.save(path, "PNG")
         images.append(str(path))
+        _emit_image(index, path)
         _log(f"generated control image {index + 1}/{len(seeds)} -> {path}")
 
     payload = {"images": images}
@@ -403,6 +425,7 @@ def main() -> int:
         path = out_dir / f"{filename_prefix}_{index:04d}.png"
         result.image.save(path, "PNG")
         images.append(str(path))
+        _emit_image(index, path)
         _log(f"generated image {index + 1}/{len(seeds)} -> {path}")
 
     payload = {"images": images}

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1001,6 +1001,11 @@
           { "id": "down_right", "label": "Down · right" },
           { "id": "front", "label": "Front" }
         ],
+        // Best-effort pose library: same multi-image skeleton trick as the base
+        // 9B (sc-2262), routed through the shared mlx_flux2 adapter. Because the
+        // pose path is an edit-with-reference, the KV cache engages, so pose
+        // generation runs faster than the base 9B path. Best-effort tier.
+        "poseLibrary": true,
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",
@@ -1092,6 +1097,11 @@
           { "id": "down_right", "label": "Down · right" },
           { "id": "front", "label": "Front" }
         ],
+        // Best-effort pose library: same multi-image skeleton trick as the base
+        // 9B (sc-2262), routed through the shared mlx_flux2 adapter. This is the
+        // undistilled 24-step line, so pose generation is slower than the distill
+        // and requires the local conversion + base klein install. Best-effort tier.
+        "poseLibrary": true,
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",

--- a/tests/test_mlx_sidecar_stream.py
+++ b/tests/test_mlx_sidecar_stream.py
@@ -1,0 +1,212 @@
+"""Streaming behaviour of the shared MLX sidecar controller (sc-2412).
+
+``_MlxSidecarStream`` is what makes the mflux families (FLUX.1 / FLUX.2 / Qwen /
+Z-Image) surface each image as it's produced instead of all at once when the
+sidecar exits. These tests drive the real controller against a tiny stand-in
+``runner`` script (plain ``sys.executable`` — no mflux / MLX needed) so the
+streaming, fallback, failure, and cancel paths are exercised end-to-end through
+a real subprocess + the reader thread, not mocks.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from scene_worker import image_adapters as ia
+
+
+def _spec(work: Path, n: int) -> Path:
+    spec_path = work / "spec.json"
+    spec_path.write_text(
+        json.dumps({"outDir": str(work), "seeds": list(range(1, n + 1)), "model": "flux_schnell"}),
+        encoding="utf-8",
+    )
+    return spec_path
+
+
+def _stream(work: Path, runner: Path, total: int, *, cancel=lambda: False) -> ia._MlxSidecarStream:
+    return ia._MlxSidecarStream(
+        cmd=[sys.executable, str(runner), str(work / "spec.json")],
+        job_id="job_stream",
+        adapter_id="mlx_flux",
+        work_dir=work,
+        stdout_log=work / "stdout.log",
+        total=total,
+        cancel_requested=cancel,
+        read_result=ia.MlxFluxAdapter._read_result,
+        complete_event="mlx_flux_sidecar_complete",
+        failed_event="mlx_flux_sidecar_failed",
+        fail_label="MLX FLUX",
+    ).start()
+
+
+def test_stream_surfaces_each_image_before_the_process_exits(tmp_path):
+    """The crux of sc-2412: image 0 must be returned by wait_for_image WHILE the
+    sidecar is still running (gated on later images), proving per-image streaming
+    rather than the old all-at-once-at-exit behaviour."""
+    runner = tmp_path / "runner_stream.py"
+    runner.write_text(
+        textwrap.dedent(
+            """
+            import json, sys, time
+            from pathlib import Path
+
+            spec = json.loads(Path(sys.argv[1]).read_text())
+            out = Path(spec["outDir"])
+            images = []
+            for i in range(len(spec["seeds"])):
+                p = out / f"img_{i:04d}.png"
+                p.write_bytes(b"placeholder")
+                images.append(str(p))
+                print(json.dumps({"event": "image", "index": i, "path": str(p)}), flush=True)
+                # Block until the test releases this image, so it can observe that
+                # earlier images are already consumable while the run continues.
+                gate = out / f"gate_{i}"
+                while not gate.exists():
+                    time.sleep(0.01)
+            (out / "result.json").write_text(json.dumps({"images": images}))
+            print(json.dumps({"images": images}), flush=True)
+            """
+        ),
+        encoding="utf-8",
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    _spec(work, 3)
+
+    # Safety net: if anything hangs, cancel after 30s so the test fails instead of
+    # blocking CI forever.
+    start = time.monotonic()
+    stream = _stream(work, runner, 3, cancel=lambda: time.monotonic() - start > 30)
+    try:
+        first = stream.wait_for_image(0)
+        assert first.endswith("img_0000.png")
+        # Still running (gated on gate_0) — image 0 surfaced mid-flight.
+        assert stream._proc.poll() is None
+
+        (work / "gate_0").touch()
+        assert stream.wait_for_image(1).endswith("img_0001.png")
+        (work / "gate_1").touch()
+        assert stream.wait_for_image(2).endswith("img_0002.png")
+        (work / "gate_2").touch()
+
+        stream.finish()  # validates count + clean exit
+    finally:
+        stream.shutdown()
+
+
+def test_stream_falls_back_to_result_json_without_markers(tmp_path):
+    """Graceful degradation: a runner that emits no per-image markers still works
+    — wait_for_image falls back to the authoritative result.json ordering once the
+    process exits (i.e. the old all-at-once behaviour). Correctness never depends
+    on the markers."""
+    runner = tmp_path / "runner_silent.py"
+    runner.write_text(
+        textwrap.dedent(
+            """
+            import json, sys
+            from pathlib import Path
+
+            spec = json.loads(Path(sys.argv[1]).read_text())
+            out = Path(spec["outDir"])
+            images = []
+            for i in range(len(spec["seeds"])):
+                p = out / f"img_{i:04d}.png"
+                p.write_bytes(b"placeholder")
+                images.append(str(p))
+            (out / "result.json").write_text(json.dumps({"images": images}))
+            print(json.dumps({"images": images}), flush=True)
+            """
+        ),
+        encoding="utf-8",
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    _spec(work, 3)
+
+    stream = _stream(work, runner, 3)
+    try:
+        assert stream.wait_for_image(0).endswith("img_0000.png")
+        assert stream.wait_for_image(2).endswith("img_0002.png")
+        stream.finish()
+    finally:
+        stream.shutdown()
+
+
+def test_stream_surfaces_sidecar_failure(tmp_path):
+    """A non-zero exit with an error result must raise the same enriched error the
+    old blocking _run_sidecar raised."""
+    runner = tmp_path / "runner_fail.py"
+    runner.write_text(
+        textwrap.dedent(
+            """
+            import json, sys
+            from pathlib import Path
+
+            spec = json.loads(Path(sys.argv[1]).read_text())
+            out = Path(spec["outDir"])
+            (out / "result.json").write_text(json.dumps({"error": "boom"}))
+            print(json.dumps({"error": "boom"}), flush=True)
+            sys.exit(1)
+            """
+        ),
+        encoding="utf-8",
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    _spec(work, 2)
+
+    stream = _stream(work, runner, 2)
+    try:
+        with pytest.raises(RuntimeError, match="MLX FLUX generation failed"):
+            stream.wait_for_image(0)
+    finally:
+        stream.shutdown()
+
+
+def test_runner_emit_image_marker_shape(capsys):
+    """Lock the producer side of the contract: mlx_flux_runner._emit_image must
+    print exactly the marker shape _MlxSidecarStream parses. (Importing the runner
+    is safe — it only pulls json/sys/pathlib at module scope; mflux is lazy.)"""
+    from scene_worker import mlx_flux_runner as runner
+
+    runner._emit_image(2, Path("/work/img_0002.png"))
+    out = capsys.readouterr().out.strip()
+    assert json.loads(out) == {"event": "image", "index": 2, "path": "/work/img_0002.png"}
+
+
+def test_stream_cancel_raises_and_terminates(tmp_path):
+    """Cancellation while waiting raises InterruptedError and kills the sidecar."""
+    runner = tmp_path / "runner_sleep.py"
+    runner.write_text(
+        textwrap.dedent(
+            """
+            import time
+            # Never produces an image; just hangs until terminated.
+            while True:
+                time.sleep(0.05)
+            """
+        ),
+        encoding="utf-8",
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    _spec(work, 1)
+
+    cancelled = {"flag": False}
+    stream = _stream(work, runner, 1, cancel=lambda: cancelled["flag"])
+    timer = threading.Timer(0.3, lambda: cancelled.__setitem__("flag", True))
+    timer.start()
+    try:
+        with pytest.raises(InterruptedError):
+            stream.wait_for_image(0)
+        assert stream._proc.poll() is not None  # terminated
+    finally:
+        timer.cancel()
+        stream.shutdown()

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2995,7 +2995,21 @@ def test_mlx_flux2_pose_set_builds_per_iteration_skeleton_specs(tmp_path, monkey
 
     def fake_run_sidecar(self, *, job_id, work_dir, label, total, spec, progress, cancel_requested):
         captured["spec"] = spec
-        return [str(work_dir / f"out_{i}.png") for i in range(total)]
+
+        # _run_sidecar now returns a streaming controller (sc-2412) rather than a
+        # list; these spec-building tests also stub write_incremental_outputs, so
+        # wait_for_image is never called — finish()/shutdown() just no-op.
+        class _Stream:
+            def wait_for_image(self, index):
+                return str(work_dir / f"out_{index}.png")
+
+            def finish(self):
+                pass
+
+            def shutdown(self):
+                pass
+
+        return _Stream()
 
     monkeypatch.setattr(ia.MlxFlux2Adapter, "_run_sidecar", fake_run_sidecar)
 
@@ -3066,7 +3080,21 @@ def test_mlx_z_image_pose_set_builds_control_skeleton_specs(tmp_path, monkeypatc
 
     def fake_run_sidecar(self, *, job_id, work_dir, label, total, spec, progress, cancel_requested):
         captured["spec"] = spec
-        return [str(work_dir / f"out_{i}.png") for i in range(total)]
+
+        # _run_sidecar now returns a streaming controller (sc-2412) rather than a
+        # list; these spec-building tests also stub write_incremental_outputs, so
+        # wait_for_image is never called — finish()/shutdown() just no-op.
+        class _Stream:
+            def wait_for_image(self, index):
+                return str(work_dir / f"out_{index}.png")
+
+            def finish(self):
+                pass
+
+            def shutdown(self):
+                pass
+
+        return _Stream()
 
     monkeypatch.setattr(ia.MlxZImageAdapter, "_run_sidecar", fake_run_sidecar)
 
@@ -3140,7 +3168,21 @@ def test_mlx_z_image_pose_set_reference_identity_init_is_opt_in(tmp_path, monkey
 
     def fake_run_sidecar(self, *, job_id, work_dir, label, total, spec, progress, cancel_requested):
         captured["spec"] = spec
-        return [str(work_dir / f"out_{i}.png") for i in range(total)]
+
+        # _run_sidecar now returns a streaming controller (sc-2412) rather than a
+        # list; these spec-building tests also stub write_incremental_outputs, so
+        # wait_for_image is never called — finish()/shutdown() just no-op.
+        class _Stream:
+            def wait_for_image(self, index):
+                return str(work_dir / f"out_{index}.png")
+
+            def finish(self):
+                pass
+
+            def shutdown(self):
+                pass
+
+        return _Stream()
 
     monkeypatch.setattr(ia.MlxZImageAdapter, "_run_sidecar", fake_run_sidecar)
     monkeypatch.setattr(

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -11219,6 +11219,10 @@ def test_best_effort_backbones_declare_pose_library_capability():
     for model_id, story in (
         ("qwen_image_edit_2511_lightning", "sc-2256"),
         ("flux2_klein_9b", "sc-2262"),
+        # The other two klein variants share the same mlx_flux2 best-effort pose
+        # path, so they're offered in the picker for output comparison too.
+        ("flux2_klein_9b_kv", "sc-2262"),
+        ("flux2_klein_9b_true_v2", "sc-2262"),
     ):
         entry = manifest_by_id.get(model_id, {})
         assert entry.get("ui", {}).get("poseLibrary") is True, (


### PR DESCRIPTION
This PR contains two related Character-Studio / MLX changes.

---

## 1. Offer all FLUX.2 [klein] variants in the pose picker

The Pose generator only showed a single \"FLUX.2 [klein] 9B\" even when the `9B-KV` and `9B True V2` variants were installed, because the picker filters image models by `ui.poseLibrary` and only the base `flux2_klein_9b` declared it. This adds `ui.poseLibrary: true` to `flux2_klein_9b_kv` and `flux2_klein_9b_true_v2` so any installed variant can be selected for output comparison.

- Pure manifest opt-in — the frontend already renders a model `<select>` when >1 pose backbone is available, and `MlxFlux2Adapter` already supports all three variants on the same best-effort skeleton+reference pose path. Frozen mflux fork (epic 2337) untouched.
- Extends `test_best_effort_backbones_declare_pose_library_capability` to cover both new ids.

Caveats: pose output on the variants isn't hardware-validated (only base 9B was, sc-2003); True-V2 needs its install-time conversion before it can run.

---

## 2. Stream MLX sidecar images incrementally (sc-2412)

The four mflux families (FLUX.1, FLUX.2-klein, Qwen-MLX, Z-Image-MLX) ran generation out-of-process and blocked until the sidecar exited, then returned ALL images at once — so multi-image batches (angle/pose sets, batch counts) appeared in the UI in one burst at job end, unlike the in-process torch adapters which stream each image as it finishes.

**Fix:**
- **Runner** (`mlx_flux_runner.py`): emits a flushed per-image stdout marker `{\"event\":\"image\",\"index\":i,\"path\":...}` after each PNG save (both generation loops). `result.json` stays authoritative.
- **Controller** (`_MlxSidecarStream` in `image_adapters.py`): runs the sidecar with `stdout=PIPE` + a daemon reader thread that mirrors output to `stdout.log` (preserves native-crash tracebacks) and parses markers. `wait_for_image(i)` blocks only until image `i` lands; **falls back to `result.json` ordering when markers are absent** (graceful degradation = old behavior). `finish()` validates clean-exit + count + emits the completion event (cancel-polling preserved); `shutdown()` is an idempotent, never-raises cleanup.
- **4 adapters**: their near-identical blocking `_run_sidecar` bodies now delegate to the shared controller; each `generate()` wires `image_at_index(i)` → `stream.wait_for_image(i)`, so the unchanged pull-based `ImageAssetWriter.write_incremental_outputs` now streams each asset. SDXL-MLX (in-process, already streams) and the Lens sidecar (different runner) are untouched. Adapter/runner glue, not the frozen mflux fork — not blocked by epic 2337.

**Tests:** the 3 `fake_run_sidecar` monkeypatches now return a stream stub; new `tests/test_mlx_sidecar_stream.py` drives the *real* controller against a stand-in runner subprocess and proves image 0 surfaces while the process is still running (true streaming), plus no-marker fallback, sidecar-failure surfacing, cancellation, and the marker contract.

**Verification:** full worker suite on a CI-matching env (Py 3.12 + pytest 9.0.2/httpx/pillow/numpy) — `510 passed, 9 skipped`. Still owed: real-Mac E2E with a live mflux sidecar to visually confirm UI streaming (CI proves the protocol/parsing against a stand-in runner, not real MLX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)