### PR TITLE
sc-3020: image-job runtime — ImageRequest DTO + streaming asset facts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +1916,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2427,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3104,6 +3133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,6 +3683,7 @@ dependencies = [
  "axum",
  "futures-util",
  "glob",
+ "image",
  "mlx-gen",
  "mlx-gen-z-image",
  "nix",

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -1,0 +1,276 @@
+//! The image-generation job request (epic 3018, sc-3020).
+//!
+//! Parses a job `payload` into a typed request, mirroring the Python worker's
+//! `image_request_from_job` (apps/worker/scene_worker/image_adapters.py) so the
+//! native MLX Rust worker reads the same payload the UI already sends. The `advanced`
+//! and `model_manifest_entry` maps pass through verbatim (they carry per-family knobs
+//! like steps/guidanceScale/mlxQuantize/poses/angleSet/controlScale/referenceStrength
+//! and the resolved model manifest entry), so adding a family needs no DTO change.
+
+use serde_json::Value;
+
+use crate::contracts::JsonObject;
+
+/// Default model when the payload omits one (matches the Python worker).
+const DEFAULT_MODEL: &str = "z_image_turbo";
+const DEFAULT_MODE: &str = "text_to_image";
+const DEFAULT_STYLE_PRESET: &str = "cinematic";
+const DEFAULT_FIT_MODE: &str = "crop";
+const FIT_MODES: [&str; 4] = ["crop", "pad", "outpaint", "stretch"];
+
+/// A typed image-generation request, parsed from a job payload.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImageRequest {
+    pub project_id: String,
+    pub mode: String,
+    pub prompt: String,
+    pub negative_prompt: String,
+    pub model: String,
+    /// Number of images, clamped to 1..=8.
+    pub count: u32,
+    /// Base seed (per-image seeds in `seeds` take precedence).
+    pub seed: Option<i64>,
+    /// Explicit per-image seeds.
+    pub seeds: Vec<i64>,
+    /// Output dimensions, clamped to 256..=4096.
+    pub width: u32,
+    pub height: u32,
+    pub style_preset: String,
+    /// LoRA specs, passed through verbatim (shape resolved per family).
+    pub loras: Vec<Value>,
+    pub character_id: Option<String>,
+    pub character_look_id: Option<String>,
+    pub source_asset_id: Option<String>,
+    pub reference_asset_id: Option<String>,
+    pub mask_asset_id: Option<String>,
+    /// One of crop/pad/outpaint/stretch (default crop).
+    pub fit_mode: String,
+    /// The resolved model manifest entry (repo/quant/limits/…), passed through.
+    pub model_manifest_entry: JsonObject,
+    /// Per-family advanced knobs (steps, guidanceScale, mlxQuantize, …), passed through.
+    pub advanced: JsonObject,
+}
+
+impl ImageRequest {
+    /// Parse a job payload (the `payload` object of a `JobSnapshot`). Infallible:
+    /// missing fields fall back to the Python defaults and `project_id` may be empty
+    /// — the caller validates it is present (the worker rejects an empty project id).
+    pub fn from_payload(payload: &JsonObject) -> Self {
+        Self {
+            project_id: string_or(payload, "projectId", ""),
+            mode: nonempty_string_or(payload, "mode", DEFAULT_MODE),
+            prompt: string_or(payload, "prompt", ""),
+            negative_prompt: string_or(payload, "negativePrompt", ""),
+            model: nonempty_string_or(payload, "model", DEFAULT_MODEL),
+            count: clamped_u32(payload, "count", 4, 1, 8),
+            seed: optional_i64(payload, "seed"),
+            seeds: int_array(payload, "seeds"),
+            width: clamped_u32(payload, "width", 1024, 256, 4096),
+            height: clamped_u32(payload, "height", 1024, 256, 4096),
+            style_preset: nonempty_string_or(payload, "stylePreset", DEFAULT_STYLE_PRESET),
+            loras: array_or_empty(payload, "loras"),
+            character_id: optional_id(payload, "characterId"),
+            character_look_id: optional_id(payload, "characterLookId"),
+            source_asset_id: optional_id(payload, "sourceAssetId"),
+            reference_asset_id: optional_id(payload, "referenceAssetId"),
+            mask_asset_id: optional_id(payload, "maskAssetId"),
+            fit_mode: normalize_fit_mode(payload.get("fitMode").and_then(Value::as_str)),
+            model_manifest_entry: object_or_empty(payload, "modelManifestEntry"),
+            advanced: object_or_empty(payload, "advanced"),
+        }
+    }
+
+    /// The resolved seed for image `index`: an explicit per-image seed wins, else the
+    /// base seed offset by the index (so a multi-image batch from one seed differs),
+    /// else `None` (the generator picks a random seed and records it).
+    pub fn seed_for(&self, index: usize) -> Option<i64> {
+        if let Some(seed) = self.seeds.get(index) {
+            return Some(*seed);
+        }
+        self.seed.map(|base| base.wrapping_add(index as i64))
+    }
+}
+
+fn string_or(payload: &JsonObject, key: &str, default: &str) -> String {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or(default)
+        .to_owned()
+}
+
+/// Like `string_or` but a present-but-empty value also falls back to the default
+/// (matches the Python `.get(key, default)` where the UI never sends an empty model).
+fn nonempty_string_or(payload: &JsonObject, key: &str, default: &str) -> String {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_owned()
+}
+
+fn optional_id(payload: &JsonObject, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+/// Read an int that may arrive as a JSON number or a numeric string, clamp to
+/// `[min, max]`, default when absent/unparseable.
+fn clamped_u32(payload: &JsonObject, key: &str, default: u32, min: u32, max: u32) -> u32 {
+    payload
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or(default)
+        .clamp(min, max)
+}
+
+fn optional_i64(payload: &JsonObject, key: &str) -> Option<i64> {
+    payload.get(key).and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    })
+}
+
+fn int_array(payload: &JsonObject, key: &str) -> Vec<i64> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| {
+                    value
+                        .as_i64()
+                        .or_else(|| value.as_str()?.trim().parse().ok())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn array_or_empty(payload: &JsonObject, key: &str) -> Vec<Value> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn object_or_empty(payload: &JsonObject, key: &str) -> JsonObject {
+    payload
+        .get(key)
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn normalize_fit_mode(value: Option<&str>) -> String {
+    let normalized = value
+        .unwrap_or(DEFAULT_FIT_MODE)
+        .trim()
+        .to_ascii_lowercase();
+    if FIT_MODES.contains(&normalized.as_str()) {
+        normalized
+    } else {
+        DEFAULT_FIT_MODE.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload(value: Value) -> JsonObject {
+        value.as_object().cloned().unwrap()
+    }
+
+    #[test]
+    fn defaults_when_payload_is_minimal() {
+        let request = ImageRequest::from_payload(&payload(json!({ "projectId": "proj_1" })));
+        assert_eq!(request.project_id, "proj_1");
+        assert_eq!(request.mode, "text_to_image");
+        assert_eq!(request.model, "z_image_turbo");
+        assert_eq!(request.count, 4);
+        assert_eq!(request.width, 1024);
+        assert_eq!(request.height, 1024);
+        assert_eq!(request.style_preset, "cinematic");
+        assert_eq!(request.fit_mode, "crop");
+        assert_eq!(request.prompt, "");
+        assert!(request.seed.is_none());
+        assert!(request.seeds.is_empty());
+        assert!(request.loras.is_empty());
+        assert!(request.advanced.is_empty());
+    }
+
+    #[test]
+    fn clamps_count_and_dimensions() {
+        let request = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p", "count": 99, "width": 10, "height": 99999
+        })));
+        assert_eq!(request.count, 8);
+        assert_eq!(request.width, 256);
+        assert_eq!(request.height, 4096);
+
+        let low = ImageRequest::from_payload(&payload(json!({ "projectId": "p", "count": 0 })));
+        assert_eq!(low.count, 1);
+    }
+
+    #[test]
+    fn reads_numeric_strings_and_seeds() {
+        let request = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p", "count": "3", "seed": "42", "seeds": [1, "2", null, 3]
+        })));
+        assert_eq!(request.count, 3);
+        assert_eq!(request.seed, Some(42));
+        assert_eq!(request.seeds, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn seed_for_prefers_explicit_then_offsets_base() {
+        let explicit = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p", "seed": 100, "seeds": [7, 8]
+        })));
+        assert_eq!(explicit.seed_for(0), Some(7));
+        assert_eq!(explicit.seed_for(1), Some(8));
+        // No explicit seed at index 2 -> base + index.
+        assert_eq!(explicit.seed_for(2), Some(102));
+
+        let none = ImageRequest::from_payload(&payload(json!({ "projectId": "p" })));
+        assert_eq!(none.seed_for(0), None);
+    }
+
+    #[test]
+    fn normalizes_fit_mode_and_passes_through_maps() {
+        let request = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p",
+            "fitMode": "OUTPAINT",
+            "advanced": { "steps": 8, "mlxQuantize": 8 },
+            "modelManifestEntry": { "family": "z-image", "repo": "x" },
+            "loras": [{ "path": "a.safetensors", "weight": 0.8 }]
+        })));
+        assert_eq!(request.fit_mode, "outpaint");
+        assert_eq!(request.advanced.get("steps"), Some(&json!(8)));
+        assert_eq!(
+            request.model_manifest_entry.get("family"),
+            Some(&json!("z-image"))
+        );
+        assert_eq!(request.loras.len(), 1);
+
+        let bogus =
+            ImageRequest::from_payload(&payload(json!({ "projectId": "p", "fitMode": "weird" })));
+        assert_eq!(bogus.fit_mode, "crop");
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod character_store;
 pub mod contracts;
 pub mod credentials;
 pub mod hf_home;
