### PR TITLE
Fix permanent "incomplete cache" for diffusers models with a *Processor component (Qwen-Image-Edit-2511)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1181,7 +1181,13 @@ fn required_diffusers_component_files(component: &str, class_name: &str) -> Vec<
     if class.contains("tokenizer") {
         return vec![format!("{component}/tokenizer_config.json")];
     }
-    if class.contains("featureextractor") || class.contains("imageprocessor") {
+    // Transformers preprocessing wrappers (feature extractors, image processors,
+    // and composite `*Processor` classes like Qwen2VLProcessor) carry no model
+    // weights and ship a `preprocessor_config.json` rather than a `config.json`.
+    // `contains("processor")` subsumes `imageprocessor` and also catches the
+    // composite processors that would otherwise fall through to the weight-bearing
+    // default and be reported as permanently missing config.json + weights.
+    if class.contains("featureextractor") || class.contains("processor") {
         return vec![format!("{component}/preprocessor_config.json")];
     }
     let component_dir = component.trim();
@@ -1198,7 +1204,7 @@ fn diffusers_component_requires_weights(component: &str, class_name: &str) -> bo
         || class.contains("scheduler")
         || class.contains("tokenizer")
         || class.contains("featureextractor")
-        || class.contains("imageprocessor"))
+        || class.contains("processor"))
 }
 
 fn diffusers_component_has_weight_file(snapshot: &FsPath, component: &str) -> bool {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4454,6 +4454,106 @@ async fn downloadable_model_catalog_ignores_absent_optional_diffusers_components
 }
 
 #[tokio::test]
