### PR TITLE
sc-3019: Rust GPU image worker scaffold + mlx-gen link + build/CI seam

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,44 @@
+# SceneWorks workspace Cargo config.
+#
+# This file is the build seam for the native MLX inference path (epic 3018). The
+# Rust GPU worker links the `mlx-gen` engine (epic 2337) as a macOS-only Cargo
+# dependency, which builds Apple MLX from source. Two things have to be set HERE,
+# in the consuming workspace, because Cargo does NOT read a *dependency's*
+# `.cargo/config.toml` — only the config of the workspace that invokes the build.
+
+[env]
+# Build MLX at the macOS 26.2 deployment target so the Apple matrix-unit ("NAX")
+# Metal kernels both compile in AND codegen correctly. mlx-sys's build.rs floors
+# the target at macOS 14 (Metal 310), which trips MLX's kernel gate and defines
+# -DMLX_METAL_NO_NAX, omitting the fast steel_gemm_*_nax / steel_attention_nax
+# kernels -> ~2.5x slower DiT. The NAX kernels use Apple's Metal Performance
+# Primitives matrix-unit intrinsic (mpp::tensor_ops::matmul2d), which is only
+# valid for macOS >= 26.2 — at 26.0 the kernels still compile but metalfe
+# MISCOMPILES the 16-bit (bf16/f16) tensor-op to garbage. 26.2 makes them correct
+# AND fast. This MUST live in the SceneWorks workspace: if it is only in mlx-gen's
+# own config it does not travel to this consumer, NAX silently compiles out, and
+# the Mac path regresses ~2.5x. Mirrors mlx-gen/.cargo/config.toml; see sc-2772.
+#
+# NOT forced: Cargo only applies an [env] value when the variable is unset, so a
+# local/shipping build defaults to 26.2 (correct NAX), while a hosted-macOS CI job
+# can override to 15.0 by exporting MACOSX_DEPLOYMENT_TARGET=15.0 — GitHub's hosted
+# macOS runners cap at macos-15 / SDK 15 and cannot provide SDK >= 26.2. CI then
+# builds for correctness only; it cannot exercise the NAX fast path (is_nax_
+# available() is false there), so the lower target is harmless. NB: mlx-sys's
+# build.rs has no rerun-if-env-changed, so a clean rebuild of pmetal-mlx-sys is
+# required for a change here to take effect.
+MACOSX_DEPLOYMENT_TARGET = "26.2"
+
+# Heavy-recompile mitigation (the "compile MLX once" concern, epic 3018 build seam).
+# Building MLX from source is the slow part of a clean build, and a fresh git
+# worktree gets its own `target/` so it recompiles MLX from scratch. To share
+# compiled artifacts across worktrees/clean builds WITHOUT hard-requiring a tool
+# that may be absent (sccache is not installed by default, and a committed
+# `rustc-wrapper`/`target-dir` would break every machine and CI lane that lacks
+# it), this is left as an opt-in via environment rather than pinned here:
+#
+#   brew install sccache
+#   export RUSTC_WRAPPER=sccache          # caches compiled crates across target dirs
+#   export CARGO_TARGET_DIR=~/.cache/sceneworks-target   # one shared target dir
+#
+# See docs/rust-mlx-build.md.

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -1,0 +1,63 @@
+name: macOS MLX worker
+
+# Compiles the Rust GPU worker with the native MLX engine (mlx-gen, epic 2337)
+# linked in — the macOS-only build that the Linux `parity` job (check.yml) and the
+# Windows desktop job cannot exercise, because mlx-gen is gated to
+# `cfg(target_os = "macos")` and builds Apple MLX from source.
+#
+# CORRECTNESS-ONLY. GitHub's hosted macOS runners cap at macos-15 / SDK 15 and
+# cannot provide SDK >= 26.2, so this overrides the workspace 26.2 deployment-target
+# pin (/.cargo/config.toml) to 15.0. At 15.0 the NAX matrix-unit kernels compile out
+# (is_nax_available() is false), so this job verifies the link + logic but CANNOT
+# exercise or guard the NAX fast path — the `nax_guard` integration test is therefore
+# NOT run here; it requires a self-hosted macOS >= 26.2 runner to be meaningful (it
+# would only test fallback kernels at 15.0). See sc-3019 / sc-2772.
+#
+# Scoped to the isolated epic integration branch (rust-mlx-integration) + its story
+# PRs, because building MLX from source is heavy; promote to per-PR on main at cutover
+# (sc-3032) if desired. mlx-gen + its pmetal-mlx-rs fork are public, so no token is
+# needed to fetch them.
+
+on:
+  push:
+    branches:
+      - rust-mlx-integration
+    paths: &mlx_paths
+      - "crates/**"
+      - "apps/rust-worker/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/config.toml"
+      - ".github/workflows/macos-mlx.yml"
+  pull_request:
+    branches:
+      - rust-mlx-integration
+    paths: *mlx_paths
+  workflow_dispatch:
+
+concurrency:
+  group: macos-mlx-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos-worker:
+    runs-on: macos-15
+    env:
+      # Hosted runners cannot provide SDK >= 26.2; build for correctness at 15.0.
+      # The workspace [env] pin is non-forced, so this env value wins.
+      MACOSX_DEPLOYMENT_TARGET: "15.0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # MLX-from-source dominates the build; cache the shared target + git deps.
+          key: macos-mlx-worker
+      - name: Build the MLX GPU worker (mlx-gen linked)
+        run: cargo build -p sceneworks-worker
+      - name: Worker logic tests (non-MLX)
+        run: cargo test -p sceneworks-worker --lib
+      - name: Clippy (MLX worker)
+        run: cargo clippy -p sceneworks-worker --all-targets -- -D warnings

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -1,27 +1,31 @@
 name: macOS MLX worker
 
