### PR TITLE
fix(lora): make lycoris-lora LoKr work end-to-end — upload family auto-detect + generation apply (sc-2626, sc-2631)

### DIFF
--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -352,17 +352,47 @@ def reject_lycoris_loras(specs: list[LoraSpec], adapter_id: str) -> None:
             )
 
 
-def _lycoris_module_prefix(path: str | Path) -> str:
+def _lycoris_module_prefix(path: str | Path, module: Any = None) -> str:
     """The ``LycorisNetwork.LORA_PREFIX`` that maps this file's keys onto a denoiser
-    module. kohya/ai-toolkit DiT adapters prefix denoiser keys with ``lora_unet``
-    (the lycoris loader matches ``f"{PREFIX}_{module_name}"``)."""
+    module — the lycoris loader matches each key as ``f"{PREFIX}_{module_name}"``
+    (the submodule path with ``.`` rewritten to ``_``).
 
-    for name in _adapter_tensor_names(path, limit=8):
-        head = name.split(".", 1)[0]
+    Exporters disagree on the prefix: kohya / musubi use ``lora_unet``, some
+    diffusers-based trainers ``lora_transformer``, and the ``lycoris-lora`` library's
+    own ``save_weights`` defaults to ``lycoris``. When ``module`` is given, recover
+    the prefix exactly by stripping a real (underscored) submodule name off the
+    file's keys — this works for any convention, including ones not enumerated here.
+    Falls back to a known-prefix sniff (default ``lora_unet``) when no module is
+    available or nothing lines up."""
+
+    heads = [name.split(".", 1)[0] for name in _adapter_tensor_names(path)]
+    if module is not None:
+        # Longest submodule names first so e.g. ``transformer_blocks_0_attn_to_q`` is
+        # stripped before the bare ``transformer_blocks_0`` that also prefixes it,
+        # yielding the shortest (correct) leading prefix.
+        module_names = sorted(
+            {name.replace(".", "_") for name, _ in module.named_modules() if name},
+            key=len,
+            reverse=True,
+        )
+        votes: dict[str, int] = {}
+        for head in heads:
+            for mod_name in module_names:
+                if head.endswith("_" + mod_name):
+                    prefix = head[: -len(mod_name) - 1]
+                    if prefix:
+                        votes[prefix] = votes.get(prefix, 0) + 1
+                    break
+        if votes:
+            # Most-matched prefix wins; ties broken toward the most specific (longest).
+            return max(votes, key=lambda candidate: (votes[candidate], len(candidate)))
+    for head in heads[:8]:
         if head.startswith("lora_unet"):
             return "lora_unet"
         if head.startswith("lora_transformer"):
             return "lora_transformer"
+        if head.startswith("lycoris"):
+            return "lycoris"
     return "lora_unet"
 
 
@@ -442,7 +472,7 @@ def apply_lycoris_adapter(pipe: Any, spec: LoraSpec, *, adapter_id: str) -> None
             "(epic 2193)."
         ) from exc
 
-    prefix = _lycoris_module_prefix(spec.path)
+    prefix = _lycoris_module_prefix(spec.path, module)
     saved_prefix = LycorisNetwork.LORA_PREFIX
     try:
         LycorisNetwork.LORA_PREFIX = prefix

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -526,6 +526,53 @@ const SIGNATURES: &[BucketSignature] = &[
         ],
     },
     BucketSignature {
+        bucket: Bucket::MmDit,
+        // kohya / musubi-tuner / LyCORIS (lycoris-lora) Qwen-Image & Z-Image LoRAs
+        // flatten the dual-stream MMDiT module path into underscore-delimited keys
+        // behind a `lora_unet_` / `lora_transformer_` / `lycoris_` prefix, e.g.
+        // `lycoris_transformer_blocks_0_attn_add_k_proj.lokr_w1` or
+        // `lora_unet_transformer_blocks_0_img_mlp_net_0_proj.lora_down.weight`. The
+        // dotted MMDiT signature above can't see these (no `transformer.
+        // transformer_blocks.` segment). `_transformer_blocks_` (underscores on both
+        // sides) is the discriminator: Wan kohya uses `_blocks_`, SD/SDXL kohya use
+        // `_down_blocks_`/`_up_blocks_`/`_mid_block_`, and SDXL's nested
+        // `_transformer_blocks_` never carries the joint-attention `add_{q,k}_proj`
+        // or dual-stream `_img_mlp_`/`_txt_mlp_` that group two requires. Flux's
+        // single-stream keys are disqualified so a (double+single) Flux LoRA never
+        // lands here despite sharing `transformer_blocks` + `add_q_proj`.
+        require_all_of: &[
+            &["_transformer_blocks_"],
+            &[
+                "_img_mlp_",
+                "_txt_mlp_",
+                "add_q_proj",
+                "add_k_proj",
+                "to_added_q",
+                "to_added_k",
+            ],
+        ],
+        disqualifiers: &[
+            "single_transformer_blocks",
+            "single_blocks_",
+            ".attn1.",
+            ".attn2.",
+            "_attn1_",
+            "_attn2_",
+        ],
+        markers: &[
+            "_transformer_blocks_",
+            "_img_mlp_",
+            "_txt_mlp_",
+            "add_q_proj",
+            "add_k_proj",
+            "to_added_q",
+            "to_added_k",
+            "_attn_to_q",
+            "_attn_to_k",
+            "_attn_to_v",
+        ],
+    },
+    BucketSignature {
         bucket: Bucket::Sdxl,
         // SDXL ships two text encoders, so kohya-style LoRAs always carry
         // both `lora_te1_` and `lora_te2_` prefixes alongside `lora_unet_`.
@@ -628,17 +675,23 @@ fn max_transformer_block_index(keys: &[String]) -> Option<usize> {
 }
 
 fn parse_block_index(key: &str) -> Option<usize> {
-    let needle = "transformer_blocks.";
+    // Diffusers separates with dots (`transformer_blocks.<N>.`); kohya / LyCORIS
+    // flatten to underscores (`transformer_blocks_<N>_`). Accept either separator.
+    let needle = "transformer_blocks";
     let mut rest = key;
     while let Some(position) = rest.find(needle) {
-        let candidate = &rest[position + needle.len()..];
+        let after = &rest[position + needle.len()..];
+        let candidate = match after.as_bytes().first() {
+            Some(b'.' | b'_') => &after[1..],
+            _ => after,
+        };
         let digits: String = candidate.chars().take_while(char::is_ascii_digit).collect();
         if !digits.is_empty() {
             if let Ok(index) = digits.parse::<usize>() {
                 return Some(index);
             }
         }
-        rest = &candidate[digits.len()..];
+        rest = after;
     }
     None
 }
@@ -1185,6 +1238,66 @@ mod tests {
     #[test]
     fn low_mm_dit_block_count_is_inconclusive() {
         let keys = diffusers_double_stream_keys("transformer", 24);
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert!(detect_lora_family(&header).is_none());
+    }
+
+    /// kohya / musubi-tuner / LyCORIS export of a dual-stream MMDiT (Qwen-Image /
+    /// Z-Image) adapter: module paths flattened with underscores behind `prefix`,
+    /// carrying LoKr (`lokr_w1`/`lokr_w2`/`alpha`) tensors. Mirrors the real
+    /// lycoris-lora file shape from sc-2626.
+    fn lycoris_underscore_mmdit_keys(prefix: &str, block_count: usize) -> Vec<String> {
+        let mut keys = Vec::new();
+        for block in 0..block_count {
+            for module in [
+                "attn_to_q",
+                "attn_to_k",
+                "attn_to_v",
+                "attn_to_out_0",
+                "attn_add_q_proj",
+                "attn_add_k_proj",
+                "attn_add_v_proj",
+                "attn_to_add_out",
+                "img_mlp_net_0_proj",
+                "img_mlp_net_2",
+                "txt_mlp_net_0_proj",
+                "txt_mlp_net_2",
+            ] {
+                let base = format!("{prefix}_transformer_blocks_{block}_{module}");
+                keys.push(format!("{base}.lokr_w1"));
+                keys.push(format!("{base}.lokr_w2"));
+                keys.push(format!("{base}.alpha"));
+            }
+        }
+        keys
+    }
+
+    #[test]
+    fn detects_lycoris_underscore_qwen_image_lokr() {
+        // The real failing upload (sc-2626): a lycoris-lora-exported Qwen-Image LoKr
+        // whose keys carry the library's default `lycoris` prefix and underscore-
+        // flattened module paths — invisible to the dotted MMDiT signature.
+        let keys = lycoris_underscore_mmdit_keys("lycoris", 60);
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("qwen-image"));
+    }
+
+    #[test]
+    fn detects_kohya_underscore_qwen_image() {
+        // kohya / musubi-tuner flatten with a `lora_unet` prefix instead.
+        let keys = lycoris_underscore_mmdit_keys("lora_unet", 60);
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("qwen-image"));
+    }
+
+    #[test]
+    fn low_underscore_mm_dit_block_count_is_inconclusive() {
+        // Same conservative block-count gate as the dotted path: too few blocks to
+        // tell Qwen from Z-Image → inconclusive rather than a wrong guess.
+        let keys = lycoris_underscore_mmdit_keys("lycoris", 24);
         let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
 
         assert!(detect_lora_family(&header).is_none());

--- a/tests/test_lycoris_lokr.py
+++ b/tests/test_lycoris_lokr.py
@@ -89,6 +89,74 @@ def test_reject_lokr_loras_allows_plain_lora(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# Prefix derivation (no torch / no lycoris).
+#
+# The lycoris loader addresses a denoiser submodule as ``f"{PREFIX}_{name}"`` (the
+# module path with dots → underscores). Exporters disagree on PREFIX, and picking
+# the wrong one matches 0 modules and aborts the apply. Recover it from the file's
+# keys against the model's real submodule names (epic 2193).
+# --------------------------------------------------------------------------- #
+
+
+class _FakeNamedModules:
+    """Minimal stand-in exposing ``named_modules()`` for prefix derivation."""
+
+    def __init__(self, names):
+        self._names = list(names)
+
+    def named_modules(self):
+        # The root module yields a "" name; include it like a real nn.Module does.
+        return [("", object())] + [(name, object()) for name in self._names]
+
+
+_QWEN_MODULE_NAMES = (
+    "transformer_blocks.0.attn.to_q",
+    "transformer_blocks.0.attn.add_k_proj",
+    "transformer_blocks.0.attn.to_add_out",
+    "transformer_blocks.0.img_mlp.net.0.proj",
+)
+
+
+def _patch_tensor_names(monkeypatch, names):
+    monkeypatch.setattr(lora_adapters, "_adapter_tensor_names", lambda _p, limit=256: list(names))
+
+
+def test_prefix_derived_lycoris_library_default(monkeypatch):
+    # The real failing file: keys carry the lycoris-lora library's own default
+    # `lycoris` prefix, which the old known-prefix sniff defaulted past to lora_unet.
+    _patch_tensor_names(
+        monkeypatch,
+        [f"lycoris_{name.replace('.', '_')}.lokr_w1" for name in _QWEN_MODULE_NAMES],
+    )
+    module = _FakeNamedModules(_QWEN_MODULE_NAMES)
+    assert lora_adapters._lycoris_module_prefix("x.safetensors", module) == "lycoris"
+
+
+def test_prefix_derived_kohya_lora_unet(monkeypatch):
+    _patch_tensor_names(
+        monkeypatch,
+        [f"lora_unet_{name.replace('.', '_')}.lokr_w1" for name in _QWEN_MODULE_NAMES],
+    )
+    module = _FakeNamedModules(_QWEN_MODULE_NAMES)
+    assert lora_adapters._lycoris_module_prefix("x.safetensors", module) == "lora_unet"
+
+
+def test_prefix_sniff_recognizes_lycoris_without_module(monkeypatch):
+    # No module to match against → fall back to the known-prefix sniff, which must
+    # still recognize the `lycoris` default (not blindly return lora_unet).
+    _patch_tensor_names(monkeypatch, ["lycoris_transformer_blocks_0_attn_to_q.lokr_w1"])
+    assert lora_adapters._lycoris_module_prefix("x.safetensors") == "lycoris"
+
+
+def test_prefix_falls_back_to_lora_unet_on_no_match(monkeypatch):
+    # Keys whose module path matches nothing in the model (wrong architecture) → no
+    # vote → sniff → default lora_unet, so the apply raises the clear 0-match error.
+    _patch_tensor_names(monkeypatch, ["weird_blocks_0_thing.lokr_w1"])
+    module = _FakeNamedModules(_QWEN_MODULE_NAMES)
+    assert lora_adapters._lycoris_module_prefix("x.safetensors", module) == "lora_unet"
+
+
+# --------------------------------------------------------------------------- #
 # torch + lycoris round-trip through the production path
 # --------------------------------------------------------------------------- #
 
@@ -163,3 +231,74 @@ def test_lycoris_apply_and_restore_roundtrip(tmp_path):
     )
     assert (to_q(x) - base).abs().max().item() > 1e-6
     lora_adapters.clear_loras(pipe, pstate2.adapter_names, adapter_id="qwen_image")
+
+
+def test_lycoris_library_default_prefix_roundtrip(tmp_path):
+    """A LoKr exported by the lycoris-lora library (keys prefixed ``lycoris_``, its
+    ``save_weights`` default) must apply on a DiT denoiser — the prefix is recovered
+    from the model's submodule names, not assumed to be ``lora_unet`` (epic 2193)."""
+
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("lycoris")
+    import json
+
+    import torch.nn as nn
+    from safetensors.torch import save_file
+
+    class Node(nn.Module):
+        pass
+
+    transformer = Node()
+    blocks = Node()
+    transformer.add_module("transformer_blocks", blocks)
+    b0 = Node()
+    blocks.add_module("0", b0)
+    attn = Node()
+    b0.add_module("attn", attn)
+    attn.add_module("to_q", nn.Linear(16, 16, bias=False))
+    attn.add_module("to_k", nn.Linear(16, 16, bias=False))
+
+    def lokr_tensors():
+        return {
+            "lokr_w1": torch.randn(4, 4) * 0.3,
+            "lokr_w2": torch.randn(4, 4) * 0.3,
+            "alpha": torch.tensor(4.0),
+        }
+
+    state = {}
+    for leaf in ("to_q", "to_k"):
+        # The lycoris-lora library's own prefix — the exact case the old sniff missed.
+        name = f"lycoris_transformer_blocks_0_attn_{leaf}"
+        for k, v in lokr_tensors().items():
+            state[f"{name}.{k}"] = v
+    path = tmp_path / "lycoris_lokr.safetensors"
+    save_file(
+        state,
+        str(path),
+        metadata={"lycoris_config": json.dumps({"algo": "lokr", "factor": 4})},
+    )
+
+    # No networkType / ss_network_module stamp — detected purely by lokr_* keys.
+    assert classify_adapter_network(str(path)) == "lycoris"
+
+    class FakePipe:
+        def __init__(self, tr):
+            self.transformer = tr
+
+        def load_lora_weights(self, *a, **k):
+            raise AssertionError("load_lora_weights called for a LyCORIS adapter")
+
+    pipe = FakePipe(transformer)
+    to_q = transformer.transformer_blocks._modules["0"].attn.to_q
+    torch.manual_seed(0)
+    x = torch.randn(2, 16)
+    base = to_q(x).clone()
+
+    lora = {"id": "human_focus", "path": str(path), "weight": 1.0, "name": "human_focus"}
+    pstate = lora_adapters.apply_loras_to_pipeline(
+        pipe, [lora], adapter_id="qwen_image", model_family="qwen"
+    )
+    assert (to_q(x) - base).abs().max().item() > 1e-6, "lycoris-prefixed LoKr did not apply"
+
+    lora_adapters.clear_loras(pipe, pstate.adapter_names, adapter_id="qwen_image")
+    assert (to_q(x) - base).abs().max().item() < 1e-6, "clear_loras left LyCORIS residue"


