### PR TITLE
Complete generation recipe replay

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -225,7 +225,12 @@ pub(crate) async fn persist_reported_assets(
     let job_id_owned = job_id.to_owned();
     let built = project_call(state.clone(), move |store| {
         if let Some(generation_set) = generation_set.as_ref() {
-            store.write_generation_set(&project_id, &job_id_owned, generation_set)?;
+            store.write_generation_set(
+                &project_id,
+                &job_id_owned,
+                generation_set,
+                asset_writes.first(),
+            )?;
         }
         let mut built = Vec::with_capacity(asset_writes.len());
         for fact in &asset_writes {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1327,6 +1327,27 @@ export function App() {
     setActiveView("Image");
   }
 
+  function recipeForAsset(asset) {
+    return asset?.generationSet?.recipe ?? asset?.recipe ?? null;
+  }
+
+  function sendAssetRecipeToImage(asset) {
+    const recipe = recipeForAsset(asset);
+    if (!asset || !recipe) {
+      return;
+    }
+    setSelectedAssetId(asset.id);
+    closePreview();
+    setStudioLaunch({
+      id: crypto.randomUUID(),
+      view: "Image",
+      assetId: asset.id,
+      sourceAssetId: asset.lineage?.sourceAssetId ?? null,
+      recipe,
+    });
+    setActiveView("Image");
+  }
+
   function sendAssetToVideo(asset, mode = null) {
     if (!asset) {
       return;
@@ -1814,6 +1835,7 @@ export function App() {
             }
             setPreviewAsset(asset);
           }}
+          onUseRecipe={sendAssetRecipeToImage}
           previousAsset={previewNavigation.previous}
           purgeAsset={async (asset) => {
             await purgeAsset(asset);

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -379,6 +379,7 @@ export function FullscreenPreview({
   onClose,
   onEditImage,
   onPreviewAsset,
+  onUseRecipe,
   previousAsset,
   purgeAsset,
   updateAssetStatus,
@@ -440,6 +441,11 @@ export function FullscreenPreview({
             </div>
           ) : null}
           <div className="preview-actions">
+            {onUseRecipe && asset.type === "image" && (asset.generationSet?.recipe || asset.recipe) ? (
+              <button onClick={() => onUseRecipe(asset)} type="button">
+                Use this recipe
+              </button>
+            ) : null}
             {onEditImage && asset.type === "image" ? (
               <button onClick={() => onEditImage(asset)} type="button">
                 Edit

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -1959,6 +1959,49 @@ describe("SceneWorks app shell", () => {
     expect(container.querySelector(".preview-modal img").getAttribute("src")).toContain("original.png");
   });
 
+  it("offers recipe reuse from FullscreenPreview image assets", async () => {
+    const noop = () => {};
+    const onUseRecipe = vi.fn();
+    const asset = {
+      id: "asset-recipe",
+      displayName: "Plate",
+      type: "image",
+      status: {},
+      file: { path: "assets/images/plate.png" },
+      generationSet: {
+        recipe: {
+          mode: "text_to_image",
+          model: "z_image_turbo",
+          prompt: "mist over a glass atrium",
+        },
+      },
+      recipe: { prompt: "asset fallback" },
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={asset}
+          deleteAsset={noop}
+          nextAsset={null}
+          onClose={noop}
+          onPreviewAsset={noop}
+          onUseRecipe={onUseRecipe}
+          previousAsset={null}
+          purgeAsset={noop}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Use this recipe").click();
+    });
+
+    expect(onUseRecipe).toHaveBeenCalledWith(asset);
+  });
+
   it("reports the scroll direction when navigating the FullscreenPreview", async () => {
     const noop = () => {};
     const onPreviewAsset = vi.fn();
@@ -3608,6 +3651,129 @@ describe("SceneWorks app shell", () => {
 
     expect(container.textContent).toContain("Generate Image");
     expect(container.textContent).toContain("Running");
+  });
+
+  it("replays a library asset recipe through fullscreen preview into Image Studio", async () => {
+    const createdJobs = [];
+    const imagePayloads = [];
+    const generatedAsset = {
+      id: "asset-replay",
+      projectId: "project-1",
+      generationSetId: "genset-replay",
+      type: "image",
+      displayName: "Atrium still",
+      file: { path: "assets/images/atrium.png", mimeType: "image/png" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+      generationSet: {
+        recipe: {
+          mode: "text_to_image",
+          model: "z_image_turbo",
+          prompt: "mist over a glass atrium",
+          negativePrompt: "flat lighting",
+          seed: 1234,
+          loras: [{ id: "ready_style", weight: 0.65 }],
+          normalizedSettings: { width: 1536, height: 1024, count: 3 },
+          rawAdapterSettings: { steps: 14, guidanceScale: 2.5 },
+        },
+      },
+      recipe: { prompt: "asset fallback prompt" },
+    };
+    global.fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/assets")) {
+        return Promise.resolve(response([generatedAsset]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "z_image_turbo",
+              name: "Z-Image",
+              type: "image",
+              family: "z-image",
+              limits: { resolutions: ["1024x1024", "1536x1024"] },
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/loras")) {
+        return Promise.resolve(response([{ id: "ready_style", name: "Ready Style", family: "z-image", scope: "global" }]));
+      }
+      if (path.endsWith("/image/jobs") && options.method === "POST") {
+        const payload = JSON.parse(options.body);
+        imagePayloads.push(payload);
+        const job = {
+          id: "image-job-replay",
+          type: "image_generate",
+          status: "queued",
+          stage: "queued",
+          progress: 0,
+          elapsedSeconds: 0,
+          projectId: "project-1",
+          projectName: "Noir",
+          requestedGpu: payload.requestedGpu,
+          payload,
+        };
+        createdJobs.unshift(job);
+        return Promise.resolve(response(job));
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(response(createdJobs));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Assets").click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".asset-tile").dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    await settle();
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Use this recipe").click();
+    });
+    await settle();
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+
+    expect(imagePayloads[0]).toMatchObject({
+      projectId: "project-1",
+      projectName: "Noir",
+      mode: "text_to_image",
+      model: "z_image_turbo",
+      prompt: "mist over a glass atrium",
+      negativePrompt: "flat lighting",
+      seed: 1234,
+      count: 3,
+      width: 1536,
+      height: 1024,
+      recipePresetId: null,
+      loras: [expect.objectContaining({ id: "ready_style", weight: 0.65 })],
+      advanced: expect.objectContaining({
+        resolution: "1536x1024",
+        steps: 14,
+        guidanceScale: 2.5,
+      }),
+    });
   });
 
   it("shows completed image batch items before the whole job finishes", async () => {
@@ -6143,6 +6309,94 @@ describe("SceneWorks app shell", () => {
         recipePresetId: "cinematic",
         loras: [],
         advanced: { resolution: "1280x720" },
+      }),
+    );
+  });
+
+  it("prefills Image Studio from a saved generation recipe launch", async () => {
+    const createImageJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob,
+          deleteAsset: () => {},
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "z_image_turbo",
+              name: "Z-Image",
+              type: "image",
+              family: "z-image",
+              limits: {
+                resolutions: ["1024x1024", "1536x1024"],
+                samplers: ["default", "euler"],
+                schedulers: ["default", "shift"],
+              },
+            },
+          ],
+          latestAssets: [],
+          loras: [{ id: "ready_style", name: "Ready Style", family: "z-image", scope: "global" }],
+          launchRequest: {
+            id: "recipe-replay-1",
+            view: "Image",
+            recipe: {
+              mode: "text_to_image",
+              model: "z_image_turbo",
+              prompt: "mist over a glass atrium",
+              negativePrompt: "flat lighting",
+              seed: 1234,
+              loras: [{ id: "ready_style", weight: 0.65 }],
+              normalizedSettings: { width: 1536, height: 1024, count: 3 },
+              rawAdapterSettings: {
+                steps: 14,
+                guidanceScale: 2.5,
+                sampler: "euler",
+                scheduler: "shift",
+                schedulerShift: 2.2,
+              },
+            },
+          },
+          onPreview: () => {},
+          purgeAsset: () => {},
+          presets: [{ id: "cinematic", name: "Cinematic", model: "z_image_turbo", workflow: "text_to_image" }],
+          requestedGpu: "auto",
+          selectedAsset: null,
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container.querySelector(".image-studio form").requestSubmit();
+    });
+    await settle();
+
+    expect(createImageJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "text_to_image",
+        model: "z_image_turbo",
+        prompt: "mist over a glass atrium",
+        negativePrompt: "flat lighting",
+        seed: 1234,
+        count: 3,
+        width: 1536,
+        height: 1024,
+        recipePresetId: null,
+        loras: [expect.objectContaining({ id: "ready_style", weight: 0.65 })],
+        advanced: expect.objectContaining({
+          resolution: "1536x1024",
+          steps: 14,
+          guidanceScale: 2.5,
+          sampler: "euler",
+          scheduler: "shift",
+          schedulerShift: 2.2,
+        }),
       }),
     );
   });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -114,6 +114,37 @@ function formatResolutionLabel(value) {
   return height ? `${width} × ${height}` : value;
 }
 
+function finiteRecipeNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function recipeResolution(recipe) {
+  const settings = recipe?.normalizedSettings ?? {};
+  const width = finiteRecipeNumber(settings.width);
+  const height = finiteRecipeNumber(settings.height);
+  if (width && height) {
+    return `${width}x${height}`;
+  }
+  const rawResolution = recipe?.rawAdapterSettings?.resolution;
+  return typeof rawResolution === "string" && rawResolution.includes("x") ? rawResolution : null;
+}
+
+function recipeMode(recipe) {
+  return IMAGE_MODES.includes(recipe?.mode) ? recipe.mode : "text_to_image";
+}
+
+function recipeLoraId(lora) {
+  return typeof lora === "string" ? lora : lora?.id ?? lora?.loraId;
+}
+
+function recipeLoraWeight(lora) {
+  if (typeof lora === "string") {
+    return undefined;
+  }
+  return finiteRecipeNumber(lora?.weight) ?? undefined;
+}
+
 function jobResultAssets(job, assets) {
   const catalogById = new Map(assets.map((asset) => [asset.id, asset]));
   const resultAssets = (job.result?.assets ?? []).filter((asset) => asset?.type === "image");
@@ -311,6 +342,9 @@ export function ImageStudio() {
 
   useEffect(() => {
     if (launchRequest?.view !== "Image") {
+      return;
+    }
+    if (launchRequest.recipe) {
       return;
     }
     if (launchRequest.characterId) {
@@ -512,6 +546,69 @@ export function ImageStudio() {
     trackedLocalJobs,
     initialPresetId: saved.selectedPresetId ?? null,
   });
+  useEffect(() => {
+    if (launchRequest?.view !== "Image" || !launchRequest.recipe) {
+      return;
+    }
+    const recipe = launchRequest.recipe;
+    const settings = recipe.normalizedSettings ?? {};
+    const rawSettings = recipe.rawAdapterSettings ?? {};
+    const nextMode = recipeMode(recipe);
+    const resolutionFromRecipe = recipeResolution(recipe);
+    const recipeLoras = Array.isArray(recipe.loras) ? recipe.loras : [];
+    const loraIds = recipeLoras.map(recipeLoraId).filter(Boolean);
+    const loraWeightMap = Object.fromEntries(
+      recipeLoras
+        .map((lora) => [recipeLoraId(lora), recipeLoraWeight(lora)])
+        .filter(([id, weight]) => id && weight !== undefined),
+    );
+
+    skipReferenceTuningReset.current = true;
+    setSelectedPresetId(noPresetId);
+    setMode(nextMode);
+    if (recipe.model) {
+      setModel(recipe.model);
+    }
+    setPrompt(String(recipe.prompt ?? ""));
+    promptEdited.current = true;
+    setNegativePrompt(String(recipe.negativePrompt ?? ""));
+    const seedValue = finiteRecipeNumber(recipe.seed);
+    setSeed(seedValue === null ? "" : String(seedValue));
+    const countValue = finiteRecipeNumber(settings.count);
+    if (countValue) {
+      setCount(countValue);
+    }
+    if (resolutionFromRecipe) {
+      setResolution(resolutionFromRecipe);
+    }
+    setSelectedLoraIds(loraIds);
+    setLoraWeights(loraWeightMap);
+    setStepsOverride(rawSettings.steps ?? rawSettings.numInferenceSteps ?? "");
+    setGuidanceOverride(rawSettings.guidanceScale ?? "");
+    setSampler(rawSettings.sampler ?? "default");
+    setScheduler(rawSettings.scheduler ?? "default");
+    setSchedulerShift(rawSettings.schedulerShift ?? rawSettings.timestepShift ?? 3.0);
+    setCharacterId(settings.characterId ?? "");
+    setCharacterLookId(settings.characterLookId ?? "");
+    setReferenceAssetId(rawSettings.referenceAssetId ?? launchRequest.referenceAssetId ?? "");
+    setIpAdapterScale(rawSettings.ipAdapterScale ?? settings.ipAdapterScale ?? ipAdapterScale);
+    setControlnetScale(rawSettings.controlnetConditioningScale ?? rawSettings.controlnetScale ?? settings.controlnetScale ?? controlnetScale);
+    setTrueCfgScale(rawSettings.trueCfgScale ?? settings.trueCfgScale ?? trueCfgScale);
+    setViewAngle(rawSettings.viewAngle ?? settings.viewAngle ?? "");
+    setSelectedPoseIds([]);
+    if (nextMode === "edit_image") {
+      setSourceAssetId(launchRequest.sourceAssetId ?? launchRequest.assetId ?? settings.sourceAssetId ?? "");
+      setFitMode(rawSettings.fitMode ?? settings.fitMode ?? "crop");
+    }
+    const upscale = rawSettings.upscale ?? settings.upscale;
+    setUpscaleEnabled(Boolean(upscale?.enabled));
+    if (upscale?.factor) {
+      setUpscaleFactor(upscale.factor);
+    }
+    if (upscale?.engine) {
+      handleUpscaleEngineChange(upscale.engine);
+    }
+  }, [launchRequest?.id]);
   const compatibleLoras = useMemo(() => loras.filter((lora) => {
     if (lora.presetManaged) {
       return false;

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -127,6 +127,18 @@ pub(crate) fn normalize_asset(
             );
         }
     }
+    if let Some(generation_set_id) = asset.get("generationSetId").and_then(Value::as_str) {
+        let generation_set_path = project_path
+            .join("generation-sets")
+            .join(format!("{generation_set_id}.json"));
+        if generation_set_path.exists() {
+            if let Ok(generation_set) = read_json(&generation_set_path) {
+                if let Some(object) = asset.as_object_mut() {
+                    object.insert("generationSet".to_owned(), generation_set);
+                }
+            }
+        }
+    }
     let sidecar_rel = relative_string(project_path, sidecar_path)?;
     if let Some(object) = asset.as_object_mut() {
         object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -914,6 +914,8 @@ pub struct GenerationSet {
     pub negative_prompt: String,
     pub count: u32,
     pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe: Option<Recipe>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1402,6 +1402,7 @@ impl ProjectStore {
         project_id: &str,
         job_id: &str,
         generation_set: &Value,
+        recipe_fact: Option<&Value>,
     ) -> ProjectStoreResult<()> {
         let (project_path, _project_guard) = self.lock_project(project_id)?;
         let id = generation_set
@@ -1423,6 +1424,19 @@ impl ProjectStore {
             "count": get("count"),
             "createdAt": get("createdAt"),
         });
+        let embedded_recipe = generation_set.get("recipe").cloned().or_else(|| {
+            recipe_fact.and_then(|fact| {
+                build_generated_asset_sidecar(project_id, job_id, id, fact)
+                    .get("recipe")
+                    .cloned()
+            })
+        });
+        let mut record = record;
+        if let Some(recipe) = embedded_recipe {
+            if let Some(object) = record.as_object_mut() {
+                object.insert("recipe".to_owned(), recipe);
+            }
+        }
         let dir = project_path.join("generation-sets");
         fs::create_dir_all(&dir)?;
         write_json(&dir.join(format!("{id}.json")), &record)?;
@@ -3292,6 +3306,64 @@ mod tests {
     }
 
     #[test]
+    fn write_generation_set_embeds_replayable_recipe_from_first_asset_fact() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Fixture").expect("project creates");
+        let generation_set = json!({
+            "id": "genset_recipe",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "city",
+            "negativePrompt": "",
+            "count": 1,
+            "createdAt": "2026-05-25T00:00:00Z",
+        });
+        let fact = json!({
+            "assetId": "asset_abc",
+            "mediaPath": "assets/images/genset_recipe/city.png",
+            "mimeType": "image/png",
+            "width": 1280,
+            "height": 768,
+            "normalizedWidth": 1024,
+            "normalizedHeight": 768,
+            "count": 1,
+            "family": "z-image",
+            "seed": 42,
+            "displayName": "city #1",
+            "createdAt": "2026-05-25T00:00:00Z",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "adapter": "z_image_diffusers",
+            "prompt": "city",
+            "negativePrompt": "",
+            "loras": [{"id": "style_lora", "weight": 0.8}],
+            "stylePreset": "none",
+            "rawAdapterSettings": {"steps": 8},
+        });
+
+        store
+            .write_generation_set(&project.id, "job-1", &generation_set, Some(&fact))
+            .expect("generation set writes");
+
+        let written: Value = serde_json::from_str(
+            &std::fs::read_to_string(
+                std::path::Path::new(&project.path).join("generation-sets/genset_recipe.json"),
+            )
+            .expect("generation set file exists"),
+        )
+        .expect("generation set json parses");
+        assert_eq!(written["recipe"]["adapter"], json!("z_image_diffusers"));
+        assert_eq!(written["recipe"]["seed"], json!(42));
+        assert_eq!(written["recipe"]["loras"][0]["id"], json!("style_lora"));
+        assert_eq!(
+            written["recipe"]["normalizedSettings"]["width"],
+            json!(1024)
+        );
+        assert_eq!(written["recipe"]["rawAdapterSettings"]["steps"], json!(8));
+    }
+
+    #[test]
     fn build_generated_asset_sidecar_derives_video_type_from_mime() {
         let fact = json!({
             "assetId": "asset_v",
@@ -3756,6 +3828,93 @@ mod tests {
         assert_eq!(assets[0]["type"], "document");
         // The document asset carries a derived origin (sc-2024).
         assert_eq!(assets[0]["origin"], "document_studio");
+    }
+
+    #[test]
+    fn asset_reads_include_generation_set_recipe_when_available() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Recipes").expect("project creates");
+        let project_path = std::path::PathBuf::from(&project.path);
+        let image_dir = project_path.join("assets/images");
+        std::fs::write(image_dir.join("image.png"), b"image").expect("image writes");
+        std::fs::write(
+            image_dir.join("image.sceneworks.json"),
+            serde_json::to_string_pretty(&json!({
+                "id": "asset-1",
+                "type": "image",
+                "displayName": "Image",
+                "createdAt": "2026-06-07T00:00:00Z",
+                "generationSetId": "genset_recipe",
+                "file": {"path": "assets/images/image.png"},
+                "status": {"favorite": false, "rating": 0, "rejected": false, "trashed": false},
+                "recipe": {
+                    "mode": "text_to_image",
+                    "model": "z_image_turbo",
+                    "adapter": "z_image_diffusers",
+                    "prompt": "single asset",
+                    "negativePrompt": "",
+                    "seed": 7,
+                    "loras": [],
+                    "normalizedSettings": {},
+                    "rawAdapterSettings": {}
+                },
+                "lineage": {"parents": [], "sourceAssetId": Value::Null, "sourceTimestamp": Value::Null, "jobId": "job-1"}
+            }))
+            .expect("json"),
+        )
+        .expect("sidecar writes");
+        std::fs::write(
+            project_path.join("generation-sets/genset_recipe.json"),
+            serde_json::to_string_pretty(&json!({
+                "schemaVersion": 1,
+                "id": "genset_recipe",
+                "projectId": project.id,
+                "jobId": "job-1",
+                "mode": "text_to_image",
+                "model": "z_image_turbo",
+                "prompt": "batch prompt",
+                "negativePrompt": "",
+                "count": 4,
+                "createdAt": "2026-06-07T00:00:00Z",
+                "recipe": {
+                    "mode": "text_to_image",
+                    "model": "z_image_turbo",
+                    "adapter": "z_image_diffusers",
+                    "prompt": "batch prompt",
+                    "negativePrompt": "",
+                    "seed": 42,
+                    "loras": [{"id": "style_lora", "weight": 0.75}],
+                    "normalizedSettings": {"count": 4, "width": 1024, "height": 1024},
+                    "rawAdapterSettings": {"steps": 8}
+                }
+            }))
+            .expect("json"),
+        )
+        .expect("generation set writes");
+
+        store.reindex_project(&project.id).expect("reindex works");
+
+        let assets = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .expect("assets list");
+        assert_eq!(
+            assets[0]["generationSet"]["recipe"]["prompt"],
+            "batch prompt"
+        );
+        assert_eq!(assets[0]["generationSet"]["recipe"]["seed"], json!(42));
+        assert_eq!(
+            assets[0]["generationSet"]["recipe"]["normalizedSettings"]["count"],
+            json!(4)
+        );
+
+        let detail = store
+            .get_asset(&project.id, "asset-1")
+            .expect("asset detail reads");
+        assert_eq!(
+            detail["generationSet"]["recipe"]["loras"][0]["id"],
+            "style_lora"
+        );
     }
 
     #[test]

--- a/packages/schemas/generation-set.schema.json
+++ b/packages/schemas/generation-set.schema.json
@@ -14,6 +14,7 @@
     "prompt": { "type": "string" },
     "negativePrompt": { "type": "string" },
     "count": { "type": "integer", "minimum": 1 },
-    "createdAt": { "type": "string", "format": "date-time" }
+    "createdAt": { "type": "string", "format": "date-time" },
+    "recipe": { "$ref": "recipe.schema.json" }
   }
 }

--- a/tests/fixtures/rust_migration_contracts/resource_sidecars.json
+++ b/tests/fixtures/rust_migration_contracts/resource_sidecars.json
@@ -44,7 +44,7 @@
     {
       "name": "generationSet",
       "path": "sidecars/generation-set.json",
-      "requiredTopLevelKeys": ["schemaVersion", "id", "projectId", "jobId", "mode", "model", "prompt", "negativePrompt", "count", "createdAt"]
+      "requiredTopLevelKeys": ["schemaVersion", "id", "projectId", "jobId", "mode", "model", "prompt", "negativePrompt", "count", "createdAt", "recipe"]
     },
     {
       "name": "recipe",

--- a/tests/fixtures/rust_migration_contracts/sidecars/generation-set.json
+++ b/tests/fixtures/rust_migration_contracts/sidecars/generation-set.json
@@ -8,6 +8,22 @@
   "prompt": "mist over hills",
   "negativePrompt": "",
   "count": 4,
-  "createdAt": "2026-05-17T13:00:00Z"
+  "createdAt": "2026-05-17T13:00:00Z",
+  "recipe": {
+    "mode": "text_to_image",
+    "model": "z_image_turbo",
+    "adapter": "procedural_preview",
+    "prompt": "mist over hills",
+    "negativePrompt": "",
+    "seed": 101,
+    "loras": [],
+    "stylePreset": "cinematic",
+    "normalizedSettings": {
+      "width": 1024,
+      "height": 1024,
+      "count": 4,
+      "family": "z_image"
+    },
+    "rawAdapterSettings": {}
+  }
 }
-


### PR DESCRIPTION
## Summary
- persist replayable generation recipes into generation-set sidecars and expose them on asset responses
- add Image Studio recipe replay launch handling
- add fullscreen preview "Use this recipe" action with end-to-end web coverage

## Validation
- cargo fmt --check
- cargo test -p sceneworks-core
- cargo test -p sceneworks-core --test contract_roundtrip
- cargo test -p sceneworks-rust-api
- npm --prefix apps/web test -- main.test.jsx
- npm --prefix apps/web run build