### PR TITLE
feat(image-editor): tile-ControlNet detail-enhance tool (sc-2438)

### DIFF
--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -12,6 +12,7 @@ export const GPU_REQUIRED_JOB_TYPES = new Set([
   "image_vqa",
   "image_interleave",
   "image_upscale",
+  "image_detail",
   "video_generate",
   "video_extend",
   "video_bridge",

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -11,10 +11,10 @@ const MAX_SCALE = 16;
 const ZOOM_STEP = 1.2;
 const MIN_CROP_PX = 8;
 
-// Tools still to come in epic 2427 — rendered as an inert scaffold so the frame
-// (and the next slices' insertion points) are in place. Move + Crop + Upscale +
-// Color + AI Edit are live.
-const UPCOMING_TOOLS = [{ id: "detail", label: "Detail", story: "sc-2438" }];
+// Future-tool scaffold (epic 2427) — rendered as inert buttons so the frame + the
+// next slices' insertion points stay in place. All current epic-2427 tools are live
+// (Move + Crop + Upscale + Color + AI Edit + Detail), so this is empty for now.
+const UPCOMING_TOOLS = [];
 
 // Models that can edit an existing image with a prompt — the manifest tags them
 // with an `edit_image`/`image_edit` capability (same filter the Image Studio uses).
@@ -23,6 +23,13 @@ export function editCapableModels(imageModels) {
     const caps = model.capabilities ?? [];
     return caps.includes("edit_image") || caps.includes("image_edit");
   });
+}
+
+// Models that can run the tile-ControlNet detail refine — the manifest tags them
+// `image_detail` (sc-2437/sc-2438; SDXL/RealVisXL only). RealVisXL is the recommended
+// photoreal backbone per the spike.
+export function detailCapableModels(imageModels) {
+  return (imageModels ?? []).filter((model) => (model.capabilities ?? []).includes("image_detail"));
 }
 
 // The `POST /api/v1/image/jobs` body for an in-editor prompt edit (sc-2435). Reuses
@@ -144,6 +151,25 @@ export function buildUpscaleJobBody({ project, requestedGpu, sourceAssetId, fact
     projectName: project.name ?? null,
     requestedGpu,
     payload: { projectId: project.id, sourceAssetId, factor, engine, displayName },
+  };
+}
+
+// The `POST /api/v1/jobs` body for a standalone image_detail job (sc-2438). Same
+// generic-jobs shape as upscale; the worker reads model + advanced.strength/cnScale
+// from the payload (recipe defaults locked by the sc-2437 spike). Pure for testing.
+export function buildDetailJobBody({ project, requestedGpu, sourceAssetId, model, strength, cnScale, displayName }) {
+  return {
+    type: "image_detail",
+    projectId: project.id,
+    projectName: project.name ?? null,
+    requestedGpu,
+    payload: {
+      projectId: project.id,
+      sourceAssetId,
+      model,
+      displayName,
+      advanced: { strength, cnScale },
+    },
   };
 }
 
@@ -283,6 +309,14 @@ export function ImageEditor() {
   const [editPrompt, setEditPrompt] = useState("");
   const [editSeed, setEditSeed] = useState("");
 
+  // Detail enhance (sc-2438): tile-ControlNet refine over the working image. Backbone
+  // (SDXL/RealVisXL) + strength (the "detail amount" — higher invents more texture) +
+  // structure-lock (controlnet scale). Defaults are the sc-2437 spike's locked recipe.
+  const detailModels = detailCapableModels(imageModels);
+  const [detailModel, setDetailModel] = useState("");
+  const [detailStrength, setDetailStrength] = useState(0.55);
+  const [detailCnScale, setDetailCnScale] = useState(0.7);
+
   // Inpaint mask (sc-2436): freehand brush strokes in image-pixel coords, rasterized
   // to a mask asset on Run for inpaint-capable models. `maskMode` is the paint sub-mode
   // of the AI Edit tool (Stage panning is suspended while it's on).
@@ -298,6 +332,12 @@ export function ImageEditor() {
     const caps = editCapableModels(imageModels);
     if (caps.length && !caps.some((model) => model.id === editModel)) setEditModel(caps[0].id);
   }, [imageModels, editModel]);
+
+  // Same default/self-heal for the detail backbone.
+  useEffect(() => {
+    const caps = detailCapableModels(imageModels);
+    if (caps.length && !caps.some((model) => model.id === detailModel)) setDetailModel(caps[0].id);
+  }, [imageModels, detailModel]);
 
   // The chosen edit model + whether it accepts an inpaint mask (gates the mask tool).
   const selectedEditModel = editModels.find((model) => model.id === editModel) ?? null;
@@ -787,6 +827,24 @@ export function ImageEditor() {
     });
   }
 
