### PR TITLE
sc-3028: Z-Image strict-pose ControlNet (Fun-CN-Union) through the Rust GPU worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +76,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "async-trait"
@@ -1929,6 +1954,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "imageproc"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602b4e8a4cc3e98372b766cd184ab532999bc0e839b7469e759511ccabc65d77"
+dependencies = [
+ "ab_glyph",
+ "approx",
+ "getrandom 0.2.17",
+ "image",
+ "itertools 0.12.1",
+ "nalgebra",
+ "num",
+ "rand 0.8.6",
+ "rand_distr",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2034,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2211,6 +2262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2361,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "memchr"
@@ -2521,6 +2588,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2655,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,12 +2694,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2868,6 +3006,15 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
 ]
 
 [[package]]
@@ -3210,7 +3357,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3259,12 +3406,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3274,7 +3442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3287,10 +3464,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3640,6 +3833,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3718,6 +3920,7 @@ dependencies = [
  "futures-util",
  "glob",
  "image",
+ "imageproc",
  "mlx-gen",
  "mlx-gen-flux",
  "mlx-gen-flux2",
@@ -4097,6 +4300,19 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -4820,7 +5036,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -5097,6 +5313,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typeid"
@@ -5560,6 +5782,16 @@ dependencies = [
  "thiserror 2.0.18",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -12,6 +12,11 @@ glob = "0.3"
 # dependency small and cross-platform (the image-job pipeline + its tests run on every
 # platform; only real MLX inference is macOS-gated).
 image = { version = "0.25", default-features = false, features = ["png"] }
+# CPU raster for DWPose skeleton rendering (epic 3018, sc-3028): filled polygons
+# (rotated-ellipse limbs), circles (joints/points), for the Z-Image strict-pose
+# ControlNet. Pure-Rust + cross-platform (the renderer + its tests run everywhere;
+# only the MLX control generation is macOS-gated). Pinned to the image 0.25 line.
+imageproc = { version = "0.25", default-features = false }
 nix = { version = "0.29", default-features = false, features = ["process", "signal"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -21,8 +21,8 @@ use sceneworks_core::image_request::ImageRequest;
 // See mlx-gen-z-image/tests/registry.rs ("the SceneWorks worker").
 #[cfg(target_os = "macos")]
 use mlx_gen::{
-    AdapterKind, AdapterSpec, CancelFlag, GenerationOutput, GenerationRequest, Generator, LoadSpec,
-    Progress, Quant, WeightsSource,
+    AdapterKind, AdapterSpec, CancelFlag, Conditioning, ControlKind, GenerationOutput,
+    GenerationRequest, Generator, Image, LoadSpec, Progress, Quant, WeightsSource,
 };
 #[cfg(target_os = "macos")]
 use mlx_gen_flux as _;
@@ -244,7 +244,20 @@ pub(crate) async fn run_image_generate_job(
     // Real in-process MLX inference on macOS for engine-backed models; otherwise the
     // procedural stub (keeps non-macOS + not-yet-ported models working).
     #[cfg(target_os = "macos")]
-    let handled = if mlx_available(&request, settings) {
+    let handled = if zimage_control_available(&request, settings) {
+        // Z-Image strict-pose (advanced.poses) → Fun-Controlnet-Union, one image per pose.
+        generate_zimage_control_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if mlx_available(&request, settings) {
         generate_mlx_stream(
             api,
             settings,
@@ -970,7 +983,7 @@ async fn generate_mlx_stream(
         .collect();
 
     let cancel = CancelFlag::new();
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
 
     let blocking = {
         let prompt = request.prompt.clone();
@@ -1020,6 +1033,48 @@ async fn generate_mlx_stream(
         })
     };
 
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        adapter_label,
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+/// Consume the streamed generation events (step / decoding / image) from the blocking
+/// thread: write each finished image as an asset fact, stream progress, and poll cancel
+/// ~every 2s (draining the channel after a cancel so the blocking sender never blocks).
+/// Shared by the base txt2img path ([`generate_mlx_stream`]) and the Z-Image strict-pose
+/// control path ([`generate_zimage_control_stream`]). `total` is the number of images
+/// the job produces (the request count, or the pose count).
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn consume_gen_events(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    adapter_label: &str,
+    raw_settings: &JsonObject,
+    total: usize,
+    mut rx: tokio::sync::mpsc::Receiver<GenEvent>,
+    cancel: CancelFlag,
+    blocking: tokio::task::JoinHandle<WorkerResult<()>>,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let total_u32 = total as u32;
     let mut canceled = false;
     let mut last_cancel_check = Instant::now();
     while let Some(event) = rx.recv().await {
@@ -1030,7 +1085,7 @@ async fn generate_mlx_stream(
             GenEvent::Step {
                 index,
                 current,
-                total,
+                total: step_total,
             } => {
                 if last_cancel_check.elapsed() >= Duration::from_secs(2) {
                     last_cancel_check = Instant::now();
@@ -1049,12 +1104,8 @@ async fn generate_mlx_stream(
                     image_progress(
                         JobStatus::Running,
                         ProgressStage::Generating,
-                        step_fraction(index, current, total, request.count),
-                        &format!(
-                            "Image {}/{} — step {current}/{total}.",
-                            index + 1,
-                            request.count
-                        ),
+                        step_fraction(index, current, step_total, total_u32),
+                        &format!("Image {}/{total} — step {current}/{step_total}.", index + 1),
                         Some(streaming_result(plan, asset_writes)),
                         backend,
                     ),
@@ -1068,8 +1119,8 @@ async fn generate_mlx_stream(
                     image_progress(
                         JobStatus::Running,
                         ProgressStage::Generating,
-                        step_fraction(index, 1, 1, request.count),
-                        &format!("Image {}/{} — decoding.", index + 1, request.count),
+                        step_fraction(index, 1, 1, total_u32),
+                        &format!("Image {}/{total} — decoding.", index + 1),
                         Some(streaming_result(plan, asset_writes)),
                         backend,
                     ),
@@ -1101,8 +1152,8 @@ async fn generate_mlx_stream(
                     image_progress(
                         JobStatus::Running,
                         ProgressStage::Generating,
-                        0.1 + 0.85 * ((index + 1) as f64 / request.count as f64),
-                        &format!("Generated image {}/{}.", index + 1, request.count),
+                        0.1 + 0.85 * ((index + 1) as f64 / total as f64),
+                        &format!("Generated image {}/{total}.", index + 1),
                         Some(streaming_result(plan, asset_writes)),
                         backend,
                     ),
@@ -1115,7 +1166,7 @@ async fn generate_mlx_stream(
 
     let task_result = blocking
         .await
-        .map_err(|error| WorkerError::InvalidPayload(format!("Z-Image task join: {error}")))?;
+        .map_err(|error| WorkerError::InvalidPayload(format!("generation task join: {error}")))?;
     if canceled {
         // check_cancel already posted the Canceled update; treat the (likely) generate
         // error as the clean cancel.
@@ -1125,6 +1176,345 @@ async fn generate_mlx_stream(
     }
     task_result
 }
+
+// ---------------------------------------------------------------------------
+// Z-Image strict-pose ControlNet (macOS, sc-3028): the Fun-Controlnet-Union
+// `z_image_turbo_control` variant. One image per pose, each driven by a DWPose
+// skeleton rendered from the pose's keypoints (see `openpose_skeleton`).
+// ---------------------------------------------------------------------------
+
+/// The engine registry id for the Z-Image Fun-Controlnet-Union variant.
+#[cfg(target_os = "macos")]
+const ZIMAGE_CONTROL_ENGINE_ID: &str = "z_image_turbo_control";
+/// Default Fun-Controlnet-Union control-weights repo + file (sc-2257 parity).
+#[cfg(target_os = "macos")]
+const ZIMAGE_CONTROL_REPO: &str = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1";
+#[cfg(target_os = "macos")]
+const ZIMAGE_CONTROL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors";
+
+/// The object-shaped `advanced.poses` entries (the strict-pose tier; empty otherwise).
+#[cfg(target_os = "macos")]
+fn pose_entries(request: &ImageRequest) -> Vec<&Value> {
+    request
+        .advanced
+        .get("poses")
+        .and_then(Value::as_array)
+        .map(|poses| poses.iter().filter(|pose| pose.is_object()).collect())
+        .unwrap_or_default()
+}
+
+/// True when this is a Z-Image strict-pose job (z-image + ≥1 pose) whose base weights
+/// resolve — routed to the Fun-Controlnet-Union control path rather than plain txt2img.
+/// Control-weights presence is checked in the stream so a missing checkpoint errors
+/// loudly instead of silently dropping the poses to the txt2img path.
+#[cfg(target_os = "macos")]
+fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == "z_image_turbo"
+        && !pose_entries(request).is_empty()
+        && resolve_weights_dir(request, settings).is_some()
+}
+
+/// Resolve the Fun-Controlnet-Union checkpoint (`advanced.controlWeights.{repo,filename}`
+/// else defaults) to a single `.safetensors` in the HF cache. `None` when absent (the
+/// model-download flow fetches it ahead of generation, like base weights).
+#[cfg(target_os = "macos")]
+fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+    let control = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object);
+    let str_field = |key: &str, default: &'static str| -> String {
+        control
+            .and_then(|control| control.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(default)
+            .to_owned()
+    };
+    let repo = str_field("repo", ZIMAGE_CONTROL_REPO);
+    let filename = str_field("filename", ZIMAGE_CONTROL_FILE);
+    let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo)?;
+    let path = snapshot.join(filename);
+    path.exists().then_some(path)
+}
+
+/// Pose ControlNet lock strength: `advanced.controlScale` (default 0.9, clamp [0,2]).
+#[cfg(target_os = "macos")]
+fn resolve_control_scale(request: &ImageRequest) -> f32 {
+    request
+        .advanced
+        .get("controlScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(0.9)
+        .clamp(0.0, 2.0)
+}
+
+/// A pose's parsed keypoints, ready for [`crate::openpose_skeleton::draw_wholebody`].
+#[cfg(target_os = "macos")]
+struct PoseInput {
+    keypoints: Vec<crate::openpose_skeleton::Keypoint>,
+    hands: Option<Vec<crate::openpose_skeleton::Hand>>,
+    face: Option<Vec<crate::openpose_skeleton::Keypoint>>,
+}
+
+#[cfg(target_os = "macos")]
+fn parse_poses(request: &ImageRequest) -> Vec<PoseInput> {
+    use crate::openpose_skeleton::{normalize_face, normalize_hands, normalize_keypoints};
+    pose_entries(request)
+        .into_iter()
+        .map(|entry| PoseInput {
+            keypoints: entry
+                .get("keypoints")
+                .map(normalize_keypoints)
+                .unwrap_or_else(|| vec![None; 18]),
+            hands: entry.get("hands").and_then(normalize_hands),
+            face: entry.get("face").and_then(normalize_face),
+        })
+        .collect()
+}
+
+/// Load the Z-Image Fun-Controlnet-Union generator (base snapshot + control overlay).
+#[cfg(target_os = "macos")]
+fn zimage_control_load(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> WorkerResult<Box<dyn Generator>> {
+    let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
+        .with_control(WeightsSource::File(control_weights));
+    if let Some(quant) = quant {
+        spec = spec.with_quant(quant);
+    }
+    if !adapters.is_empty() {
+        spec = spec.with_adapters(adapters);
+    }
+    mlx_gen::load(ZIMAGE_CONTROL_ENGINE_ID, &spec).map_err(|error| {
+        WorkerError::InvalidPayload(format!("Z-Image control load failed: {error}"))
+    })
+}
+
+/// Generate one strict-pose image: the `control` skeleton drives the Fun-Controlnet-Union
+/// pose branch at `control_scale`. Z-Image-Turbo is guidance-distilled (no CFG / negative).
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn zimage_control_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    control: Image,
+    control_scale: f32,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        conditioning: vec![Conditioning::Control {
+            image: control,
+            kind: ControlKind::Pose,
+            scale: control_scale,
+        }],
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator.generate(&request, on_progress).map_err(|error| {
+        WorkerError::InvalidPayload(format!("control generation failed: {error}"))
+    })?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::InvalidPayload("control generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::InvalidPayload(
+            "control generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn zimage_control_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    // Z-Image-Turbo is guidance-distilled — no CFG.
+    raw.insert("guidanceScale".to_owned(), Value::Null);
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw
+}
+
+/// Real Z-Image strict-pose generation: one image per pose, each conditioned on a DWPose
+/// skeleton rendered from the pose keypoints + locked by the Fun-Controlnet-Union branch.
+/// Mirrors [`generate_mlx_stream`]'s blocking-thread + streamed-events shape (the MLX
+/// generator is `!Send` + single-thread), reusing [`consume_gen_events`].
+#[cfg(target_os = "macos")]
+async fn generate_zimage_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    // Identity img2img-init (sc-2328) is an opt-in escape hatch (off by default, validated
+    // marginal on 8-step Turbo). The engine accepts a Reference, but resolving
+    // referenceAssetId → image needs asset-path plumbing not yet in the Rust worker — so an
+    // explicit referenceStrength errors loudly here rather than silently dropping it
+    // (tracked follow-up). Pose-only (no referenceStrength) is the default tier.
+    let identity_init = request
+        .advanced
+        .get("referenceStrength")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .is_some_and(|strength| strength > 0.0);
+    if identity_init {
+        return Err(WorkerError::InvalidPayload(
+            "Identity img2img-init (referenceStrength) is not yet supported on the Rust Z-Image \
+             strict-pose path; omit referenceStrength for pose-only generation."
+                .to_owned(),
+        ));
+    }
+
+    let weights_dir = resolve_weights_dir(request, settings)
+        .ok_or_else(|| WorkerError::InvalidPayload("Z-Image weights not found".to_owned()))?;
+    let control_weights = resolve_control_weights(request, settings).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Z-Image strict-pose control weights not found (download {ZIMAGE_CONTROL_REPO})."
+        ))
+    })?;
+    let (quant, quant_bits) = resolve_quant(request);
+    let zimage = mlx_model("z_image_turbo")
+        .ok_or_else(|| WorkerError::InvalidPayload("z-image model row missing".to_owned()))?;
+    let steps = resolve_steps(request, zimage);
+    let control_scale = resolve_control_scale(request);
+    let adapters = resolve_adapters(request)?;
+    let repo = model_repo(request, zimage);
+    let poses = parse_poses(request);
+    let count = poses.len();
+    let raw_settings =
+        zimage_control_raw_settings(request, &repo, steps, quant_bits, control_scale, count);
+    // Strict pose shares one seed across the set so noise-derived attributes (hair,
+    // wardrobe, lighting) stay constant while only the pose changes (Python parity).
+    let seed = resolve_seed(request, 0);
+
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+
+    let blocking = {
+        let prompt = request.prompt.clone();
+        let (width, height) = (request.width, request.height);
+        let cancel = cancel.clone();
+        let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+        tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let generator = zimage_control_load(weights_dir, control_weights, quant, adapters)?;
+            for (index, pose) in poses.into_iter().enumerate() {
+                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                    width,
+                    height,
+                    &pose.keypoints,
+                    pose.hands.as_deref(),
+                    pose.face.as_deref(),
+                    stickwidth,
+                );
+                let control = Image {
+                    width,
+                    height,
+                    pixels: skeleton.into_raw(),
+                };
+                let mut on_progress = |progress: Progress| {
+                    let event = match progress {
+                        Progress::Step { current, total } => GenEvent::Step {
+                            index,
+                            current,
+                            total,
+                        },
+                        Progress::Decoding => GenEvent::Decoding { index },
+                    };
+                    let _ = tx.blocking_send(event);
+                };
+                let (width, height, pixels) = zimage_control_generate_one(
+                    generator.as_ref(),
+                    &prompt,
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    control,
+                    control_scale,
+                    &cancel,
+                    &mut on_progress,
+                )?;
+                if tx
+                    .blocking_send(GenEvent::Image {
+                        index,
+                        seed,
+                        width,
+                        height,
+                        pixels,
+                    })
+                    .is_err()
+                {
+                    break; // receiver gone — stop generating.
+                }
+            }
+            Ok(())
+        })
+    };
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        ZIMAGE_ADAPTER_LABEL,
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+/// The asset `adapter` id for Z-Image (strict-pose shares the base z-image label).
+#[cfg(target_os = "macos")]
+const ZIMAGE_ADAPTER_LABEL: &str = "mlx_z_image";
 
 #[cfg(test)]
 mod tests {
@@ -1643,6 +2033,152 @@ mod tests {
             Some(7.0),
             Some("blurry, low quality".to_owned()),
         );
+    }
+
+    // --- Z-Image strict-pose control path (sc-3028) ---
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_control_scale_defaults_and_clamps() {
+        assert_eq!(
+            resolve_control_scale(&request(json!({ "projectId": "p" }))),
+            0.9
+        );
+        assert_eq!(
+            resolve_control_scale(&request(
+                json!({ "projectId": "p", "advanced": { "controlScale": 0.65 } })
+            )),
+            0.65
+        );
+        // Clamp to [0, 2].
+        assert_eq!(
+            resolve_control_scale(&request(
+                json!({ "projectId": "p", "advanced": { "controlScale": 5.0 } })
+            )),
+            2.0
+        );
+        assert_eq!(
+            resolve_control_scale(&request(
+                json!({ "projectId": "p", "advanced": { "controlScale": -1.0 } })
+            )),
+            0.0
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn pose_entries_filters_to_objects() {
+        let req = request(json!({
+            "projectId": "p",
+            "advanced": { "poses": [{ "id": "a" }, "not-an-object", { "id": "b" }] }
+        }));
+        assert_eq!(pose_entries(&req).len(), 2);
+        // No poses → empty (not a strict-pose job).
+        assert!(pose_entries(&request(json!({ "projectId": "p" }))).is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parse_poses_extracts_keypoints_hands_face() {
+        let req = request(json!({
+            "projectId": "p",
+            "advanced": { "poses": [{
+                "id": "a",
+                "keypoints": [[0.5, 0.2], [0.5, 0.35]],
+                "hands": [[[0.1, 0.1]], [[0.2, 0.2]]],
+                "face": [[0.5, 0.18]]
+            }] }
+        }));
+        let poses = parse_poses(&req);
+        assert_eq!(poses.len(), 1);
+        assert_eq!(poses[0].keypoints.len(), 18); // padded
+        assert_eq!(poses[0].keypoints[0], Some((0.5, 0.2)));
+        assert!(poses[0].hands.is_some());
+        assert!(poses[0].face.is_some());
+    }
+
+    /// Real-weights smoke: Z-Image strict-pose ControlNet. Loads the base
+    /// `Tongyi-MAI/Z-Image-Turbo` snapshot + the cached Fun-Controlnet-Union checkpoint,
+    /// renders a DWPose skeleton, and generates one pose image. Needs both in the HF
+    /// cache + a Metal device; run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored zimage_control_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real Z-Image + Fun-Controlnet-Union weights + Metal device"]
+    fn zimage_control_real_weights_generates_one_pose() {
+        let base = hf_snapshot("models--Tongyi-MAI--Z-Image-Turbo");
+        let control = std::fs::read_dir(dirs_home().join(
+            ".cache/huggingface/hub/models--alibaba-pai--Z-Image-Turbo-Fun-Controlnet-Union-2.1/snapshots",
+        ))
+        .expect("control snapshots dir")
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| path.is_dir())
+        .map(|dir| dir.join(super::ZIMAGE_CONTROL_FILE))
+        .filter(|path| path.exists())
+        .expect("control weights file");
+
+        let generator =
+            zimage_control_load(base, control, Some(mlx_gen::Quant::Q8), Vec::new()).unwrap();
+
+        // A minimal standing skeleton at 512².
+        let kp = crate::openpose_skeleton::normalize_keypoints(&json!([
+            [0.5, 0.2],
+            [0.5, 0.35],
+            [0.42, 0.35],
+            [0.40, 0.5],
+            [0.40, 0.65],
+            [0.58, 0.35],
+            [0.60, 0.5],
+            [0.60, 0.65],
+            [0.45, 0.6],
+            [0.45, 0.8],
+            [0.45, 0.95],
+            [0.55, 0.6],
+            [0.55, 0.8],
+            [0.55, 0.95],
+            [0.48, 0.18],
+            [0.52, 0.18],
+            [0.46, 0.2],
+            [0.54, 0.2]
+        ]));
+        let skeleton = crate::openpose_skeleton::draw_wholebody(
+            512,
+            512,
+            &kp,
+            None,
+            None,
+            crate::openpose_skeleton::body_stickwidth(512, 512),
+        );
+        let control = mlx_gen::Image {
+            width: 512,
+            height: 512,
+            pixels: skeleton.into_raw(),
+        };
+
+        let cancel = mlx_gen::CancelFlag::new();
+        let mut steps_seen = 0u32;
+        let (w, h, pixels) = zimage_control_generate_one(
+            generator.as_ref(),
+            "a person standing in a meadow",
+            512,
+            512,
+            42,
+            8,
+            control,
+            0.9,
+            &cancel,
+            &mut |p| {
+                if let mlx_gen::Progress::Step { current, .. } = p {
+                    steps_seen = steps_seen.max(current);
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!((w, h), (512, 512));
+        assert_eq!(pixels.len(), 512 * 512 * 3);
+        assert!(steps_seen >= 1, "expected denoise step progress");
+        assert!(pixels.windows(2).any(|w| w[0] != w[1]));
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -44,6 +44,7 @@ use media_jobs::*;
 mod image_jobs;
 use image_jobs::*;
 mod downloads;
+mod openpose_skeleton;
 use downloads::*;
 
 const INSTALL_MARKER: &str = ".sceneworks-download-complete.json";

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -44,6 +44,10 @@ use media_jobs::*;
 mod image_jobs;
 use image_jobs::*;
 mod downloads;
+// The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
+// control path; on other platforms it still builds + unit-tests (cross-platform
+// raster), but its items are otherwise unused — so allow dead_code off macOS.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod openpose_skeleton;
 use downloads::*;
 

--- a/crates/sceneworks-worker/src/openpose_skeleton.rs
+++ b/crates/sceneworks-worker/src/openpose_skeleton.rs
@@ -1,0 +1,470 @@
+//! DWPose / OpenPose skeleton rendering for the Z-Image strict-pose ControlNet
+//! (epic 3018, sc-3028). A faithful CPU-raster port of the Python worker's
+//! `openpose_skeleton.py` (`draw_wholebody`): the COCO-18 body skeleton (colored
+//! rotated-ellipse limbs + joint dots) plus optional hand (21×2) and face (68)
+//! landmarks, in the format the `Z-Image-Turbo-Fun-Controlnet-Union-2.1` pose head
+//! was trained on. Pure raster (cross-platform + testable everywhere); only the MLX
+//! control generation that consumes the skeleton is macOS-gated.
+//!
+//! Keypoints arrive square-canonical (normalized `[0,1]`, short axis padded at
+//! capture — epic 2282), so they render into the largest centered square of the
+//! (possibly non-square) canvas with black letterbox margins.
+
+use image::{Rgb, RgbImage};
+use imageproc::drawing::{draw_filled_circle_mut, draw_polygon_mut};
+use imageproc::point::Point;
+use serde_json::Value;
+
+/// A normalized keypoint in `[0,1]` square-canonical space, or `None` (dropped /
+/// low-confidence).
+pub type Keypoint = Option<(f32, f32)>;
+
+/// One hand's 21 keypoints.
+pub type Hand = Vec<Keypoint>;
+
+/// COCO-18 limb connections (joint index pairs), in render order.
+const LIMB_SEQ: [(usize, usize); 17] = [
+    (1, 2),
+    (1, 5),
+    (2, 3),
+    (3, 4),
+    (5, 6),
+    (6, 7),
+    (1, 8),
+    (8, 9),
+    (9, 10),
+    (1, 11),
+    (11, 12),
+    (12, 13),
+    (1, 0),
+    (0, 14),
+    (14, 16),
+    (0, 15),
+    (15, 17),
+];
+
+/// Per-limb / per-joint colors (RGB), matching controlnet_aux's `draw_bodypose`.
+const COLORS: [(u8, u8, u8); 18] = [
+    (255, 0, 0),
+    (255, 85, 0),
+    (255, 170, 0),
+    (255, 255, 0),
+    (170, 255, 0),
+    (85, 255, 0),
+    (0, 255, 0),
+    (0, 255, 85),
+    (0, 255, 170),
+    (0, 255, 255),
+    (0, 170, 255),
+    (0, 85, 255),
+    (0, 0, 255),
+    (85, 0, 255),
+    (170, 0, 255),
+    (255, 0, 255),
+    (255, 0, 170),
+    (255, 0, 85),
+];
+
+/// DWPose hand skeleton (21 keypoints): wrist (0) + 4 joints per finger. Edge order
+/// matches controlnet_aux `draw_handpose` so the per-edge HSV coloring lands the same
+/// way the Fun-Controlnet-Union pose head was trained on.
+const HAND_EDGES: [(usize, usize); 20] = [
+    (0, 1),
+    (1, 2),
+    (2, 3),
+    (3, 4),
+    (0, 5),
+    (5, 6),
+    (6, 7),
+    (7, 8),
+    (0, 9),
+    (9, 10),
+    (10, 11),
+    (11, 12),
+    (0, 13),
+    (13, 14),
+    (14, 15),
+    (15, 16),
+    (0, 17),
+    (17, 18),
+    (18, 19),
+    (19, 20),
+];
+
+/// Coerce a job-payload keypoint list into exactly `count` normalized points.
+/// Accepts `[x, y]`, `[x, y, conf]` (conf ≤ 0 → dropped), or `null` per entry.
+/// Mirrors Python `normalize_points`.
+pub fn normalize_points(raw: &Value, count: usize) -> Vec<Keypoint> {
+    let mut points: Vec<Keypoint> = Vec::with_capacity(count);
+    if let Some(items) = raw.as_array() {
+        for entry in items {
+            points.push(parse_keypoint(entry));
+        }
+    }
+    points.truncate(count);
+    points.resize(count, None);
+    points
+}
+
+fn parse_keypoint(entry: &Value) -> Keypoint {
+    let array = entry.as_array()?;
+    if array.len() < 2 {
+        return None;
+    }
+    // A present, non-positive confidence drops the point (Python `conf <= 0`).
+    if let Some(conf) = array.get(2).and_then(Value::as_f64) {
+        if conf <= 0.0 {
+            return None;
+        }
+    }
+    let x = array.first().and_then(Value::as_f64)?;
+    let y = array.get(1).and_then(Value::as_f64)?;
+    Some((x as f32, y as f32))
+}
+
+/// 18 normalized body keypoints (COCO-18).
+pub fn normalize_keypoints(raw: &Value) -> Vec<Keypoint> {
+    normalize_points(raw, 18)
+}
+
+/// Optional hand keypoints as `[left21, right21]`. Accepts a `[left, right]` pair or a
+/// flat 42-point list; `None`/empty → `None`. Mirrors Python `normalize_hands`.
+pub fn normalize_hands(raw: &Value) -> Option<Vec<Vec<Keypoint>>> {
+    let items = raw.as_array().filter(|items| !items.is_empty())?;
+    // A [left, right] pair (each a list of points) vs a flat 42-point list: the pair
+    // form has an array whose first element is itself an array.
+    let is_pair = items
+        .first()
+        .and_then(Value::as_array)
+        .and_then(|first| first.first())
+        .map(Value::is_array)
+        .unwrap_or(false);
+    let mut hands: Vec<Vec<Keypoint>> = if is_pair {
+        items
+            .iter()
+            .take(2)
+            .map(|hand| normalize_points(hand, 21))
+            .collect()
+    } else {
+        let flat = normalize_points(raw, 42);
+        vec![flat[..21].to_vec(), flat[21..].to_vec()]
+    };
+    while hands.len() < 2 {
+        hands.push(vec![None; 21]);
+    }
+    Some(hands)
+}
+
+/// Optional face keypoints as 68 normalized points; `None`/empty → `None`.
+pub fn normalize_face(raw: &Value) -> Option<Vec<Keypoint>> {
+    let has_points = raw.as_array().is_some_and(|items| !items.is_empty());
+    has_points.then(|| normalize_points(raw, 68))
+}
+
+/// Centered-square placement for normalized `[0,1]` keypoints: `(side, off_x, off_y)`.
+fn square_fit(canvas_w: u32, canvas_h: u32) -> (f32, f32, f32) {
+    let side = canvas_w.min(canvas_h);
+    let off_x = (canvas_w - side) / 2;
+    let off_y = (canvas_h - side) / 2;
+    (side as f32, off_x as f32, off_y as f32)
+}
+
+/// Place a normalized keypoint into canvas pixel space via the centered square.
+fn placed(point: Keypoint, side: f32, ox: f32, oy: f32) -> Option<(f32, f32)> {
+    point.map(|(x, y)| (ox + x * side, oy + y * side))
+}
+
+/// HSV→RGB at full saturation/value (matplotlib `hsv_to_rgb([h, 1, 1])`), for the
+/// per-edge hand-bone coloring. Mirrors Python `_hsv_to_rgb`.
+fn hsv_to_rgb(hue: f32) -> Rgb<u8> {
+    let i = (hue * 6.0) as i32 % 6;
+    let f = hue * 6.0 - (hue * 6.0).floor();
+    let (q, t) = (1.0 - f, f);
+    let (r, g, b) = match i {
+        0 => (1.0, t, 0.0),
+        1 => (q, 1.0, 0.0),
+        2 => (0.0, 1.0, t),
+        3 => (0.0, q, 1.0),
+        4 => (t, 0.0, 1.0),
+        _ => (1.0, 0.0, q),
+    };
+    Rgb([(r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8])
+}
+
+/// `cv2.ellipse2Poly`: sample an ellipse (`axes` half-extents, rotated by `angle_deg`)
+/// at 1° steps into a closed polygon. 360 distinct vertices (first ≠ last).
+fn ellipse2poly(cx: f32, cy: f32, ax: f32, ay: f32, angle_deg: f32) -> Vec<Point<i32>> {
+    let alpha = angle_deg.to_radians();
+    let (sa, ca) = (alpha.sin(), alpha.cos());
+    (0..360)
+        .map(|theta| {
+            let rad = (theta as f32).to_radians();
+            let (x, y) = (ax * rad.cos(), ay * rad.sin());
+            let px = cx + x * ca - y * sa;
+            let py = cy + x * sa + y * ca;
+            Point::new(px.round() as i32, py.round() as i32)
+        })
+        .collect()
+}
+
+/// Fill a convex polygon (`cv2.fillConvexPoly`). No-ops on a degenerate polygon
+/// (imageproc panics if the first and last points coincide / it is empty).
+fn fill_poly(canvas: &mut RgbImage, poly: &[Point<i32>], color: Rgb<u8>) {
+    if poly.len() < 3 || poly.first() == poly.last() {
+        return;
+    }
+    draw_polygon_mut(canvas, poly, color);
+}
+
+/// A thick line as a filled rotated rectangle (`cv2.line` with `thickness`).
+fn draw_thick_line(
+    canvas: &mut RgbImage,
+    a: (f32, f32),
+    b: (f32, f32),
+    width: f32,
+    color: Rgb<u8>,
+) {
+    let (dx, dy) = (b.0 - a.0, b.1 - a.1);
+    let len = (dx * dx + dy * dy).sqrt();
+    if len < 1.0 {
+        return;
+    }
+    // Unit normal, scaled to half the line width.
+    let (nx, ny) = (-dy / len * width / 2.0, dx / len * width / 2.0);
+    let quad = [
+        Point::new((a.0 + nx).round() as i32, (a.1 + ny).round() as i32),
+        Point::new((b.0 + nx).round() as i32, (b.1 + ny).round() as i32),
+        Point::new((b.0 - nx).round() as i32, (b.1 - ny).round() as i32),
+        Point::new((a.0 - nx).round() as i32, (a.1 - ny).round() as i32),
+    ];
+    fill_poly(canvas, &quad, color);
+}
+
+/// Render the COCO-18 body skeleton onto a fresh black canvas.
+fn draw_bodypose(
+    canvas_w: u32,
+    canvas_h: u32,
+    keypoints: &[Keypoint],
+    stickwidth: u32,
+) -> RgbImage {
+    let mut canvas = RgbImage::new(canvas_w, canvas_h);
+    let (side, ox, oy) = square_fit(canvas_w, canvas_h);
+    let pts: Vec<Option<(f32, f32)>> = keypoints.iter().map(|p| placed(*p, side, ox, oy)).collect();
+    let stick = stickwidth as f32;
+
+    for (i, (a, b)) in LIMB_SEQ.iter().enumerate() {
+        let (Some((xa, ya)), Some((xb, yb))) = (
+            pts.get(*a).copied().flatten(),
+            pts.get(*b).copied().flatten(),
+        ) else {
+            continue;
+        };
+        let (mx, my) = ((xa + xb) / 2.0, (ya + yb) / 2.0);
+        let length = (xa - xb).hypot(ya - yb);
+        let angle = (ya - yb).atan2(xa - xb).to_degrees();
+        let poly = ellipse2poly(mx, my, length / 2.0, stick, angle);
+        fill_poly(&mut canvas, &poly, rgb(COLORS[i]));
+    }
+
+    for (i, point) in pts.iter().enumerate().take(18) {
+        if let Some((x, y)) = point {
+            draw_filled_circle_mut(
+                &mut canvas,
+                (x.round() as i32, y.round() as i32),
+                stickwidth as i32,
+                rgb(COLORS[i]),
+            );
+        }
+    }
+    canvas
+}
+
+/// Draw one or both 21-point hand skeletons in place: per-edge HSV finger bones + blue
+/// joint dots.
+fn draw_handpose(
+    canvas: &mut RgbImage,
+    hands: &[Vec<Keypoint>],
+    line_width: f32,
+    point_radius: i32,
+) {
+    let (side, ox, oy) = square_fit(canvas.width(), canvas.height());
+    for hand in hands {
+        let pts: Vec<Option<(f32, f32)>> = hand.iter().map(|p| placed(*p, side, ox, oy)).collect();
+        for (index, (a, b)) in HAND_EDGES.iter().enumerate() {
+            let (Some(pa), Some(pb)) = (
+                pts.get(*a).copied().flatten(),
+                pts.get(*b).copied().flatten(),
+            ) else {
+                continue;
+            };
+            let color = hsv_to_rgb(index as f32 / HAND_EDGES.len() as f32);
+            draw_thick_line(canvas, pa, pb, line_width, color);
+        }
+        for point in pts.iter().flatten() {
+            draw_filled_circle_mut(
+                canvas,
+                (point.0.round() as i32, point.1.round() as i32),
+                point_radius,
+                Rgb([0, 0, 255]),
+            );
+        }
+    }
+}
+
+/// Draw face landmark constellations (white dots) in place.
+fn draw_facepose(canvas: &mut RgbImage, face: &[Keypoint], point_radius: i32) {
+    let (side, ox, oy) = square_fit(canvas.width(), canvas.height());
+    for point in face.iter().flatten() {
+        let (x, y) = (ox + point.0 * side, oy + point.1 * side);
+        draw_filled_circle_mut(
+            canvas,
+            (x.round() as i32, y.round() as i32),
+            point_radius,
+            Rgb([255, 255, 255]),
+        );
+    }
+}
+
+/// Render a DWPose whole-body control image: the COCO-18 body skeleton plus optional
+/// hand (21×2) + face (68) landmarks. `stickwidth` is the body stick/joint size (the
+/// caller scales it to the output resolution); hand bones / face dots scale here.
+pub fn draw_wholebody(
+    canvas_w: u32,
+    canvas_h: u32,
+    keypoints: &[Keypoint],
+    hands: Option<&[Vec<Keypoint>]>,
+    face: Option<&[Keypoint]>,
+    stickwidth: u32,
+) -> RgbImage {
+    let mut canvas = draw_bodypose(canvas_w, canvas_h, keypoints, stickwidth);
+    let scale = canvas_w.min(canvas_h) as f32;
+    if let Some(hands) = hands.filter(|hands| !hands.is_empty()) {
+        let line_width = (scale * 0.004).round().max(2.0);
+        let point_radius = (scale * 0.004).round().max(2.0) as i32;
+        draw_handpose(&mut canvas, hands, line_width, point_radius);
+    }
+    if let Some(face) = face.filter(|face| !face.is_empty()) {
+        let point_radius = (scale * 0.003).round().max(2.0) as i32;
+        draw_facepose(&mut canvas, face, point_radius);
+    }
+    canvas
+}
+
+/// The body stick/joint width for an output resolution: `max(6, min(w,h) * 0.012)`
+/// (~12px @1024²). Mirrors the Python adapter's `stick`.
+pub fn body_stickwidth(width: u32, height: u32) -> u32 {
+    ((width.min(height) as f32 * 0.012).round() as u32).max(6)
+}
+
+fn rgb(color: (u8, u8, u8)) -> Rgb<u8> {
+    Rgb([color.0, color.1, color.2])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn normalize_points_pads_truncates_and_drops_low_confidence() {
+        // [x,y], [x,y,conf>0], conf<=0 → None, null → None, short → None.
+        let raw = json!([[0.1, 0.2], [0.3, 0.4, 0.9], [0.5, 0.6, 0.0], null, [0.7]]);
+        let pts = normalize_points(&raw, 6);
+        assert_eq!(pts.len(), 6);
+        assert_eq!(pts[0], Some((0.1, 0.2)));
+        assert_eq!(pts[1], Some((0.3, 0.4)));
+        assert_eq!(pts[2], None); // conf == 0 dropped
+        assert_eq!(pts[3], None); // null
+        assert_eq!(pts[4], None); // length < 2
+        assert_eq!(pts[5], None); // padded
+    }
+
+    #[test]
+    fn normalize_keypoints_is_always_18() {
+        assert_eq!(normalize_keypoints(&json!([])).len(), 18);
+        assert_eq!(normalize_keypoints(&json!([[0.5, 0.5]])).len(), 18);
+    }
+
+    #[test]
+    fn normalize_hands_accepts_pair_and_flat() {
+        let pair = json!([[[0.1, 0.1]], [[0.2, 0.2]]]);
+        let hands = normalize_hands(&pair).unwrap();
+        assert_eq!(hands.len(), 2);
+        assert_eq!(hands[0].len(), 21);
+        assert_eq!(hands[0][0], Some((0.1, 0.1)));
+
+        let flat: Vec<Value> = (0..42).map(|i| json!([i as f32 / 42.0, 0.5])).collect();
+        let hands = normalize_hands(&json!(flat)).unwrap();
+        assert_eq!(hands.len(), 2);
+        assert_eq!(hands[0].len(), 21);
+        assert_eq!(hands[1].len(), 21);
+
+        assert!(normalize_hands(&json!([])).is_none());
+    }
+
+    #[test]
+    fn square_fit_letterboxes_non_square() {
+        assert_eq!(square_fit(100, 100), (100.0, 0.0, 0.0));
+        // Wide canvas: square is the height, centered horizontally.
+        assert_eq!(square_fit(200, 100), (100.0, 50.0, 0.0));
+        // Tall canvas: square is the width, centered vertically.
+        assert_eq!(square_fit(100, 200), (100.0, 0.0, 50.0));
+    }
+
+    #[test]
+    fn body_stickwidth_scales_and_floors() {
+        assert_eq!(body_stickwidth(1024, 1024), 12);
+        assert_eq!(body_stickwidth(512, 512), 6); // 512*0.012=6.14 → 6
+        assert_eq!(body_stickwidth(256, 256), 6); // floor
+        assert_eq!(body_stickwidth(2048, 2048), 25); // 24.576 → 25
+    }
+
+    #[test]
+    fn draw_wholebody_paints_a_skeleton_on_black() {
+        // A minimal torso (neck→hips) renders colored pixels on a black canvas.
+        let kp = normalize_keypoints(&json!([
+            [0.5, 0.2],
+            [0.5, 0.35],
+            [0.42, 0.35],
+            [0.40, 0.5],
+            [0.40, 0.65],
+            [0.58, 0.35],
+            [0.60, 0.5],
+            [0.60, 0.65],
+            [0.45, 0.6],
+            [0.45, 0.8],
+            [0.45, 0.95],
+            [0.55, 0.6],
+            [0.55, 0.8],
+            [0.55, 0.95],
+            [0.48, 0.18],
+            [0.52, 0.18],
+            [0.46, 0.2],
+            [0.54, 0.2]
+        ]));
+        let img = draw_wholebody(128, 128, &kp, None, None, body_stickwidth(128, 128));
+        assert_eq!((img.width(), img.height()), (128, 128));
+        let non_black = img.pixels().filter(|p| p.0 != [0, 0, 0]).count();
+        assert!(non_black > 0, "expected a rendered skeleton");
+        // The top joint (nose, COLORS[0] = red) should appear somewhere.
+        assert!(
+            img.pixels().any(|p| p.0 == [255, 0, 0]),
+            "expected red nose joint"
+        );
+    }
+
+    #[test]
+    fn draw_wholebody_empty_pose_is_all_black() {
+        let kp = normalize_keypoints(&json!([]));
+        let img = draw_wholebody(64, 64, &kp, None, None, body_stickwidth(64, 64));
+        assert!(img.pixels().all(|p| p.0 == [0, 0, 0]));
+    }
+
+    #[test]
+    fn hsv_to_rgb_spans_the_wheel() {
+        assert_eq!(hsv_to_rgb(0.0), Rgb([255, 0, 0])); // red
+                                                       // Mid-wheel is cyan-ish (green+blue present, red absent).
+        let mid = hsv_to_rgb(0.5);
+        assert_eq!(mid.0[0], 0);
+    }
+}


### PR DESCRIPTION
Story **sc-3028** (epic 3018, advanced #10). The first conditioning story — the Z-Image strict-pose tier (sc-2257) on the Rust GPU worker: **one image per pose**, each driven by a DWPose skeleton rendered from the pose's keypoints and locked by the Fun-Controlnet-Union pose branch.

## What landed
- **`openpose_skeleton.rs`** — a faithful CPU-raster port of the Python `draw_wholebody` (via `imageproc`): COCO-18 body (rotated-ellipse limbs through `ellipse2Poly` + joint dots), hands (per-edge HSV bones + blue dots), face (white dots), square-canonical normalization, `stickwidth = max(6, min(w,h)*0.012)`. Pure raster, **cross-platform + unit-tested** (runs on every CI lane).
- **`image_jobs.rs` control path** — `z_image_turbo_control`: resolve the Fun-CN-Union weights (`advanced.controlWeights` or defaults, from the HF cache), `control_scale` (`advanced.controlScale`, default 0.9, clamp [0,2]); load via `LoadSpec::with_control`; per pose render a skeleton → `Conditioning::Control { Pose, scale }` and generate. One image per pose, **shared seed** across the set (noise-attribute consistency, Python parity). Routed **ahead of** the txt2img path so poses are never silently dropped.
- **Refactor** — extracted `consume_gen_events` (the shared streamed-events loop) from `generate_mlx_stream` so the control path reuses the identical progress/cancel/asset-write machinery (no duplication, behavior-preserving).

## Verified end-to-end on real cached weights (in-process, no Python)
Base Z-Image + Fun-Controlnet-Union load, DWPose skeleton render, one 8-step Q8 pose image → valid non-flat 512² with step progress, **~9.5s**.

## Deferred (surfaced + tracked): identity img2img-init — sc-3146
The OPT-IN identity init (`referenceStrength`, sc-2328) is **not** in this PR. It's off by default, validated marginal on 8-step Turbo, and needs `referenceAssetId`→path plumbing not yet in the Rust worker. The engine accepts the optional `Reference`, but rather than half-wire it, an explicit `referenceStrength > 0` **errors loudly (no silent drop)** and I filed **sc-3146** (epic 3018) for the full wiring before the sc-3032 cutover. Pose-only is the default tier (matches the Python default).

## Routing
Already in place from sc-3021: `z_image_mlx_eligible` keeps `reference + poses` (and plain poses) on the mlx worker; this PR makes the worker actually serve them via the control path.

## Cargo.lock
Adds `imageproc` (+ its pure-Rust transitive deps) for the raster. Heavier than ideal for polygon/circle fills, but it's a well-tested standard and the renderer is verified (unit tests + real skeleton-conditioned generation); hand-rolling the fills risked CN-faithfulness bugs.

## Tests
8 renderer unit tests (cross-platform) + control-helper tests (`control_scale` clamp, `pose_entries` filter, `parse_poses`) + `#[ignore]` real-weights pose smoke. `cargo fmt` + `clippy --all-targets -D warnings` + `cargo test` + `cargo build` green; macOS NAX guard green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)