-# Compiles the Rust GPU worker with the native MLX engine (mlx-gen, epic 2337)
-# linked in — the macOS-only build that the Linux `parity` job (check.yml) and the
+# Compiles AND tests the Rust GPU worker with the native MLX engine (mlx-gen, epic
+# 2337) linked in — the macOS-only build the Linux `parity` job (check.yml) and the
 # Windows desktop job cannot exercise, because mlx-gen is gated to
 # `cfg(target_os = "macos")` and builds Apple MLX from source.
 #
-# CORRECTNESS-ONLY. GitHub's hosted macOS runners cap at macos-15 / SDK 15 and
-# cannot provide SDK >= 26.2, so this overrides the workspace 26.2 deployment-target
-# pin (/.cargo/config.toml) to 15.0. At 15.0 the NAX matrix-unit kernels compile out
-# (is_nax_available() is false), so this job verifies the link + logic but CANNOT
-# exercise or guard the NAX fast path — the `nax_guard` integration test is therefore
-# NOT run here; it requires a self-hosted macOS >= 26.2 runner to be meaningful (it
-# would only test fallback kernels at 15.0). See sc-3019 / sc-2772.
+# RUNS ON A SELF-HOSTED macOS 26.2+ RUNNER. GitHub's hosted macOS images top out well
+# below macOS 26.2, so they could only build at a lowered deployment target and could
+# NOT exercise the NAX matrix-unit fast path at all. A self-hosted 26.2+ runner builds
+# at the workspace 26.2 pin (/.cargo/config.toml — no override) and actually RUNS
+# `nax_guard`, the only way CI can guarantee the NAX 16-bit kernels are correct
+# (sc-2772 / sc-3019). It also keeps the heavy MLX-from-source build warm across runs
+# (the runner reuses its target dir), so MLX compiles once, not every run.
 #
-# Scoped to the isolated epic integration branch (rust-mlx-integration) + its story
-# PRs, because building MLX from source is heavy; promote to per-PR on main at cutover
-# (sc-3032) if desired. mlx-gen + its pmetal-mlx-rs fork are public, so no token is
-# needed to fetch them.
+# Runner prerequisites: macOS >= 26.2, full Xcode + the Metal Toolchain, a Rust
+# toolchain, registered with the `nax` label. See docs/rust-mlx-build.md.
+#
+# SECURITY: this repo is PUBLIC, and GitHub warns against running self-hosted runners
+# for public repos because a fork PR could execute arbitrary code on the runner. The
+# job-level `if:` below restricts execution to same-repo branches (the epic's story
+# branches pushed to origin), so fork PRs never run here. Keep "Require approval for
+# all external contributors' workflows" enabled in the repo Actions settings as
+# defense in depth.
 
 on:
   push:
-    branches:
-      - rust-mlx-integration
+    branches: [rust-mlx-integration]
     paths: &mlx_paths
       - "crates/**"
       - "apps/rust-worker/**"
@@ -30,8 +34,7 @@ on:
       - ".cargo/config.toml"
       - ".github/workflows/macos-mlx.yml"
   pull_request:
-    branches:
-      - rust-mlx-integration
+    branches: [rust-mlx-integration]
     paths: *mlx_paths
   workflow_dispatch:
 
@@ -40,24 +43,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-macos-worker:
-    runs-on: macos-15
-    env:
-      # Hosted runners cannot provide SDK >= 26.2; build for correctness at 15.0.
-      # The workspace [env] pin is non-forced, so this env value wins.
-      MACOSX_DEPLOYMENT_TARGET: "15.0"
+  nax-worker:
+    # Same-repo only — never execute untrusted fork code on the self-hosted runner.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: [self-hosted, macOS, ARM64, nax]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # MLX-from-source dominates the build; cache the shared target + git deps.
-          key: macos-mlx-worker
-      - name: Build the MLX GPU worker (mlx-gen linked)
+      # No MACOSX_DEPLOYMENT_TARGET override: the workspace /.cargo/config.toml pins
+      # 26.2, so the NAX kernels compile in and the fast path is actually built.
+      - name: Build the MLX GPU worker (mlx-gen linked, NAX at 26.2)
         run: cargo build -p sceneworks-worker
-      - name: Worker logic tests (non-MLX)
-        run: cargo test -p sceneworks-worker --lib
+      - name: Worker tests incl. the NAX 16-bit SDPA guard
+        run: cargo test -p sceneworks-worker
       - name: Clippy (MLX worker)
         run: cargo clippy -p sceneworks-worker --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -163,6 +165,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -172,6 +180,26 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -346,6 +374,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +397,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfb"