+  function runDetail() {
+    if (!detailModel) return;
+    runAiOp({
+      label: "detail",
+      edit: { op: "detail", model: detailModel, strength: detailStrength, cnScale: detailCnScale },
+      buildBody: (scratch) =>
+        buildDetailJobBody({
+          project: activeProject,
+          requestedGpu,
+          sourceAssetId: scratch.id,
+          model: detailModel,
+          strength: detailStrength,
+          cnScale: detailCnScale,
+          displayName: working?.source?.name,
+        }),
+    });
+  }
+
   async function runEdit() {
     const prompt = editPrompt.trim();
     if (!prompt || !editModel || !working) return;
@@ -1126,6 +1184,15 @@ export function ImageEditor() {
               Upscale
             </button>
             <button
+              className={tool === "detail" ? "image-editor-tool active" : "image-editor-tool"}
+              disabled={!!aiOp || detailModels.length === 0}
+              onClick={() => setTool("detail")}
+              title="Detail enhance (tile-ControlNet refine)"
+              type="button"
+            >
+              Detail
+            </button>
+            <button
               className={tool === "color" ? "image-editor-tool active" : "image-editor-tool"}
               disabled={!!aiOp}
               onClick={startColorGrade}
@@ -1227,6 +1294,61 @@ export function ImageEditor() {
             <button className="primary" disabled={!!aiOp} onClick={runUpscale} type="button">
               Upscale
             </button>
+            <button onClick={() => setTool("move")} type="button">
+              Cancel
+            </button>
+          </div>
+        ) : null}
+
+        {tool === "detail" && working ? (
+          <div className="image-editor-cropbar image-editor-detailbar">
+            {detailModels.length === 0 ? (
+              <span className="image-editor-cropdims">No detail-capable models installed</span>
+            ) : (
+              <>
+                <select
+                  aria-label="Detail backbone"
+                  className="image-editor-editmodel"
+                  onChange={(event) => setDetailModel(event.target.value)}
+                  value={detailModel}
+                >
+                  {detailModels.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.label ?? model.id}
+                    </option>
+                  ))}
+                </select>
+                <label className="image-editor-slider" title="Detail amount — higher invents more texture">
+                  <span className="image-editor-slider-label">Detail</span>
+                  <input
+                    aria-label="Detail strength"
+                    max={0.8}
+                    min={0.3}
+                    onChange={(event) => setDetailStrength(Number(event.target.value))}
+                    step={0.05}
+                    type="range"
+                    value={detailStrength}
+                  />
+                  <span className="image-editor-slider-value">{Math.round(detailStrength * 100)}</span>
+                </label>
+                <label className="image-editor-slider" title="Structure lock — higher keeps the result closer to the source">
+                  <span className="image-editor-slider-label">Structure</span>
+                  <input
+                    aria-label="Structure lock"
+                    max={1}
+                    min={0.4}
+                    onChange={(event) => setDetailCnScale(Number(event.target.value))}
+                    step={0.05}
+                    type="range"
+                    value={detailCnScale}
+                  />
+                  <span className="image-editor-slider-value">{Math.round(detailCnScale * 100)}</span>
+                </label>
+                <button className="primary" disabled={!!aiOp || !detailModel} onClick={runDetail} type="button">
+                  Enhance
+                </button>
+              </>
+            )}
             <button onClick={() => setTool("move")} type="button">
               Cancel
             </button>
