### PR TITLE
Bind lightbox navigation to its launch collection

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -26,7 +26,12 @@ import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
 import { AppContext } from "./context/AppContext.js";
-import { dropUpscaledVariants, findFoldedAssetById, foldUpscaledAssetVariants } from "./assetVariants.js";
+import {
+  dropUpscaledVariants,
+  findFoldedAssetById,
+  foldUpscaledAssetVariants,
+  restrictFoldedToScope,
+} from "./assetVariants.js";
 import { buildWorkersById } from "./workers.js";
 
 // Desktop (Tauri) shell detection. The first-run setup wizard is desktop-only;
@@ -415,9 +420,36 @@ export function App() {
   const [jobPrompt, setJobPrompt] = useState("Placeholder generation");
   const [latestGenerationSetId, setLatestGenerationSetId] = useState(null);
   const [previewAsset, setPreviewAsset] = useState(null);
+  // The collection the fullscreen preview was launched from, as an ordered list
+  // of asset ids. Navigation (next/previous and the discard-advance) stays bound
+  // to this set so scrolling never escapes into the Library or another
+  // character's assets. `null` falls back to "all assets" for any legacy caller
+  // that opens the preview without a scope.
+  const [previewScopeIds, setPreviewScopeIds] = useState(null);
   // Which way the user last scrolled in the fullscreen preview, so discarding an
   // asset advances in that same direction.
   const previewDirectionRef = useRef("next");
+  // Open the fullscreen preview bound to the collection it was launched from.
+  // `scopeAssets` is the exact list the calling gallery rendered (folded or not);
+  // we snapshot its ids so navigation tracks the live asset state but never
+  // wanders outside that collection. Passing no scope clears it (global nav).
+  const openPreview = (asset, scopeAssets) => {
+    if (!asset) {
+      setPreviewScopeIds(null);
+      setPreviewAsset(null);
+      return;
+    }
+    setPreviewScopeIds(
+      Array.isArray(scopeAssets) && scopeAssets.length
+        ? scopeAssets.map((item) => item.id)
+        : null,
+    );
+    setPreviewAsset(asset);
+  };
+  const closePreview = () => {
+    setPreviewScopeIds(null);
+    setPreviewAsset(null);
+  };
   const [studioLaunch, setStudioLaunch] = useState(null);
   const [error, setError] = useState("");
   const [theme, setTheme] = useState(readStoredTheme);
@@ -565,19 +597,25 @@ export function App() {
     () => (previewAsset ? findFoldedAssetById(foldedPreviewAssets, previewAsset.id) ?? previewAsset : null),
     [foldedPreviewAssets, previewAsset],
   );
+  // The ordered, folded set the preview can navigate — restricted to the launch
+  // collection so scrolling never escapes into the Library or another character.
+  const previewScopeAssets = useMemo(
+    () => restrictFoldedToScope(foldedPreviewAssets, previewScopeIds),
+    [foldedPreviewAssets, previewScopeIds],
+  );
   const previewNavigation = useMemo(() => {
-    if (!previewedAsset || foldedPreviewAssets.length < 2) {
+    if (!previewedAsset || previewScopeAssets.length < 2) {
       return { previous: null, next: null };
     }
-    const currentIndex = foldedPreviewAssets.findIndex((asset) => asset.id === previewedAsset.id);
+    const currentIndex = previewScopeAssets.findIndex((asset) => asset.id === previewedAsset.id);
     if (currentIndex < 0) {
       return { previous: null, next: null };
     }
     return {
-      previous: currentIndex > 0 ? foldedPreviewAssets[currentIndex - 1] : null,
-      next: currentIndex < foldedPreviewAssets.length - 1 ? foldedPreviewAssets[currentIndex + 1] : null,
+      previous: currentIndex > 0 ? previewScopeAssets[currentIndex - 1] : null,
+      next: currentIndex < previewScopeAssets.length - 1 ? previewScopeAssets[currentIndex + 1] : null,
     };
-  }, [foldedPreviewAssets, previewedAsset]);
+  }, [previewScopeAssets, previewedAsset]);
   const latestAssets = useMemo(
     () => assets.filter((asset) => asset.generationSetId === latestGenerationSetId),
     [assets, latestGenerationSetId],
@@ -1422,7 +1460,7 @@ export function App() {
   const appContextValue = {
     activeProject,
     mediaAssets,
-    setPreviewAsset,
+    setPreviewAsset: openPreview,
     sendAssetToImage,
     sendAssetToVideo,
     activeTimeline,
@@ -1721,10 +1759,16 @@ export function App() {
             const target =
               previewDirectionRef.current === "previous" ? previous ?? next : next ?? previous;
             await deleteAsset(asset);
-            setPreviewAsset(target ?? null);
+            // Advance within the launch collection; close (and drop the scope)
+            // once it is exhausted.
+            if (target) {
+              setPreviewAsset(target);
+            } else {
+              closePreview();
+            }
           }}
           nextAsset={previewNavigation.next}
-          onClose={() => setPreviewAsset(null)}
+          onClose={closePreview}
           onEditImage={sendAssetToImageEdit}
           onPreviewAsset={(asset, direction) => {
             if (direction) {
@@ -1735,7 +1779,7 @@ export function App() {
           previousAsset={previewNavigation.previous}
           purgeAsset={async (asset) => {
             await purgeAsset(asset);
-            setPreviewAsset(null);
+            closePreview();
           }}
           updateAssetStatus={updateAssetStatus}
         />

--- a/apps/web/src/assetVariants.js
+++ b/apps/web/src/assetVariants.js
@@ -65,3 +65,24 @@ export function findFoldedAssetById(foldedAssets, assetId) {
       asset.variants?.upscaled?.id === assetId,
   );
 }
+
+// Restrict the fullscreen preview's navigable set to the collection it was
+// launched from. `scopeIds` is the ordered snapshot of asset ids the launching
+// gallery rendered; we resolve each against the live folded assets (so trashed/
+// purged items drop out and upscale variants stay folded) and keep the
+// collection's order. A null/empty scope means "everything" (legacy callers).
+export function restrictFoldedToScope(foldedAssets, scopeIds) {
+  if (!scopeIds) {
+    return foldedAssets;
+  }
+  const seen = new Set();
+  const scoped = [];
+  for (const id of scopeIds) {
+    const folded = findFoldedAssetById(foldedAssets, id);
+    if (folded && !seen.has(folded.id)) {
+      seen.add(folded.id);
+      scoped.push(folded);
+    }
+  }
+  return scoped;
+}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -5,7 +5,7 @@ import { App, ErrorBoundary, eventUrl } from "./main.jsx";
 import { AssetPickerField } from "./components/AssetPicker.jsx";
 import { AssetDetail, FullscreenPreview } from "./components/assetPanels.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
-import { dropUpscaledVariants, foldUpscaledAssetVariants } from "./assetVariants.js";
+import { dropUpscaledVariants, foldUpscaledAssetVariants, restrictFoldedToScope } from "./assetVariants.js";
 import { extractFamilies } from "./presetUtils.js";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { CharacterAssets, CharacterDatasets } from "./screens/characterPanels.jsx";
@@ -8297,6 +8297,9 @@ describe("SceneWorks app shell", () => {
           upscaled,
         },
       }),
+      // The library binds the preview to its currently filtered view so
+      // navigation can't escape into other collections.
+      expect.arrayContaining([expect.objectContaining({ id: "asset-upscaled" })]),
     );
   });
 
@@ -8320,6 +8323,36 @@ describe("SceneWorks app shell", () => {
       "asset-upscaled",
       "asset-other",
     ]);
+  });
+
+  it("binds fullscreen preview navigation to the launch collection", () => {
+    // The full project (what the old global navigation roamed across).
+    const folded = [
+      { id: "batch-1", type: "image" },
+      { id: "batch-2", type: "image" },
+      { id: "library-1", type: "image" },
+      { id: "character-1", type: "image" },
+    ];
+
+    // Launched from a two-image batch -> navigation stays on those two, in order,
+    // and never reaches the library/character assets.
+    expect(restrictFoldedToScope(folded, ["batch-1", "batch-2"]).map((asset) => asset.id)).toEqual([
+      "batch-1",
+      "batch-2",
+    ]);
+
+    // A scoped id that has since been discarded/purged drops out instead of
+    // leaking the neighbouring collection in to fill its slot.
+    expect(restrictFoldedToScope(folded, ["batch-1", "gone", "batch-2"]).map((asset) => asset.id)).toEqual([
+      "batch-1",
+      "batch-2",
+    ]);
+
+    // A folded scope id resolves through its variants, and no scope falls back to
+    // the full set (legacy callers).
+    const variant = { id: "up-1", type: "image", variants: { original: { id: "orig-1" }, upscaled: { id: "up-1" } } };
+    expect(restrictFoldedToScope([variant, folded[2]], ["orig-1"]).map((asset) => asset.id)).toEqual(["up-1"]);
+    expect(restrictFoldedToScope(folded, null)).toBe(folded);
   });
 
   it("shows discarded assets in Trashcan and exposes restore and purge actions", async () => {

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -719,7 +719,7 @@ export function EditorScreen() {
             <div className="asset-bin-list">
               {[...mainAssets, ...stillAssets].slice(0, 18).map((asset) => (
                 <article className="bin-asset" key={asset.id}>
-                  <button onClick={() => onPreview(asset)} type="button">
+                  <button onClick={() => onPreview(asset, [...mainAssets, ...stillAssets].slice(0, 18))} type="button">
                     <AssetMedia asset={asset} />
                   </button>
                   <strong>{asset.displayName}</strong>

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -995,7 +995,7 @@ export function ImageStudio() {
                     thumbnailsVariant="image-grid"
                     thumbnailAssets={completedAssets}
                     expectedThumbnailCount={expectedCount}
-                    onThumbnailClick={onPreview}
+                    onThumbnailClick={(asset) => onPreview(asset, completedAssets)}
                     onCancel={onCancelJob}
                     onOpenQueue={onOpenQueue}
                   />
@@ -1011,7 +1011,7 @@ export function ImageStudio() {
                       asset={asset}
                       deleteAsset={deleteAsset}
                       key={asset.id}
-                      onPreview={onPreview}
+                      onPreview={(previewed) => onPreview(previewed, latestAssets)}
                       purgeAsset={purgeAsset}
                       updateAssetStatus={updateAssetStatus}
                     />

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -23,7 +23,9 @@ export function LibraryScreen() {
     updateAssetStatus,
     updateAssetTags,
   } = useAppContext();
-  const onPreview = setPreviewAsset;
+  // Bind the fullscreen preview to the currently filtered library view so
+  // navigation stays inside the same type/tag/trash scope the user is browsing.
+  const onPreview = (asset) => setPreviewAsset(asset, visibleAssets);
   const onSendImage = (asset) => sendAssetToImage(asset);
   const onSendVideo = (asset) => sendAssetToVideo(asset);
   const onSendEditor = (asset) => {

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -275,7 +275,7 @@ export function QueueScreen() {
                 job={enrichedJob}
                 thumbnailsVariant={variant}
                 thumbnailAssets={thumbnails}
-                onThumbnailClick={setPreviewAsset ?? undefined}
+                onThumbnailClick={setPreviewAsset ? (asset) => setPreviewAsset(asset, thumbnails) : undefined}
                 onCancel={(j) => jobAction(j, "cancel")}
                 onRetry={(j) => jobAction(j, "retry")}
                 onDuplicate={(j) => jobAction(j, "duplicate")}

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1733,7 +1733,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                                 key={asset.id}
                               >
                                 <div className="training-caption-card-head">
-                                  <button className="training-caption-card-thumb" onClick={() => onPreview(asset)} type="button">
+                                  <button className="training-caption-card-thumb" onClick={() => onPreview(asset, memberAssets)} type="button">
                                     <AssetThumbnail asset={asset} />
                                   </button>
                                   <div className="training-caption-card-meta">

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -827,7 +827,7 @@ export function VideoStudio() {
                       job={job}
                       thumbnailsVariant="video-player"
                       thumbnailAssets={jobAssets}
-                      onThumbnailClick={onPreview}
+                      onThumbnailClick={(asset) => onPreview(asset, jobAssets)}
                       onCancel={onCancelJob}
                       onOpenQueue={onOpenQueue}
                     />
@@ -890,7 +890,7 @@ export function VideoStudio() {
                 </div>
                 <div className="recent-clips-strip">
                   {videoAssets.slice(0, 4).map((asset) => (
-                    <button className="tray-item" key={asset.id} onClick={() => onPreview(asset)} type="button">
+                    <button className="tray-item" key={asset.id} onClick={() => onPreview(asset, videoAssets.slice(0, 4))} type="button">
                       <AssetMedia asset={asset} />
                       <span>{asset.displayName}</span>
                     </button>
@@ -948,7 +948,7 @@ export function VideoStudio() {
                     asset={asset}
                     deleteAsset={deleteAsset}
                     key={asset.id}
-                    onPreview={onPreview}
+                    onPreview={(previewed) => onPreview(previewed, latestAssets.slice(1))}
                     purgeAsset={purgeAsset}
                     updateAssetStatus={updateAssetStatus}
                   />

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -79,6 +79,10 @@ export function CharacterReferences({
   submitReference,
   updateCharacterReference,
 }) {
+  // Fullscreen preview stays bound to this character's reference images.
+  const referenceAssets = (selectedCharacter.references ?? [])
+    .map((reference) => reference.asset)
+    .filter(Boolean);
   return (
     <section className="character-section">
       <div className="section-heading">
@@ -103,7 +107,7 @@ export function CharacterReferences({
       <div className="character-reference-grid">
         {(selectedCharacter.references ?? []).map((reference) => (
           <article className={reference.approved ? "reference-card approved" : "reference-card"} key={reference.assetId}>
-            <button className="reference-media" onClick={() => reference.asset && onPreview(reference.asset)} type="button">
+            <button className="reference-media" onClick={() => reference.asset && onPreview(reference.asset, referenceAssets)} type="button">
               {reference.asset ? <AssetMedia asset={reference.asset} /> : <span>Missing asset</span>}
             </button>
             <div>
@@ -429,7 +433,7 @@ export function CharacterTest({
               <AssetCard
                 asset={asset}
                 deleteAsset={deleteAsset}
-                onPreview={onPreview}
+                onPreview={(previewed) => onPreview(previewed, characterAssets)}
                 purgeAsset={purgeAsset}
                 updateAssetStatus={updateAssetStatus}
               />
@@ -663,7 +667,7 @@ export function CharacterAngleSet({
               thumbnailsVariant="image-grid"
               thumbnailAssets={jobImageAssets(job, assets)}
               expectedThumbnailCount={angleCount}
-              onThumbnailClick={onPreview}
+              onThumbnailClick={(previewed) => onPreview?.(previewed, jobImageAssets(job, assets))}
               onCancel={onCancel}
               onRetry={onRetry}
               onDuplicate={onDuplicate}
@@ -680,7 +684,7 @@ export function CharacterAngleSet({
               aria-label={`Preview ${asset.displayName ?? asset.id}`}
               className="reference-thumb"
               key={asset.id}
-              onClick={() => onPreview?.(asset)}
+              onClick={() => onPreview?.(asset, characterImages)}
               type="button"
             >
               <AssetMedia asset={asset} controls={false} />
@@ -763,7 +767,7 @@ export function CharacterAssets({
               <button
                 aria-label={`Preview ${asset.displayName ?? asset.id}`}
                 className="reference-thumb"
-                onClick={() => onPreview?.(asset)}
+                onClick={() => onPreview?.(asset, visibleAssets)}
                 type="button"
               >
                 <AssetMedia asset={asset} controls={false} />
@@ -1127,7 +1131,7 @@ export function CharacterPoseLibrary({
               expectedThumbnailCount={
                 Array.isArray(job.payload?.advanced?.poses) ? job.payload.advanced.poses.length : selectedPoseIds.length
               }
-              onThumbnailClick={onPreview}
+              onThumbnailClick={(previewed) => onPreview?.(previewed, jobImageAssets(job, assets))}
               onCancel={onCancel}
               onRetry={onRetry}
               onDuplicate={onDuplicate}
@@ -1144,7 +1148,7 @@ export function CharacterPoseLibrary({
               aria-label={`Preview ${asset.displayName ?? asset.id}`}
               className="reference-thumb"
               key={asset.id}
-              onClick={() => onPreview?.(asset)}
+              onClick={() => onPreview?.(asset, characterImages)}
               type="button"
             >
               <AssetMedia asset={asset} controls={false} />


### PR DESCRIPTION
## Problem

Opening an asset into the fullscreen lightbox from any collection let you scroll **past** that collection's assets and into others — the main Asset Library, or even a different character's library. Because the lightbox always walked a single global list of every non-trashed asset, **Discard** would then trash an asset from a collection you weren't viewing.

## Fix

The lightbox is now bound to the collection it was launched from.

- **`App.jsx`** — opening the preview snapshots the launching gallery's list as an ordered set of asset ids (`previewScopeIds`). `previewNavigation` and the discard-advance are derived from that scope instead of the global list. Close/purge clear the scope, and exhausting the collection closes the preview rather than jumping to a neighbour elsewhere. A no-scope call still falls back to global navigation, so untouched callers keep working.
- **`assetVariants.js`** — new `restrictFoldedToScope(foldedAssets, scopeIds)` resolves each scoped id against the live folded assets (discarded/purged items drop out, upscale variants stay folded) while preserving the collection's order.
- Every launch point now passes the exact list it renders as the scope.

### Collections bound

| Collection | File |
|---|---|
| Image **Latest Batch** + in-progress job thumbnails | `ImageStudio.jsx` |
| Video **Recent Clips** strip, review grid, job thumbnails | `VideoStudio.jsx` |
| Character **References / Assets / Angles / Poses / Test** | `characterPanels.jsx` |
| **Queue** worker output (per job) | `QueueScreen.jsx` |
| Asset **Library** (respects type/tag/trash filters) | `LibraryScreen.jsx` |
| Editor asset bin, Training caption grid | `EditorScreen.jsx`, `TrainingStudio.jsx` |

## Testing

- Web vitest suite green (278 in this branch; also ran against the main checkout's fuller set with these changes applied — 298 pass).
- New `restrictFoldedToScope` unit test: stays in-collection, drops discarded/purged ids, resolves folded variants, null scope = global fallback. Existing Library preview assertion updated to expect the scope arg.
- App boots clean in the dev server (no build/console errors across the touched screens).

## Reviewer notes

- Backend API wasn't running locally, so the click-through wasn't exercised end-to-end in the browser — that path is covered by the test suite rather than a live screenshot.
- The branch is slightly behind `main` (predates `ImageStudio.test.jsx`/`VideoStudio.test.jsx`); those tests were verified against these changes in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)