### PR DESCRIPTION
Makes a third-party **LyCORIS LoKr** exported by the `lycoris-lora` library work end-to-end in SceneWorks — both at upload (family auto-detect) and at generation (applying the adapter). Surfaced by a real file ("Human Focus Photography", a Qwen-Image LoKr, 720 modules) used in Character Studio → Poses on Qwen-Image-Edit 2511 Lightning.

Root cause is shared: these files are **underscore-flattened behind the lycoris-lora library's own default key prefix `lycoris`** (e.g. `lycoris_transformer_blocks_0_attn_to_q.lokr_w1`), and two separate code paths only understood the kohya `lora_unet` / diffusers-dotted conventions.

## 1. Generation apply (sc-2626) — `apps/worker/scene_worker/lora_adapters.py`

The lycoris loader matches each key as `f"{LORA_PREFIX}_{module_name}"`. `_lycoris_module_prefix` only knew `lora_unet`/`lora_transformer` and defaulted to `lora_unet`, so it matched `lora_unet_…` against the file's `lycoris_…` keys → **0 of 720 modules** → "matched 0 modules (prefix 'lora_unet')".

Fix: derive the prefix **generically** — strip a real (underscored) `module.named_modules()` name off the file's keys and vote on the remainder. Handles `lora_unet`, `lora_transformer`, `lycoris`, and any future convention. Known-prefix sniff kept as fallback (now also recognizing `lycoris`).

