### PR TITLE
[codex] Tolerate HF cache mount inspection errors

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -589,11 +589,12 @@ pub(crate) async fn download_model_with_hf_cli(
         }
     };
     let stderr = stderr_task.await.unwrap_or_default();
-    let cache_path = huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
-        WorkerError::InvalidPayload(format!(
-            "Unable to resolve Hugging Face cache path for {repo}."
-        ))
-    })?;
+    let repo_cache_path =
+        huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "Unable to resolve Hugging Face cache path for {repo}."
+            ))
+        })?;
     if !status.success() {
         let stderr = String::from_utf8_lossy(&stderr);
         // Some Windows installs run the Python-based HF CLI with a legacy stdio
@@ -603,6 +604,8 @@ pub(crate) async fn download_model_with_hf_cli(
         if hf_cli_encoding_failure(&stderr)
             && huggingface_snapshot_dir(&settings.data_dir, repo).is_some()
         {
+            let cache_path =
+                huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_cache_path);
             write_model_install_marker(marker_dir, &job.payload, repo, &job.id).await?;
             return Ok(Some(cache_path));
         }
@@ -615,6 +618,7 @@ pub(crate) async fn download_model_with_hf_cli(
         return Err(WorkerError::InvalidPayload(message));
     }
 
+    let cache_path = huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_cache_path);
     write_model_install_marker(marker_dir, &job.payload, repo, &job.id).await?;
     Ok(Some(cache_path))
 }
@@ -923,6 +927,9 @@ pub(crate) fn check_downloaded_model_family(
 ) -> DownloadFamilyCheck {
     let detected = match detect_model_family(model_dir) {
         Ok(detected) => detected,
+        Err(error) if downloaded_model_detection_io_error_is_inconclusive(&error) => {
+            return DownloadFamilyCheck::Proceed;
+        }
         Err(error) => return DownloadFamilyCheck::DetectionFailed(error),
     };
     match reconcile_detected_family(supplied, detected) {
@@ -931,11 +938,29 @@ pub(crate) fn check_downloaded_model_family(
     }
 }
 
+pub(crate) fn downloaded_model_detection_io_error_is_inconclusive(
+    error: &SafetensorsHeaderError,
+) -> bool {
+    let SafetensorsHeaderError::Io(io_error) = error else {
+        return false;
+    };
+    // Hugging Face snapshots may contain symlinks/reparse points into `blobs`.
+    // On some Windows machines, opening those links fails with ERROR_UNTRUSTED_
+    // MOUNT_POINT (448). The download is already complete; this optional family
+    // check should become inconclusive rather than failing the model install.
+    io_error.raw_os_error() == Some(448)
+        || io_error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("untrusted mount point")
+}
+
 /// Enforce family parity with model import on a completed download: verify the
 /// downloaded weights match the catalog-declared family and fail the job on a
-/// confident mismatch (or an unreadable header). Returns `Ok(true)` when the
-/// download may complete, `Ok(false)` when the job was already failed and the
-/// caller should return.
+/// confident mismatch or a clearly invalid header. Windows cache-link traversal
+/// errors are treated as inconclusive because the download itself has completed.
+/// Returns `Ok(true)` when the download may complete, `Ok(false)` when the job was
+/// already failed and the caller should return.
 pub(crate) async fn reconcile_downloaded_model_family(
     api: &ApiClient,
     job: &JobSnapshot,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -28,8 +28,8 @@ use super::media_jobs::{
     run_ffmpeg,
 };
 use super::model_jobs::{
-    check_downloaded_model_family, finalize_converted_dir, hf_cli_encoding_failure,
-    DownloadFamilyCheck, HF_CLI_UTF8_ENV,
+    check_downloaded_model_family, downloaded_model_detection_io_error_is_inconclusive,
+    finalize_converted_dir, hf_cli_encoding_failure, DownloadFamilyCheck, HF_CLI_UTF8_ENV,
 };
 use super::supervisor::{
     auto_worker_specs, child_environment, restart_exited_children_with_spawner,
@@ -40,8 +40,8 @@ use super::{
     fresh_asset_id, import_lora_source_file_as, import_lora_source_path, now_rfc3339,
     parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
     safe_download_dir, safe_project_path, value_f64, wan_moe_pair_filenames,
-    write_model_install_marker, CredentialScheme, JsonObject, Settings, WorkerCredential,
-    WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
+    write_model_install_marker, CredentialScheme, JsonObject, SafetensorsHeaderError, Settings,
+    WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
     DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
 };
 
@@ -91,6 +91,19 @@ fn hf_cli_environment_forces_python_utf8_output() {
     assert_eq!(env.get("PYTHONUTF8"), Some(&"1"));
     assert_eq!(env.get("PYTHONIOENCODING"), Some(&"utf-8"));
     assert_eq!(env.get("HF_HUB_DISABLE_PROGRESS_BARS"), Some(&"1"));
+}
+
+#[test]
+fn downloaded_model_windows_untrusted_mount_detection_is_inconclusive() {
+    let error = SafetensorsHeaderError::Io(std::io::Error::from_raw_os_error(448));
+
+    assert!(downloaded_model_detection_io_error_is_inconclusive(&error));
+    assert!(!downloaded_model_detection_io_error_is_inconclusive(
+        &SafetensorsHeaderError::InvalidHeader
+    ));
+    assert!(!downloaded_model_detection_io_error_is_inconclusive(
+        &SafetensorsHeaderError::Io(std::io::Error::from_raw_os_error(5))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
﻿## Summary
- Return the concrete Hugging Face snapshot directory after CLI downloads instead of the broader repo cache root.
- Treat Windows `ERROR_UNTRUSTED_MOUNT_POINT` / "untrusted mount point" failures during downloaded-model family inspection as inconclusive, not fatal.
- Add regression coverage for the Windows cache traversal classifier.

## Root Cause
After the UTF-8 fix, the model download completed and SceneWorks moved on to its optional post-download family check. Hugging Face cache snapshots can contain symlinks or Windows reparse points into the shared `blobs` directory. On some Windows configurations, opening those cache links fails with OS error 448 even though the model files are already downloaded. The family check was treating that inspection failure as a download failure.

## Validation
- `cargo fmt --package sceneworks-worker`
- `cargo test -p sceneworks-worker downloaded_model_windows -- --nocapture`
- `cargo test -p sceneworks-worker hf_cli -- --nocapture`
- `cargo test -p sceneworks-worker`
