### PR TITLE
[codex] Retain training sample cycles

### DIFF
--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -279,6 +279,34 @@ function ThumbnailGrid({ assets, variant, onThumbnailClick, isRunning, expectedC
   );
 }
 
+function ThumbnailGroups({ groups, variant, onThumbnailClick }) {
+  const sections = Array.isArray(groups) ? groups.filter((group) => Array.isArray(group?.assets) && group.assets.length) : [];
+  if (!sections.length) {
+    return null;
+  }
+  return (
+    <div className="worker-progress-card__thumbnail-groups" role="group" aria-label="Job output samples">
+      {sections.map((group, index) => (
+        <section
+          className="worker-progress-card__thumbnail-group"
+          key={group.id ?? `${group.label ?? "sample"}-${index}`}
+        >
+          {group.label ? (
+            <div className="worker-progress-card__thumbnail-group-label">{group.label}</div>
+          ) : null}
+          <ThumbnailGrid
+            assets={group.assets}
+            variant={variant}
+            onThumbnailClick={onThumbnailClick}
+            isRunning={false}
+            expectedCount={0}
+          />
+        </section>
+      ))}
+    </div>
+  );
+}
+
 function VideoThumbnail({ assets, onThumbnailClick }) {
   const asset = Array.isArray(assets) ? assets[0] : null;
   if (!asset) {
@@ -323,11 +351,14 @@ function VideoThumbnail({ assets, onThumbnailClick }) {
   );
 }
 
-function ThumbnailsRegion({ variant, finalAssets, interimAssets, onThumbnailClick, isRunning, expectedCount }) {
+function ThumbnailsRegion({ variant, finalAssets, interimAssets, thumbnailGroups, onThumbnailClick, isRunning, expectedCount }) {
   if (variant === "hidden") return null;
   if (!THUMBNAIL_VARIANTS.has(variant)) return null;
   if (variant === "video-player") {
     return <VideoThumbnail assets={finalAssets} onThumbnailClick={onThumbnailClick} />;
+  }
+  if (Array.isArray(thumbnailGroups) && thumbnailGroups.some((group) => Array.isArray(group?.assets) && group.assets.length)) {
+    return <ThumbnailGroups groups={thumbnailGroups} variant={variant} onThumbnailClick={onThumbnailClick} />;
   }
   const merged = mergeThumbnails(finalAssets, interimAssets);
   return (
@@ -352,6 +383,7 @@ export function WorkerProgressCard({
   className,
   thumbnailsVariant = "hidden",
   thumbnailAssets,
+  thumbnailGroups,
   interimThumbnailAssets,
   expectedThumbnailCount,
   onThumbnailClick,
@@ -490,6 +522,7 @@ export function WorkerProgressCard({
       <ThumbnailsRegion
         variant={thumbnailsVariant}
         finalAssets={thumbnailAssets}
+        thumbnailGroups={thumbnailGroups}
         interimAssets={interimThumbnailAssets}
         onThumbnailClick={onThumbnailClick}
         isRunning={!isTerminal}

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -417,6 +417,26 @@ describe("WorkerProgressCard thumbnails", () => {
     expect(skeletons).toHaveLength(3);
   });
 
+  it("renders grouped thumbnail cycles with section labels", () => {
+    api = render(
+      <WorkerProgressCard
+        job={runningJob}
+        thumbnailsVariant="image-grid"
+        thumbnailGroups={[
+          { id: "step-500", label: "Sample #2 - Step 500", assets: [imageAssets[0]] },
+          { id: "step-250", label: "Sample #1 - Step 250", assets: [imageAssets[1]] },
+        ]}
+        expectedThumbnailCount={4}
+      />,
+      makeContext([]),
+    );
+    const groups = api.container.querySelectorAll(".worker-progress-card__thumbnail-group");
+    expect(groups).toHaveLength(2);
+    expect(groups[0].textContent).toContain("Sample #2 - Step 500");
+    expect(groups[1].textContent).toContain("Sample #1 - Step 250");
+    expect(api.container.querySelectorAll(".worker-progress-card__thumb-cell.skeleton")).toHaveLength(0);
+  });
+
   it("does not render skeletons after the job completes", () => {
     api = render(
       <WorkerProgressCard

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -723,15 +723,6 @@ function DatasetHealth({ health, action }) {
   );
 }
 
-function latestTrainingSamples(job) {
-  const latest = Array.isArray(job.result?.latestTrainingSamples) ? job.result.latestTrainingSamples : [];
-  if (latest.length) {
-    return latest.slice(-4);
-  }
-  const samples = Array.isArray(job.result?.trainingSamples) ? job.result.trainingSamples : [];
-  return samples.slice(-4);
-}
-
 // Convert a training-sample record into an asset-shaped object that AssetThumbnail
 // (via assetUrl) can render. Worker emits {url, relativePath, step, prompt}; we
 // translate to either { url } (when relative) or { file: { path } } (when path-
@@ -756,20 +747,78 @@ function trainingSampleToAsset(sample, projectId, label, key) {
   return null;
 }
 
-// Resolve the training-sample assets for a job. Pads with placeholder labels
-// (the sample-prompt list) so the image-grid skeleton cells communicate
-// "this slot is coming" just like image batches.
-function trainingSampleAssets(job, projectId) {
-  const samples = latestTrainingSamples(job);
+function trainingSampleIdentity(sample, index) {
+  return sample?.relativePath ?? sample?.path ?? sample?.url ?? `${sample?.step ?? "sample"}-${sample?.prompt ?? ""}-${index}`;
+}
+
+function allTrainingSamples(job) {
+  const samples = Array.isArray(job.result?.trainingSamples) ? job.result.trainingSamples : [];
+  const latest = Array.isArray(job.result?.latestTrainingSamples) ? job.result.latestTrainingSamples : [];
+  const seen = new Set();
+  return [...samples, ...latest].filter((sample, index) => {
+    const key = trainingSampleIdentity(sample, index);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function sampleStepKey(sample, index) {
+  const numeric = Number(sample?.step);
+  return Number.isFinite(numeric) && numeric > 0 ? `step-${numeric}` : `sample-${index}`;
+}
+
+function sampleStepValue(samples, fallbackIndex) {
+  const numeric = Number(samples[0]?.step);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : fallbackIndex;
+}
+
+// Resolve all training-sample cycles for a job. Each sampling step gets its own
+// worker-card section so newer cycles stack above older cycles instead of
+// replacing them.
+export function trainingSampleGroups(job, projectId) {
+  const samples = allTrainingSamples(job);
   const samplePrompts = Array.isArray(job.result?.samplePrompts)
     ? job.result.samplePrompts
     : samplePromptsFromTrigger(job.payload?.plan?.config?.triggerWord);
-  return samplePrompts.slice(0, 4).map((prompt, index) => {
-    const sample = samples[index];
-    if (!sample) return null;
-    const label = sample?.step ? `Step ${sample.step}` : prompt;
-    return trainingSampleToAsset(sample, projectId, label, `${job.id}-sample-${index}`);
-  }).filter(Boolean);
+  const grouped = [];
+  const groupsByStep = new Map();
+  samples.forEach((sample, index) => {
+    const key = sampleStepKey(sample, index);
+    if (!groupsByStep.has(key)) {
+      const group = { key, firstIndex: index, samples: [] };
+      groupsByStep.set(key, group);
+      grouped.push(group);
+    }
+    groupsByStep.get(key).samples.push(sample);
+  });
+
+  return grouped
+    .map((group, index) => {
+      const step = sampleStepValue(group.samples, group.firstIndex);
+      return { ...group, chronologicalSampleNumber: index + 1, step };
+    })
+    .sort((a, b) => b.step - a.step)
+    .map((group) => {
+      const stepLabel = Number.isFinite(Number(group.samples[0]?.step)) ? ` - Step ${group.samples[0].step}` : "";
+      const assets = group.samples.map((sample, index) => {
+        const prompt = sample?.prompt ?? samplePrompts[index] ?? `Sample ${index + 1}`;
+        return trainingSampleToAsset(
+          sample,
+          projectId,
+          prompt,
+          `${job.id}-sample-${group.key}-${trainingSampleIdentity(sample, index)}`,
+        );
+      }).filter(Boolean);
+      return {
+        id: `${job.id}-sample-group-${group.key}`,
+        label: `Sample #${group.chronologicalSampleNumber}${stepLabel}`,
+        assets,
+      };
+    })
+    .filter((group) => group.assets.length);
 }
 
 function TrainingLiveProgress({ jobs, projectId }) {
@@ -791,7 +840,7 @@ function TrainingLiveProgress({ jobs, projectId }) {
             key={job.id}
             job={job}
             thumbnailsVariant="image-grid"
-            thumbnailAssets={trainingSampleAssets(job, projectId)}
+            thumbnailGroups={trainingSampleGroups(job, projectId)}
             expectedThumbnailCount={4}
           />
         ))}

--- a/apps/web/src/screens/TrainingStudio.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.test.jsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { configDraftFromTarget, trainingConfigSnapshot } from "./TrainingStudio.jsx";
+import { configDraftFromTarget, trainingConfigSnapshot, trainingSampleGroups } from "./TrainingStudio.jsx";
 
 // Minimal target mirroring a LoKr-capable builtin (sc-2195 gating): networkType
 // lives in defaults.advanced, the choice is gated by limits.networkTypes.
@@ -68,5 +68,49 @@ describe("TrainingStudio network type", () => {
     const snap = snapshot({ ...draft, networkType: "lokr", decomposeFactor: "" });
     expect(snap.config.advanced.networkType).toBe("lokr");
     expect(snap.config.advanced).not.toHaveProperty("decomposeFactor");
+  });
+});
+
+describe("TrainingStudio training samples", () => {
+  it("groups every sampling cycle newest first", () => {
+    const groups = trainingSampleGroups(
+      {
+        id: "job-1",
+        payload: { plan: { config: { triggerWord: "Mira" } } },
+        result: {
+          samplePrompts: ["front", "side"],
+          trainingSamples: [
+            { step: 250, prompt: "front", relativePath: "training/job-1/samples/step-000250/front.png" },
+            { step: 250, prompt: "side", relativePath: "training/job-1/samples/step-000250/side.png" },
+            { step: 500, prompt: "front", relativePath: "training/job-1/samples/step-000500/front.png" },
+            { step: 500, prompt: "side", relativePath: "training/job-1/samples/step-000500/side.png" },
+          ],
+        },
+      },
+      "project-1",
+    );
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].label).toBe("Sample #2 - Step 500");
+    expect(groups[0].assets).toHaveLength(2);
+    expect(groups[0].assets[0].file.path).toBe("training/job-1/samples/step-000500/front.png");
+    expect(groups[1].label).toBe("Sample #1 - Step 250");
+  });
+
+  it("deduplicates latest samples already present in the cumulative list", () => {
+    const groups = trainingSampleGroups(
+      {
+        id: "job-1",
+        payload: {},
+        result: {
+          trainingSamples: [{ step: 250, prompt: "front", relativePath: "training/job-1/samples/step-000250/front.png" }],
+          latestTrainingSamples: [{ step: 250, prompt: "front", relativePath: "training/job-1/samples/step-000250/front.png" }],
+        },
+      },
+      "project-1",
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].assets).toHaveLength(1);
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7460,6 +7460,35 @@ label {
   position: relative;
 }
 
+.worker-progress-card__thumbnail-groups {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.worker-progress-card__thumbnail-group {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.worker-progress-card__thumbnail-group-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.worker-progress-card__thumbnail-group-label::after {
+  content: "";
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--border);
+}
+
 .worker-progress-card__thumb-cell {
   display: block;
   padding: 0;

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -784,6 +784,10 @@ impl JobsStore {
         let peak_load = update
             .peak_gpu_load_pct
             .map(|value| value.clamp(0.0, 100.0));
+        let mut result = update.result;
+        if let Some(result) = result.as_mut() {
+            merge_training_sample_history(&transaction, job_id, result)?;
+        }
         transaction.execute(
             "
             update jobs
@@ -814,7 +818,7 @@ impl JobsStore {
                 progress,
                 update.message,
                 update.error,
-                optional_dumps(update.result.as_ref())?,
+                optional_dumps(result.as_ref())?,
                 update.eta_seconds,
                 completed_at,
                 canceled_at,
@@ -1224,6 +1228,85 @@ fn loads_object(value: Option<&str>) -> Map<String, Value> {
     value
         .and_then(|text| serde_json::from_str::<Map<String, Value>>(text).ok())
         .unwrap_or_default()
+}
+
+fn merge_training_sample_history(
+    connection: &Connection,
+    job_id: &str,
+    incoming: &mut Map<String, Value>,
+) -> JobsStoreResult<()> {
+    let has_training_samples = incoming
+        .get("trainingSamples")
+        .and_then(Value::as_array)
+        .is_some();
+    let has_latest_training_samples = incoming
+        .get("latestTrainingSamples")
+        .and_then(Value::as_array)
+        .is_some();
+    if !has_training_samples && !has_latest_training_samples {
+        return Ok(());
+    }
+
+    let existing_json: Option<String> = connection
+        .query_row(
+            "select result_json from jobs where id = ?1",
+            params![job_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let existing = loads_object(existing_json.as_deref());
+    let mut samples = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    append_training_samples(&mut samples, &mut seen, existing.get("trainingSamples"));
+    append_training_samples(&mut samples, &mut seen, incoming.get("trainingSamples"));
+    append_training_samples(
+        &mut samples,
+        &mut seen,
+        incoming.get("latestTrainingSamples"),
+    );
+
+    if !samples.is_empty() {
+        incoming.insert("trainingSamples".to_owned(), Value::Array(samples));
+    }
+    Ok(())
+}
+
+fn append_training_samples(
+    samples: &mut Vec<Value>,
+    seen: &mut std::collections::HashSet<String>,
+    value: Option<&Value>,
+) {
+    let Some(array) = value.and_then(Value::as_array) else {
+        return;
+    };
+    for sample in array {
+        let key = training_sample_key(sample, samples.len());
+        if seen.insert(key) {
+            samples.push(sample.clone());
+        }
+    }
+}
+
+fn training_sample_key(sample: &Value, fallback_index: usize) -> String {
+    let Some(object) = sample.as_object() else {
+        return format!("sample:{fallback_index}");
+    };
+    for key in ["relativePath", "path", "url"] {
+        if let Some(value) = object.get(key).and_then(Value::as_str) {
+            if !value.is_empty() {
+                return format!("{key}:{value}");
+            }
+        }
+    }
+    let step = object
+        .get("step")
+        .map(Value::to_string)
+        .unwrap_or_else(|| "unknown".to_owned());
+    let prompt = object
+        .get("prompt")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    format!("step:{step}:prompt:{prompt}:index:{fallback_index}")
 }
 
 fn loads_vec<T>(value: Option<&str>) -> Vec<T>

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -688,6 +688,58 @@ fn training_progress_stages_persist_under_running_and_reject_unknown_status() {
 }
 
 #[test]
+fn training_progress_merges_latest_sample_batches_into_history() {
+    let store = store("training-sample-history");
+    let job = store
+        .create_job(lora_train_job("auto", false))
+        .expect("training job creates");
+
+    for (step, path) in [
+        (250, "training/job-1/samples/step-000250/front.png"),
+        (500, "training/job-1/samples/step-000500/front.png"),
+    ] {
+        store
+            .update_job_progress(
+                &job.id,
+                ProgressUpdate {
+                    status: JobStatus::Running,
+                    stage: ProgressStage::Rendering,
+                    progress: 0.5,
+                    message: format!("Rendered samples at step {step}."),
+                    error: None,
+                    result: Some(object(json!({
+                        "latestTrainingSamples": [{
+                            "step": step,
+                            "prompt": "front",
+                            "relativePath": path,
+                        }]
+                    }))),
+                    eta_seconds: None,
+                    peak_gpu_memory_pct: None,
+                    peak_gpu_load_pct: None,
+                    backend: None,
+                },
+            )
+            .expect("sample progress updates");
+    }
+
+    let updated = store.get_job(&job.id).expect("job loads");
+    let samples = updated
+        .result
+        .get("trainingSamples")
+        .and_then(Value::as_array)
+        .expect("training sample history is present");
+
+    assert_eq!(samples.len(), 2);
+    assert_eq!(samples[0]["step"], json!(250));
+    assert_eq!(samples[1]["step"], json!(500));
+    assert_eq!(
+        updated.result["latestTrainingSamples"][0]["relativePath"],
+        json!("training/job-1/samples/step-000500/front.png")
+    );
+}
+
+#[test]
 fn gpu_generation_jobs_reject_cpu_requested_gpu() {
     let store = store("gpu-jobs-reject-cpu");
 


### PR DESCRIPTION
## Summary
- retain all LoRA training sample cycles in the WorkerProgressCard instead of replacing the prior cycle
- group samples newest-first with separator labels like `Sample #2 - Step 500`
- merge `latestTrainingSamples` into stored `trainingSamples` so latest-only progress updates preserve sample history

## Validation
- `npm test -- --run src/components/WorkerProgressCard.test.jsx src/screens/TrainingStudio.test.jsx`
- `cargo test -p sceneworks-core training_progress_merges_latest_sample_batches_into_history`
- `git diff --check`