### PR TITLE
sc-3034: Wan2.2 (T2V/I2V/TI2V) through the Rust GPU worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2060,15 +2060,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2498,6 +2489,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-wan"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
@@ -2763,7 +2766,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3945,6 +3948,7 @@ dependencies = [
  "mlx-gen-flux2",
  "mlx-gen-qwen-image",
  "mlx-gen-sdxl",
+ "mlx-gen-wan",
  "mlx-gen-z-image",
  "nix",
  "pmetal-mlx-rs",
@@ -5403,6 +5407,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -138,16 +138,12 @@ pub fn ltx_frame_count(raw_frames: u32) -> u32 {
 }
 
 /// Wan2.2 temporal stride: the VAE math `t_lat = (frames − 1) / 4 + 1` requires
-/// `frames ≡ 1 (mod 4)`, so frames snap to the nearest `4n + 1`, minimum 1.
+/// `frames ≡ 1 (mod 4)`. Frames floor to the largest `4k + 1` at or below `raw`,
+/// with a 5-frame minimum — the Python worker's `_run_wan_mlx`
+/// `max(5, raw - ((raw - 1) % 4))`.
 pub fn wan_frame_count(raw_frames: u32) -> u32 {
     let raw = raw_frames.max(1);
-    let lower = raw - ((raw - 1) % 4);
-    let upper = lower + 4;
-    if raw - lower <= upper - raw {
-        lower
-    } else {
-        upper
-    }
+    (raw - ((raw - 1) % 4)).max(5)
 }
 
 /// Whether `model` is an LTX-2.3 family id (`ltx_2_3`, `ltx_2_3_eros`, …).
@@ -354,13 +350,17 @@ mod tests {
     }
 
     #[test]
-    fn wan_frame_count_snaps_to_4n_plus_1() {
-        assert_eq!(wan_frame_count(1), 1);
+    fn wan_frame_count_floors_to_4n_plus_1_min_5() {
+        // Exact 1+4k values >= 5 are unchanged.
         assert_eq!(wan_frame_count(5), 5);
         assert_eq!(wan_frame_count(81), 81);
-        assert_eq!(wan_frame_count(2), 1); // |2-1|=1 <= |5-2|=3 -> lower
-        assert_eq!(wan_frame_count(4), 5); // |4-1|=3 > |5-4|=1 -> upper
-        assert_eq!(wan_frame_count(83), 81); // |83-81|=2 <= |85-83|=2 -> lower
+        // Floors to the 1+4k at or below raw (Python `raw - ((raw-1)%4)`).
+        assert_eq!(wan_frame_count(48), 45); // 48-(47%4=3)
+        assert_eq!(wan_frame_count(83), 81); // 83-(82%4=2)
+        assert_eq!(wan_frame_count(8), 5); // 8-(7%4=3)
+                                           // 5-frame floor for tiny counts.
+        assert_eq!(wan_frame_count(1), 5);
+        assert_eq!(wan_frame_count(4), 5);
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -74,6 +74,10 @@ mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
 mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
+# Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
+# (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
+# inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -784,7 +784,7 @@ fn resolve_negative_prompt(request: &ImageRequest, model: &MlxModel) -> Option<S
 
 /// First non-empty of installedPath/sourcePath/path/source.path on a LoRA spec.
 #[cfg(target_os = "macos")]
-fn lora_path(lora: &Value) -> Option<PathBuf> {
+pub(crate) fn lora_path(lora: &Value) -> Option<PathBuf> {
     for key in ["installedPath", "sourcePath", "path"] {
         if let Some(value) = lora
             .get(key)
@@ -807,7 +807,7 @@ fn lora_path(lora: &Value) -> Option<PathBuf> {
 /// `networkType: lokr`) → `Lokr`; third-party LyCORIS (LoHa / kohya LoKr) is not
 /// reconstructable here → rejected; everything else → `Lora`.
 #[cfg(target_os = "macos")]
-fn classify_adapter(file: &Path) -> WorkerResult<AdapterKind> {
+pub(crate) fn classify_adapter(file: &Path) -> WorkerResult<AdapterKind> {
     let header = read_safetensors_header(file)
         .map_err(|error| WorkerError::InvalidPayload(format!("LoRA header: {error}")))?;
     let metadata = header.get("__metadata__");
@@ -1853,7 +1853,7 @@ fn flux2_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
 /// Resolve a reference/source asset id to an in-memory RGB8 image (the engine VAE-
 /// encodes + resizes it). Uses the indexed `ProjectStore::get_asset` → `file.path`.
 #[cfg(target_os = "macos")]
-fn load_reference_image(
+pub(crate) fn load_reference_image(
     data_dir: &Path,
     project_id: &str,
     asset_id: &str,

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -25,6 +25,23 @@ use sceneworks_core::video_request::{is_ltx_model, VideoRequest};
 use super::*;
 use crate::media_jobs::{run_ffmpeg, FfmpegContext};
 
+// Real MLX Wan2.2 generation (macOS, sc-3034). The provider crate self-registers its
+// three models via `inventory` only when linked + referenced (`use mlx_gen_wan as _;`,
+// the same link-time pattern as the image families in `image_jobs.rs`).
+#[cfg(target_os = "macos")]
+use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
+#[cfg(target_os = "macos")]
+use mlx_gen::{
+    AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
+    LoadSpec, MoeExpert, Precision, Progress, Quant, WeightsSource,
+};
+#[cfg(target_os = "macos")]
+use mlx_gen_wan as _;
+#[cfg(target_os = "macos")]
+use sceneworks_core::video_request::wan_frame_count;
+#[cfg(target_os = "macos")]
+use std::time::{Duration, Instant};
+
 /// Stub adapter id recorded on generated assets — matches the Python
 /// `ProceduralVideoAdapter.id` so the asset sidecar reads identically.
 const STUB_ADAPTER: &str = "procedural_video";
@@ -111,7 +128,36 @@ pub(crate) async fn run_video_generate_job(
         ),
     )
     .await?;
-    let decoded = generate_stub_video(&request, seed);
+    // Generate: real MLX Wan on macOS for Wan models with resolvable weights, else the
+    // procedural stub (LTX real path = sc-3035; non-macOS or missing weights = stub).
+    #[cfg(target_os = "macos")]
+    let (decoded, adapter, raw_settings) = match wan_engine_id(&request.model) {
+        Some(engine_id) if wan_available(&request, settings) => (
+            generate_wan(
+                api,
+                settings,
+                job,
+                &request,
+                &project_path,
+                engine_id,
+                backend,
+            )
+            .await?,
+            WAN_ADAPTER,
+            wan_raw_settings(&request),
+        ),
+        _ => (
+            generate_stub_video(&request, seed),
+            STUB_ADAPTER,
+            stub_raw_settings(&request),
+        ),
+    };
+    #[cfg(not(target_os = "macos"))]
+    let (decoded, adapter, raw_settings) = (
+        generate_stub_video(&request, seed),
+        STUB_ADAPTER,
+        stub_raw_settings(&request),
+    );
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
 
     check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
@@ -131,8 +177,8 @@ pub(crate) async fn run_video_generate_job(
     let ctx = FfmpegContext::new(api, settings, &job.id, CANCEL_MESSAGE);
     encode_media(&plan.media_path, decoded, Some(ctx)).await?;
 
-    let fact = video_asset_fact(&plan, seed);
-    let result = streaming_result(&plan, &fact);
+    let fact = video_asset_fact(&plan, seed, adapter, raw_settings);
+    let result = streaming_result(&plan, &fact, adapter);
     update_job(
         api,
         &job.id,
@@ -554,7 +600,9 @@ async fn write_poster_frame(media_path: &Path) {
 
 /// The flat per-asset fact the Rust API turns into an indexed video asset (every key
 /// is consumed by the API's video sidecar builder). Mirrors `video_generation_result`.
-fn video_asset_fact(plan: &VideoPlan, seed: i64) -> Value {
+/// `adapter` is the generating adapter id (`procedural_video` stub / `mlx_wan` real)
+/// and `raw_settings` its recorded knobs.
+fn video_asset_fact(plan: &VideoPlan, seed: i64, adapter: &str, raw_settings: Value) -> Value {
     let request = &plan.request;
     let title: String = request.prompt.chars().take(56).collect();
     let title = title.trim();
@@ -584,11 +632,11 @@ fn video_asset_fact(plan: &VideoPlan, seed: i64) -> Value {
         "createdAt": plan.created_at,
         "mode": request.mode,
         "model": request.model,
-        "adapter": STUB_ADAPTER,
+        "adapter": adapter,
         "prompt": request.prompt,
         "negativePrompt": request.negative_prompt,
         "loras": request.loras,
-        "rawAdapterSettings": stub_raw_settings(plan),
+        "rawAdapterSettings": raw_settings,
         "sourceAssetId": request.source_asset_id,
         "lastFrameAssetId": request.last_frame_asset_id,
         "sourceClipAssetId": request.source_clip_asset_id,
@@ -601,8 +649,7 @@ fn video_asset_fact(plan: &VideoPlan, seed: i64) -> Value {
     })
 }
 
-fn stub_raw_settings(plan: &VideoPlan) -> Value {
-    let request = &plan.request;
+fn stub_raw_settings(request: &VideoRequest) -> Value {
     json!({
         "model": request.model,
         "frameCount": request.frame_count(),
@@ -615,12 +662,12 @@ fn stub_raw_settings(plan: &VideoPlan) -> Value {
 
 /// The job-result shape the API streams from: `assetWrites` + the `generationSet`
 /// fact. A video job always reports exactly one asset (`expectedCount` 1).
-fn streaming_result(plan: &VideoPlan, fact: &Value) -> JsonObject {
+fn streaming_result(plan: &VideoPlan, fact: &Value, adapter: &str) -> JsonObject {
     let request = &plan.request;
     json!({
         "generationSetId": plan.genset_id,
         "expectedCount": 1,
-        "adapter": STUB_ADAPTER,
+        "adapter": adapter,
         "model": request.model,
         "generationSet": {
             "id": plan.genset_id,
@@ -660,6 +707,506 @@ fn video_progress(
         backend: Some(backend.to_owned()),
         extra: BTreeMap::new(),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Real MLX Wan2.2 generation (macOS, via mlx-gen-wan, sc-3034): T2V/TI2V (5B
+// dense, z48 VAE), T2V/I2V (A14B dual-expert MoE) + MoE/Lightning LoRA. Decodes
+// the engine's `GenerationOutput::Video { frames, fps, audio: None }` into a
+// `DecodedVideo` and reuses the [`encode_media`] pipeline above. LTX (sc-3035) and
+// every other model keep the procedural stub.
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real MLX Wan asset (mirrors the image `mlx_*` convention).
+#[cfg(target_os = "macos")]
+const WAN_ADAPTER: &str = "mlx_wan";
+
+/// At most 3 user LoRAs per job (mirrors the image path's `MAX_JOB_LORAS`).
+#[cfg(target_os = "macos")]
+const MAX_JOB_LORAS: usize = 3;
+
+/// Raw-settings recorded on a real MLX Wan asset: the request's `advanced` knobs plus
+/// the real-inference markers (mirrors the image `mlx_raw_settings`).
+#[cfg(target_os = "macos")]
+fn wan_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("frameCount".to_owned(), json!(request.frame_count()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    Value::Object(raw)
+}
+
+/// SceneWorks Wan model id → mlx-gen registry id, or `None` if `model` is not a Wan
+/// family id this worker serves.
+#[cfg(target_os = "macos")]
+fn wan_engine_id(model: &str) -> Option<&'static str> {
+    match model {
+        "wan_2_2" => Some("wan2_2_ti2v_5b"),
+        "wan_2_2_t2v_14b" => Some("wan2_2_t2v_14b"),
+        "wan_2_2_i2v_14b" => Some("wan2_2_i2v_14b"),
+        _ => None,
+    }
+}
+
+/// Whether the linked Wan engine can serve this request now: a Wan model id with
+/// resolvable on-disk weights. Off macOS / non-Wan / weights-absent → the stub
+/// (mirrors the image `mlx_available` weights gate).
+#[cfg(target_os = "macos")]
+fn wan_available(request: &VideoRequest, settings: &Settings) -> bool {
+    match wan_engine_id(&request.model) {
+        Some(engine_id) => resolve_wan_model_dir(settings, &request.model, engine_id).is_ok(),
+        None => false,
+    }
+}
+
+/// Resolve the converted MLX snapshot directory for a Wan model (mirrors the Python
+/// `_resolve_wan_mlx`): an env override, then the app-managed `<data>/models/mlx/<id>`,
+/// then (T2V-14B only) the turnkey HF MLX snapshot. Errors clearly if none is present.
+#[cfg(target_os = "macos")]
+fn resolve_wan_model_dir(
+    settings: &Settings,
+    model: &str,
+    _engine_id: &str,
+) -> WorkerResult<PathBuf> {
+    let (env, local_id, hf_repo): (&str, &str, Option<&str>) = match model {
+        "wan_2_2" => ("SCENEWORKS_MLX_WAN5B_DIR", "wan_2_2", None),
+        "wan_2_2_t2v_14b" => (
+            "SCENEWORKS_MLX_WAN14B_T2V_DIR",
+            "wan_2_2_t2v_14b",
+            Some("AITRADER/Wan2.2-T2V-A14B-mlx-bf16"),
+        ),
+        "wan_2_2_i2v_14b" => ("SCENEWORKS_MLX_WAN14B_I2V_DIR", "wan_2_2_i2v_14b", None),
+        other => {
+            return Err(WorkerError::InvalidPayload(format!(
+                "not a Wan model: {other}"
+            )))
+        }
+    };
+    if let Some(dir) = local_mlx_dir(settings, env, local_id) {
+        return Ok(dir);
+    }
+    if let Some(repo) = hf_repo {
+        if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, repo) {
+            return Ok(dir);
+        }
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{model}: no MLX weights found. Convert/download the Wan checkpoint into {}{}.",
+        settings
+            .data_dir
+            .join("models")
+            .join("mlx")
+            .join(local_id)
+            .display(),
+        hf_repo
+            .map(|repo| format!(" (or download the turnkey repo {repo})"))
+            .unwrap_or_default(),
+    )))
+}
+
+/// A locally-converted MLX dir for the model (env override, then
+/// `<data>/models/mlx/<id>`), counted only when it holds a `config.json` — mirrors the
+/// Python `_local_mlx_dir`, so a locally-quantized conversion supersedes a turnkey download.
+#[cfg(target_os = "macos")]
+fn local_mlx_dir(settings: &Settings, env: &str, local_id: &str) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(override_dir) = std::env::var(env) {
+        let trimmed = override_dir.trim();
+        if !trimmed.is_empty() {
+            candidates.push(PathBuf::from(trimmed));
+        }
+    }
+    candidates.push(settings.data_dir.join("models").join("mlx").join(local_id));
+    candidates
+        .into_iter()
+        .find(|dir| dir.join("config.json").is_file())
+}
+
+/// The 4-step Lightning distill LoRA pair (high/low) for the T2V-A14B
+/// (`lightx2v/Wan2.2-Lightning`, the rank-64 Seko V1.1 distill). Errors if not downloaded.
+#[cfg(target_os = "macos")]
+fn resolve_lightning_loras(settings: &Settings) -> WorkerResult<(PathBuf, PathBuf)> {
+    let snapshot = huggingface_snapshot_dir(&settings.data_dir, "lightx2v/Wan2.2-Lightning")
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "wan_2_2_t2v_14b: the Lightning distill LoRA (lightx2v/Wan2.2-Lightning) is not \
+                 downloaded — fetch it via the model manager"
+                    .to_owned(),
+            )
+        })?;
+    let base = "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1";
+    let high = snapshot.join(base).join("high_noise_model.safetensors");
+    let low = snapshot.join(base).join("low_noise_model.safetensors");
+    for file in [&high, &low] {
+        if !file.is_file() {
+            return Err(WorkerError::InvalidPayload(format!(
+                "wan_2_2_t2v_14b: Lightning LoRA file missing: {}",
+                file.display()
+            )));
+        }
+    }
+    Ok((high, low))
+}
+
+/// The `.low_noise.safetensors` sibling of a Wan A14B MoE high-noise LoRA file, or
+/// `None` when the file is not the high-noise half of a pair (port of the Python
+/// `wan_moe_low_noise_sibling`; case-insensitive `.high_noise.safetensors` suffix).
+#[cfg(target_os = "macos")]
+fn wan_moe_low_noise_sibling(primary: &Path) -> Option<PathBuf> {
+    const HIGH: &str = ".high_noise.safetensors";
+    let name = primary.file_name()?.to_str()?;
+    if !name.to_ascii_lowercase().ends_with(HIGH) {
+        return None;
+    }
+    let stem = &name[..name.len() - HIGH.len()];
+    let sibling = primary.with_file_name(format!("{stem}.low_noise.safetensors"));
+    sibling.is_file().then_some(sibling)
+}
+
+/// Resolve a LoRA spec's file (a directory → its first `.safetensors`), verifying it exists.
+#[cfg(target_os = "macos")]
+fn resolve_lora_file(path: PathBuf) -> WorkerResult<PathBuf> {
+    let file = if path.is_dir() {
+        first_safetensors_path(&path).ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "LoRA has no .safetensors under {}",
+                path.display()
+            ))
+        })?
+    } else {
+        path
+    };
+    if !file.exists() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "LoRA file is missing: {}",
+            file.display()
+        )));
+    }
+    Ok(file)
+}
+
+/// A LoRA spec's strength (`weight`, default 0.8 — matches the image path).
+#[cfg(target_os = "macos")]
+fn lora_scale(lora: &Value) -> f32 {
+    lora.get("weight")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .unwrap_or(0.8) as f32
+}
+
+/// Build the adapter specs for a Wan generation (sc-3034): the Lightning distill pair
+/// (T2V-14B only, tagged high/low) followed by the user LoRAs. On the MoE models a user
+/// `*.high_noise.safetensors` with a `.low_noise` sibling tags high→High / low→Low; a
+/// single-file LoRA is shared (both experts on MoE, the single model on the 5B). LyCORIS
+/// is rejected; peft LoKr is allowed (the engine merges it, like the image path).
+#[cfg(target_os = "macos")]
+fn resolve_wan_adapters(
+    settings: &Settings,
+    request: &VideoRequest,
+    engine_id: &str,
+) -> WorkerResult<Vec<AdapterSpec>> {
+    if request.loras.len() > MAX_JOB_LORAS {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
+        )));
+    }
+    let is_moe = engine_id == "wan2_2_t2v_14b" || engine_id == "wan2_2_i2v_14b";
+    let mut specs: Vec<AdapterSpec> = Vec::new();
+
+    // Lightning distill (T2V-14B only): 4-step, applied per-expert at strength 1.0.
+    if engine_id == "wan2_2_t2v_14b" {
+        let (high, low) = resolve_lightning_loras(settings)?;
+        specs.push(moe_adapter(high, 1.0, AdapterKind::Lora, MoeExpert::High));
+        specs.push(moe_adapter(low, 1.0, AdapterKind::Lora, MoeExpert::Low));
+    }
+
+    for lora in &request.loras {
+        let path = lora_path(lora).ok_or_else(|| {
+            WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
+        })?;
+        let file = resolve_lora_file(path)?;
+        let kind = classify_adapter(&file)?;
+        let scale = lora_scale(lora);
+        match (is_moe, wan_moe_low_noise_sibling(&file)) {
+            (true, Some(low)) => {
+                // A MoE pair → high half to the high-noise expert, the sibling to the low.
+                let low_kind = classify_adapter(&low)?;
+                specs.push(moe_adapter(file, scale, kind, MoeExpert::High));
+                specs.push(moe_adapter(low, scale, low_kind, MoeExpert::Low));
+            }
+            _ => {
+                // Single-file → shared (both experts on MoE; the dense single model on the 5B).
+                specs.push(AdapterSpec {
+                    path: file,
+                    scale,
+                    kind,
+                    pass_scales: None,
+                    moe_expert: None,
+                });
+            }
+        }
+    }
+    Ok(specs)
+}
+
+#[cfg(target_os = "macos")]
+fn moe_adapter(path: PathBuf, scale: f32, kind: AdapterKind, expert: MoeExpert) -> AdapterSpec {
+    AdapterSpec {
+        path,
+        scale,
+        kind,
+        pass_scales: None,
+        moe_expert: Some(expert),
+    }
+}
+
+/// The first-frame conditioning for a Wan generation: required for I2V-14B, optional for
+/// the TI2V-5B (present → image-conditioned mask-blend, absent → pure T2V), and ignored
+/// by the T2V-14B (text-only). Loads `source_asset_id` to an in-memory RGB8 image.
+#[cfg(target_os = "macos")]
+fn resolve_wan_conditioning(
+    settings: &Settings,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &str,
+) -> WorkerResult<Vec<Conditioning>> {
+    let required = engine_id == "wan2_2_i2v_14b";
+    let accepts = required || engine_id == "wan2_2_ti2v_5b";
+    if !accepts {
+        return Ok(Vec::new());
+    }
+    match request.source_asset_id.as_deref() {
+        Some(asset_id) => {
+            let image = load_reference_image(
+                &settings.data_dir,
+                &request.project_id,
+                asset_id,
+                project_path,
+            )?;
+            Ok(vec![Conditioning::Reference {
+                image,
+                strength: None,
+            }])
+        }
+        None if required => Err(WorkerError::InvalidPayload(
+            "wan_2_2_i2v_14b: image-to-video requires a source image (sourceAssetId).".to_owned(),
+        )),
+        None => Ok(Vec::new()),
+    }
+}
+
+/// Map `advanced.mlxQuantize` to a quant level (≤0 → dense, ≤4 → Q4, else Q8). Absent →
+/// `None`: dense bf16, or the engine builds it quantized from a pre-quantized snapshot.
+#[cfg(target_os = "macos")]
+fn resolve_wan_quant(request: &VideoRequest) -> Option<Quant> {
+    let bits = request.advanced.get("mlxQuantize").and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    })?;
+    match bits {
+        b if b <= 0 => None,
+        b if b <= 4 => Some(Quant::Q4),
+        _ => Some(Quant::Q8),
+    }
+}
+
+/// Per-model sampling overrides: the T2V-14B runs the 4-step Lightning distill at guide
+/// 1.0; the 5B / I2V-14B use the engine's config defaults (`None` → engine fills in).
+#[cfg(target_os = "macos")]
+fn wan_sampling(engine_id: &str) -> (Option<u32>, Option<f32>) {
+    if engine_id == "wan2_2_t2v_14b" {
+        (Some(4), Some(1.0))
+    } else {
+        (None, None)
+    }
+}
+
+/// The resolved inputs for one Wan generation (engine load + request build), split out
+/// so the engine call is unit-testable on real weights without the API/job plumbing.
+#[cfg(target_os = "macos")]
+struct WanGenInput {
+    engine_id: &'static str,
+    model_dir: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+    conditioning: Vec<Conditioning>,
+    prompt: String,
+    negative_prompt: Option<String>,
+    width: u32,
+    height: u32,
+    frames: u32,
+    fps: u32,
+    steps: Option<u32>,
+    guidance: Option<f32>,
+    seed: u64,
+}
+
+/// Load the Wan model and run one generation to RGB8 frames (+ fps), streaming denoise
+/// progress via `on_progress` and honoring `cancel`. Synchronous + blocking (the
+/// `Box<dyn Generator>` is `!Send`); the caller runs it on a blocking thread.
+#[cfg(target_os = "macos")]
+fn run_wan_generation(
+    input: WanGenInput,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(Vec<RgbFrame>, u32)> {
+    let spec = LoadSpec {
+        weights: WeightsSource::Dir(input.model_dir),
+        quantize: input.quant,
+        precision: Precision::Bf16,
+        control: None,
+        adapters: input.adapters,
+    };
+    let generator = mlx_gen::load(input.engine_id, &spec)
+        .map_err(|error| WorkerError::InvalidPayload(format!("Wan load failed: {error}")))?;
+    let req = GenerationRequest {
+        prompt: input.prompt,
+        negative_prompt: input.negative_prompt,
+        width: input.width,
+        height: input.height,
+        frames: Some(input.frames),
+        fps: Some(input.fps),
+        steps: input.steps,
+        guidance: input.guidance,
+        seed: Some(input.seed),
+        conditioning: input.conditioning,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&req, on_progress)
+        .map_err(|error| WorkerError::InvalidPayload(format!("Wan generation failed: {error}")))?;
+    match output {
+        GenerationOutput::Video { frames, fps, .. } => Ok((
+            frames
+                .into_iter()
+                .map(|image| RgbFrame {
+                    width: image.width,
+                    height: image.height,
+                    pixels: image.pixels,
+                })
+                .collect(),
+            fps,
+        )),
+        GenerationOutput::Images(_) => Err(WorkerError::InvalidPayload(
+            "Wan returned images, expected video frames".to_owned(),
+        )),
+    }
+}
+
+/// Run a real MLX Wan generation on the blocking thread (the `Box<dyn Generator>` is
+/// `!Send` and the MLX device is single-thread), streaming denoise progress back to the
+/// async worker (which forwards it + polls cancel ~every 2s). Returns the decoded video
+/// (RGB8 frames + fps, no audio) for the shared [`encode_media`] pipeline.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn generate_wan(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    let model_dir = resolve_wan_model_dir(settings, &request.model, engine_id)?;
+    let adapters = resolve_wan_adapters(settings, request, engine_id)?;
+    let conditioning = resolve_wan_conditioning(settings, request, project_path, engine_id)?;
+    let quant = resolve_wan_quant(request);
+    let frames = wan_frame_count(request.raw_frame_count());
+    let seed = resolve_video_seed(request);
+    let (steps, guidance) = wan_sampling(engine_id);
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let prompt = request.prompt.clone();
+    let (width, height, fps) = (request.width, request.height, request.fps);
+
+    let input = WanGenInput {
+        engine_id,
+        model_dir,
+        quant,
+        adapters,
+        conditioning,
+        prompt,
+        negative_prompt,
+        width,
+        height,
+        frames,
+        fps,
+        steps,
+        guidance,
+        seed: seed as u64,
+    };
+
+    let cancel = CancelFlag::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Progress>(64);
+    let blocking = {
+        let cancel = cancel.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<(Vec<RgbFrame>, u32)> {
+            let mut on_progress = |progress: Progress| {
+                let _ = tx.blocking_send(progress);
+            };
+            run_wan_generation(input, &cancel, &mut on_progress)
+        })
+    };
+
+    // Forward denoise progress (Generating stage, ~0.25..0.58) + poll cancel ~every 2s.
+    let mut canceled = false;
+    let mut last_cancel = Instant::now();
+    while let Some(progress) = rx.recv().await {
+        if canceled {
+            continue; // drain so the blocking sender never blocks.
+        }
+        if last_cancel.elapsed() >= Duration::from_secs(2) {
+            last_cancel = Instant::now();
+            if check_cancel(api, &job.id, CANCEL_MESSAGE).await.is_err() {
+                cancel.cancel();
+                canceled = true;
+                continue;
+            }
+            heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+        }
+        let (fraction, message) = match progress {
+            Progress::Step { current, total } => (
+                0.25 + 0.30 * (current as f64 / total.max(1) as f64),
+                format!("Generating frames — step {current}/{total}."),
+            ),
+            Progress::Decoding => (0.58, "Decoding frames.".to_owned()),
+        };
+        update_job(
+            api,
+            &job.id,
+            video_progress(
+                JobStatus::Running,
+                ProgressStage::Generating,
+                fraction,
+                &message,
+                None,
+                backend,
+            ),
+        )
+        .await?;
+    }
+
+    let result = blocking
+        .await
+        .map_err(|error| WorkerError::InvalidPayload(format!("Wan task join: {error}")))?;
+    if canceled {
+        return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+    }
+    let (frames, out_fps) = result?;
+    Ok(DecodedVideo {
+        frames,
+        fps: out_fps,
+        audio: None,
+    })
 }
 
 #[cfg(test)]
@@ -804,7 +1351,7 @@ mod tests {
             "sourceAssetId": "asset_src", "personTrackId": "track_1"
         }));
         let plan = VideoPlan::new(&request, Path::new("/tmp/project"));
-        let fact = video_asset_fact(&plan, 42);
+        let fact = video_asset_fact(&plan, 42, "procedural_video", stub_raw_settings(&request));
         assert_eq!(fact["type"], json!("video"));
         assert_eq!(fact["mimeType"], json!("video/mp4"));
         assert_eq!(fact["mediaPath"], json!(plan.media_rel));
@@ -815,11 +1362,130 @@ mod tests {
         assert_eq!(fact["sourceAssetId"], json!("asset_src"));
         assert_eq!(fact["personTrackId"], json!("track_1"));
         assert_eq!(fact["displayName"], json!("A red fox"));
+        assert_eq!(fact["rawAdapterSettings"]["stub"], json!(true));
 
-        let result = streaming_result(&plan, &fact);
+        let result = streaming_result(&plan, &fact, "procedural_video");
         assert_eq!(result["expectedCount"], json!(1));
+        assert_eq!(result["adapter"], json!("procedural_video"));
         assert_eq!(result["assetWrites"].as_array().unwrap().len(), 1);
         assert_eq!(result["generationSet"]["count"], json!(1));
+    }
+
+    /// Wan model-id → engine-id mapping + the family predicates that drive routing.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_engine_id_maps_the_three_models() {
+        assert_eq!(wan_engine_id("wan_2_2"), Some("wan2_2_ti2v_5b"));
+        assert_eq!(wan_engine_id("wan_2_2_t2v_14b"), Some("wan2_2_t2v_14b"));
+        assert_eq!(wan_engine_id("wan_2_2_i2v_14b"), Some("wan2_2_i2v_14b"));
+        assert_eq!(wan_engine_id("ltx_2_3"), None);
+        assert_eq!(wan_engine_id("z_image_turbo"), None);
+    }
+
+    /// Per-model sampling: only the T2V-14B forces the 4-step Lightning preset; the
+    /// others defer to the engine config defaults.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_sampling_only_overrides_t2v_14b() {
+        assert_eq!(wan_sampling("wan2_2_t2v_14b"), (Some(4), Some(1.0)));
+        assert_eq!(wan_sampling("wan2_2_ti2v_5b"), (None, None));
+        assert_eq!(wan_sampling("wan2_2_i2v_14b"), (None, None));
+    }
+
+    /// `advanced.mlxQuantize` maps to a quant level; absent → dense / engine-resolved.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_quant_maps_mlx_quantize() {
+        let q4 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
+        assert_eq!(resolve_wan_quant(&q4), Some(Quant::Q4));
+        let q8 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 8 } }));
+        assert_eq!(resolve_wan_quant(&q8), Some(Quant::Q8));
+        let dense = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
+        assert_eq!(resolve_wan_quant(&dense), None);
+        let absent = request(json!({ "projectId": "p" }));
+        assert_eq!(resolve_wan_quant(&absent), None);
+    }
+
+    /// The `.high_noise.safetensors` → `.low_noise.safetensors` sibling convention
+    /// (case-insensitive; only fires when the sibling file exists).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_moe_sibling_pairs_high_and_low() {
+        let dir = std::env::temp_dir().join(format!("sw_moe_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let high = dir.join("char.high_noise.safetensors");
+        let low = dir.join("char.low_noise.safetensors");
+        std::fs::write(&high, b"x").unwrap();
+        // No sibling yet → None.
+        assert_eq!(wan_moe_low_noise_sibling(&high), None);
+        std::fs::write(&low, b"x").unwrap();
+        assert_eq!(wan_moe_low_noise_sibling(&high), Some(low));
+        // A single-file (non-high-noise) LoRA never pairs.
+        let single = dir.join("plain.safetensors");
+        std::fs::write(&single, b"x").unwrap();
+        assert_eq!(wan_moe_low_noise_sibling(&single), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A locally-converted Wan2.2 TI2V-5B dir if one is present (env override or the
+    /// app-managed default), else `None` so the real-weight smoke skips.
+    #[cfg(target_os = "macos")]
+    fn wan_5b_dir() -> Option<PathBuf> {
+        if let Ok(dir) = std::env::var("SCENEWORKS_MLX_WAN5B_DIR") {
+            let path = PathBuf::from(dir.trim());
+            if path.join("config.json").is_file() {
+                return Some(path);
+            }
+        }
+        let home = std::env::var("HOME").ok()?;
+        let path = PathBuf::from(home)
+            .join("Library/Application Support/SceneWorks/data/models/mlx/wan_2_2");
+        path.join("config.json").is_file().then_some(path)
+    }
+
+    /// Real in-process Wan2.2 TI2V-5B T2V through the engine (the lightest Wan model —
+    /// ~10 GB, safe on a 128 GB Mac). Loads the converted 5B snapshot and denoises a
+    /// tiny 5-frame clip, asserting frames come back RGB8-sized with streamed progress.
+    /// `#[ignore]` — the weights live outside CI; run manually where they are present.
+    #[cfg(target_os = "macos")]
+    #[ignore = "loads the real Wan2.2 TI2V-5B weights; run manually on a Mac with them present"]
+    #[test]
+    fn wan_5b_real_weights() {
+        let Some(model_dir) = wan_5b_dir() else {
+            eprintln!("skipping wan_5b_real_weights: no converted TI2V-5B dir found");
+            return;
+        };
+        let input = WanGenInput {
+            engine_id: "wan2_2_ti2v_5b",
+            model_dir,
+            quant: None,
+            adapters: Vec::new(),
+            conditioning: Vec::new(),
+            prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
+            negative_prompt: None,
+            width: 256,
+            height: 256,
+            frames: 5,
+            fps: 16,
+            steps: Some(8),
+            guidance: None,
+            seed: 7,
+        };
+        let cancel = CancelFlag::new();
+        let mut steps = 0u32;
+        let mut on_progress = |progress: Progress| {
+            if let Progress::Step { .. } = progress {
+                steps += 1;
+            }
+        };
+        let (frames, fps) =
+            run_wan_generation(input, &cancel, &mut on_progress).expect("5B T2V generation");
+        assert_eq!(frames.len(), 5, "5 frames (1 + 4·1)");
+        assert!(fps >= 1);
+        assert!(steps > 0, "denoise progress streamed");
+        assert!(frames
+            .iter()
+            .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize));
     }
 
     /// Full encode → mp4 + poster, exercised against a real ffmpeg. Skips when no


### PR DESCRIPTION
**Story:** [sc-3034](https://app.shortcut.com/trefry/story/3034) (epic [3018](https://app.shortcut.com/trefry/epic/3018)). Merges into `rust-mlx-integration` (never `main`).

Wires `mlx-gen-wan` into the video runtime so the three Wan2.2 models generate **real, in-process MLX video** through the Rust worker, decoding `mlx_gen::GenerationOutput::Video` into the same `DecodedVideo` the procedural stub used — so the encode/mux/poster pipeline is unchanged (Wan emits frames, no audio).

### What's in it
- **`video_jobs::generate_wan`** (macOS): resolves the converted MLX snapshot dir (env override → `<data>/models/mlx/<id>` → the T2V-14B turnkey HF snapshot `AITRADER/Wan2.2-T2V-A14B-mlx-bf16`), builds the `GenerationRequest` (frames `4n+1`, fps, conditioning), and runs `mlx_gen::load` + `generate` on a blocking thread streaming denoise progress + cooperative cancel (~2s poll). Extracted `run_wan_generation` so the engine call is unit-testable on real weights without the API plumbing.
  - `wan_2_2` → `wan2_2_ti2v_5b` (dense T2V + image-conditioned TI2V; engine-default steps),
  - `wan_2_2_t2v_14b` → `wan2_2_t2v_14b` (dual-expert MoE T2V; the 4-step Lightning distill `lightx2v/Wan2.2-Lightning` baked per-expert, guide 1.0),
  - `wan_2_2_i2v_14b` → `wan2_2_i2v_14b` (MoE I2V; requires a source image).
- **MoE / Lightning LoRA** via `AdapterSpec.moe_expert`: a user `*.high_noise.safetensors` with a `.low_noise` sibling tags high→High / low→Low (the Python `wan_moe_low_noise_sibling` filename convention); a single-file LoRA is shared across experts (and is the only form on the dense 5B). peft LoKr is allowed (the engine merges it, mirroring the image-path correction); LyCORIS is rejected.
- **`VideoRequest::wan_frame_count`** corrected to the Python floor `max(5, raw - ((raw-1)%4))` (it was *nearest* in the prior runtime story — a parity fix). i2v source loaded via the reused `load_reference_image`; `advanced.mlxQuantize` → Q4/Q8. Reuses `image_jobs` `load_reference_image`/`lora_path`/`classify_adapter` (made `pub(crate)`).
- Real-Wan asset records adapter `mlx_wan` + `realModelInference`; the stub stays `procedural_video`. **No video-routing change** — the MLX-vs-Python routing decision is its own (later) story; the `video_generate` capability + dispatch arm carry it on the integration branch.

### Verification
- **Verified end-to-end on real Wan2.2 TI2V-5B weights** (M5 Max): `wan_5b_real_weights` loads the converted 5B snapshot and denoises a 5-frame 256×256 clip to RGB8 frames with streamed progress (`#[ignore]`, weights outside CI). The 14B variants rely on the engine's own real-weight goldens (`mlx-gen-wan` s6 / ti2v parity) — bf16 ~133 GB peak makes a worker-level E2E unsafe on this 128 GB Mac.
- Unit tests for the model-id map, per-model sampling, quant mapping, and the MoE high/low sibling pairing.
- `npm run rust:check` green (fmt + clippy `-D warnings` + tests + build); `nax_guard` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)