### PR TITLE
Fix Windows worker parent PID watchdog

### DIFF
--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+import ctypes
+from ctypes import wintypes
 import json
 import os
 import signal
@@ -1868,6 +1870,29 @@ def _force_utf8_stdio() -> None:
 
 
 def _pid_alive(pid: int) -> bool:
+    if os.name == "nt":
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        process_query_limited_information = 0x1000
+        still_active = 259
+        handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+        if not handle:
+            # Access denied still means the process exists; invalid parameter is
+            # the usual Windows error for a PID that no longer resolves.
+            return ctypes.get_last_error() == 5
+        try:
+            exit_code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            return exit_code.value == still_active
+        finally:
+            kernel32.CloseHandle(handle)
+
     try:
         os.kill(pid, 0)
     except ProcessLookupError:


### PR DESCRIPTION
## Summary
- replace the worker parent PID liveness probe on Windows with OpenProcess/GetExitCodeProcess
- keep the existing os.kill(pid, 0) behavior for Unix platforms
- prevent Windows desktop GPU workers from self-terminating immediately after launch

## Verification
- python -m py_compile apps\\worker\\scene_worker\\runtime.py
- rebuilt Windows Tauri installers successfully
- launched fixed Windows desktop build and confirmed both NVIDIA GPU workers registered through /api/v1/workers