### PR TITLE
Standalone image_upscale job (reuse existing Real-ESRGAN/AuraSR engines)

### DIFF
--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -11,6 +11,7 @@ export const GPU_REQUIRED_JOB_TYPES = new Set([
   "image_edit",
   "image_vqa",
   "image_interleave",
+  "image_upscale",
   "video_generate",
   "video_extend",
   "video_bridge",

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -7921,6 +7921,152 @@ def find_asset_media_path(project_path: Path, asset_id: str) -> Path:
     raise RuntimeError(f"Source image asset not found: {asset_id}.")
 
 
+def _source_display_name(project_path: Path, asset_id: str) -> str | None:
+    sidecar_path = find_asset_sidecar_path(project_path, asset_id)
+    if sidecar_path is None:
+        return None
+    try:
+        return read_json(sidecar_path).get("displayName")
+    except (OSError, ValueError):
+        return None
+
+
+def run_image_upscale(
+    settings: WorkerSettings,
+    job: dict[str, Any],
+    *,
+    project_path: Path,
+    progress: ProgressCallback,
+    cancel_requested: CancelCallback,
+) -> dict[str, Any]:
+    """Standalone upscale of an existing image asset (Image Editor, epic 2427).
+
+    Resolves a `sourceAssetId` to its on-disk image (native resolution — unlike
+    ``load_source_image`` it does not resize to a request W×H), runs the existing
+    Real-ESRGAN / AuraSR engine, and writes exactly one child asset with lineage
+    back to the source (``parents`` + ``extra.isUpscaled``). The asset-write fact
+    mirrors the inline upscale post-step so the Rust persist path is unchanged.
+    """
+    payload = job["payload"]
+    source_asset_id = payload.get("sourceAssetId")
+    if not source_asset_id:
+        raise RuntimeError("Upscale jobs require a source image asset.")
+    factor = safe_int(payload.get("factor"), 2, 2, 4)
+    if factor not in {2, 4}:
+        factor = 2
+    engine = str(payload.get("engine") or "real-esrgan").strip() or "real-esrgan"
+    advanced = payload.get("advanced") if isinstance(payload.get("advanced"), dict) else {}
+    manifest_entry = (
+        payload.get("modelManifestEntry") if isinstance(payload.get("modelManifestEntry"), dict) else {}
+    )
+
+    progress("preparing", "preparing", 0.12, "Loading source image.")
+    source_path = find_asset_media_path(project_path, source_asset_id)
+    try:
+        image = Image.open(source_path).convert("RGB")
+    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise RuntimeError(f"Source image could not be loaded safely: {source_path}") from exc
+
+    # Minimal request: only the upscale machinery (engine + weight resolution) reads
+    # these fields; width/height carry the native source size for telemetry only.
+    request = ImageRequest(
+        project_id=str(payload.get("projectId") or ""),
+        mode="image_upscale",
+        prompt="",
+        negative_prompt="",
+        model=engine,
+        count=1,
+        seed=None,
+        seeds=[],
+        width=image.width,
+        height=image.height,
+        style_preset="",
+        loras=[],
+        character_id=None,
+        character_look_id=None,
+        source_asset_id=source_asset_id,
+        reference_asset_id=None,
+        advanced=advanced,
+        model_manifest_entry=manifest_entry,
+        upscale=UpscaleRequest(enabled=True, factor=factor, engine=engine),
+    )
+    upscaler = create_image_upscaler(request, settings=settings, job_id=job.get("id"))
+    if upscaler is None:
+        raise RuntimeError(f"Unsupported image upscale engine: {engine}.")
+
+    progress("running", "running", 0.45, f"Upscaling {factor}x with {upscaler.id}.")
+    upscaled = upscaler.upscale(image, request=request, cancel_requested=cancel_requested)
+    if cancel_requested():
+        raise InterruptedError("Image upscale canceled by user.")
+
+    created_at = utc_now()
+    generation_set_id = f"genset_{uuid4().hex}"
+    images_dir = project_path / "assets" / "images" / generation_set_id
+    images_dir.mkdir(parents=True, exist_ok=True)
+    asset_id = f"asset_{uuid4().hex}"
+    filename = f"{created_at[:10]}_upscaled_x{factor}_{asset_id[6:14]}.png"
+    media_rel = f"assets/images/{generation_set_id}/{filename}"
+    upscaled.save(project_path / media_rel, "PNG")
+
+    source_name = payload.get("displayName") or _source_display_name(project_path, source_asset_id) or "Image"
+    upscale_settings = {
+        "enabled": True,
+        "engine": upscaler.id,
+        "factor": factor,
+        "sourceWidth": image.width,
+        "sourceHeight": image.height,
+        "width": upscaled.width,
+        "height": upscaled.height,
+    }
+    fact = {
+        "assetId": asset_id,
+        "mediaPath": media_rel,
+        "mimeType": "image/png",
+        "type": "image",
+        "width": upscaled.width,
+        "height": upscaled.height,
+        "normalizedWidth": upscaled.width,
+        "normalizedHeight": upscaled.height,
+        "count": 1,
+        "seed": 0,
+        "displayName": f"{source_name} ({factor}x upscaled)",
+        "createdAt": created_at,
+        "mode": "image_upscale",
+        "model": upscaler.id,
+        "adapter": upscaler.id,
+        "prompt": "",
+        "negativePrompt": "",
+        "loras": [],
+        "stylePreset": "",
+        "sourceAssetId": source_asset_id,
+        "rawAdapterSettings": {"upscale": upscale_settings},
+        "parents": [source_asset_id],
+        "extra": {
+            "isUpscaled": True,
+            "upscaledFromAssetId": source_asset_id,
+            "factor": factor,
+            "engine": upscaler.id,
+        },
+    }
+    generation_set = {
+        "id": generation_set_id,
+        "mode": "image_upscale",
+        "model": upscaler.id,
+        "prompt": "",
+        "negativePrompt": "",
+        "count": 1,
+        "createdAt": created_at,
+    }
+    return {
+        "generationSetId": generation_set_id,
+        "expectedCount": 1,
+        "adapter": upscaler.id,
+        "model": upscaler.id,
+        "generationSet": generation_set,
+        "assetWrites": [fact],
+    }
+
+
 def render_preview_image(request: ImageRequest, model_target: dict[str, Any], seed: int, index: int) -> Image.Image:
     import numpy as np
 

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -35,6 +35,7 @@ from .image_adapters import (
     evict_other_image_adapters,
     image_request_from_job,
     release_image_worker_memory,
+    run_image_upscale,
     torch_inference_backend_available,
 )
 from .instantid_adapter import InstantIDAdapter
@@ -105,6 +106,12 @@ INTERLEAVE_JOB_TYPES = ("image_interleave",)
 # utility worker never claims it. Keep in sync with
 # crates/sceneworks-core/src/contracts.rs::JobType/WorkerCapability.
 PROMPT_REFINE_JOB_TYPES = ("prompt_refine",)
+# Standalone image upscale (Image Editor, epic 2427): Real-ESRGAN / AuraSR on an
+# existing asset → one child asset. Torch-backed, GPU-required like generation;
+# advertised by a backend-capable Python worker. Keep in sync with
+# contracts.rs::JobType/WorkerCapability, jobs_store::job_requires_gpu, and
+# apps/web/src/jobTypes.js::GPU_REQUIRED_JOB_TYPES.
+IMAGE_UPSCALE_JOB_TYPES = ("image_upscale",)
 # Every runtime-dispatchable job-type group, in a stable order, for the
 # ``--check`` diagnostic. Derived from the groups above so run_check can't drift
 # out of sync and underreport readiness (sc-1635: VQA + interleave were
@@ -120,6 +127,7 @@ ALL_JOB_TYPES = (
     + VQA_JOB_TYPES
     + INTERLEAVE_JOB_TYPES
     + PROMPT_REFINE_JOB_TYPES
+    + IMAGE_UPSCALE_JOB_TYPES
 )
 
 
@@ -158,6 +166,8 @@ def worker_capabilities(gpu: dict) -> list[str]:
             capabilities |= set(CAPTION_JOB_TYPES)
             capabilities |= set(VQA_JOB_TYPES)
             capabilities |= set(INTERLEAVE_JOB_TYPES)
+            # Standalone image upscale reuses the torch-backed engines (sc-2431).
+            capabilities |= set(IMAGE_UPSCALE_JOB_TYPES)
             # Prompt refinement loads a small LLM in-process (like captioning), so
             # it needs the inference backend and is advertised alongside it.
             capabilities |= set(PROMPT_REFINE_JOB_TYPES)
@@ -1248,6 +1258,67 @@ def run_pose_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
         heartbeat(api, settings, "idle")
 
 
+def run_upscale_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    """Run an image_upscale job: Real-ESRGAN / AuraSR on one existing asset.
+
+    Torch-backed (the engine is loaded lazily by run_image_upscale), so the worker
+    advertises image_upscale only when the inference backend is installed
+    (worker_capabilities). Writes one child asset with lineage to the source.
+    """
+    job_id = job["id"]
+    peaks: dict[str, float] = {}
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        payload = {"status": status, "stage": stage, "progress": value, "message": message}
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(None, settings))
+        update_job(api, job_id, payload)
+
+    try:
+        progress("preparing", "preparing", 0.06, "Preparing image upscale.")
+        project_id = str(job.get("payload", {}).get("projectId") or "")
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", project_id)
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda cancel: run_image_upscale(
+                settings,
+                job,
+                project_path=project_path,
+                progress=progress,
+                cancel_requested=cancel,
+            ),
+            loaded_models=lambda: [],
+            peaks=peaks,
+        )
+        update_job(
+            api,
+            job_id,
+            {"status": "completed", "stage": "completed", "progress": 1,
+             "message": "Upscaled image saved.", "result": result},
+        )
+    except InterruptedError as exc:
+        update_job(
+            api,
+            job_id,
+            {"status": "canceled", "stage": "canceled", "progress": 1, "message": str(exc)},
+        )
+    except Exception as exc:
+        needs_oom_restart = is_cuda_oom(exc)
+        message, error = friendly_failure("Image upscale", exc)
+        update_job(
+            api,
+            job_id,
+            {"status": "failed", "stage": "failed", "progress": 1, "message": message, "error": error},
+        )
+        if needs_oom_restart:
+            release_image_worker_memory()
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def run_lora_train_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     """Run a lora_train job: validate the plan, then either report a dry-run
     summary or execute the real training kernel.
@@ -1570,6 +1641,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
             emit({"event": "claimed", "jobId": job["id"], "gpuId": job["assignedGpu"], "reportedAt": utc_now()})
             if job["type"] in IMAGE_JOB_TYPES:
                 run_image_job(api, settings, job, image_adapters)
+            elif job["type"] in IMAGE_UPSCALE_JOB_TYPES:
+                run_upscale_job(api, settings, job)
             elif job["type"] in VQA_JOB_TYPES:
                 run_vqa_job(api, settings, job, image_adapters)
             elif job["type"] in INTERLEAVE_JOB_TYPES:

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -203,6 +203,10 @@ string_enum! {
         // Pose Library (epic 2282). onnxruntime-backed like person_detect; advertised
         // by the Python worker, routed via requested_gpu (not in NON_GPU_JOB_TYPES).
         PoseDetect => "pose_detect",
+        // Standalone upscale of an existing image asset (Image Editor, epic 2427).
+        // Torch-backed (Real-ESRGAN / AuraSR), GPU-required like generation; reuses
+        // the upscale engines that previously only ran as a generation post-step.
+        ImageUpscale => "image_upscale",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",
@@ -299,6 +303,10 @@ string_enum! {
         // replace-person readiness; the Rust worker never emits it. Not dead — see
         // the API "segment" capability mapping.
         PersonSegment => "person_segment",
+        // Standalone image upscale (Image Editor, epic 2427). Advertised by the
+        // Python worker when the torch inference backend is available (runtime.py);
+        // the Rust utility worker never emits it. See jobs_store::job_requires_gpu.
+        ImageUpscale => "image_upscale",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1613,6 +1613,7 @@ fn job_requires_gpu(job_type: &JobType) -> bool {
             | JobType::ImageEdit
             | JobType::ImageVqa
             | JobType::ImageInterleave
+            | JobType::ImageUpscale
             | JobType::VideoGenerate
             | JobType::VideoExtend
             | JobType::VideoBridge

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -294,6 +294,7 @@ def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
         "image_edit",
         "image_generate",
         "image_interleave",
+        "image_upscale",
         "image_vqa",
         "lora_train",
         "lora_train_execute",
@@ -304,6 +305,87 @@ def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
         "video_extend",
         "video_generate",
     ]
+
+
+def test_run_image_upscale_writes_single_child_asset(tmp_path, monkeypatch):
+    # sc-2431: standalone upscale of an existing asset. Mock the engine so the
+    # orchestration (source resolve → one child asset + lineage) is exercised
+    # without torch/weights (CI has neither).
+    from scene_worker.image_adapters import run_image_upscale
+
+    source = Image.new("RGB", (8, 6), "blue")
+    source_path = tmp_path / "src.png"
+    source.save(source_path, "PNG")
+
+    class _FakeUpscaler:
+        id = "real-esrgan"
+
+        def upscale(self, image, *, request, cancel_requested):
+            factor = request.upscale.factor
+            return image.resize((image.width * factor, image.height * factor))
+
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.find_asset_media_path",
+        lambda project_path, asset_id: source_path,
+    )
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.create_image_upscaler",
+        lambda request, **kwargs: _FakeUpscaler(),
+    )
+
+    job = {
+        "id": "job_upscale_1",
+        "payload": {
+            "projectId": "project_1",
+            "sourceAssetId": "asset_src",
+            "factor": 2,
+            "engine": "real-esrgan",
+            "displayName": "Studio still",
+        },
+    }
+    result = run_image_upscale(
+        SimpleNamespace(gpu_id=None),
+        job,
+        project_path=tmp_path,
+        progress=lambda *args: None,
+        cancel_requested=lambda: False,
+    )
+
+    writes = result["assetWrites"]
+    assert len(writes) == 1
+    fact = writes[0]
+    # Upscaled to 2x of the 8x6 source.
+    assert (fact["width"], fact["height"]) == (16, 12)
+    assert fact["mode"] == "image_upscale"
+    assert fact["sourceAssetId"] == "asset_src"
+    assert fact["parents"] == ["asset_src"]
+    assert fact["displayName"] == "Studio still (2x upscaled)"
+    assert fact["extra"] == {
+        "isUpscaled": True,
+        "upscaledFromAssetId": "asset_src",
+        "factor": 2,
+        "engine": "real-esrgan",
+    }
+    # The upscaled PNG was actually written to the reported path at 2x size.
+    written_path = tmp_path / fact["mediaPath"]
+    assert written_path.is_file()
+    assert Image.open(written_path).size == (16, 12)
+    # One generation set wrapping the single child asset.
+    assert result["expectedCount"] == 1
+    assert result["generationSet"]["id"] == result["generationSetId"]
+
+
+def test_run_image_upscale_requires_source_asset(monkeypatch, tmp_path):
+    from scene_worker.image_adapters import run_image_upscale
+
+    with pytest.raises(RuntimeError, match="source image asset"):
+        run_image_upscale(
+            SimpleNamespace(gpu_id=None),
+            {"id": "job_x", "payload": {"projectId": "p"}},
+            project_path=tmp_path,
+            progress=lambda *args: None,
+            cancel_requested=lambda: False,
+        )
 
 
 def test_gpu_worker_advertises_lora_train_execute_only_with_inference_backend(monkeypatch):
@@ -6015,6 +6097,8 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         "image_interleave",
         # sc-2041: prompt refinement is dispatched on every Python worker.
         "prompt_refine",
+        # sc-2431: standalone image upscale (Image Editor).
+        "image_upscale",
     ]
     assert events[0]["supportedJobTypes"] == events[0]["jobTypes"]
 


### PR DESCRIPTION
**epic 2427 — Image Editor**, Phase 1, [sc-2431](https://app.shortcut.com/trefry/story/2431). First backend slice — unblocks the in-editor upscale tool (sc-2433).

## What
Exposes the existing **Real-ESRGAN / AuraSR** engines (previously only an inline post-step of image generation) as a **standalone `image_upscale` GPU job**: takes an existing image asset + factor + engine, writes one upscaled **child asset** with lineage back to the source (`parents` + `extra.isUpscaled`).

Like `pose_detect`, it rides the generic `POST /api/v1/jobs` endpoint (typed `JobType` + free-form payload) — **no new API handler/route**. The frontend tool (sc-2433) will POST `{type:"image_upscale", projectId, payload:{sourceAssetId, factor, engine}}`.

## New-job-type sync surface
- `contracts.rs` — `JobType::ImageUpscale` + `WorkerCapability::ImageUpscale`.
- `jobs_store.rs` — added to `job_requires_gpu` (torch-backed).
- `apps/web/src/jobTypes.js` — `GPU_REQUIRED_JOB_TYPES`.
- worker `runtime.py` — `IMAGE_UPSCALE_JOB_TYPES` + `ALL_JOB_TYPES`; advertised only when the torch backend is present; `run_upscale_job` wrapper (mirrors `run_pose_job`) + claim-loop dispatch.
- worker `image_adapters.py` — `run_image_upscale`: resolves the source at **native resolution** (`find_asset_media_path`, not the resizing `load_source_image`), reuses `create_image_upscaler` (which self-resolves/downloads weights from HF — no manifest entry needed), and writes one child-asset fact mirroring the inline-upscale shape (`mode:"image_upscale"` → `derive_origin` = `image_studio`, so it shows in the Library).

## Tests
- sceneworks-core 30, rust-api 89, clippy + fmt clean; worker suite **499** (+2 new: `run_image_upscale` writes a single 2x child with correct lineage/fact; source-asset-required guard); parity 12; e2e 2; web 304.
- Updated two pinned assertions (the `run_check` dispatchable-jobTypes list + the sorted GPU-worker capability list).
- No `job_protocol.json` fixture change (it's a round-trip test, not an enumeration).

_Owes: real-engine E2E on Mac (torch + weights + GPU). The engine/weight path is unchanged/shared with the inline upscale; the new code is orchestration + the single-asset write, so risk is low._

🤖 Generated with [Claude Code](https://claude.com/claude-code)