### PR TITLE
Hide upscaled duplicates from Image Studio Recent Batches

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -26,7 +26,7 @@ import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
 import { AppContext } from "./context/AppContext.js";
-import { findFoldedAssetById, foldUpscaledAssetVariants } from "./assetVariants.js";
+import { dropUpscaledVariants, findFoldedAssetById, foldUpscaledAssetVariants } from "./assetVariants.js";
 import { buildWorkersById } from "./workers.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
@@ -590,9 +590,9 @@ export function App() {
   // set) as the studio "what just came out" list. Sorted newest-first.
   const recentImageAssets = useMemo(
     () =>
-      assets
-        .filter((asset) => asset.type === "image" && (!activeProject?.id || asset.projectId === activeProject.id))
-        .slice()
+      dropUpscaledVariants(
+        assets.filter((asset) => asset.type === "image" && (!activeProject?.id || asset.projectId === activeProject.id)),
+      )
         .sort(sortNewest)
         .slice(0, 20),
     [assets, activeProject?.id],

--- a/apps/web/src/assetVariants.js
+++ b/apps/web/src/assetVariants.js
@@ -42,6 +42,21 @@ export function foldUpscaledAssetVariants(assets = []) {
     });
 }
 
+// The studios' "Recent Assets" / Recent Batches list shows freshly generated
+// assets. An upscale shares its generation with the original image, so listing
+// both makes every generation look duplicated. Drop the upscaled variant when its
+// original is present and keep the original as the visible tile — the fullscreen
+// preview still exposes the upscaled image via foldUpscaledAssetVariants and the
+// Original/Upscaled toggle. (An upscale whose original is gone stays, so it never
+// vanishes entirely.)
+export function dropUpscaledVariants(assets = []) {
+  const presentIds = new Set(assets.map((asset) => asset.id));
+  return assets.filter((asset) => {
+    const originalId = upscaledFromAssetId(asset);
+    return !(originalId && presentIds.has(originalId));
+  });
+}
+
 export function findFoldedAssetById(foldedAssets, assetId) {
   return foldedAssets.find(
     (asset) =>

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5,7 +5,7 @@ import { App, ErrorBoundary, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
 import { AssetDetail, FullscreenPreview } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
-import { foldUpscaledAssetVariants } from "./assetVariants.js";
+import { dropUpscaledVariants, foldUpscaledAssetVariants } from "./assetVariants.js";
 import { extractFamilies } from "./presetUtils.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { CharacterAssets, CharacterDatasets } from "./screens/characterPanels.jsx";
@@ -8298,6 +8298,28 @@ describe("SceneWorks app shell", () => {
         },
       }),
     );
+  });
+
+  it("drops upscaled variants from Recent Batches so a generation is not shown twice", () => {
+    const original = { id: "asset-original", type: "image" };
+    const upscaled = {
+      id: "asset-upscaled",
+      type: "image",
+      extra: { isUpscaled: true, upscaledFromAssetId: "asset-original" },
+    };
+    const other = { id: "asset-other", type: "image" };
+
+    // Original present -> keep the original tile, hide its upscaled duplicate.
+    expect(dropUpscaledVariants([original, upscaled, other]).map((asset) => asset.id)).toEqual([
+      "asset-original",
+      "asset-other",
+    ]);
+
+    // Original gone (e.g. purged) -> the upscale stays so it doesn't vanish entirely.
+    expect(dropUpscaledVariants([upscaled, other]).map((asset) => asset.id)).toEqual([
+      "asset-upscaled",
+      "asset-other",
+    ]);
   });
 
   it("shows discarded assets in Trashcan and exposes restore and purge actions", async () => {


### PR DESCRIPTION
## What

Image Studio's **Recent Batches** grid was showing both the original and the upscaled image as separate cards after an upscale, making every generation look duplicated. It now shows a single card per generation — the original image. The fullscreen lightbox still surfaces the upscaled image where it matters.

## Why

`recentImageAssets` in `App.jsx` listed every image asset for the project raw. An upscale is persisted as its own asset linked to its source via `extra.upscaledFromAssetId`, so the original and its upscale both rendered as tiles.

## How

- New pure helper `dropUpscaledVariants` in `apps/web/src/assetVariants.js`: drops the upscaled variant when its original is present (keeping the original tile), and keeps the upscale only when its original is gone (e.g. purged) so nothing vanishes entirely.
- Wired into `recentImageAssets` (`apps/web/src/App.jsx`).

## Lightbox / Library unaffected

Clicking the original still resolves through the existing `foldUpscaledAssetVariants` preview fold (matched via `variants.original.id`), so the fullscreen viewer shows the upscaled image with the Original/Upscaled toggle. The Asset Library fold (which intentionally keeps the upscaled tile) is untouched.

## Tests

- Added a unit test covering both cases: original present → drop the upscale; original gone → keep the upscale.
- Full web suite green: **277 tests passed** across 13 files, including the existing FullscreenPreview toggle test and the Library fold test.

Not exercised in a live browser preview — it only manifests after a real GPU-backed upscale, which the dev server can't produce here. The behavior is deterministic on the asset data shape, which the tests cover directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)