### PR TITLE
sc-3033: Rust video-job runtime — VideoRequest DTO + frame/audio encode + mp4 mux + poster

### DIFF
--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod store_util;
 pub mod time;
 pub mod training;
 pub mod training_store;
+pub mod video_request;
 
 pub const API_PREFIX: &str = "/api/v1";
 pub const HEALTH_ROUTE: &str = "/health";

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -1,0 +1,382 @@
+//! The video-generation job request (epic 3018, sc-3033).
+//!
+//! Parses a job `payload` into a typed request, mirroring the Python worker's
+//! `video_request_from_job` (apps/worker/scene_worker/video_adapters.py) so the
+//! native MLX Rust worker reads the same payload the UI already sends. The
+//! `advanced` and `model_manifest_entry` maps pass through verbatim (they carry
+//! per-model knobs like steps/guidanceScale/imageConditioningStrength and the
+//! resolved manifest entry), so adding a model needs no DTO change.
+//!
+//! The advanced-mode asset ids (`last_frame` / `source_clip` / `bridge_right_clip`
+//! / `person_track`) are parsed and carried so the asset fact + routing layer see
+//! them, but the MLX video path (Wan / LTX text-or-image→video) does not consume
+//! them — those modes (first_last_frame / extend_clip / video_bridge /
+//! replace_person) stay on the Python torch worker (epic 3018 scope boundary;
+//! the MLX-vs-Python routing decision is sc-3036).
+
+use serde_json::Value;
+
+use crate::contracts::JsonObject;
+
+/// Defaults matching the Python `video_request_from_job` (`.get(key, default)`).
+const DEFAULT_MODE: &str = "image_to_video";
+const DEFAULT_MODEL: &str = "ltx_2_3";
+const DEFAULT_QUALITY: &str = "balanced";
+const DEFAULT_REPLACEMENT_MODE: &str = "face_only";
+
+/// A typed video-generation request, parsed from a job payload. One job produces a
+/// single video asset (unlike images, which batch `count`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct VideoRequest {
+    pub project_id: String,
+    pub mode: String,
+    pub prompt: String,
+    pub negative_prompt: String,
+    pub model: String,
+    /// Clip length in seconds, clamped to 1.0..=30.0 (Python `safe_float`).
+    pub duration: f32,
+    /// Frames per second, clamped to 1..=60 (Python `safe_int`).
+    pub fps: u32,
+    /// Output dimensions: clamped to 256..=1920, then floored to a multiple of 32
+    /// (Python `normalized_dimensions`). Defaults 768x512.
+    pub width: u32,
+    pub height: u32,
+    pub quality: String,
+    /// Base seed; `None` means derive deterministically from the prompt at run time.
+    pub seed: Option<i64>,
+    /// LoRA specs, passed through verbatim (shape resolved per family).
+    pub loras: Vec<Value>,
+    pub character_id: Option<String>,
+    pub character_look_id: Option<String>,
+    /// Image→video conditioning source (consumed by the MLX I2V path).
+    pub source_asset_id: Option<String>,
+    // --- Advanced-mode fields: parsed + carried, but Python-routed (sc-3036). ---
+    pub person_track_id: Option<String>,
+    pub replacement_mode: String,
+    pub last_frame_asset_id: Option<String>,
+    pub source_clip_asset_id: Option<String>,
+    pub bridge_right_clip_asset_id: Option<String>,
+    /// Per-model advanced knobs (steps, guidanceScale, imageConditioningStrength,
+    /// timelineContext, …), passed through.
+    pub advanced: JsonObject,
+    /// The resolved builtin+user model manifest entry (repo/quant/limits/…).
+    pub model_manifest_entry: JsonObject,
+}
+
+impl VideoRequest {
+    /// Parse a job payload (the `payload` object of a `JobSnapshot`). Infallible:
+    /// missing fields fall back to the Python defaults and `project_id` may be empty
+    /// — the caller validates it is present (the worker rejects an empty project id).
+    pub fn from_payload(payload: &JsonObject) -> Self {
+        let (width, height) = normalized_dimensions(payload.get("width"), payload.get("height"));
+        Self {
+            project_id: string_or(payload, "projectId", ""),
+            mode: string_or(payload, "mode", DEFAULT_MODE),
+            prompt: string_or(payload, "prompt", ""),
+            negative_prompt: string_or(payload, "negativePrompt", ""),
+            model: string_or(payload, "model", DEFAULT_MODEL),
+            duration: safe_float(payload.get("duration"), 6.0, 1.0, 30.0),
+            fps: safe_int(payload.get("fps"), 25, 1, 60),
+            width,
+            height,
+            quality: string_or(payload, "quality", DEFAULT_QUALITY),
+            seed: optional_i64(payload, "seed"),
+            loras: array_or_empty(payload, "loras"),
+            character_id: optional_id(payload, "characterId"),
+            character_look_id: optional_id(payload, "characterLookId"),
+            source_asset_id: optional_id(payload, "sourceAssetId"),
+            person_track_id: optional_id(payload, "personTrackId"),
+            replacement_mode: string_or(payload, "replacementMode", DEFAULT_REPLACEMENT_MODE),
+            last_frame_asset_id: optional_id(payload, "lastFrameAssetId"),
+            source_clip_asset_id: optional_id(payload, "sourceClipAssetId"),
+            bridge_right_clip_asset_id: optional_id(payload, "bridgeRightClipAssetId"),
+            advanced: object_or_empty(payload, "advanced"),
+            model_manifest_entry: object_or_empty(payload, "modelManifestEntry"),
+        }
+    }
+
+    /// Raw frame count from `duration * fps` (Python `round(duration * fps)`), at
+    /// least 1. The per-model snap ([`frame_count`](Self::frame_count)) rounds this
+    /// to the model's temporal stride.
+    pub fn raw_frame_count(&self) -> u32 {
+        ((self.duration * self.fps as f32).round() as i64).max(1) as u32
+    }
+
+    /// The frame count the model will actually produce: the raw `duration * fps`
+    /// snapped to the model's temporal constraint (LTX `8k + 1`, Wan `4n + 1`).
+    /// Unknown / stub models keep the raw count. The engine's `validate()` is
+    /// authoritative for the real models (sc-3034 / sc-3035); this mirrors the
+    /// Python worker's pre-snap so the stub clip length and the UI estimate agree.
+    pub fn frame_count(&self) -> u32 {
+        let raw = self.raw_frame_count();
+        if is_ltx_model(&self.model) {
+            ltx_frame_count(raw)
+        } else if is_wan_model(&self.model) {
+            wan_frame_count(raw)
+        } else {
+            raw
+        }
+    }
+}
+
+/// LTX-2.3 temporal stride: frames snap to the nearest `8k + 1`, minimum 9. Direct
+/// port of the Python `ltx_frame_count`.
+pub fn ltx_frame_count(raw_frames: u32) -> u32 {
+    let frame_count = raw_frames.max(9);
+    let lower = frame_count - ((frame_count - 1) % 8);
+    let upper = lower + 8;
+    if lower < 9 {
+        return upper;
+    }
+    let lower_delta = frame_count - lower;
+    let upper_delta = upper - frame_count;
+    if lower_delta <= upper_delta {
+        lower
+    } else {
+        upper
+    }
+}
+
+/// Wan2.2 temporal stride: the VAE math `t_lat = (frames − 1) / 4 + 1` requires
+/// `frames ≡ 1 (mod 4)`, so frames snap to the nearest `4n + 1`, minimum 1.
+pub fn wan_frame_count(raw_frames: u32) -> u32 {
+    let raw = raw_frames.max(1);
+    let lower = raw - ((raw - 1) % 4);
+    let upper = lower + 4;
+    if raw - lower <= upper - raw {
+        lower
+    } else {
+        upper
+    }
+}
+
+/// Whether `model` is an LTX-2.3 family id (`ltx_2_3`, `ltx_2_3_eros`, …).
+pub fn is_ltx_model(model: &str) -> bool {
+    model.starts_with("ltx")
+}
+
+/// Whether `model` is a Wan2.2 family id (`wan_2_2`, `wan_2_2_t2v_14b`, …).
+pub fn is_wan_model(model: &str) -> bool {
+    model.starts_with("wan")
+}
+
+/// Clamp + floor dimensions exactly like the Python `normalized_dimensions`: parse
+/// (default 768x512), clamp to 256..=1920, floor to a multiple of 32, floor of 256.
+fn normalized_dimensions(width: Option<&Value>, height: Option<&Value>) -> (u32, u32) {
+    let w = floor_to_32(safe_int(width, 768, 256, 1920));
+    let h = floor_to_32(safe_int(height, 512, 256, 1920));
+    (w, h)
+}
+
+fn floor_to_32(value: u32) -> u32 {
+    (value - (value % 32)).max(256)
+}
+
+fn string_or(payload: &JsonObject, key: &str, default: &str) -> String {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_owned()
+}
+
+fn optional_id(payload: &JsonObject, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn optional_i64(payload: &JsonObject, key: &str) -> Option<i64> {
+    payload.get(key).and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    })
+}
+
+/// Parse an int (JSON number or numeric string), clamp to `[min, max]`, default
+/// when absent/unparseable — the `safe_int` contract.
+fn safe_int(value: Option<&Value>, default: u32, min: u32, max: u32) -> u32 {
+    value
+        .and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or(default)
+        .clamp(min, max)
+}
+
+/// Parse a float (JSON number or numeric string), clamp to `[min, max]`, default
+/// when absent/unparseable — the `safe_float` contract.
+fn safe_float(value: Option<&Value>, default: f32, min: f32, max: f32) -> f32 {
+    value
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .filter(|value| value.is_finite())
+        .unwrap_or(default)
+        .clamp(min, max)
+}
+
+fn array_or_empty(payload: &JsonObject, key: &str) -> Vec<Value> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn object_or_empty(payload: &JsonObject, key: &str) -> JsonObject {
+    payload
+        .get(key)
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload(value: Value) -> JsonObject {
+        value.as_object().cloned().unwrap()
+    }
+
+    #[test]
+    fn defaults_when_payload_is_minimal() {
+        let request = VideoRequest::from_payload(&payload(json!({ "projectId": "proj_1" })));
+        assert_eq!(request.project_id, "proj_1");
+        assert_eq!(request.mode, "image_to_video");
+        assert_eq!(request.model, "ltx_2_3");
+        assert_eq!(request.duration, 6.0);
+        assert_eq!(request.fps, 25);
+        assert_eq!(request.width, 768);
+        assert_eq!(request.height, 512);
+        assert_eq!(request.quality, "balanced");
+        assert_eq!(request.replacement_mode, "face_only");
+        assert!(request.seed.is_none());
+        assert!(request.loras.is_empty());
+        assert!(request.advanced.is_empty());
+        assert!(request.source_asset_id.is_none());
+    }
+
+    #[test]
+    fn clamps_duration_fps_and_dimensions() {
+        let request = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "duration": 99, "fps": 999, "width": 99999, "height": 100
+        })));
+        assert_eq!(request.duration, 30.0);
+        assert_eq!(request.fps, 60);
+        // 1920 is already a multiple of 32; 100 clamps to 256.
+        assert_eq!(request.width, 1920);
+        assert_eq!(request.height, 256);
+
+        let low = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "duration": 0, "fps": 0
+        })));
+        assert_eq!(low.duration, 1.0);
+        assert_eq!(low.fps, 1);
+    }
+
+    #[test]
+    fn floors_dimensions_to_multiple_of_32() {
+        let request = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "width": 1000, "height": 543
+        })));
+        // 1000 -> 992 (31*32), 543 -> 512 (16*32).
+        assert_eq!(request.width, 992);
+        assert_eq!(request.height, 512);
+    }
+
+    #[test]
+    fn reads_numeric_strings_and_carries_advanced_fields() {
+        let request = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p",
+            "duration": "4.5",
+            "fps": "30",
+            "seed": "42",
+            "sourceAssetId": "asset_src",
+            "personTrackId": "track_1",
+            "lastFrameAssetId": "asset_last",
+            "advanced": { "guidanceScale": 4.0, "steps": 20 },
+            "modelManifestEntry": { "family": "ltx-video", "repo": "x" },
+            "loras": [{ "path": "a.safetensors", "weight": 0.8 }]
+        })));
+        assert_eq!(request.duration, 4.5);
+        assert_eq!(request.fps, 30);
+        assert_eq!(request.seed, Some(42));
+        assert_eq!(request.source_asset_id.as_deref(), Some("asset_src"));
+        assert_eq!(request.person_track_id.as_deref(), Some("track_1"));
+        assert_eq!(request.last_frame_asset_id.as_deref(), Some("asset_last"));
+        assert_eq!(request.advanced.get("steps"), Some(&json!(20)));
+        assert_eq!(
+            request.model_manifest_entry.get("family"),
+            Some(&json!("ltx-video"))
+        );
+        assert_eq!(request.loras.len(), 1);
+    }
+
+    #[test]
+    fn raw_frame_count_rounds_duration_times_fps() {
+        let request = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "stub", "duration": 2.0, "fps": 24
+        })));
+        assert_eq!(request.raw_frame_count(), 48);
+        // Unknown model keeps the raw count.
+        assert_eq!(request.frame_count(), 48);
+    }
+
+    #[test]
+    fn ltx_frame_count_snaps_to_8k_plus_1() {
+        // Exact 8k+1 values are unchanged.
+        assert_eq!(ltx_frame_count(9), 9);
+        assert_eq!(ltx_frame_count(17), 17);
+        assert_eq!(ltx_frame_count(121), 121);
+        // Below the floor snaps up to 9.
+        assert_eq!(ltx_frame_count(1), 9);
+        assert_eq!(ltx_frame_count(8), 9);
+        // Nearest wins; ties go to the lower 8k+1.
+        assert_eq!(ltx_frame_count(13), 9); // |13-9|=4 == |17-13|=4 -> lower
+        assert_eq!(ltx_frame_count(14), 17); // closer to 17
+                                             // A real default: 6s * 25fps = 150 -> nearest of 145 / 153 -> 153.
+        assert_eq!(ltx_frame_count(150), 153);
+    }
+
+    #[test]
+    fn wan_frame_count_snaps_to_4n_plus_1() {
+        assert_eq!(wan_frame_count(1), 1);
+        assert_eq!(wan_frame_count(5), 5);
+        assert_eq!(wan_frame_count(81), 81);
+        assert_eq!(wan_frame_count(2), 1); // |2-1|=1 <= |5-2|=3 -> lower
+        assert_eq!(wan_frame_count(4), 5); // |4-1|=3 > |5-4|=1 -> upper
+        assert_eq!(wan_frame_count(83), 81); // |83-81|=2 <= |85-83|=2 -> lower
+    }
+
+    #[test]
+    fn frame_count_dispatches_by_model_family() {
+        let ltx = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "ltx_2_3", "duration": 6.0, "fps": 25
+        })));
+        assert_eq!(ltx.frame_count(), ltx_frame_count(150));
+
+        let wan = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "wan_2_2_t2v_14b", "duration": 3.0, "fps": 16
+        })));
+        assert_eq!(wan.frame_count(), wan_frame_count(48));
+
+        assert!(is_ltx_model("ltx_2_3_eros"));
+        assert!(is_wan_model("wan_2_2"));
+        assert!(!is_ltx_model("wan_2_2"));
+    }
+}

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -150,18 +150,23 @@ pub(crate) fn cpu_gpu() -> DiscoveredGpu {
     }
 }
 
