### PR TITLE
Harden diffusers cache health check (eliminate phantom-file bug class)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1153,15 +1153,26 @@ fn diffusers_snapshot_health(snapshot: &FsPath) -> HuggingFaceCacheHealth {
         if class_name.is_empty() {
             continue;
         }
-        for required in required_diffusers_component_files(component, class_name) {
-            if !snapshot.join(&required).is_file() {
-                missing.push(required);
+        if diffusers_component_requires_weights(component, class_name) {
+            // Weight-bearing components (unet, transformer, vae, text_encoder,
+            // controlnet, …) reliably ship a `config.json` alongside their
+            // weight files, so require both.
+            if !snapshot.join(format!("{component}/config.json")).is_file() {
+                missing.push(format!("{component}/config.json"));
             }
-        }
-        if diffusers_component_requires_weights(component, class_name)
-            && !diffusers_component_has_weight_file(snapshot, component)
-        {
-            missing.push(format!("{component}/<weights>"));
+            if !diffusers_component_has_weight_file(snapshot, component) {
+                missing.push(format!("{component}/<weights>"));
+            }
+        } else if !diffusers_component_dir_nonempty(snapshot, component) {
+            // Weightless auxiliary components (scheduler, tokenizer, feature
+            // extractors, and image/video/composite processors) ship config
+            // files whose names vary by class — scheduler_config.json,
+            // tokenizer_config.json, preprocessor_config.json, and more. Hard
+            // coding each variant is what produced repeated false "incomplete"
+            // reports (Chroma's null optionals, Qwen2VLProcessor), so only
+            // require the component directory to exist and hold at least one
+            // file. A genuinely missing/partial component still trips this.
+            missing.push(format!("{component}/<config>"));
         }
     }
     if missing.is_empty() {
@@ -1173,31 +1184,10 @@ fn diffusers_snapshot_health(snapshot: &FsPath) -> HuggingFaceCacheHealth {
     }
 }
 
-fn required_diffusers_component_files(component: &str, class_name: &str) -> Vec<String> {
-    let class = class_name.to_ascii_lowercase();
-    if component.contains("scheduler") || class.contains("scheduler") {
-        return vec![format!("{component}/scheduler_config.json")];
-    }
-    if class.contains("tokenizer") {
-        return vec![format!("{component}/tokenizer_config.json")];
-    }
-    // Transformers preprocessing wrappers (feature extractors, image processors,
-    // and composite `*Processor` classes like Qwen2VLProcessor) carry no model
-    // weights and ship a `preprocessor_config.json` rather than a `config.json`.
-    // `contains("processor")` subsumes `imageprocessor` and also catches the
-    // composite processors that would otherwise fall through to the weight-bearing
-    // default and be reported as permanently missing config.json + weights.
-    if class.contains("featureextractor") || class.contains("processor") {
-        return vec![format!("{component}/preprocessor_config.json")];
-    }
-    let component_dir = component.trim();
-    if component_dir.is_empty() {
-        Vec::new()
-    } else {
-        vec![format!("{component_dir}/config.json")]
-    }
-}
-
+/// Classifies a diffusers `model_index.json` component as weight-bearing.
+/// Schedulers, tokenizers, feature extractors, and composite `*Processor`
+/// wrappers (e.g. Qwen2VLProcessor) carry no model weights — `contains("processor")`
+/// subsumes `imageprocessor` and the composite processors.
 fn diffusers_component_requires_weights(component: &str, class_name: &str) -> bool {
     let class = class_name.to_ascii_lowercase();
     !(component.contains("scheduler")
@@ -1205,6 +1195,15 @@ fn diffusers_component_requires_weights(component: &str, class_name: &str) -> bo
         || class.contains("tokenizer")
         || class.contains("featureextractor")
         || class.contains("processor"))
+}
+
+/// Whether a component directory exists and holds at least one file. Used as the
+/// completeness signal for weightless auxiliary components, whose config file
+/// names vary too much by class to enumerate reliably.
+fn diffusers_component_dir_nonempty(snapshot: &FsPath, component: &str) -> bool {
+    std::fs::read_dir(snapshot.join(component))
+        .map(|entries| entries.flatten().any(|entry| entry.path().is_file()))
+        .unwrap_or(false)
 }
 
 fn diffusers_component_has_weight_file(snapshot: &FsPath, component: &str) -> bool {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4553,6 +4553,141 @@ async fn downloadable_model_catalog_treats_processor_components_as_weightless() 
     assert_eq!(models[0]["missingRequiredFiles"], json!([]));
 }
 
+// Helper: write a minimal but COMPLETE set of weight-bearing components
+// (text_encoder / transformer / vae, each with config.json + a weight file) into
+// a diffusers snapshot dir, so a test can focus on a single weightless component.
+fn write_complete_weight_bearing_components(cache_dir: &std::path::Path) {
+    for dir in ["text_encoder", "transformer", "vae"] {
+        let component_dir = cache_dir.join(dir);
+        std::fs::create_dir_all(&component_dir).expect("component dir creates");
+        std::fs::write(component_dir.join("config.json"), "{}").expect("config writes");
+        std::fs::write(
+            component_dir.join("diffusion_pytorch_model.safetensors"),
+            "weights",
+        )
+        .expect("weights write");
+    }
+}
+
+fn single_model_manifest(config_dir: &std::path::Path, id: &str, repo: &str) {
+    std::fs::create_dir_all(config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        format!(
+            r#"{{ "schemaVersion": 1, "models": [{{
+                "id": "{id}", "name": "{id}", "type": "image", "family": "test",
+                "downloads": [{{ "provider": "huggingface", "repo": "{repo}" }}]
+            }}] }}"#
+        ),
+    )
+    .expect("builtin models writes");
+    for file in [
+        "user.models.jsonc",
+        "builtin.loras.jsonc",
+        "user.loras.jsonc",
+        "builtin.recipe-presets.jsonc",
+        "user.recipe-presets.jsonc",
+    ] {
+        let key = if file.contains("preset") {
+            "presets"
+        } else if file.contains("lora") {
+            "loras"
+        } else {
+            "models"
+        };
+        std::fs::write(
+            config_dir.join(file),
+            format!(r#"{{ "schemaVersion": 1, "{key}": [] }}"#),
+        )
+        .expect("empty manifest writes");
+    }
+}
+
+#[tokio::test]
+async fn downloadable_model_catalog_accepts_weightless_component_with_nonstandard_config_name() {
+    // Hardening: completeness for weightless auxiliary components is keyed on
+    // "the directory exists and holds a file", not a hard-coded config filename.
+    // A processor that ships an unexpected config name must still read complete,
+    // so future class variants can't re-trigger a permanent false "incomplete".
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    single_model_manifest(
+        &temp_dir.path().join("config/manifests"),
+        "weightless_model",
+        "owner/weightless",
+    );
+    let cache_dir = temp_dir
+        .path()
+        .join("data/cache/huggingface/hub/models--owner--weightless/snapshots/abc123");
+    std::fs::create_dir_all(&cache_dir).expect("hf cache creates");
+    std::fs::write(
+        cache_dir.join("model_index.json"),
+        r#"{
+          "_class_name": "SomePipeline",
+          "processor": ["transformers", "SomeFutureProcessor"],
+          "text_encoder": ["transformers", "T5EncoderModel"],
+          "transformer": ["diffusers", "SomeTransformer2DModel"],
+          "vae": ["diffusers", "AutoencoderKL"]
+        }"#,
+    )
+    .expect("model index writes");
+    write_complete_weight_bearing_components(&cache_dir);
+    // processor dir exists with a config whose name we do NOT special-case.
+    let processor_dir = cache_dir.join("processor");
+    std::fs::create_dir_all(&processor_dir).expect("processor dir creates");
+    std::fs::write(processor_dir.join("processor_config.json"), "{}").expect("processor config");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["cacheState"], "complete");
+    assert_eq!(models[0]["repairAvailable"], false);
+    assert_eq!(models[0]["missingRequiredFiles"], json!([]));
+}
+
+#[tokio::test]
+async fn downloadable_model_catalog_flags_empty_weightless_component_dir() {
+    // The hardening must not silently pass everything: a genuinely absent/empty
+    // weightless component directory still reports incomplete (partial download).
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    single_model_manifest(
+        &temp_dir.path().join("config/manifests"),
+        "partial_model",
+        "owner/partial",
+    );
+    let cache_dir = temp_dir
+        .path()
+        .join("data/cache/huggingface/hub/models--owner--partial/snapshots/abc123");
+    std::fs::create_dir_all(&cache_dir).expect("hf cache creates");
+    std::fs::write(
+        cache_dir.join("model_index.json"),
+        r#"{
+          "_class_name": "SomePipeline",
+          "tokenizer": ["transformers", "T5Tokenizer"],
+          "text_encoder": ["transformers", "T5EncoderModel"],
+          "transformer": ["diffusers", "SomeTransformer2DModel"],
+          "vae": ["diffusers", "AutoencoderKL"]
+        }"#,
+    )
+    .expect("model index writes");
+    write_complete_weight_bearing_components(&cache_dir);
+    // tokenizer dir is created but left EMPTY (partial download).
+    std::fs::create_dir_all(cache_dir.join("tokenizer")).expect("empty tokenizer dir");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["cacheState"], "incomplete");
+    assert_eq!(models[0]["repairAvailable"], true);
+    assert_eq!(
+        models[0]["missingRequiredFiles"],
+        json!(["tokenizer/<config>"])
+    );
+}
+
 #[tokio::test]
 async fn model_download_job_forwards_catalog_family_for_worker_reconciliation() {
     // sc-1663: the download job must carry the catalog-declared family so the


### PR DESCRIPTION
## Summary

Durable follow-up to #424 and #425. Both were the **same bug class**: the cache-completeness check hard-codes a per-component-class config filename, so any component whose config file is named differently than expected gets reported permanently *"incomplete"* — and clicking **Fix** can never satisfy it, because the demanded file doesn't exist in the repo.

- #424 — Chroma's `[null, null]` optional components (`feature_extractor`, `image_encoder`)
- #425 — Qwen-Image-Edit-2511's `processor` (`Qwen2VLProcessor`, ships `preprocessor_config.json`, not `config.json`)

Each was a one-off filename special-case. This PR removes the recurring failure mode.

## Change

In `apps/rust-api/src/models.rs`, split components into two completeness rules:

- **Weight-bearing** (unet, transformer, vae, text_encoder, controlnet, …): unchanged — require `config.json` **and** a weight file. Reliable for these classes (diffusers/transformers always write `config.json`).
- **Weightless auxiliary** (schedulers, tokenizers, feature extractors, image/video/composite processors): require only that the **component directory exists and holds at least one file**, instead of naming an exact config file. Config filenames vary too much across these classes to enumerate — that variation is exactly what produced #424 and #425.

`[null, null]` absent optionals are still skipped (from #424). The now-unused `required_diffusers_component_files` helper is removed.

## Verification

- On-disk replication against the full local HuggingFace cache: **0** diffusers models flagged incomplete — identical outcome to #425, but now robust to config-filename variation.
- New tests:
  - `..._accepts_weightless_component_with_nonstandard_config_name` — a processor shipping an unexpected config name reads **complete** (would have failed pre-hardening).
  - `..._flags_empty_weightless_component_dir` — an empty component dir still reports **incomplete** (`tokenizer/<config>`), so detection of genuine partial downloads isn't lost.
  - Existing #424/#425 completeness tests still pass.
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p sceneworks-rust-api --all-targets` — clean
- `cargo test -p sceneworks-rust-api` — **94 passed, 0 failed**

## Reviewer notes

- Behavior-preserving for every model currently in the catalog; it only widens what counts as a "complete" weightless component, plus keeps detecting genuinely empty/missing component dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)