### PR TITLE
sc-3029: FLUX.2-klein edit / reference + KV-cache through the Rust GPU worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,9 +1948,22 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -3318,6 +3331,12 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -6612,3 +6631,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1522,22 +1522,11 @@ fn sdxl_mlx_eligible(payload: &Map<String, Value>) -> bool {
     !request_has_lycoris_lora(payload)
 }
 
-/// FLUX.2-klein (sc-3025) MLX-routing conditions. FLUX.2-klein is an **MLX-only**
-/// family (no torch backend), so this is not an MLX-vs-torch choice — it gates the
-/// *txt2img* surface this story delivers. `edit_image`, a reference (single or multi),
-/// and the KV-cache edit path stay out (story sc-3029). A third-party LyCORIS LoRA
-/// falls back to the procedural placeholder rather than erroring on the mlx worker.
+/// FLUX.2-klein MLX-routing conditions. FLUX.2-klein is an **MLX-only** family (no
+/// torch backend), so everything it does runs on MLX: txt2img (sc-3025) AND
+/// edit/reference + KV-cache + multi-reference (sc-3029). The only exclusion is a
+/// third-party LyCORIS LoRA neither the engine nor the worker can apply.
 fn flux2_mlx_eligible(payload: &Map<String, Value>) -> bool {
-    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
-        return false;
-    }
-    let has_reference = payload
-        .get("referenceAssetId")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().is_empty());
-    if has_reference {
-        return false;
-    }
     !request_has_lycoris_lora(payload)
 }
 
@@ -2025,17 +2014,16 @@ mod mlx_routing_tests {
     }
 
     #[test]