-/// The Apple-Silicon native MLX GPU worker (epic 3018): advertises `image_generate`,
-/// served in-process by the linked mlx-gen engine. `Gpu` (not `Cpu`) so the API's
-/// `worker_supports_job` lets GPU jobs route here; it deliberately does NOT carry the
-/// CPU utility capabilities, so downloads/imports/etc. still go to the CPU worker.
-/// Video + the remaining image capabilities are added as their stories land
-/// (sc-3022.. image, sc-3034.. video).
+/// The Apple-Silicon native MLX GPU worker (epic 3018): advertises `image_generate`
+/// and `video_generate`, served in-process by the linked mlx-gen engine. `Gpu` (not
+/// `Cpu`) so the API's `worker_supports_job` lets GPU jobs route here; it deliberately
+/// does NOT carry the CPU utility capabilities, so downloads/imports/etc. still go to
+/// the CPU worker. `video_generate` is claimed from the video runtime onward (sc-3033);
+/// the procedural stub backs models whose real MLX path is not yet linked (Wan sc-3034,
+/// LTX+audio sc-3035), and the API-side MLX-vs-Python routing is sc-3036.
 #[cfg(target_os = "macos")]
 pub(crate) fn mlx_gpu() -> DiscoveredGpu {
     DiscoveredGpu {
         id: "mlx".to_owned(),
         name: "Apple Silicon (MLX)".to_owned(),
-        capabilities: vec![WorkerCapability::Gpu, WorkerCapability::ImageGenerate],
+        capabilities: vec![
+            WorkerCapability::Gpu,
+            WorkerCapability::ImageGenerate,
+            WorkerCapability::VideoGenerate,
+        ],
         utilization: None,
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -594,7 +594,7 @@ fn image_progress(
     }
 }
 
-fn backend_label(gpu_id: &str) -> &str {
+pub(crate) fn backend_label(gpu_id: &str) -> &str {
     if gpu_id.trim().is_empty() {
         "cpu"
     } else {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -43,6 +43,8 @@ mod media_jobs;
 use media_jobs::*;
 mod image_jobs;
 use image_jobs::*;
+mod video_jobs;
+use video_jobs::*;
 mod downloads;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on other platforms it still builds + unit-tests (cross-platform
@@ -463,6 +465,14 @@ async fn run_utility_job(
         JobType::ImageGenerate => run_image_generate_job(api, settings, &job)
             .await
             .map_err(|error| ("Image generation failed.", error)),
+        // Native MLX video generation, served in-process by the linked mlx-gen engine
+        // on the macOS Apple-Silicon GPU worker (epic 3018). sc-3033 ships the runtime
+        // + procedural stub; the real Wan (sc-3034) / LTX+audio (sc-3035) models link
+        // their provider crates. Off macOS the capability is never advertised, so this
+        // arm is unreachable there.
+        JobType::VideoGenerate => run_video_generate_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Video generation failed.", error)),
         JobType::ModelDownload => run_model_download_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Model download failed.", error)),

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -18,6 +18,25 @@ pub(crate) struct FfmpegContext<'a> {
     cancel_message: &'a str,
 }
 
+impl<'a> FfmpegContext<'a> {
+    /// Build a context so callers in sibling modules (e.g. video generation,
+    /// `video_jobs`) can drive [`run_ffmpeg`] with the same periodic-heartbeat +
+    /// cooperative-cancel loop the in-module callers use.
+    pub(crate) fn new(
+        api: &'a ApiClient,
+        settings: &'a Settings,
+        job_id: &'a str,
+        cancel_message: &'a str,
+    ) -> Self {
+        Self {
+            api,
+            settings,
+            job_id,
+            cancel_message,
+        }
+    }
+}
+
 pub(crate) async fn run_frame_extract_job(
     api: &ApiClient,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -423,18 +423,22 @@ fn rust_cpu_capabilities_do_not_claim_gpu_generation_jobs() {
         .any(|capability| capability.as_str() == "image_generate"));
 }
 
-/// The Apple-Silicon MLX GPU worker (epic 3018) advertises `image_generate` so the
-/// API routes generation to it, but it must NOT pick up CPU utility jobs (those stay
-/// on the CPU worker) — the inverse of the CPU-worker contract above.
+/// The Apple-Silicon MLX GPU worker (epic 3018) advertises `image_generate` +
+/// `video_generate` so the API routes generation to it, but it must NOT pick up CPU
+/// utility jobs (those stay on the CPU worker) — the inverse of the CPU-worker
+/// contract above. `video_generate` lands with the video runtime (sc-3033).
 #[cfg(target_os = "macos")]
 #[test]
-fn mlx_gpu_advertises_image_generate_only() {
+fn mlx_gpu_advertises_generation_capabilities_only() {
     let mlx = mlx_gpu();
     assert_eq!(mlx.id, "mlx");
     let capabilities = worker_capabilities_with_utility(&mlx, true);
     assert!(capabilities
         .iter()
         .any(|capability| capability.as_str() == "image_generate"));
+    assert!(capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "video_generate"));
     assert!(capabilities
         .iter()
         .any(|capability| capability.as_str() == "gpu"));

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1,0 +1,871 @@
+//! Native video-generation jobs — runtime pipeline + procedural stub (epic 3018, sc-3033).
+//!
+//! Parses the job into a [`VideoRequest`], produces a single video (one mp4 asset,
+//! unlike images which batch `count`), and reports a flat "fact" the Rust API turns
+//! into an indexed asset (mirroring `video_generation_result` in the Python worker's
+//! `video_adapters.py`). The shared encode pipeline takes the engine's video output
+//! shape — RGB8 `frames` + `fps` + an optional synchronized `audio` track — writes
+//! the frames to an mp4 (libx264), muxes a 16-bit-PCM WAV as AAC when audio is present
+//! (`-shortest`), remuxes `+faststart` (WKWebView range-seek), and extracts a poster
+//! frame. It reuses [`crate::media_jobs::run_ffmpeg`] (binary resolution + the
+//! periodic-heartbeat / cooperative-cancel loop).
+//!
+//! sc-3033 ships only the **procedural stub** generator (a moving gradient + a quiet
+//! synchronized tone for the LTX family, mirroring the engine: LTX emits audio, Wan
+//! does not). The real in-process MLX video models — Wan2.2 (sc-3034) and LTX-2.3 +
+//! audio (sc-3035) — link the `mlx-gen-wan` / `mlx-gen-ltx` provider crates and decode
+//! `mlx_gen::GenerationOutput::Video { frames, fps, audio }` into the same
+//! [`DecodedVideo`], so the encode/mux/poster path below is unchanged for them.
+
+use std::f32::consts::PI;
+use std::path::Path;
+
+use sceneworks_core::video_request::{is_ltx_model, VideoRequest};
+
+use super::*;
+use crate::media_jobs::{run_ffmpeg, FfmpegContext};
+
+/// Stub adapter id recorded on generated assets — matches the Python
+/// `ProceduralVideoAdapter.id` so the asset sidecar reads identically.
+const STUB_ADAPTER: &str = "procedural_video";
+const CANCEL_MESSAGE: &str = "Video generation canceled by user.";
+
+/// Decoded video ready for muxing — the worker-side shape both the procedural stub
+/// (sc-3033) and the real engine output (`mlx_gen::GenerationOutput::Video`,
+/// sc-3034/3035) feed into [`encode_media`]. Mirrors the engine contract: `frames`
+/// are RGB8, `audio` is `Some` for LTX (a synchronized track) and `None` for Wan.
+/// The frames are held in memory (the engine returns them that way); the duration
+/// clamp (≤30s) in [`VideoRequest`] bounds the footprint.
+struct DecodedVideo {
+    frames: Vec<RgbFrame>,
+    fps: u32,
+    audio: Option<AudioTrack>,
+}
+
+/// One RGB8 frame, row-major, `pixels.len() == width * height * 3` (the engine's
+/// `Image`).
+struct RgbFrame {
+    width: u32,
+    height: u32,
+    pixels: Vec<u8>,
+}
+
+/// Interleaved PCM audio — the engine's `AudioTrack` (LTX-2.3 synchronized audio).
+struct AudioTrack {
+    samples: Vec<f32>,
+    sample_rate: u32,
+    channels: u16,
+}
+
+/// Dispatch handler for `JobType::VideoGenerate`: generate, encode, and stream a
+/// single video asset through the Rust GPU worker.
+pub(crate) async fn run_video_generate_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let request = VideoRequest::from_payload(&job.payload);
+    if request.project_id.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Missing payload.projectId".to_owned(),
+        ));
+    }
+    let project =
+        ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
+    let project_path = PathBuf::from(project.path);
+    let plan = VideoPlan::new(&request, &project_path);
+    if let Some(parent) = plan.media_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let backend = backend_label(&settings.gpu_id);
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        video_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.05,
+            "Preparing video.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+
+    // sc-3033 ships the procedural stub only; the real MLX video models (Wan sc-3034,
+    // LTX+audio sc-3035) decode `GenerationOutput::Video` into a `DecodedVideo` here.
+    check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
+    let seed = resolve_video_seed(&request);
+    update_job(
+        api,
+        &job.id,
+        video_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.2,
+            "Rendering frames.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+    let decoded = generate_stub_video(&request, seed);
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+
+    check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
+    update_job(
+        api,
+        &job.id,
+        video_progress(
+            JobStatus::Running,
+            ProgressStage::Muxing,
+            0.6,
+            "Encoding video.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+    let ctx = FfmpegContext::new(api, settings, &job.id, CANCEL_MESSAGE);
+    encode_media(&plan.media_path, decoded, Some(ctx)).await?;
+
+    let fact = video_asset_fact(&plan, seed);
+    let result = streaming_result(&plan, &fact);
+    update_job(
+        api,
+        &job.id,
+        video_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Generated video.",
+            Some(result),
+            backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Per-job invariants for the single video this job produces.
+struct VideoPlan {
+    request: VideoRequest,
+    genset_id: String,
+    asset_id: String,
+    created_at: String,
+    family: String,
+    /// `assets/videos/<genset>/<date>_<model>_<slug>.mp4` (project-relative).
+    media_rel: String,
+    /// Absolute path to the media file.
+    media_path: PathBuf,
+}
+
+impl VideoPlan {
+    fn new(request: &VideoRequest, project_path: &Path) -> Self {
+        let genset_id = format!("genset_{}", Uuid::new_v4().simple());
+        let asset_id = fresh_asset_id();
+        let created_at = now_rfc3339();
+        let family = resolve_family(request);
+        let slug = slugify(&request.prompt, "video", Some(42));
+        // Nest under the per-generation id so two renders sharing date+model+slug
+        // cannot collide on a flat path (mirrors the image + Python video adapters).
+        let media_rel = format!(
+            "assets/videos/{genset_id}/{}_{}_{slug}.mp4",
+            &created_at[..10],
+            request.model
+        );
+        let media_path = project_path.join(&media_rel);
+        Self {
+            request: request.clone(),
+            genset_id,
+            asset_id,
+            created_at,
+            family,
+            media_rel,
+            media_path,
+        }
+    }
+}
+
+/// Resolve the seed, matching the Python `resolve_seed(seed, prompt)`: an explicit
+/// seed wins, else the first 4 bytes of `sha256(prompt)` (its `hexdigest()[:8]`).
+fn resolve_video_seed(request: &VideoRequest) -> i64 {
+    if let Some(seed) = request.seed {
+        return seed;
+    }
+    let digest = Sha256::digest(request.prompt.as_bytes());
+    u32::from_be_bytes([digest[0], digest[1], digest[2], digest[3]]) as i64
+}
+
+/// The asset's video family, from the resolved manifest entry when present, else
+/// inferred from the model id (parity with the Python `VIDEO_MODEL_TARGETS` family).
+fn resolve_family(request: &VideoRequest) -> String {
+    if let Some(family) = request
+        .model_manifest_entry
+        .get("family")
+        .and_then(Value::as_str)
+    {
+        if !family.trim().is_empty() {
+            return family.to_owned();
+        }
+    }
+    if is_ltx_model(&request.model) {
+        "ltx-video".to_owned()
+    } else if request.model.starts_with("wan") {
+        "wan-video".to_owned()
+    } else {
+        "video".to_owned()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Procedural stub generator (sc-3033). Real MLX models land in sc-3034/3035.
+// ---------------------------------------------------------------------------
+
+/// Build a deterministic placeholder clip: `frame_count` moving-gradient frames at
+/// the request fps, plus a quiet synchronized tone for the LTX family (the engine
+/// emits audio for LTX and none for Wan, so the stub mirrors that split — exercising
+/// both the audio-mux and video-only encode paths).
+fn generate_stub_video(request: &VideoRequest, seed: i64) -> DecodedVideo {
+    let frame_count = request.frame_count();
+    let fps = request.fps.max(1);
+    let (width, height) = (request.width, request.height);
+    let frames = (0..frame_count)
+        .map(|index| RgbFrame {
+            width,
+            height,
+            pixels: stub_video_rgb8(width, height, seed, index, frame_count),
+        })
+        .collect();
+    let audio = is_ltx_model(&request.model).then(|| stub_audio_track(frame_count, fps));
+    DecodedVideo { frames, fps, audio }
+}
+
+/// Deterministic per-frame pixels: a vertical gradient from a per-seed base colour to
+/// white, with a bright vertical band that sweeps left→right across the clip so frames
+/// differ (visible motion). Exactly `width * height * 3` RGB8 bytes.
+fn stub_video_rgb8(width: u32, height: u32, seed: i64, index: u32, frame_count: u32) -> Vec<u8> {
+    let seed = seed as u64;
+    let base = [
+        (seed & 0xFF) as u8,
+        ((seed >> 8) & 0xFF) as u8,
+        ((seed >> 16) & 0xFF) as u8,
+    ];
+    let v_span = height.saturating_sub(1).max(1) as f32;
+    // The sweeping band's centre column for this frame.
+    let progress = index as f32 / frame_count.max(1) as f32;
+    let band_centre = progress * width.saturating_sub(1).max(1) as f32;
+    let band_half = (width as f32 * 0.06).max(1.0);
+    let mut buffer = Vec::with_capacity((width as usize) * (height as usize) * 3);
+    for y in 0..height {
+        let t = y as f32 / v_span;
+        let row = [lerp(base[0], t), lerp(base[1], t), lerp(base[2], t)];
+        for x in 0..width {
+            let dist = (x as f32 - band_centre).abs();
+            if dist <= band_half {
+                // Brighten toward white inside the band (1.0 at centre → 0 at edge).
+                let highlight = 1.0 - dist / band_half;
+                buffer.push(lerp(row[0], highlight));
+                buffer.push(lerp(row[1], highlight));
+                buffer.push(lerp(row[2], highlight));
+            } else {
+                buffer.extend_from_slice(&row);
+            }
+        }
+    }
+    buffer
+}
+
+fn lerp(a: u8, t: f32) -> u8 {
+    let a = a as f32;
+    (a + (255.0 - a) * t).round().clamp(0.0, 255.0) as u8
+}
+
+/// A quiet 220 Hz mono tone matching the clip length (`frame_count / fps` seconds) at
+/// 48 kHz — enough to exercise the WAV-write + AAC-mux + `-shortest` path end to end.
+fn stub_audio_track(frame_count: u32, fps: u32) -> AudioTrack {
+    let sample_rate = 48_000u32;
+    let duration = frame_count as f32 / fps.max(1) as f32;
+    let n = (sample_rate as f32 * duration).round().max(1.0) as usize;
+    let freq = 220.0f32;
+    let samples = (0..n)
+        .map(|i| (2.0 * PI * freq * (i as f32 / sample_rate as f32)).sin() * 0.2)
+        .collect();
+    AudioTrack {
+        samples,
+        sample_rate,
+        channels: 1,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encode pipeline: frames → mp4 (+ optional AAC audio) → faststart → poster.
+// Reuses `media_jobs::run_ffmpeg`. Pure of the API except the optional `ctx`
+// (heartbeat/cancel), so it is exercisable in tests with a real ffmpeg.
+// ---------------------------------------------------------------------------
+
+/// Write `decoded` to `media_path` as an mp4: frames → libx264, an optional 16-bit
+/// PCM WAV muxed as AAC (`-shortest`), then a best-effort `+faststart` remux and
+/// `.poster.jpg`. `media_path` is created (atomically renamed from a temp) only on
+/// success; all intermediates are removed regardless of outcome.
+async fn encode_media(
+    media_path: &Path,
+    decoded: DecodedVideo,
+    ctx: Option<FfmpegContext<'_>>,
+) -> WorkerResult<()> {
+    let frames_dir = media_path.with_extension("frames");
+    let enc_tmp = media_path.with_extension("enc.mp4");
+    let wav_tmp = media_path.with_extension("audio.wav");
+    let mux_tmp = media_path.with_extension("mux.mp4");
+    let result = encode_inner(
+        media_path,
+        decoded,
+        ctx,
+        &frames_dir,
+        &enc_tmp,
+        &wav_tmp,
+        &mux_tmp,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&frames_dir).await;
+    let _ = tokio::fs::remove_file(&enc_tmp).await;
+    let _ = tokio::fs::remove_file(&wav_tmp).await;
+    let _ = tokio::fs::remove_file(&mux_tmp).await;
+    if result.is_err() {
+        // A failure (or cancel) before the atomic rename leaves no media_path; if the
+        // rename itself half-completed, drop the partial so the asset never points at it.
+        let _ = tokio::fs::remove_file(media_path).await;
+    }
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn encode_inner(
+    media_path: &Path,
+    decoded: DecodedVideo,
+    ctx: Option<FfmpegContext<'_>>,
+    frames_dir: &Path,
+    enc_tmp: &Path,
+    wav_tmp: &Path,
+    mux_tmp: &Path,
+) -> WorkerResult<()> {
+    let fps = decoded.fps.max(1);
+    let audio = decoded.audio;
+    let frames = decoded.frames;
+    if frames.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "video generation produced no frames".to_owned(),
+        ));
+    }
+
+    // 1. Write the frame sequence (blocking PNG encodes off the async runtime).
+    tokio::fs::create_dir_all(frames_dir).await?;
+    let dir = frames_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+        for (index, frame) in frames.into_iter().enumerate() {
+            let RgbFrame {
+                width,
+                height,
+                pixels,
+            } = frame;
+            let image = image::RgbImage::from_raw(width, height, pixels).ok_or_else(|| {
+                WorkerError::InvalidPayload("video frame buffer size mismatch".to_owned())
+            })?;
+            let path = dir.join(format!("frame_{index:05}.png"));
+            image
+                .save_with_format(&path, image::ImageFormat::Png)
+                .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    // 2. Frames → mp4 (libx264, yuv420p — request dims are multiples of 32, so even).
+    let pattern = frames_dir.join("frame_%05d.png");
+    run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-framerate".to_owned(),
+            fps.to_string(),
+            "-start_number".to_owned(),
+            "0".to_owned(),
+            "-i".to_owned(),
+            pattern.to_string_lossy().into_owned(),
+            "-c:v".to_owned(),
+            "libx264".to_owned(),
+            "-pix_fmt".to_owned(),
+            "yuv420p".to_owned(),
+            "-r".to_owned(),
+            fps.to_string(),
+            enc_tmp.to_string_lossy().into_owned(),
+        ],
+        ctx,
+    )
+    .await?;
+
+    // 3. Mux the audio track (LTX) as AAC, else the video-only mp4 is the result.
+    let finished_tmp = if let Some(audio) = audio {
+        write_wav_pcm16(&audio, wav_tmp)?;
+        run_ffmpeg(
+            vec![
+                "ffmpeg".to_owned(),
+                "-nostdin".to_owned(),
+                "-y".to_owned(),
+                "-i".to_owned(),
+                enc_tmp.to_string_lossy().into_owned(),
+                "-i".to_owned(),
+                wav_tmp.to_string_lossy().into_owned(),
+                "-c:v".to_owned(),
+                "copy".to_owned(),
+                "-c:a".to_owned(),
+                "aac".to_owned(),
+                "-shortest".to_owned(),
+                mux_tmp.to_string_lossy().into_owned(),
+            ],
+            ctx,
+        )
+        .await?;
+        mux_tmp
+    } else {
+        enc_tmp
+    };
+
+    // 4. Publish atomically, then best-effort faststart + poster (mirrors Python).
+    tokio::fs::rename(finished_tmp, media_path).await?;
+    faststart_mp4(media_path).await;
+    write_poster_frame(media_path).await;
+    Ok(())
+}
+
+/// Peak-normalize the f32 PCM to 16-bit and write a canonical WAV. Silence (peak 0)
+/// stays silent rather than dividing by zero.
+fn write_wav_pcm16(audio: &AudioTrack, path: &Path) -> WorkerResult<()> {
+    let peak = audio
+        .samples
+        .iter()
+        .fold(0.0f32, |max, &sample| max.max(sample.abs()));
+    let scale = if peak > 0.0 {
+        i16::MAX as f32 / peak
+    } else {
+        0.0
+    };
+    let mut pcm = Vec::with_capacity(audio.samples.len() * 2);
+    for &sample in &audio.samples {
+        let value = (sample * scale)
+            .round()
+            .clamp(i16::MIN as f32, i16::MAX as f32) as i16;
+        pcm.extend_from_slice(&value.to_le_bytes());
+    }
+
+    let channels = audio.channels.max(1);
+    let bits_per_sample = 16u16;
+    let block_align = channels * bits_per_sample / 8;
+    let byte_rate = audio.sample_rate * block_align as u32;
+    let data_len = pcm.len() as u32;
+
+    let mut buffer = Vec::with_capacity(44 + pcm.len());
+    buffer.extend_from_slice(b"RIFF");
+    buffer.extend_from_slice(&(36 + data_len).to_le_bytes());
+    buffer.extend_from_slice(b"WAVE");
+    buffer.extend_from_slice(b"fmt ");
+    buffer.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
+    buffer.extend_from_slice(&1u16.to_le_bytes()); // audio format = PCM
+    buffer.extend_from_slice(&channels.to_le_bytes());
+    buffer.extend_from_slice(&audio.sample_rate.to_le_bytes());
+    buffer.extend_from_slice(&byte_rate.to_le_bytes());
+    buffer.extend_from_slice(&block_align.to_le_bytes());
+    buffer.extend_from_slice(&bits_per_sample.to_le_bytes());
+    buffer.extend_from_slice(b"data");
+    buffer.extend_from_slice(&data_len.to_le_bytes());
+    buffer.extend_from_slice(&pcm);
+    std::fs::write(path, buffer)?;
+    Ok(())
+}
+
+/// Best-effort `+faststart` remux (moov atom to the front so WKWebView can start
+/// playback without a tail byte-range seek). A missing/failing ffmpeg leaves the
+/// original untouched — the API's byte-range support is the load-bearing guarantee.
+async fn faststart_mp4(media_path: &Path) {
+    if !media_path.exists() {
+        return;
+    }
+    let remuxed = media_path.with_extension("faststart.mp4");
+    let ok = run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            media_path.to_string_lossy().into_owned(),
+            "-c".to_owned(),
+            "copy".to_owned(),
+            "-movflags".to_owned(),
+            "+faststart".to_owned(),
+            remuxed.to_string_lossy().into_owned(),
+        ],
+        None,
+    )
+    .await
+    .is_ok();
+    if ok {
+        let _ = tokio::fs::rename(&remuxed, media_path).await;
+    } else {
+        let _ = tokio::fs::remove_file(&remuxed).await;
+    }
+}
+
+/// Best-effort poster extraction to `<name>.poster.jpg` (WKWebView does not paint a
+/// `<video>`'s first frame on its own). A missing/failing ffmpeg leaves no poster.
+async fn write_poster_frame(media_path: &Path) {
+    if !media_path.exists() {
+        return;
+    }
+    let poster = media_path.with_extension("poster.jpg");
+    let ok = run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            media_path.to_string_lossy().into_owned(),
+            "-frames:v".to_owned(),
+            "1".to_owned(),
+            "-q:v".to_owned(),
+            "3".to_owned(),
+            poster.to_string_lossy().into_owned(),
+        ],
+        None,
+    )
+    .await
+    .is_ok();
+    if !ok {
+        let _ = tokio::fs::remove_file(&poster).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Asset fact + streaming result (mirrors `video_generation_result`).
+// ---------------------------------------------------------------------------
+
+/// The flat per-asset fact the Rust API turns into an indexed video asset (every key
+/// is consumed by the API's video sidecar builder). Mirrors `video_generation_result`.
+fn video_asset_fact(plan: &VideoPlan, seed: i64) -> Value {
+    let request = &plan.request;
+    let title: String = request.prompt.chars().take(56).collect();
+    let title = title.trim();
+    let display_name = if title.is_empty() {
+        "Generated video".to_owned()
+    } else {
+        title.to_owned()
+    };
+    let timeline_context = request
+        .advanced
+        .get("timelineContext")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    json!({
+        "type": "video",
+        "assetId": plan.asset_id,
+        "mediaPath": plan.media_rel,
+        "mimeType": "video/mp4",
+        "width": request.width,
+        "height": request.height,
+        "duration": request.duration,
+        "fps": request.fps,
+        "quality": request.quality,
+        "family": plan.family,
+        "seed": seed,
+        "displayName": display_name,
+        "createdAt": plan.created_at,
+        "mode": request.mode,
+        "model": request.model,
+        "adapter": STUB_ADAPTER,
+        "prompt": request.prompt,
+        "negativePrompt": request.negative_prompt,
+        "loras": request.loras,
+        "rawAdapterSettings": stub_raw_settings(plan),
+        "sourceAssetId": request.source_asset_id,
+        "lastFrameAssetId": request.last_frame_asset_id,
+        "sourceClipAssetId": request.source_clip_asset_id,
+        "bridgeRightClipAssetId": request.bridge_right_clip_asset_id,
+        "characterId": request.character_id,
+        "characterLookId": request.character_look_id,
+        "personTrackId": request.person_track_id,
+        "replacementMode": request.replacement_mode,
+        "timelineContext": timeline_context,
+    })
+}
+
+fn stub_raw_settings(plan: &VideoPlan) -> Value {
+    let request = &plan.request;
+    json!({
+        "model": request.model,
+        "frameCount": request.frame_count(),
+        "fps": request.fps,
+        "duration": request.duration,
+        "quality": request.quality,
+        "stub": true,
+    })
+}
+
+/// The job-result shape the API streams from: `assetWrites` + the `generationSet`
+/// fact. A video job always reports exactly one asset (`expectedCount` 1).
+fn streaming_result(plan: &VideoPlan, fact: &Value) -> JsonObject {
+    let request = &plan.request;
+    json!({
+        "generationSetId": plan.genset_id,
+        "expectedCount": 1,
+        "adapter": STUB_ADAPTER,
+        "model": request.model,
+        "generationSet": {
+            "id": plan.genset_id,
+            "mode": request.mode,
+            "model": request.model,
+            "prompt": request.prompt,
+            "negativePrompt": request.negative_prompt,
+            "count": 1,
+            "createdAt": plan.created_at,
+        },
+        "assetWrites": [fact],
+    })
+    .as_object()
+    .cloned()
+    .expect("json! object literal")
+}
+
+/// Progress payload with the worker's real backend label (mirrors `image_progress`).
+fn video_progress(
+    status: JobStatus,
+    stage: ProgressStage,
+    progress: f64,
+    message: &str,
+    result: Option<JsonObject>,
+    backend: &str,
+) -> ProgressRequest {
+    ProgressRequest {
+        status,
+        stage,
+        progress: number_from_f64(progress),
+        message: message.to_owned(),
+        error: None,
+        result,
+        eta_seconds: None,
+        peak_gpu_memory_pct: None,
+        peak_gpu_load_pct: None,
+        backend: Some(backend.to_owned()),
+        extra: BTreeMap::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(value: Value) -> VideoRequest {
+        VideoRequest::from_payload(&value.as_object().cloned().unwrap())
+    }
+
+    #[test]
+    fn plan_builds_nested_media_path() {
+        let request = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "A red fox runs"
+        }));
+        let plan = VideoPlan::new(&request, Path::new("/tmp/project"));
+        assert!(plan
+            .media_rel
+            .starts_with(&format!("assets/videos/{}/", plan.genset_id)));
+        assert!(plan.media_rel.ends_with(".mp4"));
+        assert!(plan.media_rel.contains("_ltx_2_3_"));
+        assert!(plan.asset_id.starts_with("asset_"));
+        assert_eq!(plan.family, "ltx-video");
+        assert_eq!(
+            plan.media_path,
+            Path::new("/tmp/project").join(&plan.media_rel)
+        );
+    }
+
+    #[test]
+    fn family_prefers_manifest_then_infers_from_model() {
+        let manifest = request(json!({
+            "projectId": "p", "model": "ltx_2_3",
+            "modelManifestEntry": { "family": "ltx-custom" }
+        }));
+        assert_eq!(resolve_family(&manifest), "ltx-custom");
+        let wan = request(json!({ "projectId": "p", "model": "wan_2_2_t2v_14b" }));
+        assert_eq!(resolve_family(&wan), "wan-video");
+        let other = request(json!({ "projectId": "p", "model": "mystery" }));
+        assert_eq!(resolve_family(&other), "video");
+    }
+
+    #[test]
+    fn resolve_seed_prefers_explicit_then_hashes_prompt() {
+        let explicit = request(json!({ "projectId": "p", "seed": 123 }));
+        assert_eq!(resolve_video_seed(&explicit), 123);
+        // No seed → deterministic from the prompt (re-run reproduces).
+        let a = request(json!({ "projectId": "p", "prompt": "sunset" }));
+        let b = request(json!({ "projectId": "p", "prompt": "sunset" }));
+        assert_eq!(resolve_video_seed(&a), resolve_video_seed(&b));
+        let c = request(json!({ "projectId": "p", "prompt": "sunrise" }));
+        assert_ne!(resolve_video_seed(&a), resolve_video_seed(&c));
+    }
+
+    #[test]
+    fn stub_video_frames_have_correct_size_and_audio_split() {
+        // LTX → audio present; the frame buffers are exactly width*height*3.
+        let ltx = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "width": 256, "height": 256,
+            "duration": 1.0, "fps": 9
+        }));
+        let decoded = generate_stub_video(&ltx, 7);
+        assert_eq!(decoded.frames.len(), ltx.frame_count() as usize);
+        assert_eq!(decoded.fps, 9);
+        for frame in &decoded.frames {
+            assert_eq!(frame.pixels.len(), 256 * 256 * 3);
+        }
+        let audio = decoded.audio.expect("LTX stub emits audio");
+        assert_eq!(audio.sample_rate, 48_000);
+        assert_eq!(audio.channels, 1);
+        assert!(!audio.samples.is_empty());
+
+        // Wan → no audio track (mirrors the engine).
+        let wan = request(json!({
+            "projectId": "p", "model": "wan_2_2_t2v_14b", "duration": 1.0, "fps": 16
+        }));
+        assert!(generate_stub_video(&wan, 7).audio.is_none());
+    }
+
+    #[test]
+    fn stub_frames_differ_across_time() {
+        // The sweeping band makes frame 0 and a later frame differ (real motion).
+        let request = request(json!({
+            "projectId": "p", "model": "wan_2_2", "width": 256, "height": 64,
+            "duration": 1.0, "fps": 16
+        }));
+        let decoded = generate_stub_video(&request, 3);
+        assert!(decoded.frames.len() >= 2);
+        assert_ne!(
+            decoded.frames[0].pixels,
+            decoded.frames[decoded.frames.len() - 1].pixels
+        );
+    }
+
+    #[test]
+    fn wav_header_is_canonical_and_peak_normalized() {
+        let audio = AudioTrack {
+            samples: vec![0.0, 0.5, -0.25, 0.5],
+            sample_rate: 48_000,
+            channels: 1,
+        };
+        let dir = std::env::temp_dir().join(format!("sw_wav_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("a.wav");
+        write_wav_pcm16(&audio, &path).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(&bytes[0..4], b"RIFF");
+        assert_eq!(&bytes[8..12], b"WAVE");
+        assert_eq!(&bytes[36..40], b"data");
+        // 4 mono 16-bit samples → 8 bytes of PCM, 44-byte header.
+        assert_eq!(bytes.len(), 44 + 8);
+        // Peak (0.5) maps to i16::MAX; the matching trough (-0.25) is half-scale negative.
+        let first = i16::from_le_bytes([bytes[44], bytes[45]]);
+        let peak = i16::from_le_bytes([bytes[46], bytes[47]]);
+        let trough = i16::from_le_bytes([bytes[48], bytes[49]]);
+        assert_eq!(first, 0);
+        assert_eq!(peak, i16::MAX);
+        assert_eq!(trough, -(i16::MAX / 2) - 1); // -0.25/0.5 * 32767, rounded
+    }
+
+    #[test]
+    fn silent_audio_does_not_divide_by_zero() {
+        let audio = AudioTrack {
+            samples: vec![0.0; 16],
+            sample_rate: 48_000,
+            channels: 1,
+        };
+        let dir = std::env::temp_dir().join(format!("sw_wav_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("silent.wav");
+        write_wav_pcm16(&audio, &path).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes[44..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn asset_fact_and_streaming_result_shape() {
+        let request = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "A red fox",
+            "duration": 4.0, "fps": 24, "width": 768, "height": 512,
+            "sourceAssetId": "asset_src", "personTrackId": "track_1"
+        }));
+        let plan = VideoPlan::new(&request, Path::new("/tmp/project"));
+        let fact = video_asset_fact(&plan, 42);
+        assert_eq!(fact["type"], json!("video"));
+        assert_eq!(fact["mimeType"], json!("video/mp4"));
+        assert_eq!(fact["mediaPath"], json!(plan.media_rel));
+        assert_eq!(fact["adapter"], json!("procedural_video"));
+        assert_eq!(fact["seed"], json!(42));
+        assert_eq!(fact["duration"], json!(4.0));
+        assert_eq!(fact["fps"], json!(24));
+        assert_eq!(fact["sourceAssetId"], json!("asset_src"));
+        assert_eq!(fact["personTrackId"], json!("track_1"));
+        assert_eq!(fact["displayName"], json!("A red fox"));
+
+        let result = streaming_result(&plan, &fact);
+        assert_eq!(result["expectedCount"], json!(1));
+        assert_eq!(result["assetWrites"].as_array().unwrap().len(), 1);
+        assert_eq!(result["generationSet"]["count"], json!(1));
+    }
+
+    /// Full encode → mp4 + poster, exercised against a real ffmpeg. Skips when no
+    /// ffmpeg is reachable (SCENEWORKS_FFMPEG or `ffmpeg` on PATH) so it never fails a
+    /// host without the binary; CI with ffmpeg runs it for real.
+    #[tokio::test]
+    async fn encode_stub_to_mp4_with_audio_and_poster() {
+        if !ffmpeg_reachable() {
+            eprintln!("skipping encode_stub_to_mp4_with_audio_and_poster: ffmpeg not found");
+            return;
+        }
+        let request = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "fox",
+            "duration": 1.0, "fps": 9, "width": 128, "height": 128
+        }));
+        let decoded = generate_stub_video(&request, 11);
+        assert!(decoded.audio.is_some());
+        let dir = std::env::temp_dir().join(format!("sw_vid_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let media_path = dir.join("clip.mp4");
+        encode_media(&media_path, decoded, None).await.unwrap();
+        assert!(media_path.exists(), "mp4 must be written");
+        assert!(media_path.metadata().unwrap().len() > 0);
+        assert!(
+            media_path.with_extension("poster.jpg").exists(),
+            "poster must be extracted"
+        );
+        // Intermediates are cleaned up.
+        assert!(!media_path.with_extension("frames").exists());
+        assert!(!media_path.with_extension("enc.mp4").exists());
+        assert!(!media_path.with_extension("audio.wav").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn ffmpeg_reachable() -> bool {
+        if let Ok(path) = std::env::var("SCENEWORKS_FFMPEG") {
+            if !path.trim().is_empty() && Path::new(&path).exists() {
+                return true;
+            }
+        }
+        std::process::Command::new("ffmpeg")
+            .arg("-version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+}


### PR DESCRIPTION
**Story:** [sc-3033](https://app.shortcut.com/trefry/story/3033) (epic [3018](https://app.shortcut.com/trefry/epic/3018)) — first video story. Merges into `rust-mlx-integration` (never `main`, per the epic branch strategy).

The shared video pipeline — the video analog of the image-job runtime (sc-3020). **Worker-side + a procedural stub; no `mlx-gen-wan`/`mlx-gen-ltx` dependency.** The real Wan (sc-3034) and LTX+audio (sc-3035) models will decode `mlx_gen::GenerationOutput::Video { frames, fps, audio }` into the same `DecodedVideo`, so the encode/mux/poster path here is unchanged for them. (Reading the engine video API first confirmed the output shape: `Video { frames: Vec<Image>, fps, audio: Option<AudioTrack> }`, `audio` Some for LTX / None for Wan.)

### What's in it
- **`sceneworks-core/src/video_request.rs`** — `VideoRequest::from_payload` mirroring the Python `video_request_from_job` (mode `image_to_video`, model `ltx_2_3`, duration 6 [1–30], fps 25 [1–60], dims clamp 256–1920 then floor %32, quality `balanced`, seed/loras/character/source_asset_id/advanced/manifest). Advanced-mode asset ids (`last_frame`/`source_clip`/`bridge_right_clip`/`person_track`) are parsed + carried but flagged Python-routed (those modes stay torch; routing is sc-3036). Pure frame-count helpers `ltx_frame_count` (nearest 8k+1, ported from Python) and `wan_frame_count` (nearest 4n+1, from the VAE temporal stride `t_lat=(frames−1)/4+1`).
- **`crates/sceneworks-worker/src/video_jobs.rs`** — `run_video_generate_job`: procedural stub `Video{frames,fps,audio}` (LTX id emits a quiet tone, Wan none — mirroring the engine) → frames → libx264 mp4 (reusing `media_jobs::run_ffmpeg` + `FfmpegContext` for the heartbeat/cancel loop) → 16-bit PCM WAV (peak-normalize) + AAC mux `-shortest` → best-effort `+faststart` remux → `.poster.jpg`. Single video asset fact (`video_generation_result` shape, `expectedCount` 1) + streaming progress + cancel + atomic publish + temp cleanup.
- **Wiring** — dispatch arm `JobType::VideoGenerate => run_video_generate_job` (`lib.rs`); the `mlx` worker now advertises `WorkerCapability::VideoGenerate` (`gpu.rs`); `FfmpegContext::new` constructor + `backend_label` made `pub(crate)` for reuse; capability test updated. No new crate deps.

### Scope boundary (3033 vs 3034/3035/3036)
Precedent: sc-3019 (image scaffold) advertised `image_generate` + added the dispatch arm up-front, relying on the stub fallback + integration-branch isolation. This mirrors that for video. The procedural stub backs every model until its real MLX path links (Wan sc-3034, LTX+audio sc-3035); the API-side MLX-vs-Python routing decision is sc-3036.

### Verification
- `npm run rust:check` green: fmt + clippy `-D warnings` + tests + build; `nax_guard` green.
- **Verified end-to-end on real ffmpeg** — `encode_stub_to_mp4_with_audio_and_poster` runs (not skipped on this host): stub frames + audio → mp4 + AAC + poster, intermediates cleaned. Plus unit tests for the DTO/clamps/frame-count helpers, WAV header + peak-normalize (incl. silence guard), stub frame size + audio split, asset-fact/streaming shape, and the capability set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)