### PR TITLE
Inpaint backend: maskAssetId + SDXL inpaint adapter path (sc-2476)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -393,6 +393,11 @@ pub(crate) struct ImageJobRequest {
     // "many images from one reference" flow. ip_adapter_scale rides in `advanced`.
     #[serde(default)]
     pub(crate) reference_asset_id: Option<String>,
+    // Optional inpaint mask asset (sc-2476): white = edit region. Honored only by
+    // inpaint-capable models (the `image_inpaint` capability, SDXL family); others
+    // ignore it and run the whole-image edit. Threaded to the worker payload as-is.
+    #[serde(default)]
+    pub(crate) mask_asset_id: Option<String>,
     #[serde(default = "default_requested_gpu")]
     pub(crate) requested_gpu: String,
     #[serde(default, skip_serializing_if = "ImageUpscaleRequest::is_disabled")]

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -512,8 +512,10 @@ MODEL_TARGETS = {
         "label": "Stable Diffusion XL",
         "family": "sdxl",
         # Unified base checkpoint: StableDiffusionXLPipeline (T2I) +
-        # StableDiffusionXLImg2ImgPipeline (edit).
+        # StableDiffusionXLImg2ImgPipeline (edit) + StableDiffusionXLInpaintPipeline
+        # (masked edit when a maskAssetId is present — sc-2476).
         "supportsEdit": True,
+        "supportsInpaint": True,
         # Real CFG with negative prompt (not distilled): ~30 steps at guidance
         # 7.0, native 1024x1024. Two CLIP text encoders, so no max_seq_len knob.
         # Ships EulerDiscreteScheduler, which we keep (scheduler UI is epic 1753).
@@ -546,6 +548,7 @@ MODEL_TARGETS = {
         # face-identity engine on the same checkpoint (sc-2008 vs sc-2009).
         "family": "sdxl",
         "supportsEdit": True,
+        "supportsInpaint": True,
         # Real CFG with negative prompt: ~30 steps at guidance 7.0, native 1024.
         "steps": 30,
         "guidanceScale": 7.0,
@@ -662,6 +665,9 @@ class ImageRequest:
     advanced: dict[str, Any]
     model_manifest_entry: dict[str, Any]
     upscale: UpscaleRequest = field(default_factory=UpscaleRequest)
+    # Optional inpaint mask asset (sc-2476): white = edit region. Only honored by
+    # inpaint-capable adapters (SDXL family); others ignore it (whole-image edit).
+    mask_asset_id: str | None = None
 
 
 class ImageUpscaler(Protocol):
@@ -710,6 +716,7 @@ def image_request_from_job(job: dict[str, Any]) -> ImageRequest:
         character_look_id=payload.get("characterLookId"),
         source_asset_id=payload.get("sourceAssetId"),
         reference_asset_id=payload.get("referenceAssetId"),
+        mask_asset_id=payload.get("maskAssetId"),
         model_manifest_entry=(
             payload.get("modelManifestEntry") if isinstance(payload.get("modelManifestEntry"), dict) else {}
         ),
@@ -5671,7 +5678,16 @@ class SdxlDiffusersAdapter:
             # re-generation). It sizes the output from the source, so height/width
             # are dropped by filter_call_kwargs.
             kwargs["image"] = load_source_image(project_path, request)
-            kwargs["strength"] = float(request.advanced.get("strength", 0.6))
+            use_inpaint = bool(request.mask_asset_id) and model_supports_inpaint(request.model)
+            kwargs["strength"] = float(request.advanced.get("strength", 0.85 if use_inpaint else 0.6))
+            if use_inpaint:
+                # Masked inpaint (sc-2476): confine the edit to the white mask region;
+                # the pipeline preserves everything outside. Reuses the resident edit
+                # pipe's components (shared UNet/VAE/encoders → no reload, no extra
+                # VRAM, LoRA-merged UNet carries over). The inpaint pipeline keeps
+                # height/width (unlike img2img), and the mask is aligned to W×H.
+                kwargs["mask_image"] = load_mask_image(project_path, request)
+                pipe = self._as_inpaint_pipe(pipe)
         elif self._use_ip_adapter(request):
             # IP-Adapter conditions T2I on a reference image (style/identity). Vary
             # prompt/seed across the batch to get many images of the same subject.
@@ -5685,6 +5701,22 @@ class SdxlDiffusersAdapter:
         if cancel_requested is not None and cancel_requested():
             raise InterruptedError("Image generation canceled by user.")
         return output.images[0].convert("RGB")
+
+    @staticmethod
+    def _as_inpaint_pipe(pipe: Any) -> Any:
+        """Wrap the resident edit pipe in StableDiffusionXLInpaintPipeline for a masked
+        edit (sc-2476). Passing the loaded pipe's `components` reuses the same module
+        instances — no weight reload, no extra VRAM, and any merged LoRA on the shared
+        UNet carries over. The spike (sc-2475) confirmed the base SDXL 4-ch UNet runs
+        diffusers' legacy mask-blend inpaint cleanly on MPS."""
+        diffusers = importlib.import_module("diffusers")
+        inpaint_class = getattr(diffusers, "StableDiffusionXLInpaintPipeline", None)
+        if inpaint_class is None:
+            raise RuntimeError(
+                "The installed diffusers package does not expose "
+                "StableDiffusionXLInpaintPipeline; install diffusers >= 0.19."
+            )
+        return inpaint_class(**pipe.components)
 
     def _apply_loras(self, pipe: Any, request: ImageRequest, *, lora_key: str | None = None) -> None:
         # lora_key pins the cache slot when the pipe is neither the text nor img2img
@@ -7717,6 +7749,13 @@ def model_supports_edit(model_id: str) -> bool:
     return bool(MODEL_TARGETS.get(model_id, {}).get("supportsEdit"))
 
 
+def model_supports_inpaint(model_id: str) -> bool:
+    """Whether the model honors an inpaint mask (sc-2476). SDXL family only for now —
+    its adapter wraps the loaded pipe's components in StableDiffusionXLInpaintPipeline.
+    Non-inpaint models ignore maskAssetId and run the whole-image edit."""
+    return bool(MODEL_TARGETS.get(model_id, {}).get("supportsInpaint"))
+
+
 def resolve_seed(seed: int | None, prompt: str, index: int, seeds: list[int] | None = None) -> int:
     if seed is not None:
         return int(seed) + index
@@ -7891,6 +7930,21 @@ def load_source_image(project_path: Path, request: ImageRequest) -> Image.Image:
     except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
         raise RuntimeError(f"Source image could not be loaded safely: {source_path}") from exc
     return image.resize((request.width, request.height))
+
+
+def load_mask_image(project_path: Path, request: ImageRequest) -> Image.Image:
+    # Inpaint mask (sc-2476): grayscale, white = edit region. Resolved only through the
+    # project sidecar/DB (find_asset_media_path constrains to the project root) — no
+    # client path escape hatch, same guard as the source. Resized to the output W×H so
+    # it aligns pixel-for-pixel with the source `load_source_image` returns.
+    if not request.mask_asset_id:
+        raise RuntimeError("Inpaint requires a mask image asset.")
+    mask_path = find_asset_media_path(project_path, request.mask_asset_id)
+    try:
+        mask = Image.open(mask_path).convert("L")
+    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise RuntimeError(f"Mask image could not be loaded safely: {mask_path}") from exc
+    return mask.resize((request.width, request.height))
 
 
 def load_reference_image(project_path: Path, reference_asset_id: str) -> Image.Image:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1336,7 +1336,8 @@
       "adapter": "sdxl_diffusers",
       // character_image: h94/IP-Adapter plus-face for Character Studio reference
       // (sc-2007 resemblance tier; faithful likeness belongs to InstantID — sc-2009).
-      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
+      // image_inpaint: StableDiffusionXLInpaintPipeline masked edits (sc-2476).
+      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "character_image", "style_variations"],
       "downloads": [
         {
           // Diffusers checkpoint: SDXL base 1.0 (UNet + dual CLIP text encoders
@@ -1418,9 +1419,9 @@
       "type": "image",
       "adapter": "sdxl_diffusers",
       // Photoreal SDXL finetune with the full SDXL feature set (t2i + edit +
-      // reference). Plain photoreal alternative to InstantID — IP-Adapter
-      // plus-face for resemblance, sdxl-family LoRA support.
-      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
+      // reference + masked inpaint, sc-2476). Plain photoreal alternative to
+      // InstantID — IP-Adapter plus-face for resemblance, sdxl-family LoRA support.
+      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "character_image", "style_variations"],
       "downloads": [
         {
           // Same checkpoint as the InstantID built-in below — single HF cache

--- a/scripts/spikes/sc2476_inpaint_adapter_validate.py
+++ b/scripts/spikes/sc2476_inpaint_adapter_validate.py
@@ -1,0 +1,160 @@
+"""sc-2476 validation — exercise the REAL SDXL inpaint adapter path on M5 Max.
+
+Closes the sc-2476 acceptance criterion ("real masked-inpaint run on the M5 Max produces
+a coherent localized edit") and de-risks the one piece the sc-2475 spike did NOT cover:
+``SdxlDiffusersAdapter._as_inpaint_pipe`` — wrapping the loaded edit pipe's `components`
+in ``StableDiffusionXLInpaintPipeline`` (shared modules, no reload). The spike proved the
+diffusers inpaint pipeline itself; this proves our adapter wiring of it.
+
+It drives REAL adapter code (`SdxlDiffusersAdapter._as_inpaint_pipe`, `load_mask_image`,
+`load_source_image`) against the SDXL base checkpoint already cached. `find_asset_media_path`
+is monkeypatched to read source/mask PNGs off disk (asset-sidecar resolution is orthogonal
+to what this validates), mirroring the worker unit tests.
+
+Run with the SceneWorks desktop venv (torch/diffusers/PIL):
+  "/Users/michael/Library/Application Support/SceneWorks/python/venv/bin/python" \
+      scripts/spikes/sc2476_inpaint_adapter_validate.py \
+      --source /path/to/photo.png --prompt "a vase of bright sunflowers"
+
+Outputs PNGs + a JSON summary under --out (default /tmp/sc2476_inpaint_adapter).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+for _pkg in (_REPO / "apps" / "worker",):
+    if str(_pkg) not in sys.path:
+        sys.path.insert(0, str(_pkg))
+
+os.environ.setdefault("SCENEWORKS_GPU_ID", "mps")
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+from PIL import Image, ImageDraw, ImageFilter  # noqa: E402
+
+from scene_worker import image_adapters as ia  # noqa: E402
+from scene_worker.image_adapters import (  # noqa: E402
+    SdxlDiffusersAdapter,
+    image_request_from_job,
+    load_mask_image,
+    load_source_image,
+)
+
+
+def _device() -> str:
+    if torch.backends.mps.is_available():
+        return "mps"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def _ellipse_mask(size: int, feather: int) -> Image.Image:
+    mask = Image.new("L", (size, size), 0)
+    pad = size // 6
+    ImageDraw.Draw(mask).ellipse([pad, pad, size - pad, size - pad], fill=255)
+    return mask.filter(ImageFilter.GaussianBlur(feather)) if feather else mask
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="sdxl", help="MODEL_TARGETS key (sdxl or realvisxl).")
+    parser.add_argument("--source", required=True, help="Source image (square-fit to --size).")
+    parser.add_argument("--prompt", default="a vase of bright sunflowers, sharp focus")
+    parser.add_argument("--negative-prompt", default="blurry, lowres")
+    parser.add_argument("--size", type=int, default=1024)
+    parser.add_argument("--strength", type=float, default=0.85)
+    parser.add_argument("--feather", type=int, default=12)
+    parser.add_argument("--out", default="/tmp/sc2476_inpaint_adapter")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    device = _device()
+    size = args.size
+
+    # Stage source + mask on disk; point the adapter's asset resolver at them.
+    source = Image.open(args.source).convert("RGB").resize((size, size), Image.LANCZOS)
+    source_path = out / "source.png"
+    source.save(source_path)
+    mask = _ellipse_mask(size, args.feather)
+    mask_path = out / "mask.png"
+    mask.save(mask_path)
+
+    paths = {"asset_source": source_path, "asset_mask": mask_path}
+    orig_resolver = ia.find_asset_media_path
+    ia.find_asset_media_path = lambda project_path, asset_id: paths[asset_id]
+
+    request = image_request_from_job({
+        "payload": {
+            "projectId": "p", "mode": "edit_image", "model": args.model,
+            "prompt": args.prompt, "negativePrompt": args.negative_prompt,
+            "sourceAssetId": "asset_source", "maskAssetId": "asset_mask",
+            "width": size, "height": size, "advanced": {"strength": args.strength},
+        }
+    })
+
+    # Sanity: the loaders return aligned, correctly-typed inputs.
+    src_img = load_source_image(out, request)
+    mask_img = load_mask_image(out, request)
+    assert src_img.size == (size, size) and mask_img.size == (size, size)
+    assert mask_img.mode == "L"
+
+    adapter = SdxlDiffusersAdapter()
+    model_target = ia.MODEL_TARGETS[args.model]
+    settings = __import__("types").SimpleNamespace(gpu_id=device)
+
+    print(f"=== loading {args.model} edit pipe on {device} ===", flush=True)
+    t_load = time.time()
+    pipe = adapter._load_pipeline(  # noqa: SLF001 — spike drives the real internal path
+        settings, request, model_target, progress=lambda *a: None, job_id="sc2476",
+    )
+    load_s = round(time.time() - t_load, 1)
+
+    # THE thing under test: wrap the loaded edit pipe's components in the inpaint pipeline.
+    inpaint_pipe = adapter._as_inpaint_pipe(pipe)  # noqa: SLF001
+    inpaint_class = type(inpaint_pipe).__name__
+    shared_unet = inpaint_pipe.unet is pipe.unet  # must reuse the SAME module (no reload)
+    print(f"  loaded in {load_s}s → wrapped as {inpaint_class} (shared UNet={shared_unet})", flush=True)
+
+    print("=== running masked inpaint via the real adapter path ===", flush=True)
+    t0 = time.time()
+    result = adapter._run_pipeline(settings, pipe, request, seed=1234, project_path=out)  # noqa: SLF001
+    elapsed = round(time.time() - t0, 1)
+    result.save(out / "result.png")
+
+    # Outside-mask preservation: outside ≈ source, inside changed.
+    src = np.asarray(source, dtype=np.float32)
+    res = np.asarray(result.convert("RGB").resize(source.size), dtype=np.float32)
+    m = np.asarray(mask.resize(source.size), dtype=np.float32) / 255.0
+    inside, outside = m > 0.5, m <= 0.5
+    diff = np.abs(res - src).mean(axis=2)
+    inside_diff = round(float(diff[inside].mean()), 2)
+    outside_diff = round(float(diff[outside].mean()), 2)
+
+    verdict = "GO" if inside_diff >= 15 and outside_diff <= 8 else "REVIEW"
+    summary = {
+        "device": device, "model": args.model, "size": size, "strength": args.strength,
+        "inpaintClass": inpaint_class, "sharedUnet": shared_unet,
+        "seconds": elapsed, "insideMeanDiff": inside_diff, "outsideMeanDiff": outside_diff,
+        "verdict": verdict,
+    }
+    (out / "summary.json").write_text(json.dumps(summary, indent=2))
+    ia.find_asset_media_path = orig_resolver
+
+    print("\n" + "=" * 60)
+    print(json.dumps(summary, indent=2))
+    print(f"VERDICT: {verdict}  (result.png + summary.json in {out})")
+    print("GO = adapter wrapped the pipe (sharedUnet=True) + inside Δ≥15 & outside Δ≤8.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1612,6 +1612,7 @@
       "count": 4,
       "height": 1024,
       "loras": [],
+      "maskAssetId": null,
       "mode": "text_to_image",
       "model": "base-model",
       "modelManifestEntry": {
@@ -1708,6 +1709,7 @@
       "count": 4,
       "height": 1024,
       "loras": [],
+      "maskAssetId": null,
       "mode": "text_to_image",
       "model": "base-model",
       "modelManifestEntry": {
@@ -1799,6 +1801,7 @@
         "count": 4,
         "height": 1024,
         "loras": [],
+        "maskAssetId": null,
         "mode": "text_to_image",
         "model": "base-model",
         "modelManifestEntry": {
@@ -1890,6 +1893,7 @@
       "count": 4,
       "height": 1024,
       "loras": [],
+      "maskAssetId": null,
       "mode": "text_to_image",
       "model": "base-model",
       "modelManifestEntry": {
@@ -2885,6 +2889,7 @@
       "count": 4,
       "height": 1024,
       "loras": [],
+      "maskAssetId": null,
       "mode": "text_to_image",
       "model": "base-model",
       "modelManifestEntry": {

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -50,8 +50,10 @@ from scene_worker.image_adapters import (
     image_batch_progress,
     image_request_from_job,
     lens_resolution_for,
+    load_mask_image,
     load_reference_image,
     model_supports_edit,
+    model_supports_inpaint,
     pipeline_component_devices,
     require_inference_backend_for_gpu_worker,
     interleave_resolution_for,
@@ -373,6 +375,50 @@ def test_run_image_upscale_writes_single_child_asset(tmp_path, monkeypatch):
     # One generation set wrapping the single child asset.
     assert result["expectedCount"] == 1
     assert result["generationSet"]["id"] == result["generationSetId"]
+
+
+def test_image_request_threads_mask_asset_id(monkeypatch):
+    # sc-2476: an edit job can carry an inpaint mask alongside the source.
+    request = image_request_from_job(
+        {"payload": {"projectId": "p", "mode": "edit_image", "sourceAssetId": "asset_src",
+                     "maskAssetId": "asset_mask"}}
+    )
+    assert request.mask_asset_id == "asset_mask"
+    # Absent maskAssetId → None (whole-image edit).
+    plain = image_request_from_job({"payload": {"projectId": "p", "sourceAssetId": "asset_src"}})
+    assert plain.mask_asset_id is None
+
+
+def test_model_supports_inpaint_matrix():
+    # sc-2476: SDXL family honors a mask; instruction-edit / img2img-only models don't.
+    assert model_supports_inpaint("sdxl") is True
+    assert model_supports_inpaint("realvisxl") is True
+    assert model_supports_inpaint("qwen_image_edit_2511") is False
+    assert model_supports_inpaint("z_image_edit") is False
+    assert model_supports_inpaint("unknown_model") is False
+
+
+def test_load_mask_image_resolves_grayscale_and_aligns_to_output(tmp_path, monkeypatch):
+    # sc-2476: the mask resolves only through the project sidecar (no path escape) and
+    # is returned grayscale, resized to the output W×H so it aligns with the source.
+    mask = Image.new("RGB", (40, 30), "white")
+    mask_path = tmp_path / "mask.png"
+    mask.save(mask_path, "PNG")
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.find_asset_media_path",
+        lambda project_path, asset_id: mask_path,
+    )
+    request = image_request_from_job(
+        {"payload": {"projectId": "p", "mode": "edit_image", "sourceAssetId": "asset_src",
+                     "maskAssetId": "asset_mask", "width": 512, "height": 256}}
+    )
+    loaded = load_mask_image(tmp_path, request)
+    assert loaded.mode == "L"
+    assert loaded.size == (512, 256)
+
+    # No mask id → explicit error (callers gate on mask_asset_id first).
+    with pytest.raises(RuntimeError, match="mask image asset"):
+        load_mask_image(tmp_path, image_request_from_job({"payload": {"projectId": "p"}}))
 
 
 def test_run_image_upscale_requires_source_asset(monkeypatch, tmp_path):


### PR DESCRIPTION
Backend for **masked AI edits**, built on the **sc-2475 GO spike**. An `image_edit` job can now carry an inpaint mask; inpaint-capable models confine the edit to the masked region and preserve everything outside. Unblocks **sc-2436** (the frontend mask UI).

## Changes
- **Contract:** `ImageJobRequest.maskAssetId` (`Option`, `serde(default)`) — threads to the worker payload as-is via `to_json_object`. No new `JobType`, existing requests unchanged, **no response-snapshot drift** (89 rust-api green).
- **Worker:**
  - `ImageRequest.mask_asset_id` + `image_request_from_job` reads `maskAssetId`.
  - `load_mask_image` — grayscale (white = edit), resized to the output W×H so it aligns with the source, same sidecar-only path guard (no path escape).
  - `model_supports_inpaint`.
  - The SDXL adapter, when a mask is present on an inpaint-capable model, **wraps the loaded edit pipe's `components` in `StableDiffusionXLInpaintPipeline`** (`_as_inpaint_pipe` — shared UNet/VAE/encoders → no reload, no extra VRAM, merged LoRA carries over) and runs with `mask_image` + the spike's strength default (~0.85). Non-inpaint models are untouched.
- **Capability:** `image_inpaint` on `sdxl` + `realvisxl` (manifest `capabilities` + `MODEL_TARGETS.supportsInpaint`). Models without it **ignore `maskAssetId` and run the existing whole-image edit** — graceful fallback, no regression.

## Tests
New worker tests: `maskAssetId` threading, the inpaint capability matrix, and `load_mask_image` (grayscale + W×H alignment). **482 worker** + **89 rust-api** + **79 core** green.

> ⚠️ Two worker tests (`test_python_worker_only_advertises_inference_job_capabilities`, `test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs`) fail **only locally** — they assume a no-torch env but the desktop venv has torch+MPS, which flips capability detection (a `video_generate` leak). They **pre-exist on main** (verified via stash) and **pass in CI's no-torch env** (that's why #408 was green). Flagging per repo convention — want me to harden their torch isolation in a follow-up?

## Validation owed
`scripts/spikes/sc2476_inpaint_adapter_validate.py` drives the **real adapter inpaint path** (the `_as_inpaint_pipe` component-wrap the spike didn't cover) on the M5 Max:
```
"…/python/venv/bin/python" scripts/spikes/sc2476_inpaint_adapter_validate.py \
  --source /path/to/photo.png --prompt "a vase of bright sunflowers"
```
It asserts the wrap reuses the same UNet (`sharedUnet=True`) and checks inside/outside-mask Δ. Run it to close the "real masked edit on M5 Max" AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)