### PR TITLE
Queue thumbnails: deleted placeholder for purged outputs, dim discarded

### DIFF
--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -247,19 +247,24 @@ function ThumbnailGrid({ assets, variant, onThumbnailClick, isRunning, expectedC
         ) : null;
         const key = asset.id ?? `interim-${index}`;
         const isInterim = asset.__interim === true;
+        // Discarded (trashed-but-not-purged) assets stay in the catalog, so the
+        // resolved record carries the live status. Dim them so they read as
+        // "set aside" without hiding what the run produced.
+        const isDiscarded = asset.status?.trashed === true;
+        const cellClasses = `${cellClass}${isInterim ? " interim" : ""}${isDiscarded ? " discarded" : ""}`;
         return interactive ? (
           <button
             key={key}
-            className={`${cellClass}${isInterim ? " interim" : ""}`}
+            className={cellClasses}
             type="button"
             onClick={() => onThumbnailClick(asset)}
-            aria-label={asset.displayName ?? "Open asset"}
+            aria-label={`${asset.displayName ?? "Open asset"}${isDiscarded ? " (discarded)" : ""}`}
           >
             {inner}
             {label}
           </button>
         ) : (
-          <span key={key} className={`${cellClass}${isInterim ? " interim" : ""}`}>
+          <span key={key} className={cellClasses}>
             {inner}
             {label}
           </span>

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -457,4 +457,43 @@ describe("WorkerProgressCard thumbnails", () => {
     );
     expect(api.container.querySelector(".worker-progress-card__thumbnails")).toBeNull();
   });
+
+  it("dims discarded (trashed) thumbnails without hiding them", () => {
+    const discarded = { id: "a-3", type: "image", url: "/api/v1/files/a-3.png", status: { trashed: true } };
+    api = render(
+      <WorkerProgressCard
+        job={completedJob}
+        thumbnailsVariant="small-row"
+        thumbnailAssets={[imageAssets[0], discarded]}
+        onThumbnailClick={() => {}}
+      />,
+      makeContext([]),
+    );
+    const cells = api.container.querySelectorAll(".worker-progress-card__thumb-cell");
+    expect(cells).toHaveLength(2);
+    const dimmed = api.container.querySelectorAll(".worker-progress-card__thumb-cell.discarded");
+    expect(dimmed).toHaveLength(1);
+    expect(dimmed[0].getAttribute("aria-label")).toContain("(discarded)");
+  });
+
+  it("swaps a broken (purged) thumbnail for the deleted-asset placeholder", () => {
+    api = render(
+      <WorkerProgressCard
+        job={completedJob}
+        thumbnailsVariant="small-row"
+        thumbnailAssets={[imageAssets[0]]}
+      />,
+      makeContext([]),
+    );
+    const img = api.container.querySelector("img.worker-progress-card__thumb-media");
+    expect(img).not.toBeNull();
+    expect(api.container.querySelector(".asset-thumb-missing")).toBeNull();
+    act(() => {
+      img.dispatchEvent(new window.Event("error", { bubbles: false }));
+    });
+    expect(api.container.querySelector("img.worker-progress-card__thumb-media")).toBeNull();
+    const placeholder = api.container.querySelector(".asset-thumb-missing");
+    expect(placeholder).not.toBeNull();
+    expect(placeholder.getAttribute("aria-label")).toBe("Deleted asset");
+  });
 });

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -31,6 +31,30 @@ export function posterUrl(asset) {
   return src.replace(/\.\w+$/, ".poster.jpg");
 }
 
