### PR TITLE
Fix false "incomplete cache" banner for diffusers models with absent optional components

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1145,6 +1145,14 @@ fn diffusers_snapshot_health(snapshot: &FsPath) -> HuggingFaceCacheHealth {
             .and_then(|items| items.get(1))
             .and_then(Value::as_str)
             .unwrap_or_default();
+        // diffusers records optional components that the pipeline doesn't use
+        // as `[null, null]` (e.g. ChromaPipeline's `feature_extractor` and
+        // `image_encoder`). These have no directory or files on disk by design,
+        // so an empty class name means "absent" — skip it rather than reporting
+        // its config/weights as missing and marking the whole model incomplete.
+        if class_name.is_empty() {
+            continue;
+        }
         for required in required_diffusers_component_files(component, class_name) {
             if !snapshot.join(&required).is_file() {
                 missing.push(required);

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4357,6 +4357,101 @@ async fn downloadable_model_catalog_flags_incomplete_huggingface_snapshots() {
 }
 
 #[tokio::test]
+async fn downloadable_model_catalog_ignores_absent_optional_diffusers_components() {
+    // Chroma's model_index.json declares `feature_extractor` and `image_encoder`
+    // as `[null, null]` — diffusers' sentinel for optional components the pipeline
+    // doesn't use, which have no files on disk by design. The health check must
+    // not report them as missing, otherwise a fully-installed model is flagged
+    // incomplete on every platform.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "chroma1_base",
+                "name": "Chroma1-Base",
+                "type": "image",
+                "family": "chroma",
+                "downloads": [{ "provider": "huggingface", "repo": "lodestones/Chroma1-Base" }]
+              }]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    for file in [
+        "user.models.jsonc",
+        "builtin.loras.jsonc",
+        "user.loras.jsonc",
+        "builtin.recipe-presets.jsonc",
+        "user.recipe-presets.jsonc",
+    ] {
+        let key = if file.contains("preset") {
+            "presets"
+        } else if file.contains("lora") {
+            "loras"
+        } else {
+            "models"
+        };
+        std::fs::write(
+            config_dir.join(file),
+            format!(r#"{{ "schemaVersion": 1, "{key}": [] }}"#),
+        )
+        .expect("empty manifest writes");
+    }
+    let cache_dir = temp_dir
+        .path()
+        .join("data/cache/huggingface/hub/models--lodestones--Chroma1-Base/snapshots/abc123");
+    std::fs::create_dir_all(&cache_dir).expect("hf cache creates");
+    std::fs::write(
+        cache_dir.join("model_index.json"),
+        r#"{
+          "_class_name": "ChromaPipeline",
+          "feature_extractor": [null, null],
+          "image_encoder": [null, null],
+          "scheduler": ["diffusers", "FlowMatchEulerDiscreteScheduler"],
+          "text_encoder": ["transformers", "T5EncoderModel"],
+          "tokenizer": ["transformers", "T5Tokenizer"],
+          "transformer": ["diffusers", "ChromaTransformer2DModel"],
+          "vae": ["diffusers", "AutoencoderKL"]
+        }"#,
+    )
+    .expect("model index writes");
+    for (dir, file) in [
+        ("scheduler", "scheduler_config.json"),
+        ("text_encoder", "config.json"),
+        ("tokenizer", "tokenizer_config.json"),
+        ("transformer", "config.json"),
+        ("vae", "config.json"),
+    ] {
+        let component_dir = cache_dir.join(dir);
+        std::fs::create_dir_all(&component_dir).expect("component dir creates");
+        std::fs::write(component_dir.join(file), "{}").expect("component config writes");
+    }
+    for dir in ["text_encoder", "transformer", "vae"] {
+        std::fs::write(
+            cache_dir.join(dir).join("diffusion_pytorch_model.safetensors"),
+            "weights",
+        )
+        .expect("component weights write");
+    }
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["id"], "chroma1_base");
+    assert_eq!(models[0]["installState"], "installed");
+    assert_eq!(models[0]["cacheState"], "complete");
+    assert_eq!(models[0]["repairAvailable"], false);
+    assert_eq!(models[0]["missingRequiredFiles"], json!([]));
+}
+
+#[tokio::test]
 async fn model_download_job_forwards_catalog_family_for_worker_reconciliation() {
     // sc-1663: the download job must carry the catalog-declared family so the
     // worker can re-verify the downloaded weights match it (parity with import).

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4434,7 +4434,9 @@ async fn downloadable_model_catalog_ignores_absent_optional_diffusers_components
     }
     for dir in ["text_encoder", "transformer", "vae"] {
         std::fs::write(
-            cache_dir.join(dir).join("diffusion_pytorch_model.safetensors"),
+            cache_dir
+                .join(dir)
+                .join("diffusion_pytorch_model.safetensors"),
             "weights",
         )
         .expect("component weights write");


### PR DESCRIPTION
## Summary

The Model Manager's cache-completeness check was flagging fully-installed diffusers models as **incomplete** — showing the *"Cached files are incomplete: feature_extractor/&lt;weights&gt;, feature_extractor/config.json, image_encoder/&lt;weights&gt;…"* banner with a **Fix** button — even when nothing was actually missing. This was most visible on the Mac install (all three Chroma1 cards), but the root cause is platform-independent.

## Root cause

`diffusers_snapshot_health` reads `model_index.json` and validates every listed component. diffusers records optional components a pipeline doesn't use as `[null, null]` — e.g. `ChromaPipeline`'s `feature_extractor` / `image_encoder`, or `safety_checker` on many SD pipelines. These have **no directory or files on disk by design**.

The loop only skipped a component when its spec was a bare JSON `null`, **not** when it was a `[null, null]` array. So the class name resolved to `""` and fell through to the default *"needs `config.json` + weights"* rule, reporting each absent optional as missing:

```
feature_extractor/<weights>, feature_extractor/config.json, image_encoder/<weights>, image_encoder/config.json
```

Sorted + truncated to 3 = exactly the banner text. Because `[null, null]` optionals are common across diffusers pipelines, *every* affected card showed the identical message.

Confirmed against the on-disk Chroma cache: only `feature_extractor`/`image_encoder` were flagged, never `vae`/`transformer`, so the real (symlinked) components resolve fine — this is **not** a symlink/path bug.

## Why it looked fine on Windows

Same manifest (`files: []`), same `model_index.json`, same Rust code on both OSes — so this isn't a platform code path. The likely reason the Windows validation looked clean is test coverage rather than OS behavior (single-file/imported models bypass the diffusers branch; or the tested models lacked `[null, null]` optionals). The fix is platform-independent and cannot regress Windows.

## Change

`apps/rust-api/src/models.rs` — skip any component whose resolved class name is empty (the `[null, null]` "absent" sentinel) before demanding its files:

```rust
if class_name.is_empty() {
    continue;
}
```

## Tests

- New regression test `downloadable_model_catalog_ignores_absent_optional_diffusers_components` using a real Chroma-shaped `model_index.json` with `[null, null]` optionals, asserting `cacheState == "complete"`.
- `cargo clippy -p sceneworks-rust-api --all-targets` — clean
- `cargo test -p sceneworks-rust-api` — **91 passed, 0 failed**

## Reviewer notes

- No data migration or re-download needed — affected models were never actually missing files; the banner will simply stop appearing once the new detection ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)