### PR TITLE
sc-3397: Qwen-Image-Edit through the Rust GPU worker

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1606,6 +1606,9 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux_schnell",
     "flux_dev",
     "qwen_image",
+    "qwen_image_edit",
+    "qwen_image_edit_2509",
+    "qwen_image_edit_2511",
     "flux2_klein_9b",
     "flux2_klein_9b_kv",
     "flux2_klein_9b_true_v2",
@@ -1639,6 +1642,9 @@ fn image_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
         "z_image_turbo" => z_image_mlx_eligible(&job.payload),
         "flux_schnell" | "flux_dev" => flux_mlx_eligible(&job.payload),
         "qwen_image" => qwen_mlx_eligible(&job.payload),
+        "qwen_image_edit" | "qwen_image_edit_2509" | "qwen_image_edit_2511" => {
+            qwen_edit_mlx_eligible(&job.payload)
+        }
         "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" => {
             flux2_mlx_eligible(&job.payload)
         }
@@ -1719,6 +1725,34 @@ fn qwen_mlx_eligible(payload: &Map<String, Value>) -> bool {
         return false;
     }
     !request_has_lycoris_lora(payload)
+}
+
+/// Qwen-Image-Edit (sc-3397) MLX-routing conditions. The `qwen_image_edit` / `_2509` /
+/// `_2511` ids run the engine's `qwen_image_edit` model on the Rust worker (the edit
+/// sibling of `qwen_mlx_eligible`). Eligible when the job carries the reference the edit
+/// model requires: `edit_image` with a `sourceAssetId` (or a `referenceAssetId`), or
+/// `character_image` with a `referenceAssetId` (the subject-variation / best-effort-pose
+/// / angle-set flows — all reference-conditioned). A third-party LyCORIS LoRA falls back
+/// to torch (engine + worker apply LoRA + peft LoKr, but not arbitrary LyCORIS). The
+/// `_2511_lightning` distill is not routed here yet (needs the sampler + distill-LoRA
+/// wiring of sc-3398), and base-Qwen strict pose stays on torch until epic 3401 lands.
+fn qwen_edit_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    if request_has_lycoris_lora(payload) {
+        return false;
+    }
+    let has_reference = payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    let has_source = payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    match payload.get("mode").and_then(Value::as_str) {
+        Some("edit_image") => has_source || has_reference,
+        Some("character_image") => has_reference,
+        _ => false,
+    }
 }
 
 /// FLUX.1 (sc-3023) MLX-routing conditions, ported from `_should_route_flux_to_mlx`:
