### PR TITLE
sc-3031: E2E parity validation (Rust mlx-gen worker vs Python MLX path) + sc-3219 skeleton fix

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -3941,9 +3941,9 @@ mod tests {
     }
 
     /// sc-3031 A/B dump (pose): generate ONE strict-pose image through the **real new-adapter
-    /// path** — the production `resolve_control_weights` / `resolve_control_scale` / `parse_poses`
-    /// + `draw_wholebody` skeleton render + `zimage_control_load` / `zimage_control_generate_one`
-    /// core that `generate_zimage_control_stream` drives — and write it to `$SC3031_OUT` for
+    /// path** — the production `resolve_control_weights` / `resolve_control_scale` / `parse_poses`,
+    /// the `draw_wholebody` skeleton render, and `zimage_control_load` / `zimage_control_generate_one`
+    /// (the core that `generate_zimage_control_stream` drives) — and write it to `$SC3031_OUT` for
     /// head-to-head comparison against the Python `MlxZImageAdapter` strict-pose tier (drive the
     /// Python side with the SAME `advanced.poses` payload). Env: `SC3031_PAYLOAD` (must carry
     /// `advanced.poses`), `SC3031_OUT`; set `SCENEWORKS_DATA_DIR` + `HF_HOME`.

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -3823,6 +3823,62 @@ mod tests {
         assert!(poses[0].face.is_some());
     }
 
+    /// sc-3031 A/B dump (NOT a CI test): generate ONE image through the **real new-adapter
+    /// path** — the production resolvers (`model_repo` / `resolve_steps` / `resolve_guidance` /
+    /// `resolve_negative_prompt` / `resolve_quant` / `resolve_adapters` / `resolve_weights_dir` /
+    /// `resolve_seed`) + the `mlx_load` + `mlx_generate_one` core that `generate_mlx_stream`
+    /// drives — and write it to `$SC3031_OUT` for head-to-head comparison against the Python
+    /// `Mlx*Adapter` output. Covers the txt2img families (z-image / flux / qwen / flux2 / sdxl).
+    /// Env: `SC3031_PAYLOAD` (job-payload JSON object), `SC3031_OUT` (.png path); set
+    /// `SCENEWORKS_DATA_DIR` + `HF_HOME` so weights resolve. Run:
+    /// `SC3031_PAYLOAD=… SC3031_OUT=… cargo test -p sceneworks-worker --lib -- --ignored --exact \
+    ///   image_jobs::tests::sc3031_ab_dump_txt2img`
+    #[cfg(target_os = "macos")]
+    #[ignore = "sc-3031 A/B dump harness: drive via SC3031_PAYLOAD + SC3031_OUT"]
+    #[test]
+    fn sc3031_ab_dump_txt2img() {
+        let payload: Value =
+            serde_json::from_str(&std::env::var("SC3031_PAYLOAD").expect("SC3031_PAYLOAD"))
+                .expect("SC3031_PAYLOAD is JSON");
+        let out = std::env::var("SC3031_OUT").expect("SC3031_OUT");
+        let req = request(payload);
+        let settings = Settings::from_env(); // honors SCENEWORKS_DATA_DIR + HF_HOME
+
+        let model = mlx_model(&req.model).expect("an MLX txt2img model id");
+        let _repo = model_repo(&req, model);
+        let steps = resolve_steps(&req, model);
+        let guidance = resolve_guidance(&req, model);
+        let negative = resolve_negative_prompt(&req, model);
+        let (quant, _bits) = resolve_quant(&req);
+        let weights = resolve_weights_dir(&req, &settings).expect("weights in HF cache");
+        let adapters = resolve_adapters(&req).expect("adapters");
+        let seed = resolve_seed(&req, 0);
+        let generator = mlx_load(model.engine_id, weights, quant, adapters).expect("load");
+
+        let cancel = CancelFlag::new();
+        let (w, h, pixels) = mlx_generate_one(
+            generator.as_ref(),
+            &req.prompt,
+            req.width,
+            req.height,
+            seed,
+            steps,
+            guidance,
+            negative,
+            &cancel,
+            &mut |_| {},
+        )
+        .expect("generate");
+        image::RgbImage::from_raw(w, h, pixels)
+            .expect("rgb buffer")
+            .save(&out)
+            .expect("save png");
+        eprintln!(
+            "sc3031 rust dump: model={} {w}x{h} seed={seed} steps={steps} guidance={guidance:?} -> {out}",
+            req.model
+        );
+    }
+
     /// Real-weights smoke: Z-Image strict-pose ControlNet. Loads the base
     /// `Tongyi-MAI/Z-Image-Turbo` snapshot + the cached Fun-Controlnet-Union checkpoint,
     /// renders a DWPose skeleton, and generates one pose image. Needs both in the HF

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -3879,6 +3879,111 @@ mod tests {
         );
     }
 
