### PR TITLE
feat(studios): "Save as Preset" in Image & Video studios (epic 2418)

### DIFF
--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -753,7 +753,57 @@ pub(crate) fn validate_recipe_preset_defaults(value: Option<&Value>) -> Result<(
             ));
         }
     }
+    // Studio "Save as Preset" snapshots carry generation knobs in defaults. Each
+    // is range-checked only when present and numeric; non-numeric values are left
+    // to forward-compat (never panics), and non-finite or out-of-range values are
+    // rejected so a malformed payload can't be persisted.
+    if let Some(steps) = recipe_preset_default_number(object, "steps") {
+        if steps.fract() != 0.0 || !(1.0..=200.0).contains(&steps) {
+            return Err(ApiError::bad_request(
+                "Recipe preset steps must be a whole number between 1 and 200",
+            ));
+        }
+    }
+    for (key, min, max) in RECIPE_PRESET_DEFAULT_RANGES {
+        if let Some(number) = recipe_preset_default_number(object, key) {
+            if number < *min || number > *max {
+                return Err(ApiError::bad_request(format!(
+                    "Recipe preset {key} must be between {min} and {max}"
+                )));
+            }
+        }
+    }
     Ok(())
+}
+
+// Numeric generation knobs a studio snapshot may store in `defaults`, with the
+// inclusive range each must fall in. Ranges are deliberately generous so valid
+// model-specific values are never rejected — they only catch clearly bad input.
+const RECIPE_PRESET_DEFAULT_RANGES: &[(&str, f64, f64)] = &[
+    ("guidanceScale", 0.0, 60.0),
+    ("schedulerShift", 0.0, 20.0),
+    ("trueCfgScale", 0.0, 30.0),
+    ("ipAdapterScale", 0.0, 2.0),
+    ("controlnetScale", 0.0, 4.0),
+    ("upscaleFactor", 1.0, 8.0),
+    ("duration", 1.0, 120.0),
+    ("fps", 1.0, 240.0),
+    ("videoCfgGuidanceScale", 0.0, 60.0),
+    ("videoStgGuidanceScale", 0.0, 60.0),
+    ("videoRescaleScale", 0.0, 10.0),
+];
+
+// Read a defaults knob as a finite f64 whether stored as a JSON number or a
+// numeric string (older studio snapshots stringified text inputs). Returns None
+// for absent, non-numeric, or non-finite values so callers simply skip them.
+fn recipe_preset_default_number(object: &JsonObject, key: &str) -> Option<f64> {
+    let value = object.get(key)?;
+    let number = value.as_f64().or_else(|| {
+        value
+            .as_str()
+            .and_then(|text| text.trim().parse::<f64>().ok())
+    })?;
+    number.is_finite().then_some(number)
 }
 
 pub(crate) fn validate_recipe_preset_model_workflow(

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5165,6 +5165,167 @@ async fn recipe_preset_crud_routes_persist_global_and_project_presets() {
 }
 
 #[tokio::test]
+async fn recipe_preset_accepts_full_studio_snapshot_and_rejects_bad_defaults() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [
+                {
+                  "id": "z_image_turbo",
+                  "name": "Z Image Turbo",
+                  "family": "z-image",
+                  "type": "image",
+                  "adapter": "z_image_diffusers",
+                  "capabilities": ["text_to_image"],
+                  "downloads": [],
+                  "paths": {},
+                  "defaults": {},
+                  "limits": {},
+                  "loraCompatibility": {},
+                  "ui": {}
+                }
+              ]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "loras": [
+                {
+                  "id": "style_lora",
+                  "name": "Style LoRA",
+                  "family": "z-image",
+                  "triggerWords": [],
+                  "compatibility": { "families": ["z-image"] },
+                  "source": { "provider": "local", "path": "loras/style.safetensors" }
+                }
+              ]
+            }
+            "#,
+    )
+    .expect("user loras writes");
+    let lora_dir = temp_dir.path().join("data/loras");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    write_test_safetensors(&lora_dir.join("style.safetensors"));
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // A full studio snapshot: literal prompt + cfg/steps/sampler + a weighted LoRA.
+    let (status, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({
+            "name": "Atrium Look",
+            "model": "z_image_turbo",
+            "workflow": "text_to_image",
+            "modes": ["text_to_image", "character_image", "style_variations"],
+            "defaults": {
+                "prompt": "a portrait in the atrium",
+                "negativePrompt": "blurry",
+                "resolution": "1024x1024",
+                "count": 4,
+                "mode": "character_image",
+                "guidanceScale": 5.0,
+                "steps": 28,
+                "sampler": "default",
+                "ipAdapterScale": 0.8
+            },
+            "loras": [{ "id": "style_lora", "weight": 0.65 }]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["id"], "atrium_look");
+    // The flatten-extra defaults round-trip intact through persistence.
+    assert_eq!(created["defaults"]["prompt"], "a portrait in the atrium");
+    assert_eq!(created["defaults"]["guidanceScale"], 5.0);
+    assert_eq!(created["defaults"]["steps"], 28);
+    assert_eq!(created["defaults"]["sampler"], "default");
+    assert_eq!(created["defaults"]["mode"], "character_image");
+    assert_eq!(created["builtInLoras"][0]["id"], "style_lora");
+    assert_eq!(created["builtInLoras"][0]["weight"], 0.65);
+
+    // Re-reading the catalog returns the persisted snapshot.
+    let (status, listed) = request(app.clone(), "GET", "/api/v1/recipe-presets", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    let saved = listed
+        .as_array()
+        .expect("presets array")
+        .iter()
+        .find(|preset| preset["id"] == "atrium_look")
+        .expect("saved preset listed");
+    assert_eq!(saved["defaults"]["prompt"], "a portrait in the atrium");
+    assert_eq!(saved["defaults"]["steps"], 28);
+
+    // An out-of-range guidance scale is rejected.
+    let (status, error) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({
+            "name": "Too Hot",
+            "model": "z_image_turbo",
+            "workflow": "text_to_image",
+            "defaults": { "guidanceScale": 999.0 }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        error["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("guidanceScale"),
+        "unexpected error: {error}"
+    );
+
+    // A non-integer steps value is rejected.
+    let (status, _error) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({
+            "name": "Bad Steps",
+            "model": "z_image_turbo",
+            "workflow": "text_to_image",
+            "defaults": { "steps": 3.5 }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn empty_builtin_preset_and_lora_manifests_ship_empty_catalogs() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -274,3 +274,102 @@ export function presetValidationMessage(validation) {
   }
   return `Save blocked: ${parts.join("; ")}. Wait for imports to finish, remove incompatible LoRAs, or choose a matching model.`;
 }
+
+// ── Studio "Save as Preset" round-trip helpers ───────────────────────────────
+// The Image/Video studios snapshot their current working state into a recipe
+// preset and restore it on apply. These helpers keep that round-trip in one
+// tested place so both studios stay thin.
+
+// Slugify a preset name into a valid recipe-preset id (lowercase letters,
+// digits, dash, underscore). Mirrors the backend's slugify_preset_id so the id
+// the client previews matches what the server stores.
+export function slugifyPresetId(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "_")
+    .replace(/^[_-]+|[_-]+$/g, "");
+}
+
+// Map an active studio mode to the recipe workflow it persists under. Inverts
+// defaultModesByWorkflow, so character_image / style_variations both fold into
+// text_to_image (the only workflow whose modes include them).
+export function workflowForMode(mode) {
+  for (const [workflow, modes] of Object.entries(defaultModesByWorkflow)) {
+    if (modes.includes(mode)) {
+      return workflow;
+    }
+  }
+  return mode;
+}
+
+// True when `name` collides with an existing preset by case-insensitive name or
+// by slugged id — the two ways the backend rejects a duplicate. Powers a friendly
+// client-side check before POSTing.
+export function presetNameTaken(name, presets = []) {
+  const trimmed = String(name ?? "").trim().toLowerCase();
+  if (!trimmed) {
+    return false;
+  }
+  const id = slugifyPresetId(name);
+  return presets.some((preset) => {
+    const presetName = String(preset?.name ?? "").trim().toLowerCase();
+    return presetName === trimmed || (Boolean(id) && preset?.id === id);
+  });
+}
+
+// Coerce a possibly-stringy numeric input ("30", 4.5) to a finite number, or
+// undefined when blank or non-numeric — so cleanPresetDefaults drops it and the
+// stored default stays a real number the backend can range-check.
+export function finiteNumberOrUndefined(value) {
+  if (value === "" || value === null || value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+// Drop keys whose value is null, undefined, or an empty string (the studios'
+// "use the model default" sentinel). Numbers (including 0) and booleans survive
+// so 0-valued knobs and `false` toggles round-trip intact.
+export function cleanPresetDefaults(defaults = {}) {
+  const cleaned = {};
+  for (const [key, value] of Object.entries(defaults)) {
+    if (value === null || value === undefined || value === "") {
+      continue;
+    }
+    cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+// Build the createPreset payload from a studio's current state. `defaults` is the
+// raw snapshot of visible knobs (including the literal `prompt`); callers must
+// never include the seed. Top-level model/workflow/loras carry the fields the
+// backend validates (model<->workflow capability, lora<->model compatibility).
+export function buildStudioPresetPayload({ name, scope = "project", mode, model, loras = [], defaults = {} }) {
+  const workflow = workflowForMode(mode);
+  return {
+    id: slugifyPresetId(name),
+    name: String(name ?? "").trim(),
+    scope,
+    workflow,
+    modes: workflowModes(workflow),
+    model,
+    loras: loras.map((lora) => ({
+      id: lora.id,
+      weight: Number.isFinite(Number(lora.weight)) ? Number(lora.weight) : loraWeight(lora),
+    })),
+    defaults: cleanPresetDefaults(defaults),
+  };
+}
+
+// Apply one preset-default value through the remember/restore snapshot machinery
+// so switching back to None (or another preset) restores the user's prior value.
+// Generalizes the inline pattern the studios already use for count/resolution.
+export function applyPresetDefault(snapshots, key, setter, value) {
+  setter((current) => {
+    rememberPresetDefault(snapshots, key, current, value);
+    return value;
+  });
+}

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { presetMatchesModel } from "./presetUtils.js";
+import {
+  applyPresetDefault,
+  buildStudioPresetPayload,
+  cleanPresetDefaults,
+  clearPresetDefault,
+  finiteNumberOrUndefined,
+  presetMatchesModel,
+  presetNameTaken,
+  slugifyPresetId,
+  workflowForMode,
+} from "./presetUtils.js";
 
 const ltx = { id: "ltx_2_3", family: "ltx-video" };
 const ltxEros = { id: "ltx_2_3_eros", family: "ltx-video" };
@@ -29,5 +39,167 @@ describe("presetMatchesModel", () => {
 
   it("stays strict (no family fallback) when the catalog is unavailable", () => {
     expect(presetMatchesModel({ model: "ltx_2_3" }, ltxEros)).toBe(false);
+  });
+});
+
+describe("workflowForMode", () => {
+  it("folds character and variation modes into text_to_image", () => {
+    expect(workflowForMode("text_to_image")).toBe("text_to_image");
+    expect(workflowForMode("character_image")).toBe("text_to_image");
+    expect(workflowForMode("style_variations")).toBe("text_to_image");
+  });
+
+  it("maps the single-mode workflows to themselves", () => {
+    expect(workflowForMode("edit_image")).toBe("edit_image");
+    expect(workflowForMode("image_to_video")).toBe("image_to_video");
+    expect(workflowForMode("text_to_video")).toBe("text_to_video");
+    expect(workflowForMode("first_last_frame")).toBe("first_last_frame");
+  });
+
+  it("returns an unknown mode unchanged", () => {
+    expect(workflowForMode("something_else")).toBe("something_else");
+  });
+});
+
+describe("slugifyPresetId", () => {
+  it("lowercases and replaces runs of invalid characters with a single underscore", () => {
+    expect(slugifyPresetId("Atrium Portraits!")).toBe("atrium_portraits");
+  });
+
+  it("trims leading and trailing separators so the id starts alphanumeric", () => {
+    expect(slugifyPresetId("  --Neon Noir--  ")).toBe("neon_noir");
+    expect(slugifyPresetId("neon-noir")).toBe("neon-noir");
+  });
+
+  it("returns empty string for non-sluggable input", () => {
+    expect(slugifyPresetId("日本語")).toBe("");
+    expect(slugifyPresetId("")).toBe("");
+  });
+});
+
+describe("presetNameTaken", () => {
+  const presets = [
+    { id: "atrium_portraits", name: "Atrium Portraits" },
+    { id: "neon-noir", name: "Neon Noir" },
+  ];
+
+  it("matches an existing name case-insensitively", () => {
+    expect(presetNameTaken("atrium portraits", presets)).toBe(true);
+  });
+
+  it("matches when a different name slugs to an existing id", () => {
+    expect(presetNameTaken("Atrium  Portraits!", presets)).toBe(true);
+  });
+
+  it("is false for a fresh name and for blank input", () => {
+    expect(presetNameTaken("Sunset Pier", presets)).toBe(false);
+    expect(presetNameTaken("   ", presets)).toBe(false);
+  });
+});
+
+describe("finiteNumberOrUndefined", () => {
+  it("coerces numeric strings and numbers", () => {
+    expect(finiteNumberOrUndefined("30")).toBe(30);
+    expect(finiteNumberOrUndefined("4.5")).toBe(4.5);
+    expect(finiteNumberOrUndefined(0)).toBe(0);
+  });
+
+  it("returns undefined for blank or non-numeric input", () => {
+    expect(finiteNumberOrUndefined("")).toBeUndefined();
+    expect(finiteNumberOrUndefined(null)).toBeUndefined();
+    expect(finiteNumberOrUndefined("abc")).toBeUndefined();
+    expect(finiteNumberOrUndefined(undefined)).toBeUndefined();
+  });
+});
+
+describe("cleanPresetDefaults", () => {
+  it("drops null/undefined/empty-string but keeps 0 and false", () => {
+    expect(
+      cleanPresetDefaults({ steps: 0, guidanceScale: "", sampler: null, upscaleEnabled: false, resolution: "1024x1024", motion: undefined }),
+    ).toEqual({ steps: 0, upscaleEnabled: false, resolution: "1024x1024" });
+  });
+});
+
+describe("buildStudioPresetPayload", () => {
+  it("snapshots a character-mode image config without the seed", () => {
+    const payload = buildStudioPresetPayload({
+      name: "Atrium Portraits!",
+      scope: "project",
+      mode: "character_image",
+      model: "instantid_sdxl",
+      loras: [{ id: "kelsie", weight: 0.75 }],
+      defaults: {
+        prompt: "a portrait in the atrium",
+        negativePrompt: "",
+        resolution: "1024x1024",
+        count: 4,
+        guidanceScale: 5,
+        steps: "",
+        sampler: "default",
+      },
+    });
+    expect(payload).toMatchObject({
+      id: "atrium_portraits",
+      name: "Atrium Portraits!",
+      scope: "project",
+      workflow: "text_to_image",
+      model: "instantid_sdxl",
+      loras: [{ id: "kelsie", weight: 0.75 }],
+    });
+    // modes carry every entry point the picker should surface the preset under.
+    expect(payload.modes).toContain("character_image");
+    // empty-string knobs are omitted; the literal prompt is preserved.
+    expect(payload.defaults).toEqual({
+      prompt: "a portrait in the atrium",
+      resolution: "1024x1024",
+      count: 4,
+      guidanceScale: 5,
+      sampler: "default",
+    });
+    expect(payload.defaults).not.toHaveProperty("seed");
+  });
+
+  it("coerces a non-finite lora weight to the lora's fallback", () => {
+    const payload = buildStudioPresetPayload({
+      name: "x",
+      mode: "text_to_video",
+      model: "ltx_2_3",
+      loras: [{ id: "wobble", weight: "not-a-number", defaultWeight: 0.6 }],
+      defaults: {},
+    });
+    expect(payload.workflow).toBe("text_to_video");
+    expect(payload.loras).toEqual([{ id: "wobble", weight: 0.6 }]);
+  });
+});
+
+describe("applyPresetDefault + clearPresetDefault round-trip", () => {
+  // Mirrors how the studios drive a state setter: the setter receives either a
+  // value or an updater, and the snapshots ref is what the studio keeps in useRef.
+  function makeSetter(initial) {
+    let value = initial;
+    return {
+      setter: (updater) => {
+        value = typeof updater === "function" ? updater(value) : updater;
+      },
+      get: () => value,
+    };
+  }
+
+  it("applies a preset value then restores the user's prior value on clear", () => {
+    const snapshots = { current: {} };
+    const box = makeSetter("user prompt");
+    applyPresetDefault(snapshots, "prompt", box.setter, "preset prompt");
+    expect(box.get()).toBe("preset prompt");
+    clearPresetDefault(box.setter, snapshots, "prompt");
+    expect(box.get()).toBe("user prompt");
+  });
+
+  it("leaves a user override in place when they changed the value after applying", () => {
+    const snapshots = { current: {} };
+    const box = makeSetter(4);
+    applyPresetDefault(snapshots, "count", box.setter, 8);
+    box.setter(2); // user manually edits after the preset applied
+    clearPresetDefault(box.setter, snapshots, "count");
+    expect(box.get()).toBe(2);
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -65,12 +65,17 @@ function defaultCharacterPrompt(character) {
   }
 }
 import {
+  applyPresetDefault,
+  buildStudioPresetPayload,
+  finiteNumberOrUndefined,
   loraMatchesModel,
   loraWeight,
+  presetNameTaken,
   serializeLora,
   clearPresetDefault,
   noPresetId,
   rememberPresetDefault,
+  slugifyPresetId,
 } from "../presetUtils.js";
 import {
   onPromptKeyDown,
@@ -94,6 +99,10 @@ import {
 
 // Used only for models that don't declare limits.resolutions (e.g. user-imported).
 const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x1280"];
+// Studio sub-modes a saved preset may restore (the "type") — the tabs the mode
+// segmented control actually exposes. Edit lives in its own workflow; text and
+// character share the text_to_image workflow.
+const IMAGE_MODES = ["text_to_image", "edit_image", "character_image"];
 const UPSCALE_ENGINES = [
   { id: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
   { id: "aura-sr", label: "AuraSR", factors: [4] },
@@ -159,6 +168,7 @@ export function ImageStudio() {
     assets,
     characters,
     createImageJob,
+    createPreset,
     refinePrompt,
     deleteAsset,
     purgeAsset,
@@ -260,6 +270,13 @@ export function ImageStudio() {
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
   const [submitting, setSubmitting] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);
+  // "Save as Preset" sidebar control — snapshots the current config into the
+  // workspace preset library. Defaults to project scope, falling back to global
+  // when no project is open (project-scoped presets require a project).
+  const [presetName, setPresetName] = useState("");
+  const [presetScope, setPresetScope] = useState(activeProject ? "project" : "global");
+  const [savingPreset, setSavingPreset] = useState(false);
+  const [presetSaveMessage, setPresetSaveMessage] = useState({ tone: "neutral", text: "" });
   const presetDefaultSnapshots = useRef({});
   const editImageAssets = useMemo(
     () => assets.filter((asset) => asset.type === "image" || asset.type === "frame"),
@@ -533,38 +550,56 @@ export function ImageStudio() {
   const skipPresetDefaultsOnHydrate = useRef(
     Object.keys(saved).length > 0 && saved.selectedPresetId !== noPresetId,
   );
+  // [defaults key, setter] pairs restored through the remember/clear snapshot
+  // machinery, so switching to None (or another preset) puts the user's prior
+  // value back. Only keys the preset actually carries are applied, so older
+  // presets (which only stored count/resolution/negativePrompt) keep working and
+  // full-snapshot presets restore the prompt, cfg, sampler, reference + upscale
+  // knobs. The model is intentionally absent — presets never switch the model.
+  const presetDefaultFields = [
+    ["prompt", setPrompt],
+    ["negativePrompt", setNegativePrompt],
+    ["resolution", setResolution],
+    ["count", setCount],
+    ["guidanceScale", setGuidanceOverride],
+    ["steps", setStepsOverride],
+    ["sampler", setSampler],
+    ["scheduler", setScheduler],
+    ["schedulerShift", setSchedulerShift],
+    ["ipAdapterScale", setIpAdapterScale],
+    ["controlnetScale", setControlnetScale],
+    ["trueCfgScale", setTrueCfgScale],
+    ["viewAngle", setViewAngle],
+    ["upscaleEnabled", setUpscaleEnabled],
+    ["upscaleFactor", setUpscaleFactor],
+    ["upscaleEngine", setUpscaleEngine],
+  ];
   useEffect(() => {
     if (skipPresetDefaultsOnHydrate.current && selectedPreset) {
       skipPresetDefaultsOnHydrate.current = false;
       return;
     }
     if (!selectedPreset) {
-      clearPresetDefault(setCount, presetDefaultSnapshots, "count");
-      clearPresetDefault(setResolution, presetDefaultSnapshots, "resolution");
-      clearPresetDefault(setNegativePrompt, presetDefaultSnapshots, "negativePrompt");
+      for (const [key, setter] of presetDefaultFields) {
+        clearPresetDefault(setter, presetDefaultSnapshots, key);
+      }
       return;
     }
     const defaults = selectedPreset.defaults ?? {};
-    if (defaults.count) {
-      const appliedValue = Number(defaults.count);
-      setCount((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "count", current, appliedValue);
-        return appliedValue;
-      });
+    for (const [key, setter] of presetDefaultFields) {
+      if (Object.prototype.hasOwnProperty.call(defaults, key)) {
+        applyPresetDefault(presetDefaultSnapshots, key, setter, defaults[key]);
+      }
     }
-    if (defaults.resolution) {
-      const appliedValue = defaults.resolution;
-      setResolution((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "resolution", current, appliedValue);
-        return appliedValue;
-      });
+    // Filling the prompt box counts as a user edit, so character mode's default
+    // prompt won't clobber the restored prompt.
+    if (Object.prototype.hasOwnProperty.call(defaults, "prompt")) {
+      promptEdited.current = true;
     }
-    if (Object.prototype.hasOwnProperty.call(defaults, "negativePrompt")) {
-      const appliedValue = defaults.negativePrompt ?? "";
-      setNegativePrompt((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "negativePrompt", current, appliedValue);
-        return appliedValue;
-      });
+    // Restore the saved sub-mode ("type"). Edit presets only surface in edit
+    // mode, so this only ever flips between text/character within one workflow.
+    if (IMAGE_MODES.includes(defaults.mode)) {
+      setMode(defaults.mode);
     }
   }, [selectedPreset?.id]);
 
@@ -620,6 +655,73 @@ export function ImageStudio() {
   function effectiveLoraWeight(lora) {
     const override = loraWeights[lora.id];
     return Number.isFinite(override) ? override : loraWeight(lora);
+  }
+
+  // Snapshot the current working config into a named recipe preset in the
+  // workspace library. Captures the literal prompt + every visible knob + the
+  // selected LoRAs with their weights; the seed is intentionally left out so the
+  // preset stays reusable. The backend additionally enforces id uniqueness and
+  // model/workflow + LoRA compatibility, surfaced here via err.message.
+  async function handleSaveAsPreset() {
+    const trimmed = presetName.trim();
+    if (!trimmed) {
+      setPresetSaveMessage({ tone: "error", text: "Name the preset before saving." });
+      return;
+    }
+    if (!slugifyPresetId(trimmed)) {
+      setPresetSaveMessage({ tone: "error", text: "Use letters or numbers in the preset name." });
+      return;
+    }
+    if (presetScope === "project" && !activeProject) {
+      setPresetSaveMessage({ tone: "error", text: "Open a project first, or save to all projects." });
+      return;
+    }
+    if (presetNameTaken(trimmed, presets)) {
+      setPresetSaveMessage({ tone: "error", text: `"${trimmed}" already exists — pick a unique name.` });
+      return;
+    }
+    const payload = buildStudioPresetPayload({
+      name: trimmed,
+      scope: presetScope,
+      mode,
+      model,
+      loras: selectedLoras.map((lora) => ({ id: lora.id, weight: effectiveLoraWeight(lora) })),
+      defaults: {
+        prompt,
+        negativePrompt,
+        resolution,
+        count,
+        mode,
+        guidanceScale: finiteNumberOrUndefined(guidanceOverride),
+        steps: finiteNumberOrUndefined(stepsOverride),
+        sampler,
+        scheduler,
+        schedulerShift,
+        upscaleEnabled,
+        upscaleFactor,
+        upscaleEngine,
+        // Reference/identity knobs only matter for the character flow; keep them
+        // out of plain text/edit presets so they don't carry irrelevant state.
+        ...(mode === "character_image"
+          ? { ipAdapterScale, controlnetScale, trueCfgScale, viewAngle }
+          : {}),
+      },
+    });
+    setSavingPreset(true);
+    setPresetSaveMessage({ tone: "neutral", text: "" });
+    try {
+      const created = await createPreset(payload);
+      setSelectedPresetId(created?.id ?? payload.id);
+      setPresetName("");
+      setPresetSaveMessage({
+        tone: "success",
+        text: `Saved "${trimmed}" to ${presetScope === "project" ? "this project" : "all projects"}.`,
+      });
+    } catch (err) {
+      setPresetSaveMessage({ tone: "error", text: err.message });
+    } finally {
+      setSavingPreset(false);
+    }
   }
 
   function setLoraWeight(id, value) {
@@ -1061,6 +1163,64 @@ export function ImageStudio() {
                   </button>
                 ))}
               </div>
+            </div>
+
+            <div className="save-preset">
+              <div className="save-preset-row">
+                <input
+                  aria-label="Preset name"
+                  className="save-preset-name"
+                  disabled={savingPreset}
+                  onChange={(event) => {
+                    setPresetName(event.target.value);
+                    if (presetSaveMessage.text) {
+                      setPresetSaveMessage({ tone: "neutral", text: "" });
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      handleSaveAsPreset();
+                    }
+                  }}
+                  placeholder="Name this setup…"
+                  value={presetName}
+                />
+                <button
+                  className="save-preset-btn"
+                  disabled={savingPreset || !presetName.trim()}
+                  onClick={handleSaveAsPreset}
+                  type="button"
+                >
+                  <Icon.Preset size={14} /> {savingPreset ? "Saving…" : "Save as Preset"}
+                </button>
+              </div>
+              <div className="save-preset-scope scope-segment" role="radiogroup" aria-label="Preset scope">
+                <button
+                  aria-checked={presetScope === "project"}
+                  className={presetScope === "project" ? "active" : ""}
+                  disabled={!activeProject}
+                  onClick={() => setPresetScope("project")}
+                  role="radio"
+                  type="button"
+                >
+                  <Icon.Folder size={13} /> This project
+                </button>
+                <button
+                  aria-checked={presetScope === "global"}
+                  className={presetScope === "global" ? "active" : ""}
+                  onClick={() => setPresetScope("global")}
+                  role="radio"
+                  type="button"
+                >
+                  <Icon.Stars size={13} /> All projects
+                </button>
+              </div>
+              {presetSaveMessage.text ? (
+                <p className={presetSaveMessage.tone === "success" ? "inline-success" : "inline-warning"}>
+                  {presetSaveMessage.text}
+                </p>
+              ) : null}
             </div>
 
             <div className="control-grid preset-rail-row">

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1,0 +1,151 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Pose loaders fetch best-effort on mount; stub the API so render never touches
+// the network. The studio's own mutations go through context fns, not apiFetch.
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn(async () => ({})),
+  };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { ImageStudio } from "./ImageStudio.jsx";
+
+const Z_IMAGE = {
+  id: "z_image_turbo",
+  name: "Z Image Turbo",
+  type: "image",
+  family: "z-image",
+  capabilities: ["text_to_image"],
+  defaults: { resolution: "1024x1024" },
+  limits: { resolutions: ["1024x1024", "1536x1024"] },
+  loraCompatibility: {},
+  ui: {},
+};
+
+function baseContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    characters: [],
+    createImageJob: vi.fn(),
+    createPreset: vi.fn(async (payload) => ({ id: payload.id })),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    purgeAsset: vi.fn(),
+    gpuOptions: [],
+    imageModels: [Z_IMAGE],
+    latestImageAssets: [],
+    recentImageAssets: [],
+    studioLaunch: null,
+    imageLocalJobs: [],
+    loras: [],
+    jobAction: vi.fn(),
+    rememberLocalGenerationJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    presets: [],
+    requestedGpu: "",
+    selectedAsset: null,
+    setRequestedGpu: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function click(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function setInput(element, value) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+  setter.call(element, value);
+  element.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+const saveButton = (container) =>
+  [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
+const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
+
+describe("ImageStudio Save as Preset", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {}); // flush mount effects (pose loaders, etc.)
+  }
+
+  it("snapshots the current config into a preset payload without the seed", async () => {
+    const context = baseContext();
+    await render(context);
+
+    const input = nameInput(container);
+    expect(input).toBeTruthy();
+    await act(async () => setInput(input, "Atrium Look"));
+    await click(saveButton(container));
+
+    expect(context.createPreset).toHaveBeenCalledTimes(1);
+    const payload = context.createPreset.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      id: "atrium_look",
+      name: "Atrium Look",
+      scope: "project",
+      workflow: "text_to_image",
+      model: "z_image_turbo",
+    });
+    // The literal prompt rides in defaults; the seed never does.
+    expect(payload.defaults.prompt).toBe("A cinematic frame of a neon street at midnight");
+    expect(payload.defaults).not.toHaveProperty("seed");
+    expect(container.textContent).toContain('Saved "Atrium Look" to this project.');
+  });
+
+  it("blocks a duplicate name client-side before calling the API", async () => {
+    const context = baseContext({
+      presets: [
+        {
+          id: "atrium_look",
+          name: "Atrium Look",
+          scope: "project",
+          workflow: "text_to_image",
+          model: "z_image_turbo",
+          modes: ["text_to_image", "character_image", "style_variations"],
+        },
+      ],
+    });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Atrium Look"));
+    await click(saveButton(container));
+
+    expect(context.createPreset).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("already exists");
+  });
+});

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -60,13 +60,18 @@ function jobVideoResultAssets(job, assets) {
   return [];
 }
 import {
+  applyPresetDefault,
+  buildStudioPresetPayload,
   clearPresetDefault,
+  finiteNumberOrUndefined,
   loraLooksLikeIcLora,
   loraMatchesModel,
   loraWeight,
   noPresetId,
+  presetNameTaken,
   rememberPresetDefault,
   serializeLora,
+  slugifyPresetId,
 } from "../presetUtils.js";
 import {
   onPromptKeyDown,
@@ -92,6 +97,10 @@ import {
 const ltxVideoModelId = "ltx_2_3";
 const ltxIcLoraRequiredModes = new Set(["extend_clip", "video_bridge"]);
 
+// Video sub-modes that map onto a recipe workflow. extend_clip / replace_person
+// aren't recipe workflows, so "Save as Preset" is gated to these.
+const VIDEO_PRESET_MODES = ["image_to_video", "text_to_video", "first_last_frame"];
+
 export function VideoStudio() {
   const {
     activeProject,
@@ -100,6 +109,7 @@ export function VideoStudio() {
     createPersonDetectionJob,
     createPersonTrackJob,
     createVideoJob,
+    createPreset,
     refinePrompt,
     deleteAsset,
     purgeAsset,
@@ -203,6 +213,13 @@ export function VideoStudio() {
   const [previewPlaying, setPreviewPlaying] = useState(false);
   const [previewTime, setPreviewTime] = useState(0);
   const [previewDuration, setPreviewDuration] = useState(0);
+  // "Save as Preset" sidebar control — snapshots the current config into the
+  // workspace preset library. Defaults to project scope, falling back to global
+  // when no project is open (project-scoped presets require a project).
+  const [presetName, setPresetName] = useState("");
+  const [presetScope, setPresetScope] = useState(activeProject ? "project" : "global");
+  const [savingPreset, setSavingPreset] = useState(false);
+  const [presetSaveMessage, setPresetSaveMessage] = useState({ tone: "neutral", text: "" });
   const presetDefaultSnapshots = useRef({});
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
@@ -330,6 +347,79 @@ export function VideoStudio() {
     return Number.isFinite(override) ? override : loraWeight(lora);
   }
 
+  // Snapshot the current working config into a named recipe preset in the
+  // workspace library. Captures the literal prompt + every visible knob + the
+  // selected LoRAs with their weights; the seed is intentionally left out so the
+  // preset stays reusable. The backend additionally enforces id uniqueness and
+  // model/workflow + LoRA compatibility, surfaced here via err.message.
+  async function handleSaveAsPreset() {
+    const trimmed = presetName.trim();
+    if (!trimmed) {
+      setPresetSaveMessage({ tone: "error", text: "Name the preset before saving." });
+      return;
+    }
+    if (!slugifyPresetId(trimmed)) {
+      setPresetSaveMessage({ tone: "error", text: "Use letters or numbers in the preset name." });
+      return;
+    }
+    if (!VIDEO_PRESET_MODES.includes(mode)) {
+      setPresetSaveMessage({ tone: "error", text: "Switch to Image, Text, or First/Last mode to save a preset." });
+      return;
+    }
+    if (presetScope === "project" && !activeProject) {
+      setPresetSaveMessage({ tone: "error", text: "Open a project first, or save to all projects." });
+      return;
+    }
+    if (presetNameTaken(trimmed, presets)) {
+      setPresetSaveMessage({ tone: "error", text: `"${trimmed}" already exists — pick a unique name.` });
+      return;
+    }
+    const payload = buildStudioPresetPayload({
+      name: trimmed,
+      scope: presetScope,
+      mode,
+      model,
+      loras: selectedLoras.map((lora) => ({ id: lora.id, weight: effectiveLoraWeight(lora) })),
+      defaults: {
+        prompt,
+        negativePrompt,
+        resolution,
+        duration,
+        fps,
+        quality,
+        mode,
+        guidanceScale: finiteNumberOrUndefined(guidanceOverride),
+        steps: finiteNumberOrUndefined(stepsOverride),
+        sampler,
+        scheduler,
+        schedulerShift,
+        precision,
+        quantization,
+        ltxPipeline,
+        distilledVariant,
+        motion,
+        videoCfgGuidanceScale: finiteNumberOrUndefined(ltxVideoCfg),
+        videoStgGuidanceScale: finiteNumberOrUndefined(ltxVideoStg),
+        videoRescaleScale: finiteNumberOrUndefined(ltxVideoRescale),
+      },
+    });
+    setSavingPreset(true);
+    setPresetSaveMessage({ tone: "neutral", text: "" });
+    try {
+      const created = await createPreset(payload);
+      setSelectedPresetId(created?.id ?? payload.id);
+      setPresetName("");
+      setPresetSaveMessage({
+        tone: "success",
+        text: `Saved "${trimmed}" to ${presetScope === "project" ? "this project" : "all projects"}.`,
+      });
+    } catch (err) {
+      setPresetSaveMessage({ tone: "error", text: err.message });
+    } finally {
+      setSavingPreset(false);
+    }
+  }
+
   function setLoraWeight(id, value) {
     setLoraWeights((current) => ({ ...current, [id]: value }));
   }
@@ -422,54 +512,53 @@ export function VideoStudio() {
   const skipPresetDefaultsOnHydrate = useRef(
     Object.keys(saved).length > 0 && saved.selectedPresetId !== noPresetId,
   );
+  // [defaults key, setter] pairs restored through the remember/clear snapshot
+  // machinery, so switching to None (or another preset) puts the user's prior
+  // value back. Only keys the preset carries are applied, so older presets keep
+  // working and full-snapshot presets restore the prompt, cfg, sampler, and the
+  // native LTX guidance knobs. The model is intentionally absent — presets never
+  // switch the model.
+  const presetDefaultFields = [
+    ["prompt", setPrompt],
+    ["negativePrompt", setNegativePrompt],
+    ["resolution", setResolution],
+    ["duration", setDuration],
+    ["fps", setFps],
+    ["quality", setQuality],
+    ["guidanceScale", setGuidanceOverride],
+    ["steps", setStepsOverride],
+    ["sampler", setSampler],
+    ["scheduler", setScheduler],
+    ["schedulerShift", setSchedulerShift],
+    ["precision", setPrecision],
+    ["quantization", setQuantization],
+    ["ltxPipeline", setLtxPipeline],
+    ["distilledVariant", setDistilledVariant],
+    ["motion", setMotion],
+    ["videoCfgGuidanceScale", setLtxVideoCfg],
+    ["videoStgGuidanceScale", setLtxVideoStg],
+    ["videoRescaleScale", setLtxVideoRescale],
+  ];
   useEffect(() => {
     if (skipPresetDefaultsOnHydrate.current && selectedPreset) {
       skipPresetDefaultsOnHydrate.current = false;
       return;
     }
     if (!selectedPreset) {
-      clearPresetDefault(setDuration, presetDefaultSnapshots, "duration");
-      clearPresetDefault(setFps, presetDefaultSnapshots, "fps");
-      clearPresetDefault(setQuality, presetDefaultSnapshots, "quality");
-      clearPresetDefault(setResolution, presetDefaultSnapshots, "resolution");
-      clearPresetDefault(setNegativePrompt, presetDefaultSnapshots, "negativePrompt");
+      for (const [key, setter] of presetDefaultFields) {
+        clearPresetDefault(setter, presetDefaultSnapshots, key);
+      }
       return;
     }
     const defaults = selectedPreset.defaults ?? {};
-    if (defaults.duration) {
-      const appliedValue = Number(defaults.duration);
-      setDuration((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "duration", current, appliedValue);
-        return appliedValue;
-      });
+    for (const [key, setter] of presetDefaultFields) {
+      if (Object.prototype.hasOwnProperty.call(defaults, key)) {
+        applyPresetDefault(presetDefaultSnapshots, key, setter, defaults[key]);
+      }
     }
-    if (defaults.fps) {
-      const appliedValue = Number(defaults.fps);
-      setFps((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "fps", current, appliedValue);
-        return appliedValue;
-      });
-    }
-    if (defaults.quality) {
-      const appliedValue = defaults.quality;
-      setQuality((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "quality", current, appliedValue);
-        return appliedValue;
-      });
-    }
-    if (defaults.resolution) {
-      const appliedValue = defaults.resolution;
-      setResolution((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "resolution", current, appliedValue);
-        return appliedValue;
-      });
-    }
-    if (Object.prototype.hasOwnProperty.call(defaults, "negativePrompt")) {
-      const appliedValue = defaults.negativePrompt ?? "";
-      setNegativePrompt((current) => {
-        rememberPresetDefault(presetDefaultSnapshots, "negativePrompt", current, appliedValue);
-        return appliedValue;
-      });
+    // Restore the saved sub-mode ("type") when it's a generatable video workflow.
+    if (VIDEO_PRESET_MODES.includes(defaults.mode)) {
+      setMode(defaults.mode);
     }
   }, [selectedPreset?.id]);
 
@@ -1004,6 +1093,65 @@ export function VideoStudio() {
                     </button>
                   ))}
                 </div>
+              </div>
+
+              <div className="save-preset">
+                <div className="save-preset-row">
+                  <input
+                    aria-label="Preset name"
+                    className="save-preset-name"
+                    disabled={savingPreset}
+                    onChange={(event) => {
+                      setPresetName(event.target.value);
+                      if (presetSaveMessage.text) {
+                        setPresetSaveMessage({ tone: "neutral", text: "" });
+                      }
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        handleSaveAsPreset();
+                      }
+                    }}
+                    placeholder="Name this setup…"
+                    value={presetName}
+                  />
+                  <button
+                    className="save-preset-btn"
+                    disabled={savingPreset || !presetName.trim() || !VIDEO_PRESET_MODES.includes(mode)}
+                    onClick={handleSaveAsPreset}
+                    title={VIDEO_PRESET_MODES.includes(mode) ? undefined : "Presets are available in Image→Video, Text→Video, or First/Last mode."}
+                    type="button"
+                  >
+                    <Icon.Preset size={14} /> {savingPreset ? "Saving…" : "Save as Preset"}
+                  </button>
+                </div>
+                <div className="save-preset-scope scope-segment" role="radiogroup" aria-label="Preset scope">
+                  <button
+                    aria-checked={presetScope === "project"}
+                    className={presetScope === "project" ? "active" : ""}
+                    disabled={!activeProject}
+                    onClick={() => setPresetScope("project")}
+                    role="radio"
+                    type="button"
+                  >
+                    <Icon.Folder size={13} /> This project
+                  </button>
+                  <button
+                    aria-checked={presetScope === "global"}
+                    className={presetScope === "global" ? "active" : ""}
+                    onClick={() => setPresetScope("global")}
+                    role="radio"
+                    type="button"
+                  >
+                    <Icon.Stars size={13} /> All projects
+                  </button>
+                </div>
+                {presetSaveMessage.text ? (
+                  <p className={presetSaveMessage.tone === "success" ? "inline-success" : "inline-warning"}>
+                    {presetSaveMessage.text}
+                  </p>
+                ) : null}
               </div>
 
               <label>

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1,0 +1,156 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn(async () => ({})),
+  };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { VideoStudio } from "./VideoStudio.jsx";
+
+const LTX = {
+  id: "ltx_2_3",
+  name: "LTX 2.3",
+  type: "video",
+  family: "ltx-video",
+  capabilities: ["image_to_video", "text_to_video", "first_last_frame"],
+  defaults: { duration: 6, resolution: "768x512", fps: 25 },
+  limits: {},
+  quantization: {},
+  loraCompatibility: {},
+  ui: {},
+};
+
+function baseContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    characters: [],
+    createPersonDetectionJob: vi.fn(),
+    createPersonTrackJob: vi.fn(),
+    createVideoJob: vi.fn(),
+    createPreset: vi.fn(async (payload) => ({ id: payload.id })),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    purgeAsset: vi.fn(),
+    gpuOptions: [],
+    latestVideoAssets: [],
+    recentVideoAssets: [],
+    studioLaunch: null,
+    loras: [],
+    jobs: [],
+    videoLocalJobs: [],
+    jobAction: vi.fn(),
+    rememberLocalGenerationJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setSelectedAssetId: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    personTracks: [],
+    personReadiness: {},
+    presets: [],
+    requestedGpu: "",
+    saveTrackCorrections: vi.fn(),
+    selectedAsset: null,
+    setRequestedGpu: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    videoModels: [LTX],
+    ...overrides,
+  };
+}
+
+async function click(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function setInput(element, value) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+  setter.call(element, value);
+  element.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+const saveButton = (container) =>
+  [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
+const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
+
+describe("VideoStudio Save as Preset", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("snapshots the video config into an image_to_video preset without the seed", async () => {
+    const context = baseContext();
+    await render(context);
+
+    const input = nameInput(container);
+    expect(input).toBeTruthy();
+    await act(async () => setInput(input, "Push In"));
+    await click(saveButton(container));
+
+    expect(context.createPreset).toHaveBeenCalledTimes(1);
+    const payload = context.createPreset.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      id: "push_in",
+      name: "Push In",
+      scope: "project",
+      workflow: "image_to_video",
+      model: "ltx_2_3",
+    });
+    expect(payload.defaults.prompt).toBe("Camera slowly pushes in while the scene comes alive");
+    expect(payload.defaults).not.toHaveProperty("seed");
+    expect(container.textContent).toContain('Saved "Push In" to this project.');
+  });
+
+  it("blocks a duplicate name client-side before calling the API", async () => {
+    const context = baseContext({
+      presets: [
+        {
+          id: "push_in",
+          name: "Push In",
+          scope: "project",
+          workflow: "image_to_video",
+          model: "ltx_2_3",
+          modes: ["image_to_video"],
+        },
+      ],
+    });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Push In"));
+    await click(saveButton(container));
+
+    expect(context.createPreset).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("already exists");
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2433,6 +2433,60 @@ label {
   gap: 10px;
 }
 
+/* "Save as Preset" — inline sidebar control that snapshots the current setup. */
+.save-preset {
+  display: grid;
+  gap: 8px;
+}
+
+.save-preset-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.save-preset-name {
+  flex: 1;
+  min-width: 0;
+  min-height: 34px;
+  padding: 0 11px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 13px;
+}
+
+.save-preset-name:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.save-preset-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  min-height: 34px;
+  padding: 0 13px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 12.5px;
+  font-weight: 600;
+  transition: filter var(--t-fast), opacity var(--t-fast);
+}
+
+.save-preset-btn:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.save-preset-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .advanced-toggle {
   align-self: start;
   display: inline-flex;


### PR DESCRIPTION
## What & why

Adds an inline **"Save as Preset"** control to the Image and Video Studio sidebars (preset-name input + button + **This project / All projects** scope toggle). It snapshots the current working config — model, prompt, settings, and LoRAs — into the workspace's existing recipe-preset library, and selecting that preset later restores it all. Requested so a known-good prompt+model+settings+LoRA combination can be saved in one click.

The recipe-preset system already existed (backend CRUD in `recipe_presets.rs`, `usePresets`, the Preset Manager screen). This PR adds the missing *inline* shortcut and extends what the studios capture and restore. `RecipePresetDefaults` already round-trips arbitrary keys via `#[serde(flatten)]`, so **no storage schema change was needed**.

## Behaviour (decisions confirmed with @michaeltrefry)
- **Full snapshot**: top-level `model` / `workflow` / `modes` / `loras` (with weights) + a `defaults` block carrying the literal prompt, negative prompt, resolution, count, cfg/guidance, steps, sampler/scheduler/shift, and per-studio knobs (image: ipAdapter/controlnet/trueCfg/viewAngle/upscale; video: duration/fps/quality/precision/quantization/ltxPipeline/distilledVariant/motion/ltxVideo cfg-stg-rescale).
- **Literal prompt** stored in `defaults.prompt` and filled into the prompt box on apply (not prefix/suffix — that would double-apply at generation).
- **Seed excluded** so presets stay reusable.
- **Default scope = active project**, with a global toggle.
- **Model rule preserved (epic 1306)**: presets are model-scoped and apply never switches the model — a preset only surfaces under its model (or a family sibling).

## Changes
- **`presetUtils.js`** — `workflowForMode`, `slugifyPresetId`, `presetNameTaken`, `cleanPresetDefaults`, `finiteNumberOrUndefined`, `buildStudioPresetPayload`, `applyPresetDefault` (+22 unit tests).
- **`ImageStudio.jsx` / `VideoStudio.jsx`** — save control; extended the preset-apply effect from `{count/resolution/negativePrompt}` to a declarative field list that restores the literal prompt + every knob + the saved sub-mode via the existing remember/clear snapshot pattern. Video save is gated to recipe-workflow modes (extend_clip/replace_person disabled).
- **`styles.css`** — `.save-preset*` styling (scope toggle reuses `.scope-segment`).
- **`recipe_presets.rs`** — bounds-validate the new numeric defaults (steps whole 1..=200; generous ranges for the rest; numeric-string tolerant; unknown keys permissive, never panics).
- New `ImageStudio.test.jsx` / `VideoStudio.test.jsx` render the real studios and assert the `createPreset` payload (literal prompt, no seed, project scope) + the client-side duplicate-name block; new rust-api round-trip/rejection test.

## Testing
- **296** web vitest green · **89** rust-api green (recipe_presets parity snapshots unchanged) · `cargo fmt` clean · `vite build` clean.
- ⚠️ **No live click-through**: the app boots only via the full `docker compose` stack (no vite proxy; GPU worker can't run in this env). End-to-end wiring is covered by the full-component interaction tests + the backend round-trip test — worth a quick manual pass when the stack is up.

## Shortcut
[Epic 2418](https://app.shortcut.com/trefry/epic/2418) — sc-2419 (helpers), sc-2420 (Image), sc-2421 (Video), sc-2422 (backend). All In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)