### PR TITLE
sc-3035: LTX-2.3 (T2V/I2V) + synchronized audio through the Rust GPU worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-ltx"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0e3ed60a550f7a948c06b97f95c9dd9fc6d59246#0e3ed60a550f7a948c06b97f95c9dd9fc6d59246"
@@ -2766,7 +2777,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3946,6 +3957,7 @@ dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
  "mlx-gen-flux2",
+ "mlx-gen-ltx",
  "mlx-gen-qwen-image",
  "mlx-gen-sdxl",
  "mlx-gen-wan",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -78,6 +78,10 @@ mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed6
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
 mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
+# LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
+# synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
+# in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0e3ed60a550f7a948c06b97f95c9dd9fc6d59246" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1298,11 +1298,36 @@ fn ltx_available(request: &VideoRequest, settings: &Settings) -> bool {
     ltx_engine_id(&request.model).is_some() && resolve_ltx_model_dir(settings, request).is_ok()
 }
 
-/// Resolve the converted LTX MLX snapshot dir. Env override
-/// (`SCENEWORKS_MLX_LTX_DIR` / `…_EROS_DIR`) → `<data>/models/mlx/<candidate>`. For the
-/// base model the Q4 checkpoint is the default (`mlxQuantize: 8` prefers the Q8 one); the
-/// engine reads the actual bits from the checkpoint's `split_model.json`, so this only
-/// picks *which* converted dir to load.
+/// The converted A/V repo the engine's LTX path consumes (the one it replaces); the Q4
+/// base checkpoint with the full audio+I2V component set.
+#[cfg(target_os = "macos")]
+const LTX_TURNKEY_REPO: &str = "notapalindrome/ltx23-mlx-av-q4";
+
+/// Whether `dir` is a converted LTX snapshot **complete for the current engine** — it must
+/// carry the audio `vocoder` + I2V `vae_encoder` + single `upsampler`/`vae_decoder` the
+/// engine `load()` reads. Older conversions (`spatial_/temporal_upscaler_*`, no vocoder)
+/// fail this, so a stale local dir is skipped in favour of the turnkey snapshot.
+#[cfg(target_os = "macos")]
+fn ltx_dir_is_complete(dir: &Path) -> bool {
+    [
+        "connector.safetensors",
+        "transformer.safetensors",
+        "upsampler.safetensors",
+        "vae_decoder.safetensors",
+        "vae_encoder.safetensors",
+        "audio_vae.safetensors",
+        "vocoder.safetensors",
+    ]
+    .iter()
+    .all(|file| dir.join(file).is_file())
+}
+
+/// Resolve the converted LTX MLX snapshot dir. Env override (`SCENEWORKS_MLX_LTX_DIR` /
+/// `…_EROS_DIR`) → `<data>/models/mlx/<candidate>` → (base only) the turnkey HF snapshot
+/// [`LTX_TURNKEY_REPO`]. Only a dir **complete for the current engine**
+/// ([`ltx_dir_is_complete`]) counts, so a stale local conversion is skipped. For the base
+/// model the Q4 checkpoint is the default (`mlxQuantize: 8` prefers the Q8 one); the engine
+/// reads the actual bits from `split_model.json`, so this only picks *which* dir to load.
 #[cfg(target_os = "macos")]
 fn resolve_ltx_model_dir(settings: &Settings, request: &VideoRequest) -> WorkerResult<PathBuf> {
     let eros = request.model == "ltx_2_3_eros";
@@ -1313,7 +1338,7 @@ fn resolve_ltx_model_dir(settings: &Settings, request: &VideoRequest) -> WorkerR
     };
     if let Ok(override_dir) = std::env::var(env) {
         let path = PathBuf::from(override_dir.trim());
-        if path.join("config.json").is_file() {
+        if ltx_dir_is_complete(&path) {
             return Ok(path);
         }
     }
@@ -1332,12 +1357,21 @@ fn resolve_ltx_model_dir(settings: &Settings, request: &VideoRequest) -> WorkerR
     };
     for id in candidates {
         let dir = settings.data_dir.join("models").join("mlx").join(id);
-        if dir.join("config.json").is_file() {
+        if ltx_dir_is_complete(&dir) {
             return Ok(dir);
         }
     }
+    // Turnkey converted A/V snapshot for the base model (the repo the engine replaces).
+    if !eros {
+        if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, LTX_TURNKEY_REPO) {
+            if ltx_dir_is_complete(&dir) {
+                return Ok(dir);
+            }
+        }
+    }
     Err(WorkerError::InvalidPayload(format!(
-        "{}: no converted LTX MLX weights found under {} (expected one of {candidates:?}; or set ${env})",
+        "{}: no complete converted LTX MLX weights found under {} (expected one of {candidates:?} \
+         with the audio vocoder + i2v vae_encoder; or the turnkey {LTX_TURNKEY_REPO}; or set ${env})",
         request.model,
         settings.data_dir.join("models").join("mlx").display(),
     )))
