### PR TITLE
[codex] Improve resumable model downloads

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -88,14 +88,34 @@ pub(crate) async fn cancel_job(
 pub(crate) async fn retry_job(
     State(state): State<AppState>,
     Path(job_id): Path<String>,
+    request: AxumRequest,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    let payload = retry_job_request_from_body(request).await?;
     let job = store_call(state.clone(), move |store, _timeout| {
-        store.retry_job(&job_id)
+        store.retry_job(
+            &job_id,
+            RetryJob {
+                payload_changes: payload.payload_changes,
+            },
+        )
     })
     .await?;
     publish(&state, "job.updated", &job);
     publish_queue(&state).await?;
     Ok((StatusCode::CREATED, Json(job)))
+}
+
+async fn retry_job_request_from_body(request: AxumRequest) -> Result<RetryJobRequest, ApiError> {
+    let bytes = to_bytes(request.into_body(), 1024 * 1024)
+        .await
+        .map_err(|error| {
+            ApiError::bad_request(format!("Unable to read retry request body: {error}"))
+        })?;
+    if bytes.iter().all(|byte| byte.is_ascii_whitespace()) {
+        return Ok(RetryJobRequest::default());
+    }
+    serde_json::from_slice::<RetryJobRequest>(&bytes)
+        .map_err(|error| ApiError::bad_request(format!("Invalid retry request body: {error}")))
 }
 
 pub(crate) async fn duplicate_job(

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use axum::body::Body;
+use axum::body::{to_bytes, Body};
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{
     DefaultBodyLimit, FromRequest, Multipart, Path, Query, Request as AxumRequest, State,
@@ -22,10 +22,11 @@ use parking_lot::Mutex;
 use sceneworks_core::contracts::{
     ClaimRequest, ClaimResponse, ContractNumber, DuplicateJobRequest, ImageUpscaleRequest,
     JobCreateRequest, JobSnapshot, JobStatus, JobType, JsonObject, ProgressRequest, QueueSummary,
-    WorkerCapability, WorkerHeartbeatRequest, WorkerRegisterRequest, WorkerSnapshot, WorkerStatus,
+    RetryJobRequest, WorkerCapability, WorkerHeartbeatRequest, WorkerRegisterRequest,
+    WorkerSnapshot, WorkerStatus,
 };
 use sceneworks_core::jobs_store::{
-    CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker,
+    CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker, RetryJob,
     WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1455,10 +1455,13 @@ export function App() {
     }
   }
 
-  async function jobAction(job, action) {
+  async function jobAction(job, action, options = {}) {
     try {
       const path = action === "duplicate" ? `/api/v1/jobs/${job.id}/duplicate` : `/api/v1/jobs/${job.id}/${action}`;
-      const body = action === "duplicate" ? { payloadChanges: { duplicatedAt: new Date().toISOString() } } : {};
+      const body =
+        action === "duplicate"
+          ? { payloadChanges: { duplicatedAt: new Date().toISOString() } }
+          : (options.body ?? {});
       const updatedJob = await apiFetch(path, token, { method: "POST", body: JSON.stringify(body) });
       setJobs((items) => [updatedJob, ...items.filter((item) => item.id !== updatedJob.id)].sort(sortNewest));
       setError("");

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -345,6 +345,7 @@ export function WorkerProgressCard({
   job,
   onCancel,
   onRetry,
+  onFreshRetry,
   onDuplicate,
   onOpenQueue,
   hideOpenQueue = false,
@@ -381,9 +382,18 @@ export function WorkerProgressCard({
 
   const isTerminal = terminalStatuses.has(job.status);
   const attempts = job.attempts ?? 1;
+  const isModelDownload = job.type === "model_download";
   const canCancel = onCancel && !isTerminal && !job.cancelRequested;
-  const canRetry = onRetry && actionStatuses.has(job.status) && attempts < MAX_ATTEMPTS;
-  const canDuplicate = onDuplicate && actionStatuses.has(job.status) && attempts < MAX_ATTEMPTS;
+  const canRetryBase = actionStatuses.has(job.status) && attempts < MAX_ATTEMPTS;
+  const canRetry = onRetry && canRetryBase && !isModelDownload;
+  const canResumeDownload = onRetry && canRetryBase && isModelDownload && job.status !== "completed";
+  const canFreshDownload =
+    onFreshRetry &&
+    canRetryBase &&
+    isModelDownload &&
+    job.status !== "completed" &&
+    (attempts > 1 || ["resume", "fresh"].includes(job.payload?.downloadAction));
+  const canDuplicate = onDuplicate && canRetryBase && !isModelDownload;
   const showOpenQueue = !!onOpenQueue && !hideOpenQueue;
 
   const chipLabel = getJobTypeChip(job.type);
@@ -447,6 +457,24 @@ export function WorkerProgressCard({
             type="button"
           >
             {job.cancelRequested ? "Canceling…" : "Cancel"}
+          </button>
+        ) : null}
+        {canResumeDownload ? (
+          <button
+            className="secondary-action"
+            onClick={() => onRetry(job, { payloadChanges: { downloadAction: "resume" } })}
+            type="button"
+          >
+            Resume Download
+          </button>
+        ) : null}
+        {canFreshDownload ? (
+          <button
+            className="secondary-action"
+            onClick={() => onFreshRetry(job, { payloadChanges: { downloadAction: "fresh" } })}
+            type="button"
+          >
+            Retry Download
           </button>
         ) : null}
         {canRetry ? (

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -229,6 +229,49 @@ describe("WorkerProgressCard layout", () => {
     expect(labels).toEqual(["Cancel"]);
   });
 
+  it("uses resume-first actions for failed model downloads", () => {
+    const job = {
+      id: "j",
+      type: "model_download",
+      status: "failed",
+      progress: 0.7,
+      attempts: 1,
+      payload: { modelId: "realvisxl" },
+      error: "download ended early",
+    };
+    const onRetry = vi.fn();
+    const onFreshRetry = vi.fn();
+    api = render(
+      <WorkerProgressCard job={job} onRetry={onRetry} onFreshRetry={onFreshRetry} onDuplicate={vi.fn()} />,
+      makeContext([]),
+    );
+    let buttons = Array.from(api.container.querySelectorAll(".worker-progress-card__actions button"));
+    expect(buttons.map((button) => button.textContent)).toEqual(["Resume Download"]);
+    act(() => {
+      buttons[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+    expect(onRetry).toHaveBeenCalledWith(job, { payloadChanges: { downloadAction: "resume" } });
+    expect(onFreshRetry).not.toHaveBeenCalled();
+
+    api.cleanup();
+    const resumedJob = {
+      ...job,
+      id: "j2",
+      attempts: 2,
+      payload: { ...job.payload, downloadAction: "resume" },
+    };
+    api = render(
+      <WorkerProgressCard job={resumedJob} onRetry={onRetry} onFreshRetry={onFreshRetry} />,
+      makeContext([]),
+    );
+    buttons = Array.from(api.container.querySelectorAll(".worker-progress-card__actions button"));
+    expect(buttons.map((button) => button.textContent)).toEqual(["Resume Download", "Retry Download"]);
+    act(() => {
+      buttons[1].dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+    expect(onFreshRetry).toHaveBeenCalledWith(resumedJob, { payloadChanges: { downloadAction: "fresh" } });
+  });
+
   it("hides View in Queue when hideOpenQueue is true", () => {
     const job = { id: "j", type: "image_generate", status: "running", progress: 0, attempts: 1, payload: {} };
     const onOpenQueue = vi.fn();

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -203,6 +203,8 @@ export function ModelManagerScreen() {
     presets: recipePresets = [],
   } = useAppContext();
   const onCancelJob = (job) => jobAction(job, "cancel");
+  const onResumeDownloadJob = (job, payload) => jobAction(job, "retry", { body: payload ?? {} });
+  const onFreshDownloadJob = (job, payload) => jobAction(job, "retry", { body: payload ?? {} });
   const onConvertModel = createModelConvertJob;
   const onDeleteLora = deleteLoraAction;
   const onDeleteModel = deleteModelAction;
@@ -562,7 +564,13 @@ export function ModelManagerScreen() {
           </div>
         </dl>
         {localDownloadJob ? (
-          <WorkerProgressCard job={localDownloadJob} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+          <WorkerProgressCard
+            job={localDownloadJob}
+            onCancel={onCancelJob}
+            onRetry={onResumeDownloadJob}
+            onFreshRetry={onFreshDownloadJob}
+            onOpenQueue={onOpenQueue}
+          />
         ) : null}
         {mlxState ? (
           <div className="mlx-status">
@@ -597,13 +605,21 @@ export function ModelManagerScreen() {
           </div>
         ) : null}
         <div className="model-card-actions">
-          <button disabled={installed || !model.downloadable || Boolean(downloadJob)} onClick={() => onDownloadModel(model)} type="button">
+          <button
+            disabled={installed || !model.downloadable || Boolean(downloadJob)}
+            onClick={() =>
+              failedDownload
+                ? onResumeDownloadJob(localDownloadJob, { payloadChanges: { downloadAction: "resume" } })
+                : onDownloadModel(model)
+            }
+            type="button"
+          >
             {downloadJob
               ? downloadJob.status
               : installed
                 ? "Ready"
                 : failedDownload
-                  ? "Retry Download"
+                  ? "Resume Download"
                   : model.downloadSizeLabel
                     ? `Download ${downloadSize}`
                     : "Download"}

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -277,7 +277,8 @@ export function QueueScreen() {
                 thumbnailAssets={thumbnails}
                 onThumbnailClick={setPreviewAsset ? (asset) => setPreviewAsset(asset, thumbnails) : undefined}
                 onCancel={(j) => jobAction(j, "cancel")}
-                onRetry={(j) => jobAction(j, "retry")}
+                onRetry={(j, payload) => jobAction(j, "retry", { body: payload ?? {} })}
+                onFreshRetry={(j, payload) => jobAction(j, "retry", { body: payload ?? {} })}
                 onDuplicate={(j) => jobAction(j, "duplicate")}
                 hideOpenQueue
               />

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -764,6 +764,15 @@ pub struct DuplicateJobRequest {
     pub extra: ExtraFields,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RetryJobRequest {
+    #[serde(default)]
+    pub payload_changes: JsonObject,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SidecarPatterns {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -150,6 +150,11 @@ pub struct DuplicateJob {
 }
 
 #[derive(Debug, Clone)]
+pub struct RetryJob {
+    pub payload_changes: Map<String, Value>,
+}
+
+#[derive(Debug, Clone)]
 pub struct RegisterWorker {
     pub worker_id: String,
     pub gpu_id: String,
@@ -413,7 +418,7 @@ impl JobsStore {
         Ok(job)
     }
 
-    pub fn retry_job(&self, job_id: &str) -> JobsStoreResult<JobSnapshot> {
+    pub fn retry_job(&self, job_id: &str, request: RetryJob) -> JobsStoreResult<JobSnapshot> {
         let _guard = self.lock.lock();
         let mut connection = self.connect()?;
         let transaction = connection.transaction()?;
@@ -423,13 +428,15 @@ impl JobsStore {
                 max_attempts: MAX_JOB_ATTEMPTS,
             });
         }
+        let mut payload = job.payload;
+        payload.extend(request.payload_changes);
         let job = self.create_job_on_connection(
             &transaction,
             CreateJob {
                 job_type: job.job_type,
                 project_id: job.project_id,
                 project_name: job.project_name,
-                payload: job.payload,
+                payload,
                 requested_gpu: job.requested_gpu,
                 source_job_id: Some(job.id),
                 duplicate_of_job_id: None,

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -6,7 +6,7 @@ use sceneworks_core::contracts::{
     JobStatus, JobType, ProgressStage, WorkerCapability, WorkerStatus, WorkerUtilizationSnapshot,
 };
 use sceneworks_core::jobs_store::{
-    CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker,
+    CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker, RetryJob,
     WorkerHeartbeat, MAX_JOB_ATTEMPTS,
 };
 use serde_json::{json, Map, Value};
@@ -1017,7 +1017,12 @@ fn retry_job_is_capped() {
         .expect("job creates");
 
     assert!(matches!(
-        store.retry_job(&job.id),
+        store.retry_job(
+            &job.id,
+            RetryJob {
+                payload_changes: Map::new(),
+            },
+        ),
         Err(JobsStoreError::RetryLimit {
             max_attempts: MAX_JOB_ATTEMPTS
         })
@@ -1039,11 +1044,33 @@ fn cancel_retry_and_duplicate_preserve_python_metadata_shapes() {
     assert!(canceled.completed_at.is_some());
     assert!(canceled.canceled_at.is_some());
 
-    let retry = store.retry_job(&canceled.id).expect("job retries");
+    let retry = store
+        .retry_job(
+            &canceled.id,
+            RetryJob {
+                payload_changes: Map::new(),
+            },
+        )
+        .expect("job retries");
     assert_eq!(retry.source_job_id.as_deref(), Some(canceled.id.as_str()));
     assert_eq!(retry.attempts, canceled.attempts + 1);
     assert_eq!(retry.duplicate_of_job_id, None);
     assert_eq!(retry.payload, canceled.payload);
+
+    let resume_retry = store
+        .retry_job(
+            &canceled.id,
+            RetryJob {
+                payload_changes: object(json!({ "downloadAction": "resume" })),
+            },
+        )
+        .expect("resume retry creates");
+    assert_eq!(
+        resume_retry.source_job_id.as_deref(),
+        Some(canceled.id.as_str())
+    );
+    assert_eq!(resume_retry.payload["prompt"], json!("mist over hills"));
+    assert_eq!(resume_retry.payload["downloadAction"], json!("resume"));
 
     let duplicate = store
         .duplicate_job(

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -90,7 +90,10 @@ pub(crate) struct DownloadContext<'a> {
     pub(crate) settings: &'a Settings,
     pub(crate) job_id: &'a str,
     pub(crate) cancel_message: &'a str,
+    pub(crate) fresh_download: bool,
 }
+
+const AUTO_RESUME_ATTEMPTS: usize = 1;
 
 /// Download a single file to `dest` (resumable via HTTP Range), reporting transfer
 /// progress and rejecting a truncated response. `label` names the file in the
@@ -103,69 +106,152 @@ async fn download_file(
     label: &str,
     progress: &mut DownloadProgress<'_>,
 ) -> WorkerResult<()> {
-    let existing_bytes = existing_download_bytes(dest, expected_size).await?;
-    if expected_size.is_some_and(|size| existing_bytes == size) {
-        return Ok(());
-    }
-    let mut request = context.client.get(url);
-    if existing_bytes > 0 {
-        request = request.header(header::RANGE, format!("bytes={existing_bytes}-"));
-    }
-    let response = with_hf_auth(context.settings, request).send().await?;
-    let status = response.status();
-    if !status.is_success() {
-        return Err(WorkerError::Http(response.error_for_status().unwrap_err()));
-    }
-    let appending = existing_bytes > 0 && status == StatusCode::PARTIAL_CONTENT;
-    if existing_bytes > 0 && !appending {
-        progress.discard_started_bytes(existing_bytes);
-    }
-    let mut response = response;
-    let mut output = if appending {
-        tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(dest)
-            .await?
-    } else {
-        tokio::fs::File::create(dest).await?
-    };
-    let mut interval = tokio::time::interval(progress.report_interval());
-    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    // A tokio interval's first tick is immediate; consume it so the first chunk
-    // doesn't spuriously fire a zero-byte progress report before any transfer.
-    interval.tick().await;
-    loop {
-        tokio::select! {
-            chunk = response.chunk() => {
-                let Some(chunk) = chunk? else {
-                    break;
-                };
-                output.write_all(&chunk).await?;
-                progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
-            }
-            _ = interval.tick() => {
-                report_download_progress(context, progress).await?;
-            }
+    if context.fresh_download {
+        let removed_bytes = remove_incomplete_download(dest, expected_size).await?;
+        if removed_bytes > 0 {
+            progress.discard_started_bytes(removed_bytes);
         }
     }
-    output.flush().await?;
-    // A truncated transfer (e.g. the server closes the stream at what looks like a
-    // clean EOF) would otherwise be treated as success and the bad file only surface
-    // as an opaque load failure later. When the expected size is known, verify it and
-    // remove the partial so the next attempt re-downloads.
-    if let Some(expected) = expected_size {
-        let written = tokio::fs::metadata(dest).await?.len();
-        if written != expected {
-            let _ = tokio::fs::remove_file(dest).await;
-            return Err(WorkerError::InvalidPayload(format!(
-                "{label} download ended at {} but expected {}",
-                format_bytes(written),
-                format_bytes(expected)
+    let mut resume_attempts_remaining = if context.fresh_download {
+        0
+    } else {
+        AUTO_RESUME_ATTEMPTS
+    };
+    loop {
+        let existing_bytes = existing_download_bytes(dest, expected_size).await?;
+        if expected_size.is_some_and(|size| existing_bytes == size) {
+            return Ok(());
+        }
+        let mut request = context.client.get(url);
+        if existing_bytes > 0 {
+            request = request.header(header::RANGE, format!("bytes={existing_bytes}-"));
+        }
+        let response = with_hf_auth(context.settings, request).send().await?;
+        let status = response.status();
+        if status == StatusCode::RANGE_NOT_SATISFIABLE && existing_bytes > 0 {
+            if let Some(expected) = expected_size {
+                return Err(WorkerError::InvalidPayload(download_size_mismatch_message(
+                    label,
+                    existing_bytes,
+                    expected,
+                )));
+            }
+        }
+        if !status.is_success() {
+            return Err(WorkerError::Http(response.error_for_status().unwrap_err()));
+        }
+        let appending = existing_bytes > 0 && status == StatusCode::PARTIAL_CONTENT;
+        if existing_bytes > 0 && !appending {
+            progress.discard_started_bytes(existing_bytes);
+        }
+        let mut response = response;
+        let mut output = if appending {
+            tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(dest)
+                .await?
+        } else {
+            tokio::fs::File::create(dest).await?
+        };
+        let mut interval = tokio::time::interval(progress.report_interval());
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // A tokio interval's first tick is immediate; consume it so the first chunk
+        // doesn't spuriously fire a zero-byte progress report before any transfer.
+        interval.tick().await;
+        let mut transfer_error = None;
+        loop {
+            tokio::select! {
+                chunk = response.chunk() => {
+                    match chunk {
+                        Ok(Some(chunk)) => {
+                            output.write_all(&chunk).await?;
+                            progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
+                        }
+                        Ok(None) => break,
+                        Err(error) => {
+                            transfer_error = Some(WorkerError::from(error));
+                            break;
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    report_download_progress(context, progress).await?;
+                }
+            }
+        }
+        output.flush().await?;
+        if let Some(error) = transfer_error {
+            if let Some(expected) = expected_size {
+                let written = tokio::fs::metadata(dest).await?.len();
+                if written == expected {
+                    return Ok(());
+                }
+                if written < expected && resume_attempts_remaining > 0 {
+                    resume_attempts_remaining -= 1;
+                    continue;
+                }
+            }
+            return Err(error);
+        }
+        // A truncated transfer (e.g. the server closes the stream at what looks like a
+        // clean EOF) would otherwise be treated as success and the bad file only surface
+        // as an opaque load failure later. When the expected size is known, verify it.
+        // Short files are preserved so a later retry can resume them; overlong files are
+        // discarded because appending would only move them farther away from the target.
+        if let Some(expected) = expected_size {
+            let written = tokio::fs::metadata(dest).await?.len();
+            if written == expected {
+                return Ok(());
+            }
+            if written < expected && resume_attempts_remaining > 0 {
+                resume_attempts_remaining -= 1;
+                continue;
+            }
+            if written > expected {
+                let _ = tokio::fs::remove_file(dest).await;
+            }
+            return Err(WorkerError::InvalidPayload(download_size_mismatch_message(
+                label, written, expected,
             )));
         }
+        return Ok(());
     }
-    Ok(())
+}
+
+async fn remove_incomplete_download(path: &Path, expected_size: Option<u64>) -> WorkerResult<u64> {
+    let Ok(metadata) = tokio::fs::metadata(path).await else {
+        return Ok(0);
+    };
+    let existing_bytes = metadata.len();
+    if expected_size
+        .map(|expected| metadata.len() != expected)
+        .unwrap_or(true)
+    {
+        tokio::fs::remove_file(path).await?;
+        return Ok(existing_bytes);
+    }
+    Ok(0)
+}
+
+fn format_bytes_with_exact(value: u64) -> String {
+    format!("{} ({value} bytes)", format_bytes(value))
+}
+
+fn download_size_mismatch_message(label: &str, actual: u64, expected: u64) -> String {
+    let delta = actual.abs_diff(expected);
+    let direction = if actual < expected {
+        "missing"
+    } else {
+        "extra"
+    };
+    format!(
+        "{label} download ended at {} but expected {}; {} {}.",
+        format_bytes_with_exact(actual),
+        format_bytes_with_exact(expected),
+        format_bytes_with_exact(delta),
+        direction
+    )
 }
 
 /// Download a Hugging Face snapshot as a flat file tree under `target_dir`. Used by
@@ -488,10 +574,10 @@ pub(crate) async fn download_source_url(
     }
     output.flush().await?;
     if expected_bytes.is_some_and(|expected| progress.downloaded_bytes() != expected) {
-        return Err(WorkerError::InvalidPayload(format!(
-            "LoRA sourceUrl download ended at {} but expected {}",
-            format_bytes(progress.downloaded_bytes()),
-            format_bytes(expected_bytes.unwrap_or_default())
+        return Err(WorkerError::InvalidPayload(download_size_mismatch_message(
+            &format!("{source_label} sourceUrl"),
+            progress.downloaded_bytes(),
+            expected_bytes.unwrap_or_default(),
         )));
     }
     Ok(())

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -21,6 +21,7 @@ pub(crate) async fn run_model_download_job(
     };
     let files = payload_string_array(&job.payload, "files");
     let revision = optional_payload_string(&job.payload, "revision").unwrap_or("main");
+    let fresh_download = optional_payload_string(&job.payload, "downloadAction") == Some("fresh");
     // The worker is the trust boundary (jobs API is unauthenticated for local use), so a
     // client-supplied targetDir must be constrained to app-managed data/models the same way
     // import jobs are, not used verbatim.
@@ -133,6 +134,7 @@ pub(crate) async fn run_model_download_job(
             settings,
             job_id: &job.id,
             cancel_message: "Model download canceled by user.",
+            fresh_download,
         },
         &repo_dir,
         revision,
@@ -553,6 +555,10 @@ pub(crate) async fn download_model_with_hf_cli(
     for pattern in files {
         command.arg("--include").arg(pattern);
     }
+    let fresh_download = optional_payload_string(&job.payload, "downloadAction") == Some("fresh");
+    if fresh_download {
+        command.arg("--force-download");
+    }
 
     let mut child = command.spawn().map_err(|error| {
         WorkerError::InvalidPayload(format!(
@@ -709,6 +715,7 @@ pub(crate) async fn run_lora_import_job(
                 settings,
                 job_id: &job.id,
                 cancel_message: "LoRA import canceled by user.",
+                fresh_download: false,
             },
             &target_dir,
             &snapshot,
@@ -750,6 +757,7 @@ pub(crate) async fn run_lora_import_job(
                 settings,
                 job_id: &job.id,
                 cancel_message: "LoRA import canceled by user.",
+                fresh_download: false,
             },
             source_url,
             &target_dir,
@@ -995,6 +1003,7 @@ pub(crate) async fn run_model_import_job(
                 settings,
                 job_id: &job.id,
                 cancel_message: "Model import canceled by user.",
+                fresh_download: false,
             },
             &target_dir,
             &snapshot,
@@ -1016,6 +1025,7 @@ pub(crate) async fn run_model_import_job(
                 settings,
                 job_id: &job.id,
                 cancel_message: "Model import canceled by user.",
+                fresh_download: false,
             },
             source_url,
             &target_dir,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -592,6 +592,7 @@ async fn lora_url_import_downloads_to_named_file() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &format!("{source_url}/loras/style.safetensors"),
         &target_dir,
@@ -628,6 +629,7 @@ async fn lora_url_import_skips_existing_matching_file() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &format!("{source_url}/loras/style.safetensors"),
         &target_dir,
@@ -676,6 +678,7 @@ async fn download_snapshot_rejects_truncated_file() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &repo_dir,
         "main",
@@ -686,13 +689,113 @@ async fn download_snapshot_rejects_truncated_file() {
     .expect_err("truncated shard is rejected");
 
     assert!(error.to_string().contains("expected"));
-    // The partial blob is removed so a retry re-downloads, and the snapshot is
+    // The partial blob is preserved so a retry can resume it, and the snapshot is
     // never materialized over a corrupt blob.
-    assert!(!repo_dir
-        .join("blobs")
-        .join("etag-shard.safetensors")
-        .exists());
+    assert_eq!(
+        tokio::fs::read(repo_dir.join("blobs").join("etag-shard.safetensors"))
+            .await
+            .unwrap(),
+        b"trun"
+    );
     assert!(!repo_dir.join("snapshots").exists());
+}
+
+#[tokio::test]
+async fn download_snapshot_resumes_existing_partial_blob() {
+    let temp = tempdir().expect("tempdir creates");
+    let base_url = spawn_binary_stub(b"weights!!".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base_url.clone();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let repo_dir = temp.path().join("models--owner--model");
+    let blob_path = repo_dir.join("blobs").join("etag-model.safetensors");
+    tokio::fs::create_dir_all(blob_path.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&blob_path, b"weig").await.unwrap();
+
+    let snapshot = HuggingFaceSnapshot {
+        files: vec![SnapshotFile {
+            path: "model.safetensors".to_owned(),
+            size: Some(9),
+            download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+        }],
+    };
+    let mut progress = DownloadProgress::new(
+        "owner/model",
+        4,
+        snapshot.total_bytes(),
+        Duration::from_secs(3600),
+    );
+
+    download_snapshot_into_cache(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        },
+        &repo_dir,
+        "main",
+        &snapshot,
+        &mut progress,
+    )
+    .await
+    .expect("partial blob resumes");
+
+    assert_eq!(tokio::fs::read(&blob_path).await.unwrap(), b"weights!!");
+}
+
+#[tokio::test]
+async fn download_snapshot_fresh_retry_discards_partial_blob() {
+    let temp = tempdir().expect("tempdir creates");
+    let base_url = spawn_binary_stub(b"weights!!".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base_url.clone();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let repo_dir = temp.path().join("models--owner--model");
+    let blob_path = repo_dir.join("blobs").join("etag-model.safetensors");
+    tokio::fs::create_dir_all(blob_path.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&blob_path, b"bad").await.unwrap();
+
+    let snapshot = HuggingFaceSnapshot {
+        files: vec![SnapshotFile {
+            path: "model.safetensors".to_owned(),
+            size: Some(9),
+            download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+        }],
+    };
+    let mut progress = DownloadProgress::new(
+        "owner/model",
+        3,
+        snapshot.total_bytes(),
+        Duration::from_secs(3600),
+    );
+
+    download_snapshot_into_cache(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: true,
+        },
+        &repo_dir,
+        "main",
+        &snapshot,
+        &mut progress,
+    )
+    .await
+    .expect("fresh retry redownloads from the beginning");
+
+    assert_eq!(tokio::fs::read(&blob_path).await.unwrap(), b"weights!!");
 }
 
 #[tokio::test]
@@ -726,6 +829,7 @@ async fn download_snapshot_writes_hugging_face_cache_layout() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &repo_dir,
         "main",
@@ -810,6 +914,7 @@ async fn download_snapshot_into_cache_matches_real_huggingface_layout() {
             settings: &settings,
             job_id: "real",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &repo_dir,
         "main",
@@ -871,6 +976,7 @@ async fn lora_url_import_rejects_failed_and_oversized_downloads() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &format!("{missing_url}/loras/missing.safetensors"),
         &temp.path().join("missing-target"),
@@ -890,6 +996,7 @@ async fn lora_url_import_rejects_failed_and_oversized_downloads() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &format!("{large_url}/loras/large.safetensors"),
         &temp.path().join("large-target"),
@@ -916,6 +1023,7 @@ async fn lora_url_import_honors_midstream_cancel() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "LoRA import canceled by user.",
+            fresh_download: false,
         },
         &format!("{source_url}/loras/style.safetensors"),
         &temp.path().join("cancel-target"),
@@ -1018,6 +1126,7 @@ async fn source_url_follows_redirect_and_strips_auth_across_hosts() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &format!("{download_base}/download/style.safetensors"),
         &target_dir,
@@ -1050,6 +1159,7 @@ async fn source_url_rejects_redirect_to_non_http_scheme() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &format!("{download_base}/download/style.safetensors"),
         &temp.path().join("scheme-target"),
@@ -1077,6 +1187,7 @@ async fn source_url_rejects_excessive_redirects() {
             settings: &settings,
             job_id: "job-1",
             cancel_message: "canceled",
+            fresh_download: false,
         },
         &format!("{download_base}/download/style.safetensors"),
         &temp.path().join("loop-target"),
@@ -1569,6 +1680,29 @@ async fn binary_stub(State(state): State<BinaryStubState>, headers: HeaderMap) -
         response.headers_mut().insert(
             axum::http::header::CONTENT_RANGE,
             axum::http::HeaderValue::from_str(&format!("bytes */{length}"))
+                .expect("content range header"),
+        );
+        return response;
+    }
+    if let Some(start) = headers
+        .get(axum::http::header::RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("bytes="))
+        .and_then(|value| value.strip_suffix('-'))
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|start| *start < length)
+    {
+        let body = state.bytes[start..].to_vec();
+        let mut response = body.into_response();
+        *response.status_mut() = AxumStatusCode::PARTIAL_CONTENT;
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from_str(&(length - start).to_string())
+                .expect("content length header"),
+        );
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_RANGE,
+            axum::http::HeaderValue::from_str(&format!("bytes {start}-{}/{length}", length - 1))
                 .expect("content range header"),
         );
         return response;


### PR DESCRIPTION
﻿## What changed

- Preserve short partial model downloads and automatically attempt one ranged resume before failing.
- Add exact byte counts and missing/extra deltas to download size mismatch errors.
- Add resume vs fresh retry intent to job retries so model downloads show `Resume Download` first and `Retry Download` can explicitly discard partials.
- Teach direct download tests to cover preserved partials, ranged resume, and fresh redownload behavior.

## Why

Large Hugging Face model downloads could fail after transferring almost the whole file, then SceneWorks deleted the partial and displayed rounded sizes like `6.5 GB but expected 6.5 GB`. That made the error confusing and forced expensive redownloads.

## Impact

Users can resume failed model downloads by default. If resume keeps failing, the UI keeps `Resume Download` available and also offers `Retry Download` to delete partial data and start over deliberately.

## Validation

- `cargo test -p sceneworks-worker download_snapshot --lib`
- `cargo test -p sceneworks-core --test jobs_store`
- `cargo test -p sceneworks-rust-api model_download --lib`
- `npm test -- --run src/components/WorkerProgressCard.test.jsx`