-    fn flux2_plain_txt2img_is_eligible_edit_and_reference_are_not() {
+    fn flux2_txt2img_and_edit_are_eligible_lycoris_is_not() {
+        // FLUX.2 is MLX-only: txt2img (sc-3025) AND edit/reference (sc-3029) all route MLX.
         assert!(flux2_mlx_eligible(&object(
             json!({ "prompt": "a red fox" })
         )));
-        // edit + reference (single/multi) are sc-3029, not this story.
-        assert!(!flux2_mlx_eligible(&object(
-            json!({ "mode": "edit_image" })
-        )));
-        assert!(!flux2_mlx_eligible(&object(
+        assert!(flux2_mlx_eligible(&object(json!({ "mode": "edit_image" }))));
+        assert!(flux2_mlx_eligible(&object(
             json!({ "referenceAssetId": "asset_1" })
         )));
+        // Only a third-party LyCORIS LoRA (unapplicable on the MLX path) is excluded.
         assert!(!flux2_mlx_eligible(&object(json!({
             "loras": [{ "networkType": "lycoris" }]
         }))));

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1616,6 +1616,37 @@ fn flux2_klein_variants_route_to_mlx_worker() {
 }
 
 #[test]
+fn flux2_edit_reference_job_routes_to_mlx_worker() {
+    let store = store("mlx-routing-flux2-edit");
+    register_gpu_worker(&store, "worker-torch", "mps", image_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
+
+    // FLUX.2 is MLX-only, so an edit/reference job (sc-3029) routes to the mlx worker
+    // (sc-3025 kept these on Python; the edit path now exists on Rust).
+    let job = store
+        .create_job(image_job_with(
+            json!({
+                "model": "flux2_klein_9b_kv",
+                "mode": "edit_image",
+                "prompt": "make it golden hour",
+                "sourceAssetId": "asset_1"
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims flux2 edit job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
 fn sdxl_and_realvisxl_route_to_mlx_worker() {
     let store = store("mlx-routing-sdxl");
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -11,7 +11,9 @@ glob = "0.3"
 # PNG encoding for generated image assets (epic 3018, sc-3020). png-only keeps the
 # dependency small and cross-platform (the image-job pipeline + its tests run on every
 # platform; only real MLX inference is macOS-gated).
-image = { version = "0.25", default-features = false, features = ["png"] }
+# png to encode generated assets (sc-3020); jpeg/webp to decode reference/source
+# images for the FLUX.2 edit path (sc-3029) — uploads aren't only PNG.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 # CPU raster for DWPose skeleton rendering (epic 3018, sc-3028): filled polygons
 # (rotated-ellipse limbs), circles (joints/points), for the Z-Image strict-pose
 # ControlNet. Pure-Rust + cross-platform (the renderer + its tests run everywhere;

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -257,6 +257,19 @@ pub(crate) async fn run_image_generate_job(
         )
         .await?;
         true
+    } else if flux2_edit_available(&request, settings) {
+        // FLUX.2-klein edit/reference (mode edit_image or a reference) → edit variant.
+        generate_flux2_edit_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
     } else if mlx_available(&request, settings) {
         generate_mlx_stream(
             api,
@@ -1516,6 +1529,310 @@ async fn generate_zimage_control_stream(
 #[cfg(target_os = "macos")]
 const ZIMAGE_ADAPTER_LABEL: &str = "mlx_z_image";
 
+// ---------------------------------------------------------------------------
+// FLUX.2-klein edit / reference (macOS, sc-3029): the `flux2_klein_9b_edit` and
+// `flux2_klein_9b_kv_edit` variants. FLUX.2-klein is MLX-only (no torch), so this
+// is where its edit/reference jobs run. One output per requested count, each
+// conditioned on the shared reference image(s); the -kv variant auto-engages the
+// reference-K/V cache (~2.4× edit speedup).
+// ---------------------------------------------------------------------------
+
+/// The engine edit-variant id for a FLUX.2 SceneWorks model, or `None` if the model
+/// has no edit variant. The base 9b + true_v2 share `flux2_klein_9b_edit`; the -kv
+/// distill uses `flux2_klein_9b_kv_edit` (reference-K/V cache).
+#[cfg(target_os = "macos")]
+fn flux2_edit_engine_id(model: &str) -> Option<&'static str> {
+    match model {
+        "flux2_klein_9b" | "flux2_klein_9b_true_v2" => Some("flux2_klein_9b_edit"),
+        "flux2_klein_9b_kv" => Some("flux2_klein_9b_kv_edit"),
+        _ => None,
+    }
+}
+
+/// Reference asset ids for a FLUX.2 edit: the character-flow `referenceAssetId`, else
+/// the Image-Edit `sourceAssetId` (edit_image mode). Mirrors the Python
+/// `ref_id = referenceAssetId or (sourceAssetId if edit_image)`.
+#[cfg(target_os = "macos")]
+fn flux2_edit_reference_ids(request: &ImageRequest) -> Vec<String> {
+    if let Some(id) = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        return vec![id.to_owned()];
+    }
+    if request.mode == "edit_image" {
+        if let Some(id) = request
+            .source_asset_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+        {
+            return vec![id.to_owned()];
+        }
+    }
+    Vec::new()
+}
+
+/// True when this is a FLUX.2 edit job (a flux2 edit-capable model + ≥1 reference)
+/// whose base weights resolve — routed to the edit variant rather than txt2img.
+#[cfg(target_os = "macos")]
+fn flux2_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
+    flux2_edit_engine_id(&request.model).is_some()
+        && !flux2_edit_reference_ids(request).is_empty()
+        && resolve_weights_dir(request, settings).is_some()
+}
+
+/// Resolve a reference/source asset id to an in-memory RGB8 image (the engine VAE-
+/// encodes + resizes it). Uses the indexed `ProjectStore::get_asset` → `file.path`.
+#[cfg(target_os = "macos")]
+fn load_reference_image(
+    data_dir: &Path,
+    project_id: &str,
+    asset_id: &str,
+    project_path: &Path,
+) -> WorkerResult<Image> {
+    let asset = ProjectStore::new(data_dir.to_path_buf(), "worker")
+        .get_asset(project_id, asset_id)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("reference asset {asset_id}: {error}"))
+        })?;
+    let rel = asset
+        .get("file")
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!("reference asset {asset_id} has no media path"))
+        })?;
+    let path = project_path.join(rel);
+    let decoded = image::open(&path)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("reference image {}: {error}", path.display()))
+        })?
+        .to_rgb8();
+    Ok(Image {
+        width: decoded.width(),
+        height: decoded.height(),
+        pixels: decoded.into_raw(),
+    })
+}
+
+/// One `Reference` (single) or one `MultiReference` (N) edit conditioning from the
+/// resolved reference images (cloned per output).
+#[cfg(target_os = "macos")]
+fn build_edit_conditioning(references: &[Image]) -> Vec<Conditioning> {
+    if references.len() == 1 {
+        vec![Conditioning::Reference {
+            image: references[0].clone(),
+            strength: None,
+        }]
+    } else {
+        vec![Conditioning::MultiReference {
+            images: references.to_vec(),
+        }]
+    }
+}
+
+/// Generate one FLUX.2 edit image conditioned on `conditioning` (the reference set).
+/// Distilled klein: guidance 1.0, no negative prompt.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn flux2_edit_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: Option<f32>,
+    conditioning: Vec<Conditioning>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        guidance,
+        conditioning,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&request, on_progress)
+        .map_err(|error| WorkerError::InvalidPayload(format!("edit generation failed: {error}")))?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::InvalidPayload("edit generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::InvalidPayload(
+            "edit generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn flux2_edit_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    engine_id: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: Option<f32>,
+    reference_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert(
+        "guidanceScale".to_owned(),
+        guidance.map(|value| json!(value)).unwrap_or(Value::Null),
+    );
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert("editEngine".to_owned(), Value::String(engine_id.to_owned()));
+    raw.insert("referenceCount".to_owned(), json!(reference_count));
+    raw
+}
+
+/// Real FLUX.2 edit generation: load the edit variant once, then `count` outputs each
+/// conditioned on the shared reference set. Mirrors [`generate_mlx_stream`]'s blocking-
+/// thread + streamed-events shape and reuses [`consume_gen_events`].
+#[cfg(target_os = "macos")]
+async fn generate_flux2_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let model = mlx_model(&request.model)
+        .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
+    let engine_id = flux2_edit_engine_id(&request.model)
+        .ok_or_else(|| WorkerError::InvalidPayload("not a FLUX.2 edit model".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings)
+        .ok_or_else(|| WorkerError::InvalidPayload("FLUX.2 weights not found".to_owned()))?;
+    let (quant, quant_bits) = resolve_quant(request);
+    let steps = resolve_steps(request, model);
+    let guidance = resolve_guidance(request, model);
+    let adapters = resolve_adapters(request)?;
+    let repo = model_repo(request, model);
+    let adapter_label = model.adapter_label;
+
+    // Resolve the reference image(s) on the async side (decode → Send Image moved in).
+    let reference_ids = flux2_edit_reference_ids(request);
+    let mut references = Vec::with_capacity(reference_ids.len());
+    for id in &reference_ids {
+        references.push(load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            id,
+            project_path,
+        )?);
+    }
+    if references.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "FLUX.2 edit requires a reference image".to_owned(),
+        ));
+    }
+    let raw_settings = flux2_edit_raw_settings(
+        request,
+        &repo,
+        engine_id,
+        steps,
+        quant_bits,
+        guidance,
+        references.len(),
+    );
+    let count = request.count as usize;
+    let seeds: Vec<i64> = (0..count)
+        .map(|index| resolve_seed(request, index))
+        .collect();
+
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+
+    let blocking = {
+        let prompt = request.prompt.clone();
+        let (width, height) = (request.width, request.height);
+        let seeds = seeds.clone();
+        let cancel = cancel.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let generator = mlx_load(engine_id, weights_dir, quant, adapters)?;
+            for (index, seed) in seeds.into_iter().enumerate() {
+                let conditioning = build_edit_conditioning(&references);
+                let mut on_progress = |progress: Progress| {
+                    let event = match progress {
+                        Progress::Step { current, total } => GenEvent::Step {
+                            index,
+                            current,
+                            total,
+                        },
+                        Progress::Decoding => GenEvent::Decoding { index },
+                    };
+                    let _ = tx.blocking_send(event);
+                };
+                let (width, height, pixels) = flux2_edit_generate_one(
+                    generator.as_ref(),
+                    &prompt,
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
+                    conditioning,
+                    &cancel,
+                    &mut on_progress,
+                )?;
+                if tx
+                    .blocking_send(GenEvent::Image {
+                        index,
+                        seed,
+                        width,
+                        height,
+                        pixels,
+                    })
+                    .is_err()
+                {
+                    break; // receiver gone — stop generating.
+                }
+            }
+            Ok(())
+        })
+    };
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        adapter_label,
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2167,6 +2484,116 @@ mod tests {
             8,
             control,
             0.9,
+            &cancel,
+            &mut |p| {
+                if let mlx_gen::Progress::Step { current, .. } = p {
+                    steps_seen = steps_seen.max(current);
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!((w, h), (512, 512));
+        assert_eq!(pixels.len(), 512 * 512 * 3);
+        assert!(steps_seen >= 1, "expected denoise step progress");
+        assert!(pixels.windows(2).any(|w| w[0] != w[1]));
+    }
+
+    // --- FLUX.2 edit path (sc-3029) ---
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn flux2_edit_engine_id_maps_variants() {
+        assert_eq!(
+            flux2_edit_engine_id("flux2_klein_9b"),
+            Some("flux2_klein_9b_edit")
+        );
+        assert_eq!(
+            flux2_edit_engine_id("flux2_klein_9b_true_v2"),
+            Some("flux2_klein_9b_edit")
+        );
+        assert_eq!(
+            flux2_edit_engine_id("flux2_klein_9b_kv"),
+            Some("flux2_klein_9b_kv_edit")
+        );
+        assert_eq!(flux2_edit_engine_id("z_image_turbo"), None);
+        assert_eq!(flux2_edit_engine_id("sdxl"), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn flux2_edit_reference_ids_prefers_reference_then_source() {
+        // referenceAssetId (character flow) wins.
+        assert_eq!(
+            flux2_edit_reference_ids(&request(json!({
+                "projectId": "p", "referenceAssetId": "ref_1", "sourceAssetId": "src_1"
+            }))),
+            vec!["ref_1".to_owned()]
+        );
+        // sourceAssetId only in edit_image mode.
+        assert_eq!(
+            flux2_edit_reference_ids(&request(json!({
+                "projectId": "p", "mode": "edit_image", "sourceAssetId": "src_1"
+            }))),
+            vec!["src_1".to_owned()]
+        );
+        // sourceAssetId without edit_image mode is ignored (it's the txt2img path).
+        assert!(flux2_edit_reference_ids(&request(json!({
+            "projectId": "p", "sourceAssetId": "src_1"
+        })))
+        .is_empty());
+        assert!(flux2_edit_reference_ids(&request(json!({ "projectId": "p" }))).is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn build_edit_conditioning_single_vs_multi() {
+        let img = |seed| mlx_gen::Image {
+            width: 8,
+            height: 8,
+            pixels: stub_rgb8(8, 8, seed),
+        };
+        match build_edit_conditioning(std::slice::from_ref(&img(1))).as_slice() {
+            [mlx_gen::Conditioning::Reference { .. }] => {}
+            other => panic!("expected one Reference, got {other:?}"),
+        }
+        match build_edit_conditioning(&[img(1), img(2)]).as_slice() {
+            [mlx_gen::Conditioning::MultiReference { images }] => assert_eq!(images.len(), 2),
+            other => panic!("expected MultiReference, got {other:?}"),
+        }
+    }
+
+    /// Real-weights smoke: FLUX.2-klein edit. Loads `flux2_klein_9b_edit` (base 9B
+    /// snapshot) and generates one image conditioned on a synthetic reference. Needs
+    /// the HF cache (`black-forest-labs/FLUX.2-klein-9B`) + a Metal device; run on
+    /// demand: `cargo test -p sceneworks-worker --lib -- --ignored flux2_edit_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real FLUX.2-klein-9b weights + Metal device"]
+    fn flux2_edit_real_weights_generates_one_image() {
+        let snapshot = hf_snapshot("models--black-forest-labs--FLUX.2-klein-9b");
+        let generator = mlx_load(
+            "flux2_klein_9b_edit",
+            snapshot,
+            Some(mlx_gen::Quant::Q8),
+            Vec::new(),
+        )
+        .unwrap();
+        let reference = mlx_gen::Image {
+            width: 512,
+            height: 512,
+            pixels: stub_rgb8(512, 512, 7),
+        };
+        let cancel = mlx_gen::CancelFlag::new();
+        let mut steps_seen = 0u32;
+        let (w, h, pixels) = flux2_edit_generate_one(
+            generator.as_ref(),
+            "make it a watercolor painting",
+            512,
+            512,
+            42,
+            4,
+            Some(1.0),
+            build_edit_conditioning(std::slice::from_ref(&reference)),
             &cancel,
             &mut |p| {
                 if let mlx_gen::Progress::Step { current, .. } = p {


### PR DESCRIPTION
Story **sc-3029** (epic 3018, advanced #11). FLUX.2-klein is the **only MLX family with no torch fallback**, so this moves its edit/reference jobs onto the Rust worker.

## What landed
- **`flux2_edit_engine_id`** — base 9b + true_v2 → `flux2_klein_9b_edit`; the -kv distill → `flux2_klein_9b_kv_edit` (the reference-K/V cache auto-engages, ~2.4× edit speedup).
- **`load_reference_image`** — resolve `referenceAssetId` (character flow) or `sourceAssetId` (edit_image mode) → `ProjectStore::get_asset` (indexed) → `file.path` → decode to `mlx_gen::Image`. Added **jpeg + webp** decode features (references aren't only PNG). This resolver also unblocks the Z-Image img2img-init follow-up (sc-3146).
- **`generate_flux2_edit_stream`** — load the edit variant once, then `count` outputs each conditioned on the shared reference set: `Conditioning::Reference` (single) or `Conditioning::MultiReference` (N). 4 steps, guidance 1.0, **no negative** (distilled klein). Reuses `consume_gen_events`; dispatched **ahead of** the txt2img path so a reference is never silently dropped.

## Routing (sc-3021/3025 update)
`flux2_mlx_eligible` now allows edit/reference — FLUX.2 is MLX-only, so txt2img **and** edit all run on MLX; only a third-party LyCORIS LoRA (unapplicable on either) is excluded. Updated the sc-3025 unit test that had asserted edit/reference were *not* eligible.

## Scope note
FLUX.2-klein edit is **single-reference** in practice (the payload carries one `referenceAssetId`/`sourceAssetId`); the engine's `MultiReference` is wired here but has no multi-id payload field yet — the pose-tier per-iteration `[skeleton, ref]` pairs are sc-3030.

## Verified end-to-end on real cached weights (in-process, no Python)
`flux2_klein_9b_edit` loads + generates one 4-step Q8 edit conditioned on a reference (**~8s**).

## Tests
Worker unit tests (edit engine map, reference-id precedence, single-vs-multi conditioning) + `#[ignore]` real-weights edit smoke; `jobs_store` unit + integration test for flux2 edit routing. `cargo fmt` + `clippy --all-targets -D warnings` + `cargo test` + `cargo build` green; macOS NAX guard green locally. `Cargo.lock` adds the jpeg/webp decoders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)