### PR TITLE
Image Editor shell polish + viewport-locked app shell (independent sidebar/workspace scroll)

### DIFF
--- a/apps/web/src/components/DatasetAddDialog.jsx
+++ b/apps/web/src/components/DatasetAddDialog.jsx
@@ -58,7 +58,21 @@ function CandidateGrid({ assets, selectedIds, onToggle, emptyLabel }) {
 // from the (scoped) Asset Library, or pull a character's images. The dataset
 // editor owns membership + import; this dialog only collects a selection or
 // hands files back via onImport.
-export function DatasetAddDialog({ assets = [], memberIds = [], characters = [], importing = false, onImport, onAdd, onClose }) {
+export function DatasetAddDialog({
+  assets = [],
+  memberIds = [],
+  characters = [],
+  importing = false,
+  onImport,
+  onAdd,
+  onClose,
+  title = "Add images to dataset",
+  eyebrow = "Add images",
+  confirmLabel = "Add",
+  fileAccept = "image/*,.txt,text/plain",
+  fileHint = "Drag images and caption .txt files here, or",
+  multiple = true,
+}) {
   const [tab, setTab] = useState("file");
   const [selectedIds, setSelectedIds] = useState([]);
   const [characterId, setCharacterId] = useState(characters[0]?.id ?? "");
@@ -88,7 +102,12 @@ export function DatasetAddDialog({ assets = [], memberIds = [], characters = [],
   );
 
   function toggle(id) {
-    setSelectedIds((ids) => (ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id]));
+    setSelectedIds((ids) => {
+      if (ids.includes(id)) {
+        return ids.filter((value) => value !== id);
+      }
+      return multiple ? [...ids, id] : [id];
+    });
   }
 
   function commit() {
@@ -118,8 +137,8 @@ export function DatasetAddDialog({ assets = [], memberIds = [], characters = [],
     <Modal className="dataset-add-modal" labelledBy="dataset-add-title" onClose={onClose}>
       <header className="dataset-add-head">
         <div>
-          <p className="eyebrow">Add images</p>
-          <h2 id="dataset-add-title">Add images to dataset</h2>
+          <p className="eyebrow">{eyebrow}</p>
+          <h2 id="dataset-add-title">{title}</h2>
         </div>
         <button className="modal-close" onClick={onClose} type="button">
           Close
@@ -151,12 +170,12 @@ export function DatasetAddDialog({ assets = [], memberIds = [], characters = [],
           }}
           onDrop={handleDrop}
         >
-          <p>Drag images and caption .txt files here, or</p>
+          <p>{fileHint}</p>
           <label className="file-upload-button">
             <input
-              accept="image/*,.txt,text/plain"
+              accept={fileAccept}
               disabled={importing}
-              multiple
+              multiple={multiple}
               onChange={(event) => {
                 onImport(event.target.files);
                 event.target.value = "";
@@ -207,7 +226,8 @@ export function DatasetAddDialog({ assets = [], memberIds = [], characters = [],
               Done
             </button>
             <button className="primary-action" disabled={!selectedIds.length} onClick={commit} type="button">
-              Add {selectedIds.length || ""}
+              {confirmLabel}
+              {multiple ? ` ${selectedIds.length || ""}` : ""}
             </button>
           </div>
         </footer>

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Stage, Layer, Image as KonvaImage, Rect, Transformer } from "react-konva";
 import { useAppContext } from "../context/AppContext.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
-import { AssetPickerModal } from "../components/AssetPicker.jsx";
+import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 16;
@@ -88,7 +88,7 @@ function blobToImage(blob) {
 }
 
 export function ImageEditor() {
-  const { activeProject, assets, setPreviewAsset } = useAppContext();
+  const { assets, characters, setPreviewAsset } = useAppContext();
 
   // The working-image session: the single bitmap every tool operates on, plus its
   // provenance. This state is the contract consumed by crop/upscale/save and the
@@ -105,7 +105,6 @@ export function ImageEditor() {
   const [cropRect, setCropRect] = useState(null); // image-pixel coords, or null
 
   const containerRef = useRef(null);
-  const fileInputRef = useRef(null);
   const objectUrlRef = useRef(null);
   const needsFitRef = useRef(false);
   const cropRectRef = useRef(null);
@@ -344,237 +343,227 @@ export function ImageEditor() {
 
   return (
     <section className="main-surface image-editor-surface">
-      <div className="surface-header image-editor-header">
-        <div className="section-heading">
-          <p className="eyebrow">Image Editor</p>
-          <h2>{working ? working.source.name : "Edit an image"}</h2>
-        </div>
-        <div className="image-editor-actions">
-          <button onClick={() => setPickerOpen(true)} type="button" disabled={!activeProject}>
-            Open from project
+      <div className="image-editor-bar">
+        <span className="image-editor-title" title={working ? working.source.name : undefined}>
+          {working ? working.source.name : "No image open"}
+        </span>
+        <div className="image-editor-bar-actions">
+          <button className="primary" onClick={() => setPickerOpen(true)} type="button">
+            Open
           </button>
-          <button className="primary" onClick={() => fileInputRef.current?.click()} type="button">
-            Upload image
-          </button>
-          {working ? (
+          {working && working.source.assetId ? (
             <button
-              onClick={() => working.source.assetId && setPreviewAsset?.(imageAssets.find((a) => a.id === working.source.assetId))}
+              onClick={() => setPreviewAsset?.(imageAssets.find((item) => item.id === working.source.assetId))}
+              title="Preview the source asset"
               type="button"
-              disabled={!working.source.assetId}
-              title={working.source.assetId ? "Preview the source asset" : "Uploaded image — not yet a project asset"}
             >
               Source
             </button>
           ) : null}
-          <input
-            accept="image/*"
-            hidden
-            onChange={(event) => {
-              const file = event.target.files?.[0];
-              if (file) openFile(file);
-              event.target.value = "";
-            }}
-            ref={fileInputRef}
-            type="file"
-          />
         </div>
       </div>
 
       {status.error ? <div className="notice notice-error image-editor-notice">{status.error}</div> : null}
 
-      <div className="image-editor-body">
-        <aside className="image-editor-toolbar" aria-label="Editor tools">
-          <button
-            className={tool === "move" ? "image-editor-tool active" : "image-editor-tool"}
-            onClick={cancelCrop}
-            title="Move / pan"
-            type="button"
+      <div
+        className="image-editor-canvas-wrap"
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={handleDrop}
+        ref={containerRef}
+      >
+        {working && stageSize.width > 0 && stageSize.height > 0 ? (
+          <Stage
+            draggable={tool !== "crop"}
+            height={stageSize.height}
+            onDragEnd={(event) => {
+              if (event.target !== event.target.getStage()) return;
+              const stage = event.target.getStage();
+              setView((prev) => ({ ...prev, x: stage.x(), y: stage.y() }));
+            }}
+            onWheel={handleWheel}
+            scaleX={view.scale}
+            scaleY={view.scale}
+            width={stageSize.width}
+            x={view.x}
+            y={view.y}
           >
-            Move
-          </button>
-          <button
-            className={tool === "crop" ? "image-editor-tool active" : "image-editor-tool"}
-            disabled={!working}
-            onClick={startCrop}
-            title="Crop"
-            type="button"
-          >
-            Crop
-          </button>
-          {UPCOMING_TOOLS.map((upcoming) => (
+            <Layer>
+              <Rect
+                fill="#ffffff"
+                height={working.height}
+                shadowBlur={12}
+                shadowColor="rgba(0,0,0,0.35)"
+                width={working.width}
+                x={0}
+                y={0}
+              />
+              <KonvaImage height={working.height} image={working.image} width={working.width} x={0} y={0} />
+              {tool === "crop" && cropRect ? (
+                <>
+                  {cropOverlayRects(working.width, working.height, cropRect).map((rect, index) => (
+                    <Rect
+                      key={index}
+                      fill="rgba(0,0,0,0.55)"
+                      height={rect.height}
+                      listening={false}
+                      width={rect.width}
+                      x={rect.x}
+                      y={rect.y}
+                    />
+                  ))}
+                  <Rect
+                    draggable
+                    fill="rgba(255,255,255,0.01)"
+                    height={cropRect.height}
+                    onDragEnd={handleCropDragEnd}
+                    onTransformEnd={handleCropTransformEnd}
+                    ref={cropRectRef}
+                    stroke="#ffffff"
+                    strokeScaleEnabled={false}
+                    strokeWidth={2}
+                    width={cropRect.width}
+                    x={cropRect.x}
+                    y={cropRect.y}
+                  />
+                  <Transformer
+                    anchorSize={8}
+                    borderStroke="#ffffff"
+                    boundBoxFunc={(oldBox, newBox) =>
+                      newBox.width < MIN_CROP_PX || newBox.height < MIN_CROP_PX ? oldBox : newBox
+                    }
+                    enabledAnchors={
+                      ratioKey === "free"
+                        ? ["top-left", "top-center", "top-right", "middle-left", "middle-right", "bottom-left", "bottom-center", "bottom-right"]
+                        : ["top-left", "top-right", "bottom-left", "bottom-right"]
+                    }
+                    keepRatio={ratioKey !== "free"}
+                    ref={transformerRef}
+                    rotateEnabled={false}
+                  />
+                </>
+              ) : null}
+            </Layer>
+          </Stage>
+        ) : (
+          <div className="image-editor-empty">
+            {status.loading ? (
+              <p>Loading image…</p>
+            ) : (
+              <>
+                <p className="image-editor-empty-title">Open an image to start editing</p>
+                <p className="image-editor-empty-hint">Drag &amp; drop an image here, or click Open.</p>
+              </>
+            )}
+          </div>
+        )}
+
+        {working ? (
+          <aside className="image-editor-toolbar" aria-label="Editor tools">
             <button
-              className="image-editor-tool"
-              disabled
-              key={upcoming.id}
-              title={`${upcoming.label} — coming soon (${upcoming.story})`}
+              className={tool === "move" ? "image-editor-tool active" : "image-editor-tool"}
+              onClick={cancelCrop}
+              title="Move / pan"
               type="button"
             >
-              {upcoming.label}
+              Move
             </button>
-          ))}
-        </aside>
-
-        <div
-          className="image-editor-canvas-wrap"
-          onDragOver={(event) => event.preventDefault()}
-          onDrop={handleDrop}
-          ref={containerRef}
-        >
-          {working && stageSize.width > 0 && stageSize.height > 0 ? (
-            <Stage
-              draggable={tool !== "crop"}
-              height={stageSize.height}
-              onDragEnd={(event) => {
-                if (event.target !== event.target.getStage()) return;
-                const stage = event.target.getStage();
-                setView((prev) => ({ ...prev, x: stage.x(), y: stage.y() }));
-              }}
-              onWheel={handleWheel}
-              scaleX={view.scale}
-              scaleY={view.scale}
-              width={stageSize.width}
-              x={view.x}
-              y={view.y}
+            <button
+              className={tool === "crop" ? "image-editor-tool active" : "image-editor-tool"}
+              onClick={startCrop}
+              title="Crop"
+              type="button"
             >
-              <Layer>
-                <Rect
-                  fill="#ffffff"
-                  height={working.height}
-                  shadowBlur={12}
-                  shadowColor="rgba(0,0,0,0.35)"
-                  width={working.width}
-                  x={0}
-                  y={0}
-                />
-                <KonvaImage height={working.height} image={working.image} width={working.width} x={0} y={0} />
-                {tool === "crop" && cropRect ? (
-                  <>
-                    {cropOverlayRects(working.width, working.height, cropRect).map((rect, index) => (
-                      <Rect
-                        key={index}
-                        fill="rgba(0,0,0,0.55)"
-                        height={rect.height}
-                        listening={false}
-                        width={rect.width}
-                        x={rect.x}
-                        y={rect.y}
-                      />
-                    ))}
-                    <Rect
-                      draggable
-                      fill="rgba(255,255,255,0.01)"
-                      height={cropRect.height}
-                      onDragEnd={handleCropDragEnd}
-                      onTransformEnd={handleCropTransformEnd}
-                      ref={cropRectRef}
-                      stroke="#ffffff"
-                      strokeScaleEnabled={false}
-                      strokeWidth={2}
-                      width={cropRect.width}
-                      x={cropRect.x}
-                      y={cropRect.y}
-                    />
-                    <Transformer
-                      anchorSize={8}
-                      borderStroke="#ffffff"
-                      boundBoxFunc={(oldBox, newBox) =>
-                        newBox.width < MIN_CROP_PX || newBox.height < MIN_CROP_PX ? oldBox : newBox
-                      }
-                      enabledAnchors={
-                        ratioKey === "free"
-                          ? ["top-left", "top-center", "top-right", "middle-left", "middle-right", "bottom-left", "bottom-center", "bottom-right"]
-                          : ["top-left", "top-right", "bottom-left", "bottom-right"]
-                      }
-                      keepRatio={ratioKey !== "free"}
-                      ref={transformerRef}
-                      rotateEnabled={false}
-                    />
-                  </>
-                ) : null}
-              </Layer>
-            </Stage>
-          ) : (
-            <div className="image-editor-empty">
-              {status.loading ? (
-                <p>Loading image…</p>
-              ) : (
-                <>
-                  <p className="image-editor-empty-title">Open an image to start editing</p>
-                  <p className="image-editor-empty-hint">
-                    Drag &amp; drop an image here, upload a file, or open one from this project.
-                  </p>
-                </>
-              )}
-            </div>
-          )}
-
-          {tool === "crop" && cropRect ? (
-            <div className="image-editor-cropbar">
-              <div className="image-editor-ratios" role="group" aria-label="Crop ratio">
-                {CROP_RATIOS.map((entry) => (
-                  <button
-                    className={ratioKey === entry.key ? "active" : ""}
-                    key={entry.key}
-                    onClick={() => chooseRatio(entry.key)}
-                    type="button"
-                  >
-                    {entry.label}
-                  </button>
-                ))}
-              </div>
+              Crop
+            </button>
+            {UPCOMING_TOOLS.map((upcoming) => (
               <button
-                className={rotated ? "active" : ""}
-                disabled={ratioKey === "free" || ratioKey === "1:1"}
-                onClick={toggleRotate}
-                title="Rotate ratio (swap orientation)"
+                className="image-editor-tool"
+                disabled
+                key={upcoming.id}
+                title={`${upcoming.label} — coming soon (${upcoming.story})`}
                 type="button"
               >
-                ⟲ Rotate
+                {upcoming.label}
               </button>
-              <span className="image-editor-cropdims">
-                {Math.round(cropRect.width)} × {Math.round(cropRect.height)}
-              </span>
-              <button className="primary" onClick={applyCrop} type="button">
-                Apply
-              </button>
-              <button onClick={cancelCrop} type="button">
-                Cancel
-              </button>
-            </div>
-          ) : null}
+            ))}
+          </aside>
+        ) : null}
 
-          {working ? (
-            <div className="image-editor-viewbar">
-              <button onClick={() => zoomAtCenter(1 / ZOOM_STEP)} title="Zoom out" type="button">
-                −
-              </button>
-              <span className="image-editor-zoom">{Math.round(view.scale * 100)}%</span>
-              <button onClick={() => zoomAtCenter(ZOOM_STEP)} title="Zoom in" type="button">
-                +
-              </button>
-              <button onClick={fitToView} type="button">
-                Fit
-              </button>
-              <button onClick={actualSize} type="button">
-                100%
-              </button>
-              <span className="image-editor-dims">
-                {working.width} × {working.height}
-              </span>
+        {tool === "crop" && cropRect ? (
+          <div className="image-editor-cropbar">
+            <div className="image-editor-ratios" role="group" aria-label="Crop ratio">
+              {CROP_RATIOS.map((entry) => (
+                <button
+                  className={ratioKey === entry.key ? "active" : ""}
+                  key={entry.key}
+                  onClick={() => chooseRatio(entry.key)}
+                  type="button"
+                >
+                  {entry.label}
+                </button>
+              ))}
             </div>
-          ) : null}
-        </div>
+            <button
+              className={rotated ? "active" : ""}
+              disabled={ratioKey === "free" || ratioKey === "1:1"}
+              onClick={toggleRotate}
+              title="Rotate ratio (swap orientation)"
+              type="button"
+            >
+              ⟲ Rotate
+            </button>
+            <span className="image-editor-cropdims">
+              {Math.round(cropRect.width)} × {Math.round(cropRect.height)}
+            </span>
+            <button className="primary" onClick={applyCrop} type="button">
+              Apply
+            </button>
+            <button onClick={cancelCrop} type="button">
+              Cancel
+            </button>
+          </div>
+        ) : null}
+
+        {working ? (
+          <div className="image-editor-viewbar">
+            <button onClick={() => zoomAtCenter(1 / ZOOM_STEP)} title="Zoom out" type="button">
+              −
+            </button>
+            <span className="image-editor-zoom">{Math.round(view.scale * 100)}%</span>
+            <button onClick={() => zoomAtCenter(ZOOM_STEP)} title="Zoom in" type="button">
+              +
+            </button>
+            <button onClick={fitToView} type="button">
+              Fit
+            </button>
+            <button onClick={actualSize} type="button">
+              100%
+            </button>
+            <span className="image-editor-dims">
+              {working.width} × {working.height}
+            </span>
+          </div>
+        ) : null}
       </div>
 
       {pickerOpen ? (
-        <AssetPickerModal
-          assets={imageAssets}
-          initialSelectedIds={[]}
+        <DatasetAddDialog
+          assets={assets ?? []}
+          characters={characters ?? []}
+          confirmLabel="Open"
+          eyebrow="Open"
+          fileAccept="image/*"
+          fileHint="Drag an image here, or"
           multiple={false}
-          onCancel={() => setPickerOpen(false)}
-          onConfirm={(ids) => {
+          onAdd={(ids) => {
             setPickerOpen(false);
             if (ids[0]) openAsset(ids[0]);
+          }}
+          onClose={() => setPickerOpen(false)}
+          onImport={(files) => {
+            const file = files?.[0];
+            setPickerOpen(false);
+            if (file) openFile(file);
           }}
           title="Open image"
         />

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -24,14 +24,15 @@ function baseContext(overrides = {}) {
   return {
     activeProject: null,
     assets: [],
+    characters: [],
     setPreviewAsset: vi.fn(),
     ...overrides,
   };
 }
 
 const toolButtons = (container) => [...container.querySelectorAll(".image-editor-tool")];
-const actionButton = (container, label) =>
-  [...container.querySelectorAll(".image-editor-actions button")].find((b) => b.textContent.trim() === label);
+const barButtons = (container) => [...container.querySelectorAll(".image-editor-bar-actions button")];
+const barButton = (container, label) => barButtons(container).find((b) => b.textContent.trim() === label);
 
 describe("ImageEditor scaffold", () => {
   let container;
@@ -61,29 +62,25 @@ describe("ImageEditor scaffold", () => {
     await act(async () => {});
   }
 
-  it("renders the empty state and inert tool scaffold without a working image", async () => {
+  it("renders the empty state with the tool palette hidden until an image loads", async () => {
     await render(baseContext());
 
     expect(container.textContent).toContain("Open an image to start editing");
-    // No working image → no Konva stage / view controls yet.
+    // No working image → no Konva stage, view controls, or floating tool palette.
     expect(container.querySelector(".image-editor-viewbar")).toBeNull();
-
-    const tools = toolButtons(container);
-    expect(tools.map((b) => b.textContent.trim())).toEqual(["Move", "Crop", "Upscale", "AI Edit", "Detail", "Color"]);
-    // Move is the active default. Without a loaded image Crop is gated off, and the
-    // remaining tools are inert placeholders for later slices — so all but Move are
-    // disabled here.
-    expect(tools[0].disabled).toBe(false);
-    expect(tools.slice(1).every((b) => b.disabled)).toBe(true);
+    expect(toolButtons(container)).toHaveLength(0);
   });
 
-  it("gates 'Open from project' on an active project but always offers upload", async () => {
+  it("offers a single always-enabled 'Open' action (source is chosen in the dialog)", async () => {
     await render(baseContext());
-    expect(actionButton(container, "Open from project").disabled).toBe(true);
-    expect(actionButton(container, "Upload image")).toBeTruthy();
+    expect(barButtons(container).map((b) => b.textContent.trim())).toEqual(["Open"]);
+    expect(barButton(container, "Open").disabled).toBe(false);
 
+    // Still a single, always-enabled Open with a project — there are no separate
+    // "Open from project" / "Upload" buttons; the dialog picks the source.
     await render(baseContext({ activeProject: { id: "project_1", name: "My Project" } }));
-    expect(actionButton(container, "Open from project").disabled).toBe(false);
+    expect(barButtons(container).map((b) => b.textContent.trim())).toEqual(["Open"]);
+    expect(barButton(container, "Open").disabled).toBe(false);
   });
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -209,7 +209,11 @@ button:focus-visible {
 .app {
   display: grid;
   grid-template-columns: var(--side-w) minmax(0, 1fr);
-  min-height: 100vh;
+  /* Lock the shell to the viewport so the page itself never scrolls; the sidebar
+     and the workspace each scroll independently within their own region. */
+  grid-template-rows: minmax(0, 1fr);
+  height: 100vh;
+  overflow: hidden;
   background: var(--bg);
 }
 
@@ -220,6 +224,7 @@ button:focus-visible {
   padding: 18px 14px;
   background: var(--bg-2);
   border-right: 1px solid var(--border);
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -705,6 +710,8 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
   background: var(--bg);
 }
 
@@ -5118,11 +5125,14 @@ label {
   margin: 8px 16px 0;
 }
 
-/* The tool palette floats over the canvas on the right, like the zoom bar. */
+/* The tool palette floats over the canvas on the right, like the zoom bar. It
+   scrolls within itself if it ever outgrows the canvas height (more tools/panels). */
 .image-editor-toolbar {
   position: absolute;
   top: 12px;
   right: 12px;
+  max-height: calc(100% - 24px);
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5072,41 +5072,65 @@ label {
 
 /* ── Image Editor (epic 2427) ───────────────────────────────────────────── */
 .image-editor-surface {
-  gap: 14px;
-}
-
-.image-editor-header {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.image-editor-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.image-editor-notice {
-  margin: 0;
-}
-
-.image-editor-body {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 12px;
+  flex-direction: column;
+  gap: 0;
   min-height: 0;
 }
 
+/* Full-bleed: drop the card chrome + workspace gutter so the canvas fills the
+   whole content area (the screen title already lives in the top page header). */
+.workspace > section.main-surface.image-editor-surface {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+}
+
+/* Thin bar under the page header: image title + Open / Source. */
+.image-editor-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.image-editor-title {
+  font-weight: 600;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.image-editor-bar-actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.image-editor-notice {
+  margin: 8px 16px 0;
+}
+
+/* The tool palette floats over the canvas on the right, like the zoom bar. */
 .image-editor-toolbar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
   display: flex;
   flex-direction: column;
   gap: 6px;
   padding: 8px;
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  background: var(--surface-2);
+  background: var(--surface);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
 }
 
 .image-editor-tool {
@@ -5121,9 +5145,10 @@ label {
 
 .image-editor-canvas-wrap {
   position: relative;
-  height: clamp(420px, calc(100vh - 240px), 1080px);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
+  flex: 1 1 auto;
+  /* Fills the surface via flex; the floor keeps the canvas from collapsing if the
+     flex chain ever resolves to zero height (e.g. a 0-height ancestor). */
+  min-height: 420px;
   background: repeating-conic-gradient(var(--surface-2) 0% 25%, var(--surface) 0% 50%) 50% / 24px 24px;
   overflow: hidden;
 }


### PR DESCRIPTION
**epic 2427 — Image Editor**, [sc-2446](https://app.shortcut.com/trefry/story/2446). UX polish on the editor shell from review of the live editor (refines the foundation + crop already on `main`).

## Editor shell
- **Full-bleed canvas** — drop the card chrome (border/radius/padding) and the workspace gutter; the canvas fills the entire content area (a 420px floor keeps it from collapsing if the flex chain ever resolves to 0 height).
- **No duplicate "Image Editor"** — removed the in-surface eyebrow/heading; the title lives only in the page header.
- **Thin bar under the header** — image title left, a single **Open** button right.
- **Unified Open dialog** — one **Open** opens `DatasetAddDialog` (File / Asset Library / Character tabs); the source is chosen inside the dialog, replacing the separate "Open from project" + "Upload image" buttons. `DatasetAddDialog` gained optional props (`title`, `eyebrow`, `confirmLabel`, `fileAccept`, `fileHint`, `multiple`) with **defaults that preserve its three existing callers**. The editor passes `multiple={false}` → single-file picker + single-select grid; datasets keep multi.
- **Floating tool palette** — moved to the right, floating over the canvas like the zoom bar; hidden until an image loads; scrolls within itself if it outgrows the canvas.

## Viewport-locked app shell (fixes header/bar scrolling off)
- Lock `.app` to the viewport (`height:100vh` + `grid-template-rows: minmax(0,1fr)` + `overflow:hidden`) so the page itself never scrolls.
- The left nav **sidebar scrolls independently** within its own region (`min-height:0` + existing `overflow-y:auto`).
- The **workspace scrolls independently** (`overflow-y:auto` + `min-height:0`); the sticky topbar stays pinned and the editor's title/Open bar no longer scrolls off (the editor fills the viewport and doesn't scroll). Applies to all screens — content scrolls within the workspace instead of the page.

## Verification
- 304/304 web tests; production build clean.
- Live browser (prebuilt rust-api + throwaway project): full-bleed edge-to-edge canvas; Open dialog with the three tabs + single-select + `image/*`; tool palette floats right. At 1280×720 (previously broken): page not scrollable, sidebar scrolls to its bottom items, editor bar pinned at top:64, Image Studio still scrolls within the workspace with the topbar fixed, modals still overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)