### PR TITLE
Image Editor: in-editor AI prompt edit (reuse existing edit models)

### DIFF
--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -13,11 +13,39 @@ const MIN_CROP_PX = 8;
 
 // Tools still to come in epic 2427 — rendered as an inert scaffold so the frame
 // (and the next slices' insertion points) are in place. Move + Crop + Upscale +
-// Color are live.
-const UPCOMING_TOOLS = [
-  { id: "edit", label: "AI Edit", story: "sc-2435" },
-  { id: "detail", label: "Detail", story: "sc-2438" },
-];
+// Color + AI Edit are live.
+const UPCOMING_TOOLS = [{ id: "detail", label: "Detail", story: "sc-2438" }];
+
+// Models that can edit an existing image with a prompt — the manifest tags them
+// with an `edit_image`/`image_edit` capability (same filter the Image Studio uses).
+export function editCapableModels(imageModels) {
+  return (imageModels ?? []).filter((model) => {
+    const caps = model.capabilities ?? [];
+    return caps.includes("edit_image") || caps.includes("image_edit");
+  });
+}
+
+// The `POST /api/v1/image/jobs` body for an in-editor prompt edit (sc-2435). Reuses
+// the existing `mode:"edit_image"` flow: the working bitmap is staged as a scratch
+// asset (sc-2432) and referenced by `sourceAssetId`; the result is the new working
+// image at the same dimensions. Pure for unit testing.
+export function buildEditJobBody({ project, requestedGpu, sourceAssetId, model, prompt, seed, width, height }) {
+  return {
+    projectId: project.id,
+    projectName: project.name ?? null,
+    requestedGpu,
+    mode: "edit_image",
+    sourceAssetId,
+    model,
+    prompt,
+    negativePrompt: "",
+    width,
+    height,
+    seed: seed == null || seed === "" ? null : Number(seed),
+    count: 1,
+    advanced: {},
+  };
+}
 
 // Color-grade controls (sc-2439). Each is a normalized −1..1 slider where 0 is the
 // identity; `gradePixel` defines the math. Pure data so the panel + reset are trivial.
@@ -207,6 +235,7 @@ export function ImageEditor() {
     importAsset,
     purgeAsset,
     registerLeaveGuard,
+    imageModels,
   } = useAppContext();
 
   // The working-image session: the single bitmap every tool operates on, plus its