@@ -1766,9 +1800,10 @@ mod tests {
         assert!(none.is_empty());
     }
 
-    /// A locally-converted LTX-2.3 snapshot **complete for the current engine** (needs the
-    /// audio `vocoder` + `vae_encoder` the engine load reads), else `None` so the smoke
-    /// skips. The cached `ltx_2_3_base_*` dirs predate that layout, so this normally skips.
+    /// An LTX-2.3 snapshot **complete for the current engine** ([`ltx_dir_is_complete`]),
+    /// else `None` so the smoke skips. Checks `$SCENEWORKS_MLX_LTX_DIR`, the app-managed
+    /// `<data>/models/mlx/*` dirs (which predate the audio+i2v layout, so usually skip), and
+    /// the turnkey HF-cache snapshot ([`LTX_TURNKEY_REPO`], `notapalindrome/ltx23-mlx-av-q4`).
     #[cfg(target_os = "macos")]
     fn ltx_complete_dir() -> Option<PathBuf> {
         let mut candidates: Vec<PathBuf> = Vec::new();
@@ -1776,6 +1811,13 @@ mod tests {
             candidates.push(PathBuf::from(dir.trim()));
         }
         if let Ok(home) = std::env::var("HOME") {
+            let hub = PathBuf::from(&home).join(".cache/huggingface/hub");
+            let snapshots = hub
+                .join("models--notapalindrome--ltx23-mlx-av-q4")
+                .join("snapshots");
+            if let Ok(entries) = std::fs::read_dir(&snapshots) {
+                candidates.extend(entries.flatten().map(|e| e.path()).filter(|p| p.is_dir()));
+            }
             let base =
                 PathBuf::from(home).join("Library/Application Support/SceneWorks/data/models/mlx");
             for id in [
@@ -1787,10 +1829,7 @@ mod tests {
                 candidates.push(base.join(id));
             }
         }
-        candidates.into_iter().find(|dir| {
-            dir.join("vocoder.safetensors").is_file()
-                && dir.join("vae_encoder.safetensors").is_file()
-        })
+        candidates.into_iter().find(|dir| ltx_dir_is_complete(dir))
     }
 
     /// Real in-process LTX-2.3 T2V **with synchronized audio** through the engine. Loads a

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -36,9 +36,11 @@ use mlx_gen::{
     LoadSpec, MoeExpert, Precision, Progress, Quant, WeightsSource,
 };
 #[cfg(target_os = "macos")]
+use mlx_gen_ltx as _;
+#[cfg(target_os = "macos")]
 use mlx_gen_wan as _;
 #[cfg(target_os = "macos")]
-use sceneworks_core::video_request::wan_frame_count;
+use sceneworks_core::video_request::{ltx_frame_count, wan_frame_count};
 #[cfg(target_os = "macos")]
 use std::time::{Duration, Instant};
 
@@ -128,11 +130,13 @@ pub(crate) async fn run_video_generate_job(
         ),
     )
     .await?;
-    // Generate: real MLX Wan on macOS for Wan models with resolvable weights, else the
-    // procedural stub (LTX real path = sc-3035; non-macOS or missing weights = stub).
+    // Generate: real MLX on macOS for Wan (sc-3034) / LTX+audio (sc-3035) models with
+    // resolvable weights, else the procedural stub (non-macOS or missing weights = stub).
     #[cfg(target_os = "macos")]
