### PR TITLE
[codex] Fix HF CLI Windows encoding downloads

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -549,6 +549,7 @@ pub(crate) async fn download_model_with_hf_cli(
         .arg(&cache_dir)
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
+    configure_hf_cli_environment(&mut command);
     if let Some(token) = &settings.huggingface_token {
         command.env("HF_TOKEN", token);
     }
@@ -588,8 +589,23 @@ pub(crate) async fn download_model_with_hf_cli(
         }
     };
     let stderr = stderr_task.await.unwrap_or_default();
+    let cache_path = huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Unable to resolve Hugging Face cache path for {repo}."
+        ))
+    })?;
     if !status.success() {
         let stderr = String::from_utf8_lossy(&stderr);
+        // Some Windows installs run the Python-based HF CLI with a legacy stdio
+        // codepage. The download can complete, then the process exits non-zero
+        // while printing a Unicode checkmark/progress footer. If the cache now has
+        // a snapshot, keep the completed transfer instead of failing the job.
+        if hf_cli_encoding_failure(&stderr)
+            && huggingface_snapshot_dir(&settings.data_dir, repo).is_some()
+        {
+            write_model_install_marker(marker_dir, &job.payload, repo, &job.id).await?;
+            return Ok(Some(cache_path));
+        }
         let detail = bounded_tail(&stderr, 10, 2000);
         let message = if detail.trim().is_empty() {
             "Hugging Face CLI download failed without stderr output.".to_owned()
@@ -599,13 +615,28 @@ pub(crate) async fn download_model_with_hf_cli(
         return Err(WorkerError::InvalidPayload(message));
     }
 
-    let cache_path = huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
-        WorkerError::InvalidPayload(format!(
-            "Unable to resolve Hugging Face cache path for {repo}."
-        ))
-    })?;
     write_model_install_marker(marker_dir, &job.payload, repo, &job.id).await?;
     Ok(Some(cache_path))
+}
+
+pub(crate) const HF_CLI_UTF8_ENV: [(&str, &str); 3] = [
+    ("PYTHONUTF8", "1"),
+    ("PYTHONIOENCODING", "utf-8"),
+    ("HF_HUB_DISABLE_PROGRESS_BARS", "1"),
+];
+
+pub(crate) fn configure_hf_cli_environment(command: &mut Command) {
+    for (key, value) in HF_CLI_UTF8_ENV {
+        command.env(key, value);
+    }
+}
+
+pub(crate) fn hf_cli_encoding_failure(stderr: &str) -> bool {
+    let normalized = stderr.to_ascii_lowercase();
+    normalized.contains("charmap")
+        && (normalized.contains("codec can't encode")
+            || normalized.contains("unicodeencodeerror")
+            || normalized.contains("character maps to <undefined>"))
 }
 
 pub(crate) async fn hf_cli_program() -> Option<&'static str> {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -28,7 +28,8 @@ use super::media_jobs::{
     run_ffmpeg,
 };
 use super::model_jobs::{
-    check_downloaded_model_family, finalize_converted_dir, DownloadFamilyCheck,
+    check_downloaded_model_family, finalize_converted_dir, hf_cli_encoding_failure,
+    DownloadFamilyCheck, HF_CLI_UTF8_ENV,
 };
 use super::supervisor::{
     auto_worker_specs, child_environment, restart_exited_children_with_spawner,
@@ -71,6 +72,25 @@ fn wan_video_safetensors_keys() -> Vec<String> {
         }
     }
     keys
+}
+
+#[test]
+fn hf_cli_windows_encoding_failures_are_detected() {
+    let stderr = "Fetching 28 files: 100%|##########| 28/28 [00:00<00:00, 14016.05it/s]\n\
+                  Error: Invalid value. 'charmap' codec can't encode character '\\u2713' \
+                  in position 5: character maps to <undefined>";
+
+    assert!(hf_cli_encoding_failure(stderr));
+    assert!(!hf_cli_encoding_failure("Error: Repository not found."));
+}
+
+#[test]
+fn hf_cli_environment_forces_python_utf8_output() {
+    let env: HashMap<_, _> = HF_CLI_UTF8_ENV.into_iter().collect();
+
+    assert_eq!(env.get("PYTHONUTF8"), Some(&"1"));
+    assert_eq!(env.get("PYTHONIOENCODING"), Some(&"utf-8"));
+    assert_eq!(env.get("HF_HUB_DISABLE_PROGRESS_BARS"), Some(&"1"));
 }
 
 #[test]


### PR DESCRIPTION
﻿## Summary
- Force the Hugging Face CLI subprocess to use UTF-8 output on Windows.
- Disable HF progress bars for model download jobs so CLI rendering cannot break completed transfers.
- Treat the known Windows `charmap`/Unicode encode crash as recoverable when a Hugging Face snapshot was created.

## Root Cause
The Python-based `hf download` command can inherit a legacy Windows stdio codepage. Large downloads may complete, then the CLI exits non-zero while printing a Unicode completion/progress character, causing SceneWorks to report a failed download even though the cache is populated.

## Validation
- `cargo fmt --package sceneworks-worker`
- `cargo test -p sceneworks-worker`
