### PR TITLE
fix(image-edit): MLX fast-follow — honor crop/pad before FLUX.2-klein sidecar (sc-2557)

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -4377,8 +4377,11 @@ class MlxFlux2Adapter:
         # mflux's Flux2KleinEdit can read it directly. Two studios feed the same
         # single-reference edit path: Character Studio sends it as
         # referenceAssetId, while the Image Edit studio sends the source image as
-        # sourceAssetId (edit_image mode). No PIL round-trip: find_asset_media_path
-        # returns the project-scoped path and mflux's loader handles dtype/resize.
+        # sourceAssetId (edit_image mode). find_asset_media_path returns the
+        # project-scoped path and mflux's loader handles dtype/resize. The
+        # edit_image source is then re-fitted to the output W×H below (sc-2557) so
+        # off-aspect edits honor fit_mode instead of stretching; the Character
+        # Studio reference stays at native resolution.
         reference_paths: list[str] = []
         edit_source_id = request.source_asset_id if request.mode == "edit_image" else None
         ref_id = request.reference_asset_id or edit_source_id
@@ -4458,6 +4461,32 @@ class MlxFlux2Adapter:
         )
         work_dir = Path(tempfile.mkdtemp(prefix="mlx_flux2_sidecar_"))
         self._scratch_dir = work_dir
