### PR TITLE
Image Editor: Save / export edited image as new asset (lineage) + download

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -69,35 +69,69 @@ pub(crate) async fn import_asset(
     Path(project_id): Path<String>,
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    // Gather all fields: the `file` (required) plus optional `sourceAssetId` and
+    // `provenance` carried by the Image Editor's Save (sc-2434) to record lineage.
+    // Field order isn't guaranteed, so collect everything before importing.
+    let mut file: Option<(String, Option<String>, PathBuf)> = None;
+    let mut source_asset_id: Option<String> = None;
+    let mut provenance: Option<serde_json::Value> = None;
     while let Some(field) = multipart
         .next_field()
         .await
         .map_err(|error| ApiError::bad_request(error.to_string()))?
     {
-        if field.name() != Some("file") {
-            continue;
+        match field.name() {
+            Some("file") => {
+                let filename = field.file_name().unwrap_or("upload").to_owned();
+                let content_type = field.content_type().map(str::to_owned);
+                let temp_path = write_upload_field_to_temp_file(&state, field).await?;
+                file = Some((filename, content_type, temp_path));
+            }
+            Some("sourceAssetId") => {
+                let value = field
+                    .text()
+                    .await
+                    .map_err(|error| ApiError::bad_request(error.to_string()))?;
+                let value = value.trim();
+                if !value.is_empty() {
+                    source_asset_id = Some(value.to_owned());
+                }
+            }
+            Some("provenance") => {
+                let value = field
+                    .text()
+                    .await
+                    .map_err(|error| ApiError::bad_request(error.to_string()))?;
+                if !value.trim().is_empty() {
+                    provenance = Some(serde_json::from_str(&value).map_err(|error| {
+                        ApiError::bad_request(format!("Invalid provenance JSON: {error}"))
+                    })?);
+                }
+            }
+            _ => {}
         }
-        let filename = field.file_name().unwrap_or("upload").to_owned();
-        let content_type = field.content_type().map(str::to_owned);
-        let temp_path = write_upload_field_to_temp_file(&state, field).await?;
-        let source_path = temp_path.clone();
-        let asset = project_call(state, move |store| {
-            store.import_asset(
-                &project_id,
-                UploadAsset {
-                    filename,
-                    content_type,
-                    source_path,
-                },
-            )
-        })
-        .await
-        .inspect_err(|_| {
-            let _ = std::fs::remove_file(&temp_path);
-        })?;
-        return Ok((StatusCode::CREATED, Json(asset)));
     }
-    Err(ApiError::bad_request("Upload file field is required"))
+
+    let (filename, content_type, temp_path) =
+        file.ok_or_else(|| ApiError::bad_request("Upload file field is required"))?;
+    let source_path = temp_path.clone();
+    let asset = project_call(state, move |store| {
+        store.import_asset(
+            &project_id,
+            UploadAsset {
+                filename,
+                content_type,
+                source_path,
+                source_asset_id,
+                provenance,
+            },
+        )
+    })
+    .await
+    .inspect_err(|_| {
+        let _ = std::fs::remove_file(&temp_path);
+    })?;
+    Ok((StatusCode::CREATED, Json(asset)))
 }
 
 pub(crate) async fn write_upload_field_to_temp_file(

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, eventUrl, isAbortError } from "./api.js";
 import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
@@ -476,6 +476,22 @@ export function App() {
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
   const generatedAssetRefreshesRef = useRef(new Map());
+  // A screen (the Image Editor, sc-2434) can register a guard that runs before a
+  // user-initiated navigation leaves it — e.g. to confirm discarding unsaved edits.
+  // Programmatic setActiveView calls (post-generation hops) deliberately bypass it.
+  const leaveGuardRef = useRef(null);
+  const registerLeaveGuard = useCallback((guard) => {
+    leaveGuardRef.current = guard;
+    return () => {
+      if (leaveGuardRef.current === guard) leaveGuardRef.current = null;
+    };
+  }, []);
+  const navTo = useCallback((viewId) => {
+    if (viewId === activeViewRef.current) return;
+    const guard = leaveGuardRef.current;
+    if (guard && !guard()) return; // guard returned false → user cancelled the leave
+    setActiveView(viewId);
+  }, []);
 
   const {
     characters,
@@ -1417,6 +1433,10 @@ export function App() {
     }
     const body = new FormData();
     body.append("file", file);
+    // Optional lineage for derived imports (Image Editor Save, sc-2434): link the
+    // new asset to the source it was opened from + record the edit-chain provenance.
+    if (options.sourceAssetId) body.append("sourceAssetId", options.sourceAssetId);
+    if (options.provenance) body.append("provenance", JSON.stringify(options.provenance));
     try {
       const imported = await apiFetch(`/api/v1/projects/${activeProject.id}/assets`, token, {
         method: "POST",
@@ -1565,6 +1585,7 @@ export function App() {
     trainingTargetsError,
     // Navigation
     setActiveView,
+    registerLeaveGuard,
     // Characters
     characters,
     createCharacter,
@@ -1619,7 +1640,7 @@ export function App() {
                   <button
                     className={activeView === item.id ? "nav-item active" : "nav-item"}
                     key={item.id}
-                    onClick={() => setActiveView(item.id)}
+                    onClick={() => navTo(item.id)}
                     title={label}
                     type="button"
                   >

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -44,6 +44,29 @@ export function buildUpscaleJobBody({ project, requestedGpu, sourceAssetId, fact
   };
 }
 
+// Filename for a Save / Download export (sc-2434): the source name with an
+// "-edited" suffix before the extension, always .png — the working image is
+// rasterized to PNG, so the original extension would be misleading. Pure.
+export function editedFilename(source) {
+  const base = (source?.name || "image").replace(/\.[^./\\]+$/, "").trim() || "image";
+  return `${base}-edited.png`;
+}
+
+// Provenance for a saved edit, stored under the new asset's top-level `extra`
+// (sc-2434): which source it was derived from + the ordered edit chain
+// (crop/upscale/…) applied this session. Pure for unit testing.
+export function buildSaveProvenance({ source, edits, width, height }) {
+  return {
+    editor: "image_editor",
+    source: source?.assetId
+      ? { kind: "asset", assetId: source.assetId, name: source.name ?? null }
+      : { kind: "upload", name: source?.name ?? null },
+    edits: edits ?? [],
+    width: width ?? null,
+    height: height ?? null,
+  };
+}
+
 // Predefined crop ratios (width / height). Rotate swaps to the transpose; 1:1 and
 // Freeform are unaffected.
 const CROP_RATIOS = [
@@ -124,6 +147,7 @@ export function ImageEditor() {
     jobs,
     importAsset,
     purgeAsset,
+    registerLeaveGuard,
   } = useAppContext();
 
   // The working-image session: the single bitmap every tool operates on, plus its
@@ -143,6 +167,14 @@ export function ImageEditor() {
   // Upscale tool (sc-2433): engine + factor for the in-flight request.
   const [upscaleEngine, setUpscaleEngine] = useState("real-esrgan");
   const [upscaleFactor, setUpscaleFactor] = useState(2);
+
+  // Save / export (sc-2434). `dirty` tracks edits not yet persisted to the Library;
+  // `edits` is the ordered provenance chain; `savedAssetId` flags a completed Save
+  // for the bar's "Saved" hint. A fresh open clears all three.
+  const [dirty, setDirty] = useState(false);
+  const [edits, setEdits] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [savedAssetId, setSavedAssetId] = useState(null);
   // An in-flight AI op (upscale now; AI-edit / detail later) on the working image.
   // The seam (sc-2432): stage the working bitmap as a scratch asset, run a worker
   // job against it, load the result back, then purge the scratch + result so the
@@ -220,6 +252,10 @@ export function ImageEditor() {
       try {
         const { image, objectUrl } = await blobToImage(blob);
         installWorkingImage(image, objectUrl, source);
+        // A freshly opened image is a clean session — clear edit/provenance state.
+        setEdits([]);
+        setDirty(false);
+        setSavedAssetId(null);
         setStatus({ loading: false, error: "" });
       } catch (err) {
         setStatus({ loading: false, error: err.message || "Could not open image" });
@@ -268,7 +304,7 @@ export function ImageEditor() {
   function handleDrop(event) {
     event.preventDefault();
     const file = event.dataTransfer?.files?.[0];
-    if (file) openFile(file);
+    if (file && confirmDiscardEdits()) openFile(file);
   }
 
   function handleWheel(event) {
@@ -374,6 +410,8 @@ export function ImageEditor() {
     if (!blob) return;
     const { image, objectUrl } = await blobToImage(blob);
     installWorkingImage(image, objectUrl, working.source);
+    setEdits((prev) => [...prev, { op: "crop", width: sw, height: sh }]);
+    setDirty(true);
   }, [working, cropRect, installWorkingImage]);
 
   // Bind the transformer to the crop rect whenever crop mode is active.
@@ -387,33 +425,38 @@ export function ImageEditor() {
   }, [tool, cropRect]);
 
   // ── AI ops on the working image (sc-2432 seam) ────────────────────────────
-  // Rasterize the current working image to a PNG File for upload.
-  const workingImageToFile = useCallback(() => {
-    return new Promise((resolve, reject) => {
-      if (!working) {
-        reject(new Error("No working image."));
-        return;
-      }
-      const canvas = document.createElement("canvas");
-      canvas.width = working.width;
-      canvas.height = working.height;
-      canvas.getContext("2d").drawImage(working.image, 0, 0);
-      const base = (working.source.name || "image").replace(/\.[^./\\]+$/, "");
-      canvas.toBlob((blob) => {
-        if (!blob) {
-          reject(new Error("Could not encode the working image."));
+  // Rasterize the current working image to a PNG File. `filename` overrides the
+  // name (Save/Download use the "-edited" name; the AI-op scratch upload doesn't care).
+  const workingImageToFile = useCallback(
+    (filename) => {
+      return new Promise((resolve, reject) => {
+        if (!working) {
+          reject(new Error("No working image."));
           return;
         }
-        resolve(new File([blob], `${base}.png`, { type: "image/png" }));
-      }, "image/png");
-    });
-  }, [working]);
+        const canvas = document.createElement("canvas");
+        canvas.width = working.width;
+        canvas.height = working.height;
+        canvas.getContext("2d").drawImage(working.image, 0, 0);
+        const base = (working.source.name || "image").replace(/\.[^./\\]+$/, "");
+        const name = filename || `${base}.png`;
+        canvas.toBlob((blob) => {
+          if (!blob) {
+            reject(new Error("Could not encode the working image."));
+            return;
+          }
+          resolve(new File([blob], name, { type: "image/png" }));
+        }, "image/png");
+      });
+    },
+    [working],
+  );
 
   // Stage the working image as a scratch asset, start a worker job against it, and
   // track it. The watcher below loads the result back and purges scratch + result —
   // intermediates never persist; only Save (sc-2434) lands a Library asset.
   const runAiOp = useCallback(
-    async ({ buildBody, label }) => {
+    async ({ buildBody, label, edit }) => {
       if (!working || aiOp || !activeProject) return;
       setStatus({ loading: false, error: "" });
       let scratch;
@@ -429,7 +472,7 @@ export function ImageEditor() {
           method: "POST",
           body: JSON.stringify(buildBody(scratch)),
         });
-        setAiOp({ jobId: job.id, scratch, source: working.source, label });
+        setAiOp({ jobId: job.id, scratch, source: working.source, label, edit });
         setTool("move");
       } catch (err) {
         purgeAsset(scratch).catch(() => {});
@@ -444,6 +487,7 @@ export function ImageEditor() {
     const factor = valid.includes(upscaleFactor) ? upscaleFactor : valid[0];
     runAiOp({
       label: "upscale",
+      edit: { op: "upscale", engine: upscaleEngine, factor },
       buildBody: (scratch) =>
         buildUpscaleJobBody({
           project: activeProject,
@@ -462,7 +506,7 @@ export function ImageEditor() {
     if (!aiOp?.jobId) return;
     const job = jobs?.find((item) => item.id === aiOp.jobId);
     if (!job || !terminalStatuses.has(job.status)) return;
-    const { scratch, source } = aiOp;
+    const { scratch, source, edit } = aiOp;
     setAiOp(null); // stop tracking immediately so this can't re-enter on the next jobs tick
     const resultAsset = job.status === "completed" ? job.result?.assets?.[0] ?? null : null;
     (async () => {
@@ -472,6 +516,8 @@ export function ImageEditor() {
           if (!res.ok) throw new Error(`Failed to load result (${res.status})`);
           const { image, objectUrl } = await blobToImage(await res.blob());
           installWorkingImage(image, objectUrl, source);
+          if (edit) setEdits((prev) => [...prev, edit]);
+          setDirty(true);
         } else {
           setStatus({ loading: false, error: job.error ?? job.message ?? "The operation failed." });
         }
@@ -484,6 +530,83 @@ export function ImageEditor() {
     })();
   }, [aiOp, jobs, installWorkingImage, purgeAsset]);
 
+  // ── Save / export (sc-2434) ───────────────────────────────────────────────
+  // Persist the working image as a NEW Library asset, never overwriting the
+  // source. Lineage links it back to the asset it was opened from (uploads have
+  // no source to link); the edit chain rides along as provenance.
+  const runSave = useCallback(async () => {
+    if (!working || saving) return;
+    setSaving(true);
+    setStatus({ loading: false, error: "" });
+    try {
+      const file = await workingImageToFile(editedFilename(working.source));
+      const saved = await importAsset(file, {
+        throwOnError: true,
+        sourceAssetId: working.source.assetId,
+        provenance: buildSaveProvenance({
+          source: working.source,
+          edits,
+          width: working.width,
+          height: working.height,
+        }),
+      });
+      setSavedAssetId(saved?.id ?? null);
+      setDirty(false);
+    } catch (err) {
+      setStatus({ loading: false, error: `Could not save: ${err.message || err}` });
+    } finally {
+      setSaving(false);
+    }
+  }, [working, saving, workingImageToFile, importAsset, edits]);
+
+  // Export the working image straight to disk as a PNG (no project involvement).
+  const runDownload = useCallback(async () => {
+    if (!working) return;
+    try {
+      const file = await workingImageToFile(editedFilename(working.source));
+      const url = URL.createObjectURL(file);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = file.name;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setStatus({ loading: false, error: `Could not export: ${err.message || err}` });
+    }
+  }, [working, workingImageToFile]);
+
+  // Confirm before an action that would discard unsaved edits (Open / drag-drop a
+  // new image while dirty). Returns true when it's safe to proceed.
+  function confirmDiscardEdits() {
+    if (!dirty) return true;
+    return (
+      typeof window.confirm !== "function" ||
+      window.confirm("You have unsaved edits. Open a new image and discard them?")
+    );
+  }
+
+  // Warn before leaving with unsaved edits: a browser unload (close/refresh) and an
+  // in-app navigation away (the App nav consults this guard, sc-2434).
+  useEffect(() => {
+    if (!dirty) return undefined;
+    const onBeforeUnload = (event) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    const unregister = registerLeaveGuard?.(
+      () =>
+        typeof window.confirm !== "function" ||
+        window.confirm("You have unsaved edits in the Image Editor. Leave and discard them?"),
+    );
+    return () => {
+      window.removeEventListener("beforeunload", onBeforeUnload);
+      if (typeof unregister === "function") unregister();
+    };
+  }, [dirty, registerLeaveGuard]);
+
   const activeAiJob = aiOp ? jobs?.find((item) => item.id === aiOp.jobId) : null;
 
   return (
@@ -493,7 +616,7 @@ export function ImageEditor() {
           {working ? working.source.name : "No image open"}
         </span>
         <div className="image-editor-bar-actions">
-          <button className="primary" onClick={() => setPickerOpen(true)} type="button">
+          <button className={working ? "" : "primary"} onClick={() => setPickerOpen(true)} type="button">
             Open
           </button>
           {working && working.source.assetId ? (
@@ -504,6 +627,23 @@ export function ImageEditor() {
             >
               Source
             </button>
+          ) : null}
+          {working ? (
+            <>
+              <button onClick={runDownload} title="Download a PNG to your computer" type="button">
+                Download
+              </button>
+              {savedAssetId && !dirty ? <span className="image-editor-saved">Saved ✓</span> : null}
+              <button
+                className="primary"
+                disabled={!dirty || saving}
+                onClick={runSave}
+                title="Save a new image to the project Library"
+                type="button"
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </>
           ) : null}
         </div>
       </div>
@@ -772,13 +912,13 @@ export function ImageEditor() {
           multiple={false}
           onAdd={(ids) => {
             setPickerOpen(false);
-            if (ids[0]) openAsset(ids[0]);
+            if (ids[0] && confirmDiscardEdits()) openAsset(ids[0]);
           }}
           onClose={() => setPickerOpen(false)}
           onImport={(files) => {
             const file = files?.[0];
             setPickerOpen(false);
-            if (file) openFile(file);
+            if (file && confirmDiscardEdits()) openFile(file);
           }}
           title="Open image"
         />

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -19,6 +19,8 @@ import {
   centeredCropRect,
   upscaleFactorsForEngine,
   buildUpscaleJobBody,
+  editedFilename,
+  buildSaveProvenance,
 } from "./ImageEditor.jsx";
 
 // These tests cover the non-canvas surface of the editor (empty state, the inert
@@ -37,6 +39,7 @@ function baseContext(overrides = {}) {
     jobs: [],
     importAsset: vi.fn(),
     purgeAsset: vi.fn(),
+    registerLeaveGuard: vi.fn(),
     ...overrides,
   };
 }
@@ -148,5 +151,43 @@ describe("upscale job", () => {
         displayName: "shot.png",
       },
     });
+  });
+});
+
+describe("save / export", () => {
+  it("derives an -edited.png export filename, always PNG", () => {
+    expect(editedFilename({ name: "shot.jpg" })).toBe("shot-edited.png");
+    expect(editedFilename({ name: "portrait.png" })).toBe("portrait-edited.png");
+    expect(editedFilename({ name: "no-extension" })).toBe("no-extension-edited.png");
+    // Falls back to a default when the source has no usable name.
+    expect(editedFilename(null)).toBe("image-edited.png");
+    expect(editedFilename({})).toBe("image-edited.png");
+  });
+
+  it("builds provenance that links a saved edit to its asset source + edit chain", () => {
+    const provenance = buildSaveProvenance({
+      source: { kind: "asset", assetId: "asset_src", name: "shot.png" },
+      edits: [{ op: "crop", width: 100, height: 100 }, { op: "upscale", engine: "real-esrgan", factor: 4 }],
+      width: 400,
+      height: 400,
+    });
+    expect(provenance).toEqual({
+      editor: "image_editor",
+      source: { kind: "asset", assetId: "asset_src", name: "shot.png" },
+      edits: [{ op: "crop", width: 100, height: 100 }, { op: "upscale", engine: "real-esrgan", factor: 4 }],
+      width: 400,
+      height: 400,
+    });
+  });
+
+  it("records uploads as a source kind with no asset id (nothing to link)", () => {
+    const provenance = buildSaveProvenance({
+      source: { kind: "upload", name: "drag.png" },
+      edits: [],
+      width: 10,
+      height: 20,
+    });
+    expect(provenance.source).toEqual({ kind: "upload", name: "drag.png" });
+    expect(provenance.edits).toEqual([]);
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5117,8 +5117,16 @@ label {
 
 .image-editor-bar-actions {
   display: flex;
+  align-items: center;
   flex-shrink: 0;
   gap: 8px;
+}
+
+/* "Saved ✓" hint shown after a successful Save, until the next edit (sc-2434). */
+.image-editor-saved {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
 }
 
 .image-editor-notice {

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -188,6 +188,13 @@ pub struct UploadAsset {
     pub filename: String,
     pub content_type: Option<String>,
     pub source_path: PathBuf,
+    /// Optional source asset this upload was derived from (Image Editor Save,
+    /// sc-2434). Sets `lineage.parents`/`sourceAssetId` so the saved edit links
+    /// back to the asset it was opened from; the source is never modified.
+    pub source_asset_id: Option<String>,
+    /// Optional free-form provenance (e.g. the Image Editor edit chain) stored
+    /// under the asset's top-level `extra`, mirroring generated-asset extras.
+    pub provenance: Option<Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -1124,7 +1131,7 @@ impl ProjectStore {
             })
             .to_owned();
 
-        let asset = json!({
+        let mut asset = json!({
             "schemaVersion": 1,
             "id": asset_id,
             "projectId": project_id,
@@ -1161,12 +1168,27 @@ impl ProjectStore {
                 "rawAdapterSettings": { "contentType": content_type }
             },
             "lineage": {
-                "parents": [],
-                "sourceAssetId": Value::Null,
+                "parents": upload
+                    .source_asset_id
+                    .clone()
+                    .map(|id| vec![Value::String(id)])
+                    .unwrap_or_default(),
+                "sourceAssetId": upload
+                    .source_asset_id
+                    .clone()
+                    .map(Value::String)
+                    .unwrap_or(Value::Null),
                 "sourceTimestamp": Value::Null,
                 "jobId": Value::Null
             }
         });
+        // Provenance (e.g. the Image Editor edit chain) rides the same top-level
+        // `extra` slot generated assets use, so the Library/lineage UI can read it.
+        if let Some(provenance) = &upload.provenance {
+            if let Some(object) = asset.as_object_mut() {
+                object.insert("extra".to_owned(), provenance.clone());
+            }
+        }
         let sidecar_path = media_path.with_extension("sceneworks.json");
         write_json(&sidecar_path, &asset)?;
         index_asset(&project_path, &asset, Some(&sidecar_path))?;
@@ -2974,7 +2996,7 @@ mod tests {
     use super::{
         build_generated_asset_sidecar, guess_mime_from_filename, is_safe_relative_path,
         normalize_asset_tags, AssetScope, CharacterCreateInput, CharacterLookInput, ProjectStore,
-        ProjectStoreError, GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS,
+        ProjectStoreError, UploadAsset, GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS,
     };
     use serde_json::{json, Value};
     use std::sync::Arc;
@@ -3350,6 +3372,70 @@ mod tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0]["id"], asset["id"]);
         assert_eq!(listed[0]["pose"]["category"], json!("Dance"));
+    }
+
+    #[test]
+    fn import_asset_records_source_lineage_and_provenance() {
+        // Image Editor Save (sc-2434): a rasterized edit is uploaded with the id
+        // of the asset it was opened from + an edit-chain provenance blob. The new
+        // asset must link back via lineage and carry the provenance in `extra`,
+        // while the original source asset is left untouched.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Edits").expect("project creates");
+
+        // The original source asset (a plain import, no lineage).
+        let src_file = temp_dir.path().join("source.png");
+        std::fs::write(&src_file, b"\x89PNG source bytes").expect("source writes");
+        let source = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "source.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: src_file,
+                    source_asset_id: None,
+                    provenance: None,
+                },
+            )
+            .expect("source imports");
+        let source_id = source["id"].as_str().expect("source id").to_owned();
+        assert_eq!(source["lineage"]["sourceAssetId"], Value::Null);
+
+        // The edited bitmap saved from the editor, derived from the source.
+        let edited_file = temp_dir.path().join("source-edited.png");
+        std::fs::write(&edited_file, b"\x89PNG edited bytes").expect("edited writes");
+        let provenance = json!({
+            "editor": "image_editor",
+            "edits": [{ "op": "crop" }, { "op": "upscale", "engine": "real-esrgan", "factor": 4 }],
+        });
+        let edited = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "source-edited.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: edited_file,
+                    source_asset_id: Some(source_id.clone()),
+                    provenance: Some(provenance.clone()),
+                },
+            )
+            .expect("edited imports");
+
+        // New, distinct asset that links back to the source and is Library-visible.
+        assert_ne!(edited["id"], source["id"]);
+        assert_eq!(edited["origin"], json!("upload"));
+        assert_eq!(edited["lineage"]["sourceAssetId"], json!(source_id));
+        assert_eq!(edited["lineage"]["parents"], json!([source_id]));
+        // Provenance survives normalization in the top-level `extra` slot.
+        assert_eq!(edited["extra"], provenance);
+
+        // The source asset itself is untouched: still no lineage.
+        let source_after = store
+            .get_asset(&project.id, &source_id)
+            .expect("source still present");
+        assert_eq!(source_after["lineage"]["sourceAssetId"], Value::Null);
+        assert!(source_after.get("extra").is_none());
     }
 
     #[test]

--- a/crates/sceneworks-core/tests/character_store.rs
+++ b/crates/sceneworks-core/tests/character_store.rs
@@ -153,6 +153,8 @@ fn references_sync_asset_metadata_and_character_reference_table() {
                 filename: "reference.png".to_owned(),
                 content_type: Some("image/png".to_owned()),
                 source_path: source,
+                source_asset_id: None,
+                provenance: None,
             },
         )
         .expect("asset imports");


### PR DESCRIPTION
Closes the last Phase-1 story of epic 2427 (Image Editor): **sc-2434**. The working-image session can now be committed to a durable result — non-destructively.

## What's in it
- **Save → new Library asset.** Rasterizes the working image and imports it as a brand-new asset (never overwrites the source). Lineage links it back to the asset it was opened from (`lineage.parents`/`sourceAssetId`), and the crop/upscale edit chain rides along as provenance under the asset's top-level `extra`.
- **Download → disk.** Exports the working image straight to the browser as a PNG.
- **Unsaved-changes guard.** A `beforeunload` listener (tab close/refresh) plus an in-app nav guard — `App` registers a leave-guard that the sidebar consults before switching screens, and Open/drag-drop confirms before replacing a dirty working image. Programmatic navigation (post-generation hops) deliberately bypasses the guard.

## Backend seam
The upload path gained two optional multipart fields so a derived import can carry lineage:
- `apps/rust-api/src/assets.rs` `import_asset` now gathers optional `sourceAssetId` + `provenance` alongside `file`.
- `ProjectStore::import_asset` (`crates/sceneworks-core`) sets `lineage.parents`/`sourceAssetId` and stashes `provenance` in the top-level `extra` (the same slot generated assets use; survives `normalize_asset`).
- Uploads with neither field are byte-for-byte unchanged. No API DTO/contract change (multipart request; response shape already carries lineage/extra).

## Verification
Live end-to-end against a real API (open → crop → Save):
- New asset at **248×248** working resolution, `origin: upload` (Library-visible), `lineage` → source, full provenance in `extra`.
- **Source untouched** (still 310×310, empty lineage, no extra).
- **Download** captured a valid `image/png` (4539 bytes) with the `-edited.png` filename.
- **Unsaved guard** fires on in-app nav: blocks when the confirm is cancelled, proceeds when confirmed.

Tests: **309 web** (+3 new save/export unit tests) + **89 rust-api** + **79 core** (+1 new lineage/provenance test) + **6 character_store** green; web build clean.

Owes nothing new on Mac GPU — Save/Download/guard are client + upload-path only (no GPU worker involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)