### PR TITLE
sc-3026: SDXL-MLX (sdxl + realvisxl) txt2img through the Rust GPU worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-sdxl"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+ "regex",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
@@ -2600,7 +2612,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3710,6 +3722,7 @@ dependencies = [
  "mlx-gen-flux",
  "mlx-gen-flux2",
  "mlx-gen-qwen-image",
+ "mlx-gen-sdxl",
  "mlx-gen-z-image",
  "nix",
  "pmetal-mlx-rs",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1453,8 +1453,8 @@ fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResu
 /// Models the in-process Rust MLX worker generates today, by id. This set grows
 /// one family story at a time as each lands real generation in
 /// `sceneworks-worker::image_jobs` — sc-3022 Z-Image, sc-3023 FLUX.1, sc-3024 Qwen,
-/// sc-3025 FLUX.2 (live), then sc-3026 SDXL. A model id absent here is never routed to
-/// the mlx worker, so the Python torch path stays authoritative for it.
+/// sc-3025 FLUX.2, sc-3026 SDXL (live). A model id absent here is never routed to the
+/// mlx worker, so the Python torch path stays authoritative for it.
 const MLX_ROUTED_MODELS: &[&str] = &[
     "z_image_turbo",
     "flux_schnell",
@@ -1463,6 +1463,8 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux2_klein_9b",
     "flux2_klein_9b_kv",
     "flux2_klein_9b_true_v2",
+    "sdxl",
+    "realvisxl",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -1494,10 +1496,30 @@ fn image_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
         "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" => {
             flux2_mlx_eligible(&job.payload)
         }
-        // Each family story adds its arm alongside real generation: sc-3026 sdxl.
-        // Until then a model in MLX_ROUTED_MODELS must have an arm.
+        "sdxl" | "realvisxl" => sdxl_mlx_eligible(&job.payload),
+        // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
+}
+
+/// SDXL (sc-3026) MLX-routing conditions, ported from `_should_route_sdxl_to_mlx`:
+/// text-to-image only — SDXL reference/IP-Adapter and `edit_image` stay on the Python
+/// torch path (`SdxlDiffusersAdapter`). A third-party LyCORIS LoRA falls back to torch,
+/// but — unlike the old Python MLX-SDXL gate, which sent *all* LoKr to torch — peft
+/// LoKr stays on MLX: the Rust `mlx-gen-sdxl` path supports LoKr natively (the vendored
+/// `_mlx_sd` path it replaces did not).
+fn sdxl_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    let has_reference = payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    if has_reference {
+        return false;
+    }
+    !request_has_lycoris_lora(payload)
 }
 
 /// FLUX.2-klein (sc-3025) MLX-routing conditions. FLUX.2-klein is an **MLX-only**