@@ -2260,8 +2294,8 @@ fn sort_json_value(value: &mut Value) {
 #[cfg(test)]
 mod mlx_routing_tests {
     use super::{
-        flux2_mlx_eligible, flux_mlx_eligible, qwen_mlx_eligible, request_has_lycoris_lora,
-        sdxl_mlx_eligible, z_image_mlx_eligible,
+        flux2_mlx_eligible, flux_mlx_eligible, qwen_edit_mlx_eligible, qwen_mlx_eligible,
+        request_has_lycoris_lora, sdxl_mlx_eligible, z_image_mlx_eligible,
     };
     use serde_json::{json, Map, Value};
 
@@ -2373,6 +2407,61 @@ mod mlx_routing_tests {
             "advanced": { "poses": [{ "id": "p1" }] }
         }))));
         assert!(!qwen_mlx_eligible(&object(json!({
+            "loras": [{ "networkType": "lycoris" }]
+        }))));
+    }
+
+    #[test]
+    fn qwen_edit_routes_edit_and_reference_flows_to_mlx() {
+        // sc-3397: the qwen_image_edit ids run the engine's `qwen_image_edit` model.
+        // edit_image with a source → eligible.
+        assert!(qwen_edit_mlx_eligible(&object(json!({
+            "mode": "edit_image", "sourceAssetId": "src_1"
+        }))));
+        // character_image with a reference (subject variation) → eligible.
+        assert!(qwen_edit_mlx_eligible(&object(json!({
+            "mode": "character_image", "referenceAssetId": "ref_1"
+        }))));
+        // character_image + reference + best-effort poses → still eligible. Unlike the base
+        // Qwen strict-pose ControlNet (torch until epic 3401), the edit best-effort pose tier
+        // is native multi-image ([reference, skeleton]) → MLX.
+        assert!(qwen_edit_mlx_eligible(&object(json!({
+            "mode": "character_image", "referenceAssetId": "ref_1",
+            "advanced": { "poses": [{ "id": "p1" }] }
+        }))));
+        // character_image + reference + angle set → eligible.
+        assert!(qwen_edit_mlx_eligible(&object(json!({
+            "mode": "character_image", "referenceAssetId": "ref_1",
+            "advanced": { "angleSet": true }
+        }))));
+        // A peft LoKr is fine on the MLX edit path.
+        assert!(qwen_edit_mlx_eligible(&object(json!({
+            "mode": "edit_image", "sourceAssetId": "src_1",
+            "loras": [{ "networkType": "lokr" }]
+        }))));
+    }
+
+    #[test]
+    fn qwen_edit_without_reference_or_with_lycoris_falls_back_to_torch() {
+        // edit_image with nothing to edit (no source, no reference) → torch.
+        assert!(!qwen_edit_mlx_eligible(&object(
+            json!({ "mode": "edit_image" })
+        )));
+        // character_image without a reference → torch (the edit model needs a reference).
+        assert!(!qwen_edit_mlx_eligible(&object(
+            json!({ "mode": "character_image" })
+        )));
+        // A plain txt2img mode is not an edit job (that's the base qwen_image MLX path).
+        assert!(!qwen_edit_mlx_eligible(&object(json!({
+            "mode": "text_to_image", "sourceAssetId": "src_1"
+        }))));
+        // Whitespace-only ids are treated as absent.
+        assert!(!qwen_edit_mlx_eligible(&object(json!({
+            "mode": "edit_image", "sourceAssetId": "   "
+        }))));
+        // Third-party LyCORIS has no native MLX loader → torch.
+        assert!(!qwen_edit_mlx_eligible(&object(json!({
+            "mode": "edit_image", "sourceAssetId": "src_1",
             "loras": [{ "networkType": "lycoris" }]
         }))));
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1439,6 +1439,38 @@ fn mlx_eligible_image_job_defers_from_torch_worker_to_idle_mlx_worker() {
 }
 
 #[test]
+fn qwen_edit_image_job_defers_to_mlx_worker() {
+    let store = store("mlx-routing-qwen-edit");
+    register_gpu_worker(&store, "worker-torch", "mps", image_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
+
+    // Qwen-Image-Edit (sc-3397): an edit_image job with a source routes to the mlx worker.
+    let job = store
+        .create_job(image_job_with(
+            json!({
+                "model": "qwen_image_edit_2511",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1",
+                "prompt": "make it a watercolor painting"
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    // The torch worker defers it to the idle mlx worker, which claims it.
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
 fn mlx_worker_excluded_from_torch_only_image_job() {
     let store = store("mlx-routing-exclude");
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -102,11 +102,50 @@ const MLX_MODELS: &[MlxModel] = &[
     MlxModel {
         // Non-distilled true-CFG base: 20 steps + guidance 4.0 + negative prompt
         // (Python MODEL_TARGETS / MlxQwenAdapter). mlx-gen's own default is 4 steps,
-        // so steps are passed explicitly. Edit + strict-pose ControlNet stay on torch.
+        // so steps are passed explicitly. Edit moves to MLX (sc-3397, the `qwen_image_edit`
+        // engine model below); base-Qwen strict-pose ControlNet stays on torch until the
+        // engine port lands (epic 3401).
         sceneworks_id: "qwen_image",
         engine_id: "qwen_image",
         default_repo: "Qwen/Qwen-Image",
         default_steps: 20,
+        supports_guidance: true,
+        default_guidance: 4.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_qwen",
+    },
+    // Qwen-Image-Edit (sc-3397) — the three base edit ids all resolve to the engine's
+    // single `qwen_image_edit` model (Reference/MultiReference, true CFG, LoRA/LoKr, Q4/Q8);
+    // `qwen_image_edit`/`_2509` alias to the 2511 weights (Python MODEL_TARGETS, sc-2160).
+    // 40 steps (engine's own default is 4 — passed explicitly, like the txt2img row). The
+    // edit path resolves guidance from `trueCfgScale` (4.0), NOT `guidanceScale`; see
+    // `resolve_qwen_edit_guidance`. The `_2511_lightning` distill (sampler + lightx2v LoRA)
+    // is a separate story (sc-3398) and is intentionally absent here.
+    MlxModel {
+        sceneworks_id: "qwen_image_edit",
+        engine_id: "qwen_image_edit",
+        default_repo: "Qwen/Qwen-Image-Edit-2511",
+        default_steps: 40,
+        supports_guidance: true,
+        default_guidance: 4.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_qwen",
+    },
+    MlxModel {
+        sceneworks_id: "qwen_image_edit_2509",
+        engine_id: "qwen_image_edit",
+        default_repo: "Qwen/Qwen-Image-Edit-2511",
+        default_steps: 40,
+        supports_guidance: true,
+        default_guidance: 4.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_qwen",
+    },
+    MlxModel {
+        sceneworks_id: "qwen_image_edit_2511",
+        engine_id: "qwen_image_edit",
+        default_repo: "Qwen/Qwen-Image-Edit-2511",
+        default_steps: 40,
         supports_guidance: true,
         default_guidance: 4.0,
         supports_negative_prompt: true,
@@ -211,7 +250,7 @@ pub(crate) async fn run_image_generate_job(
     // the requested `count` (sc-3030) — bake the real total into the plan so the
     // generation set + streamed `expectedCount` match what lands in the gallery.
     #[cfg(target_os = "macos")]
-    let plan = ImagePlan::with_count(&request, flux2_image_count(&request, settings));
+    let plan = ImagePlan::with_count(&request, grouped_image_count(&request, settings));
     #[cfg(not(target_os = "macos"))]
     let plan = ImagePlan::with_count(&request, request.count);
 
@@ -266,6 +305,20 @@ pub(crate) async fn run_image_generate_job(
     } else if flux2_edit_available(&request, settings) {
         // FLUX.2-klein edit/reference (mode edit_image or a reference) → edit variant.
         generate_flux2_edit_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if qwen_edit_available(&request, settings) {
+        // Qwen-Image-Edit (mode edit_image / Character-Studio reference / best-effort
+        // pose / angle set) → the engine's `qwen_image_edit` model (sc-3397).
+        generate_qwen_edit_stream(
             api,
             settings,
             job,
@@ -2259,6 +2312,398 @@ async fn generate_flux2_edit_stream(
 }
 
 // ---------------------------------------------------------------------------
+// Qwen-Image-Edit (macOS, sc-3397): the `qwen_image_edit` / `_2509` / `_2511` ids, all
+// served by the engine's single `qwen_image_edit` model (Reference/MultiReference
+// dual-latent). This is where Qwen edit/reference jobs run — `edit_image`, the
+// Character-Studio reference flow (subject variation), the 11-angle set, and the
+// best-effort pose tier (`[reference, skeleton]` multi-image). True CFG (negative prompt
+// + guidance from `trueCfgScale`), LoRA/LoKr, Q4/Q8, fit_image. Base-Qwen strict-pose
+// ControlNet stays on torch until the engine port lands (epic 3401); the `_2511_lightning`
+// distill (sampler + lightx2v LoRA) is sc-3398.
+// ---------------------------------------------------------------------------
+
+/// The engine edit-model id for a Qwen SceneWorks model, or `None` if it has no edit
+/// variant. `qwen_image_edit` / `_2509` / `_2511` all map to the single `qwen_image_edit`
+/// engine model (`_2511_lightning` is sc-3398, deliberately excluded).
+#[cfg(target_os = "macos")]
+fn qwen_edit_engine_id(model: &str) -> Option<&'static str> {
+    match model {
+        "qwen_image_edit" | "qwen_image_edit_2509" | "qwen_image_edit_2511" => {
+            Some("qwen_image_edit")
+        }
+        _ => None,
+    }
+}
+
+/// Reference asset ids for a Qwen edit: the character-flow `referenceAssetId`, else the
+/// Image-Edit `sourceAssetId` (edit_image mode). Mirrors the Python
+/// `ref = referenceAssetId or (sourceAssetId if edit_image)` and the FLUX.2 edit path.
+#[cfg(target_os = "macos")]
+fn qwen_edit_reference_ids(request: &ImageRequest) -> Vec<String> {
+    if let Some(id) = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        return vec![id.to_owned()];
+    }
+    if request.mode == "edit_image" {
+        if let Some(id) = request
+            .source_asset_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+        {
+            return vec![id.to_owned()];
+        }
+    }
+    Vec::new()
+}
+
+/// True when this is a Qwen edit job (a qwen edit-capable model + ≥1 reference) whose
+/// weights resolve — routed to the `qwen_image_edit` engine model rather than txt2img.
+#[cfg(target_os = "macos")]
+fn qwen_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
+    qwen_edit_engine_id(&request.model).is_some()
+        && !qwen_edit_reference_ids(request).is_empty()
+        && resolve_weights_dir(request, settings).is_some()
+}
+
+/// The number of images this image_generate job produces, accounting for grouped edit
+/// sets (Character-Studio angle set = 11, best-effort pose set = n) on either edit
+/// family; otherwise `request.count`. Threaded into [`ImagePlan`] so the generation
+/// set's `count`/`expectedCount` match what actually lands in the gallery (the UI
+/// streams against it). Qwen edit reuses the shared [`flux2_grouping`] decision.
+#[cfg(target_os = "macos")]
+fn grouped_image_count(request: &ImageRequest, settings: &Settings) -> u32 {
+    if qwen_edit_available(request, settings) {
+        match flux2_grouping(request) {
+            Flux2Grouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
+            Flux2Grouping::Poses(count) => count as u32,
+            Flux2Grouping::Plain => request.count,
+        }
+    } else {
+        flux2_image_count(request, settings)
+    }
+}
+
+/// Resolve the Qwen edit true-CFG guidance. The engine's `guidance` IS the true CFG
+/// (diffusers `true_cfg_scale`), so this reads `advanced.trueCfgScale` (NOT
+/// `guidanceScale`, the inert embedded-guidance knob that the Python edit path pins at
+/// 1.0) else the family default (4.0). The Character-Studio reference path clamps to
+/// [1, 10] (Python `_reference_true_cfg_scale`); `edit_image` floors at 1.0 (the engine
+/// needs CFG > 1 to engage).
+#[cfg(target_os = "macos")]
+fn resolve_qwen_edit_guidance(request: &ImageRequest, model: &MlxModel) -> f32 {
+    let raw = request
+        .advanced
+        .get("trueCfgScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(model.default_guidance);
+    if request.mode == "character_image" {
+        raw.clamp(1.0, 10.0)
+    } else {
+        raw.max(1.0)
+    }
+}
+
+/// Flat telemetry for a Qwen edit generation (parity with `flux2_edit_raw_settings`).
+#[cfg(target_os = "macos")]
+fn qwen_edit_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: f32,
+    reference_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    // The engine guidance is the true CFG — record it under the key the Python path uses.
+    raw.insert("trueCfgScale".to_owned(), json!(guidance));
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert(
+        "editEngine".to_owned(),
+        Value::String("qwen_image_edit".to_owned()),
+    );
+    raw.insert("referenceCount".to_owned(), json!(reference_count));
+    raw
+}
+
+/// Generate one Qwen edit image conditioned on `conditioning` (the reference set). True
+/// CFG: passes the negative prompt + `guidance`. Mirrors [`flux2_edit_generate_one`].
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn qwen_edit_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    negative_prompt: Option<String>,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: f32,
+    conditioning: Vec<Conditioning>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        negative_prompt,
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        guidance: Some(guidance),
+        conditioning,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&request, on_progress)
+        .map_err(|error| WorkerError::InvalidPayload(format!("edit generation failed: {error}")))?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::InvalidPayload("edit generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::InvalidPayload(
+            "edit generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+/// Real Qwen-Image-Edit generation: load the `qwen_image_edit` engine model once, then
+/// one output per grouped iteration each conditioned on the shared reference set. Mirrors
+/// [`generate_flux2_edit_stream`]'s blocking-thread + streamed-events shape and reuses the
+/// shared grouping ([`flux2_grouping`]) and [`consume_gen_events`]; differs in true-CFG
+/// guidance (`trueCfgScale`) + the negative prompt, the `[reference, skeleton]` pose order
+/// (reference first drives the VL identity prompt), and the body-only pose skeleton.
+#[cfg(target_os = "macos")]
+async fn generate_qwen_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let model = mlx_model(&request.model)
+        .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
+    let engine_id = qwen_edit_engine_id(&request.model)
+        .ok_or_else(|| WorkerError::InvalidPayload("not a Qwen edit model".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings).ok_or_else(|| {
+        WorkerError::InvalidPayload("Qwen-Image-Edit weights not found".to_owned())
+    })?;
+    let (quant, quant_bits) = resolve_quant(request);
+    let steps = resolve_steps(request, model);
+    let guidance = resolve_qwen_edit_guidance(request, model);
+    let negative_prompt = resolve_negative_prompt(request, model);
+    let adapters = resolve_adapters(request)?;
+    let repo = model_repo(request, model);
+    let adapter_label = model.adapter_label;
+
+    // Resolve the reference image(s) on the async side (decode → Send Image moved in).
+    let reference_ids = qwen_edit_reference_ids(request);
+    let mut references = Vec::with_capacity(reference_ids.len());
+    for id in &reference_ids {
+        references.push(load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            id,
+            project_path,
+        )?);
+    }
+    if references.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Qwen-Image-Edit requires a reference image".to_owned(),
+        ));
+    }
+    // sc-3030 fit_image: pre-fit the Image-Edit source to the output W×H (crop / pad /
+    // outpaint→pad) so an off-aspect edit doesn't stretch. Character-Studio references
+    // stay native (the `should_fit_edit_source` gate excludes them).
+    if should_fit_edit_source(request) {
+        references = references
+            .into_iter()
+            .map(|reference| {
+                fit_engine_image(reference, request.width, request.height, &request.fit_mode)
+            })
+            .collect::<WorkerResult<Vec<_>>>()?;
+    }
+
+    // Per-iteration grouping (shared with the FLUX.2 edit path): a Character-Studio angle
+    // set (11 shared-seed, per-angle prompt) / best-effort pose tier (one per pose, shared
+    // seed, each a `[reference, skeleton]` set) / else the plain per-image reference path.
+    let grouping = flux2_grouping(request);
+    let set_seed = resolve_seed(request, 0);
+    let (seeds, prompts, pose_keypoints): (
+        Vec<i64>,
+        Vec<String>,
+        Option<Vec<Vec<crate::openpose_skeleton::Keypoint>>>,
+    ) = match &grouping {
+        Flux2Grouping::Poses(count) => {
+            // Shared seed so only the pose changes across the set (Python parity).
+            let keypoints = parse_poses(request)
+                .into_iter()
+                .map(|pose| pose.keypoints)
+                .collect();
+            let prompts = vec![augment_prompt_for_pose(&request.prompt); *count];
+            (vec![set_seed; *count], prompts, Some(keypoints))
+        }
+        Flux2Grouping::Angles => {
+            // Shared seed so noise-derived attributes (hair, lighting) stay constant
+            // across angles — only the head pose changes.
+            let prompts = CHARACTER_ANGLE_SET_ORDER
+                .iter()
+                .map(|angle| augment_prompt_for_angle(&request.prompt, angle))
+                .collect();
+            (
+                vec![set_seed; CHARACTER_ANGLE_SET_ORDER.len()],
+                prompts,
+                None,
+            )
+        }
+        Flux2Grouping::Plain => {
+            let count = request.count as usize;
+            let seeds = (0..count)
+                .map(|index| resolve_seed(request, index))
+                .collect();
+            (seeds, vec![request.prompt.clone(); count], None)
+        }
+    };
+    let total = seeds.len();
+
+    let mut raw_settings = qwen_edit_raw_settings(
+        request,
+        &repo,
+        steps,
+        quant_bits,
+        guidance,
+        references.len(),
+    );
+    match grouping {
+        Flux2Grouping::Angles => {
+            raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
+        }
+        Flux2Grouping::Poses(_) => {
+            raw_settings.insert("poseLibrary".to_owned(), Value::Bool(true));
+        }
+        Flux2Grouping::Plain => {}
+    }
+
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+
+    let blocking = {
+        let (width, height) = (request.width, request.height);
+        let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+        let cancel = cancel.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let generator = mlx_load(engine_id, weights_dir, quant, adapters)?;
+            for (index, (seed, prompt)) in seeds.into_iter().zip(prompts).enumerate() {
+                // Pose tier: pair the reference with this pose's body-only skeleton (DWPose
+                // body, no hands/face — Python `draw_bodypose`) as a `[reference, skeleton]`
+                // multi-image set. Reference FIRST: the engine VL-encodes references[0] for
+                // the prompt embeds (identity), the skeleton is added dual-latent geometry.
+                let conditioning = match &pose_keypoints {
+                    Some(keypoints) => {
+                        let skeleton = crate::openpose_skeleton::draw_wholebody(
+                            width,
+                            height,
+                            &keypoints[index],
+                            None,
+                            None,
+                            stickwidth,
+                        );
+                        vec![Conditioning::MultiReference {
+                            images: vec![
+                                references[0].clone(),
+                                Image {
+                                    width,
+                                    height,
+                                    pixels: skeleton.into_raw(),
+                                },
+                            ],
+                        }]
+                    }
+                    None => build_edit_conditioning(&references),
+                };
+                let mut on_progress = |progress: Progress| {
+                    let event = match progress {
+                        Progress::Step { current, total } => GenEvent::Step {
+                            index,
+                            current,
+                            total,
+                        },
+                        Progress::Decoding => GenEvent::Decoding { index },
+                    };
+                    let _ = tx.blocking_send(event);
+                };
+                let (out_w, out_h, pixels) = qwen_edit_generate_one(
+                    generator.as_ref(),
+                    &prompt,
+                    negative_prompt.clone(),
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
+                    conditioning,
+                    &cancel,
+                    &mut on_progress,
+                )?;
+                if tx
+                    .blocking_send(GenEvent::Image {
+                        index,
+                        seed,
+                        width: out_w,
+                        height: out_h,
+                        pixels,
+                    })
+                    .is_err()
+                {
+                    break; // receiver gone — stop generating.
+                }
+            }
+            Ok(())
+        })
+    };
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        adapter_label,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
 // SDXL advanced conditioning (macOS, epic 3041 / sc-3060): reference (IP-Adapter),
 // img2img edit, masked inpaint, and outpaint on the `sdxl` engine model. The plain
 // txt2img + LoRA path stays on `generate_mlx_stream`; this branch handles every SDXL
@@ -3621,6 +4066,7 @@ mod tests {
             "flux1_schnell",
             "flux1_dev",
             "qwen_image",
+            "qwen_image_edit",
             "flux2_klein_9b",
             "sdxl",
         ] {
@@ -4431,6 +4877,187 @@ mod tests {
         // stretch → exact target dims (aspect not preserved).
         let stretched = fit_rgb(&source, 40, 30, "stretch");
         assert_eq!((stretched.width(), stretched.height()), (40, 30));
+    }
+
+    // --- Qwen-Image-Edit path (sc-3397) ---
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn qwen_edit_model_table_rows() {
+        for id in [
+            "qwen_image_edit",
+            "qwen_image_edit_2509",
+            "qwen_image_edit_2511",
+        ] {
+            let m = mlx_model(id).unwrap();
+            assert_eq!(m.engine_id, "qwen_image_edit");
+            assert_eq!(m.default_repo, "Qwen/Qwen-Image-Edit-2511");
+            assert_eq!(m.default_steps, 40);
+            assert_eq!(m.default_guidance, 4.0);
+            assert_eq!(m.adapter_label, "mlx_qwen");
+            assert!(m.supports_guidance && m.supports_negative_prompt);
+        }
+        // The Lightning distill is intentionally not wired here yet (sc-3398).
+        assert!(mlx_model("qwen_image_edit_2511_lightning").is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn qwen_edit_engine_id_maps_variants() {
+        for id in [
+            "qwen_image_edit",
+            "qwen_image_edit_2509",
+            "qwen_image_edit_2511",
+        ] {
+            assert_eq!(qwen_edit_engine_id(id), Some("qwen_image_edit"));
+        }
+        // Base txt2img Qwen, the Lightning distill, and other families have no edit variant.
+        assert_eq!(qwen_edit_engine_id("qwen_image"), None);
+        assert_eq!(qwen_edit_engine_id("qwen_image_edit_2511_lightning"), None);
+        assert_eq!(qwen_edit_engine_id("flux2_klein_9b"), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn qwen_edit_reference_ids_prefers_reference_then_source() {
+        // referenceAssetId (character flow) wins over a source.
+        assert_eq!(
+            qwen_edit_reference_ids(&request(json!({
+                "projectId": "p", "referenceAssetId": "ref_1", "sourceAssetId": "src_1"
+            }))),
+            vec!["ref_1".to_owned()]
+        );
+        // sourceAssetId only in edit_image mode.
+        assert_eq!(
+            qwen_edit_reference_ids(&request(json!({
+                "projectId": "p", "mode": "edit_image", "sourceAssetId": "src_1"
+            }))),
+            vec!["src_1".to_owned()]
+        );
+        // sourceAssetId without edit_image mode is ignored (the txt2img path).
+        assert!(qwen_edit_reference_ids(&request(json!({
+            "projectId": "p", "sourceAssetId": "src_1"
+        })))
+        .is_empty());
+        assert!(qwen_edit_reference_ids(&request(json!({ "projectId": "p" }))).is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_qwen_edit_guidance_reads_true_cfg_scale_not_guidance_scale() {
+        let model = mlx_model("qwen_image_edit_2511").unwrap();
+        // Default is the family true-CFG default (4.0).
+        assert_eq!(
+            resolve_qwen_edit_guidance(
+                &request(json!({ "projectId": "p", "mode": "edit_image" })),
+                model
+            ),
+            4.0
+        );
+        // guidanceScale (the inert embedded-guidance knob the Python edit path pins at 1.0)
+        // is IGNORED — only trueCfgScale drives the engine's true CFG.
+        assert_eq!(
+            resolve_qwen_edit_guidance(
+                &request(json!({
+                    "projectId": "p", "mode": "edit_image",
+                    "advanced": { "guidanceScale": 1.0 }
+                })),
+                model
+            ),
+            4.0
+        );
+        // trueCfgScale overrides.
+        assert_eq!(
+            resolve_qwen_edit_guidance(
+                &request(json!({
+                    "projectId": "p", "mode": "edit_image",
+                    "advanced": { "trueCfgScale": 6.0 }
+                })),
+                model
+            ),
+            6.0
+        );
+        // The character reference path clamps to [1, 10].
+        assert_eq!(
+            resolve_qwen_edit_guidance(
+                &request(json!({
+                    "projectId": "p", "mode": "character_image",
+                    "advanced": { "trueCfgScale": 50.0 }
+                })),
+                model
+            ),
+            10.0
+        );
+        assert_eq!(
+            resolve_qwen_edit_guidance(
+                &request(json!({
+                    "projectId": "p", "mode": "character_image",
+                    "advanced": { "trueCfgScale": 0.5 }
+                })),
+                model
+            ),
+            1.0
+        );
+        // edit_image floors at 1.0 (the engine needs CFG > 1 to engage).
+        assert_eq!(
+            resolve_qwen_edit_guidance(
+                &request(json!({
+                    "projectId": "p", "mode": "edit_image",
+                    "advanced": { "trueCfgScale": 0.5 }
+                })),
+                model
+            ),
+            1.0
+        );
+    }
+
+    /// Real-weights smoke: Qwen-Image-Edit. Loads `qwen_image_edit` (Qwen-Image-Edit-2511
+    /// snapshot) and generates one image conditioned on a synthetic reference — true CFG
+    /// (guidance 4.0 + a negative prompt). Needs the HF cache (`Qwen/Qwen-Image-Edit-2511`)
+    /// and a Metal device; run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored qwen_edit_real_weights`.
+    /// Uses 4 steps + 512² for speed (the production default is 40 steps).
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real Qwen-Image-Edit-2511 weights + Metal device"]
+    fn qwen_edit_real_weights_generates_one_image() {
+        let snapshot = hf_snapshot("models--Qwen--Qwen-Image-Edit-2511");
+        let generator = mlx_load(
+            "qwen_image_edit",
+            snapshot,
+            Some(mlx_gen::Quant::Q8),
+            Vec::new(),
+        )
+        .unwrap();
+        let reference = mlx_gen::Image {
+            width: 512,
+            height: 512,
+            pixels: stub_rgb8(512, 512, 7),
+        };
+        let cancel = mlx_gen::CancelFlag::new();
+        let mut steps_seen = 0u32;
+        let (w, h, pixels) = qwen_edit_generate_one(
+            generator.as_ref(),
+            "make it a watercolor painting",
+            Some("blurry, low quality".to_owned()),
+            512,
+            512,
+            42,
+            4,
+            4.0,
+            build_edit_conditioning(std::slice::from_ref(&reference)),
+            &cancel,
+            &mut |p| {
+                if let mlx_gen::Progress::Step { current, .. } = p {
+                    steps_seen = steps_seen.max(current);
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!((w, h), (512, 512));
+        assert_eq!(pixels.len(), 512 * 512 * 3);
+        assert!(steps_seen >= 1, "expected denoise step progress");
+        assert!(pixels.windows(2).any(|w| w[0] != w[1]));
     }
 
     /// Real-weights smoke: the best-effort pose tier — a `[skeleton, reference]`


### PR DESCRIPTION
## What & why

Migrates **Qwen-Image-Edit** off the Python torch/MPS path onto the in-process Rust **mlx-gen** engine (the `qwen_image_edit` model), finishing the de-Python of the Qwen image path on Mac. Qwen txt2img already cut over in [sc-3024](https://app.shortcut.com/trefry/story/3024); this closes the edit side ([sc-3397](https://app.shortcut.com/trefry/story/3397), epic [3018](https://app.shortcut.com/trefry/epic/3018)).

The engine already ships a `qwen_image_edit` model (Reference/MultiReference, true CFG, LoRA/LoKr, Q4/Q8), so this is a worker-integration change structurally identical to the shipped FLUX.2-edit path — **not** a new port.

## Changes

**Worker — `crates/sceneworks-worker/src/image_jobs.rs`**
- `MlxModel` rows for `qwen_image_edit` / `_2509` / `_2511` → engine `qwen_image_edit` (repo `Qwen/Qwen-Image-Edit-2511`, 40 steps, true-CFG 4.0, negative prompt, `adapter_label` `mlx_qwen`).
- `qwen_edit_engine_id`, `qwen_edit_reference_ids`, `qwen_edit_available`, `resolve_qwen_edit_guidance`, `qwen_edit_raw_settings`, `qwen_edit_generate_one`, `generate_qwen_edit_stream`; dispatch arm in `run_image_generate_job` + `grouped_image_count`.
- Covers: `edit_image` (single source), Character-Studio reference (subject variation), best-effort pose (`[reference, skeleton]`, reference-first, body-only skeleton), 11-angle set, LoRA/LoKr (max 3), Q4/Q8, `fit_image`, true-CFG negative prompt, incremental streaming + cancel. Reuses the FLUX.2 edit grouping/fit/streaming helpers.

**Routing — `crates/sceneworks-core/src/jobs_store.rs`**
- 3 edit ids added to `MLX_ROUTED_MODELS` + `qwen_edit_mlx_eligible` (`edit_image` w/ source **or** `character_image` w/ reference; third-party LyCORIS → torch).

## Reviewer notes
- **Parity gotcha:** the engine's `guidance` IS the true CFG, so `resolve_qwen_edit_guidance` reads `advanced.trueCfgScale` (default 4.0; character path clamps [1,10]; `edit_image` floors 1.0), **not** `guidanceScale` (the inert diffusers embedded-guidance knob the Python path pins at 1.0). Steps default 40 (engine default is 4, passed explicitly — same as txt2img passing 20).
- **Stays torch — tracked, not written off:** base-Qwen **strict pose** (`QwenImageControlNet`) has no engine equivalent yet → epic [3401](https://app.shortcut.com/trefry/epic/3401) ports it into mlx-gen (spike-first sc-3402→3407). The **Lightning** variant (`sampler="lightning"` + lightx2v distill LoRA) is [sc-3398](https://app.shortcut.com/trefry/story/3398). Base `qwen_image` reference/edit stays torch (the base repo has no edit weights).

## Verification
`npm run rust:check` fully green: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, whole-workspace `cargo test` (worker 122 passed/23 ignored incl. new qwen-edit unit tests; core 59 integration incl. new `qwen_edit_image_job_defers_to_mlx_worker` + routing units; existing `qwen_txt2img_routes_to_mlx_but_pose_stays_on_torch` still passes — no regression), and `cargo build`. Added an `#[ignore]` real-weights smoke `qwen_edit_real_weights_generates_one_image`.

**Owes (epic pattern):** real-Mac A/B parity vs the Python `QwenImageAdapter` edit path (edit / reference / pose / angle / LoRA) — needs a Mac with cached `Qwen/Qwen-Image-Edit-2511` weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)