+pub mod image_request;
 pub mod jobs_store;
 pub mod lora_family;
 pub mod lora_url;

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 [dependencies]
 futures-util = "0.3"
 glob = "0.3"
+# PNG encoding for generated image assets (epic 3018, sc-3020). png-only keeps the
+# dependency small and cross-platform (the image-job pipeline + its tests run on every
+# platform; only real MLX inference is macOS-gated).
+image = { version = "0.25", default-features = false, features = ["png"] }
 nix = { version = "0.29", default-features = false, features = ["process", "signal"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1,169 +1,444 @@
-//! Native MLX image generation jobs (epic 3018).
+//! Native MLX image generation jobs — runtime pipeline (epic 3018, sc-3020).
 //!
-//! On macOS the worker links the `mlx-gen` engine (epic 2337) in-process and runs
-//! generation with no Python adapter/sidecar. This scaffold (sc-3019) wires the
-//! `image_generate` dispatch + capability so a job round-trips through the Rust GPU
-//! worker and proves the engine is linked and its model registry resolves; the real
-//! `ImageRequest` DTO + asset writer land in sc-3020 and per-family inference in
-//! sc-3022.. . Off macOS the engine is absent, so the job is rejected — non-macOS
-//! workers never advertise `image_generate`, making that path unreachable in
-//! practice; it only keeps the dispatch arm cross-platform.
+//! Parses the job into an [`ImageRequest`], generates `count` images, saves each PNG
+//! into the project's `assets/images/`, and reports flat "facts" the Rust API turns
+//! into indexed assets. The API's `persist_reported_assets` (apps/rust-api jobs.rs)
+//! runs on EVERY progress update — idempotently building each sidecar via
+//! `build_image_sidecar_parts` and indexing project.db — so emitting the accumulating
+//! `assetWrites` per image is what streams results into the gallery as they land.
+//!
+//! sc-3020 ships the pipeline with a **procedural stub** generator (adapter
+//! `procedural_preview`); sc-3022 swaps the stub for real Z-Image inference via the
+//! linked mlx-gen engine. The stub keeps this whole path cross-platform-testable.
 
 use super::*;
+use sceneworks_core::image_request::ImageRequest;
 
 // Force the Z-Image provider crate to link so its `inventory::submit!` registration
-// survives linker GC: an only-declared-but-never-referenced dependency can have its
-// link-section statics dropped, taking the model registration with it. Each
-// per-family story (sc-3022..) adds its provider crate + a matching `use … as _;`
-// here. See mlx-gen-z-image/tests/registry.rs (which names "the SceneWorks worker").
+// survives linker GC (an only-declared dependency can be dropped). Each per-family
+// story adds its provider + a matching `use … as _;`. See mlx-gen-z-image/tests/
+// registry.rs ("the SceneWorks worker"). Real inference lands in sc-3022.
 #[cfg(target_os = "macos")]
 use mlx_gen_z_image as _;
 
-/// Dispatch handler for `JobType::ImageGenerate`. The scaffold reports progress and
-/// returns a result describing the linked engine; it does not run inference yet.
+/// The stub adapter id recorded on generated assets (matches the contract fixture
+/// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
+const STUB_ADAPTER: &str = "procedural_preview";
+
+/// Dispatch handler for `JobType::ImageGenerate`: generate, save, and stream image
+/// assets through the Rust GPU worker.
 pub(crate) async fn run_image_generate_job(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
-    check_cancel(api, &job.id, "Worker canceled the image job before start.").await?;
+    let request = ImageRequest::from_payload(&job.payload);
+    if request.project_id.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Missing payload.projectId".to_owned(),
+        ));
+    }
+    let project =
+        ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
+    let project_path = PathBuf::from(project.path);
+    tokio::fs::create_dir_all(project_path.join("assets").join("images")).await?;
+
+    let plan = ImagePlan::new(&request);
+    let backend = backend_label(&settings.gpu_id);
+
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     update_job(
         api,
         &job.id,
-        progress_payload(
+        image_progress(
             JobStatus::Preparing,
             ProgressStage::Preparing,
-            0.1,
-            "Preparing native MLX image worker.",
+            0.05,
+            &format!("Preparing {} image(s) ({STUB_ADAPTER}).", request.count),
             None,
-            None,
-            None,
+            backend,
         ),
     )
     .await?;
 
-    let result = image_generate_scaffold_result(job)?;
+    let mut asset_writes: Vec<Value> = Vec::with_capacity(request.count as usize);
+    for index in 0..request.count as usize {
+        check_cancel(api, &job.id, "Image generation canceled by user.").await?;
+        let fact = render_and_save(&plan, index, &project_path)?;
+        asset_writes.push(Value::Object(fact));
+        let progress = 0.1 + 0.85 * ((index + 1) as f64 / request.count as f64);
+        update_job(
+            api,
+            &job.id,
+            image_progress(
+                JobStatus::Running,
+                ProgressStage::Generating,
+                progress,
+                &format!("Generated image {}/{}.", index + 1, request.count),
+                Some(streaming_result(&plan, &asset_writes)),
+                backend,
+            ),
+        )
+        .await?;
+        heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    }
 
     update_job(
         api,
         &job.id,
-        progress_payload(
+        image_progress(
             JobStatus::Completed,
             ProgressStage::Completed,
             1.0,
-            "Native MLX image worker scaffold ready (no inference yet — sc-3020/sc-3022+).",
-            None,
-            Some(result),
-            None,
+            &format!("Generated {} image(s).", request.count),
+            Some(streaming_result(&plan, &asset_writes)),
+            backend,
         ),
     )
     .await?;
     Ok(())
 }
 
-/// macOS: prove `mlx-gen` is linked and its link-time registry is populated.
-/// `descriptor()` reads only the `inventory` statics — it loads no weights and
-/// initializes no Metal device — so this is safe to call from the scaffold.
-#[cfg(target_os = "macos")]
-fn image_generate_scaffold_result(job: &JobSnapshot) -> WorkerResult<JsonObject> {
-    let mut registered: Vec<String> = mlx_gen::registry::generators()
-        .map(|registration| (registration.descriptor)().id.to_owned())
-        .collect();
-    registered.sort();
-    registered.dedup();
+/// Per-job invariants shared across every image in the generation set.
+struct ImagePlan {
+    request: ImageRequest,
+    genset_id: String,
+    created_at: String,
+    family: String,
+    slug: String,
+    generation_set: Value,
+}
 
-    let requested_model = job
-        .payload
-        .get("model")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_owned();
+impl ImagePlan {
+    fn new(request: &ImageRequest) -> Self {
+        let genset_id = format!("genset_{}", Uuid::new_v4().simple());
+        let created_at = now_rfc3339();
+        let family = resolve_family(request);
+        let slug = slugify(&request.prompt, "image", Some(42));
+        let generation_set = json!({
+            "id": genset_id,
+            "mode": request.mode,
+            "model": request.model,
+            "prompt": request.prompt,
+            "negativePrompt": request.negative_prompt,
+            "count": request.count,
+            "createdAt": created_at,
+        });
+        Self {
+            request: request.clone(),
+            genset_id,
+            created_at,
+            family,
+            slug,
+            generation_set,
+        }
+    }
+}
 
-    let mut result = JsonObject::new();
-    result.insert("scaffold".to_owned(), Value::Bool(true));
-    result.insert("engine".to_owned(), Value::String("mlx-gen".to_owned()));
-    result.insert(
-        "registeredModels".to_owned(),
-        Value::Array(registered.into_iter().map(Value::String).collect()),
+/// Render image `index`, save its PNG under `assets/images/`, and return the flat
+/// fact the API turns into an indexed asset (every key here is consumed by
+/// `build_image_sidecar_parts`). The stub fills a deterministic per-seed gradient.
+fn render_and_save(
+    plan: &ImagePlan,
+    index: usize,
+    project_path: &Path,
+) -> WorkerResult<JsonObject> {
+    let request = &plan.request;
+    let seed = request.seed_for(index).unwrap_or_else(random_seed);
+    let pixels = stub_rgb8(request.width, request.height, seed);
+    let rgb_image = image::RgbImage::from_raw(request.width, request.height, pixels)
+        .ok_or_else(|| WorkerError::InvalidPayload("image buffer size mismatch".to_owned()))?;
+
+    let filename = format!(
+        "{}_{}_{}_{:04}.png",
+        &plan.created_at[..10],
+        request.model,
+        plan.slug,
+        index + 1
     );
-    result.insert("requestedModel".to_owned(), Value::String(requested_model));
-    result.insert("completedAt".to_owned(), Value::String(now_rfc3339()));
-    Ok(result)
+    let media_rel = format!("assets/images/{filename}");
+    let media_path = project_path.join(&media_rel);
+    let temp_path = media_path.with_extension("tmp.png");
+    rgb_image
+        .save_with_format(&temp_path, image::ImageFormat::Png)
+        .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
+    std::fs::rename(&temp_path, &media_path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&temp_path);
+    })?;
+
+    let title: String = request.prompt.chars().take(56).collect();
+    let title = title.trim();
+    let display_name = format!(
+        "{} #{}",
+        if title.is_empty() {
+            "Generated image"
+        } else {
+            title
+        },
+        index + 1
+    );
+
+    let mut raw_settings = request.advanced.clone();
+    // Honest marker: this is the procedural stub, not real model inference (sc-3022
+    // sets realModelInference:true + repo/steps/guidance/mlxQuantize).
+    raw_settings.insert("realModelInference".to_owned(), Value::Bool(false));
+    raw_settings.insert("adapter".to_owned(), Value::String(STUB_ADAPTER.to_owned()));
+
+    let fact = json!({
+        "assetId": fresh_asset_id(),
+        "type": "image",
+        "mediaPath": media_rel,
+        "mimeType": "image/png",
+        "width": request.width,
+        "height": request.height,
+        "normalizedWidth": request.width,
+        "normalizedHeight": request.height,
+        "count": request.count,
+        "family": plan.family,
+        "seed": seed,
+        "index": index,
+        "displayName": display_name,
+        "createdAt": now_rfc3339(),
+        "mode": request.mode,
+        "model": request.model,
+        "adapter": STUB_ADAPTER,
+        "prompt": request.prompt,
+        "negativePrompt": request.negative_prompt,
+        "loras": request.loras,
+        "stylePreset": request.style_preset,
+        "characterId": request.character_id,
+        "characterLookId": request.character_look_id,
+        "sourceAssetId": request.source_asset_id,
+        "rawAdapterSettings": raw_settings,
+    });
+    Ok(fact.as_object().cloned().expect("json! object literal"))
 }
 
-/// Non-macOS: the MLX engine is not linked. Unreachable in practice (only the macOS
-/// Apple-Silicon worker advertises `image_generate`); kept so the dispatch arm
-/// compiles on every platform.
-#[cfg(not(target_os = "macos"))]
-fn image_generate_scaffold_result(_job: &JobSnapshot) -> WorkerResult<JsonObject> {
-    Err(WorkerError::InvalidPayload(
-        "Native MLX image generation is only available on the macOS (Apple Silicon) GPU worker."
-            .to_owned(),
-    ))
+/// The job-result shape the API streams from: `assetWrites` + the `generationSet`
+/// fact drive `persist_reported_assets` (idempotent per progress update).
+fn streaming_result(plan: &ImagePlan, asset_writes: &[Value]) -> JsonObject {
+    json!({
+        "generationSetId": plan.genset_id,
+        "expectedCount": plan.request.count,
+        "adapter": STUB_ADAPTER,
+        "model": plan.request.model,
+        "generationSet": plan.generation_set,
+        "assetWrites": asset_writes,
+    })
+    .as_object()
+    .cloned()
+    .expect("json! object literal")
 }
 
-#[cfg(all(test, target_os = "macos"))]
+/// The asset `family` for the recipe's normalizedSettings: the resolved model
+/// manifest entry wins (the UI sends it), else the linked mlx-gen descriptor's family
+/// on macOS, else empty.
+fn resolve_family(request: &ImageRequest) -> String {
+    if let Some(family) = request
+        .model_manifest_entry
+        .get("family")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return family.to_owned();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(family) = mlx_gen::registry::generators()
+            .find(|registration| (registration.descriptor)().id == request.model)
+            .map(|registration| (registration.descriptor)().family)
+        {
+            return family.to_owned();
+        }
+    }
+    String::new()
+}
+
+/// Progress payload with the worker's real backend label (the shared
+/// `progress_payload` hardcodes `cpu`; the MLX worker reports `mlx`). Peak GPU/unified
+/// memory is left unset for the procedural stub — it allocates no device memory; real
+/// peak-memory sampling lands with real inference (sc-3022).
+fn image_progress(
+    status: JobStatus,
+    stage: ProgressStage,
+    progress: f64,
+    message: &str,
+    result: Option<JsonObject>,
+    backend: &str,
+) -> ProgressRequest {
+    ProgressRequest {
+        status,
+        stage,
+        progress: number_from_f64(progress),
+        message: message.to_owned(),
+        error: None,
+        result,
+        eta_seconds: None,
+        peak_gpu_memory_pct: None,
+        peak_gpu_load_pct: None,
+        backend: Some(backend.to_owned()),
+        extra: BTreeMap::new(),
+    }
+}
+
+fn backend_label(gpu_id: &str) -> &str {
+    if gpu_id.trim().is_empty() {
+        "cpu"
+    } else {
+        gpu_id
+    }
+}
+
+/// A non-deterministic seed when the request supplies none (recorded on the asset so
+/// the result is reproducible). Derived from a v4 UUID to avoid a new RNG dependency.
+fn random_seed() -> i64 {
+    (Uuid::new_v4().as_u128() as u64 & 0x7FFF_FFFF) as i64
+}
+
+/// Deterministic placeholder pixels: a vertical gradient from a per-seed base colour
+/// to white, so each seed yields a distinct, valid RGB8 image of exactly `width *
+/// height * 3` bytes.
+fn stub_rgb8(width: u32, height: u32, seed: i64) -> Vec<u8> {
+    let seed = seed as u64;
+    let base = [
+        (seed & 0xFF) as u8,
+        ((seed >> 8) & 0xFF) as u8,
+        ((seed >> 16) & 0xFF) as u8,
+    ];
+    let span = height.saturating_sub(1).max(1) as f32;
+    let mut buffer = Vec::with_capacity((width as usize) * (height as usize) * 3);
+    for y in 0..height {
+        let t = y as f32 / span;
+        let row = [lerp(base[0], t), lerp(base[1], t), lerp(base[2], t)];
+        for _ in 0..width {
+            buffer.extend_from_slice(&row);
+        }
+    }
+    buffer
+}
+
+/// Linear interpolate channel value `a` toward white (255) by `t` in `[0, 1]`.
+fn lerp(a: u8, t: f32) -> u8 {
+    let a = a as f32;
+    (a + (255.0 - a) * t).round().clamp(0.0, 255.0) as u8
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
-    fn image_job(model: &str) -> JobSnapshot {
-        serde_json::from_value(serde_json::json!({
-            "id": "job-img-1",
-            "type": "image_generate",
-            "status": "running",
-            "projectId": null,
-            "projectName": null,
-            "payload": { "model": model },
-            "result": {},
-            "requestedGpu": "mlx",
-            "assignedGpu": "mlx",
-            "workerId": "test-mlx-worker",
-            "progress": 0.0,
-            "stage": "preparing",
-            "message": "",
-            "error": null,
-            "etaSeconds": null,
-            "elapsedSeconds": null,
-            "attempts": 1,
-            "sourceJobId": null,
-            "duplicateOfJobId": null,
-            "cancelRequested": false,
-            "createdAt": "2026-06-05T00:00:00Z",
-            "updatedAt": "2026-06-05T00:00:00Z",
-            "startedAt": null,
-            "completedAt": null,
-            "canceledAt": null,
-            "lastHeartbeatAt": null
-        }))
-        .expect("valid image_generate job snapshot")
+    fn request(value: Value) -> ImageRequest {
+        ImageRequest::from_payload(&value.as_object().cloned().unwrap())
     }
 
     #[test]
-    fn scaffold_result_reports_linked_engine_and_registry() {
-        let job = image_job("z_image_turbo");
-        let result = image_generate_scaffold_result(&job).expect("scaffold result on macOS");
+    fn render_and_save_writes_png_and_contract_fact() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_path = dir.path();
+        std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+        // Distinct dimensions (>= the 256 min, so they survive clamping) also catch a
+        // width/height transpose in the encoder.
+        let req = request(json!({
+            "projectId": "p", "model": "z_image_turbo", "prompt": "Mist over hills",
+            "count": 2, "width": 320, "height": 256, "seed": 101,
+            "stylePreset": "cinematic", "modelManifestEntry": { "family": "z-image" }
+        }));
+        let plan = ImagePlan::new(&req);
+
+        let fact = render_and_save(&plan, 0, project_path).unwrap();
+
+        // The PNG exists at the reported relative path and decodes at the requested size.
+        let media_rel = fact.get("mediaPath").and_then(Value::as_str).unwrap();
+        assert!(media_rel.starts_with("assets/images/"));
+        assert!(media_rel.ends_with("_0001.png"));
+        let decoded = image::open(project_path.join(media_rel)).unwrap();
+        assert_eq!((decoded.width(), decoded.height()), (320, 256));
+
+        // The fact carries every field the API's build_image_sidecar_parts consumes.
+        for key in [
+            "assetId",
+            "mediaPath",
+            "mimeType",
+            "width",
+            "height",
+            "normalizedWidth",
+            "normalizedHeight",
+            "count",
+            "family",
+            "seed",
+            "displayName",
+            "createdAt",
+            "mode",
+            "model",
+            "adapter",
+            "prompt",
+            "negativePrompt",
+            "loras",
+            "stylePreset",
+            "characterId",
+            "characterLookId",
+            "sourceAssetId",
+            "rawAdapterSettings",
+        ] {
+            assert!(fact.contains_key(key), "fact missing key {key}");
+        }
+        assert_eq!(fact["adapter"], json!("procedural_preview"));
+        assert_eq!(fact["family"], json!("z-image"));
+        assert_eq!(fact["seed"], json!(101));
+        assert_eq!(fact["mimeType"], json!("image/png"));
+        assert_eq!(fact["width"], json!(320));
+        assert_eq!(fact["displayName"], json!("Mist over hills #1"));
+        // Honest: the stub is not real inference.
         assert_eq!(
-            result.get("engine").and_then(Value::as_str),
-            Some("mlx-gen")
+            fact["rawAdapterSettings"]["realModelInference"],
+            json!(false)
         );
-        assert_eq!(result.get("scaffold").and_then(Value::as_bool), Some(true));
-        assert_eq!(
-            result.get("requestedModel").and_then(Value::as_str),
-            Some("z_image_turbo")
-        );
-        // The Z-Image provider linked into the worker self-registered via inventory:
-        // proof the cross-crate, link-time mlx-gen registry resolves inside our binary
-        // (and that the `use mlx_gen_z_image as _;` defeats linker GC of the static).
-        let registered = result
-            .get("registeredModels")
-            .and_then(Value::as_array)
-            .expect("registeredModels array");
-        assert!(
-            registered
-                .iter()
-                .any(|m| m.as_str() == Some("z_image_turbo")),
-            "expected z_image_turbo in registry, got {registered:?}"
-        );
+    }
+
+    #[test]
+    fn distinct_seeds_produce_distinct_pixels() {
+        let a = stub_rgb8(8, 8, 1);
+        let b = stub_rgb8(8, 8, 5000);
+        assert_eq!(a.len(), 8 * 8 * 3);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn plan_builds_generation_set_with_unique_seeds() {
+        let plan = ImagePlan::new(&request(
+            json!({ "projectId": "p", "prompt": "x", "count": 3, "seed": 5 }),
+        ));
+        assert!(plan.genset_id.starts_with("genset_"));
+        assert_eq!(plan.generation_set["count"], json!(3));
+        assert_ne!(plan.request.seed_for(0), plan.request.seed_for(1));
+    }
+
+    #[test]
+    fn streaming_result_carries_facts_for_api_persistence() {
+        let plan = ImagePlan::new(&request(
+            json!({ "projectId": "p", "prompt": "x", "count": 1 }),
+        ));
+        let writes = vec![json!({ "assetId": "a1" })];
+        let result = streaming_result(&plan, &writes);
+        assert_eq!(result["generationSetId"], json!(plan.genset_id));
+        assert_eq!(result["assetWrites"].as_array().map(Vec::len), Some(1));
+        assert_eq!(result["adapter"], json!("procedural_preview"));
+        assert!(result.contains_key("generationSet"));
+    }
+
+    #[test]
+    fn backend_label_defaults_empty_to_cpu() {
+        assert_eq!(backend_label("mlx"), "mlx");
+        assert_eq!(backend_label(""), "cpu");
+    }
+
+    /// The Z-Image provider linked into the worker self-registered via inventory —
+    /// proof the cross-crate mlx-gen registry resolves inside our binary (sc-3019).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mlx_engine_registry_links_z_image() {
+        assert!(mlx_gen::registry::generators().any(|reg| (reg.descriptor)().id == "z_image_turbo"));
     }
 }


### PR DESCRIPTION
**Epic [3018](https://app.shortcut.com/trefry/epic/3018) · Foundations #2 · story [sc-3020](https://app.shortcut.com/trefry/story/3020)** — base `rust-mlx-integration`.

The shared image pipeline every family reuses, driven by a **procedural stub** generator. Real Z-Image inference is the next story; this proves the whole asset path end to end. Done = stub images stream into a project as real indexed assets with progress + cancel.

### What's here
- **`sceneworks-core::image_request`** — typed `ImageRequest` + `from_payload`, mirroring the Python `image_request_from_job`: count clamp 1–8, dimensions 256–4096, numeric-string coercion, `fit_mode` normalize, `advanced`/`modelManifestEntry` passthrough. Unit-tested.
- **Worker pipeline (`image_jobs.rs`)** — parse the request, resolve the project path (`ProjectStore::get_project`, read-only), generate `count` images, PNG-encode (new `image` crate, png-only, cross-platform) into `assets/images/{date}_{model}_{slug}_NNNN.png`, and emit flat `assetWrites` + `generationSet` facts.
- **Streaming via the existing contract** — the worker reports facts; the API's `update_job_progress → persist_reported_assets` builds each sidecar (`build_image_sidecar_parts`) + indexes `project.db` on *every* progress update (idempotent). The worker does **not** reimplement the sidecar schema — core owns it (story 1656). Per-image incremental updates are the stream; cancel polls `cancel_requested` between images; the temp PNG is cleaned on write failure.
- Stub adapter id `procedural_preview` + honest `realModelInference: false` (matches the contract fixture `asset-image.sceneworks.json`). `backend` reports the worker's gpu id (`mlx`); peak-memory is intentionally unset for the stub (it allocates no device memory — real sampling lands with real inference).

### Scope reduction vs. the story text (found during validation)
The "ImageAssetWriter equivalent" largely already exists in core (`persist_generated_asset`/`write_generation_set`/`build_image_sidecar_parts`), invoked by the API on each progress update. So this story produces the **facts** that path consumes rather than re-building the sidecar/index — smaller, and identical output to the Python worker.

### Validation (macOS 26.5)
`npm run rust:check` green — fmt + clippy `-D warnings` + all test binaries (core `image_request` 5, worker `image_jobs` 6, NAX guard, + the rest) + build. A superset of Linux CI; the self-hosted macOS NAX lane will also run on this PR. Cross-platform: only real MLX inference is macOS-gated; the pipeline + its tests run everywhere.

### Not in this story (by design)
Real per-family inference (swap the stub for mlx-gen Z-Image), routing MLX jobs to the worker, and real peak-memory sampling are their own stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)