@@ -230,6 +259,20 @@ export function ImageEditor() {
   // Color grade (sc-2439): non-destructive −1..1 adjustments previewed live via a
   // Konva filter, baked into the working image on Apply.
   const [colorAdjust, setColorAdjust] = useState(IDENTITY_COLOR_ADJUST);
+
+  // AI prompt edit (sc-2435): an edit-capable model + instruction + optional seed,
+  // run against the working image through the existing edit_image flow.
+  const editModels = editCapableModels(imageModels);
+  const [editModel, setEditModel] = useState("");
+  const [editPrompt, setEditPrompt] = useState("");
+  const [editSeed, setEditSeed] = useState("");
+
+  // Default the edit-model selection to the first edit-capable model once the model
+  // list loads, and recover if the current pick stops being edit-capable.
+  useEffect(() => {
+    const caps = editCapableModels(imageModels);
+    if (caps.length && !caps.some((model) => model.id === editModel)) setEditModel(caps[0].id);
+  }, [imageModels, editModel]);
 
   // Save / export (sc-2434). `dirty` tracks edits not yet persisted to the Library;
   // `edits` is the ordered provenance chain; `savedAssetId` flags a completed Save
@@ -571,7 +614,7 @@ export function ImageEditor() {
   // track it. The watcher below loads the result back and purges scratch + result —
   // intermediates never persist; only Save (sc-2434) lands a Library asset.
   const runAiOp = useCallback(
-    async ({ buildBody, label, edit }) => {
+    async ({ buildBody, label, edit, endpoint = "/api/v1/jobs" }) => {
       if (!working || aiOp || !activeProject) return;
       setStatus({ loading: false, error: "" });
       let scratch;
@@ -583,10 +626,11 @@ export function ImageEditor() {
         return;
       }
       try {
-        const job = await apiFetch("/api/v1/jobs", token, {
+        const job = await apiFetch(endpoint, token, {
           method: "POST",
           body: JSON.stringify(buildBody(scratch)),
         });
+        if (!job?.id) throw new Error("The job was not created.");
         setAiOp({ jobId: job.id, scratch, source: working.source, label, edit });
         setTool("move");
       } catch (err) {
@@ -611,6 +655,27 @@ export function ImageEditor() {
           factor,
           engine: upscaleEngine,
           displayName: working?.source?.name,
+        }),
+    });
+  }
+
+  function runEdit() {
+    const prompt = editPrompt.trim();
+    if (!prompt || !editModel || !working) return;
+    runAiOp({
+      label: "edit",
+      endpoint: "/api/v1/image/jobs",
+      edit: { op: "edit", model: editModel, prompt },
+      buildBody: (scratch) =>
+        buildEditJobBody({
+          project: activeProject,
+          requestedGpu,
+          sourceAssetId: scratch.id,
+          model: editModel,
+          prompt,
+          seed: editSeed,
+          width: working.width,
+          height: working.height,
         }),
     });
   }
@@ -903,6 +968,15 @@ export function ImageEditor() {
             >
               Color
             </button>
+            <button
+              className={tool === "edit" ? "image-editor-tool active" : "image-editor-tool"}
+              disabled={!!aiOp}
+              onClick={() => setTool("edit")}
+              title="AI prompt edit"
+              type="button"
+            >
+              AI Edit
+            </button>
             {UPCOMING_TOOLS.map((upcoming) => (
               <button
                 className="image-editor-tool"
@@ -1023,11 +1097,60 @@ export function ImageEditor() {
           </div>
         ) : null}
 
+        {tool === "edit" && working ? (
+          <div className="image-editor-cropbar image-editor-editbar">
+            {editModels.length === 0 ? (
+              <span className="image-editor-cropdims">No edit-capable models installed</span>
+            ) : (
+              <>
+                <select
+                  aria-label="Edit model"
+                  className="image-editor-editmodel"
+                  onChange={(event) => setEditModel(event.target.value)}
+                  value={editModel}
+                >
+                  {editModels.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.label ?? model.id}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  aria-label="Edit prompt"
+                  className="image-editor-editprompt"
+                  onChange={(event) => setEditPrompt(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && editPrompt.trim() && !aiOp) runEdit();
+                  }}
+                  placeholder="Describe the edit…"
+                  type="text"
+                  value={editPrompt}
+                />
+                <input
+                  aria-label="Seed (optional)"
+                  className="image-editor-editseed"
+                  min={0}
+                  onChange={(event) => setEditSeed(event.target.value)}
+                  placeholder="Seed"
+                  type="number"
+                  value={editSeed}
+                />
+                <button className="primary" disabled={!editPrompt.trim() || !!aiOp} onClick={runEdit} type="button">
+                  Edit
+                </button>
+              </>
+            )}
+            <button onClick={() => setTool("move")} type="button">
+              Cancel
+            </button>
+          </div>
+        ) : null}
+
         {aiOp ? (
           <div className="image-editor-busy">
             <div className="image-editor-busy-card">
               <p className="image-editor-busy-title">
-                {aiOp.label === "upscale" ? "Upscaling…" : "Working…"}
+                {aiOp.label === "upscale" ? "Upscaling…" : aiOp.label === "edit" ? "Editing…" : "Working…"}
               </p>
               <p className="image-editor-busy-msg">
                 {activeAiJob?.message ||

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -25,6 +25,8 @@ import {
   applyColorAdjustments,
   isIdentityAdjust,
   IDENTITY_COLOR_ADJUST,
+  editCapableModels,
+  buildEditJobBody,
 } from "./ImageEditor.jsx";
 
 // These tests cover the non-canvas surface of the editor (empty state, the inert
@@ -44,6 +46,7 @@ function baseContext(overrides = {}) {
     importAsset: vi.fn(),
     purgeAsset: vi.fn(),
     registerLeaveGuard: vi.fn(),
+    imageModels: [],
     ...overrides,
   };
 }
@@ -244,5 +247,62 @@ describe("color grade", () => {
     const untouched = new Uint8ClampedArray([10, 20, 30, 40]);
     applyColorAdjustments(untouched, IDENTITY_COLOR_ADJUST);
     expect([...untouched]).toEqual([10, 20, 30, 40]);
+  });
+});
+
+describe("AI prompt edit", () => {
+  it("filters models to those tagged edit_image / image_edit", () => {
+    const models = [
+      { id: "z_image_turbo", capabilities: ["text_to_image"] },
+      { id: "qwen_image_edit_2511", capabilities: ["text_to_image", "edit_image"] },
+      { id: "sdxl", capabilities: ["image_edit"] },
+      { id: "no_caps" },
+    ];
+    expect(editCapableModels(models).map((m) => m.id)).toEqual(["qwen_image_edit_2511", "sdxl"]);
+    expect(editCapableModels([])).toEqual([]);
+    expect(editCapableModels(undefined)).toEqual([]);
+  });
+
+  it("builds the edit_image job body the /api/v1/image/jobs endpoint expects", () => {
+    const body = buildEditJobBody({
+      project: { id: "project_1", name: "My Project" },
+      requestedGpu: "auto",
+      sourceAssetId: "asset_scratch",
+      model: "qwen_image_edit_2511",
+      prompt: "make it night",
+      seed: "42",
+      width: 768,
+      height: 1024,
+    });
+    expect(body).toEqual({
+      projectId: "project_1",
+      projectName: "My Project",
+      requestedGpu: "auto",
+      mode: "edit_image",
+      sourceAssetId: "asset_scratch",
+      model: "qwen_image_edit_2511",
+      prompt: "make it night",
+      negativePrompt: "",
+      width: 768,
+      height: 1024,
+      seed: 42,
+      count: 1,
+      advanced: {},
+    });
+  });
+
+  it("treats an empty/blank seed as null (random)", () => {
+    const base = {
+      project: { id: "p", name: "P" },
+      requestedGpu: "auto",
+      sourceAssetId: "a",
+      model: "m",
+      prompt: "x",
+      width: 10,
+      height: 10,
+    };
+    expect(buildEditJobBody({ ...base, seed: "" }).seed).toBeNull();
+    expect(buildEditJobBody({ ...base, seed: null }).seed).toBeNull();
+    expect(buildEditJobBody({ ...base, seed: 7 }).seed).toBe(7);
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5281,6 +5281,20 @@ label {
   color: var(--text-muted);
 }
 
+/* AI prompt-edit bar (sc-2435): model picker + prompt + seed inline. */
+.image-editor-editbar .image-editor-editprompt {
+  min-width: 260px;
+  flex: 1 1 260px;
+}
+
+.image-editor-editbar .image-editor-editseed {
+  width: 80px;
+}
+
+.image-editor-editbar .image-editor-editmodel {
+  max-width: 200px;
+}
+
 /* In-flight AI op (upscale, later edit/detail): a blocking overlay over the canvas. */
 .image-editor-busy {
   position: absolute;


### PR DESCRIPTION
**sc-2435** (epic 2427, Phase 2). Brings the prompt-based image edit into the Image Editor, operating on the working image.

## What's in it
- **"AI Edit" is now a live tool** — an edit panel with:
  - an **edit-model picker** filtered to the `edit_image`/`image_edit` capability (the same filter Image Studio uses),
  - a **prompt** input, and an optional **seed**.
- **Runs through the existing `edit_image` flow:** the working bitmap is staged as a scratch asset (the sc-2432 seam) and referenced as `sourceAssetId`; the job POSTs to `/api/v1/image/jobs`; the result returns to the canvas as the new working image, and the scratch + result are purged. Composes with crop / upscale / color in the same session, and the edit is recorded in the Save provenance chain (`{op:"edit", model, prompt}`).
- **Generalized the shared `runAiOp` seam** with an `endpoint` param so one path serves both the generic `/api/v1/jobs` (upscale) and `/api/v1/image/jobs` (edit).
- Pure helpers `editCapableModels` + `buildEditJobBody`, unit-tested.

## Verification
Live against a real API:
- The panel lists the **11 edit-capable models**, defaults to the first.
- Entering a prompt + clicking **Edit** stages a scratch asset and POSTs an `image_edit` job to `/api/v1/image/jobs` with the exact expected payload — `mode=edit_image`, `sourceAssetId`=scratch, `model=qwen_image_edit_2511`, `prompt`, working `width/height`, `seed=null`, `count=1` (confirmed server-side).
- The busy overlay shows **"Editing…"**; the job sits `queued` (no GPU worker in the verify env).

The result round-trip reuses the **same watcher path already proven end-to-end by the upscale tool** (`load result.assets[0] → install → purge`); only the GPU model execution itself is unverified here — same caveat as the upscale tool.

Tests: **319 web** (+3 edit unit tests) + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)