### PR TITLE
sc-3043/sc-3049: wire lora_train to the Rust mlx-gen trainer + Mac→Rust training routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2470,8 +2470,9 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
+ "image",
  "inventory",
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2481,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2491,8 +2492,9 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
+ "image",
  "inventory",
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2503,20 +2505,23 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
+ "image",
  "inventory",
  "mlx-gen",
  "pmetal-mlx-rs",
  "serde_json",
  "unicode-normalization",
+ "zip",
 ]
 
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=269c8a29cb81b43735722d7931d66e35ebb846de#269c8a29cb81b43735722d7931d66e35ebb846de"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
 dependencies = [
+ "image",
  "inventory",
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2778,7 +2783,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5357,6 +5362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6650,6 +6661,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default-members = [
 version = "0.2.0"
 edition = "2021"
 rust-version = "1.80"
+license-file = "LICENSE"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,75 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+Required Notice: Copyright 2026 Michael Trefry and the SceneWorks contributors
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -257,3 +257,22 @@ First-run installs CUDA torch wheels from `cu128` by default (override with
 | High-end | NVIDIA RTX PRO 6000 Blackwell (96 GB) | ✅ Validated | torch 2.8 `cu128`; Qwen image (~36 s incl. load), native LTX-2.3 text-to-video (~80 s for a 2 s clip), and timeline export verified end-to-end |
 | Other CUDA | RTX 30/40-series, etc. | ⏳ Untested | Expected to work via the `cu128` wheels with a recent driver; not yet validated |
 | CPU-only | — | ⚠️ Limited | No GPU inference; image/video generation unavailable |
+
+## Licensing
+
+SceneWorks is a non-commercial, **source-available** project. Its own source
+code is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE): you
+may use, modify, and share it freely for any **noncommercial** purpose, but
+commercial use is not granted. (This is a source-available license, not an
+OSI-approved "open source" license, because it restricts commercial use.) For
+commercial licensing, contact the copyright holder.
+
+**Model weights are not covered by this license.** SceneWorks downloads
+third-party model weights at runtime, and each model keeps its own license —
+some non-commercial (e.g. FLUX.1 [dev], FLUX.2 [klein] 9B), some permissive
+(Apache-2.0 / OpenRAIL). You are responsible for complying with each model's
+license when you download and use it; the SceneWorks license here applies only
+to SceneWorks' own code, not to the weights it runs.
+
+Bundled third-party source under `apps/*/scene_worker/_vendor/` is covered by
+its own `LICENSE` files (Apache-2.0 / MIT), retained alongside that code.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -711,6 +711,7 @@ impl JobsStore {
         }
         if should_defer_image_to_mlx_worker(&transaction, &queued, &worker)?
             || should_defer_video_to_mlx_worker(&transaction, &queued, &worker)?
+            || should_defer_training_to_mlx_worker(&transaction, &queued, &worker)?
         {
             return Ok(None);
         }
@@ -1433,6 +1434,27 @@ fn should_defer_video_to_mlx_worker(
     idle_mlx_worker_can_claim(connection, job, worker)
 }
 
+/// Training sibling of [`should_defer_image_to_mlx_worker`] (epic 3039): a non-mlx
+/// GPU worker defers an `auto` MLX-eligible `lora_train` job when an idle `mlx`
+/// worker can run it, so the native Rust trainer (`mlx_gen::load_trainer`) claims
+/// it. Same fallback guarantees — no mlx worker registered (Windows/Linux, or the
+/// mlx worker is down) → nothing defers and the Python torch trainer runs it; an
+/// explicit (non-`auto`) GPU choice is always honoured. The torch trainers stay
+/// the cross-platform path + the Mac fallback (sc-3049), so a job is never stuck.
+fn should_defer_training_to_mlx_worker(
+    connection: &Connection,
+    job: &JobSnapshot,
+    worker: &WorkerSnapshot,
+) -> JobsStoreResult<bool> {
+    if job.requested_gpu != "auto"
+        || worker.gpu_id.eq_ignore_ascii_case("mlx")
+        || !training_job_is_mlx_eligible(job)
+    {
+        return Ok(false);
+    }
+    idle_mlx_worker_can_claim(connection, job, worker)
+}
+
 /// Whether an idle `mlx` worker (other than `worker`) exists that supports `job`
 /// and has no active GPU job — the shared tail of the image/video MLX deferral.
 fn idle_mlx_worker_can_claim(
@@ -1758,6 +1780,67 @@ fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     true
 }
 
+/// SceneWorks training kernels with a native mlx-gen Rust trainer (epic 3039):
+/// the engine registers `z_image_turbo`/`sdxl`/`ltx_2_3`/`wan2_2_*` trainers, which
+/// the worker reaches via these SceneWorks kernel ids (the mlx worker maps kernel +
+/// base model → engine trainer id). `kolors_lora` (SDXL + ChatGLM3) and `lens_lora`
+/// (sidecar) have no mlx-gen crate, so they stay on the Python torch worker. A
+/// kernel absent here is never routed to the mlx worker.
+const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
+    "z_image_lora",
+    "sdxl_lora",
+    "wan_lora",
+    "wan_moe_lora",
+    "ltx_mlx_lora",
+];
+
+/// Epic 3039 routing — does this `lora_train` job belong on the in-process Rust MLX
+/// worker (vs the Python torch worker)? The training sibling of
+/// [`image_job_is_mlx_eligible`]/[`video_job_is_mlx_eligible`]: the engine has a
+/// native trainer for the family. Both dry-run and real runs are eligible (the
+/// dry-run validates the same resolved plan). LoKr-on-Wan stays torch — the mlx Wan
+/// inference path can't load a Kronecker adapter, mirroring [`video_job_is_mlx_eligible`];
+/// LoKr on Z-Image/SDXL/LTX is fine (the Rust engine applies it natively).
+///
+/// The resolved plan is stamped into the job payload at submit (apps/rust-api
+/// training.rs) for both dry-run and real runs, so the kernel + network type are
+/// readable here without touching the dataset or weights.
+fn training_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
+    if !matches!(job.job_type, JobType::LoraTrain) {
+        return false;
+    }
+    let Some(plan) = job.payload.get("plan").and_then(Value::as_object) else {
+        return false;
+    };
+    let kernel = plan
+        .get("target")
+        .and_then(Value::as_object)
+        .and_then(|target| target.get("kernel"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !MLX_ROUTED_TRAINING_KERNELS.contains(&kernel) {
+        return false;
+    }
+    // LoKr-on-Wan stays on the torch path (no Kronecker merge in the mlx Wan path).
+    if matches!(kernel, "wan_lora" | "wan_moe_lora") && training_plan_is_lokr(plan) {
+        return false;
+    }
+    true
+}
+
+/// Whether a resolved training plan requests a LoKr (Kronecker) adapter. The network
+/// type lives in the plan's `config.advanced.networkType` (SceneWorks training
+/// contract), distinct from a generation request's per-LoRA `networkType`.
+fn training_plan_is_lokr(plan: &Map<String, Value>) -> bool {
+    plan.get("config")
+        .and_then(Value::as_object)
+        .and_then(|config| config.get("advanced"))
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("networkType"))
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("lokr"))
+}
+
 fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     if job_requires_gpu(&job.job_type) && worker.gpu_id.eq_ignore_ascii_case("cpu") {
         return false;
@@ -1786,6 +1869,13 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
                 | JobType::PersonReplace
         ) && !video_job_is_mlx_eligible(job)
         {
+            return false;
+        }
+        // Training (epic 3039): the mlx worker trains only the MLX-native families
+        // (z_image / sdxl / wan / ltx) via `mlx_gen::load_trainer`. `kolors_lora` +
+        // `lens_lora` (no mlx-gen crate) and LoKr-on-Wan stay on the Python torch
+        // worker. Applies to both dry-run and real runs.
+        if matches!(job.job_type, JobType::LoraTrain) && !training_job_is_mlx_eligible(job) {
             return false;
         }
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1463,6 +1463,180 @@ fn explicit_gpu_image_job_is_not_deferred_to_mlx_worker() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
 }
 