@@ -1361,7 +1483,13 @@ export function ImageEditor() {
           <div className="image-editor-busy">
             <div className="image-editor-busy-card">
               <p className="image-editor-busy-title">
-                {aiOp.label === "upscale" ? "Upscaling…" : aiOp.label === "edit" ? "Editing…" : "Working…"}
+                {aiOp.label === "upscale"
+                  ? "Upscaling…"
+                  : aiOp.label === "edit"
+                    ? "Editing…"
+                    : aiOp.label === "detail"
+                      ? "Enhancing detail…"
+                      : "Working…"}
               </p>
               <p className="image-editor-busy-msg">
                 {activeAiJob?.message ||

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -29,6 +29,8 @@ import {
   buildEditJobBody,
   modelIsInpaintCapable,
   maskHasContent,
+  detailCapableModels,
+  buildDetailJobBody,
 } from "./ImageEditor.jsx";
 
 // These tests cover the non-canvas surface of the editor (empty state, the inert
@@ -158,6 +160,44 @@ describe("upscale job", () => {
         factor: 4,
         engine: "real-esrgan",
         displayName: "shot.png",
+      },
+    });
+  });
+});
+
+describe("detail job", () => {
+  it("filters to image_detail-capable models", () => {
+    const models = [
+      { id: "realvisxl", capabilities: ["text_to_image", "edit_image", "image_detail"] },
+      { id: "flux", capabilities: ["text_to_image"] },
+      { id: "sdxl", capabilities: ["image_detail"] },
+    ];
+    expect(detailCapableModels(models).map((m) => m.id)).toEqual(["realvisxl", "sdxl"]);
+    expect(detailCapableModels([])).toEqual([]);
+    expect(detailCapableModels(undefined)).toEqual([]);
+  });
+
+  it("builds the image_detail job body the worker expects (model + advanced.strength/cnScale)", () => {
+    const body = buildDetailJobBody({
+      project: { id: "project_1", name: "My Project" },
+      requestedGpu: "auto",
+      sourceAssetId: "asset_scratch",
+      model: "realvisxl",
+      strength: 0.55,
+      cnScale: 0.7,
+      displayName: "shot.png",
+    });
+    expect(body).toEqual({
+      type: "image_detail",
+      projectId: "project_1",
+      projectName: "My Project",
+      requestedGpu: "auto",
+      payload: {
+        projectId: "project_1",
+        sourceAssetId: "asset_scratch",
+        model: "realvisxl",
+        displayName: "shot.png",
+        advanced: { strength: 0.55, cnScale: 0.7 },
       },
     });
   });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5295,6 +5295,11 @@ label {
   max-width: 200px;
 }
 
+/* Detail-enhance bar (sc-2438): backbone picker + strength/structure sliders. */
+.image-editor-detailbar .image-editor-editmodel {
+  max-width: 200px;
+}
+
 /* In-flight AI op (upscale, later edit/detail): a blocking overlay over the canvas. */
 .image-editor-busy {
   position: absolute;

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -516,6 +516,10 @@ MODEL_TARGETS = {
         # (masked edit when a maskAssetId is present — sc-2476).
         "supportsEdit": True,
         "supportsInpaint": True,
+        # Tile-ControlNet detail refine (image_detail job, sc-2437/sc-2438): the
+        # standalone run_image_detail builds StableDiffusionXLControlNetImg2ImgPipeline
+        # on this checkpoint + xinsir/controlnet-tile-sdxl-1.0.
+        "supportsDetail": True,
         # Real CFG with negative prompt (not distilled): ~30 steps at guidance
         # 7.0, native 1024x1024. Two CLIP text encoders, so no max_seq_len knob.
         # Ships EulerDiscreteScheduler, which we keep (scheduler UI is epic 1753).
@@ -549,6 +553,9 @@ MODEL_TARGETS = {
         "family": "sdxl",
         "supportsEdit": True,
         "supportsInpaint": True,
+        # Tile-ControlNet detail refine (image_detail job, sc-2437/sc-2438) — the
+        # photoreal SDXL prior is the recommended detail backbone per the spike.
+        "supportsDetail": True,
         # Real CFG with negative prompt: ~30 steps at guidance 7.0, native 1024.
         "steps": 30,
         "guidanceScale": 7.0,
@@ -7756,6 +7763,13 @@ def model_supports_inpaint(model_id: str) -> bool:
     return bool(MODEL_TARGETS.get(model_id, {}).get("supportsInpaint"))
 
 
+def model_supports_detail(model_id: str) -> bool:
+    """Whether the model can run the tile-ControlNet detail refine (image_detail job,
+    sc-2437/sc-2438). SDXL family only — run_image_detail builds
+    StableDiffusionXLControlNetImg2ImgPipeline on the checkpoint + a tile ControlNet."""
+    return bool(MODEL_TARGETS.get(model_id, {}).get("supportsDetail"))
+
+
 def resolve_seed(seed: int | None, prompt: str, index: int, seeds: list[int] | None = None) -> int:
     if seed is not None:
         return int(seed) + index
@@ -8116,6 +8130,332 @@ def run_image_upscale(
         "expectedCount": 1,
         "adapter": upscaler.id,
         "model": upscaler.id,
+        "generationSet": generation_set,
+        "assetWrites": [fact],
+    }
+
+
+# xinsir tile ControlNet (Apache-2.0, ~2.5 GB, ungated) — locks structure so the
+# tiled img2img refine can run high denoise and add micro-texture without drifting
+# (sc-2437 round-2 spike = GO). Self-downloads on first use (no manifest entry).
+TILE_CONTROLNET_REPO = "xinsir/controlnet-tile-sdxl-1.0"
+
+
+def _clamp_float(value: Any, default: float, lo: float, hi: float) -> float:
+    try:
+        result = float(value) if value is not None else default
+    except (TypeError, ValueError):
+        result = default
+    return max(lo, min(hi, result))
+
+
+def _detail_feather(tile_w: int, tile_h: int, overlap: int) -> Any:
+    """Raised-cosine alpha ramp over the overlap borders so tiles blend seamlessly
+    (proven no-seams in the sc-2437 spike, including on the tile-CN path)."""
+    import numpy as np
+
+    def ramp(n: int) -> Any:
+        w = np.ones(n, dtype=np.float32)
+        if overlap > 0 and n > overlap:
+            idx = np.arange(overlap, dtype=np.float32)
+            edge = 0.5 - 0.5 * np.cos(np.pi * (idx + 0.5) / overlap)
+            w[:overlap] = edge
+            w[-overlap:] = edge[::-1]
+        return w
+
+    return np.outer(ramp(tile_h), ramp(tile_w))
+
+
+def _refine_tiled_detail(
+    pipe: Any,
+    image: Image.Image,
+    *,
+    prompt: str,
+    negative: str,
+    strength: float,
+    cn_scale: float,
+    tile: int,
+    overlap: int,
+    steps: int,
+    guidance: float,
+    seed: int,
+    cancel_requested: CancelCallback | None,
+    on_tile: Any = None,
+) -> tuple[Image.Image, int]:
+    """Tile-ControlNet img2img refine with raised-cosine feather blend (sc-2437 round-2).
+
+    Each tile is refined by StableDiffusionXLControlNetImg2ImgPipeline with the tile
+    itself as both the img2img init and the ControlNet conditioning (control=same — the
+    spike showed pre-blurring drags detail down). The tile CN locks composition so the
+    high denoise adds SDXL-prior micro-texture without rewriting the picture; tiles are
+    blended with a raised-cosine feather over the overlap (no visible seams)."""
+    import numpy as np
+
+    torch = importlib.import_module("torch")
+    width, height = image.size
+    step = max(tile - overlap, 1)
+    acc = np.zeros((height, width, 3), dtype=np.float32)
+    wsum = np.zeros((height, width, 1), dtype=np.float32)
+    xs = list(range(0, max(width - overlap, 1), step))
+    ys = list(range(0, max(height - overlap, 1), step))
+    total = len(xs) * len(ys)
+    done = 0
+    for y in ys:
+        for x in xs:
+            if cancel_requested is not None and cancel_requested():
+                raise InterruptedError("Detail enhancement canceled by user.")
+            x0 = min(x, max(width - tile, 0))
+            y0 = min(y, max(height - tile, 0))
+            crop = image.crop((x0, y0, x0 + tile, y0 + tile))
+            tile_w, tile_h = crop.size
+            generator = torch.Generator(device="cpu").manual_seed(seed + done)
+            refined = pipe(
+                prompt=prompt,
+                negative_prompt=negative,
+                image=crop,
+                control_image=crop,
+                strength=strength,
+                controlnet_conditioning_scale=cn_scale,
+                num_inference_steps=steps,
+                guidance_scale=guidance,
+                generator=generator,
+            ).images[0]
+            if refined.size != (tile_w, tile_h):
+                refined = refined.resize((tile_w, tile_h))
+            feather = _detail_feather(tile_w, tile_h, overlap)[:, :, None]
+            acc[y0:y0 + tile_h, x0:x0 + tile_w] += np.asarray(refined.convert("RGB"), dtype=np.float32) * feather
+            wsum[y0:y0 + tile_h, x0:x0 + tile_w] += feather
+            done += 1
+            if on_tile is not None:
+                on_tile(done, total)
+    wsum[wsum == 0] = 1.0
+    out = np.clip(acc / wsum, 0, 255).astype(np.uint8)
+    return Image.fromarray(out, "RGB"), total
+
+
+def _load_detail_pipeline(
+    settings: WorkerSettings,
+    *,
+    model: str,
+    advanced: dict[str, Any],
+    job_id: str | None,
+    progress: ProgressCallback,
+) -> Any:
+    """Build the tile-ControlNet img2img pipeline for run_image_detail. Extracted as a
+    seam so the orchestration is unit-testable without torch/diffusers/weights (the
+    test mocks this + _refine_tiled_detail, like run_image_upscale mocks the engine)."""
+    torch = importlib.import_module("torch")
+    diffusers = importlib.import_module("diffusers")
+    require_inference_backend_for_gpu_worker(torch, settings.gpu_id)
+    device = select_torch_device(torch, settings.gpu_id)
+    activate_torch_device(torch, device)
+    dtype = select_torch_dtype(torch, device, advanced.get("dtype"))
+    model_target = MODEL_TARGETS[model]
+    repo = advanced.get("modelRepo") or model_target["repo"]
+    variant = model_target.get("variant")
+
+    cn_class = getattr(diffusers, "ControlNetModel", None)
+    pipeline_class = getattr(diffusers, "StableDiffusionXLControlNetImg2ImgPipeline", None)
+    if cn_class is None or pipeline_class is None:
+        raise RuntimeError(
+            "The installed diffusers package does not expose "
+            "StableDiffusionXLControlNetImg2ImgPipeline / ControlNetModel; "
+            "install diffusers >= 0.25 for tile-ControlNet detail refine."
+        )
+    cache_action = "Loading cached" if huggingface_repo_cache_exists(repo) else "Downloading"
+    progress("loading_model", "loading_model", 0.2, f"{cache_action} {model_target['label']} + tile ControlNet.")
+    emit_worker_event(
+        "image_detail_load_start",
+        jobId=job_id,
+        model=model,
+        repo=repo,
+        controlNet=TILE_CONTROLNET_REPO,
+        device=device,
+        dtype=str(dtype),
+    )
+    controlnet = cn_class.from_pretrained(TILE_CONTROLNET_REPO, torch_dtype=dtype)
+    try:
+        pipe = pipeline_class.from_pretrained(repo, controlnet=controlnet, torch_dtype=dtype, variant=variant)
+    except Exception:
+        # Checkpoints without an fp16-variant subfolder fall back to default precision.
+        pipe = pipeline_class.from_pretrained(repo, controlnet=controlnet, torch_dtype=dtype)
+    pipe.to(device)
+    if hasattr(pipe, "set_progress_bar_config"):
+        pipe.set_progress_bar_config(disable=True)
+    vae = getattr(pipe, "vae", None)
+    if vae is not None and hasattr(vae, "enable_tiling"):
+        vae.enable_tiling()
+    elif hasattr(pipe, "enable_vae_tiling"):
+        pipe.enable_vae_tiling()
+    emit_worker_event(
+        "image_detail_load_complete",
+        jobId=job_id,
+        model=model,
+        componentDevices=pipeline_component_devices(pipe),
+    )
+    return pipe
+
+
+def _release_detail_pipeline() -> None:
+    """Free the detail pipeline's inference memory after a tiled refine. Self-guards so
+    the no-torch unit-test path (which mocks the pipeline load) is unaffected."""
+    try:
+        torch = importlib.import_module("torch")
+    except ImportError:
+        return
+    release_inference_memory(torch)
+
+
+def run_image_detail(
+    settings: WorkerSettings,
+    job: dict[str, Any],
+    *,
+    project_path: Path,
+    progress: ProgressCallback,
+    cancel_requested: CancelCallback,
+) -> dict[str, Any]:
+    """Standalone tile-ControlNet detail refine of an existing image asset (Image
+    Editor, epic 2427; spike sc-2437 = GO).
+
+    Resolves a ``sourceAssetId`` to its on-disk image at native resolution, builds a
+    StableDiffusionXLControlNetImg2ImgPipeline on the requested SDXL/RealVisXL
+    checkpoint + the xinsir tile ControlNet, runs a feathered tiled img2img refine, and
+    writes exactly one child asset with lineage back to the source (``parents`` +
+    ``extra.isDetailEnhanced``). Mirrors run_image_upscale; composes after it (refine
+    after upscale = "creative upscale"). Generative: higher ``strength`` invents more
+    plausible texture into smooth/ambiguous regions (Magnific/SUPIR-style)."""
+    payload = job["payload"]
+    source_asset_id = payload.get("sourceAssetId")
+    if not source_asset_id:
+        raise RuntimeError("Detail-enhance jobs require a source image asset.")
+    model = str(payload.get("model") or "realvisxl").strip() or "realvisxl"
+    if not model_supports_detail(model):
+        raise RuntimeError(f"{model} does not support detail enhancement.")
+    advanced = payload.get("advanced") if isinstance(payload.get("advanced"), dict) else {}
+    # Recipe defaults locked by the sc-2437 round-2 spike (RealVisXL + control=same):
+    # strength ~0.55 adds texture while the tile CN holds composition (higher invents
+    # more); cn_scale ~0.7 locks structure (avoid high-cn x high-strength = softens).
+    strength = _clamp_float(advanced.get("strength"), 0.55, 0.2, 1.0)
+    cn_scale = _clamp_float(advanced.get("cnScale"), 0.7, 0.1, 1.5)
+    steps = safe_int(advanced.get("steps"), 24, 1, 60)
+    guidance = _clamp_float(advanced.get("guidanceScale"), 5.0, 1.0, 15.0)
+    tile = safe_int(advanced.get("tile"), 1024, 512, 1536)
+    overlap = safe_int(advanced.get("overlap"), 128, 0, 512)
+    prompt = str(advanced.get("prompt") or "ultra detailed, sharp focus, fine texture, high quality")
+    negative = str(advanced.get("negativePrompt") or "blurry, soft, lowres, smooth, plastic")
+    try:
+        seed = int(payload.get("seed")) if payload.get("seed") is not None else 7
+    except (TypeError, ValueError):
+        seed = 7
+
+    progress("preparing", "preparing", 0.12, "Loading source image.")
+    source_path = find_asset_media_path(project_path, source_asset_id)
+    try:
+        image = Image.open(source_path).convert("RGB")
+    except (OSError, Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise RuntimeError(f"Source image could not be loaded safely: {source_path}") from exc
+
+    pipe = _load_detail_pipeline(
+        settings, model=model, advanced=advanced, job_id=job.get("id"), progress=progress
+    )
+
+    def on_tile(done: int, total: int) -> None:
+        progress(
+            "running", "running", 0.45 + 0.5 * (done / max(total, 1)),
+            f"Refining detail tile {done}/{total}.",
+        )
+
+    try:
+        refined, tiles = _refine_tiled_detail(
+            pipe,
+            image,
+            prompt=prompt,
+            negative=negative,
+            strength=strength,
+            cn_scale=cn_scale,
+            tile=tile,
+            overlap=overlap,
+            steps=steps,
+            guidance=guidance,
+            seed=seed,
+            cancel_requested=cancel_requested,
+            on_tile=on_tile,
+        )
+    finally:
+        _release_detail_pipeline()
+    if cancel_requested():
+        raise InterruptedError("Detail enhancement canceled by user.")
+
+    progress("saving", "saving", 0.96, "Saving detail-enhanced image.")
+    created_at = utc_now()
+    generation_set_id = f"genset_{uuid4().hex}"
+    images_dir = project_path / "assets" / "images" / generation_set_id
+    images_dir.mkdir(parents=True, exist_ok=True)
+    asset_id = f"asset_{uuid4().hex}"
+    filename = f"{created_at[:10]}_detail_{asset_id[6:14]}.png"
+    media_rel = f"assets/images/{generation_set_id}/{filename}"
+    refined.save(project_path / media_rel, "PNG")
+
+    source_name = payload.get("displayName") or _source_display_name(project_path, source_asset_id) or "Image"
+    detail_settings = {
+        "enabled": True,
+        "backbone": model,
+        "controlNet": TILE_CONTROLNET_REPO,
+        "strength": strength,
+        "cnScale": cn_scale,
+        "steps": steps,
+        "guidanceScale": guidance,
+        "tile": tile,
+        "overlap": overlap,
+        "tiles": tiles,
+        "width": refined.width,
+        "height": refined.height,
+    }
+    fact = {
+        "assetId": asset_id,
+        "mediaPath": media_rel,
+        "mimeType": "image/png",
+        "type": "image",
+        "width": refined.width,
+        "height": refined.height,
+        "normalizedWidth": refined.width,
+        "normalizedHeight": refined.height,
+        "count": 1,
+        "seed": seed,
+        "displayName": f"{source_name} (detail enhanced)",
+        "createdAt": created_at,
+        "mode": "image_detail",
+        "model": model,
+        "adapter": "sdxl_diffusers",
+        "prompt": prompt,
+        "negativePrompt": negative,
+        "loras": [],
+        "stylePreset": "",
+        "sourceAssetId": source_asset_id,
+        "rawAdapterSettings": {"detail": detail_settings},
+        "parents": [source_asset_id],
+        "extra": {
+            "isDetailEnhanced": True,
+            "detailFromAssetId": source_asset_id,
+            "backbone": model,
+            "strength": strength,
+            "cnScale": cn_scale,
+        },
+    }
+    generation_set = {
+        "id": generation_set_id,
+        "mode": "image_detail",
+        "model": model,
+        "prompt": prompt,
+        "negativePrompt": negative,
+        "count": 1,
+        "createdAt": created_at,
+    }
+    return {
+        "generationSetId": generation_set_id,
+        "expectedCount": 1,
+        "adapter": "sdxl_diffusers",
+        "model": model,
         "generationSet": generation_set,
         "assetWrites": [fact],
     }

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -35,6 +35,7 @@ from .image_adapters import (
     evict_other_image_adapters,
     image_request_from_job,
     release_image_worker_memory,
+    run_image_detail,
     run_image_upscale,
     torch_inference_backend_available,
 )
@@ -112,6 +113,12 @@ PROMPT_REFINE_JOB_TYPES = ("prompt_refine",)
 # contracts.rs::JobType/WorkerCapability, jobs_store::job_requires_gpu, and
 # apps/web/src/jobTypes.js::GPU_REQUIRED_JOB_TYPES.
 IMAGE_UPSCALE_JOB_TYPES = ("image_upscale",)
+# Standalone tile-ControlNet detail refine (Image Editor, epic 2427; spike sc-2437):
+# SDXL/RealVisXL img2img + a tile ControlNet over feathered tiles on an existing
+# asset → one child asset. Torch-backed, GPU-required like generation; advertised by
+# a backend-capable Python worker. Keep in sync with contracts.rs::JobType/
+# WorkerCapability, jobs_store::job_requires_gpu, and apps/web/src/jobTypes.js.
+IMAGE_DETAIL_JOB_TYPES = ("image_detail",)
 # Every runtime-dispatchable job-type group, in a stable order, for the
 # ``--check`` diagnostic. Derived from the groups above so run_check can't drift
 # out of sync and underreport readiness (sc-1635: VQA + interleave were
@@ -128,6 +135,7 @@ ALL_JOB_TYPES = (
     + INTERLEAVE_JOB_TYPES
     + PROMPT_REFINE_JOB_TYPES
     + IMAGE_UPSCALE_JOB_TYPES
+    + IMAGE_DETAIL_JOB_TYPES
 )
 
 
@@ -168,6 +176,9 @@ def worker_capabilities(gpu: dict) -> list[str]:
             capabilities |= set(INTERLEAVE_JOB_TYPES)
             # Standalone image upscale reuses the torch-backed engines (sc-2431).
             capabilities |= set(IMAGE_UPSCALE_JOB_TYPES)
+            # Standalone tile-ControlNet detail refine: SDXL/RealVisXL img2img + tile
+            # CN, so it needs the same torch inference backend (sc-2437/sc-2438).
+            capabilities |= set(IMAGE_DETAIL_JOB_TYPES)
             # Prompt refinement loads a small LLM in-process (like captioning), so
             # it needs the inference backend and is advertised alongside it.
             capabilities |= set(PROMPT_REFINE_JOB_TYPES)
@@ -1319,6 +1330,68 @@ def run_upscale_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None
         heartbeat(api, settings, "idle")
 
 
+def run_detail_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    """Run an image_detail job: tile-ControlNet detail refine on one existing asset.
+
+    Torch-backed (the SDXL/RealVisXL img2img pipe + tile ControlNet are loaded lazily
+    by run_image_detail), so the worker advertises image_detail only when the
+    inference backend is installed (worker_capabilities). Writes one child asset with
+    lineage to the source. Mirrors run_upscale_job (sc-2431); composes after it.
+    """
+    job_id = job["id"]
+    peaks: dict[str, float] = {}
+
+    def progress(status: str, stage: str, value: float, message: str) -> None:
+        heartbeat(api, settings, "busy", job_id)
+        payload = {"status": status, "stage": stage, "progress": value, "message": message}
+        track_job_peaks(payload, peaks, settings, backend=adapter_backend(None, settings))
+        update_job(api, job_id, payload)
+
+    try:
+        progress("preparing", "preparing", 0.06, "Preparing detail enhancement.")
+        project_id = str(job.get("payload", {}).get("projectId") or "")
+        project_path = find_project_path(settings.data_dir / "recent-projects.json", project_id)
+        result = run_blocking_job_step(
+            api,
+            settings,
+            job_id,
+            "busy",
+            lambda cancel: run_image_detail(
+                settings,
+                job,
+                project_path=project_path,
+                progress=progress,
+                cancel_requested=cancel,
+            ),
+            loaded_models=lambda: [],
+            peaks=peaks,
+        )
+        update_job(
+            api,
+            job_id,
+            {"status": "completed", "stage": "completed", "progress": 1,
+             "message": "Detail-enhanced image saved.", "result": result},
+        )
+    except InterruptedError as exc:
+        update_job(
+            api,
+            job_id,
+            {"status": "canceled", "stage": "canceled", "progress": 1, "message": str(exc)},
+        )
+    except Exception as exc:
+        needs_oom_restart = is_cuda_oom(exc)
+        message, error = friendly_failure("Detail enhancement", exc)
+        update_job(
+            api,
+            job_id,
+            {"status": "failed", "stage": "failed", "progress": 1, "message": message, "error": error},
+        )
+        if needs_oom_restart:
+            release_image_worker_memory()
+    finally:
+        heartbeat(api, settings, "idle")
+
+
 def run_lora_train_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     """Run a lora_train job: validate the plan, then either report a dry-run
     summary or execute the real training kernel.
@@ -1643,6 +1716,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
                 run_image_job(api, settings, job, image_adapters)
             elif job["type"] in IMAGE_UPSCALE_JOB_TYPES:
                 run_upscale_job(api, settings, job)
+            elif job["type"] in IMAGE_DETAIL_JOB_TYPES:
+                run_detail_job(api, settings, job)
             elif job["type"] in VQA_JOB_TYPES:
                 run_vqa_job(api, settings, job, image_adapters)
             elif job["type"] in INTERLEAVE_JOB_TYPES:

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1337,7 +1337,8 @@
       // character_image: h94/IP-Adapter plus-face for Character Studio reference
       // (sc-2007 resemblance tier; faithful likeness belongs to InstantID — sc-2009).
       // image_inpaint: StableDiffusionXLInpaintPipeline masked edits (sc-2476).
-      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "character_image", "style_variations"],
+      // image_detail: tile-ControlNet detail refine (image_detail job, sc-2437/sc-2438).
+      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "image_detail", "character_image", "style_variations"],
       "downloads": [
         {
           // Diffusers checkpoint: SDXL base 1.0 (UNet + dual CLIP text encoders
@@ -1419,9 +1420,11 @@
       "type": "image",
       "adapter": "sdxl_diffusers",
       // Photoreal SDXL finetune with the full SDXL feature set (t2i + edit +
-      // reference + masked inpaint, sc-2476). Plain photoreal alternative to
-      // InstantID — IP-Adapter plus-face for resemblance, sdxl-family LoRA support.
-      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "character_image", "style_variations"],
+      // reference + masked inpaint, sc-2476 + tile-CN detail refine, sc-2437/sc-2438).
+      // The recommended detail backbone per the spike (photoreal micro-texture).
+      // Plain photoreal alternative to InstantID — IP-Adapter plus-face for
+      // resemblance, sdxl-family LoRA support.
+      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "image_detail", "character_image", "style_variations"],
       "downloads": [
         {
           // Same checkpoint as the InstantID built-in below — single HF cache

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -207,6 +207,11 @@ string_enum! {
         // Torch-backed (Real-ESRGAN / AuraSR), GPU-required like generation; reuses
         // the upscale engines that previously only ran as a generation post-step.
         ImageUpscale => "image_upscale",
+        // Standalone tile-ControlNet detail refine of an existing image asset (Image
+        // Editor, epic 2427; spike sc-2437). Torch-backed SDXL/RealVisXL img2img + a
+        // tile ControlNet run over feathered tiles to add micro-texture; GPU-required
+        // like generation. Composes after image_upscale (creative upscale).
+        ImageDetail => "image_detail",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",
@@ -307,6 +312,11 @@ string_enum! {
         // Python worker when the torch inference backend is available (runtime.py);
         // the Rust utility worker never emits it. See jobs_store::job_requires_gpu.
         ImageUpscale => "image_upscale",
+        // Standalone tile-ControlNet detail refine (Image Editor, epic 2427; spike
+        // sc-2437). Advertised by the Python worker only when the torch inference
+        // backend is available (runtime.py); the Rust utility worker never emits it.
+        // See jobs_store::job_requires_gpu.
+        ImageDetail => "image_detail",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
         ModelDownload => "model_download",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1614,6 +1614,7 @@ fn job_requires_gpu(job_type: &JobType) -> bool {
             | JobType::ImageVqa
             | JobType::ImageInterleave
             | JobType::ImageUpscale
+            | JobType::ImageDetail
             | JobType::VideoGenerate
             | JobType::VideoExtend
             | JobType::VideoBridge

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -52,6 +52,7 @@ from scene_worker.image_adapters import (
     lens_resolution_for,
     load_mask_image,
     load_reference_image,
+    model_supports_detail,
     model_supports_edit,
     model_supports_inpaint,
     pipeline_component_devices,
@@ -293,6 +294,7 @@ def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
     job_capabilities = [capability for capability in capabilities if capability != "gpu"]
 
     assert job_capabilities == [
+        "image_detail",
         "image_edit",
         "image_generate",
         "image_interleave",
@@ -428,6 +430,108 @@ def test_run_image_upscale_requires_source_asset(monkeypatch, tmp_path):
         run_image_upscale(
             SimpleNamespace(gpu_id=None),
             {"id": "job_x", "payload": {"projectId": "p"}},
+            project_path=tmp_path,
+            progress=lambda *args: None,
+            cancel_requested=lambda: False,
+        )
+
+
+def test_model_supports_detail_matrix():
+    # sc-2438: tile-ControlNet detail refine is SDXL-family only.
+    assert model_supports_detail("sdxl") is True
+    assert model_supports_detail("realvisxl") is True
+    assert model_supports_detail("qwen_image_edit_2511") is False
+    assert model_supports_detail("unknown_model") is False
+
+
+def test_run_image_detail_writes_single_child_asset(tmp_path, monkeypatch):
+    # sc-2438: standalone tile-ControlNet detail refine of an existing asset. Mock the
+    # pipeline load + the tiled refine so the orchestration (source resolve → one child
+    # asset + lineage + fact shape) runs without torch/diffusers/weights (CI has none).
+    from scene_worker.image_adapters import run_image_detail
+
+    source = Image.new("RGB", (12, 9), "green")
+    source_path = tmp_path / "src.png"
+    source.save(source_path, "PNG")
+    refined = Image.new("RGB", (12, 9), "white")
+
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.find_asset_media_path",
+        lambda project_path, asset_id: source_path,
+    )
+    monkeypatch.setattr(
+        "scene_worker.image_adapters._load_detail_pipeline",
+        lambda settings, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "scene_worker.image_adapters._refine_tiled_detail",
+        lambda pipe, image, **kwargs: (refined, 1),
+    )
+
+    job = {
+        "id": "job_detail_1",
+        "payload": {
+            "projectId": "project_1",
+            "sourceAssetId": "asset_src",
+            "model": "realvisxl",
+            "displayName": "Studio still",
+            "advanced": {"strength": 0.6, "cnScale": 0.8},
+        },
+    }
+    result = run_image_detail(
+        SimpleNamespace(gpu_id=None),
+        job,
+        project_path=tmp_path,
+        progress=lambda *args: None,
+        cancel_requested=lambda: False,
+    )
+
+    writes = result["assetWrites"]
+    assert len(writes) == 1
+    fact = writes[0]
+    # Detail refine preserves dimensions (refines in place — unlike upscale).
+    assert (fact["width"], fact["height"]) == (12, 9)
+    assert fact["mode"] == "image_detail"
+    assert fact["model"] == "realvisxl"
+    assert fact["sourceAssetId"] == "asset_src"
+    assert fact["parents"] == ["asset_src"]
+    assert fact["displayName"] == "Studio still (detail enhanced)"
+    assert fact["extra"] == {
+        "isDetailEnhanced": True,
+        "detailFromAssetId": "asset_src",
+        "backbone": "realvisxl",
+        "strength": 0.6,
+        "cnScale": 0.8,
+    }
+    written_path = tmp_path / fact["mediaPath"]
+    assert written_path.is_file()
+    assert Image.open(written_path).size == (12, 9)
+    assert result["expectedCount"] == 1
+    assert result["generationSet"]["id"] == result["generationSetId"]
+
+
+def test_run_image_detail_requires_source_asset(tmp_path):
+    from scene_worker.image_adapters import run_image_detail
+
+    with pytest.raises(RuntimeError, match="source image asset"):
+        run_image_detail(
+            SimpleNamespace(gpu_id=None),
+            {"id": "job_x", "payload": {"projectId": "p"}},
+            project_path=tmp_path,
+            progress=lambda *args: None,
+            cancel_requested=lambda: False,
+        )
+
+
+def test_run_image_detail_rejects_non_detail_model(tmp_path):
+    # A non-SDXL model is rejected before any pipeline load (no mocking needed).
+    from scene_worker.image_adapters import run_image_detail
+
+    with pytest.raises(RuntimeError, match="does not support detail"):
+        run_image_detail(
+            SimpleNamespace(gpu_id=None),
+            {"id": "job_x", "payload": {"projectId": "p", "sourceAssetId": "asset_src",
+                                        "model": "qwen_image_edit_2511"}},
             project_path=tmp_path,
             progress=lambda *args: None,
             cancel_requested=lambda: False,
@@ -6145,6 +6249,8 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         "prompt_refine",
         # sc-2431: standalone image upscale (Image Editor).
         "image_upscale",
+        # sc-2438: standalone tile-ControlNet detail refine (Image Editor).
+        "image_detail",
     ]
     assert events[0]["supportedJobTypes"] == events[0]["jobTypes"]
 


### PR DESCRIPTION
## What

Adds a **"Detail" tool** to the canvas Image Editor (epic 2427, story sc-2438). It runs a **tile-ControlNet diffusion refine** over the working image: an SDXL/RealVisXL img2img pass over feathered tiles where a tile ControlNet (`xinsir/controlnet-tile-sdxl-1.0`) locks composition, so high denoise adds fine micro-texture **without** rewriting the picture. This is the "creative upscale"/SUPIR-lite capability — it composes after the existing Upscale tool.

## Why

The sc-2437 spike proved plain tiled img2img can't add detail without drifting (negative detail gain at every strength; lamp/watch-face artifacts at high denoise). The **round-2 spike (GO on M5 Max)** showed a tile ControlNet fixes exactly that: structureDiff held ≤3.5 even at strength 1.0 (vs 9.4 drift before), and RealVisXL + `control=same` adds real texture (skin/numerals) with the composition intact. This PR implements that locked recipe.

It is **generative** — at higher strength it invents plausible detail into smooth/ambiguous regions (Magnific/SUPIR behavior). The Detail slider copy says so, and the default (0.55) is conservative.

## How

New `image_detail` job, mirroring `image_upscale` (sc-2431) — rides the generic `POST /api/v1/jobs`, so **no new API handler, DTO, or contract snapshot**:

- **contracts.rs** — `JobType` / `WorkerCapability::ImageDetail`; **jobs_store.rs** GPU-gates it.
- **worker** — `runtime.py` job group + `ALL_JOB_TYPES` + torch-gated capability + `run_detail_job` + dispatch. `image_adapters.run_image_detail` resolves the source at native res, builds `StableDiffusionXLControlNetImg2ImgPipeline` + the tile CN, runs a raised-cosine-feathered tiled img2img refine (`control_image` = the tile itself), and writes **one** child asset (`parents=[source]`, `extra.isDetailEnhanced`). Recipe defaults from the spike: **strength 0.55, cn_scale 0.7, steps 24, guidance 5, tile 1024 / overlap 128**, all `advanced`-overridable. Pipeline load is extracted to `_load_detail_pipeline` (a mockable seam). `supportsDetail` on sdxl/realvisxl + `model_supports_detail`.
- **manifest** — `image_detail` capability on `sdxl` + `realvisxl`.
- **web** — "Detail" tool: backbone picker (gated to `image_detail` models) + **Detail** (amount) / **Structure** (lock) sliders, run through the existing `runAiOp` seam + `buildDetailJobBody`; `jobTypes.js` GPU set.

## Tests

All green:

| Suite | Result |
|---|---|
| worker | **482 passed** (+4 new: orchestration writes one child asset + lineage; requires source; rejects non-detail model; `model_supports_detail` matrix) |
| web | **324 passed** (+3 new: capability filter + job-body) · production build clean |
| rust | core **154** · rust-api **89** · `cargo fmt` clean |

The two worker tests that fail locally (`test_python_worker_only_advertises_inference_job_capabilities`, `test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs`) are a **pre-existing** environment artifact — the local desktop venv has the detector/segmenter/pose backends installed, which the CI no-backend scenario lacks; verified the capability list matches exactly when those backends are absent.

## Reviewer notes

- **Owes a real Mac-GPU refine round-trip** — the engine run needs a GPU worker (same owed-E2E bucket as the sc-2433/2435/2476 round-trips). The submission flow reuses the already-live-verified upscale/edit `runAiOp` seam, and the tiling/feather blend is adversarially verified (under an identity pipe it reconstructs the source pixel-exact — no seams).
- The pipeline call + recipe are exactly what the sc-2437b spike harness validated on M5 Max.
- The sc-2437b round-2 spike harness itself is intentionally **not** included here (left uncommitted per an earlier call); happy to add it as a `chore(spike):` if wanted, like round-1's #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)