+    /// sc-3031 A/B dump (pose): generate ONE strict-pose image through the **real new-adapter
+    /// path** — the production `resolve_control_weights` / `resolve_control_scale` / `parse_poses`
+    /// + `draw_wholebody` skeleton render + `zimage_control_load` / `zimage_control_generate_one`
+    /// core that `generate_zimage_control_stream` drives — and write it to `$SC3031_OUT` for
+    /// head-to-head comparison against the Python `MlxZImageAdapter` strict-pose tier (drive the
+    /// Python side with the SAME `advanced.poses` payload). Env: `SC3031_PAYLOAD` (must carry
+    /// `advanced.poses`), `SC3031_OUT`; set `SCENEWORKS_DATA_DIR` + `HF_HOME`.
+    #[cfg(target_os = "macos")]
+    #[ignore = "sc-3031 A/B dump harness (pose): drive via SC3031_PAYLOAD + SC3031_OUT"]
+    #[test]
+    fn sc3031_ab_dump_pose() {
+        let payload: Value =
+            serde_json::from_str(&std::env::var("SC3031_PAYLOAD").expect("SC3031_PAYLOAD"))
+                .expect("SC3031_PAYLOAD is JSON");
+        let out = std::env::var("SC3031_OUT").expect("SC3031_OUT");
+        let req = request(payload);
+        let settings = Settings::from_env();
+
+        let weights = resolve_weights_dir(&req, &settings).expect("z-image weights in HF cache");
+        let control_weights =
+            resolve_control_weights(&req, &settings).expect("Fun-Controlnet-Union weights");
+        let (quant, _bits) = resolve_quant(&req);
+        let zimage = mlx_model("z_image_turbo").expect("z-image model row");
+        let steps = resolve_steps(&req, zimage);
+        let control_scale = resolve_control_scale(&req);
+        let adapters = resolve_adapters(&req).expect("adapters");
+        let seed = resolve_seed(&req, 0);
+
+        let pose = parse_poses(&req)
+            .into_iter()
+            .next()
+            .expect("advanced.poses");
+        let (w, h) = (req.width, req.height);
+        let skeleton = crate::openpose_skeleton::draw_wholebody(
+            w,
+            h,
+            &pose.keypoints,
+            pose.hands.as_deref(),
+            pose.face.as_deref(),
+            crate::openpose_skeleton::body_stickwidth(w, h),
+        );
+        let control = Image {
+            width: w,
+            height: h,
+            pixels: skeleton.into_raw(),
+        };
+
+        let generator =
+            zimage_control_load(weights, control_weights, quant, adapters).expect("load");
+        let cancel = CancelFlag::new();
+        let (ow, oh, pixels) = zimage_control_generate_one(
+            generator.as_ref(),
+            &req.prompt,
+            w,
+            h,
+            seed,
+            steps,
+            control,
+            control_scale,
+            &cancel,
+            &mut |_| {},
+        )
+        .expect("generate");
+        image::RgbImage::from_raw(ow, oh, pixels)
+            .expect("rgb buffer")
+            .save(&out)
+            .expect("save png");
+        eprintln!(
+            "sc3031 rust pose dump: {ow}x{oh} seed={seed} steps={steps} control_scale={control_scale} -> {out}"
+        );
+    }
+
+    /// sc-3031 A/B (pose, no model): render JUST the control skeleton from
+    /// `$SC3031_PAYLOAD`'s `advanced.poses` via the production `parse_poses` + `draw_wholebody`
+    /// and write it to `$SC3031_OUT`, to compare the Rust skeleton renderer against the Python
+    /// one for the same keypoints (separates skeleton-render parity from the engine/schedule).
+    /// CPU-only, instant (no weights / no Metal).
+    #[ignore = "sc-3031 skeleton-render dump: drive via SC3031_PAYLOAD + SC3031_OUT"]
+    #[test]
+    fn sc3031_dump_skeleton() {
+        let payload: Value =
+            serde_json::from_str(&std::env::var("SC3031_PAYLOAD").expect("SC3031_PAYLOAD"))
+                .expect("SC3031_PAYLOAD is JSON");
+        let out = std::env::var("SC3031_OUT").expect("SC3031_OUT");
+        let req = request(payload);
+        let pose = parse_poses(&req)
+            .into_iter()
+            .next()
+            .expect("advanced.poses");
+        let (w, h) = (req.width, req.height);
+        let skeleton = crate::openpose_skeleton::draw_wholebody(
+            w,
+            h,
+            &pose.keypoints,
+            pose.hands.as_deref(),
+            pose.face.as_deref(),
+            crate::openpose_skeleton::body_stickwidth(w, h),
+        );
+        image::RgbImage::from_raw(w, h, skeleton.into_raw())
+            .expect("rgb buffer")
+            .save(&out)
+            .expect("save png");
+        eprintln!("sc3031 rust skeleton dump: {w}x{h} -> {out}");
+    }
+
     /// Real-weights smoke: Z-Image strict-pose ControlNet. Loads the base
     /// `Tongyi-MAI/Z-Image-Turbo` snapshot + the cached Fun-Controlnet-Union checkpoint,
     /// renders a DWPose skeleton, and generates one pose image. Needs both in the HF

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -4017,7 +4017,9 @@ mod tests {
     /// `$SC3031_PAYLOAD`'s `advanced.poses` via the production `parse_poses` + `draw_wholebody`
     /// and write it to `$SC3031_OUT`, to compare the Rust skeleton renderer against the Python
     /// one for the same keypoints (separates skeleton-render parity from the engine/schedule).
-    /// CPU-only, instant (no weights / no Metal).
+    /// CPU-only, instant (no weights / no Metal). macOS-gated because it uses `parse_poses`
+    /// (part of the macOS strict-pose path); the Linux workspace-check lane configures that out.
+    #[cfg(target_os = "macos")]
     #[ignore = "sc-3031 skeleton-render dump: drive via SC3031_PAYLOAD + SC3031_OUT"]
     #[test]
     fn sc3031_dump_skeleton() {

--- a/crates/sceneworks-worker/src/openpose_skeleton.rs
+++ b/crates/sceneworks-worker/src/openpose_skeleton.rs
@@ -207,13 +207,28 @@ fn ellipse2poly(cx: f32, cy: f32, ax: f32, ay: f32, angle_deg: f32) -> Vec<Point
         .collect()
 }
 
-/// Fill a convex polygon (`cv2.fillConvexPoly`). No-ops on a degenerate polygon
-/// (imageproc panics if the first and last points coincide / it is empty).
+/// Fill a convex polygon (`cv2.fillConvexPoly`). `imageproc::draw_polygon_mut` panics
+/// when the first and last vertices coincide, so we de-duplicate consecutive-equal
+/// vertices and drop a coincident tail before filling. This matters for the thin limb
+/// ellipses: `ellipse2poly` emits 360 vertices at 1° steps, and for a small minor axis
+/// (the stickwidth) the 0° and 359° vertices round to the SAME pixel — the previous
+/// `first == last` guard then silently no-op'd the *entire* limb, erasing nearly every
+/// skeleton bone (only an occasional limb whose sub-pixel rounding broke the tie
+/// survived). De-duping keeps the limb instead of dropping it (sc-3031 parity finding).
 fn fill_poly(canvas: &mut RgbImage, poly: &[Point<i32>], color: Rgb<u8>) {
-    if poly.len() < 3 || poly.first() == poly.last() {
+    let mut pts: Vec<Point<i32>> = Vec::with_capacity(poly.len());
+    for &p in poly {
+        if pts.last() != Some(&p) {
+            pts.push(p);
+        }
+    }
+    while pts.len() > 1 && pts.first() == pts.last() {
+        pts.pop();
+    }
+    if pts.len() < 3 {
         return;
     }
-    draw_polygon_mut(canvas, poly, color);
+    draw_polygon_mut(canvas, &pts, color);
 }
 
 /// A thick line as a filled rotated rectangle (`cv2.line` with `thickness`).
@@ -450,6 +465,27 @@ mod tests {
         assert!(
             img.pixels().any(|p| p.0 == [255, 0, 0]),
             "expected red nose joint"
+        );
+    }
+
+    #[test]
+    fn draw_bodypose_fills_thin_limbs() {
+        // Regression (sc-3031): a thin limb bone must render, not just the joint dots.
+        // `ellipse2poly` emits 360 vertices at 1° steps; for a small minor axis the 0°/359°
+        // vertices round to the same pixel, and the old `first == last` guard then no-op'd
+        // the whole limb — erasing nearly every skeleton bone. Place a LONG horizontal limb
+        // (neck→R-shoulder, LIMB_SEQ[0] = (1,2)) so its midpoint is far from either joint
+        // dot (radius = stickwidth): a colored pixel there can only come from the bone.
+        let mut kp = vec![None; 18];
+        kp[1] = Some((0.2, 0.5)); // neck
+        kp[2] = Some((0.8, 0.5)); // right shoulder
+        let img = draw_bodypose(128, 128, &kp, 6);
+        // Limb spans x≈26..102 at y=64; midpoint (64,64) is ~38px from each joint (dot
+        // radius 6), so it is bone-only.
+        assert_ne!(
+            img.get_pixel(64, 64).0,
+            [0, 0, 0],
+            "thin horizontal limb bone must be filled, not dropped as degenerate"
         );
     }
 

--- a/docs/sc-3031-parity.md
+++ b/docs/sc-3031-parity.md
@@ -149,11 +149,55 @@ Perf bar: per-step time ≥ the Python MLX path with NAX on. The authoritative p
 CI lane (`tests/nax_guard.rs`, 16-bit SDPA correctness) — which confirms the shipped worker built NAX
 kernels at the 26.2 deployment target (no NAX → ~2.5× regression, so a green guard is the floor).
 
-## Phase C — spot output A/B vs the Python path ⏳
+## Phase C — head-to-head output A/B: new Rust adapter vs old Python adapter ✅ (base families)
 
-Numeric output parity is owned by the `mlx-gen` engine goldens (above). At the worker layer, a spot
-A/B on 1–2 representative models (Z-Image image, LTX A/V video) provides belt-and-suspenders that the
-integrated worker output is visually equivalent / not-worse than the legacy path. _Pending._
+The real parity test: generate the **same job** (matched model / prompt / seed / steps / quant / dims)
+through the **new Rust adapter path** and the **old Python `Mlx*Adapter`**, and diff the outputs.
+Engine goldens test the *engine*; Phase A is a static read; Phase B asserts only well-formedness —
+none is the actual head-to-head, so this is it.
+
+- **Rust side** drives the production resolvers + `mlx_load` + `mlx_generate_one` core (the same code
+  `generate_mlx_stream` runs) via the `sc3031_ab_dump_txt2img` harness (in
+  `crates/sceneworks-worker/src/image_jobs.rs`) → real PNG.
+- **Python side** runs the real `Mlx*Adapter.generate` (mflux sidecar) for the matched payload →
+  real PNG. Harness: `docs/sc-3031/ab_python.py`.
+- **Compare**: `docs/sc-3031/compare.py` (mean-abs, max-abs, px>8 fraction, PSNR, SSIM). Driver:
+  `docs/sc-3031/driver.sh`.
+
+**Run (M5 Max, 2026-06-05; matched seed 42, 512², count 1, default steps/quant per family):**
+
+| Model | mean‑abs | px>8 | PSNR | SSIM | verdict |
+|---|---|---|---|---|---|
+| flux_schnell | 0.34 | 0.1% | 50.8 dB | 0.9999 | ~identical |
+| flux_dev | 0.50 | 0.3% | 46.6 dB | 0.9998 | ~identical |
+| qwen_image | 0.87 | 0.6% | 43.6 dB | 0.9997 | ~identical |
+| flux2_klein_9b | 0.75 | 0.9% | 44.1 dB | 0.9997 | ~identical |
+| flux2_klein_9b_kv | 0.93 | 1.2% | 41.8 dB | 0.9994 | ~identical |
+| z_image_turbo | 5.88 | 25.9% | 27.6 dB | 0.985 | visually identical; see note |
+
+Five of the six base families are **near-pixel-identical** to the legacy Python adapter at the same
+seed (PSNR 42–51 dB, px>8 < 1.2%) — the new adapter reproduces the old one. **z_image** is visually
+identical (same composition / wave / sun / foam, confirmed by eye + SSIM 0.985) but has looser pixel
+parity: the diff is **confined to high-frequency texture/edges** (water/foam bottom-half mean 8.1 vs
+smooth-sky top-half 3.7; the amplified diff shows only crest/foam/sun-ring edges, no content shift or
+color band). This matches the known z_image **VAE-decode precision sensitivity** called out in the
+mlx-gen goldens README — an artifact of independent fp VAE decode amplified in a very high-frequency
+image, not a content divergence.
+
+**SDXL note:** there is no old-MLX SDXL adapter to A/B against — the vendored `_vendor/mlx_sd` path was
+already retired in **sc-3060** (Python SDXL is torch-only now). SDXL parity rests on Phase A + Phase B
++ the `mlx-gen-sdxl` engine goldens.
+
+### Remaining head-to-head surface (not yet A/B'd)
+
+Distinct new-adapter code paths still validated only by Phase B (functional E2E) + engine goldens, not
+yet head-to-head pixel-A/B'd:
+- **Z-Image strict-pose ControlNet** (`generate_zimage_control_stream` / `zimage_control_generate_one`)
+  — tractable (pose-only needs just `advanced.poses`, no reference asset).
+- **FLUX.2 edit / reference** (`generate_flux2_edit_stream`) — needs a matched reference asset on both
+  sides.
+- **Video** (Wan, LTX A/V) — the Python path is a *different engine* (`mlx-video-with-audio`), so this
+  is a quality/“not-worse” comparison, not pixel parity.
 
 ## Open items / follow-ups
 

--- a/docs/sc-3031-parity.md
+++ b/docs/sc-3031-parity.md
@@ -180,9 +180,18 @@ seed (PSNR 42–51 dB, px>8 < 1.2%) — the new adapter reproduces the old one. 
 identical (same composition / wave / sun / foam, confirmed by eye + SSIM 0.985) but has looser pixel
 parity: the diff is **confined to high-frequency texture/edges** (water/foam bottom-half mean 8.1 vs
 smooth-sky top-half 3.7; the amplified diff shows only crest/foam/sun-ring edges, no content shift or
-color band). This matches the known z_image **VAE-decode precision sensitivity** called out in the
-mlx-gen goldens README — an artifact of independent fp VAE decode amplified in a very high-frequency
-image, not a content divergence.
+color band).
+
+**Cause — under investigation in [sc-3218](https://app.shortcut.com/trefry/story/3218); NOT simply VAE
+precision.** The prior art reframes it: **sc-3007** hit the same ~40% z_image px gap and root-caused
+it as a **schedule mismatch** (old empirical-mu shift ≈ 9.89 vs production static shift = 3.0, from
+**sc-2536**); once aligned, the Rust public `generate` path matches the mflux **fork golden** at
+**0.013% px>8**, and **sc-3012** confirmed the z_image VAE decode is *exact* to the golden. So
+Rust-vs-fork-golden ≈ 0.013% while this live Rust-vs-Python-**sidecar** A/B ≈ 26% — the divergence is
+almost certainly in the **live Python mflux sidecar** (likely a stale z_image schedule and/or MLX
+version predating sc-2536), not in the Rust port and not general VAE fp precision. If confirmed, the
+new Rust adapter is the *more correct* path (it matches the fork golden); the gap reflects the old
+path's known z_image schedule bug — reassuring for the cutover. sc-3218 tracks the root-cause.
 
 **SDXL note:** there is no old-MLX SDXL adapter to A/B against — the vendored `_vendor/mlx_sd` path was
 already retired in **sc-3060** (Python SDXL is torch-only now). SDXL parity rests on Phase A + Phase B
@@ -201,5 +210,9 @@ yet head-to-head pixel-A/B'd:
 
 ## Open items / follow-ups
 
+- **[sc-3218](https://app.shortcut.com/trefry/story/3218)** — root-cause the live z_image new-vs-old
+  A/B gap (prime suspect: schedule/MLX-version mismatch in the Python mflux sidecar, per
+  sc-2536/sc-3007, not VAE precision). Visual parity is fine; not a cutover blocker.
 - Δ3 (LTX i2v `imageConditioningStrength`) — thread it into the Rust LTX `Reference.strength` if the
   engine honors it for LTX; otherwise document as unsupported. Low priority.
+- Remaining head-to-head A/B surface (z-image strict-pose, FLUX.2 edit, video) — see Phase C.

--- a/docs/sc-3031-parity.md
+++ b/docs/sc-3031-parity.md
@@ -1,0 +1,138 @@
+# sc-3031 — E2E visual/perf parity validation (Rust mlx-gen worker vs the Python MLX path)
+
+**Epic 3018.** The validation gate before the cutovers (sc-3032 image, sc-3037 video) delete the
+Python MLX path. This document is the parity record the story asks for.
+
+## What "parity" means here (and what it can't mean)
+
+The Rust engines and the Python paths are **independent implementations**, so bit-exact pixel match
+is neither expected nor the bar:
+
+- **Image:** `mlx-gen` (Rust/mlx-rs) is a port of the frozen Python **mflux** fork. They share MLX
+  kernels but differ in op ordering/bindings, so same-seed output is *close, not identical*.
+- **Video:** the Python path is the third-party **`mlx-video-with-audio`** package; the Rust path is
+  `mlx-gen-wan` / `mlx-gen-ltx` (independent ports). These are *different engines entirely* — a
+  cross-engine pixel A/B is not a meaningful parity signal.
+
+Numeric output parity is therefore established **at the engine layer**, where `mlx-gen` already
+carries an extensive golden suite dumped from the mflux fork (tolerance ~1e-2 peak / ~1e-5 mean):
+per-component + full-e2e for Z-Image (incl. Q4/Q8 + img2img), Qwen (incl. edit), FLUX.1 (incl.
+Q4/Q8), FLUX.2 (te/vae/e2e/edit), LTX (14 parity files incl. A/V e2e), and SDXL accel samplers, plus
+per-crate `perf.rs` compiled-vs-eager A/B. See `/Users/michael/Repos/mlx-gen` `tools/golden/` +
+each crate's `tests/*_real_weights.rs` / `*_parity.rs`.
+
+So sc-3031 validates the three things the engine goldens do **not** cover — the worker integration:
+
+1. **Settings-mapping parity (Phase A, below).** Does the SceneWorks Rust worker drive the engine
+   with the *same resolved parameters* the Python adapter used (steps / quant / guidance / negative /
+   seed / LoRA kind / conditioning / fit / angle / pose / frame-count)? This is where an integration
+   bug would hide, and it needs no HW. **Result: clean** — see the table.
+2. **Functional E2E on real weights (Phase B).** The `#[ignore]` real-weights smokes generate
+   correct-shaped output through the integrated worker for every runnable model.
+3. **Perf ≥ the Python path with NAX on, + streaming/cancel/peak-mem (Phase B).**
+
+---
+
+## Phase A — settings-mapping parity audit ✅
+
+Source of truth: Rust `crates/sceneworks-worker/src/{image_jobs,video_jobs}.rs` +
+`crates/sceneworks-core/src/{image_request,video_request}.rs` vs Python
+`apps/worker/scene_worker/{image_adapters,video_adapters}.py` (the `Mlx*Adapter`s).
+
+### Image
+
+| Model id | steps | guidance | negative | quant default | seed | parity |
+|---|---|---|---|---|---|---|
+| flux_schnell | 4 | none (distilled) | n/a | Q8 | `seed+idx` / `sha256(prompt:idx)` | ✅ |
+| flux_dev | 28 | 3.5 | passed | Q8 | `seed+idx` / hash | ✅ |
+| qwen_image | 20 | 4.0 | passed | Q8 | `seed+idx` / hash | ✅ |
+| z_image_turbo | 8 | 1.0 (distilled) | passed | Q8 | shared across pose/set, else `seed+idx`/hash | ✅ |
+| sdxl / realvisxl | 30 | 7.0 | passed | **Q8** (Python vendored = dense bf16) | `seed+idx` / hash | ✅ steps/guidance/seed; quant = intentional improvement (see Δ1) |
+| flux2_klein_9b / _kv | 4 | 1.0 (mandatory) | none (FLUX.2 has no CFG) | Q8 | shared across set, else `seed+idx`/hash | ✅ |
+| flux2_klein_9b_true_v2 | 24 (undistilled) | 1.0 | none | Q8 | shared / `seed+idx`/hash | ✅ |
+
+Quant resolution (all image families, identical precedence): `advanced.mlxQuantize` →
+`modelManifestEntry.mlx.quantize` → **Q8 default**; `≤0 → dense bf16`, `≤4 → Q4`, else Q8.
+
+LoRA classification (all): max 3/job; peft-LoRA accepted; peft-LoKr accepted on MLX (engine merges);
+third-party LyCORIS rejected (→ torch routing). Matches Python `classify_adapter` + the sc-3021/3027
+routing.
+
+### Image — advanced flows
+
+| Flow | Key params | parity |
+|---|---|---|
+| Z-Image strict pose (sc-3028) | controlScale default **0.9**, clamp `[0,2]`; skeleton stickwidth `max(6, round(min(w,h)·0.012))`; **shared seed** across the set; one image per pose | ✅ (formulas byte-identical) |
+| Z-Image identity img2img-init (sc-3146) | engages iff `referenceStrength>0` + `referenceAssetId`; clamp `[0.05,1.0]`, forwarded **verbatim** (mflux `image_strength` convention, no inversion) | ✅ |
+| FLUX.2 edit / KV / multi-ref (sc-3029) | engine id per variant (`flux2_klein_9b_edit` / `_kv_edit`); 1 ref → `Reference`, N → `MultiReference`; 4 steps / guidance 1.0 | ✅ |
+| Character-Studio angle set (sc-3030) | 11 canonical angles in order; per-angle prompt augment with trailing-punct strip; **shared seed** | ✅ |
+| Best-effort pose tier (sc-3030) | per-pose `[skeleton, reference]` MultiReference (skeleton first); pose prompt augment | ✅ |
+| fit_image (sc-3030) | crop = cover+center-crop; pad/outpaint = contain+letterbox-on-black; default crop; applied to edit source only | ✅ |
+
+### Video
+
+| Model id | steps | guidance | negative | frame count | fps | seed | parity |
+|---|---|---|---|---|---|---|---|
+| wan_2_2 (TI2V-5B) | engine config default | engine config (≈5.0) | user, else None → engine default | `max(5, raw-((raw-1)%4))` | request fps | `sha256(prompt)` (no index) | ✅ |
+| wan_2_2_t2v_14b | 4 (Lightning distill) | 1.0 | user / None | 4n+1 | request fps | sha256 | ✅ |
+| wan_2_2_i2v_14b | engine config | engine config | user / None | 4n+1 | sha256 | ✅ |
+| ltx_2_3 / ltx_2_3_eros | distilled (none) | none (engine CFG-baked 1.0) | none | `8k+1`, min 9, tie→lower | request fps | sha256 | ✅ frame/seed/fps; guidance = engine-API diff (Δ2) |
+
+Frame-count formulas (`ltx_frame_count`, `wan_frame_count`) are **byte-identical** Rust↔Python,
+including the LTX nearest-`8k+1` tie-break (`lower_delta <= upper_delta → lower`).
+
+Video LoRA: Wan MoE high/low via the `.high_noise`→`.low_noise` sibling convention; T2V-14B Lightning
+distill pair at strength 1.0; LTX per-pass residual; LoKr-on-Wan → torch (routing, sc-3036),
+LoKr-on-LTX stays MLX. Conditioning: Wan i2v `Reference` (required 14B / optional 5B); LTX
+`Reference`. Matches Python.
+
+### Intentional differences (NOT regressions)
+
+- **Δ1 — SDXL default quant.** Python MLX SDXL ran the vendored `_vendor/mlx_sd` path **dense (bf16)**;
+  Rust `mlx-gen-sdxl` defaults **Q8** (validated quality-neutral, ~25% peak-mem reduction; sc-3026).
+  An enhancement. `advanced.mlxQuantize=0` restores dense.
+- **Δ2 — LTX guidance/CFG.** Python `mlx-video-with-audio` exposed a `cfg_scale` knob (default 3.0).
+  Rust `mlx-gen-ltx` is the **distilled 2-stage A/V checkpoint** where CFG is baked — the engine forces
+  1.0 and rejects guidance. Different engine; `guidanceScale` is now a no-op on the LTX path. By design
+  (sc-3035).
+- **Δ3 — LTX i2v `imageConditioningStrength`.** Python threaded it (default 1.0). The Rust LTX i2v path
+  passes `Reference { strength: None }` (engine default). **Only non-default values diverge**; default
+  behavior matches. Minor — candidate follow-up if a user actually tunes it. *(filed as a note, not a
+  blocker; see "Open items")*
+
+---
+
+## Phase B — functional E2E + perf (real weights, this M5 Max) ⏳
+
+Runnable smokes (weights cached locally; run serial, `--test-threads=1`):
+
+Image (`crates/sceneworks-worker/src/image_jobs.rs`):
+`zimage_real_weights_generates_one_image`, `flux_schnell_…`, `flux_dev_…`, `qwen_…`,
+`flux2_klein_9b_…`, `flux2_klein_9b_kv_…`, `flux2_klein_9b_true_v2_…`, `sdxl_…`, `realvisxl_…`,
+`zimage_control_real_weights_generates_one_pose`, `flux2_edit_real_weights_generates_one_image`,
+`flux2_pose_tier_real_weights_generates_one_image`.
+
+Video (`…/video_jobs.rs`): `wan_5b_real_weights` (needs `SCENEWORKS_MLX_WAN5B_DIR` →
+`…/models/mlx/wan_2_2_ti2v_5b`), `ltx_real_weights_with_audio`.
+
+Not runnable E2E here: **Wan-14B** (T2V/I2V, ~133 GB bf16 peak — exceeds a safe worker budget on
+128 GB; covered by `mlx-gen-wan` engine goldens + the 5B integration smoke).
+
+| Model | smoke result | wall (load+gen) | peak RSS | notes |
+|---|---|---|---|---|
+| _to be filled by the Phase B run_ | | | | |
+
+Perf bar: per-step time ≥ the Python MLX path with NAX on. NAX is guarded in CI by the `nax-worker`
+self-hosted lane (`tests/nax_guard.rs`, 16-bit SDPA correctness) — confirms the shipped worker built
+NAX kernels at the 26.2 deployment target.
+
+## Phase C — spot output A/B vs the Python path ⏳
+
+Numeric output parity is owned by the `mlx-gen` engine goldens (above). At the worker layer, a spot
+A/B on 1–2 representative models (Z-Image image, LTX A/V video) provides belt-and-suspenders that the
+integrated worker output is visually equivalent / not-worse than the legacy path. _Pending._
+
+## Open items / follow-ups
+
+- Δ3 (LTX i2v `imageConditioningStrength`) — thread it into the Rust LTX `Reference.strength` if the
+  engine honors it for LTX; otherwise document as unsupported. Low priority.

--- a/docs/sc-3031-parity.md
+++ b/docs/sc-3031-parity.md
@@ -118,13 +118,36 @@ Video (`…/video_jobs.rs`): `wan_5b_real_weights` (needs `SCENEWORKS_MLX_WAN5B_
 Not runnable E2E here: **Wan-14B** (T2V/I2V, ~133 GB bf16 peak — exceeds a safe worker budget on
 128 GB; covered by `mlx-gen-wan` engine goldens + the 5B integration smoke).
 
-| Model | smoke result | wall (load+gen) | peak RSS | notes |
-|---|---|---|---|---|
-| _to be filled by the Phase B run_ | | | | |
+**Run (M5 Max, 2026-06-05; debug build, serial `--test-threads=1`).** All 14 runnable smokes PASS —
+every MLX-native model generates correct-shaped output end-to-end through the integrated Rust worker
+on real weights:
 
-Perf bar: per-step time ≥ the Python MLX path with NAX on. NAX is guarded in CI by the `nax-worker`
-self-hosted lane (`tests/nax_guard.rs`, 16-bit SDPA correctness) — confirms the shipped worker built
-NAX kernels at the 26.2 deployment target.
+| Model / flow | result | wall (load+gen) | peak RSS |
+|---|---|---|---|
+| z_image_turbo (txt2img) | ✅ PASS | 6.8 s | 3.5 GB |
+| flux_schnell | ✅ PASS | 6.1 s | 2.9 GB |
+| flux_dev (28-step guided) | ✅ PASS | 28.7 s | 3.4 GB |
+| qwen_image (true-CFG + neg) | ✅ PASS | 37.0 s | 16.2 GB |
+| flux2_klein_9b | ✅ PASS | 6.5 s | 5.0 GB |
+| flux2_klein_9b_kv | ✅ PASS | 6.0 s | 5.3 GB |
+| flux2_klein_9b_true_v2 (24-step) | ✅ PASS | 23.8 s | 5.0 GB |
+| sdxl | ✅ PASS | 6.5 s | 2.0 GB |
+| realvisxl | ✅ PASS | 6.4 s | 2.1 GB |
+| z_image strict-pose ControlNet | ✅ PASS | 9.9 s | 4.5 GB |
+| flux2 edit (single reference) | ✅ PASS | 8.4 s | 6.5 GB |
+| flux2 best-effort pose tier | ✅ PASS | 10.9 s | 7.2 GB |
+| wan_2_2 TI2V-5B (T2V) | ✅ PASS | 4.7 s | 23.9 GB |
+| ltx_2_3 (T2V **+ synchronized audio**) | ✅ PASS | 12.7 s | 43.9 GB |
+
+Caveat: these are *functional* smokes at small res (256–512², few steps), debug build — wall-time is
+"it works + roughly this fast" (load-dominated for the small models), not a production-res benchmark.
+The wall-times track the per-family figures measured during bring-up (sc-3022–3035). Peak RSS is the
+test-process max-resident (unified memory on Apple Silicon, so it includes GPU allocations).
+
+Perf bar: per-step time ≥ the Python MLX path with NAX on. The authoritative per-step perf signal is
+`mlx-gen`'s per-crate `perf.rs` (compiled-vs-eager A/B on real checkpoints) plus the **`nax-worker`**
+CI lane (`tests/nax_guard.rs`, 16-bit SDPA correctness) — which confirms the shipped worker built NAX
+kernels at the 26.2 deployment target (no NAX → ~2.5× regression, so a green guard is the floor).
 
 ## Phase C — spot output A/B vs the Python path ⏳
 

--- a/docs/sc-3031-parity.md
+++ b/docs/sc-3031-parity.md
@@ -197,16 +197,28 @@ path's known z_image schedule bug — reassuring for the cutover. sc-3218 tracks
 already retired in **sc-3060** (Python SDXL is torch-only now). SDXL parity rests on Phase A + Phase B
 + the `mlx-gen-sdxl` engine goldens.
 
+### Z-Image strict-pose A/B — caught a real bug (sc-3219, fixed) ✅
+
+Head-to-head'd the control path too (Rust `sc3031_ab_dump_pose` vs Python `MlxZImageAdapter`
+strict-pose tier, same `advanced.poses`). This surfaced a **shippable defect in the Rust skeleton
+renderer** (`draw_bodypose`, from sc-3028): it drew the joint dots but **almost none of the limb
+bones** — `ellipse2poly`'s 0°/359° vertices round to the same pixel for a thin limb, so `fill_poly`'s
+`first == last` guard no-op'd the *entire* limb. Rendering the same keypoints through both:
+skeleton **px>8 3.6% → 0.5%, SSIM 0.19 → 0.95** after the fix. Filed **[sc-3219](https://app.shortcut.com/trefry/story/3219)**;
+fixed in `fill_poly` (de-dup + drop coincident tail) with a `draw_bodypose_fills_thin_limbs`
+regression test (the old `draw_wholebody_paints_a_skeleton_on_black` only checked dots existed).
+
+With the corrected skeleton, the Rust pose *image* composition realigned to the Python reference (the
+broken-skeleton render was the outlier). Residual pose-image pixel divergence is dominated by the
+all-grass high-frequency texture + the z_image engine diff ([sc-3218](https://app.shortcut.com/trefry/story/3218)),
+SSIM 0.78 → 0.84 — same root cause as z_image txt2img, not the skeleton.
+
 ### Remaining head-to-head surface (not yet A/B'd)
 
-Distinct new-adapter code paths still validated only by Phase B (functional E2E) + engine goldens, not
-yet head-to-head pixel-A/B'd:
-- **Z-Image strict-pose ControlNet** (`generate_zimage_control_stream` / `zimage_control_generate_one`)
-  — tractable (pose-only needs just `advanced.poses`, no reference asset).
 - **FLUX.2 edit / reference** (`generate_flux2_edit_stream`) — needs a matched reference asset on both
-  sides.
+  sides; base flux2 txt2img already A/B'd near-identical.
 - **Video** (Wan, LTX A/V) — the Python path is a *different engine* (`mlx-video-with-audio`), so this
-  is a quality/“not-worse” comparison, not pixel parity.
+  is a quality/“not-worse” comparison, not pixel parity (functional E2E covered in Phase B).
 
 ## Open items / follow-ups
 

--- a/docs/sc-3031/ab_python.py
+++ b/docs/sc-3031/ab_python.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""sc-3031 A/B: generate ONE image through the REAL Python Mlx*Adapter (the old path
+this epic replaces) for a matched job payload, and copy the output PNG to $SC3031_OUT.
+
+Run with the MAIN worker venv python, PYTHONPATH=apps/worker:packages/shared,
+SCENEWORKS_DATA_DIR + HF_HOME + SCENEWORKS_MLX_FLUX_PYTHON set."""
+import glob
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from scene_worker.image_adapters import (
+    MlxFlux2Adapter,
+    MlxFluxAdapter,
+    MlxQwenAdapter,
+    MlxZImageAdapter,
+    image_request_from_job,
+)
+from scene_worker.settings import WorkerSettings
+
+# NOTE: SDXL has no old MLX adapter to A/B against — the vendored `_vendor/mlx_sd`
+# path was retired in sc-3060; the Python SDXL path is now torch-only. SDXL parity
+# is covered by Phase A (settings) + Phase B (E2E) + the mlx-gen-sdxl engine goldens.
+ADAPTERS = {
+    "z_image_turbo": MlxZImageAdapter,
+    "flux_schnell": MlxFluxAdapter,
+    "flux_dev": MlxFluxAdapter,
+    "qwen_image": MlxQwenAdapter,
+    "flux2_klein_9b": MlxFlux2Adapter,
+    "flux2_klein_9b_kv": MlxFlux2Adapter,
+    "flux2_klein_9b_true_v2": MlxFlux2Adapter,
+}
+
+payload = json.loads(os.environ["SC3031_PAYLOAD"])
+out = os.environ["SC3031_OUT"]
+model = payload["model"]
+
+settings = WorkerSettings()
+job = {"id": "sc3031ab", "payload": payload}
+request = image_request_from_job(job)
+proj = Path(tempfile.mkdtemp(prefix="sc3031_pyproj_"))
+
+adapter = ADAPTERS[model]()
+
+
+def _progress(*_a, **_k):
+    return None
+
+
+result = adapter.generate(
+    settings=settings,
+    job=job,
+    request=request,
+    project_path=proj,
+    progress=_progress,
+    cancel_requested=lambda: False,
+)
+
+pngs = sorted(glob.glob(str(proj / "assets" / "images" / "**" / "*.png"), recursive=True))
+assert pngs, f"no PNG produced under {proj}; result={result}"
+shutil.copy(pngs[0], out)
+print(f"sc3031 python dump: model={model} -> {out} (from {pngs[0]})")

--- a/docs/sc-3031/compare.py
+++ b/docs/sc-3031/compare.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""sc-3031 A/B compare: metrics between the Rust new-adapter PNG and the Python
+old-adapter PNG. Independent reimplementations won't be bit-exact; we report the
+same family of metrics the mlx-gen engine goldens use (mean-abs, max-abs, px>8
+fraction) plus PSNR/SSIM for a human-readable similarity read."""
+import sys
+
+import numpy as np
+from PIL import Image
+
+
+def load(path, size=None):
+    img = Image.open(path).convert("RGB")
+    if size is not None and img.size != size:
+        img = img.resize(size, Image.LANCZOS)
+    return np.asarray(img).astype(np.float64)
+
+
+def ssim(a, b):
+    # global single-window SSIM on luma (rough; for a quick read, not WCAG-grade)
+    ya = a @ [0.299, 0.587, 0.114]
+    yb = b @ [0.299, 0.587, 0.114]
+    mu_a, mu_b = ya.mean(), yb.mean()
+    va, vb = ya.var(), yb.var()
+    cov = ((ya - mu_a) * (yb - mu_b)).mean()
+    c1, c2 = (0.01 * 255) ** 2, (0.03 * 255) ** 2
+    return ((2 * mu_a * mu_b + c1) * (2 * cov + c2)) / (
+        (mu_a**2 + mu_b**2 + c1) * (va + vb + c2)
+    )
+
+
+rust_path, py_path = sys.argv[1], sys.argv[2]
+a = load(rust_path)
+b = load(py_path, size=Image.open(rust_path).size)
+diff = np.abs(a - b)
+mean_abs = diff.mean()
+max_abs = diff.max()
+px_gt8 = float((diff.max(axis=2) > 8).mean()) * 100.0
+mse = (diff**2).mean()
+psnr = float("inf") if mse == 0 else 10 * np.log10(255**2 / mse)
+print(
+    f"mean_abs={mean_abs:.2f} max_abs={max_abs:.0f} px>8={px_gt8:.1f}% "
+    f"psnr={psnr:.2f}dB ssim={ssim(a, b):.4f}"
+)

--- a/docs/sc-3031/driver.sh
+++ b/docs/sc-3031/driver.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# sc-3031 Phase C: A/B the new Rust adapter vs the old Python Mlx*Adapter, matched
+# (model, prompt, seed, dims), across the txt2img families. Records metrics to a TSV.
+set -u
+REPO=/Users/michael/Repos/SceneWorks
+cd "$REPO" || exit 1
+AB=/tmp/sc3031_ab
+MAIN="$HOME/Library/Application Support/SceneWorks/python/venv/bin/python"
+LOG="$AB/driver.log"; TSV="$AB/ab_metrics.tsv"
+: > "$LOG"; printf 'model\tmetrics\n' > "$TSV"
+
+export SCENEWORKS_DATA_DIR="$HOME/Library/Application Support/SceneWorks/data"
+export SCENEWORKS_CONFIG_DIR="$HOME/Library/Application Support/SceneWorks/config"
+export HF_HOME="$HOME/.cache/huggingface"
+export SCENEWORKS_MLX_FLUX_PYTHON="$HOME/Library/Application Support/SceneWorks/python/mlx-flux-venv/bin/python"
+export PYTHONPATH="$REPO/apps/worker:$REPO/packages/shared"
+PROMPT="a calm ocean wave at sunset, cinematic"
+
+models=(flux_schnell flux_dev qwen_image flux2_klein_9b flux2_klein_9b_kv)
+
+for m in "${models[@]}"; do
+  payload="{\"projectId\":\"ab\",\"model\":\"$m\",\"prompt\":\"$PROMPT\",\"seed\":42,\"width\":512,\"height\":512,\"count\":1}"
+  echo "[$(date '+%H:%M:%S')] ==== $m ====" | tee -a "$LOG"
+
+  echo "[$(date '+%H:%M:%S')] rust dump $m" | tee -a "$LOG"
+  SC3031_PAYLOAD="$payload" SC3031_OUT="$AB/rust_$m.png" \
+    cargo test -p sceneworks-worker --lib -- --ignored --exact \
+    image_jobs::tests::sc3031_ab_dump_txt2img --nocapture >> "$LOG" 2>&1
+  rrc=$?
+
+  echo "[$(date '+%H:%M:%S')] python dump $m" | tee -a "$LOG"
+  SC3031_PAYLOAD="$payload" SC3031_OUT="$AB/py_$m.png" \
+    "$MAIN" "$AB/ab_python.py" >> "$LOG" 2>&1
+  prc=$?
+
+  if [ $rrc -eq 0 ] && [ $prc -eq 0 ] && [ -f "$AB/rust_$m.png" ] && [ -f "$AB/py_$m.png" ]; then
+    metrics=$("$MAIN" "$AB/compare.py" "$AB/rust_$m.png" "$AB/py_$m.png" 2>>"$LOG")
+  else
+    metrics="ERROR rust_rc=$rrc py_rc=$prc"
+  fi
+  printf '%s\t%s\n' "$m" "$metrics" | tee -a "$TSV"
+done
+
+echo "[$(date '+%H:%M:%S')] ===== DONE =====" | tee -a "$LOG"
+echo "----- METRICS -----" | tee -a "$LOG"
+cat "$TSV" | tee -a "$LOG"


### PR DESCRIPTION
Epic 3018 validation gate before the cutovers (sc-3032 image, sc-3037 video). Validates that the new Rust `mlx-gen` worker reproduces the Python MLX path it replaces, across three layers — and the head-to-head A/B **caught a real shippable bug** (sc-3219, fixed here).

## TL;DR
- **Settings mapping** (Rust worker vs Python `Mlx*Adapter`s): clean — every resolved gen param matches, with 3 documented intentional deltas.
- **Functional E2E**: all 14 real-weights smokes pass on M5 Max (6 image families + Z-Image pose + FLUX.2 edit/pose + Wan-5B + LTX A/V).
- **Head-to-head A/B** (same job, same seed, new adapter vs old adapter): 5 base families near-pixel-identical (PSNR 42–51 dB); z_image visually identical (gap tracked → sc-3218); **Z-Image strict-pose surfaced a skeleton-renderer bug → fixed (sc-3219)**.

## What's a reviewer looking at
- `docs/sc-3031-parity.md` — the full parity record (Phases A/B/C, metrics, intentional deltas, open items).
- `docs/sc-3031/` — reproducible A/B harness (`ab_python.py` runs the real Python adapter, `compare.py`, `driver.sh`).
- `crates/sceneworks-worker/src/image_jobs.rs` — A/B dump harnesses (`sc3031_ab_dump_txt2img`, `sc3031_ab_dump_pose`, `sc3031_dump_skeleton`), all `#[ignore]`d test-only.
- **`crates/sceneworks-worker/src/openpose_skeleton.rs` — the only production code change** (the sc-3219 fix).

## sc-3219 — the bug this work caught (production fix)
`draw_bodypose` rendered joint **dots** but **almost no limb bones**: `ellipse2poly`'s 0°/359° vertices round to the same pixel for a thin limb, so `fill_poly`'s `first == last` guard no-op'd the entire limb. Degraded the Z-Image strict-pose control signal; CI missed it because the only test asserted "some non-black pixels exist" (dots satisfied that). Fix: `fill_poly` de-dups consecutive vertices + drops a coincident tail (clean polygon for imageproc) instead of dropping the limb. New `draw_bodypose_fills_thin_limbs` regression test. Rust-vs-Python skeleton: **px>8 3.6% → 0.5%, SSIM 0.19 → 0.95**.

## Parity = correct, not bit-exact
The Rust engines and Python paths are independent reimplementations; numeric output parity is owned by the `mlx-gen` engine goldens (vs the mflux fork, ~1e-2). This validates the *worker integration* layer the goldens don't cover. The z_image txt2img gap (visually identical, looser pixels) is tracked in **sc-3218** — prior art (sc-2536/sc-3007/sc-3012) points at a stale schedule/MLX version in the live Python sidecar, meaning the Rust adapter is likely the *more correct* path.

## Follow-ups (noted in the doc)
- sc-3218 — root-cause the z_image engine gap (not a blocker; visual parity holds).
- FLUX.2 edit + video head-to-head A/B not yet run (edit needs a matched reference asset; video is cross-engine vs `mlx-video`, covered functionally in Phase B).

## Tests
100 worker lib tests pass (18 ignored real-weights/Metal + harnesses); `cargo fmt --check` clean. Branches off / merges into `rust-mlx-integration` per the epic branch strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)