+        # Epic 2551 / sc-2557 — honor the request's fit_mode for Image Edits BEFORE
+        # the mflux sidecar. mflux's edit loader resizes the source to the requested
+        # W×H with a naive stretch, so an edit into a different aspect ratio would
+        # distort. mflux is frozen for the Rust port (epic 2337), so the fit can't
+        # live inside it; instead pre-process the source HERE — crop (default) / pad
+        # / outpaint — and hand the sidecar the fitted temp file (written into
+        # work_dir, so it is removed with the scratch dir in the finally). Only the
+        # Image Edit source is fitted: "stretch" keeps the legacy naive resize, and
+        # Character Studio's reference path (referenceAssetId) is a subject-variation
+        # flow left at native resolution. No MLX inpaint path exists, so outpaint
+        # degrades to pad geometry via fit_image (sc-2553).
+        if (
+            request.mode == "edit_image"
+            and edit_source_id
+            and not request.reference_asset_id
+            and request.fit_mode != "stretch"
+        ):
+            fitted_source = fit_image(
+                open_source_image(project_path, request),
+                request.width,
+                request.height,
+                request.fit_mode,
+            )
+            fitted_path = work_dir / "fitted_source.png"
+            fitted_source.save(fitted_path, "PNG")
+            reference_paths = [str(fitted_path)]
         # Best-effort pose tier: render each pose's skeleton to a PNG in the sidecar
         # work dir and pair it with the reference as a per-iteration [reference,
         # skeleton] set. draw_bodypose runs in the main worker venv (cv2 present).

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -3430,6 +3430,93 @@ def test_mlx_flux2_pose_set_builds_per_iteration_skeleton_specs(tmp_path, monkey
     assert captured["raw_settings"].get("poseLibrary") is True
 
 
+def test_mlx_flux2_edit_pre_fits_source_to_output_aspect(tmp_path, monkeypatch):
+    """sc-2557: an edit_image job on FLUX.2-klein into a different aspect ratio
+    pre-processes the source to the output W×H honoring fit_mode (crop default /
+    pad) and hands the sidecar that fitted temp file instead of the raw asset — so
+    mflux's edit loader can no longer stretch. "stretch" keeps the legacy raw path,
+    and the fitted temp file is cleaned up with the scratch dir when the job ends."""
+    from scene_worker import image_adapters as ia
+
+    # A wide 200×100 source → editing into a 256² square would stretch if passed raw.
+    raw_source = tmp_path / "source.png"
+    Image.new("RGB", (200, 100), (10, 120, 200)).save(raw_source)
+    monkeypatch.setattr(ia, "find_asset_media_path", lambda project_path, asset_id: raw_source)
+    monkeypatch.setattr(ia.MlxFlux2Adapter, "_sidecar_available", lambda self: True)
+
+    captured: dict = {}
+
+    def fake_run_sidecar(self, *, job_id, work_dir, label, total, spec, progress, cancel_requested):
+        captured["spec"] = spec
+        captured["work_dir"] = work_dir
+        paths = spec["imagePaths"]
+        if paths:
+            # Record the on-disk size the sidecar would actually load.
+            with Image.open(paths[0]) as im:
+                captured["image_size"] = im.size
+
+        class _Stream:
+            def wait_for_image(self, index):
+                return str(work_dir / f"out_{index}.png")
+
+            def finish(self):
+                pass
+
+            def shutdown(self):
+                pass
+
+        return _Stream()
+
+    monkeypatch.setattr(ia.MlxFlux2Adapter, "_run_sidecar", fake_run_sidecar)
+    monkeypatch.setattr(
+        ia.ImageAssetWriter,
+        "write_incremental_outputs",
+        lambda self, *, image_count, image_at_index, raw_settings, **kwargs: {"images": image_count},
+    )
+
+    def run(fit_mode):
+        captured.clear()
+        job = {
+            "id": "job_flux2_edit",
+            "payload": {
+                "projectId": "p",
+                "mode": "edit_image",
+                "model": "flux2_klein_9b",
+                "prompt": "make it night",
+                "sourceAssetId": "src-1",
+                "count": 1,
+                "width": 256,
+                "height": 256,
+                "fitMode": fit_mode,
+            },
+        }
+        ia.MlxFlux2Adapter().generate(
+            settings=SimpleNamespace(gpu_id="cpu"),
+            job=job,
+            request=image_request_from_job(job),
+            project_path=tmp_path,
+            progress=lambda *a, **k: None,
+            cancel_requested=lambda: False,
+        )
+
+    # crop (default): the sidecar gets a fitted temp file at the exact output square,
+    # NOT the raw wide asset; the scratch dir (and the temp file in it) is then reaped.
+    run("crop")
+    assert captured["spec"]["imagePaths"][0] != str(raw_source)
+    assert captured["spec"]["imagePaths"][0].endswith("fitted_source.png")
+    assert captured["image_size"] == (256, 256)
+    assert not Path(captured["work_dir"]).exists()  # temp file cleaned up after the job
+
+    # pad: also fitted to the output square (letterbox bars), distinct temp file.
+    run("pad")
+    assert captured["spec"]["imagePaths"][0].endswith("fitted_source.png")
+    assert captured["image_size"] == (256, 256)
+
+    # stretch: legacy path — the raw asset is handed straight to the sidecar (no fit).
+    run("stretch")
+    assert captured["spec"]["imagePaths"] == [str(raw_source)]
+
+
 def test_mlx_z_image_pose_set_builds_control_skeleton_specs(tmp_path, monkeypatch):
     """sc-2257: a job with advanced.poses on z_image_turbo (MLX) renders each pose to a
     skeleton and passes it as a per-iteration controlImagePaths entry + controlScale to


### PR DESCRIPTION
Closes the loop on image ratio matching for the MLX edit path (epic 2551, sc-2557).

## Problem
The torch fit-mode fix (PR #414) routed all 5 torch/diffusers edit adapters through `load_source_image` → `fit_image`. But MLX edit (`MlxFlux2Adapter` / FLUX.2-klein) **bypasses** `load_source_image`: it resolves the source asset to a path and hands it straight to the mflux sidecar, whose edit loader resizes the reference to the requested W×H with a **naive stretch**. So a FLUX.2-klein edit into a different aspect ratio still distorted.

## Fix
mflux is frozen for the Rust port (epic 2337), so the fit can't live inside it. Instead, in `MlxFlux2Adapter.generate`, when `mode == "edit_image"` and `fit_mode != "stretch"`:
- load the source, apply the shared `fit_image()` helper to the output W×H (crop default / pad / outpaint→pad geometry),
- write the result to a temp file in the sidecar `work_dir`,
- hand the sidecar **that** path instead of the raw asset.

The fitted source is already W×H, so mflux's internal resize becomes a no-op (no double-distortion). The temp file lives in `work_dir`, which is reaped in the `finally` (`discard_temp_outputs`).

Scope guards:
- **edit_image only** — Character Studio's reference path (`referenceAssetId`, a subject-variation flow) stays at native resolution.
- **`stretch` keeps the legacy raw path** for reproducibility.
- **outpaint** degrades to pad geometry via `fit_image` (no MLX inpaint path exists).

## Tests
`test_mlx_flux2_edit_pre_fits_source_to_output_aspect` (worker): a 200×100 source edited into 256² gets a fitted `fitted_source.png` temp file at exactly 256×256 for crop and pad, the raw asset for stretch, and the scratch dir (temp file) is cleaned up after the job.

Full worker suite: **483 passed, 9 skipped**.

## Validation owed
Real M5 Max (MPS) E2E that FLUX.2-klein edit respects crop and pad — MLX is Mac-only; no GPU/sidecar in this CI. Consistent with the rest of epic 2551 (every worker path owes a real-Mac check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)