### PR TITLE
fix(desktop): restore remote.urls capability grant so React-origin Tauri IPC works

### DIFF
--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -1,6 +1,9 @@
 {
   "identifier": "default",
-  "description": "Default capability set for the SceneWorks desktop shell window.",
+  "description": "Default capability set for the SceneWorks desktop shell window. The `remote` grant is REQUIRED: after setup the shell navigates the main window from tauri:// to the API-served React UI at http://127.0.0.1:<port>, and every window.__TAURI__ invoke (set_credential, choose_data_dir, reveal_in_os, restart_worker, get_gpu_info, …) is rejected by the ACL at that remote origin without it. Loopback-only; the shell health-gates the API (health_is_sceneworks) before navigating. Do not remove.",
   "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+  },
   "permissions": ["core:default"]
 }


### PR DESCRIPTION
## What

Restore the `remote.urls` grant in `apps/desktop/capabilities/default.json` so Tauri IPC works from the React UI:

```json
"remote": { "urls": ["http://127.0.0.1:*", "http://localhost:*"] }
```

Also expands the capability `description` to a "do not remove" note explaining why, so it isn't reverted again.

## Why

A user hit **"Command set_credential not allowed by ACL"** saving a HuggingFace credential, and the same for **"Command choose_data_dir not allowed by ACL"** on the Data Directory picker.

Root cause: after setup the desktop shell navigates the main window from `tauri://` to the API-served React UI at `http://127.0.0.1:<port>` (`apps/desktop/src/setup.rs`). Tauri v2 scopes IPC per capability **by origin** — without a `remote.urls` grant covering that origin, the ACL rejects *every* `window.__TAURI__` invoke from the React UI. This is **not** a per-command permission issue (app-defined commands are allowed by default in Tauri v2); it's purely the origin.

Affected commands (the whole React-origin class): `set_credential` / `list_credentials` / `delete_credential`, `choose_data_dir` (native folder picker), `reveal_in_os`, `restart_worker`, `get_gpu_info`, `get_app_settings`.

The grant was added in `ebdb56c` and **erroneously reverted in `1d65239`** ("provided no benefit"). That was a misdiagnosis: theme persistence failed for a separate localStorage / per-launch-random-port reason, which masked that the IPC grant was actually working. Theme was then moved to HTTP — but credentials and the native dialogs were never migrated and **can't** all be (native folder picker / reveal-in-OS have no HTTP equivalent), so the grant is required.

## Reviewer notes

- Loopback-only (`127.0.0.1` / `localhost`); the shell already health-gates the API (`health_is_sceneworks`) before navigating, so it won't expose commands to a foreign service.
- **Verified:** `cargo check -p sceneworks-desktop` compiles and Tauri's capability codegen accepts the change.
- **Not yet verified at runtime** — confirming the live IPC requires building and running the packaged desktop app through the setup flow (capabilities are baked in at compile time, so the fix only takes effect after a rebuild).
- Credential storage context: desktop writes the token to the OS keychain and injects it to the worker via `SCENEWORKS_CREDENTIALS` at spawn; the worker reads file-store + env at startup, so a new credential needs a **worker restart** to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)