+async fn downloadable_model_catalog_treats_processor_components_as_weightless() {
+    // Qwen-Image-Edit-2511's model_index.json declares a `processor`
+    // (Qwen2VLProcessor) — a transformers preprocessing wrapper that carries no
+    // model weights and ships `preprocessor_config.json` instead of `config.json`.
+    // The health check must not demand `processor/config.json` + `processor/<weights>`
+    // (which the repo never contains), otherwise a fully-installed model is flagged
+    // incomplete forever and the "Fix" download can never satisfy it.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "qwen_image_edit_2511",
+                "name": "Qwen-Image-Edit-2511",
+                "type": "image",
+                "family": "qwen-image",
+                "downloads": [{ "provider": "huggingface", "repo": "Qwen/Qwen-Image-Edit-2511" }]
+              }]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    for file in [
+        "user.models.jsonc",
+        "builtin.loras.jsonc",
+        "user.loras.jsonc",
+        "builtin.recipe-presets.jsonc",
+        "user.recipe-presets.jsonc",
+    ] {
+        let key = if file.contains("preset") {
+            "presets"
+        } else if file.contains("lora") {
+            "loras"
+        } else {
+            "models"
+        };
+        std::fs::write(
+            config_dir.join(file),
+            format!(r#"{{ "schemaVersion": 1, "{key}": [] }}"#),
+        )
+        .expect("empty manifest writes");
+    }
+    let cache_dir = temp_dir
+        .path()
+        .join("data/cache/huggingface/hub/models--Qwen--Qwen-Image-Edit-2511/snapshots/abc123");
+    std::fs::create_dir_all(&cache_dir).expect("hf cache creates");
+    std::fs::write(
+        cache_dir.join("model_index.json"),
+        r#"{
+          "_class_name": "QwenImageEditPlusPipeline",
+          "processor": ["transformers", "Qwen2VLProcessor"],
+          "scheduler": ["diffusers", "FlowMatchEulerDiscreteScheduler"],
+          "text_encoder": ["transformers", "Qwen2_5_VLForConditionalGeneration"],
+          "tokenizer": ["transformers", "Qwen2Tokenizer"],
+          "transformer": ["diffusers", "QwenImageTransformer2DModel"],
+          "vae": ["diffusers", "AutoencoderKLQwenImage"]
+        }"#,
+    )
+    .expect("model index writes");
+    // processor ships preprocessor_config.json + tokenizer files, but no
+    // config.json and no weights — exactly the real Qwen2VLProcessor layout.
+    for (dir, file) in [
+        ("processor", "preprocessor_config.json"),
+        ("scheduler", "scheduler_config.json"),
+        ("text_encoder", "config.json"),
+        ("tokenizer", "tokenizer_config.json"),
+        ("transformer", "config.json"),
+        ("vae", "config.json"),
+    ] {
+        let component_dir = cache_dir.join(dir);
+        std::fs::create_dir_all(&component_dir).expect("component dir creates");
+        std::fs::write(component_dir.join(file), "{}").expect("component config writes");
+    }
+    for dir in ["text_encoder", "transformer", "vae"] {
+        std::fs::write(
+            cache_dir
+                .join(dir)
+                .join("diffusion_pytorch_model.safetensors"),
+            "weights",
+        )
+        .expect("component weights write");
+    }
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["id"], "qwen_image_edit_2511");
+    assert_eq!(models[0]["installState"], "installed");
+    assert_eq!(models[0]["cacheState"], "complete");
+    assert_eq!(models[0]["repairAvailable"], false);
+    assert_eq!(models[0]["missingRequiredFiles"], json!([]));
+}
+
+#[tokio::test]
 async fn model_download_job_forwards_catalog_family_for_worker_reconciliation() {
     // sc-1663: the download job must carry the catalog-declared family so the
     // worker can re-verify the downloaded weights match it (parity with import).


### PR DESCRIPTION
## Summary

Follow-up to #424. A user reported that even after clicking **Fix** and re-downloading, the *"Cached files are incomplete"* banner still wouldn't clear for some models. Root cause is the same brittleness as #424 — the completeness check demands files the repo never ships — biting a second component class.

`diffusers_snapshot_health` classifies each `model_index.json` component to decide which files it requires. Composite transformers **`*Processor`** classes — e.g. **Qwen-Image-Edit-2511**'s `processor` (`Qwen2VLProcessor`) — carry **no model weights** and ship a **`preprocessor_config.json`** instead of a `config.json`. But only class names containing `featureextractor`/`imageprocessor` were special-cased, so `Qwen2VLProcessor` fell through to the weight-bearing default and the check demanded `processor/config.json` + `processor/<weights>`.

Those files don't exist in the repo, so:
- the model is reported **incomplete** forever,
- clicking **Fix** re-downloads the (already complete) snapshot,
- the phantom files still can't be satisfied → the banner never clears.

## Fix

`apps/rust-api/src/models.rs` — broaden the weightless / `preprocessor_config.json` branch to any class containing `processor` (which subsumes `imageprocessor`), in both `required_diffusers_component_files` and `diffusers_component_requires_weights`.

## Verification

Replicated the post-fix health logic against the actual on-disk HuggingFace cache (53 cached repos):
- After #424 alone: `Qwen-Image-Edit-2511` was the **only** diffusers model still flagged (`processor/config.json`, `processor/<weights>`).
- After this change: **0** diffusers models flagged incomplete. Chroma (fixed in #424) and all others remain `ok`.

Plus:
- New regression test `downloadable_model_catalog_treats_processor_components_as_weightless` using the real `Qwen2VLProcessor` layout (preprocessor_config.json + tokenizer files, no config.json, no weights), asserting `cacheState == "complete"`.
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p sceneworks-rust-api --all-targets` — clean
- `cargo test -p sceneworks-rust-api` — **92 passed, 0 failed**

## Reviewer notes

- No re-download or migration needed — these models were never actually missing files; the banner simply stops appearing once the new detection ships.
- **Known residual fragility (not addressed here):** completeness is still keyed on hardcoded per-component-class config filenames, which is what produced both #424 and this fix. A more durable approach for the weightless auxiliary components (scheduler/tokenizer/feature-extractor/processor) would be to require the component directory to exist and be non-empty rather than naming an exact file. Happy to do that as a separate hardening PR if desired — left out here to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)