## 2. Upload family auto-detect (sc-2631) — `crates/sceneworks-core/src/lora_family.rs`

The MM-DiT (Qwen/Z-Image) signature required **dotted** keys (`transformer.transformer_blocks.` + `.img_mlp.`/`add_q_proj`/…), so the underscore-flattened file matched no signature → `detect_lora_family` returned `None` → import fell back to a user-supplied family (the manual Qwen assignment).

Fix: add a `BucketSignature` for the underscore-flattened (kohya/musubi/LyCORIS) MM-DiT form — requires `_transformer_blocks_` plus a joint-attention/dual-stream marker, disqualifying Flux single-stream and LTX `attn1/attn2` so neither mis-lands. Also taught `parse_block_index` the underscore form so Qwen (≥39 blocks) vs Z-Image disambiguation works.

## Tests

- `tests/test_lycoris_lokr.py`: **13 pass** — +4 unit + a torch+lycoris `lycoris_`-prefix round-trip that drives the real loader.
- `cargo test -p sceneworks-core lora_family`: **38 pass** — +3 (lycoris underscore Qwen LoKr → qwen-image; kohya `lora_unet` underscore → qwen-image; low-block inconclusive); all existing detection tests unaffected.
- CI worker suite: **521 pass / 2 skip**; core + rust-api + worker Rust suites green; `cargo fmt --all` + clippy clean.
- Both fixes verified against the **real file** (60 blocks, 12 module suffixes, `lycoris` prefix): now derives `'lycoris'` at apply time and detects `qwen-image` at upload.

## Reviewer notes

- Worker (Python) + core (Rust) changes; **no wire-contract / web changes** (detection returns existing family strings → no snapshot regen). Worker must be **rebuilt/restarted** to pick up the Python fix.
- Still owes real-Mac GPU E2E (an actual Qwen-Image-Edit 2511 Lightning Poses generation with this LoKr).

Stories: [sc-2626](https://app.shortcut.com/trefry/story/2626) + [sc-2631](https://app.shortcut.com/trefry/story/2631) (epic [2193](https://app.shortcut.com/trefry/epic/2193)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)