+// Placeholder shown when an asset's underlying file can't be loaded — e.g. it
+// was purged from disk after the job ran, so the URL now 404s. Replaces the
+// browser's broken-image glyph with a clear "deleted" marker (a red X) so queue
+// thumbnails for purged outputs read as removed rather than broken.
+export function MissingMedia({ className = "" }) {
+  return (
+    <span className={`asset-thumb-missing ${className}`.trim()} role="img" aria-label="Deleted asset" title="Deleted">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M6 6l12 12M18 6L6 18" />
+      </svg>
+    </span>
+  );
+}
+
+// Image thumbnail that falls back to the deleted-asset placeholder once the
+// source fails to load (the file is gone), rather than leaving a broken image.
+function ImageThumb({ src, className }) {
+  const [failed, setFailed] = React.useState(false);
+  if (failed) {
+    return <MissingMedia className={className} />;
+  }
+  return <img alt="" className={className} src={src} onError={() => setFailed(true)} />;
+}
+
 export function AssetThumbnail({ asset, className = "" }) {
   if (!asset) {
     return null;
@@ -43,7 +67,7 @@ export function AssetThumbnail({ asset, className = "" }) {
     return <VideoPoster asset={asset} className={className} />;
   }
   if (assetCanRenderAsImage(asset)) {
-    return <img alt="" className={className} src={src} />;
+    return <ImageThumb src={src} className={className} />;
   }
   return <span className={className}>{asset.type ?? "asset"}</span>;
 }
@@ -51,8 +75,11 @@ export function AssetThumbnail({ asset, className = "" }) {
 function VideoPoster({ asset, className }) {
   const [failed, setFailed] = React.useState(false);
   const poster = posterUrl(asset);
-  if (!poster || failed) {
+  if (!poster) {
     return <span className={className}>{asset.type ?? "video"}</span>;
+  }
+  if (failed) {
+    return <MissingMedia className={className} />;
   }
   return <img alt="" className={className} src={poster} onError={() => setFailed(true)} />;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7216,11 +7216,44 @@ label {
   outline-offset: -1px;
 }
 
+/* Discarded (trashed-but-not-purged) outputs: faded so they read as set aside
+   while still showing what the run produced. Mirrors .review-card.rejected. */
+.worker-progress-card__thumb-cell.discarded .worker-progress-card__thumb-media {
+  opacity: 0.5;
+}
+
 .worker-progress-card__thumb-media {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+/* Deleted-asset placeholder (AssetThumbnail.MissingMedia). Shown in place of a
+   thumbnail whose file is gone — e.g. a purged generation output. Fills its
+   cell so the slot is preserved rather than collapsing or showing a broken
+   image. */
+.asset-thumb-missing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 24px;
+  background: var(--surface-2);
+  color: var(--danger);
+}
+
+.asset-thumb-missing svg {
+  width: 38%;
+  min-width: 14px;
+  max-width: 28px;
+  height: auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  opacity: 0.85;
 }
 
 .worker-progress-card__thumb-label {


### PR DESCRIPTION
## What

Fixes broken thumbnails in the **Queue** for runs whose generated images were later deleted, and visually distinguishes discarded outputs.

- **Purged (file gone):** the queue kept rendering the stale inline asset snapshot from `job.result.assets`, so a purged file's thumbnail 404'd and showed the browser's broken-image glyph. `AssetThumbnail` now swaps to a red‑X **"Deleted"** placeholder on the image/poster `onError`. The slot is preserved in place (not filtered out).
- **Discarded (trashed but not purged):** these assets stay in the catalog (`status.trashed=true`) and `resolveJobAssets` resolves them to the live record. `WorkerProgressCard` now dims those cells (~50% opacity) and appends "(discarded)" to the aria‑label. Still clickable to open.

## Why this approach

- Discard keeps the DB record + file; purge removes both. So discarded → dim from live `status.trashed`; purged → detected by **image load failure**, not catalog absence.
- Using load-failure (rather than "absent from the active project's catalog") keeps **cross‑project queue jobs** safe — their assets legitimately aren't in the active project's `assets` and must not be flagged as deleted.
- No data-layer changes needed; `assets` already loads with `includeTrashed=true`.

## Scope note

The red‑X placeholder lives in the shared `AssetThumbnail`, so any 404'd thumbnail (queue, studios, pickers) now shows a clean placeholder instead of a broken image. The dim treatment is scoped to the queue/progress-card thumbnails.

## Testing

- `vitest`: **300 web tests pass** (15 files), including 2 new tests — discarded cells get `.discarded` + dim, and a failed image swaps to `.asset-thumb-missing`.
- Visually verified all three states (normal / discarded / purged) render correctly against the real stylesheet: `opacity: 0.5` on the discarded image, centered red (`--danger`) X on `--surface-2` for purged.

## Files

- `apps/web/src/components/assetMedia.jsx` — `MissingMedia` placeholder + `ImageThumb`/`VideoPoster` onError fallback
- `apps/web/src/components/WorkerProgressCard.jsx` — `discarded` cell modifier + aria-label
- `apps/web/src/styles.css` — `.asset-thumb-missing` and `.discarded` rules
- `apps/web/src/components/WorkerProgressCard.test.jsx` — 2 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)