### PR TITLE
[codex] Fix Hugging Face cache health on Windows

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -816,10 +816,10 @@ pub(crate) async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiErr
         object.insert(
             "cacheState".to_owned(),
             Value::String(
-                if installed {
-                    "complete"
-                } else if cache_incomplete {
+                if cache_incomplete {
                     "incomplete"
+                } else if installed {
+                    "complete"
                 } else {
                     "missing"
                 }
@@ -1068,7 +1068,7 @@ pub(crate) fn huggingface_cache_health(
 
     let mut best_missing = Vec::new();
     for snapshot in snapshots {
-        if snapshot.join("model_index.json").is_file() {
+        if path_is_readable_file(&snapshot.join("model_index.json")) {
             let health = diffusers_snapshot_health(&snapshot);
             if health.installed {
                 return health;
@@ -1078,7 +1078,9 @@ pub(crate) fn huggingface_cache_health(
             }
             continue;
         }
-        if snapshot.join("config.json").is_file() || snapshot_has_payload_file(&snapshot) {
+        if path_is_readable_file(&snapshot.join("config.json"))
+            || snapshot_has_payload_file(&snapshot)
+        {
             return HuggingFaceCacheHealth::installed();
         }
         if best_missing.is_empty() {
@@ -1114,7 +1116,7 @@ fn snapshot_contains_pattern(snapshot: &FsPath, pattern: &str) -> bool {
             .into_iter()
             .any(|path| pattern_matches(pattern, &path));
     }
-    snapshot.join(pattern).is_file()
+    path_is_readable_file(&snapshot.join(pattern))
 }
 
 fn pattern_contains_glob(pattern: &str) -> bool {
@@ -1157,7 +1159,7 @@ fn diffusers_snapshot_health(snapshot: &FsPath) -> HuggingFaceCacheHealth {
             // Weight-bearing components (unet, transformer, vae, text_encoder,
             // controlnet, …) reliably ship a `config.json` alongside their
             // weight files, so require both.
-            if !snapshot.join(format!("{component}/config.json")).is_file() {
+            if !path_is_readable_file(&snapshot.join(format!("{component}/config.json"))) {
                 missing.push(format!("{component}/config.json"));
             }
             if !diffusers_component_has_weight_file(snapshot, component) {
@@ -1202,7 +1204,11 @@ fn diffusers_component_requires_weights(component: &str, class_name: &str) -> bo
 /// names vary too much by class to enumerate reliably.
 fn diffusers_component_dir_nonempty(snapshot: &FsPath, component: &str) -> bool {
     std::fs::read_dir(snapshot.join(component))
-        .map(|entries| entries.flatten().any(|entry| entry.path().is_file()))
+        .map(|entries| {
+            entries
+                .flatten()
+                .any(|entry| path_is_readable_file(&entry.path()))
+        })
         .unwrap_or(false)
 }
 
@@ -1218,7 +1224,7 @@ fn diffusers_component_has_weight_file(snapshot: &FsPath, component: &str) -> bo
             .and_then(|value| value.to_str())
             .unwrap_or_default()
             .to_ascii_lowercase();
-        path.is_file()
+        path_is_readable_file(&path)
             && (name.ends_with(".safetensors")
                 || name.ends_with(".bin")
                 || name.ends_with(".msgpack")
@@ -1248,7 +1254,7 @@ fn snapshot_files(snapshot: &FsPath) -> Vec<String> {
             let path = entry.path();
             if path.is_dir() {
                 stack.push(path);
-            } else if path.is_file() {
+            } else if path_is_readable_file(&path) {
                 if let Ok(relative) = path.strip_prefix(snapshot) {
                     output.push(relative.to_string_lossy().replace('\\', "/"));
                 }
@@ -1256,6 +1262,19 @@ fn snapshot_files(snapshot: &FsPath) -> Vec<String> {
         }
     }
     output
+}
+
+fn path_is_readable_file(path: &FsPath) -> bool {
+    if std::fs::metadata(path).is_ok_and(|metadata| metadata.is_file()) {
+        return true;
+    }
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !metadata.file_type().is_symlink() {
+        return false;
+    }
+    std::fs::File::open(path).is_ok()
 }
 
 pub(crate) fn manifest_download_size_bytes(model: &Value, download: &Value) -> Option<u64> {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1739,7 +1739,9 @@ async fn create_training_job_queues_real_run_when_not_dry_run() {
 /// Seeds the Z-Image-Turbo base model as installed (a managed-download
 /// marker) so a real training run clears the missing-model guardrail.
 fn seed_installed_base_model(data_dir: &std::path::Path) {
-    let model_dir = data_dir.join("models").join("z_image_turbo");
+    let model_dir = data_dir
+        .join("models")
+        .join(safe_download_dir("Tongyi-MAI/Z-Image-Turbo"));
     std::fs::create_dir_all(&model_dir).expect("model dir creates");
     std::fs::write(model_dir.join(".sceneworks-download-complete.json"), "{}")
         .expect("model marker writes");
@@ -4601,6 +4603,93 @@ fn single_model_manifest(config_dir: &std::path::Path, id: &str, repo: &str) {
         )
         .expect("empty manifest writes");
     }
+}
+
+#[tokio::test]
+async fn downloadable_model_catalog_reports_incomplete_cache_for_installed_managed_model() {
+    // A model can have SceneWorks' managed completion marker while its Hugging
+    // Face cache snapshot is partial. Keep those states independent so the UI
+    // can offer "Fix" instead of disabling the primary action as "Ready".
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let repo = "owner/mixed";
+    single_model_manifest(
+        &temp_dir.path().join("config/manifests"),
+        "mixed_model",
+        repo,
+    );
+    let managed_dir = temp_dir
+        .path()
+        .join("data/models")
+        .join(safe_download_dir(repo));
+    std::fs::create_dir_all(&managed_dir).expect("managed dir creates");
+    std::fs::write(managed_dir.join(".sceneworks-download-complete.json"), "{}")
+        .expect("managed marker writes");
+    let cache_dir = temp_dir
+        .path()
+        .join("data/cache/huggingface/hub/models--owner--mixed/snapshots/abc123");
+    std::fs::create_dir_all(&cache_dir).expect("partial hf cache creates");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["installState"], "installed");
+    assert_eq!(models[0]["cacheState"], "incomplete");
+    assert_eq!(models[0]["repairAvailable"], true);
+    assert_eq!(
+        models[0]["missingRequiredFiles"],
+        json!(["model_index.json"])
+    );
+}
+
+#[test]
+fn huggingface_cache_health_accepts_readable_snapshot_symlinked_model_index() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let repo_root = temp_dir.path().join("models--owner--symlinked");
+    let snapshot = repo_root.join("snapshots/abc123");
+    let blobs = repo_root.join("blobs");
+    std::fs::create_dir_all(&snapshot).expect("snapshot creates");
+    std::fs::create_dir_all(&blobs).expect("blobs creates");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("refs creates");
+    std::fs::write(repo_root.join("refs/main"), "abc123").expect("ref writes");
+    let blob_name = "model-index-blob";
+    std::fs::write(
+        blobs.join(blob_name),
+        r#"{ "_class_name": "EmptyPipeline" }"#,
+    )
+    .expect("blob writes");
+    let link = snapshot.join("model_index.json");
+    let relative_target = std::path::Path::new("..")
+        .join("..")
+        .join("blobs")
+        .join(blob_name);
+    if create_test_symlink_file(&relative_target, &link).is_err() {
+        std::fs::write(&link, r#"{ "_class_name": "EmptyPipeline" }"#)
+            .expect("fallback index writes");
+    }
+
+    let health = super::models::huggingface_cache_health(&repo_root, &[]);
+
+    assert!(health.installed);
+    assert!(!health.incomplete);
+    assert!(health.missing_files.is_empty());
+}
+
+#[cfg(windows)]
+fn create_test_symlink_file(
+    target: &std::path::Path,
+    link: &std::path::Path,
+) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(target, link)
+}
+
+#[cfg(unix)]
+fn create_test_symlink_file(
+    target: &std::path::Path,
+    link: &std::path::Path,
+) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
 }
 
 #[tokio::test]

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -646,6 +646,10 @@ pub(crate) fn training_base_model_installed(data_dir: &FsPath, target: &Training
                 return true;
             }
         }
+        let managed = data_dir.join("models").join(safe_download_dir(repo));
+        if model_is_installed(&managed) {
+            return true;
+        }
     }
     let managed = data_dir
         .join("models")

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -531,8 +531,8 @@ export function ModelManagerScreen() {
           <p className="eyebrow">{model.family ?? "unassociated"}</p>
           <h3>{model.name}</h3>
         </div>
-        <span className={installed ? "status-badge installed" : incomplete ? "status-badge warning" : "status-badge"}>
-          {installed ? "installed" : incomplete ? "incomplete" : "missing"}
+        <span className={incomplete ? "status-badge warning" : installed ? "status-badge installed" : "status-badge"}>
+          {incomplete ? "incomplete" : installed ? "installed" : "missing"}
         </span>
         {unassociated ? (
           <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
@@ -616,7 +616,7 @@ export function ModelManagerScreen() {
         ) : null}
         <div className="model-card-actions">
           <button
-            disabled={installed || !model.downloadable || Boolean(downloadJob)}
+            disabled={(installed && !incomplete) || !model.downloadable || Boolean(downloadJob)}
             onClick={() =>
               failedDownload
                 ? onResumeDownloadJob(localDownloadJob, { payloadChanges: { downloadAction: "resume" } })
@@ -626,15 +626,15 @@ export function ModelManagerScreen() {
           >
             {downloadJob
               ? downloadJob.status
-              : installed
-                ? "Ready"
-                : failedDownload
+              : failedDownload
                   ? "Resume Download"
                   : incomplete
                     ? "Fix"
-                    : model.downloadSizeLabel
-                    ? `Download ${downloadSize}`
-                    : "Download"}
+                    : installed
+                      ? "Ready"
+                      : model.downloadSizeLabel
+                        ? `Download ${downloadSize}`
+                        : "Download"}
           </button>
           <button className="danger-action" disabled={!canDelete || deletingItem === deleteKey} onClick={() => deleteModel(model)} type="button">
             {model.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -428,6 +428,32 @@ describe("ModelManagerScreen type-grouped layout", () => {
     );
   });
 
+  it("offers a Fix action when an installed model has an incomplete cache", async () => {
+    const createModelDownloadJob = vi.fn();
+    await render({
+      createModelDownloadJob,
+      models: [
+        {
+          ...MODELS[0],
+          installState: "installed",
+          cacheState: "incomplete",
+          repairAvailable: true,
+          missingRequiredFiles: ["model_index.json"],
+          downloadable: true,
+        },
+      ],
+    });
+    const fixButton = [...container.querySelectorAll(".model-card-actions button")].find(
+      (button) => button.textContent === "Fix",
+    );
+    expect(fixButton).toBeTruthy();
+    expect(fixButton.disabled).toBe(false);
+    await click(fixButton);
+    expect(createModelDownloadJob).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "z_image_turbo" }),
+    );
+  });
+
   it("groups LoRAs by family with a heading per family", async () => {
     await render({
       models: MODELS,


### PR DESCRIPTION
﻿## Summary
- Fix Hugging Face cache health checks for Windows snapshots whose files are symlinks to cache blobs.
- Keep incomplete-cache state visible even when a managed install marker exists, so repairable models are not mislabeled as fully ready.
- Let Trainer recognize repo-keyed managed model installs, matching how model downloads actually write completion markers.
- Keep the Model Manager repair action available for installed-but-repairable cache states.

## Root Cause
Hugging Face snapshot files on Windows can be symlinks/reparse points into the repo's `blobs` directory. The Rust API used `Path::is_file()` for cache health checks, which could fail on those snapshot links even when the linked file was readable. That made existing caches report `Cached files are incomplete: model_index.json` even though `model_index.json` was still present.

The Trainer also fell back to `data/models/<baseModelId>` after cache health failed, while managed downloads are stored by repo slug, e.g. `data/models/Tongyi-MAI__Z-Image-Turbo`.

## Validation
- `cargo test -p sceneworks-rust-api downloadable_model_catalog`
- `cargo test -p sceneworks-rust-api huggingface_cache_health_accepts_readable_snapshot_symlinked_model_index`
- `cargo test -p sceneworks-rust-api create_training_job_queues_real_run_when_not_dry_run`
- `npm test -- --run src/screens/ModelManagerScreen.test.jsx`