@@ -407,6 +453,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +480,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -504,10 +585,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -560,12 +666,60 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -583,13 +737,44 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -621,6 +806,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -809,6 +1025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +1085,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "fallible-iterator"
@@ -1350,6 +1578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1973,24 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1886,7 +2152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -1913,6 +2179,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1969,6 +2245,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach-sys"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48460c2e82a3a0de197152fdf8d2c2d5e43adc501501553e439bf2156e6f87c7"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2342,72 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlx-gen"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
+dependencies = [
+ "inventory",
+ "pmetal-mlx-rs",
+ "thiserror 2.0.18",
+ "tokenizers",
+]
+
+[[package]]
+name = "mlx-gen-z-image"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
+name = "mlx-internal-macros"
+version = "0.25.3"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=e59ffd88014340e6a49b26de95446b8b76a57932#e59ffd88014340e6a49b26de95446b8b76a57932"
+dependencies = [
+ "darling 0.21.3",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mlx-macros"
+version = "0.25.3"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=e59ffd88014340e6a49b26de95446b8b76a57932#e59ffd88014340e6a49b26de95446b8b76a57932"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2115,6 +2488,25 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2357,6 +2749,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "open"
 version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,6 +2845,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -2520,6 +2940,39 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "pmetal-mlx-rs"
+version = "0.25.8"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=e59ffd88014340e6a49b26de95446b8b76a57932#e59ffd88014340e6a49b26de95446b8b76a57932"
+dependencies = [
+ "dyn-clone",
+ "half",
+ "itertools 0.14.0",
+ "libc",
+ "mach-sys",
+ "mlx-internal-macros",
+ "mlx-macros",
+ "num-complex",
+ "num-traits",
+ "num_enum",
+ "parking_lot",
+ "paste",
+ "pmetal-mlx-sys",
+ "smallvec",
+ "strum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pmetal-mlx-sys"
+version = "0.2.4"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=e59ffd88014340e6a49b26de95446b8b76a57932#e59ffd88014340e6a49b26de95446b8b76a57932"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
 ]
 
 [[package]]
@@ -2769,6 +3222,37 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3164,7 +3648,10 @@ dependencies = [
  "axum",
  "futures-util",
  "glob",
+ "mlx-gen",
+ "mlx-gen-z-image",
  "nix",
+ "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
  "serde",
@@ -3442,7 +3929,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3627,10 +4114,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3661,6 +4166,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -4202,6 +4728,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,6 +5102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4553,6 +5121,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -22,5 +22,35 @@ uuid = { version = "1.11", features = ["v4"] }
 axum = "0.7"
 tower = { version = "0.5", features = ["util"] }
 
+# macOS NAX-presence guard (tests/nax_guard.rs): exercises a 16-bit fused SDPA op
+# directly against mlx-rs to prove the workspace .cargo/config.toml deployment-target
+# pin is in effect. Pinned to the SAME rev mlx-gen uses so Cargo builds MLX once
+# (a different rev would compile pmetal-mlx-sys twice). mlx-gen itself is already a
+# (macOS) dependency above and is usable from integration tests as-is.
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
+
+# Native MLX image+video inference engine (epic 2337), linked in-process so the
+# Rust GPU worker dispatches generation with no Python adapter/sidecar (epic 3018).
+# macOS-only: mlx-gen builds Apple MLX from source and is meaningless off Apple
+# Silicon. Git-pinned by SHA (the repo + its pmetal-mlx-rs fork are public, so this
+# resolves on Linux/Windows CI without creds and only *compiles* on macOS via the
+# target gate). The deployment-target build seam lives in /.cargo/config.toml.
+#
+# Local mlx-gen co-dev: point this at a sibling checkout via a workspace-root
+# [patch] (NOT committed — a path that is absent on CI breaks resolution):
+#   [patch."https://github.com/michaeltrefry/mlx-gen"]
+#   mlx-gen = { path = "../mlx-gen" }
+# `mlx-gen` is the core engine (load/registry/request types). Each model family
+# lives in its own provider crate that self-registers into the engine's link-time
+# `inventory` registry — the core does NOT depend on the providers, so a consumer
+# links the provider crates it serves and references each with `use … as _;`
+# (image_jobs.rs) to keep the linker from dropping the registration. Per-family
+# stories (sc-3022..3035) add their provider here; this scaffold links Z-Image
+# (sc-3022, next) to prove the cross-crate registry path end to end.
+[target.'cfg(target_os = "macos")'.dependencies]
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
+
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -4,6 +4,14 @@ pub(crate) async fn discover_gpu(requested_gpu_id: &str) -> DiscoveredGpu {
     if requested_gpu_id == "cpu" {
         return cpu_gpu();
     }
+    // Apple-Silicon native MLX GPU worker (epic 3018): an explicit `mlx` gpu id
+    // selects the in-process mlx-gen engine. Kept off the `auto`/nvidia paths so
+    // the existing macOS CPU utility worker is unaffected; the desktop launch +
+    // routing wiring that selects `mlx` lands in sc-3021/sc-3032.
+    #[cfg(target_os = "macos")]
+    if requested_gpu_id == "mlx" {
+        return mlx_gpu();
+    }
     let gpus = discover_gpus().await;
     if requested_gpu_id.is_empty() || requested_gpu_id == "auto" {
         return gpus.into_iter().next().unwrap_or_else(cpu_gpu);
@@ -138,6 +146,22 @@ pub(crate) fn cpu_gpu() -> DiscoveredGpu {
         id: "cpu".to_owned(),
         name: "Rust CPU utility worker".to_owned(),
         capabilities: vec![WorkerCapability::Placeholder, WorkerCapability::Cpu],
+        utilization: None,
+    }
+}
+
+/// The Apple-Silicon native MLX GPU worker (epic 3018): advertises `image_generate`,
+/// served in-process by the linked mlx-gen engine. `Gpu` (not `Cpu`) so the API's
+/// `worker_supports_job` lets GPU jobs route here; it deliberately does NOT carry the
+/// CPU utility capabilities, so downloads/imports/etc. still go to the CPU worker.
+/// Video + the remaining image capabilities are added as their stories land
+/// (sc-3022.. image, sc-3034.. video).
+#[cfg(target_os = "macos")]
+pub(crate) fn mlx_gpu() -> DiscoveredGpu {
+    DiscoveredGpu {
+        id: "mlx".to_owned(),
+        name: "Apple Silicon (MLX)".to_owned(),
+        capabilities: vec![WorkerCapability::Gpu, WorkerCapability::ImageGenerate],
         utilization: None,
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1,0 +1,169 @@
+//! Native MLX image generation jobs (epic 3018).
+//!
+//! On macOS the worker links the `mlx-gen` engine (epic 2337) in-process and runs
+//! generation with no Python adapter/sidecar. This scaffold (sc-3019) wires the
+//! `image_generate` dispatch + capability so a job round-trips through the Rust GPU
+//! worker and proves the engine is linked and its model registry resolves; the real
+//! `ImageRequest` DTO + asset writer land in sc-3020 and per-family inference in
+//! sc-3022.. . Off macOS the engine is absent, so the job is rejected — non-macOS
+//! workers never advertise `image_generate`, making that path unreachable in
+//! practice; it only keeps the dispatch arm cross-platform.
+
+use super::*;
+
+// Force the Z-Image provider crate to link so its `inventory::submit!` registration
+// survives linker GC: an only-declared-but-never-referenced dependency can have its
+// link-section statics dropped, taking the model registration with it. Each
+// per-family story (sc-3022..) adds its provider crate + a matching `use … as _;`
+// here. See mlx-gen-z-image/tests/registry.rs (which names "the SceneWorks worker").
+#[cfg(target_os = "macos")]
+use mlx_gen_z_image as _;
+
+/// Dispatch handler for `JobType::ImageGenerate`. The scaffold reports progress and
+/// returns a result describing the linked engine; it does not run inference yet.
+pub(crate) async fn run_image_generate_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    check_cancel(api, &job.id, "Worker canceled the image job before start.").await?;
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.1,
+            "Preparing native MLX image worker.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+
+    let result = image_generate_scaffold_result(job)?;
+
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Native MLX image worker scaffold ready (no inference yet — sc-3020/sc-3022+).",
+            None,
+            Some(result),
+            None,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// macOS: prove `mlx-gen` is linked and its link-time registry is populated.
+/// `descriptor()` reads only the `inventory` statics — it loads no weights and
+/// initializes no Metal device — so this is safe to call from the scaffold.
+#[cfg(target_os = "macos")]
+fn image_generate_scaffold_result(job: &JobSnapshot) -> WorkerResult<JsonObject> {
+    let mut registered: Vec<String> = mlx_gen::registry::generators()
+        .map(|registration| (registration.descriptor)().id.to_owned())
+        .collect();
+    registered.sort();
+    registered.dedup();
+
+    let requested_model = job
+        .payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+
+    let mut result = JsonObject::new();
+    result.insert("scaffold".to_owned(), Value::Bool(true));
+    result.insert("engine".to_owned(), Value::String("mlx-gen".to_owned()));
+    result.insert(
+        "registeredModels".to_owned(),
+        Value::Array(registered.into_iter().map(Value::String).collect()),
+    );
+    result.insert("requestedModel".to_owned(), Value::String(requested_model));
+    result.insert("completedAt".to_owned(), Value::String(now_rfc3339()));
+    Ok(result)
+}
+
+/// Non-macOS: the MLX engine is not linked. Unreachable in practice (only the macOS
+/// Apple-Silicon worker advertises `image_generate`); kept so the dispatch arm
+/// compiles on every platform.
+#[cfg(not(target_os = "macos"))]
+fn image_generate_scaffold_result(_job: &JobSnapshot) -> WorkerResult<JsonObject> {
+    Err(WorkerError::InvalidPayload(
+        "Native MLX image generation is only available on the macOS (Apple Silicon) GPU worker."
+            .to_owned(),
+    ))
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    fn image_job(model: &str) -> JobSnapshot {
+        serde_json::from_value(serde_json::json!({
+            "id": "job-img-1",
+            "type": "image_generate",
+            "status": "running",
+            "projectId": null,
+            "projectName": null,
+            "payload": { "model": model },
+            "result": {},
+            "requestedGpu": "mlx",
+            "assignedGpu": "mlx",
+            "workerId": "test-mlx-worker",
+            "progress": 0.0,
+            "stage": "preparing",
+            "message": "",
+            "error": null,
+            "etaSeconds": null,
+            "elapsedSeconds": null,
+            "attempts": 1,
+            "sourceJobId": null,
+            "duplicateOfJobId": null,
+            "cancelRequested": false,
+            "createdAt": "2026-06-05T00:00:00Z",
+            "updatedAt": "2026-06-05T00:00:00Z",
+            "startedAt": null,
+            "completedAt": null,
+            "canceledAt": null,
+            "lastHeartbeatAt": null
+        }))
+        .expect("valid image_generate job snapshot")
+    }
+
+    #[test]
+    fn scaffold_result_reports_linked_engine_and_registry() {
+        let job = image_job("z_image_turbo");
+        let result = image_generate_scaffold_result(&job).expect("scaffold result on macOS");
+        assert_eq!(
+            result.get("engine").and_then(Value::as_str),
+            Some("mlx-gen")
+        );
+        assert_eq!(result.get("scaffold").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            result.get("requestedModel").and_then(Value::as_str),
+            Some("z_image_turbo")
+        );
+        // The Z-Image provider linked into the worker self-registered via inventory:
+        // proof the cross-crate, link-time mlx-gen registry resolves inside our binary
+        // (and that the `use mlx_gen_z_image as _;` defeats linker GC of the static).
+        let registered = result
+            .get("registeredModels")
+            .and_then(Value::as_array)
+            .expect("registeredModels array");
+        assert!(
+            registered
+                .iter()
+                .any(|m| m.as_str() == Some("z_image_turbo")),
+            "expected z_image_turbo in registry, got {registered:?}"
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -41,6 +41,8 @@ mod model_jobs;
 use model_jobs::*;
 mod media_jobs;
 use media_jobs::*;
+mod image_jobs;
+use image_jobs::*;
 mod downloads;
 use downloads::*;
 
@@ -450,6 +452,12 @@ async fn run_utility_job(
         JobType::Placeholder => run_placeholder_job(api, settings, &job)
             .await
             .map_err(|error| ("Placeholder job failed.", error)),
+        // Native MLX image generation, served in-process by the linked mlx-gen
+        // engine on the macOS Apple-Silicon GPU worker (epic 3018). Off macOS the
+        // capability is never advertised, so this arm is unreachable there.
+        JobType::ImageGenerate => run_image_generate_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Image generation failed.", error)),
         JobType::ModelDownload => run_model_download_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Model download failed.", error)),

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -19,6 +19,8 @@ use super::downloads::{
     download_snapshot_into_cache, DownloadContext, DownloadProgress, HuggingFaceSnapshot,
     SnapshotFile,
 };
+#[cfg(target_os = "macos")]
+use super::gpu::mlx_gpu;
 use super::gpu::{
     cpu_gpu, cpu_worker_id, fallback_gpu, gpu_worker_id, parse_nvidia_smi_gpus, visible_gpu_ids,
     worker_capabilities_with_utility,
@@ -419,6 +421,39 @@ fn rust_cpu_capabilities_do_not_claim_gpu_generation_jobs() {
     assert!(!gpu_capabilities
         .iter()
         .any(|capability| capability.as_str() == "image_generate"));
+}
+
+/// The Apple-Silicon MLX GPU worker (epic 3018) advertises `image_generate` so the
+/// API routes generation to it, but it must NOT pick up CPU utility jobs (those stay
+/// on the CPU worker) — the inverse of the CPU-worker contract above.
+#[cfg(target_os = "macos")]
+#[test]
+fn mlx_gpu_advertises_image_generate_only() {
+    let mlx = mlx_gpu();
+    assert_eq!(mlx.id, "mlx");
+    let capabilities = worker_capabilities_with_utility(&mlx, true);
+    assert!(capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "image_generate"));
+    assert!(capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "gpu"));
+    // No CPU utility capabilities, even with utility jobs enabled — only the CPU
+    // worker (which carries `Cpu`) gets those extended onto it.
+    for utility in [
+        "model_download",
+        "model_import",
+        "timeline_export",
+        "cpu",
+        "placeholder",
+    ] {
+        assert!(
+            !capabilities
+                .iter()
+                .any(|capability| capability.as_str() == utility),
+            "MLX GPU worker should not advertise utility capability {utility}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/sceneworks-worker/tests/nax_guard.rs
+++ b/crates/sceneworks-worker/tests/nax_guard.rs
@@ -1,0 +1,110 @@
+//! NAX-presence guard for the SceneWorks workspace build seam (sc-3019, epic 3018).
+//!
+//! The native MLX path is only fast (and, for 16-bit, only *correct*) when MLX's
+//! Apple matrix-unit ("NAX") Metal kernels are compiled at a macOS 26.2-or-newer
+//! deployment target. That pin must live in the SceneWorks workspace
+//! `/.cargo/config.toml`, because Cargo does not read a dependency's config — so if
+//! the pin is removed or regressed, mlx-gen's own guard (which builds under mlx-gen's
+//! config) would NOT catch it, while this consumer-side build would silently
+//! miscompile 16-bit GEMM/SDPA to garbage (right scale, uncorrelated). This test is
+//! the loud tripwire: it exercises a 16-bit fused SDPA op against an f32 ground truth
+//! and fails when the kernels were compiled below the 26.2 floor.
+//!
+//! Mirrors `mlx-gen/mlx-gen-qwen-image/tests/sdpa_nax_repro.rs` (sc-2770/sc-2772).
+//! Needs no weights, only MLX + a Metal device, so it is gated to macOS and runs as
+//! the sole MLX-touching test in this crate (no cross-test MLX concurrency).
+
+#![cfg(target_os = "macos")]
+
+use mlx_gen::array::scalar;
+use mlx_rs::{
+    fast::scaled_dot_product_attention,
+    ops::{matmul, multiply, softmax_axis},
+    random, Array, Dtype,
+};
+
+/// Mean-absolute relative error: sum|a-b| / sum|b|, computed in f32.
+fn rel(a: &Array, b: &Array) -> f64 {
+    let n = b.shape().iter().product::<i32>();
+    let a = a.as_dtype(Dtype::Float32).unwrap().reshape(&[n]).unwrap();
+    let b = b.as_dtype(Dtype::Float32).unwrap().reshape(&[n]).unwrap();
+    let (a, b) = (a.as_slice::<f32>(), b.as_slice::<f32>());
+    let num: f64 = a.iter().zip(b).map(|(x, y)| (*x - *y).abs() as f64).sum();
+    let den: f64 = b.iter().map(|y| y.abs() as f64).sum();
+    num / den
+}
+
+/// Manual attention on logical `[1,N,L,D]`: softmax((q @ kᵀ) * scale, -1) @ v — the
+/// correct f32 reference at every dtype.
+fn manual_attn(q: &Array, k: &Array, v: &Array, scale: f32) -> Array {
+    let kt = k.transpose_axes(&[0, 1, 3, 2]).unwrap();
+    let scores = multiply(matmul(q, &kt).unwrap(), scalar(scale)).unwrap();
+    let probs = softmax_axis(&scores, -1, true).unwrap();
+    matmul(&probs, v).unwrap()
+}
+
+#[test]
+fn nax_16bit_sdpa_is_correct() {
+    let shapes = [(24i32, 64i32, 128i32), (8, 256, 64), (16, 1024, 64)];
+    let dtypes = [Dtype::Float32, Dtype::Bfloat16, Dtype::Float16];
+
+    let mut worst_16bit = 0.0f64;
+    let mut worst_f32 = 0.0f64;
+    let mut worst_manual = 0.0f64;
+
+    for (n, l, d) in shapes {
+        let scale = (d as f32).powf(-0.5);
+        let (kq, kk, kv) = (
+            random::key(0).unwrap(),
+            random::key(1).unwrap(),
+            random::key(2).unwrap(),
+        );
+        for layout in ["contiguous", "transp-view"] {
+            let (qf, kf, vf) = if layout == "contiguous" {
+                let g = |key| random::normal::<f32>(&[1, n, l, d], None, None, Some(key)).unwrap();
+                (g(&kq), g(&kk), g(&kv))
+            } else {
+                let g = |key| {
+                    random::normal::<f32>(&[1, l, n, d], None, None, Some(key))
+                        .unwrap()
+                        .transpose_axes(&[0, 2, 1, 3])
+                        .unwrap()
+                };
+                (g(&kq), g(&kk), g(&kv))
+            };
+            let gt = manual_attn(&qf, &kf, &vf, scale);
+            for dt in dtypes {
+                let (q, k, v) = (
+                    qf.as_dtype(dt).unwrap(),
+                    kf.as_dtype(dt).unwrap(),
+                    vf.as_dtype(dt).unwrap(),
+                );
+                let fast = scaled_dot_product_attention(&q, &k, &v, scale, None, None).unwrap();
+                let man = manual_attn(&q, &k, &v, scale);
+                let (r_fast, r_man) = (rel(&fast, &gt), rel(&man, &gt));
+                worst_manual = worst_manual.max(r_man);
+                if dt == Dtype::Float32 {
+                    worst_f32 = worst_f32.max(r_fast);
+                } else {
+                    worst_16bit = worst_16bit.max(r_fast);
+                }
+            }
+        }
+    }
+
+    assert!(
+        worst_manual < 0.05,
+        "manual softmax(q·kᵀ)·v reference diverged ({worst_manual:.4} ≥ 0.05) — the f32 ground \
+         truth is unreliable; re-characterize before trusting the fast-SDPA verdict."
+    );
+    assert!(
+        worst_f32 < 0.05,
+        "f32 fast SDPA diverged ({worst_f32:.4} ≥ 0.05) — the NAX f32 attention path regressed."
+    );
+    assert!(
+        worst_16bit < 0.05,
+        "NAX 16-bit fast SDPA is GARBAGE ({worst_16bit:.4} ≥ 0.05): the metal kernels were compiled \
+         below the macOS 26.2 NAX floor. Verify MACOSX_DEPLOYMENT_TARGET >= 26.2 in the SceneWorks \
+         workspace /.cargo/config.toml (a clean rebuild of pmetal-mlx-sys is needed after a change)."
+    );
+}

--- a/docs/rust-mlx-build.md
+++ b/docs/rust-mlx-build.md
@@ -1,0 +1,72 @@
+# Building the native MLX Rust GPU worker (macOS)
+
+The Rust GPU worker (`crates/sceneworks-worker`) links the [`mlx-gen`](https://github.com/michaeltrefry/mlx-gen)
+engine (epic 2337) as a `cfg(target_os = "macos")` Cargo dependency and runs image
+(and, later, video) generation **in-process** — no Python adapter, no sidecar venv,
+no subprocess. This is the consumer side of epic 3018.
+
+`mlx-gen` and its `mlx-rs` fork are **public**, git-pinned by SHA, so Linux and
+Windows builds *resolve* them but never *compile* them (the target gate excludes
+them). Only macOS compiles MLX from source.
+
+## Requirements (macOS only)
+
+- **macOS 26.2 or newer** at runtime for the NAX fast path (Apple matrix-unit
+  kernels). The app's runtime floor is pinned at cutover (sc-3032).
+- **Full Xcode + the Metal Toolchain** (`xcode-select -p` must point at Xcode, not
+  the Command Line Tools; `xcrun --find metal` must resolve).
+- A recent stable Rust toolchain (`rust-toolchain.toml` pins `stable`).
+
+## The deployment-target build seam
+
+`/.cargo/config.toml` pins `MACOSX_DEPLOYMENT_TARGET = "26.2"`. This **must** live in
+the SceneWorks workspace: Cargo does not read a dependency's `.cargo/config.toml`, so
+mlx-gen's own 26.2 pin does not travel to this consumer. If the pin is missing, MLX's
+`mlx-sys` build.rs floors the target at macOS 14, the NAX kernels compile out
+(`-DMLX_METAL_NO_NAX`), and the Mac path regresses ~2.5×. Worse, at 26.0 the 16-bit
+kernels miscompile to garbage. The `nax_guard` integration test is the loud tripwire
+for a slip:
+
+```sh
+cargo test -p sceneworks-worker --test nax_guard -- --nocapture   # needs macOS >= 26.2
+```
+
+The pin is **not forced**, so CI (and you, locally) can override it via the
+environment — GitHub's hosted macOS runners cap at SDK 15:
+
+```sh
+MACOSX_DEPLOYMENT_TARGET=15.0 cargo build -p sceneworks-worker   # correctness-only, no NAX
+```
+
+> Note: `mlx-sys`'s build.rs has no `rerun-if-env-changed`, so changing the
+> deployment target needs a clean rebuild of `pmetal-mlx-sys` to take effect.
+
+## Heavy-recompile mitigation (compile MLX once)
+
+Building MLX from source is the slow part of a clean build, and a fresh git worktree
+gets its own `target/`, recompiling MLX from scratch. To share compiled artifacts
+across worktrees/clean builds, opt in via the environment (not pinned in the committed
+config, so machines/CI lanes without the tool are unaffected):
+
+```sh
+brew install sccache
+export RUSTC_WRAPPER=sccache
+export CARGO_TARGET_DIR=~/.cache/sceneworks-target
+```
+
+## Local mlx-gen co-development
+
+The dependency is git-pinned by SHA. To iterate against a local checkout without the
+push-and-bump cycle, add a workspace-root `[patch]` (do **not** commit it — a path
+that is absent on CI breaks resolution):
+
+```toml
+# Cargo.toml (workspace root), local only
+[patch."https://github.com/michaeltrefry/mlx-gen"]
+mlx-gen = { path = "../mlx-gen" }
+mlx-gen-z-image = { path = "../mlx-gen/mlx-gen-z-image" }
+```
+
+When a co-dev change lands in mlx-gen, bump the `rev` in
+`crates/sceneworks-worker/Cargo.toml` (and the matching `mlx-rs` rev in
+`[dev-dependencies]`) to the new SHA and drop the patch.

--- a/docs/rust-mlx-build.md
+++ b/docs/rust-mlx-build.md
@@ -31,8 +31,9 @@ for a slip:
 cargo test -p sceneworks-worker --test nax_guard -- --nocapture   # needs macOS >= 26.2
 ```
 
-The pin is **not forced**, so CI (and you, locally) can override it via the
-environment — GitHub's hosted macOS runners cap at SDK 15:
+The pin is **not forced**, so you (or a hosted-runner lane that cannot provide the
+26.2 SDK) can override it via the environment. This only buys a correctness build —
+the NAX fast path is not present:
 
 ```sh
 MACOSX_DEPLOYMENT_TARGET=15.0 cargo build -p sceneworks-worker   # correctness-only, no NAX
@@ -40,6 +41,37 @@ MACOSX_DEPLOYMENT_TARGET=15.0 cargo build -p sceneworks-worker   # correctness-o
 
 > Note: `mlx-sys`'s build.rs has no `rerun-if-env-changed`, so changing the
 > deployment target needs a clean rebuild of `pmetal-mlx-sys` to take effect.
+
+## CI: the self-hosted NAX runner
+
+The macOS lane (`.github/workflows/macos-mlx.yml`) runs on a **self-hosted macOS
+26.2+ runner**, not a GitHub-hosted one. GitHub's hosted macOS images top out well
+below macOS 26.2, so they can only build at a lowered deployment target and **cannot
+exercise NAX at all** — which defeats the purpose. A self-hosted 26.2+ runner builds
+at the workspace 26.2 pin and actually *runs* `nax_guard`, so CI guards the NAX fast
+path. It also keeps the heavy MLX build warm across runs.
+
+Register this machine (or a dedicated 26.2+ Mac) as the runner — it needs full Xcode +
+the Metal Toolchain + a Rust toolchain:
+
+```sh
+TOKEN=$(gh api -X POST repos/michaeltrefry/SceneWorks/actions/runners/registration-token --jq .token)
+mkdir actions-runner && cd actions-runner
+curl -fsSL -o runner.tar.gz https://github.com/actions/runner/releases/download/v2.334.0/actions-runner-osx-arm64-2.334.0.tar.gz
+tar xzf runner.tar.gz
+./config.sh --url https://github.com/michaeltrefry/SceneWorks --token "$TOKEN" --labels nax --name nax-macos
+./run.sh                       # foreground; or install as a launchd service:
+# ./svc.sh install && ./svc.sh start
+```
+
+The workflow's `runs-on: [self-hosted, macOS, ARM64, nax]` targets exactly that
+`nax` label, so an older self-hosted Mac never picks up the NAX-requiring job.
+
+> **Public-repo security:** this repo is public, and GitHub warns against self-hosted
+> runners on public repos because a fork PR can run arbitrary code on the runner. The
+> workflow's job-level `if:` restricts execution to same-repo branches (the epic's
+> story branches), and "Require approval for all external contributors' workflows"
+> should stay on in the repo Actions settings.
 
 ## Heavy-recompile mitigation (compile MLX once)
 


### PR DESCRIPTION
**Epic [3018](https://app.shortcut.com/trefry/epic/3018) · Foundations #1 · story [sc-3019](https://app.shortcut.com/trefry/story/3019)** — base branch is `rust-mlx-integration` per the epic branch strategy (NOT `main`).

Stands up the macOS Rust GPU image worker: links the `mlx-gen` engine (epic 2337) in-process and wires the `image_generate` dispatch + capability so a job round-trips through the Rust worker. **No real inference yet** — that's sc-3020 (runtime DTO/asset writer) and sc-3022+ (families).

### What's here
- **Build seam** — workspace `/.cargo/config.toml` pins `MACOSX_DEPLOYMENT_TARGET = "26.2"` (un-forced, so a hosted-macOS CI job overrides to 15.0). This *must* live in the consuming workspace: Cargo doesn't read a dependency's config, so without it the NAX matrix-unit kernels compile out (~2.5× regression) or, at 26.0, miscompile 16-bit to garbage. **Verified live**: the MLX build linked the NAX kernels at `-platform_version macos 26.2.0`, and `nax_guard` confirms 16-bit SDPA is numerically correct.
- **Engine link** — `mlx-gen` + `mlx-gen-z-image` as `[target.'cfg(target_os="macos")'.dependencies]`, git-pinned by SHA. Both repos are public, so Linux/Windows CI *resolve* the manifests but never *compile* MLX (target gate). `image_jobs.rs` does `use mlx_gen_z_image as _;` so the provider's `inventory` registration survives linker GC.
- **Dispatch + capability** — `JobType::ImageGenerate` arm → `image_jobs::run_image_generate_job`; `gpu.rs` advertises `WorkerCapability::ImageGenerate` via a new Apple-Silicon `mlx` gpu id. `cpu`/`auto`/nvidia behavior unchanged; the MLX worker carries no CPU-utility capabilities.
- **Tests** — `tests/nax_guard.rs` (mirrors mlx-gen `sdpa_nax_repro`), `mlx_gpu` capability advertisement, and a scaffold round-trip proving the cross-crate registry resolves inside the worker binary.
- **CI** — conservative `macos-mlx.yml` (override target 15.0, scoped to `rust-mlx-integration` + its PRs + dispatch; correctness-only, can't exercise NAX on hosted runners). Linux/Windows lanes unaffected. Plus `docs/rust-mlx-build.md`.

### Validation (macOS 26.5, M-series)
- `cargo build -p sceneworks-worker` ✅ (MLX from source, NAX at 26.2)
- `npm run rust:check` ✅ (fmt + clippy `-D warnings` + all test binaries 0-failed + build) — superset of Linux CI
- `nax_16bit_sdpa_is_correct` ✅, `mlx_gpu_advertises_image_generate_only` ✅, `scaffold_result_reports_linked_engine_and_registry` ✅

### Validation gaps / notes
- The `macos-mlx.yml` workflow is **unverified until it first runs on GitHub** (no local hosted-macOS runner). Per-PR MLX-from-source builds are expensive and hosted runners can't exercise NAX — flagged for a call on per-PR vs. manual/scheduled.
- Scope reduction vs. the story text: `JobType::ImageGenerate` + `WorkerCapability::ImageGenerate` already existed in `contracts.rs` (the Python GPU worker contract), so no enum work was needed.
- The Tauri `minimumSystemVersion` 11.0→26.2 runtime-floor bump stays in sc-3032 (its planned home) to avoid breaking desktop testing on this isolated branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)