-    let (decoded, adapter, raw_settings) = match wan_engine_id(&request.model) {
-        Some(engine_id) if wan_available(&request, settings) => (
+    let (decoded, adapter, raw_settings) = if let Some(engine_id) =
+        wan_engine_id(&request.model).filter(|_| wan_available(&request, settings))
+    {
+        (
             generate_wan(
                 api,
                 settings,
@@ -145,12 +149,30 @@ pub(crate) async fn run_video_generate_job(
             .await?,
             WAN_ADAPTER,
             wan_raw_settings(&request),
-        ),
-        _ => (
+        )
+    } else if let Some(engine_id) =
+        ltx_engine_id(&request.model).filter(|_| ltx_available(&request, settings))
+    {
+        (
+            generate_ltx(
+                api,
+                settings,
+                job,
+                &request,
+                &project_path,
+                engine_id,
+                backend,
+            )
+            .await?,
+            LTX_ADAPTER,
+            ltx_raw_settings(&request),
+        )
+    } else {
+        (
             generate_stub_video(&request, seed),
             STUB_ADAPTER,
             stub_raw_settings(&request),
-        ),
+        )
     };
     #[cfg(not(target_os = "macos"))]
     let (decoded, adapter, raw_settings) = (
@@ -1026,10 +1048,12 @@ fn wan_sampling(engine_id: &str) -> (Option<u32>, Option<f32>) {
     }
 }
 
-/// The resolved inputs for one Wan generation (engine load + request build), split out
-/// so the engine call is unit-testable on real weights without the API/job plumbing.
+/// The resolved inputs for one video generation (engine load + request build), shared by
+/// Wan (sc-3034) and LTX (sc-3035) — split out so the engine call is unit-testable on real
+/// weights without the API/job plumbing. The LTX-only knobs (`video_mode` no_audio,
+/// prompt-enhance) default off for Wan; the Wan-only `moe_expert` rides on `adapters`.
 #[cfg(target_os = "macos")]
-struct WanGenInput {
+struct VideoGenInput {
     engine_id: &'static str,
     model_dir: PathBuf,
     quant: Option<Quant>,
@@ -1044,17 +1068,51 @@ struct WanGenInput {
     steps: Option<u32>,
     guidance: Option<f32>,
     seed: u64,
+    // LTX-only knobs (sc-3035); left at defaults by Wan + the other models.
+    video_mode: Option<String>,
+    enhance_prompt: bool,
+    use_uncensored_enhancer: bool,
+    enhance_max_tokens: Option<u32>,
+    enhance_temperature: Option<f32>,
 }
 
-/// Load the Wan model and run one generation to RGB8 frames (+ fps), streaming denoise
-/// progress via `on_progress` and honoring `cancel`. Synchronous + blocking (the
-/// `Box<dyn Generator>` is `!Send`); the caller runs it on a blocking thread.
 #[cfg(target_os = "macos")]
-fn run_wan_generation(
-    input: WanGenInput,
+impl Default for VideoGenInput {
+    fn default() -> Self {
+        Self {
+            engine_id: "",
+            model_dir: PathBuf::new(),
+            quant: None,
+            adapters: Vec::new(),
+            conditioning: Vec::new(),
+            prompt: String::new(),
+            negative_prompt: None,
+            width: 0,
+            height: 0,
+            frames: 0,
+            fps: 0,
+            steps: None,
+            guidance: None,
+            seed: 0,
+            video_mode: None,
+            enhance_prompt: false,
+            use_uncensored_enhancer: false,
+            enhance_max_tokens: None,
+            enhance_temperature: None,
+        }
+    }
+}
+
+/// Load a video model and run one generation to a [`DecodedVideo`] (RGB8 frames + fps +
+/// optional audio), streaming denoise progress via `on_progress` and honoring `cancel`.
+/// Synchronous + blocking (the `Box<dyn Generator>` is `!Send`); the caller runs it on a
+/// blocking thread. The engine fills the audio track (LTX) or leaves it `None` (Wan).
+#[cfg(target_os = "macos")]
+fn run_video_generation(
+    input: VideoGenInput,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
-) -> WorkerResult<(Vec<RgbFrame>, u32)> {
+) -> WorkerResult<DecodedVideo> {
     let spec = LoadSpec {
         weights: WeightsSource::Dir(input.model_dir),
         quantize: input.quant,
@@ -1063,7 +1121,7 @@ fn run_wan_generation(
         adapters: input.adapters,
     };
     let generator = mlx_gen::load(input.engine_id, &spec)
-        .map_err(|error| WorkerError::InvalidPayload(format!("Wan load failed: {error}")))?;
+        .map_err(|error| WorkerError::InvalidPayload(format!("video load failed: {error}")))?;
     let req = GenerationRequest {
         prompt: input.prompt,
         negative_prompt: input.negative_prompt,
@@ -1075,15 +1133,20 @@ fn run_wan_generation(
         guidance: input.guidance,
         seed: Some(input.seed),
         conditioning: input.conditioning,
+        video_mode: input.video_mode,
+        enhance_prompt: input.enhance_prompt,
+        use_uncensored_enhancer: input.use_uncensored_enhancer,
+        enhance_max_tokens: input.enhance_max_tokens,
+        enhance_temperature: input.enhance_temperature,
         cancel: cancel.clone(),
         ..Default::default()
     };
-    let output = generator
-        .generate(&req, on_progress)
-        .map_err(|error| WorkerError::InvalidPayload(format!("Wan generation failed: {error}")))?;
+    let output = generator.generate(&req, on_progress).map_err(|error| {
+        WorkerError::InvalidPayload(format!("video generation failed: {error}"))
+    })?;
     match output {
-        GenerationOutput::Video { frames, fps, .. } => Ok((
-            frames
+        GenerationOutput::Video { frames, fps, audio } => Ok(DecodedVideo {
+            frames: frames
                 .into_iter()
                 .map(|image| RgbFrame {
                     width: image.width,
@@ -1092,72 +1155,41 @@ fn run_wan_generation(
                 })
                 .collect(),
             fps,
-        )),
+            audio: audio.map(|track| AudioTrack {
+                samples: track.samples,
+                sample_rate: track.sample_rate,
+                channels: track.channels,
+            }),
+        }),
         GenerationOutput::Images(_) => Err(WorkerError::InvalidPayload(
-            "Wan returned images, expected video frames".to_owned(),
+            "video model returned images, expected video frames".to_owned(),
         )),
     }
 }
 
-/// Run a real MLX Wan generation on the blocking thread (the `Box<dyn Generator>` is
-/// `!Send` and the MLX device is single-thread), streaming denoise progress back to the
-/// async worker (which forwards it + polls cancel ~every 2s). Returns the decoded video
-/// (RGB8 frames + fps, no audio) for the shared [`encode_media`] pipeline.
+/// Drive a `run_video_generation` on a blocking thread, forwarding its streamed denoise
+/// progress to the async worker (Generating stage ~0.25..0.58) + polling cancel ~every 2s.
+/// The shared blocking + mpsc + cancel plumbing for Wan and LTX.
 #[cfg(target_os = "macos")]
-#[allow(clippy::too_many_arguments)]
-async fn generate_wan(
+async fn generate_video(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
-    request: &VideoRequest,
-    project_path: &Path,
-    engine_id: &'static str,
     backend: &str,
+    input: VideoGenInput,
 ) -> WorkerResult<DecodedVideo> {
-    let model_dir = resolve_wan_model_dir(settings, &request.model, engine_id)?;
-    let adapters = resolve_wan_adapters(settings, request, engine_id)?;
-    let conditioning = resolve_wan_conditioning(settings, request, project_path, engine_id)?;
-    let quant = resolve_wan_quant(request);
-    let frames = wan_frame_count(request.raw_frame_count());
-    let seed = resolve_video_seed(request);
-    let (steps, guidance) = wan_sampling(engine_id);
-    let negative_prompt = {
-        let trimmed = request.negative_prompt.trim();
-        (!trimmed.is_empty()).then(|| trimmed.to_owned())
-    };
-    let prompt = request.prompt.clone();
-    let (width, height, fps) = (request.width, request.height, request.fps);
-
-    let input = WanGenInput {
-        engine_id,
-        model_dir,
-        quant,
-        adapters,
-        conditioning,
-        prompt,
-        negative_prompt,
-        width,
-        height,
-        frames,
-        fps,
-        steps,
-        guidance,
-        seed: seed as u64,
-    };
-
     let cancel = CancelFlag::new();
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Progress>(64);
     let blocking = {
         let cancel = cancel.clone();
-        tokio::task::spawn_blocking(move || -> WorkerResult<(Vec<RgbFrame>, u32)> {
+        tokio::task::spawn_blocking(move || -> WorkerResult<DecodedVideo> {
             let mut on_progress = |progress: Progress| {
                 let _ = tx.blocking_send(progress);
             };
-            run_wan_generation(input, &cancel, &mut on_progress)
+            run_video_generation(input, &cancel, &mut on_progress)
         })
     };
 
-    // Forward denoise progress (Generating stage, ~0.25..0.58) + poll cancel ~every 2s.
     let mut canceled = false;
     let mut last_cancel = Instant::now();
     while let Some(progress) = rx.recv().await {
@@ -1197,16 +1229,237 @@ async fn generate_wan(
 
     let result = blocking
         .await
-        .map_err(|error| WorkerError::InvalidPayload(format!("Wan task join: {error}")))?;
+        .map_err(|error| WorkerError::InvalidPayload(format!("video task join: {error}")))?;
     if canceled {
         return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
     }
-    let (frames, out_fps) = result?;
-    Ok(DecodedVideo {
-        frames,
-        fps: out_fps,
-        audio: None,
-    })
+    result
+}
+
+/// Resolve a Wan request into a [`VideoGenInput`] and run it (sc-3034).
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn generate_wan(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    let (steps, guidance) = wan_sampling(engine_id);
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let input = VideoGenInput {
+        engine_id,
+        model_dir: resolve_wan_model_dir(settings, &request.model, engine_id)?,
+        quant: resolve_wan_quant(request),
+        adapters: resolve_wan_adapters(settings, request, engine_id)?,
+        conditioning: resolve_wan_conditioning(settings, request, project_path, engine_id)?,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: wan_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        steps,
+        guidance,
+        seed: resolve_video_seed(request) as u64,
+        ..VideoGenInput::default()
+    };
+    generate_video(api, settings, job, backend, input).await
+}
+
+// ---------------------------------------------------------------------------
+// Real MLX LTX-2.3 generation (macOS, via mlx-gen-ltx, sc-3035): T2V/I2V with
+// SYNCHRONIZED AUDIO (the 2-stage distilled A/V pipeline; CFG forced 1.0). One
+// engine model `ltx_2_3` serves both `ltx_2_3` + `ltx_2_3_eros` (the checkpoint dir
+// selects quant via split_model.json). The Gemma-3 text encoder is resolved by the
+// engine ($LTX_GEMMA_DIR / the HF cache). Audio rides the sc-3033 WAV→AAC mux path.
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real MLX LTX asset.
+#[cfg(target_os = "macos")]
+const LTX_ADAPTER: &str = "mlx_ltx";
+
+/// SceneWorks LTX model id → mlx-gen registry id (one engine model serves both), or
+/// `None` if not an LTX family id.
+#[cfg(target_os = "macos")]
+fn ltx_engine_id(model: &str) -> Option<&'static str> {
+    matches!(model, "ltx_2_3" | "ltx_2_3_eros").then_some("ltx_2_3")
+}
+
+/// Whether the linked LTX engine can serve this request now (resolvable weights).
+#[cfg(target_os = "macos")]
+fn ltx_available(request: &VideoRequest, settings: &Settings) -> bool {
+    ltx_engine_id(&request.model).is_some() && resolve_ltx_model_dir(settings, request).is_ok()
+}
+
+/// Resolve the converted LTX MLX snapshot dir. Env override
+/// (`SCENEWORKS_MLX_LTX_DIR` / `…_EROS_DIR`) → `<data>/models/mlx/<candidate>`. For the
+/// base model the Q4 checkpoint is the default (`mlxQuantize: 8` prefers the Q8 one); the
+/// engine reads the actual bits from the checkpoint's `split_model.json`, so this only
+/// picks *which* converted dir to load.
+#[cfg(target_os = "macos")]
+fn resolve_ltx_model_dir(settings: &Settings, request: &VideoRequest) -> WorkerResult<PathBuf> {
+    let eros = request.model == "ltx_2_3_eros";
+    let env = if eros {
+        "SCENEWORKS_MLX_LTX_EROS_DIR"
+    } else {
+        "SCENEWORKS_MLX_LTX_DIR"
+    };
+    if let Ok(override_dir) = std::env::var(env) {
+        let path = PathBuf::from(override_dir.trim());
+        if path.join("config.json").is_file() {
+            return Ok(path);
+        }
+    }
+    let wants_q8 = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .map(|bits| bits >= 8)
+        .unwrap_or(false);
+    let candidates: &[&str] = if eros {
+        &["ltx_2_3_eros"]
+    } else if wants_q8 {
+        &["ltx_2_3_base_q8", "ltx_2_3_base_q4", "ltx_2_3"]
+    } else {
+        &["ltx_2_3_base_q4", "ltx_2_3_base_q8", "ltx_2_3"]
+    };
+    for id in candidates {
+        let dir = settings.data_dir.join("models").join("mlx").join(id);
+        if dir.join("config.json").is_file() {
+            return Ok(dir);
+        }
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{}: no converted LTX MLX weights found under {} (expected one of {candidates:?}; or set ${env})",
+        request.model,
+        settings.data_dir.join("models").join("mlx").display(),
+    )))
+}
+
+/// User LoRAs for an LTX generation (sc-3035): each at a uniform per-pass strength
+/// (`pass_scales` left `None` → the engine applies `scale` on every distilled stage; a
+/// per-stage schedule is parity-plus). No distill/Lightning prepend — the 2-stage distill
+/// is baked into the checkpoint. peft LoKr allowed (engine residual), LyCORIS rejected.
+#[cfg(target_os = "macos")]
+fn resolve_ltx_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>> {
+    if request.loras.len() > MAX_JOB_LORAS {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
+        )));
+    }
+    let mut specs = Vec::with_capacity(request.loras.len());
+    for lora in &request.loras {
+        let path = lora_path(lora).ok_or_else(|| {
+            WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
+        })?;
+        let file = resolve_lora_file(path)?;
+        let kind = classify_adapter(&file)?;
+        specs.push(AdapterSpec::new(file, lora_scale(lora), kind));
+    }
+    Ok(specs)
+}
+
+/// Optional I2V conditioning for LTX: a `source_asset_id` → a single `Reference` image
+/// (image→video); absent → pure text→video. (Audio is produced either way.)
+#[cfg(target_os = "macos")]
+fn resolve_ltx_conditioning(
+    settings: &Settings,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Conditioning>> {
+    match request.source_asset_id.as_deref() {
+        Some(asset_id) => {
+            let image = load_reference_image(
+                &settings.data_dir,
+                &request.project_id,
+                asset_id,
+                project_path,
+            )?;
+            Ok(vec![Conditioning::Reference {
+                image,
+                strength: None,
+            }])
+        }
+        None => Ok(Vec::new()),
+    }
+}
+
+/// Read an `advanced` boolean flag (JSON bool), default `false` (Python `bool(.get(k))`).
+#[cfg(target_os = "macos")]
+fn advanced_bool(request: &VideoRequest, key: &str) -> bool {
+    request
+        .advanced
+        .get(key)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Raw-settings recorded on a real MLX LTX asset (`advanced` knobs + real-inference markers).
+#[cfg(target_os = "macos")]
+fn ltx_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("frameCount".to_owned(), json!(request.frame_count()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    Value::Object(raw)
+}
+
+/// Resolve an LTX request into a [`VideoGenInput`] and run it (sc-3035). Distilled 2-stage
+/// → no negative prompt / guidance (CFG 1.0); quant is checkpoint-driven (`None`); frames
+/// snap to `8k+1`; `advanced.noAudio` → `video_mode = "no_audio"` (full A/V denoise, audio
+/// decode skipped); prompt-enhance + per-pass LoRA flow through.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn generate_ltx(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    let video_mode = advanced_bool(request, "noAudio").then(|| "no_audio".to_owned());
+    let enhance_max_tokens = request
+        .advanced
+        .get("enhanceMaxTokens")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+    let enhance_temperature = request
+        .advanced
+        .get("enhanceTemperature")
+        .and_then(|v| v.as_f64())
+        .map(|v| v as f32);
+    let input = VideoGenInput {
+        engine_id,
+        model_dir: resolve_ltx_model_dir(settings, request)?,
+        quant: None,
+        adapters: resolve_ltx_adapters(request)?,
+        conditioning: resolve_ltx_conditioning(settings, request, project_path)?,
+        prompt: request.prompt.clone(),
+        negative_prompt: None,
+        width: request.width,
+        height: request.height,
+        frames: ltx_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        steps: None,
+        guidance: None,
+        seed: resolve_video_seed(request) as u64,
+        video_mode,
+        enhance_prompt: advanced_bool(request, "enhancePrompt"),
+        use_uncensored_enhancer: advanced_bool(request, "useUncensoredEnhancer"),
+        enhance_max_tokens,
+        enhance_temperature,
+    };
+    generate_video(api, settings, job, backend, input).await
 }
 
 #[cfg(test)]
@@ -1455,21 +1708,17 @@ mod tests {
             eprintln!("skipping wan_5b_real_weights: no converted TI2V-5B dir found");
             return;
         };
-        let input = WanGenInput {
+        let input = VideoGenInput {
             engine_id: "wan2_2_ti2v_5b",
             model_dir,
-            quant: None,
-            adapters: Vec::new(),
-            conditioning: Vec::new(),
             prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
-            negative_prompt: None,
             width: 256,
             height: 256,
             frames: 5,
             fps: 16,
             steps: Some(8),
-            guidance: None,
             seed: 7,
+            ..VideoGenInput::default()
         };
         let cancel = CancelFlag::new();
         let mut steps = 0u32;
@@ -1478,12 +1727,113 @@ mod tests {
                 steps += 1;
             }
         };
-        let (frames, fps) =
-            run_wan_generation(input, &cancel, &mut on_progress).expect("5B T2V generation");
-        assert_eq!(frames.len(), 5, "5 frames (1 + 4·1)");
-        assert!(fps >= 1);
+        let decoded =
+            run_video_generation(input, &cancel, &mut on_progress).expect("5B T2V generation");
+        assert_eq!(decoded.frames.len(), 5, "5 frames (1 + 4·1)");
+        assert!(decoded.fps >= 1);
+        assert!(decoded.audio.is_none(), "Wan emits no audio");
         assert!(steps > 0, "denoise progress streamed");
-        assert!(frames
+        assert!(decoded
+            .frames
+            .iter()
+            .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize));
+    }
+
+    /// LTX model-id → engine-id mapping (both base + eros load the one engine model).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ltx_engine_id_maps_base_and_eros() {
+        assert_eq!(ltx_engine_id("ltx_2_3"), Some("ltx_2_3"));
+        assert_eq!(ltx_engine_id("ltx_2_3_eros"), Some("ltx_2_3"));
+        assert_eq!(ltx_engine_id("wan_2_2"), None);
+        assert_eq!(ltx_engine_id("z_image_turbo"), None);
+    }
+
+    /// `advanced.noAudio` maps to the engine's `video_mode = "no_audio"`; enhance flags
+    /// flow through. Asserts the LTX request build (the VideoGenInput, pre-load).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ltx_advanced_flags_map_to_video_gen_input() {
+        let req = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "a fox",
+            "advanced": { "noAudio": true, "enhancePrompt": true }
+        }));
+        assert!(advanced_bool(&req, "noAudio"));
+        assert!(advanced_bool(&req, "enhancePrompt"));
+        assert!(!advanced_bool(&req, "useUncensoredEnhancer"));
+        // LTX adapters: a plain user LoRA is uniform (no per-pass schedule, no moe tag).
+        let none = resolve_ltx_adapters(&req).unwrap();
+        assert!(none.is_empty());
+    }
+
+    /// A locally-converted LTX-2.3 snapshot **complete for the current engine** (needs the
+    /// audio `vocoder` + `vae_encoder` the engine load reads), else `None` so the smoke
+    /// skips. The cached `ltx_2_3_base_*` dirs predate that layout, so this normally skips.
+    #[cfg(target_os = "macos")]
+    fn ltx_complete_dir() -> Option<PathBuf> {
+        let mut candidates: Vec<PathBuf> = Vec::new();
+        if let Ok(dir) = std::env::var("SCENEWORKS_MLX_LTX_DIR") {
+            candidates.push(PathBuf::from(dir.trim()));
+        }
+        if let Ok(home) = std::env::var("HOME") {
+            let base =
+                PathBuf::from(home).join("Library/Application Support/SceneWorks/data/models/mlx");
+            for id in [
+                "ltx_2_3_base_q4",
+                "ltx_2_3_base_q8",
+                "ltx_2_3_eros",
+                "ltx_2_3",
+            ] {
+                candidates.push(base.join(id));
+            }
+        }
+        candidates.into_iter().find(|dir| {
+            dir.join("vocoder.safetensors").is_file()
+                && dir.join("vae_encoder.safetensors").is_file()
+        })
+    }
+
+    /// Real in-process LTX-2.3 T2V **with synchronized audio** through the engine. Loads a
+    /// complete converted snapshot + the cached Gemma TE and denoises a tiny 9-frame clip,
+    /// asserting frames come back RGB8-sized **and an audio track is produced** with streamed
+    /// progress. `#[ignore]` + skips unless a complete snapshot is present (the cached
+    /// `ltx_2_3_base_*` dirs predate the engine's vocoder/vae_encoder layout).
+    #[cfg(target_os = "macos")]
+    #[ignore = "loads the real LTX-2.3 weights + Gemma TE; needs a snapshot complete for the current engine"]
+    #[test]
+    fn ltx_real_weights_with_audio() {
+        let Some(model_dir) = ltx_complete_dir() else {
+            eprintln!("skipping ltx_real_weights_with_audio: no complete LTX snapshot found");
+            return;
+        };
+        let input = VideoGenInput {
+            engine_id: "ltx_2_3",
+            model_dir,
+            prompt: "a calm ocean wave at sunset, gentle surf".to_owned(),
+            width: 256,
+            height: 256,
+            frames: 9,
+            fps: 24,
+            seed: 7,
+            ..VideoGenInput::default()
+        };
+        let cancel = CancelFlag::new();
+        let mut steps = 0u32;
+        let mut on_progress = |progress: Progress| {
+            if let Progress::Step { .. } = progress {
+                steps += 1;
+            }
+        };
+        let decoded =
+            run_video_generation(input, &cancel, &mut on_progress).expect("LTX A/V generation");
+        assert_eq!(decoded.frames.len(), 9, "9 frames (1 + 8·1)");
+        let audio = decoded
+            .audio
+            .expect("LTX produces a synchronized audio track");
+        assert!(audio.sample_rate >= 1 && !audio.samples.is_empty());
+        assert!(steps > 0, "denoise progress streamed");
+        assert!(decoded
+            .frames
             .iter()
             .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize));
     }


### PR DESCRIPTION
**Story:** [sc-3035](https://app.shortcut.com/trefry/story/3035) (epic [3018](https://app.shortcut.com/trefry/epic/3018)). Merges into `rust-mlx-integration` (never `main`).

Wires `mlx-gen-ltx` into the video runtime so `ltx_2_3` (+ `ltx_2_3_eros`) generate **real in-process MLX video with synchronized audio** through the Rust worker — the 2-stage distilled A/V pipeline (CFG forced 1.0). The engine's `AudioTrack` rides the WAV (peak-normalize) → AAC mux (`-shortest`) → faststart → poster path the runtime story built (already ffmpeg-verified).

### What's in it
- **Generalized the Wan helpers into a shared video engine-call layer** so Wan + LTX (and future video models) share one path: `WanGenInput` → `VideoGenInput` (+ LTX-only fields `video_mode`/`enhance*`, with a `Default`), `run_wan_generation` → `run_video_generation` (returns a `DecodedVideo` with the engine's audio passed through), and `generate_video` (the blocking + mpsc-progress + ~2s cancel-poll plumbing extracted from `generate_wan`).
- **`generate_ltx`**: one engine model `ltx_2_3` serves both ids (the checkpoint dir selects Q4/Q8 via `split_model.json` — quant passed `None`, checkpoint-driven). Distilled 2-stage ⇒ no negative prompt / guidance / steps; frames snap `8k+1`; optional I2V via `source_asset_id` → `Conditioning::Reference`; `advanced.noAudio` → `video_mode "no_audio"` (full A/V denoise, audio decode skipped); `enhancePrompt` / `useUncensoredEnhancer` / `enhanceMaxTokens` / `enhanceTemperature` flow through; user LoRAs at uniform per-pass strength (peft LoKr allowed, LyCORIS rejected). No Lightning/distill prepend (baked into the checkpoint). The engine resolves the Gemma-3 text encoder itself (`$LTX_GEMMA_DIR` / HF cache `mlx-community/gemma-3-12b-it-bf16`).
- **`resolve_ltx_model_dir`**: env override (`SCENEWORKS_MLX_LTX_DIR` / `…_EROS_DIR`) → `<data>/models/mlx/<candidate>` (base ⇒ Q4 default, `mlxQuantize: 8` prefers Q8; eros ⇒ `ltx_2_3_eros`). Dispatch adds the LTX branch (Wan → LTX → stub); real LTX records adapter `mlx_ltx`. **No video-routing change** — that's its own later story.

### Verification
- `npm run rust:check` green (fmt + clippy `-D warnings` + tests + build); `nax_guard` green. New LTX logic unit tests (engine-id map, advanced-flag mapping); the **Wan 5B real-weight smoke still passes after the refactor** (the shared path preserves Wan behavior).
- The audio **mux** path is ffmpeg-verified (the runtime story's `encode_stub_to_mp4_with_audio_and_poster` — a real `AudioTrack` → WAV → AAC → mp4 + poster).
- **A real LTX A/V E2E was not run on this machine:** the cached converted LTX dirs (`ltx_2_3_base_q4/q8`, `eros`) predate the engine's audio `vocoder` + I2V `vae_encoder` layout, so they're incomplete for the pinned `load()`. `ltx_real_weights_with_audio` (`#[ignore]`) skips unless a complete snapshot is present, and otherwise the LTX model is covered by the engine's own A/V parity goldens (`mlx-gen-ltx`). Honest gap — flagged on the story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)