### PR TITLE
sc-3240: wire native Rust Wan/LTX converters + platform-aware download sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2503,19 +2503,20 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "mlx-gen",
  "pmetal-mlx-rs",
  "serde_json",
  "unicode-normalization",
+ "zip",
 ]
 
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=01bf62591eb0c0e34b028c94c98a6ef7af96faa3#01bf62591eb0c0e34b028c94c98a6ef7af96faa3"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2778,7 +2779,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5357,6 +5358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6650,6 +6657,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -157,9 +157,9 @@ pub(crate) async fn create_model_download_job(
 
 /// Convert a model's native checkpoint into the local MLX format (macOS/Apple
 /// Silicon). Only valid for models whose manifest declares `mlx.requiresConversion`
-/// (Wan TI2V-5B, Wan I2V-A14B); turnkey MLX models need no conversion. The native
-/// source checkpoint must already be downloaded; the Rust utility worker shells out
-/// to the Python/MLX `mlx_video.convert_wan` tool.
+/// (Wan TI2V-5B/I2V-A14B, LTX-2.3 eros, FLUX.2-klein); turnkey MLX models need no conversion. The
+/// native source checkpoint must already be downloaded; the worker converts it in-process via the
+/// linked `mlx-gen-*` converters, selected by the `mlx.converter` discriminator (sc-3240).
 pub(crate) async fn create_model_convert_job(
     State(state): State<AppState>,
     Path(model_id): Path<String>,
@@ -182,10 +182,10 @@ pub(crate) async fn create_model_convert_job(
         .and_then(Value::as_bool)
         .unwrap_or(false);
     let quantize = payload.quantize_bits.is_some();
-    // Two sources: models that require conversion read the native diffusers
-    // checkpoint (convertSourceRepo); turnkey MLX models (a pre-converted bf16
-    // `repo`) have nothing to convert, but can still be quantized in place from
-    // that repo (`--quantize-only`), so a quant request on a turnkey model is valid.
+    // Two sources: models that require conversion read the native checkpoint (convertSourceRepo);
+    // turnkey MLX models (a pre-converted bf16 `repo`) carried a legacy in-place quantize path. The
+    // native Rust converters don't re-quantize an already-converted dir, so the worker now rejects
+    // `quantize_only` with a clear message (sc-3240) — quantize during native conversion instead.
     let (source_repo, quantize_only) = if requires_conversion {
         let repo = mlx
             .get("convertSourceRepo")
@@ -711,6 +711,13 @@ pub(crate) async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiErr
         .filter_map(|model| model.get("id").and_then(Value::as_str).map(str::to_owned))
         .collect::<std::collections::HashSet<_>>();
     let mut models = merge_entries_by_id(builtin, user);
+    // Resolve per-platform download sources before computing install state/size: some video models
+    // carry both a native MLX-convert checkpoint (macOS) and a diffusers/torch checkpoint
+    // (Windows/Linux). Keep only the entries applicable to this OS so the download job, status,
+    // size, and the frontend all agree on the right repo (sc-3240).
+    for model in &mut models {
+        retain_downloads_for_os(model, std::env::consts::OS);
+    }
     let download_contexts = models
         .iter()
         .map(model_download_context)
@@ -980,6 +987,31 @@ pub(crate) fn merge_model_manifest_entry(builtin: Option<Value>, user: Option<Va
             merged
         }
     }
+}
+
+/// Restrict a model's `downloads` to the entries applicable to `os` (`std::env::consts::OS`).
+/// A download entry with a `platforms` array applies only to the listed OSes; an entry without one
+/// is platform-agnostic and always kept. Some video models ship two source repos for the same model
+/// — the native MLX-convert checkpoint on macOS vs the diffusers/torch checkpoint on Windows/Linux
+/// (sc-3240, Wan2.2) — so filtering here makes the download job, install status, size, and the
+/// frontend's `downloads[0]` all resolve to the right per-platform repo from one seam. No-op unless
+/// at least one entry is platform-tagged, so single-repo models are untouched.
+pub(crate) fn retain_downloads_for_os(model: &mut Value, os: &str) {
+    let Some(downloads) = model.get_mut("downloads").and_then(Value::as_array_mut) else {
+        return;
+    };
+    if !downloads
+        .iter()
+        .any(|entry| entry.get("platforms").is_some())
+    {
+        return;
+    }
+    downloads.retain(
+        |entry| match entry.get("platforms").and_then(Value::as_array) {
+            Some(platforms) => platforms.iter().any(|p| p.as_str() == Some(os)),
+            None => true,
+        },
+    );
 }
 
 pub(crate) fn model_download(model: &Value) -> Option<Value> {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5739,6 +5739,56 @@ fn model_download_size_helpers_match_contract_shapes() {
 }
 
 #[test]
+fn platform_tagged_downloads_resolve_per_os() {
+    // A video model that ships a native MLX-convert checkpoint (macOS) and a diffusers/torch
+    // checkpoint (Windows/Linux) for the same model id (sc-3240).
+    let model = json!({
+        "downloads": [
+            { "provider": "huggingface", "repo": "Wan-AI/Wan2.2-TI2V-5B", "platforms": ["macos"] },
+            { "provider": "huggingface", "repo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers", "platforms": ["windows", "linux"] }
+        ]
+    });
+    let resolved_repo = |model: &Value| {
+        super::model_download(model).and_then(|download| {
+            download
+                .get("repo")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+    };
+
+    // macOS keeps the native MLX-convert source...
+    let mut mac = model.clone();
+    super::retain_downloads_for_os(&mut mac, "macos");
+    assert_eq!(
+        resolved_repo(&mac),
+        Some("Wan-AI/Wan2.2-TI2V-5B".to_owned())
+    );
+
+    // ...Windows/Linux keep the diffusers/torch repo.
+    for os in ["windows", "linux"] {
+        let mut other = model.clone();
+        super::retain_downloads_for_os(&mut other, os);
+        assert_eq!(
+            resolved_repo(&other),
+            Some("Wan-AI/Wan2.2-TI2V-5B-Diffusers".to_owned()),
+            "os={os}"
+        );
+    }
+
+    // Untagged single-repo models are untouched on every OS.
+    let mut agnostic = json!({
+        "downloads": [{ "provider": "huggingface", "repo": "owner/model" }]
+    });
+    super::retain_downloads_for_os(&mut agnostic, "macos");
+    assert_eq!(
+        agnostic["downloads"].as_array().map(Vec::len),
+        Some(1),
+        "agnostic downloads must not be filtered"
+    );
+}
+
+#[test]
 fn lora_family_filter_shapes_match_contract_fallbacks() {
     let shapes = [
         json!({ "families": ["z-image"] }),

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1830,12 +1830,18 @@
         "types": ["style", "motion", "character", "enhance"]
       },
       "mlx": {
-        // No published MLX repo; the bf16 checkpoint is converted locally
-        // (python -m mlx_video.convert --quantize --q-bits 4) into
-        // <data>/models/mlx/ltx_2_3_eros. minMemoryGb mirrors the LTX-2.3 Q4 tier.
+        // No published MLX repo; the bf16 single-file checkpoint is converted locally
+        // in-process by the Rust mlx-gen-ltx converter (sc-3240, converter "ltx_video";
+        // Q4 — the reference `--quantize --q-bits 4`) into <data>/models/mlx/ltx_2_3_eros.
+        // The loader requires the latent upsampler, which eros does not bundle, so the
+        // converter merges it from the base LTX-2.3 repo (convertBaseRepo); the convert job
+        // fetches just that ~1 GB file on demand. minMemoryGb mirrors the LTX-2.3 Q4 tier.
         "minMemoryGb": 31,
         "requiresConversion": true,
+        "converter": "ltx_video",
         "convertSourceRepo": "TenStrip/LTX2.3-10Eros",
+        "convertSourceFile": "10Eros_v1_bf16.safetensors",
+        "convertBaseRepo": "Lightricks/LTX-2.3",
         "textEncoderRepo": "mlx-community/gemma-3-12b-it-bf16",
         // 10Eros's base is not pre-distilled, so the MLX adapter auto-injects the
         // cond_safe distill LoRA (resources.distilledLora) at runtime with per-pass
@@ -1929,16 +1935,27 @@
       "type": "video",
       "adapter": "wan_video",
       "capabilities": ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
+      // Per-platform source (sc-3240): macOS converts the native checkpoint to MLX in-process
+      // (mlx-gen-wan ingests native Wan format only); Windows/Linux load the diffusers layout via
+      // the torch wan_video adapter. The API serves only the entry matching the running OS.
       "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "Wan-AI/Wan2.2-TI2V-5B",
+          "files": [],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 34196904505
+        },
         {
           "provider": "huggingface",
           "repo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
           "files": [],
+          "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 34203021834
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Wan-AI/Wan2.2-TI2V-5B-Diffusers"
+        "model": "${HF_CACHE}/Wan-AI/Wan2.2-TI2V-5B"
       },
       "defaults": {
         "duration": 5,
@@ -1984,11 +2001,13 @@
         }
       },
       "mlx": {
-        // TI2V-5B has no published MLX repo; the native diffusers checkpoint is
-        // converted locally (tracked model_convert job) into <data>/models/mlx/wan_2_2.
+        // TI2V-5B has no published MLX repo; the native checkpoint is converted locally
+        // in-process by the Rust mlx-gen-wan converter (sc-3240, converter "wan_ti2v_5b")
+        // into <data>/models/mlx/wan_2_2. Dense bf16 (no quantization).
         "minMemoryGb": 45,
         "requiresConversion": true,
-        "convertSourceRepo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        "converter": "wan_ti2v_5b",
+        "convertSourceRepo": "Wan-AI/Wan2.2-TI2V-5B",
         // MLX path is sealed (own ODE solver, no diffusers scheduler) — override
         // the top-level sampler/scheduler menu to default-only (epic 1753 §14).
         "limits": {
@@ -2113,16 +2132,28 @@
       "type": "video",
       "adapter": "wan_video",
       "capabilities": ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
+      // Per-platform source (sc-3240): macOS converts the native dual-expert checkpoint to MLX
+      // in-process (mlx-gen-wan); Windows/Linux load the diffusers/GGUF layout via the torch
+      // wan_video adapter. Native is larger than the diffusers layout (~126 GB vs ~72 GB). The
+      // API serves only the entry matching the running OS.
       "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "Wan-AI/Wan2.2-I2V-A14B",
+          "files": [],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 126202610088
+        },
         {
           "provider": "huggingface",
           "repo": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
           "files": [],
+          "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 72000000000
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+        "model": "${HF_CACHE}/Wan-AI/Wan2.2-I2V-A14B"
       },
       "defaults": {
         "duration": 5,
@@ -2170,12 +2201,14 @@
         }
       },
       "mlx": {
-        // I2V-A14B has no published MLX repo; the native diffusers checkpoint is
-        // converted locally (tracked model_convert job) into
-        // <data>/models/mlx/wan_2_2_i2v_14b. Its distill LoRA is applied at run time.
+        // I2V-A14B has no published MLX repo; the native checkpoint is converted locally
+        // in-process by the Rust mlx-gen-wan converter (sc-3240, converter "wan_i2v_14b")
+        // into <data>/models/mlx/wan_2_2_i2v_14b (in_dim 36 image-concat, z16 VAE; dense
+        // bf16 by default). Its distill LoRA is applied at run time.
         "minMemoryGb": 133,
         "requiresConversion": true,
-        "convertSourceRepo": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
+        "converter": "wan_i2v_14b",
+        "convertSourceRepo": "Wan-AI/Wan2.2-I2V-A14B",
         "limits": {
           "samplers": ["default"],
           "schedulers": ["default"]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -60,29 +60,29 @@ mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/ml
 # stories (sc-3022..3035) add their provider here; this scaffold links Z-Image
 # (sc-3022, next) to prove the cross-crate registry path end to end.
 [target.'cfg(target_os = "macos")'.dependencies]
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "01bf62591eb0c0e34b028c94c98a6ef7af96faa3" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -214,16 +214,156 @@ fn convert_flux2_klein_diffusers(
     )
 }
 
-/// Convert a model's native (diffusers) checkpoint into the local MLX format on
-/// macOS/Apple Silicon. The native checkpoint must already be downloaded into the Hugging
-/// Face cache (via a model_download job). Wan/LTX still shell out to the venv's Python
-/// `mlx_video.convert_wan` tool (the mlx-video stack owns that conversion until sc-3224 lands
-/// a Rust converter); the desktop shell points `SCENEWORKS_PYTHON` at the bundled interpreter
-/// (mirrors `SCENEWORKS_FFMPEG`), dev/server fall back to `python3`. FLUX.2-klein true_v2
-/// converts in-process via `convert_flux2_klein_diffusers` (sc-3136).
+/// Native Rust/MLX Wan2.2 weight converter (mlx-gen-wan, sc-3224 engine + sc-3240 cutover) —
+/// replaces the retired Python `mlx_video.convert_wan` subprocess. `kind` selects the family preset:
+/// `wan_ti2v_5b` (dense bf16, ignores `quant`), `wan_i2v_14b` / `wan_t2v_14b` (dual-expert MoE,
+/// optional Q4/Q8 via `quant = Some((bits, group_size))`). Reads the native checkpoint (transformer
+/// safetensors shards + the `.pth` T5/VAE) and writes the split MLX dir the loader consumes. The
+/// UMT5 `tokenizer.json` is copied separately by the caller (the converter does not emit it). Runs
+/// MLX, so macOS-only.
+#[cfg(target_os = "macos")]
+fn convert_wan_native(
+    kind: &str,
+    checkpoint_dir: &Path,
+    out_dir: &Path,
+    quant: Option<(i32, i32)>,
+) -> Result<(), String> {
+    use mlx_gen_wan::convert::{convert_i2v_14b, convert_t2v_14b, convert_ti2v_5b};
+    match kind {
+        "wan_ti2v_5b" => convert_ti2v_5b(checkpoint_dir, out_dir).map(|_| ()),
+        "wan_i2v_14b" => convert_i2v_14b(checkpoint_dir, out_dir, quant).map(|_| ()),
+        "wan_t2v_14b" => convert_t2v_14b(checkpoint_dir, out_dir, quant).map(|_| ()),
+        other => return Err(format!("Unknown Wan converter '{other}'.")),
+    }
+    .map_err(|error| error.to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn convert_wan_native(
+    _kind: &str,
+    _checkpoint_dir: &Path,
+    _out_dir: &Path,
+    _quant: Option<(i32, i32)>,
+) -> Result<(), String> {
+    Err("Wan2.2 MLX conversion requires macOS (mlx-gen-wan); the torch path serves other platforms."
+        .to_owned())
+}
+
+/// Native Rust/MLX LTX-2.3 weight converter (mlx-gen-ltx, sc-3224 engine + sc-3240 cutover). The LTX
+/// path was never actually routed through the Rust job before — only `convert_wan` was ever shelled.
+/// Splits the single-file checkpoint (`source_file`, e.g. eros `10Eros_v1_bf16.safetensors`),
+/// sanitizes + Q4/Q8-quantizes the transformer, merges the latent upsampler from `upscaler_dir` (the
+/// base `Lightricks/LTX-2.3` snapshot — the loader hard-requires `upsampler.safetensors`), and emits
+/// the split MLX dir. `bits` is the reference `python -m mlx_video.convert --quantize --q-bits <bits>`
+/// recipe (audio-inclusive). Runs MLX, so macOS-only.
+#[cfg(target_os = "macos")]
+fn convert_ltx_native(
+    source_file: &Path,
+    upscaler_dir: &Path,
+    out_dir: &Path,
+    bits: i32,
+) -> Result<(), String> {
+    let opts = mlx_gen_ltx::LtxConvertOpts::audio_quant(bits);
+    mlx_gen_ltx::convert_and_assemble(source_file, Some(upscaler_dir), out_dir, &opts)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn convert_ltx_native(
+    _source_file: &Path,
+    _upscaler_dir: &Path,
+    _out_dir: &Path,
+    _bits: i32,
+) -> Result<(), String> {
+    Err("LTX-2.3 MLX conversion requires macOS (mlx-gen-ltx); the torch path serves other platforms."
+        .to_owned())
+}
+
+/// Copy the UMT5 `tokenizer.json` the Wan MLX loader requires (`<dir>/tokenizer.json`) into the
+/// converted dir. The native Wan checkpoints bundle it at `google/umt5-xxl/tokenizer.json`; the
+/// converter does not emit it (matching the reference `convert_wan`). Sync — runs inside the
+/// blocking convert task.
+fn copy_wan_umt5_tokenizer(checkpoint_dir: &Path, out_dir: &Path) -> Result<(), String> {
+    let src = checkpoint_dir
+        .join("google")
+        .join("umt5-xxl")
+        .join("tokenizer.json");
+    std::fs::copy(&src, out_dir.join("tokenizer.json"))
+        .map(|_| ())
+        .map_err(|error| format!("copy UMT5 tokenizer.json from {}: {error}", src.display()))
+}
+
+/// The base `Lightricks/LTX-2.3` latent upsampler the LTX loader hard-requires (emitted as
+/// `upsampler.safetensors` in the converted dir). Neither the eros nor the base single-file
+/// checkpoint bundles it, so the converter merges it from the base repo at convert time.
+const LTX_SPATIAL_UPSCALER_FILE: &str = "ltx-2.3-spatial-upscaler-x2-1.1.safetensors";
+
+/// Ensure the LTX-2.3 spatial upsampler `file` from `repo` is in the Hugging Face cache — fetching
+/// just that file on demand if missing — and return the repo's snapshot dir (the converter's
+/// `upscaler_dir`). Mirrors how the torch adapter pulls its spatial upscaler at generation time, so
+/// converting eros does not require a full ~157 GB base-LTX install. Returns `None` if the file
+/// cannot be obtained (HF CLI unavailable and not already cached) so the caller surfaces a clear
+/// failure. The fetch uses a scratch marker dir so its install marker never lands in the model tree.
+async fn ensure_ltx_upscaler_cached(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    repo: &str,
+    file: &str,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, repo) {
+        if snapshot.join(file).exists() {
+            return Ok(Some(snapshot));
+        }
+    }
+    let scratch = settings
+        .data_dir
+        .join("cache")
+        .join(format!(".ltx-upscaler-fetch-{}", job.id));
+    tokio::fs::create_dir_all(&scratch).await?;
+    let files = vec![file.to_owned()];
+    let fetched =
+        download_model_with_hf_cli(api, settings, job, repo, "main", &files, &scratch).await?;
+    let _ = tokio::fs::remove_dir_all(&scratch).await;
+    let snapshot = match fetched {
+        Some(dir) => Some(dir),
+        None => huggingface_snapshot_dir(&settings.data_dir, repo),
+    };
+    Ok(snapshot.filter(|dir| dir.join(file).exists()))
+}
+
+/// Resolved native conversion plan for [`run_model_convert_job`] (sc-3240). The Python
+/// `mlx_video.convert_wan` subprocess (and its mlx-video venv) is gone — every convert-required
+/// model maps to exactly one native converter, keyed by the manifest `mlx.converter` discriminator.
+enum ConvertPlan {
+    /// FLUX.2-klein single-file fine-tune → diffusers dir (sc-3136), borrowing VAE/TE/tokenizer.
+    Flux2 {
+        source_file: PathBuf,
+        base_dir: PathBuf,
+    },
+    /// Native Wan2.2 → split MLX dir; `kind` ∈ {`wan_ti2v_5b`, `wan_i2v_14b`, `wan_t2v_14b`}.
+    Wan {
+        kind: String,
+        quant: Option<(i32, i32)>,
+    },
+    /// Single-file LTX-2.3 → split MLX dir; `upscaler_dir` carries the loader-required upsampler.
+    Ltx {
+        source_file: PathBuf,
+        upscaler_dir: PathBuf,
+        bits: i32,
+    },
+}
+
+/// Convert a model's native checkpoint into the local MLX format on macOS/Apple Silicon, fully
+/// in-process via the linked `mlx-gen-*` converters (epic 2337). The native checkpoint must already
+/// be downloaded into the Hugging Face cache (via a model_download job). The converter is selected by
+/// the manifest `mlx.converter` discriminator: `flux2_klein_diffusers` (sc-3136), `wan_ti2v_5b` /
+/// `wan_i2v_14b` / `wan_t2v_14b` (mlx-gen-wan), or `ltx_video` (mlx-gen-ltx). The Python
+/// `mlx_video.convert_wan` subprocess + `SCENEWORKS_PYTHON` wiring were retired here (sc-3240).
 ///
-/// Real conversion is exercised on Mac hardware in sc-1509; this wires the tracked
-/// job, progress, cancellation, and failure surfacing.
+/// Real conversion is exercised on Mac hardware via the `#[ignore]` real-weight tests below; this
+/// wires the tracked job, progress, cancellation, and failure surfacing.
 pub(crate) async fn run_model_convert_job(
     api: &ApiClient,
     settings: &Settings,
@@ -273,54 +413,146 @@ pub(crate) async fn run_model_convert_job(
         return Ok(());
     };
 
-    // Converter discriminator (sc-2235). Absent => the default mlx-video Wan converter
-    // (a Python subprocess; the mlx-video stack still owns Wan/LTX weight conversion until
-    // a Rust converter lands — sc-3224). "flux2_klein_diffusers" => convert a FLUX.2-klein
-    // single-file fine-tune into a diffusers dir IN-PROCESS via
-    // mlx_gen_flux2::convert_and_assemble (sc-3136 — replaced the Python mlx_flux_convert.py
-    // sidecar at the sc-3032 cutover), borrowing VAE/text-encoder/tokenizer from a base klein.
+    // Converter discriminator (sc-2235 / sc-3224 / sc-3240). Every convert-required model now
+    // declares one in its manifest `mlx.converter`; there is NO Python fallback — the
+    // `mlx_video.convert_wan` subprocess and its mlx-video venv were retired at this cutover.
+    //   flux2_klein_diffusers          -> FLUX.2-klein single-file → diffusers dir (sc-3136)
+    //   wan_ti2v_5b/i2v_14b/t2v_14b    -> native Wan2.2 → split MLX dir (mlx-gen-wan)
+    //   ltx_video                      -> single-file LTX-2.3 → split MLX dir (mlx-gen-ltx)
     let converter = optional_payload_string(&job.payload, "converter")
         .map(str::to_owned)
         .unwrap_or_default();
-    let is_flux2_klein = converter == "flux2_klein_diffusers";
 
-    let (python, flux2_source_file, flux2_base_dir) = if is_flux2_klein {
-        let source_file_name = required_payload_string(&job.payload, "sourceFile")?.to_owned();
-        let base_repo = required_payload_string(&job.payload, "baseRepo")?.to_owned();
-        let source_file = checkpoint_dir.join(&source_file_name);
-        if !source_file.is_file() {
-            fail_job(
-                api,
-                &job.id,
-                "Converted-model source file is missing.",
-                Some(format!("Expected {source_file_name} in {source_repo}.")),
-            )
-            .await?;
-            return Ok(());
+    // Quantize-only (re-quantize a pre-converted turnkey bf16 MLX dir) was a capability of the
+    // Python `convert_wan --quantize-only` with no native equivalent; it is unreachable from the UI
+    // and superseded by native-conversion-with-quant. Surface it explicitly rather than silently
+    // promoting an unconverted dir.
+    if quantize_only {
+        fail_job(
+            api,
+            &job.id,
+            "Quantize-only MLX conversion is no longer supported.",
+            Some(
+                "In-place re-quantization of a pre-converted MLX model was removed with the Python \
+                 mlx-video converter (sc-3240). Convert the native checkpoint with quantization \
+                 instead."
+                    .to_owned(),
+            ),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    // MLX quantization mapped 1:1 from the job payload (a request override or the manifest default
+    // the API forwards). bf16 Wan TI2V-5B ignores it; the A14B experts + LTX honor (bits,
+    // group_size) — group_size defaults to the reference 64 when only bits is set.
+    let quant =
+        quantize_bits.map(|bits| (bits as i32, quantize_group_size.map_or(64, |gs| gs as i32)));
+
+    let plan = match converter.as_str() {
+        "flux2_klein_diffusers" => {
+            let source_file_name = required_payload_string(&job.payload, "sourceFile")?.to_owned();
+            let base_repo = required_payload_string(&job.payload, "baseRepo")?.to_owned();
+            let source_file = checkpoint_dir.join(&source_file_name);
+            if !source_file.is_file() {
+                fail_job(
+                    api,
+                    &job.id,
+                    "Converted-model source file is missing.",
+                    Some(format!("Expected {source_file_name} in {source_repo}.")),
+                )
+                .await?;
+                return Ok(());
+            }
+            let Some(base_dir) = huggingface_snapshot_dir(&settings.data_dir, &base_repo) else {
+                fail_job(
+                    api,
+                    &job.id,
+                    "Base FLUX.2-klein model is not installed.",
+                    Some(format!(
+                        "Install {base_repo} before converting {model_id} — its VAE, text encoder, \
+                         and tokenizer are reused."
+                    )),
+                )
+                .await?;
+                return Ok(());
+            };
+            ConvertPlan::Flux2 {
+                source_file,
+                base_dir,
+            }
         }
-        let Some(base_dir) = huggingface_snapshot_dir(&settings.data_dir, &base_repo) else {
+        "wan_ti2v_5b" | "wan_i2v_14b" | "wan_t2v_14b" => ConvertPlan::Wan {
+            kind: converter.clone(),
+            quant,
+        },
+        "ltx_video" => {
+            let source_file_name = required_payload_string(&job.payload, "sourceFile")?.to_owned();
+            let source_file = checkpoint_dir.join(&source_file_name);
+            if !source_file.is_file() {
+                fail_job(
+                    api,
+                    &job.id,
+                    "LTX-2.3 source checkpoint file is missing.",
+                    Some(format!("Expected {source_file_name} in {source_repo}.")),
+                )
+                .await?;
+                return Ok(());
+            }
+            let upscaler_repo = required_payload_string(&job.payload, "baseRepo")?.to_owned();
+            let upscaler_file = optional_payload_string(&job.payload, "upscalerFile")
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or(LTX_SPATIAL_UPSCALER_FILE)
+                .to_owned();
+            let Some(upscaler_dir) =
+                ensure_ltx_upscaler_cached(api, settings, job, &upscaler_repo, &upscaler_file)
+                    .await?
+            else {
+                fail_job(
+                    api,
+                    &job.id,
+                    "LTX-2.3 spatial upscaler is unavailable.",
+                    Some(format!(
+                        "Could not obtain {upscaler_file} from {upscaler_repo}; install the base \
+                         LTX-2.3 model or check connectivity before converting {model_id}."
+                    )),
+                )
+                .await?;
+                return Ok(());
+            };
+            // Default to the reference Q4 recipe when the manifest/request specifies no bits.
+            let bits = quantize_bits.map_or(4, |bits| bits as i32);
+            ConvertPlan::Ltx {
+                source_file,
+                upscaler_dir,
+                bits,
+            }
+        }
+        "" => {
             fail_job(
                 api,
                 &job.id,
-                "Base FLUX.2-klein model is not installed.",
+                "No MLX converter is configured for this model.",
                 Some(format!(
-                    "Install {base_repo} before converting {model_id} — its VAE, text encoder, \
-                     and tokenizer are reused."
+                    "{model_id} sets mlx.requiresConversion but no mlx.converter; the Python \
+                     converter was retired (sc-3240)."
                 )),
             )
             .await?;
             return Ok(());
-        };
-        // In-process Rust/MLX convert (sc-3136): no subprocess, no mlx-flux sidecar venv.
-        // The `python` slot is unused on this path.
-        (String::new(), Some(source_file), Some(base_dir))
-    } else {
-        let py = std::env::var("SCENEWORKS_PYTHON")
-            .ok()
-            .map(|value| value.trim().to_owned())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| "python3".to_owned());
-        (py, None, None)
+        }
+        other => {
+            fail_job(
+                api,
+                &job.id,
+                "Unknown MLX converter.",
+                Some(format!(
+                    "Unrecognized mlx.converter '{other}' for {model_id}."
+                )),
+            )
+            .await?;
+            return Ok(());
+        }
     };
 
     // Convert into a unique temp sibling and only promote it on success, so a
@@ -361,108 +593,54 @@ pub(crate) async fn run_model_convert_job(
     )
     .await?;
 
-    if is_flux2_klein {
-        // Native Rust/MLX single-file → diffusers convert (mlx-gen-flux2, sc-3136) —
-        // replaces the retired Python mlx_flux_convert.py sidecar (sc-3032). The blocking
-        // MLX call isn't interruptible mid-run (~5s on real weights), so honor cancel up
-        // front; the borrowed vae/text-encoder/tokenizer are absolute symlinks that survive
-        // the temp→final atomic rename below.
-        check_cancel(api, &job.id, "MLX conversion canceled by user.").await?;
-        let source_file = flux2_source_file.expect("flux2 source resolved");
-        let base_dir = flux2_base_dir.expect("flux2 base resolved");
-        let temp = temp_dir.clone();
-        let outcome = tokio::task::spawn_blocking(move || {
-            convert_flux2_klein_diffusers(&source_file, &base_dir, &temp)
-        })
-        .await;
-        match outcome {
-            Ok(Ok(())) => {}
-            Ok(Err(detail)) => {
-                let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-                return Err(WorkerError::InvalidPayload(format!(
-                    "FLUX.2-klein conversion failed. {detail}"
-                )));
-            }
-            Err(join_error) => {
-                let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-                return Err(WorkerError::InvalidPayload(format!(
-                    "FLUX.2-klein conversion task panicked: {join_error}"
-                )));
-            }
+    // The native MLX converters are blocking and not interruptible mid-run (minutes on real
+    // weights), so honor cancel up front and run on a blocking thread. On any failure the partial
+    // temp dir is removed so it can never be promoted by the atomic rename below. The Flux2 path's
+    // borrowed vae/text-encoder/tokenizer are absolute symlinks that survive the rename.
+    check_cancel(api, &job.id, "MLX conversion canceled by user.").await?;
+    let temp = temp_dir.clone();
+    let outcome = match plan {
+        ConvertPlan::Flux2 {
+            source_file,
+            base_dir,
+        } => {
+            tokio::task::spawn_blocking(move || {
+                convert_flux2_klein_diffusers(&source_file, &base_dir, &temp)
+            })
+            .await
         }
-    } else {
-        let mut command = Command::new(&python);
-        command
-            .arg("-m")
-            .arg("mlx_video.convert_wan")
-            .arg("--checkpoint-dir")
-            .arg(&checkpoint_dir)
-            .arg("--output-dir")
-            .arg(&temp_dir)
-            .arg("--dtype")
-            .arg(&dtype)
-            .arg("--model-version")
-            .arg("auto");
-        if quantize_only {
-            command.arg("--quantize-only");
-        } else if quantize_bits.is_some() {
-            command.arg("--quantize");
+        ConvertPlan::Wan { kind, quant } => {
+            let checkpoint = checkpoint_dir.clone();
+            tokio::task::spawn_blocking(move || {
+                convert_wan_native(&kind, &checkpoint, &temp, quant)?;
+                // The Wan loader reads `<dir>/tokenizer.json`, which the converter does not emit.
+                copy_wan_umt5_tokenizer(&checkpoint, &temp)
+            })
+            .await
         }
-        if let Some(bits) = quantize_bits {
-            command.arg("--bits").arg(bits.to_string());
+        ConvertPlan::Ltx {
+            source_file,
+            upscaler_dir,
+            bits,
+        } => {
+            tokio::task::spawn_blocking(move || {
+                convert_ltx_native(&source_file, &upscaler_dir, &temp, bits)
+            })
+            .await
         }
-        if let Some(group_size) = quantize_group_size {
-            command.arg("--group-size").arg(group_size.to_string());
-        }
-        let mut child = command
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|error| {
-                WorkerError::InvalidPayload(format!(
-                    "Failed to start MLX conversion ({python}). Ensure the worker venv has \
-                     mlx-video-with-audio installed: {error}"
-                ))
-            })?;
-
-        let mut stderr = child.stderr.take();
-        let stderr_task = tokio::spawn(async move {
-            let mut bytes = Vec::new();
-            if let Some(stderr) = stderr.as_mut() {
-                let _ = stderr.read_to_end(&mut bytes).await;
-            }
-            bytes
-        });
-
-        let mut interval = tokio::time::interval(progress_report_interval(settings));
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        let status = loop {
-            tokio::select! {
-                status = child.wait() => break status?,
-                _ = interval.tick() => {
-                    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                    if let Err(error) =
-                        check_cancel(api, &job.id, "MLX conversion canceled by user.").await
-                    {
-                        let _ = child.kill().await;
-                        let _ = child.wait().await;
-                        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-                        return Err(error);
-                    }
-                }
-            }
-        };
-        let stderr_bytes = stderr_task.await.unwrap_or_default();
-
-        if !status.success() {
+    };
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(detail)) => {
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-            let stderr_text = String::from_utf8_lossy(&stderr_bytes);
-            // Keep the tail (char-safe) so the job error surfaces the real failure.
-            let tail: String = stderr_text.trim().chars().rev().take(1200).collect();
-            let detail: String = tail.chars().rev().collect();
             return Err(WorkerError::InvalidPayload(format!(
-                "MLX conversion failed (exit {}). {detail}",
-                status.code().unwrap_or(-1),
+                "MLX conversion failed. {detail}"
+            )));
+        }
+        Err(join_error) => {
+            let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+            return Err(WorkerError::InvalidPayload(format!(
+                "MLX conversion task panicked: {join_error}"
             )));
         }
     }
@@ -1295,6 +1473,105 @@ mod tests {
             assert!(
                 out.join(sub).exists(),
                 "borrowed `{sub}` missing or broken symlink in {}",
+                out.display()
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&out);
+    }
+
+    /// Real-weights smoke for the native Rust/MLX Wan2.2 TI2V-5B converter (sc-3224 engine +
+    /// sc-3240 cutover): runs the actual `convert_wan_native` + `copy_wan_umt5_tokenizer` used by
+    /// `run_model_convert_job` on the cached native checkpoint, and asserts the assembled MLX dir is
+    /// complete — including the UMT5 `tokenizer.json` the loader requires and the converter does NOT
+    /// emit (the SceneWorks install flow copies it). Needs the native repo in the HF cache. Run with:
+    ///   cargo test -p sceneworks-worker --lib -- --ignored wan_ti2v_5b_rust_convert
+    #[test]
+    #[ignore]
+    fn wan_ti2v_5b_rust_convert_real_weights() {
+        let checkpoint = hf_snapshot("models--Wan-AI--Wan2.2-TI2V-5B");
+        assert!(
+            checkpoint.join("Wan2.2_VAE.pth").is_file(),
+            "missing native Wan2.2 VAE .pth: {}",
+            checkpoint.display()
+        );
+        assert!(
+            checkpoint.join("google/umt5-xxl/tokenizer.json").is_file(),
+            "native checkpoint is missing the bundled UMT5 tokenizer.json: {}",
+            checkpoint.display()
+        );
+
+        let out = std::env::temp_dir().join(format!("sw_wan5b_convert_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&out);
+
+        convert_wan_native("wan_ti2v_5b", &checkpoint, &out, None)
+            .expect("native Wan TI2V-5B convert");
+        copy_wan_umt5_tokenizer(&checkpoint, &out).expect("copy UMT5 tokenizer");
+
+        for file in [
+            "model.safetensors",
+            "t5_encoder.safetensors",
+            "vae.safetensors",
+            "config.json",
+            // The loader-required tokenizer the converter does not emit (sc-3240).
+            "tokenizer.json",
+        ] {
+            assert!(
+                out.join(file).is_file(),
+                "converted Wan dir missing `{file}` in {}",
+                out.display()
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&out);
+    }
+
+    /// Real-weights smoke for the native Rust/MLX LTX-2.3 converter (sc-3224 engine + sc-3240
+    /// cutover) — the LTX path was never routed through the Rust job before. Runs the actual
+    /// `convert_ltx_native` used by `run_model_convert_job` on the cached eros single-file + the base
+    /// LTX-2.3 upscaler, and asserts the split MLX dir is complete, including the
+    /// `upsampler.safetensors` the loader hard-requires (merged from the base repo) and the
+    /// `split_model.json` Q4 quant manifest. Needs both repos in the HF cache. Run with:
+    ///   cargo test -p sceneworks-worker --lib -- --ignored ltx_eros_rust_convert
+    #[test]
+    #[ignore]
+    fn ltx_eros_rust_convert_real_weights() {
+        let source =
+            hf_snapshot("models--TenStrip--LTX2.3-10Eros").join("10Eros_v1_bf16.safetensors");
+        let upscaler_dir = hf_snapshot("models--Lightricks--LTX-2.3");
+        assert!(
+            source.is_file(),
+            "missing eros single-file checkpoint: {}",
+            source.display()
+        );
+        assert!(
+            upscaler_dir.join(LTX_SPATIAL_UPSCALER_FILE).is_file(),
+            "missing base LTX-2.3 spatial upscaler: {}",
+            upscaler_dir.display()
+        );
+
+        let out = std::env::temp_dir().join(format!("sw_ltx_eros_convert_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&out);
+
+        convert_ltx_native(&source, &upscaler_dir, &out, 4).expect("native LTX-2.3 eros convert");
+
+        for file in [
+            "transformer.safetensors",
+            "connector.safetensors",
+            // The loader-required latent upsampler, merged from the base LTX-2.3 repo (sc-3240).
+            "upsampler.safetensors",
+            "vae_decoder.safetensors",
+            "vae_encoder.safetensors",
+            "audio_vae.safetensors",
+            "vocoder.safetensors",
+            "config.json",
+            "embedded_config.json",
+            // The Q4 quant geometry the loader reads back (sc-2686).
+            "split_model.json",
+        ] {
+            assert!(
+                out.join(file).is_file(),
+                "converted LTX dir missing `{file}` in {}",
                 out.display()
             );
         }


### PR DESCRIPTION
Consumer cutover for the merged mlx-gen Wan/LTX converters ([mlx-gen#140](https://github.com/michaeltrefry/mlx-gen/pull/140), merge `01bf625`) — slice 5 of sc-3224. Replaces the install-time Python `mlx_video.convert_wan` subprocess with the native Rust `mlx-gen` converters, finishing the Mac MLX path's move off Python. Story: [sc-3240](https://app.shortcut.com/trefry/story/3240).

## What changed
- **Engine bump** — all 8 `mlx-gen` crate pins `269c8a2 → 01bf625` (`crates/sceneworks-worker/Cargo.toml` + `Cargo.lock`). Verified `01bf625` still carries the flux2 `convert_and_assemble` (no regression) and keeps the same `pmetal-mlx-rs` pin (MLX builds once). The lock also pulls in `zip`/`typed-path` for the converter's `.pth` reader (macOS-gated).
- **Worker** (`model_jobs.rs::run_model_convert_job`) — deleted the `python -m mlx_video.convert_wan` subprocess arm; dispatch on the manifest `mlx.converter` discriminator (`spawn_blocking`, macOS-gated, cancel honored up front):
  - `wan_ti2v_5b` / `wan_i2v_14b` / `wan_t2v_14b` → `mlx_gen_wan::convert::*`
  - `ltx_video` → `mlx_gen_ltx::convert_and_assemble` — **LTX is now actually routed through the job** (only `convert_wan` was ever shelled before).
  - Wan copies the loader-required `google/umt5-xxl/tokenizer.json` (the converter doesn't emit it). LTX fetches the base-repo spatial upsampler (~1 GB) on demand (no 157 GB base install). `quantize_only` (no native equivalent, UI-unreachable) now fails with a clear message instead of silently mis-converting.
- **Manifest** — `wan_2_2` + `wan_2_2_i2v_14b` switch `convertSourceRepo` to the native repos and carry **per-platform download entries** (native MLX source on macOS, `-Diffusers` torch repo on windows/linux) + `converter` discriminators; `ltx_2_3_eros` gains `converter` / `convertSourceFile` / `convertBaseRepo`.
- **API** — new `retain_downloads_for_os` filters `downloads[]` to the running OS in `model_catalog`, so the download job, install status, size, and the frontend's `downloads[0]` all resolve the right per-platform repo from one seam (no frontend change).

## Why per-platform downloads
These video models serve two layouts: native (the Rust MLX convert source, macOS) and `-Diffusers`/GGUF (the torch `wan_video` adapter, Windows/Linux). The Mac Download→Convert UX requires `downloads[0] == convertSourceRepo == native`. Tagging the entries by platform keeps Windows torch on `-Diffusers` (no wasteful native download) while Mac gets native — correct on both, zero wasted bytes.

## Validation
- `npm run rust:check` green — fmt, clippy `-D warnings`, **101 worker + nax + rust-api tests** (incl. new `platform_tagged_downloads_resolve_per_os`), build.
- New `#[ignore]` real-weight convert tests pass on M5 Max: `wan_ti2v_5b_rust_convert_real_weights` (162 s, incl. tokenizer copy) and `ltx_eros_rust_convert_real_weights` (Q4 + upsampler merge) — each produces a complete, loadable dir.

## Reviewer notes
- Targets `rust-mlx-integration` (epic 2337 convention), not `main`.
- Does **not** touch the in-flight Apache-2.0 licensing changes present in the working tree (left to their own change).
- sc-3242 (drop the `mlx-video-with-audio` deps) stays blocked on its `training_adapters.py` LTX-distillation gate — separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)