@@ -1886,7 +1908,7 @@ fn sort_json_value(value: &mut Value) {
 mod mlx_routing_tests {
     use super::{
         flux2_mlx_eligible, flux_mlx_eligible, qwen_mlx_eligible, request_has_lycoris_lora,
-        z_image_mlx_eligible,
+        sdxl_mlx_eligible, z_image_mlx_eligible,
     };
     use serde_json::{json, Map, Value};
 
@@ -2015,6 +2037,23 @@ mod mlx_routing_tests {
             json!({ "referenceAssetId": "asset_1" })
         )));
         assert!(!flux2_mlx_eligible(&object(json!({
+            "loras": [{ "networkType": "lycoris" }]
+        }))));
+    }
+
+    #[test]
+    fn sdxl_txt2img_eligible_edit_reference_and_lycoris_are_not() {
+        assert!(sdxl_mlx_eligible(&object(json!({ "prompt": "a red fox" }))));
+        // peft LoKr stays on MLX (the Rust SDXL path supports LoKr, unlike the old
+        // vendored path) — only third-party LyCORIS falls back to torch.
+        assert!(sdxl_mlx_eligible(&object(json!({
+            "loras": [{ "networkType": "lokr" }]
+        }))));
+        assert!(!sdxl_mlx_eligible(&object(json!({ "mode": "edit_image" }))));
+        assert!(!sdxl_mlx_eligible(&object(
+            json!({ "referenceAssetId": "asset_1" })
+        )));
+        assert!(!sdxl_mlx_eligible(&object(json!({
             "loras": [{ "networkType": "lycoris" }]
         }))));
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1616,17 +1616,81 @@ fn flux2_klein_variants_route_to_mlx_worker() {
 }
 
 #[test]
+fn sdxl_and_realvisxl_route_to_mlx_worker() {
+    let store = store("mlx-routing-sdxl");
+    register_gpu_worker(&store, "worker-torch", "mps", image_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
+
+    for model in ["sdxl", "realvisxl"] {
+        let job = store
+            .create_job(image_job_with(
+                json!({ "model": model, "prompt": "a red fox" }),
+                "auto",
+            ))
+            .unwrap_or_else(|_| panic!("{model} job creates"));
+        assert!(
+            store
+                .claim_next_job("worker-torch")
+                .expect("torch claim ok")
+                .is_none(),
+            "{model} should defer off the torch worker"
+        );
+        let claimed = store
+            .claim_next_job("worker-mlx")
+            .expect("mlx claim ok")
+            .unwrap_or_else(|| panic!("mlx claims {model}"));
+        assert_eq!(claimed.id, job.id);
+        assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+        store
+            .update_job_progress(
+                &claimed.id,
+                ProgressUpdate {
+                    status: JobStatus::Completed,
+                    stage: ProgressStage::Completed,
+                    progress: 1.0,
+                    message: "done".to_owned(),
+                    error: None,
+                    result: None,
+                    eta_seconds: None,
+                    peak_gpu_memory_pct: None,
+                    peak_gpu_load_pct: None,
+                    backend: None,
+                },
+            )
+            .expect("complete job");
+    }
+
+    // SDXL reference/IP-Adapter stays on the Python torch path.
+    let reference = store
+        .create_job(image_job_with(
+            json!({ "model": "sdxl", "prompt": "p", "referenceAssetId": "asset_1" }),
+            "auto",
+        ))
+        .expect("reference job creates");
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims sdxl reference job");
+    assert_eq!(claimed.id, reference.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
+#[test]
 fn non_mlx_model_image_job_is_not_routed_to_mlx_worker() {
     let store = store("mlx-routing-non-mlx-model");
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // A model not yet ported to the Rust worker (e.g. sdxl, sc-3026) stays on the
-    // Python path: the torch worker claims it without deferral, and the mlx worker
-    // would refuse it.
+    // A torch-only image model with no mlx-gen engine (e.g. kolors — InstantID/Kolors/
+    // PuLID/SenseNova have no MLX crate) stays on the Python path: the torch worker
+    // claims it without deferral, and the mlx worker would refuse it.
     let job = store
         .create_job(image_job_with(
-            json!({ "model": "sdxl", "prompt": "p" }),
+            json!({ "model": "kolors", "prompt": "p" }),
             "auto",
         ))
         .expect("job creates");

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -64,6 +64,9 @@ mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
 mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
+# SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
+# `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -31,6 +31,8 @@ use mlx_gen_flux2 as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_qwen_image as _;
 #[cfg(target_os = "macos")]
+use mlx_gen_sdxl as _;
+#[cfg(target_os = "macos")]
 use mlx_gen_z_image as _;
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
@@ -151,6 +153,31 @@ const MLX_MODELS: &[MlxModel] = &[
         default_guidance: 1.0,
         supports_negative_prompt: false,
         adapter_label: "mlx_flux2",
+    },
+    // SDXL (sc-3026) — U-Net, real CFG (negative prompt + guidance 7.0), 30 steps.
+    // `sdxl` and the `realvisxl` finetune share the engine's single `sdxl` model
+    // (identical arch), differing only in weights. Replaces the in-process
+    // _vendor/mlx_sd path. The engine supports Q4/Q8 (the Python vendored path had
+    // none); Q8 is the default here (engine-validated; saves ~half the U-Net memory).
+    MlxModel {
+        sceneworks_id: "sdxl",
+        engine_id: "sdxl",
+        default_repo: "stabilityai/stable-diffusion-xl-base-1.0",
+        default_steps: 30,
+        supports_guidance: true,
+        default_guidance: 7.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_sdxl",
+    },
+    MlxModel {
+        sceneworks_id: "realvisxl",
+        engine_id: "sdxl",
+        default_repo: "SG161222/RealVisXL_V5.0",
+        default_steps: 30,
+        supports_guidance: true,
+        default_guidance: 7.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_sdxl",
     },
 ];
 
@@ -1297,7 +1324,15 @@ mod tests {
             mlx_model("flux2_klein_9b_true_v2").unwrap().default_steps,
             24
         );
-        assert!(mlx_model("sdxl").is_none());
+        // SDXL + the realvisxl finetune share the single `sdxl` engine model (real CFG).
+        for id in ["sdxl", "realvisxl"] {
+            let m = mlx_model(id).unwrap();
+            assert_eq!(m.engine_id, "sdxl");
+            assert_eq!(m.adapter_label, "mlx_sdxl");
+            assert_eq!(m.default_steps, 30);
+            assert!(m.supports_guidance && m.supports_negative_prompt);
+        }
+        assert!(mlx_model("instantid_sdxl").is_none());
     }
 
     #[cfg(target_os = "macos")]
@@ -1374,8 +1409,10 @@ mod tests {
             adapter_id(&request(json!({ "model": "flux_dev" }))),
             "mlx_flux"
         );
+        assert_eq!(adapter_id(&request(json!({ "model": "sdxl" }))), "mlx_sdxl");
+        // A torch-only model with no mlx-gen engine records the procedural stub adapter.
         assert_eq!(
-            adapter_id(&request(json!({ "model": "sdxl" }))),
+            adapter_id(&request(json!({ "model": "kolors" }))),
             "procedural_preview"
         );
     }
@@ -1394,6 +1431,7 @@ mod tests {
             "flux1_dev",
             "qwen_image",
             "flux2_klein_9b",
+            "sdxl",
         ] {
             assert!(ids.contains(&id), "registry missing {id}");
         }
@@ -1559,6 +1597,38 @@ mod tests {
         let dir = dirs_home()
             .join("Library/Application Support/SceneWorks/data/models/mlx/flux2_klein_9b_true_v2");
         smoke_generate_one("flux2_klein_9b_true_v2", dir, Some(1.0), None);
+    }
+
+    /// Real-weights smoke: SDXL base (real CFG, guidance 7.0 + a negative prompt,
+    /// 30-step, Q8). Verifies the engine's SDXL quant default works (the Python
+    /// vendored path had no quant). Needs the HF cache
+    /// (`stabilityai/stable-diffusion-xl-base-1.0`) + a Metal device; run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored sdxl_real_weights`.
+    /// SDXL native is 1024²; min is 512 — this smoke uses 512² for speed.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real SDXL weights + Metal device"]
+    fn sdxl_real_weights_generates_one_image() {
+        smoke_generate_one(
+            "sdxl",
+            hf_snapshot("models--stabilityai--stable-diffusion-xl-base-1.0"),
+            Some(7.0),
+            Some("blurry, low quality".to_owned()),
+        );
+    }
+
+    /// Real-weights smoke: the RealVisXL finetune through the same `sdxl` engine model.
+    /// Needs the HF cache (`SG161222/RealVisXL_V5.0`) + a Metal device.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real RealVisXL weights + Metal device"]
+    fn realvisxl_real_weights_generates_one_image() {
+        smoke_generate_one(
+            "realvisxl",
+            hf_snapshot("models--SG161222--RealVisXL_V5.0"),
+            Some(7.0),
+            Some("blurry, low quality".to_owned()),
+        );
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Story **sc-3026** (epic 3018, family #8 — the last base image family). SDXL txt2img runs **real, in-process** through the Rust GPU worker via the linked `mlx-gen-sdxl` provider. This replaces the in-process `_vendor/mlx_sd` path (`MlxSdxlAdapter` — the one Python MLX adapter that never used the mflux sidecar); the deletion lands at cutover (sc-3032).

## sdxl + realvisxl, one engine model
Both SceneWorks ids share the engine's single `sdxl` model (the RealVisXL finetune is the same architecture), differing only by weights. SDXL is U-Net + **real CFG**: 30 steps, guidance 7.0, **negative prompt** — reusing the qwen true-CFG plumbing (`supports_guidance` + `supports_negative_prompt`). adapter `mlx_sdxl`.

## Story gates — confirmed against the engine
- **Quant:** `mlx-gen-sdxl` supports Q4/Q8 (U-Net + both CLIP encoders) — the Python vendored path had **none**. Q8 is the default here (engine-validated; ~half the U-Net memory) — a deliberate, documented improvement over Python's dense default (override with `advanced.mlxQuantize=0`). **Verified Q8 produces valid output** via the real smoke.
- **LoRA/LoKr:** the engine wires both (PEFT + kohya `lora_unet_`) and is **more capable than the vendored path — it supports LoKr**. So peft LoKr now stays on MLX (the old Python sdxl gate sent *all* LoKr to torch); only third-party LyCORIS falls back.

## Routing (sc-3021 extension)
`sdxl` + `realvisxl` → `MLX_ROUTED_MODELS` + an `sdxl_mlx_eligible` arm: **txt2img only** (SDXL reference/IP-Adapter + edit stay on the Python torch `SdxlDiffusersAdapter`); third-party LyCORIS → torch, peft LoKr → MLX.

## Verified end-to-end on real cached weights (in-process, no Python)
Run serially (concurrent multi-model loads abort the single Metal device): `sdxl` 30-step Q8 + negative prompt ✓, `realvisxl` 30-step Q8 + negative prompt ✓. Other families' smokes unchanged.

## Note
Two prior routing tests used `sdxl` as their "not-yet-ported" placeholder (`non_mlx_model` + `adapter_id`) — repointed to `kolors` (a genuinely torch-only model with no mlx-gen engine).

## Tests
Worker unit tests (sdxl/realvisxl rows, registry links `sdxl`, adapter id) + `#[ignore]` real-weights smokes for both; `jobs_store` unit + integration tests for the sdxl routing arm (incl. reference→torch). `cargo fmt` + `clippy --all-targets -D warnings` + `cargo test` + `cargo build` green; macOS NAX guard green locally. `Cargo.lock` adds only `mlx-gen-sdxl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)