+// --- Training routing (epic 3039, sc-3043/3049) ---
+
+fn training_caps() -> Vec<WorkerCapability> {
+    vec![
+        WorkerCapability::Gpu,
+        WorkerCapability::LoraTrain,
+        WorkerCapability::LoraTrainExecute,
+    ]
+}
+
+fn mlx_training_job(
+    kernel: &str,
+    base_model: &str,
+    network_type: &str,
+    dry_run: bool,
+    requested_gpu: &str,
+) -> CreateJob {
+    CreateJob {
+        job_type: JobType::LoraTrain,
+        project_id: Some("project-1".to_owned()),
+        project_name: Some("Project 1".to_owned()),
+        payload: object(json!({
+            "dryRun": dry_run,
+            "plan": {
+                "planVersion": 1,
+                "target": { "kernel": kernel, "baseModel": base_model },
+                "config": { "advanced": { "networkType": network_type } }
+            }
+        })),
+        requested_gpu: requested_gpu.to_owned(),
+        source_job_id: None,
+        duplicate_of_job_id: None,
+        attempts: 1,
+    }
+}
+
+#[test]
+fn mlx_eligible_training_job_defers_from_torch_worker_to_idle_mlx_worker() {
+    let store = store("mlx-training-defer");
+    register_gpu_worker(&store, "worker-torch", "mps", training_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
+
+    let job = store
+        .create_job(mlx_training_job(
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+
+    // The torch worker defers the MLX-native training job to the idle mlx worker.
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    // The mlx worker claims it and trains in-process via mlx-gen.
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the training job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn mlx_worker_excluded_from_kolors_training_job() {
+    let store = store("mlx-training-kolors");
+    register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
+
+    // Kolors has no mlx-gen trainer crate → torch path only.
+    let job = store
+        .create_job(mlx_training_job(
+            "kolors_lora",
+            "kolors",
+            "lora",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+
+    // The mlx worker must not claim a torch-only training job.
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+
+    // A torch worker is the home for it.
+    register_gpu_worker(&store, "worker-torch", "mps", training_caps());
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the kolors job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
+#[test]
+fn mlx_worker_excluded_from_lokr_wan_training_job() {
+    let store = store("mlx-training-lokr-wan");
+    register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
+
+    // LoKr-on-Wan has no Kronecker merge in the mlx Wan path → torch only.
+    let job = store
+        .create_job(mlx_training_job(
+            "wan_moe_lora",
+            "wan_2_2_t2v_14b",
+            "lokr",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+
+    register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the LoKr-on-Wan job");
+    assert_eq!(claimed.id, job.id);
+}
+
+#[test]
+fn lokr_z_image_training_stays_mlx_eligible() {
+    let store = store("mlx-training-lokr-zimage");
+    register_gpu_worker(&store, "worker-torch", "mps", training_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
+
+    // LoKr on Z-Image/SDXL/LTX is fine — the Rust engine applies it natively.
+    let job = store
+        .create_job(mlx_training_job(
+            "z_image_lora",
+            "z_image_turbo",
+            "lokr",
+            false,
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the LoKr Z-Image job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn mlx_eligible_training_falls_back_to_torch_when_no_mlx_worker() {
+    let store = store("mlx-training-fallback");
+    // No mlx worker (Windows/Linux, or it's down) — torch is the only path.
+    register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
+
+    let job = store
+        .create_job(mlx_training_job("sdxl_lora", "sdxl", "lora", false, "auto"))
+        .expect("job creates");
+
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the training job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("cuda:0"));
+}
+
 // --- Video routing (epic 3018, sc-3036) ---
 
 fn video_caps() -> Vec<WorkerCapability> {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -60,29 +60,29 @@ mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/ml
 # stories (sc-3022..3035) add their provider here; this scaffold links Z-Image
 # (sc-3022, next) to prove the cross-crate registry path end to end.
 [target.'cfg(target_os = "macos")'.dependencies]
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "269c8a29cb81b43735722d7931d66e35ebb846de" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -151,13 +151,21 @@ pub(crate) fn cpu_gpu() -> DiscoveredGpu {
 }
 
 /// The Apple-Silicon native MLX GPU worker (epic 3018): advertises `image_generate`,
-/// `image_detail` (tile-ControlNet refine, sc-3060), and `video_generate`, served
-/// in-process by the linked mlx-gen engine. `Gpu` (not
+/// `image_detail` (tile-ControlNet refine, sc-3060), `video_generate`, and LoRA/LoKr
+/// `lora_train` + `lora_train_execute` (epic 3039), served in-process by the linked
+/// mlx-gen engine. `Gpu` (not
 /// `Cpu`) so the API's `worker_supports_job` lets GPU jobs route here; it deliberately
 /// does NOT carry the CPU utility capabilities, so downloads/imports/etc. still go to
 /// the CPU worker. `video_generate` is claimed from the video runtime onward (sc-3033);
 /// the procedural stub backs models whose real MLX path is not yet linked (Wan sc-3034,
 /// LTX+audio sc-3035), and the API-side MLX-vs-Python routing is sc-3036.
+///
+/// Training (epic 3039, sc-3043/3049): the engine is always linked on macOS, so this
+/// worker can both validate plans (`lora_train`) and run real training
+/// (`lora_train_execute`) — unlike the Python worker, which advertises execute only
+/// when its torch backend is present. The API gates which `lora_train` jobs reach
+/// here to the MLX-native families (`jobs_store::training_job_is_mlx_eligible`);
+/// `kolors`/`lens` and LoKr-on-Wan stay on the Python torch worker.
 #[cfg(target_os = "macos")]
 pub(crate) fn mlx_gpu() -> DiscoveredGpu {
     DiscoveredGpu {
@@ -170,6 +178,10 @@ pub(crate) fn mlx_gpu() -> DiscoveredGpu {
             // `image_detail` job runs in-process on the engine here too.
             WorkerCapability::ImageDetail,
             WorkerCapability::VideoGenerate,
+            // Native Rust LoRA/LoKr training (epic 3039): plan validation +
+            // real execution, both served in-process by `mlx_gen::load_trainer`.
+            WorkerCapability::LoraTrain,
+            WorkerCapability::LoraTrainExecute,
         ],
         utilization: None,
     }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -45,6 +45,8 @@ mod image_jobs;
 use image_jobs::*;
 mod video_jobs;
 use video_jobs::*;
+mod training_jobs;
+use training_jobs::*;
 mod downloads;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on other platforms it still builds + unit-tests (cross-platform
@@ -479,6 +481,14 @@ async fn run_utility_job(
         JobType::VideoGenerate => run_video_generate_job(api, settings, &job)
             .await
             .map_err(|error| ("Video generation failed.", error)),
+        // Native MLX LoRA/LoKr training (epic 3039, sc-3043/3049), served in-process
+        // by the linked mlx-gen engine on the macOS Apple-Silicon GPU worker. The API
+        // routes only MLX-native families here (jobs_store::training_job_is_mlx_eligible);
+        // kolors/lens + LoKr-on-Wan stay on the Python torch worker, which is also the
+        // Windows/Linux path. Off macOS the execute capability is never advertised.
+        JobType::LoraTrain => run_lora_train_job(api, settings, &job)
+            .await
+            .map_err(|error| ("LoRA training failed.", error)),
         JobType::ModelDownload => run_model_download_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Model download failed.", error)),

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -1,0 +1,883 @@
+//! Native MLX LoRA/LoKr training jobs (epic 3039) — the training analog of
+//! [`image_jobs`](crate::image_jobs)/[`video_jobs`](crate::video_jobs).
+//!
+//! Parses a `lora_train` job into the Rust-resolved [`TrainingPlan`], then either
+//! validates it (dry run) or maps it onto an [`mlx_gen::TrainingRequest`] and drives
+//! `mlx_gen::load_trainer(id, &LoadSpec).train(req, on_progress)` — exactly as the
+//! image path maps `ImageRequest` → `GenerationRequest` and calls `Generator::generate`.
+//! The engine writes the adapter to the plan's `output.outputDir`; the API registers
+//! it from the staged `manifestEntry` + the files on disk (apps/rust-api jobs.rs
+//! `register_trained_lora`), so the streamed `result` here is informational/UI only.
+//!
+//! Routing (sc-3049): the API only sends MLX-native families
+//! (`z_image_lora`/`sdxl_lora`/`wan_lora`/`wan_moe_lora`/`ltx_mlx_lora`) here
+//! (`jobs_store::training_job_is_mlx_eligible`). `kolors`/`lens` and LoKr-on-Wan stay
+//! on the Python torch worker, which also remains the Windows/Linux path + the Mac
+//! fallback. The dry-run validator is cross-platform; the real run is macOS-only
+//! (mlx-gen builds Apple MLX) and unreachable elsewhere (the capability is never
+//! advertised off macOS).
+
+use super::*;
+use sceneworks_core::training::{TrainingPlan, TRAINING_PLAN_VERSION};
+
+// Force each trainer-provider crate to link so its `inventory::submit!` trainer
+// registration survives linker GC and `load_trainer` can find it. The same crates
+// are referenced by image_jobs/video_jobs for generation; re-stating the training
+// dependency here keeps it explicit and independent of those modules.
+#[cfg(target_os = "macos")]
+use mlx_gen::{
+    CancelFlag, LoadSpec, LrSchedule, NetworkType, TrainingConfig, TrainingItem, TrainingOutput,
+    TrainingProgress, TrainingRequest, WeightsSource,
+};
+#[cfg(target_os = "macos")]
+use mlx_gen_ltx as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_sdxl as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_wan as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_z_image as _;
+
+/// Run a `lora_train` job: parse the resolved plan, then either validate it
+/// (dry run, the default) or execute real training. Mirrors the Python
+/// `run_lora_train_job` split (apps/worker/scene_worker/runtime.py).
+pub(crate) async fn run_lora_train_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let plan = parse_plan(&job.payload)?;
+    let dry_run = job
+        .payload
+        .get("dryRun")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    if dry_run {
+        run_training_dry_run(api, settings, job, &plan).await
+    } else {
+        run_training_execution(api, settings, job, &plan).await
+    }
+}
+
+/// Deserialize the Rust-resolved plan stamped into the job payload at submit time
+/// (apps/rust-api training.rs). The plan round-trips through `TrainingPlan`, so a
+/// payload missing/garbling it is a hard error (never a silent no-op).
+fn parse_plan(payload: &JsonObject) -> WorkerResult<TrainingPlan> {
+    let plan = payload.get("plan").ok_or_else(|| {
+        WorkerError::InvalidPayload("Training job payload is missing a resolved plan.".to_owned())
+    })?;
+    serde_json::from_value(plan.clone())
+        .map_err(|error| WorkerError::InvalidPayload(format!("Invalid training plan: {error}")))
+}
+
+/// Validate a resolved plan the way the Python `validate_training_plan` does:
+/// reject an unknown plan version, an empty dataset, or missing dataset images.
+/// Shared by the dry-run validator and the real run so both reject the same inputs.
+fn validate_training_plan(plan: &TrainingPlan) -> WorkerResult<()> {
+    if plan.plan_version != TRAINING_PLAN_VERSION {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Unsupported training plan version {}; this worker understands version {}.",
+            plan.plan_version, TRAINING_PLAN_VERSION
+        )));
+    }
+    if plan.dataset.items.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Training plan dataset has no items to train on.".to_owned(),
+        ));
+    }
+    let missing: Vec<&str> = plan
+        .dataset
+        .items
+        .iter()
+        .filter(|item| !Path::new(&item.image_path).exists())
+        .map(|item| item.image_path.as_str())
+        .collect();
+    if !missing.is_empty() {
+        let preview = missing
+            .iter()
+            .take(3)
+            .copied()
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(WorkerError::InvalidPayload(format!(
+            "{} dataset image(s) are missing on the worker, e.g. {preview}.",
+            missing.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Dry-run: validate the plan and report what a real run would produce, with no
+/// model load or training (so a GPU worker without the engine still validates).
+/// Cross-platform — the validator and summary touch only the plan + the dataset
+/// images on disk. Mirrors the Python `_run_lora_train_dry_run`.
+async fn run_training_dry_run(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &TrainingPlan,
+) -> WorkerResult<()> {
+    let backend = backend_label(&settings.gpu_id);
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        training_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.1,
+            "Validating training plan.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+    validate_training_plan(plan)?;
+    let item_count = plan.dataset.items.len();
+    update_job(
+        api,
+        &job.id,
+        training_progress(
+            JobStatus::Running,
+            ProgressStage::Running,
+            0.5,
+            &format!("Checked {item_count} dataset item(s)."),
+            None,
+            backend,
+        ),
+    )
+    .await?;
+    update_job(
+        api,
+        &job.id,
+        training_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            &format!("Dry run validated {item_count} dataset item(s); training plan is ready."),
+            Some(dry_run_summary(plan)),
+            backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// The dry-run completion summary (keys mirror the Python `dry_run_training_summary`
+/// so the Training Studio reads an identical shape regardless of which worker runs it).
+fn dry_run_summary(plan: &TrainingPlan) -> JsonObject {
+    let base_model_installed = Path::new(&plan.target.base_model_path).exists();
+    let mut summary = JsonObject::new();
+    summary.insert("mode".to_owned(), json!("dry_run"));
+    summary.insert("validated".to_owned(), json!(true));
+    summary.insert("dryRun".to_owned(), json!(true));
+    summary.insert(
+        "datasetItemCount".to_owned(),
+        json!(plan.dataset.items.len()),
+    );
+    summary.insert("datasetId".to_owned(), json!(plan.dataset.dataset_id));
+    summary.insert(
+        "datasetVersion".to_owned(),
+        json!(plan.dataset.dataset_version),
+    );
+    summary.insert("targetId".to_owned(), json!(plan.target.target_id));
+    summary.insert("kernel".to_owned(), json!(plan.target.kernel));
+    summary.insert("loraId".to_owned(), json!(plan.output.lora_id));
+    summary.insert("outputDir".to_owned(), json!(plan.output.output_dir));
+    summary.insert("fileName".to_owned(), json!(plan.output.file_name));
+    summary.insert("baseModel".to_owned(), json!(plan.target.base_model));
+    summary.insert(
+        "baseModelRepo".to_owned(),
+        json!(plan.target.base_model_repo),
+    );
+    summary.insert(
+        "baseModelPath".to_owned(),
+        json!(plan.target.base_model_path),
+    );
+    summary.insert("baseModelInstalled".to_owned(), json!(base_model_installed));
+    summary.insert("planVersion".to_owned(), json!(plan.plan_version));
+    summary
+}
+
+/// A `lora_train` progress update with the worker's backend label (mirrors
+/// `image_jobs::image_progress`). LoRA training keeps `status: running` across the
+/// caching/training/checkpointing/saving stages; only the final update is `completed`.
+fn training_progress(
+    status: JobStatus,
+    stage: ProgressStage,
+    progress: f64,
+    message: &str,
+    result: Option<JsonObject>,
+    backend: &str,
+) -> ProgressRequest {
+    ProgressRequest {
+        status,
+        stage,
+        progress: number_from_f64(progress),
+        message: message.to_owned(),
+        error: None,
+        result,
+        eta_seconds: None,
+        peak_gpu_memory_pct: None,
+        peak_gpu_load_pct: None,
+        backend: Some(backend.to_owned()),
+        extra: BTreeMap::new(),
+    }
+}
+
+// --------------------------------------------------------------------------- #
+// Real training — macOS / Apple-Silicon only (mlx-gen builds Apple MLX). The
+// capability is never advertised off macOS, so the non-macOS arm is unreachable.
+// --------------------------------------------------------------------------- #
+
+/// Map a resolved plan's `(kernel, baseModel)` onto the mlx-gen trainer registry id
+/// (the trainer id matches the generator id of the same base model). Wan splits by
+/// the base model variant: the dense TI2V-5B (`wan_lora`) vs the two A14B MoE
+/// variants (`wan_moe_lora` + the T2V/I2V base model). `None` for a family with no
+/// mlx-gen trainer — those never route here, but the mapping fails loudly if one does.
+#[cfg(target_os = "macos")]
+fn engine_trainer_id(plan: &TrainingPlan) -> Option<&'static str> {
+    match plan.target.kernel.as_str() {
+        "z_image_lora" => Some("z_image_turbo"),
+        "sdxl_lora" => Some("sdxl"),
+        "ltx_mlx_lora" => Some("ltx_2_3"),
+        // Dense Wan2.2-TI2V-5B.
+        "wan_lora" => Some("wan2_2_ti2v_5b"),
+        // A14B dual-expert MoE; the T2V/I2V base model picks the trainer.
+        "wan_moe_lora" => match plan.target.base_model.as_str() {
+            "wan_2_2_t2v_14b" => Some("wan2_2_t2v_14b"),
+            "wan_2_2_i2v_14b" => Some("wan2_2_i2v_14b"),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Read an `advanced` field as a string, trimmed and non-empty, else `default`.
+#[cfg(target_os = "macos")]
+fn advanced_str(advanced: &JsonObject, key: &str, default: &str) -> String {
+    advanced
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_owned()
+}
+
+/// Read an `advanced` field as an f32, else `default`.
+#[cfg(target_os = "macos")]
+fn advanced_f32(advanced: &JsonObject, key: &str, default: f32) -> f32 {
+    advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(default)
+}
+
+/// Read an `advanced` field as a u32, else `default`.
+#[cfg(target_os = "macos")]
+fn advanced_u32(advanced: &JsonObject, key: &str, default: u32) -> u32 {
+    advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_u64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as u32)
+        .unwrap_or(default)
+}
+
+/// Map the SceneWorks `TrainingConfig` (plan `config` + its free-form `advanced`
+/// bag) onto the engine's typed [`mlx_gen::TrainingConfig`]. The optimizer string is
+/// passed verbatim — the engine normalizes aliases (`adamw8bit`→`adamw`,
+/// `prodigyopt`→`prodigy`). An empty `loraTargetModules` lets the family trainer use
+/// its default target set.
+#[cfg(target_os = "macos")]
+fn map_training_config(config: &sceneworks_core::training::TrainingConfig) -> TrainingConfig {
+    let advanced = &config.advanced;
+    let lora_target_modules = advanced
+        .get("loraTargetModules")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_owned))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    TrainingConfig {
+        rank: config.rank,
+        alpha: config.alpha as f32,
+        learning_rate: config.learning_rate.as_f64().unwrap_or(1e-4) as f32,
+        steps: config.steps,
+        batch_size: config.batch_size,
+        gradient_accumulation: config.gradient_accumulation,
+        resolution: config.resolution,
+        save_every: config.save_every,
+        seed: config.seed.max(0) as u64,
+        optimizer: config.optimizer.clone(),
+        weight_decay: advanced_f32(advanced, "weightDecay", 0.0),
+        lr_scheduler: LrSchedule::parse(&advanced_str(advanced, "lrScheduler", "constant")),
+        lr_warmup_steps: advanced_u32(advanced, "lrWarmupSteps", 0),
+        network_type: NetworkType::parse(&advanced_str(advanced, "networkType", "lora")),
+        decompose_factor: advanced
+            .get("decomposeFactor")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32)
+            .unwrap_or(-1),
+        lora_target_modules,
+        timestep_type: advanced_str(advanced, "timestepType", "sigmoid"),
+        timestep_bias: advanced_str(advanced, "timestepBias", "balanced"),
+        loss_type: advanced_str(advanced, "lossType", "mse"),
+        trigger_word: config.trigger_word.clone(),
+    }
+}
+
+/// One progress event streamed from the blocking training thread to the async side.
+#[cfg(target_os = "macos")]
+enum TrainEvent {
+    Progress(TrainingProgress),
+    Done(TrainingOutput),
+}
+
+/// Execute a real training run on the in-process mlx-gen engine. Loads the (frozen)
+/// base model via a [`LoadSpec`] (exactly as inference's `mlx_load`), runs the
+/// family trainer on a blocking thread, streams staged progress, honors cancellation
+/// via the engine's [`CancelFlag`], and reports the produced adapter. The adapter is
+/// written by the engine into the plan's `output.outputDir`; the API registers it
+/// from the staged manifest entry.
+#[cfg(target_os = "macos")]
+async fn run_training_execution(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &TrainingPlan,
+) -> WorkerResult<()> {
+    let backend = backend_label(&settings.gpu_id);
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        training_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.05,
+            "Preparing LoRA training.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+
+    validate_training_plan(plan)?;
+
+    let engine_id = engine_trainer_id(plan).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "No MLX trainer for kernel '{}' (base model '{}').",
+            plan.target.kernel, plan.target.base_model
+        ))
+    })?;
+
+    let weights_dir = PathBuf::from(&plan.target.base_model_path);
+    if !weights_dir.is_dir() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Base model weights are not installed at {}.",
+            weights_dir.display()
+        )));
+    }
+
+    let output_dir = PathBuf::from(&plan.output.output_dir);
+    tokio::fs::create_dir_all(&output_dir).await?;
+
+    let items: Vec<TrainingItem> = plan
+        .dataset
+        .items
+        .iter()
+        .map(|item| TrainingItem {
+            image_path: PathBuf::from(&item.image_path),
+            caption: item.caption.clone(),
+        })
+        .collect();
+    let config = map_training_config(&plan.config);
+    let total_steps = config.steps;
+    let file_name = plan.output.file_name.clone();
+    let trigger_words = plan.output.trigger_words.clone();
+
+    check_cancel(api, &job.id, "LoRA training canceled before it started.").await?;
+
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<TrainEvent>(64);
+
+    let blocking = {
+        let cancel = cancel.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let mut trainer =
+                mlx_gen::load_trainer(engine_id, &LoadSpec::new(WeightsSource::Dir(weights_dir)))
+                    .map_err(|error| {
+                    WorkerError::InvalidPayload(format!("{engine_id} trainer load failed: {error}"))
+                })?;
+            let request = TrainingRequest {
+                items,
+                config,
+                output_dir,
+                file_name,
+                trigger_words,
+                cancel,
+            };
+            trainer.validate(&request).map_err(|error| {
+                WorkerError::InvalidPayload(format!(
+                    "{engine_id} trainer rejected the plan: {error}"
+                ))
+            })?;
+            let mut on_progress = |progress: TrainingProgress| {
+                let _ = tx.blocking_send(TrainEvent::Progress(progress));
+            };
+            let output = trainer.train(&request, &mut on_progress).map_err(|error| {
+                WorkerError::InvalidPayload(format!("training failed: {error}"))
+            })?;
+            let _ = tx.blocking_send(TrainEvent::Done(output));
+            Ok(())
+        })
+    };
+
+    consume_training_events(
+        api,
+        settings,
+        job,
+        plan,
+        backend,
+        total_steps,
+        rx,
+        cancel,
+        blocking,
+    )
+    .await
+}
+
+/// Consume training events from the blocking thread: stream staged progress, poll
+/// cancel ~every 2s (draining after a cancel so the blocking sender never blocks),
+/// and on the final `Done` event report completion with the result the UI shows.
+/// Mirrors `image_jobs::consume_gen_events`.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn consume_training_events(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &TrainingPlan,
+    backend: &str,
+    total_steps: u32,
+    mut rx: tokio::sync::mpsc::Receiver<TrainEvent>,
+    cancel: CancelFlag,
+    blocking: tokio::task::JoinHandle<WorkerResult<()>>,
+) -> WorkerResult<()> {
+    let mut canceled = false;
+    let mut last_cancel_check = Instant::now();
+    let mut checkpoints: Vec<Value> = Vec::new();
+    while let Some(event) = rx.recv().await {
+        if canceled {
+            continue; // drain remaining events so the blocking sender never blocks.
+        }
+        match event {
+            TrainEvent::Progress(progress) => {
+                // Poll cancel on the long training band only (cheap stages fly by).
+                if matches!(progress, TrainingProgress::Training { .. })
+                    && last_cancel_check.elapsed() >= Duration::from_secs(2)
+                {
+                    last_cancel_check = Instant::now();
+                    if check_cancel(api, &job.id, "LoRA training canceled by user.")
+                        .await
+                        .is_err()
+                    {
+                        cancel.cancel();
+                        canceled = true;
+                        continue;
+                    }
+                }
+                if let TrainingProgress::Checkpoint { step } = progress {
+                    checkpoints.push(json!({ "step": step }));
+                }
+                let (status, stage, fraction, message) =
+                    map_training_progress(progress, total_steps);
+                update_job(
+                    api,
+                    &job.id,
+                    training_progress(status, stage, fraction, &message, None, backend),
+                )
+                .await?;
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+            }
+            TrainEvent::Done(output) => {
+                let result = training_result(plan, &output, &checkpoints);
+                update_job(
+                    api,
+                    &job.id,
+                    training_progress(
+                        JobStatus::Completed,
+                        ProgressStage::Completed,
+                        1.0,
+                        &format!("Trained LoRA saved as {}.", plan.output.file_name),
+                        Some(result),
+                        backend,
+                    ),
+                )
+                .await?;
+            }
+        }
+    }
+
+    let task_result = blocking
+        .await
+        .map_err(|error| WorkerError::InvalidPayload(format!("training task join: {error}")))?;
+    if canceled {
+        // check_cancel already posted the Canceled update; treat the engine's
+        // early return as the clean cancel.
+        return Err(WorkerError::Canceled(
+            "LoRA training canceled by user.".to_owned(),
+        ));
+    }
+    task_result
+}
+
+/// Map an engine [`TrainingProgress`] event onto a job `(status, stage, fraction,
+/// message)`. The fractions follow the kernel's bands (prepare 0–.08, load .08–.18,
+/// cache .18–.32, train/checkpoint .32–.92, save .92–1.0) so the UI's existing
+/// `caching_latents`/`training`/`checkpointing`/`saving` stages light up unchanged.
+#[cfg(target_os = "macos")]
+fn map_training_progress(
+    progress: TrainingProgress,
+    total_steps: u32,
+) -> (JobStatus, ProgressStage, f64, String) {
+    match progress {
+        TrainingProgress::Preparing => (
+            JobStatus::Running,
+            ProgressStage::Preparing,
+            0.06,
+            "Preparing dataset.".to_owned(),
+        ),
+        TrainingProgress::LoadingModel => (
+            JobStatus::Running,
+            ProgressStage::LoadingModel,
+            0.12,
+            "Loading base model.".to_owned(),
+        ),
+        TrainingProgress::Caching { current, total } => {
+            let span = if total == 0 {
+                0.0
+            } else {
+                0.14 * (current as f64 / total as f64)
+            };
+            (
+                JobStatus::Running,
+                ProgressStage::CachingLatents,
+                0.18 + span,
+                format!("Caching dataset latents ({current}/{total})."),
+            )
+        }
+        TrainingProgress::Training { step, total, loss } => (
+            JobStatus::Running,
+            ProgressStage::Training,
+            train_fraction(step, total),
+            format!("Training step {step} of {total} (loss {loss:.4})."),
+        ),
+        TrainingProgress::Checkpoint { step } => (
+            JobStatus::Running,
+            ProgressStage::Checkpointing,
+            train_fraction(step, total_steps.max(step)),
+            format!("Saved checkpoint at step {step}."),
+        ),
+        TrainingProgress::Saving => (
+            JobStatus::Running,
+            ProgressStage::Saving,
+            0.94,
+            "Saving adapter.".to_owned(),
+        ),
+    }
+}
+
+/// Scale a training micro-step into the 0.32–0.92 training band.
+#[cfg(target_os = "macos")]
+fn train_fraction(step: u32, total: u32) -> f64 {
+    if total == 0 {
+        return 0.32;
+    }
+    0.32 + 0.60 * (step as f64 / total as f64).clamp(0.0, 1.0)
+}
+
+/// Build the completion `result` the Training Studio reads (keys mirror the Python
+/// trainer's `_result`). LoRA registration is driven by the staged `manifestEntry` +
+/// the on-disk adapter (apps/rust-api `register_trained_lora`), not this result, so
+/// this is informational/UI metadata.
+#[cfg(target_os = "macos")]
+fn training_result(
+    plan: &TrainingPlan,
+    output: &TrainingOutput,
+    checkpoints: &[Value],
+) -> JsonObject {
+    let mut result = JsonObject::new();
+    result.insert("mode".to_owned(), json!("train"));
+    result.insert("kernel".to_owned(), json!(plan.target.kernel));
+    result.insert("loraId".to_owned(), json!(plan.output.lora_id));
+    result.insert("outputDir".to_owned(), json!(plan.output.output_dir));
+    result.insert("fileName".to_owned(), json!(plan.output.file_name));
+    result.insert(
+        "outputPath".to_owned(),
+        json!(output.adapter_path.display().to_string()),
+    );
+    result.insert("format".to_owned(), json!(plan.output.format));
+    result.insert("datasetId".to_owned(), json!(plan.dataset.dataset_id));
+    result.insert(
+        "datasetVersion".to_owned(),
+        json!(plan.dataset.dataset_version),
+    );
+    result.insert(
+        "datasetItemCount".to_owned(),
+        json!(plan.dataset.items.len()),
+    );
+    result.insert("targetId".to_owned(), json!(plan.target.target_id));
+    result.insert("baseModel".to_owned(), json!(plan.target.base_model));
+    result.insert("steps".to_owned(), json!(plan.config.steps));
+    result.insert("stepsCompleted".to_owned(), json!(output.steps));
+    result.insert("finalLoss".to_owned(), json!(output.final_loss));
+    result.insert("checkpoints".to_owned(), json!(checkpoints));
+    result.insert("rank".to_owned(), json!(plan.config.rank));
+    result.insert("alpha".to_owned(), json!(plan.config.alpha));
+    result.insert("resolution".to_owned(), json!(plan.config.resolution));
+    result.insert("triggerWords".to_owned(), json!(plan.output.trigger_words));
+    result.insert("planVersion".to_owned(), json!(plan.plan_version));
+    result.insert("backend".to_owned(), json!("mlx"));
+    result
+}
+
+/// Off macOS the mlx-gen engine is not linked; the `lora_train_execute` capability is
+/// never advertised, so a real run can never be claimed here. Fail loudly if one is.
+#[cfg(not(target_os = "macos"))]
+async fn run_training_execution(
+    _api: &ApiClient,
+    _settings: &Settings,
+    _job: &JobSnapshot,
+    _plan: &TrainingPlan,
+) -> WorkerResult<()> {
+    Err(WorkerError::InvalidPayload(
+        "Native MLX LoRA training requires macOS (mlx-gen); this worker cannot execute it."
+            .to_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A complete resolved plan as the API serializes it, parameterized by the
+    /// fields the worker glue reads. `baseModelPath` is a path that does not exist,
+    /// so `baseModelInstalled` is false unless a test overrides it.
+    fn plan_json(
+        kernel: &str,
+        base_model: &str,
+        network_type: &str,
+        image_paths: &[&str],
+    ) -> Value {
+        let items: Vec<Value> = image_paths
+            .iter()
+            .map(|path| json!({ "imagePath": path, "caption": "a photo of mychar" }))
+            .collect();
+        json!({
+            "schemaVersion": 1,
+            "planVersion": 1,
+            "jobId": "job-1",
+            "target": {
+                "targetId": format!("{kernel}_target"),
+                "kernel": kernel,
+                "family": "test",
+                "modality": "image",
+                "outputKind": "lora",
+                "baseModel": base_model,
+                "baseModelPath": "/tmp/sceneworks-test-base-does-not-exist"
+            },
+            "dataset": {
+                "datasetId": "ds-1",
+                "datasetVersion": 1,
+                "rootPath": "/tmp/ds",
+                "items": items
+            },
+            "config": {
+                "rank": 16,
+                "alpha": 32,
+                "learningRate": 0.0001,
+                "steps": 1000,
+                "batchSize": 1,
+                "gradientAccumulation": 2,
+                "resolution": 1024,
+                "saveEvery": 250,
+                "seed": 42,
+                "optimizer": "adamw8bit",
+                "advanced": {
+                    "networkType": network_type,
+                    "lrScheduler": "cosine",
+                    "lrWarmupSteps": 50,
+                    "weightDecay": 0.01,
+                    "decomposeFactor": 8,
+                    "loraTargetModules": ["to_q", "to_k"],
+                    "timestepType": "sigmoid",
+                    "timestepBias": "high_noise",
+                    "lossType": "mse"
+                }
+            },
+            "output": {
+                "loraId": "lora-1",
+                "outputDir": "/tmp/out",
+                "fileName": "lora.safetensors",
+                "format": "safetensors",
+                "triggerWords": ["mychar"]
+            },
+            "provenance": {
+                "datasetId": "ds-1",
+                "datasetVersion": 1,
+                "targetId": format!("{kernel}_target"),
+                "baseModel": base_model,
+                "configSnapshot": {},
+                "outputLoraId": "lora-1",
+                "sourceJobId": "job-1",
+                "createdAt": "2026-06-06T00:00:00Z"
+            }
+        })
+    }
+
+    fn parse(value: Value) -> TrainingPlan {
+        serde_json::from_value(value).expect("plan deserializes")
+    }
+
+    #[test]
+    fn validate_rejects_unknown_plan_version() {
+        let mut value = plan_json("z_image_lora", "z_image_turbo", "lora", &["/tmp/x.png"]);
+        value["planVersion"] = json!(999);
+        let error = validate_training_plan(&parse(value)).expect_err("version mismatch rejected");
+        assert!(error
+            .to_string()
+            .contains("Unsupported training plan version"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_dataset() {
+        let plan = parse(plan_json("z_image_lora", "z_image_turbo", "lora", &[]));
+        let error = validate_training_plan(&plan).expect_err("empty dataset rejected");
+        assert!(error.to_string().contains("no items"));
+    }
+
+    #[test]
+    fn validate_rejects_missing_image() {
+        let plan = parse(plan_json(
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &["/tmp/sceneworks-missing-7f3a9c.png"],
+        ));
+        let error = validate_training_plan(&plan).expect_err("missing image rejected");
+        assert!(error.to_string().contains("missing on the worker"));
+    }
+
+    #[test]
+    fn validate_accepts_present_images() {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let path = file.path().to_string_lossy().into_owned();
+        let plan = parse(plan_json("z_image_lora", "z_image_turbo", "lora", &[&path]));
+        assert!(validate_training_plan(&plan).is_ok());
+    }
+
+    #[test]
+    fn dry_run_summary_carries_plan_facts() {
+        let plan = parse(plan_json(
+            "sdxl_lora",
+            "sdxl",
+            "lora",
+            &["/tmp/a.png", "/tmp/b.png"],
+        ));
+        let summary = dry_run_summary(&plan);
+        assert_eq!(summary.get("mode").unwrap(), "dry_run");
+        assert_eq!(summary.get("kernel").unwrap(), "sdxl_lora");
+        assert_eq!(summary.get("datasetItemCount").unwrap(), 2);
+        assert_eq!(summary.get("loraId").unwrap(), "lora-1");
+        assert_eq!(summary.get("fileName").unwrap(), "lora.safetensors");
+        // The placeholder base path does not exist.
+        assert_eq!(summary.get("baseModelInstalled").unwrap(), false);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn engine_trainer_id_maps_mlx_native_families_and_rejects_the_rest() {
+        let cases: &[(&str, &str, Option<&str>)] = &[
+            ("z_image_lora", "z_image_turbo", Some("z_image_turbo")),
+            ("sdxl_lora", "sdxl", Some("sdxl")),
+            ("ltx_mlx_lora", "ltx_2_3", Some("ltx_2_3")),
+            ("wan_lora", "wan_2_2", Some("wan2_2_ti2v_5b")),
+            ("wan_moe_lora", "wan_2_2_t2v_14b", Some("wan2_2_t2v_14b")),
+            ("wan_moe_lora", "wan_2_2_i2v_14b", Some("wan2_2_i2v_14b")),
+            // No mlx-gen trainer crate — these never route here, but map to None.
+            ("kolors_lora", "kolors", None),
+            ("lens_lora", "lens", None),
+            // Unknown A14B base model variant.
+            ("wan_moe_lora", "wan_2_2_mystery", None),
+        ];
+        for (kernel, base_model, expected) in cases {
+            let plan = parse(plan_json(kernel, base_model, "lora", &["/tmp/x.png"]));
+            assert_eq!(
+                engine_trainer_id(&plan),
+                *expected,
+                "kernel={kernel} base_model={base_model}"
+            );
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn map_training_config_reads_advanced_and_passes_optimizer_verbatim() {
+        let plan = parse(plan_json(
+            "z_image_lora",
+            "z_image_turbo",
+            "lokr",
+            &["/tmp/x.png"],
+        ));
+        let cfg = map_training_config(&plan.config);
+        assert_eq!(cfg.rank, 16);
+        assert_eq!(cfg.alpha as u32, 32);
+        assert_eq!(cfg.steps, 1000);
+        assert_eq!(cfg.gradient_accumulation, 2);
+        assert_eq!(cfg.seed, 42);
+        // The optimizer alias is passed verbatim; the engine normalizes it.
+        assert_eq!(cfg.optimizer, "adamw8bit");
+        assert!((cfg.weight_decay - 0.01).abs() < 1e-6);
+        assert!((cfg.learning_rate - 0.0001).abs() < 1e-6);
+        assert_eq!(cfg.lr_warmup_steps, 50);
+        assert_eq!(cfg.decompose_factor, 8);
+        assert!(matches!(cfg.network_type, NetworkType::Lokr));
+        assert!(matches!(cfg.lr_scheduler, LrSchedule::Cosine));
+        assert_eq!(
+            cfg.lora_target_modules,
+            vec!["to_q".to_owned(), "to_k".to_owned()]
+        );
+        assert_eq!(cfg.timestep_bias, "high_noise");
+        assert_eq!(cfg.trigger_word, None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn map_training_config_defaults_when_advanced_is_empty() {
+        let mut value = plan_json("sdxl_lora", "sdxl", "lora", &["/tmp/x.png"]);
+        value["config"]["advanced"] = json!({});
+        let plan = parse(value);
+        let cfg = map_training_config(&plan.config);
+        assert!(matches!(cfg.network_type, NetworkType::Lora));
+        assert!(matches!(cfg.lr_scheduler, LrSchedule::Constant));
+        assert_eq!(cfg.lr_warmup_steps, 0);
+        assert_eq!(cfg.decompose_factor, -1);
+        assert!(cfg.lora_target_modules.is_empty());
+        assert_eq!(cfg.timestep_type, "sigmoid");
+        assert_eq!(cfg.loss_type, "mse");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.2.0",
   "description": "Local AI image and video generation studio runtime skeleton.",
+  "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "dev": "docker compose up --build",
     "stack:up": "docker compose up --build",


### PR DESCRIPTION
Epic [3039](https://app.shortcut.com/trefry/epic/3039) cross-repo tail. The engine side (sc-3042/3044/3045/3046/3047/3279/3048) is merged on mlx-gen `main` (PRs #142–147); this lands the SceneWorks worker piece (sc-3043) + the Mac→Rust training routing (sc-3049 Phase A). Branches into `rust-mlx-integration` per epic convention.

## What this does
On Mac, MLX-native LoRA/LoKr training now runs in-process on the Rust mlx-gen engine (preferred). The Python torch trainer stays the fallback (mlx worker busy/down) **and** the Windows/Linux path — no torch trainer is deleted here.

- **`crates/sceneworks-worker/src/training_jobs.rs`** (new) — `run_lora_train_job`: parses the resolved `TrainingPlan`; dry-run validate + summary (cross-platform); real-run dispatch via `mlx_gen::load_trainer(id).train(req, on_progress)` on a blocking thread with staged progress (`caching_latents`/`training`/`checkpointing`/`saving`) + cooperative cancel. Maps kernel+baseModel → engine trainer id and `TrainingConfig` → `mlx_gen::TrainingConfig` (optimizer passed verbatim; engine normalizes `adamw8bit`/`prodigyopt`).
- **`lib.rs`** — `JobType::LoraTrain` dispatch arm.
- **`gpu.rs`** — the mlx worker advertises `lora_train` + `lora_train_execute`.
- **`jobs_store.rs`** — `training_job_is_mlx_eligible` (`z_image_lora`/`sdxl_lora`/`wan_lora`/`wan_moe_lora`/`ltx_mlx_lora`; LoKr-on-Wan excluded → torch) + `should_defer_training_to_mlx_worker` + the `worker_supports_job` gate so `kolors`/`lens` + LoKr-on-Wan stay on the Python torch worker.
- **Cargo** — bump mlx-gen rev `269c8a2`→`4ea5d86` (the merged trainer surface) across the 8 worker deps; `mlx-rs` pin unchanged so MLX builds once.

## Scope correction on sc-3049 (high confidence)
The story text said "delete the torch Z-Image/SDXL/Wan trainers." Taken literally that **breaks LoRA training on Windows/CUDA** — mlx-gen is macOS-only and the mlx worker only exists `#[cfg(macos)]`, so torch is the only Windows path (and the Mac fallback). This PR matches the sc-3060 inference-cutover precedent: add Mac→Rust routing, keep torch for Windows + Mac fallback. No torch trainer deleted.

## Verification
`npm run rust:check` green — fmt clean, clippy `-D warnings` clean (all crates), tests green (core 114 lib + 55 jobs_store + 30 training_contracts, rust-api 91, worker 109 lib + nax guard), build clean. 5 new routing tests + 8 new `training_jobs` unit tests.

## Remaining (sc-3049 Phase B — parity-gated, needs real Apple-Silicon hardware)
1. Torch-vs-Rust parity validation (same dataset/seed; loss curve + adapter effect) — the story's own pre-deletion gate.
2. Then delete the Apple-Silicon-only Python `_LtxMlxLoraBackend`/`LtxMlxLoraTrainer` + drop `ltx_mlx_lora` from `_TRAINING_KERNELS` + add the torch-worker hard-refuse for `ltx_mlx_lora`.

Parity checkpoints to confirm: per-family `baseModelPath` layout (diffusers vs MLX-native) matches the engine trainer's `from_weights`; the Rust trainers don't render in-training `sampleEvery` previews (torch did) — adapter output unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)