### PR TITLE
sc-3036: Video job routing — MLX-eligible modes → Rust GPU worker, advanced/SVD → Python

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -709,7 +709,9 @@ impl JobsStore {
         if should_defer_auto_gpu_claim(&transaction, &queued, &worker)? {
             return Ok(None);
         }
-        if should_defer_image_to_mlx_worker(&transaction, &queued, &worker)? {
+        if should_defer_image_to_mlx_worker(&transaction, &queued, &worker)?
+            || should_defer_video_to_mlx_worker(&transaction, &queued, &worker)?
+        {
             return Ok(None);
         }
 
@@ -1410,6 +1412,34 @@ fn should_defer_image_to_mlx_worker(
     {
         return Ok(false);
     }
+    idle_mlx_worker_can_claim(connection, job, worker)
+}
+
+/// Video sibling of [`should_defer_image_to_mlx_worker`] (sc-3036): a non-mlx GPU
+/// worker defers an `auto` MLX-eligible `video_generate` job when an idle `mlx`
+/// worker can run it. Same fallback guarantees — no mlx worker / explicit GPU →
+/// never deferred.
+fn should_defer_video_to_mlx_worker(
+    connection: &Connection,
+    job: &JobSnapshot,
+    worker: &WorkerSnapshot,
+) -> JobsStoreResult<bool> {
+    if job.requested_gpu != "auto"
+        || worker.gpu_id.eq_ignore_ascii_case("mlx")
+        || !video_job_is_mlx_eligible(job)
+    {
+        return Ok(false);
+    }
+    idle_mlx_worker_can_claim(connection, job, worker)
+}
+
+/// Whether an idle `mlx` worker (other than `worker`) exists that supports `job`
+/// and has no active GPU job — the shared tail of the image/video MLX deferral.
+fn idle_mlx_worker_can_claim(
+    connection: &Connection,
+    job: &JobSnapshot,
+    worker: &WorkerSnapshot,
+) -> JobsStoreResult<bool> {
     let mut statement = connection.prepare(
         "
         select * from workers
@@ -1629,6 +1659,89 @@ fn request_has_lycoris_lora(payload: &Map<String, Value>) -> bool {
     })
 }
 
+/// Whether any request LoRA records `networkType == "lokr"` (SceneWorks peft LoKr).
+/// Sibling of [`request_has_lycoris_lora`]; used by the video routing to keep a
+/// LoKr-on-Wan job on the torch path (see [`video_job_is_mlx_eligible`]).
+fn request_has_lokr_lora(payload: &Map<String, Value>) -> bool {
+    let Some(loras) = payload.get("loras").and_then(Value::as_array) else {
+        return false;
+    };
+    loras.iter().any(|lora| {
+        lora.as_object()
+            .and_then(|lora| {
+                lora.get("networkType").and_then(Value::as_str).or_else(|| {
+                    lora.get("compatibility")
+                        .and_then(Value::as_object)
+                        .and_then(|compat| compat.get("networkType"))
+                        .and_then(Value::as_str)
+                })
+            })
+            .is_some_and(|recorded| recorded.trim().eq_ignore_ascii_case("lokr"))
+    })
+}
+
+/// Video models the in-process Rust MLX worker generates today (sc-3034 Wan2.2,
+/// sc-3035 LTX-2.3 + audio). Mirrors `MlxVideoAdapter._supported_models`. A model
+/// id absent here is never routed to the mlx worker — the Python torch path stays
+/// authoritative for it (and for SVD, which has no MLX crate).
+const VIDEO_MLX_ROUTED_MODELS: &[&str] = &[
+    "ltx_2_3",
+    "ltx_2_3_eros",
+    "wan_2_2",
+    "wan_2_2_t2v_14b",
+    "wan_2_2_i2v_14b",
+];
+
+/// Whether `model` is a Wan2.2 video family id (vs LTX).
+fn is_wan_video_model(model: &str) -> bool {
+    model.starts_with("wan")
+}
+
+/// Epic 3018 routing (sc-3036, the video sibling of [`image_job_is_mlx_eligible`]):
+/// does this video job belong on the in-process Rust MLX worker? Encodes today's
+/// Python `create_video_adapter` MLX-eligibility (video_adapters.py) at the claim
+/// layer, minus the worker-local gates (MPS presence / sidecar) — those are now
+/// expressed by whether an `mlx` worker is registered and idle (see
+/// [`should_defer_video_to_mlx_worker`]).
+///
+/// MLX covers **`text_to_video` + `image_to_video` on Wan/LTX only**. Everything
+/// else stays on the Python torch path: the advanced job types
+/// (`video_extend`/`video_bridge`/`person_replace`) and the advanced
+/// `video_generate` modes (`first_last_frame`/`replace_person`), SVD (no crate), a
+/// non-MLX model, a third-party LyCORIS LoRA (the mlx worker's `classify_adapter`
+/// rejects it), and **LoKr-on-Wan** (the diffusers-Wan path applies LoKr via PEFT;
+/// the mlx-video path can't — mirrors `create_video_adapter`). LoKr-on-LTX stays
+/// MLX (the torch LTX path has no LoKr loader; the Rust engine applies it natively).
+fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
+    // Only the base video_generate job type is MLX-eligible; the advanced job types
+    // (extend/bridge/person-replace) are torch-only.
+    if !matches!(job.job_type, JobType::VideoGenerate) {
+        return false;
+    }
+    let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
+        return false;
+    };
+    if !VIDEO_MLX_ROUTED_MODELS.contains(&model) {
+        return false;
+    }
+    // Mode defaults to `image_to_video`, mirroring `video_request_from_job`.
+    let mode = job
+        .payload
+        .get("mode")
+        .and_then(Value::as_str)
+        .unwrap_or("image_to_video");
+    if !matches!(mode, "text_to_video" | "image_to_video") {
+        return false;
+    }
+    if request_has_lycoris_lora(&job.payload) {
+        return false;
+    }
+    if is_wan_video_model(model) && request_has_lokr_lora(&job.payload) {
+        return false;
+    }
+    true
+}
+
 fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     if job_requires_gpu(&job.job_type) && worker.gpu_id.eq_ignore_ascii_case("cpu") {
         return false;
@@ -1640,11 +1753,24 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     // those stay on the Python worker. Non-mlx workers are unaffected here; the
     // *preference* to route eligible jobs to an idle mlx worker is a soft
     // deferral in the claim path (`should_defer_image_to_mlx_worker`).
-    if worker.gpu_id.eq_ignore_ascii_case("mlx")
-        && matches!(job.job_type, JobType::ImageGenerate)
-        && !image_job_is_mlx_eligible(job)
-    {
-        return false;
+    if worker.gpu_id.eq_ignore_ascii_case("mlx") {
+        if matches!(job.job_type, JobType::ImageGenerate) && !image_job_is_mlx_eligible(job) {
+            return false;
+        }
+        // Video (sc-3036): the mlx worker claims only MLX-eligible `video_generate`
+        // jobs (Wan/LTX text_to_video / image_to_video). The advanced video job types
+        // (extend / bridge / person-replace) and torch-only `video_generate` cases
+        // (advanced modes, SVD, non-MLX model, LoKr-on-Wan) stay on the Python worker.
+        if matches!(
+            job.job_type,
+            JobType::VideoGenerate
+                | JobType::VideoExtend
+                | JobType::VideoBridge
+                | JobType::PersonReplace
+        ) && !video_job_is_mlx_eligible(job)
+        {
+            return false;
+        }
     }
     let advertises = |capability: &str| {
         worker

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1463,6 +1463,182 @@ fn explicit_gpu_image_job_is_not_deferred_to_mlx_worker() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
 }
 
+// --- Video routing (epic 3018, sc-3036) ---
+
+fn video_caps() -> Vec<WorkerCapability> {
+    vec![WorkerCapability::Gpu, WorkerCapability::VideoGenerate]
+}
+
+fn video_job_with(payload: Value, requested_gpu: &str) -> CreateJob {
+    CreateJob {
+        job_type: JobType::VideoGenerate,
+        project_id: Some("project-1".to_owned()),
+        project_name: Some("Project 1".to_owned()),
+        payload: object(payload),
+        requested_gpu: requested_gpu.to_owned(),
+        source_job_id: None,
+        duplicate_of_job_id: None,
+        attempts: 1,
+    }
+}
+
+#[test]
+fn mlx_eligible_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
+    let store = store("mlx-video-routing-defer");
+    register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+    let job = store
+        .create_job(video_job_with(
+            json!({ "model": "wan_2_2", "mode": "text_to_video", "prompt": "a misty fjord" }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    // The torch worker defers the MLX-eligible video job to the idle mlx worker.
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn mlx_worker_excluded_from_advanced_mode_video_job() {
+    let store = store("mlx-video-routing-exclude");
+    register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+    // first_last_frame is an advanced mode — torch-only even on a Wan model (MLX
+    // covers only text_to_video / image_to_video).
+    let job = store
+        .create_job(video_job_with(
+            json!({ "model": "wan_2_2", "mode": "first_last_frame" }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+
+    register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
+#[test]
+fn mlx_eligible_video_job_falls_back_to_torch_when_no_mlx_worker() {
+    let store = store("mlx-video-routing-fallback");
+    register_gpu_worker(&store, "worker-torch", "cuda:0", video_caps());
+
+    let job = store
+        .create_job(video_job_with(
+            json!({ "model": "ltx_2_3", "mode": "text_to_video", "prompt": "p" }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("cuda:0"));
+}
+
+#[test]
+fn explicit_gpu_video_job_is_not_deferred_to_mlx_worker() {
+    let store = store("mlx-video-routing-explicit-gpu");
+    register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+    let job = store
+        .create_job(video_job_with(
+            json!({ "model": "wan_2_2", "mode": "text_to_video", "prompt": "p" }),
+            "mps",
+        ))
+        .expect("job creates");
+
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the explicit-gpu job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
+#[test]
+fn lokr_on_wan_video_stays_on_torch() {
+    let store = store("mlx-video-lokr-wan");
+    register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+    // LoKr-on-Wan → torch: the diffusers-Wan path applies LoKr via PEFT; the
+    // mlx-video path can't (mirrors create_video_adapter).
+    let job = store
+        .create_job(video_job_with(
+            json!({
+                "model": "wan_2_2_t2v_14b",
+                "mode": "text_to_video",
+                "loras": [{ "path": "a.safetensors", "networkType": "lokr" }]
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+
+    register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the LoKr-on-Wan job");
+    assert_eq!(claimed.id, job.id);
+}
+
+#[test]
+fn lokr_on_ltx_video_routes_to_mlx_worker() {
+    let store = store("mlx-video-lokr-ltx");
+    register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+    // LoKr-on-LTX stays MLX: the torch LTX path has no LoKr loader; the Rust engine
+    // applies it natively.
+    let job = store
+        .create_job(video_job_with(
+            json!({
+                "model": "ltx_2_3",
+                "mode": "text_to_video",
+                "loras": [{ "path": "a.safetensors", "networkType": "lokr" }]
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the LoKr-on-LTX job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
 #[test]
 fn flux_schnell_txt2img_routes_to_mlx_worker() {
     let store = store("mlx-routing-flux");


### PR DESCRIPTION
**Story:** [sc-3036](https://app.shortcut.com/trefry/story/3036) (epic [3018](https://app.shortcut.com/trefry/epic/3018)). Merges into `rust-mlx-integration` (never `main`). The video sibling of the image routing (sc-3021).

Encodes today's Python `create_video_adapter` MLX-eligibility at the API claim layer (in `sceneworks-core::jobs_store`), so video jobs land on the right worker — with zero behavioral change until an `mlx` worker is launched at cutover.

### Routing
- **Rust GPU worker** ← a `video_generate` job on a Wan/LTX model (`ltx_2_3`, `ltx_2_3_eros`, `wan_2_2`, `wan_2_2_t2v_14b`, `wan_2_2_i2v_14b`) in mode `text_to_video` / `image_to_video`.
- **Python torch worker** ← the advanced job types (`video_extend`, `video_bridge`, `person_replace`), advanced `video_generate` modes (`first_last_frame`, `replace_person`), SVD (no crate), any non-MLX model, a third-party LyCORIS LoRA, and **LoKr-on-Wan** (the diffusers-Wan path applies LoKr via PEFT; the mlx-video path can't — mirrors `create_video_adapter`). **LoKr-on-LTX stays MLX** (the torch LTX path has no LoKr loader; the Rust engine applies it natively).

### Mechanics (mirrors sc-3021)
- `video_job_is_mlx_eligible(job)` — the eligibility predicate above.
- `should_defer_video_to_mlx_worker` — a non-mlx GPU worker defers an `auto` MLX-eligible video job to an idle `mlx` worker. Extracted the shared idle-mlx query (`idle_mlx_worker_can_claim`), reused by the image deferral. No mlx worker / explicit GPU → never deferred (torch is the fallback; a job is never stuck).
- `worker_supports_job` — the `mlx` worker hard-refuses a `video_generate` it can't run + the advanced video job types, so they stay on Python.
- `request_has_lokr_lora` (recorded `networkType`) for the LoKr-on-Wan gate.

### Note for a future story
sc-3034's worker `resolve_wan_adapters` *can* apply peft LoKr on Wan (the engine supports it), so LoKr-on-Wan could later move to the Rust path — but this story faithfully encodes today's routing (LoKr-on-Wan → torch, which works via PEFT). That's a deliberate forward option, not a contradiction; the worker capability is simply unexercised by this routing.

### Verification
6 new integration tests through `claim_next_job` (defer / exclude-advanced-mode / fallback / explicit-gpu / LoKr-on-Wan→torch / LoKr-on-LTX→mlx); 49 jobs_store tests green. `npm run rust:check` green (fmt + clippy `-D warnings` + tests + build); `nax_guard` green. Built + verified in an isolated worktree off `rust-mlx-integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)