### PR TITLE
[codex] Fix image edit source picker filtering

### DIFF
--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -10,6 +10,12 @@ const categoryOptions = [
   ["render", "Renders"],
 ];
 
+const sourceImageTabs = [
+  ["assets", "Assets"],
+  ["upload", "File Upload"],
+  ["character", "Character"],
+];
+
 function compactDate(value) {
   if (!value) {
     return "No date";
@@ -116,6 +122,48 @@ function normalizeSelection(ids, assets, multiple) {
   return multiple ? kept : kept.slice(0, 1);
 }
 
+function projectMatches(asset, projectId) {
+  return Boolean(projectId) && asset?.projectId === projectId;
+}
+
+function activeProjectImageAsset(asset, projectId) {
+  return (
+    projectMatches(asset, projectId) &&
+    (assetCanRenderAsImage(asset) || asset?.type === "frame") &&
+    !asset?.status?.trashed &&
+    !asset?.status?.rejected
+  );
+}
+
+function characterAssetIds(character) {
+  return new Set(
+    [
+      ...(character?.approvedReferences ?? []),
+      ...(character?.references ?? []),
+    ]
+      .map((reference) => reference?.assetId ?? reference?.id)
+      .filter(Boolean),
+  );
+}
+
+function assetMatchesCharacter(asset, characterId, character) {
+  if (!characterId) {
+    return false;
+  }
+  if (asset?.recipe?.normalizedSettings?.characterId === characterId) {
+    return true;
+  }
+  if ((asset?.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId)) {
+    return true;
+  }
+  return characterAssetIds(character).has(asset?.id);
+}
+
+function filterPickerAssets(assets, query, searchIndex) {
+  const needle = query.trim().toLowerCase();
+  return assets.filter((asset) => !needle || searchIndex.get(asset.id)?.includes(needle));
+}
+
 export function AssetPreviewChips({ assets, emptyLabel = "No asset selected" }) {
   if (!assets.length) {
     return <div className="asset-picker-empty">{emptyLabel}</div>;
@@ -135,6 +183,257 @@ export function AssetPreviewChips({ assets, emptyLabel = "No asset selected" }) 
         </div>
       ))}
     </div>
+  );
+}
+
+export function ImageEditSourcePickerField({
+  assets,
+  buttonLabel = "Select image",
+  characters = [],
+  emptyLabel = "No source image selected",
+  importAsset,
+  label = "Source image",
+  onChange,
+  projectId,
+  value = "",
+}) {
+  const [open, setOpen] = useState(false);
+  const selectableAssets = useMemo(
+    () => assets.filter((asset) => activeProjectImageAsset(asset, projectId)),
+    [assets, projectId],
+  );
+  const selectedAsset = selectableAssets.find((asset) => asset.id === value) ?? assets.find((asset) => asset.id === value);
+
+  function confirm(id) {
+    onChange(id ?? "");
+    setOpen(false);
+  }
+
+  return (
+    <div className="asset-picker-field">
+      <div className="asset-picker-head">
+        <span className="asset-picker-label">{label}</span>
+        <button aria-haspopup="dialog" onClick={() => setOpen(true)} type="button">
+          {selectedAsset ? "Change" : buttonLabel}
+        </button>
+      </div>
+      <AssetPreviewChips assets={selectedAsset ? [selectedAsset] : []} emptyLabel={emptyLabel} />
+      {open ? (
+        <ImageEditSourcePickerModal
+          assets={selectableAssets}
+          characters={characters}
+          importAsset={importAsset}
+          initialSelectedId={value}
+          onCancel={() => setOpen(false)}
+          onConfirm={confirm}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSelectedId, onCancel, onConfirm }) {
+  const [tab, setTab] = useState("assets");
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState(() => (assets.some((asset) => asset.id === initialSelectedId) ? initialSelectedId : ""));
+  const [characterId, setCharacterId] = useState(characters[0]?.id ?? "");
+  const [dragActive, setDragActive] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState("");
+
+  useEffect(() => {
+    setSelectedId((id) => (id && assets.some((asset) => asset.id === id) ? id : ""));
+  }, [assets]);
+
+  useEffect(() => {
+    if (characterId && characters.some((character) => character.id === characterId)) {
+      return;
+    }
+    setCharacterId(characters[0]?.id ?? "");
+  }, [characters, characterId]);
+
+  const selectedCharacter = characters.find((character) => character.id === characterId) ?? null;
+  const characterAssets = useMemo(
+    () => assets.filter((asset) => assetMatchesCharacter(asset, characterId, selectedCharacter)),
+    [assets, characterId, selectedCharacter],
+  );
+  const allCharacterAssetCount = useMemo(
+    () =>
+      assets.filter((asset) =>
+        characters.some((character) => assetMatchesCharacter(asset, character.id, character)),
+      ).length,
+    [assets, characters],
+  );
+  const tabAssets = tab === "character" ? characterAssets : assets;
+  const searchIndex = useMemo(() => assetSearchIndex(tabAssets), [tabAssets]);
+  const visibleAssets = useMemo(() => filterPickerAssets(tabAssets, query, searchIndex), [tabAssets, query, searchIndex]);
+
+  async function handleUpload(file) {
+    if (!file || uploading) {
+      return;
+    }
+    if (!importAsset) {
+      setUploadError("File upload is unavailable in this context.");
+      return;
+    }
+    setUploading(true);
+    setUploadError("");
+    try {
+      const imported = await importAsset(file, { throwOnError: true });
+      if (imported?.id) {
+        onConfirm(imported.id);
+      }
+    } catch (err) {
+      setUploadError(err.message);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  function handleDrop(event) {
+    event.preventDefault();
+    setDragActive(false);
+    handleUpload(event.dataTransfer?.files?.[0] ?? null);
+  }
+
+  function switchTab(nextTab) {
+    setTab(nextTab);
+    setQuery("");
+    setUploadError("");
+  }
+
+  function renderAssetGrid(emptyLabel) {
+    return (
+      <div aria-multiselectable={undefined} className="asset-picker-grid" role="listbox">
+        {visibleAssets.map((asset) => {
+          const selected = selectedId === asset.id;
+          const status = statusLabel(asset);
+          return (
+            <button
+              aria-selected={selected}
+              className={selected ? "asset-picker-card selected" : "asset-picker-card"}
+              key={asset.id}
+              onClick={() => setSelectedId(asset.id)}
+              onDoubleClick={() => onConfirm(asset.id)}
+              role="option"
+              type="button"
+            >
+              <AssetThumbnail asset={asset} />
+              <span className="asset-picker-card-copy">
+                <strong>{titleFor(asset)}</strong>
+                <small>
+                  {typeLabel(asset)} | {sourceLabel(asset)}
+                </small>
+                <small title={asset.id}>
+                  {compactDate(asset.createdAt ?? asset.updatedAt)} | ID {assetIdentity(asset)}
+                  {status ? ` | ${status}` : ""}
+                </small>
+              </span>
+            </button>
+          );
+        })}
+        {visibleAssets.length ? null : <div className="empty-panel compact-panel">{emptyLabel}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <Modal className="asset-picker-modal image-edit-source-modal" labelledBy="asset-picker-title" onClose={onCancel}>
+      <header className="asset-picker-modal-head">
+        <div>
+          <p className="eyebrow">Image Edit</p>
+          <h2 id="asset-picker-title">Choose source image</h2>
+        </div>
+        <button className="modal-close" onClick={onCancel} type="button">
+          Close
+        </button>
+      </header>
+
+      <div className="asset-picker-toolbar">
+        <div className="segmented-control compact-segment" role="tablist" aria-label="Source image source">
+          {sourceImageTabs.map(([key, label]) => (
+            <button
+              aria-selected={tab === key}
+              className={tab === key ? "active" : ""}
+              key={key}
+              onClick={() => switchTab(key)}
+              role="tab"
+              type="button"
+            >
+              {label}
+              {key === "assets" ? <span>{assets.length}</span> : null}
+              {key === "character" ? <span>{allCharacterAssetCount}</span> : null}
+            </button>
+          ))}
+        </div>
+        {tab === "upload" ? null : (
+          <input
+            aria-label="Search source images"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={tab === "character" ? "Search character assets" : "Search project assets"}
+            value={query}
+          />
+        )}
+      </div>
+
+      {tab === "assets" ? renderAssetGrid("No active project images match this view") : null}
+
+      {tab === "upload" ? (
+        <div
+          className={dragActive ? "dataset-add-dropzone active" : "dataset-add-dropzone"}
+          onDragLeave={() => setDragActive(false)}
+          onDragOver={(event) => {
+            event.preventDefault();
+            setDragActive(true);
+          }}
+          onDrop={handleDrop}
+        >
+          <p>{uploading ? "Importing image..." : "Drop an image here, or"}</p>
+          <label className="file-upload-button">
+            <input
+              accept="image/*"
+              disabled={uploading}
+              onChange={(event) => {
+                handleUpload(event.target.files?.[0] ?? null);
+                event.target.value = "";
+              }}
+              type="file"
+            />
+            {uploading ? "Importing" : "Browse files"}
+          </label>
+          {uploadError ? <p className="inline-warning">{uploadError}</p> : null}
+        </div>
+      ) : null}
+
+      {tab === "character" ? (
+        <div className="dataset-add-character">
+          <label>
+            Character
+            <select aria-label="Character" onChange={(event) => setCharacterId(event.target.value)} value={characterId}>
+              {characters.length ? null : <option value="">No characters yet</option>}
+              {characters.map((character) => (
+                <option key={character.id} value={character.id}>
+                  {character.name ?? character.id}
+                </option>
+              ))}
+            </select>
+          </label>
+          {renderAssetGrid(characterId ? "No active images for this character" : "Select a character")}
+        </div>
+      ) : null}
+
+      <footer className="asset-picker-footer">
+        <span>{selectedId ? "1 selected" : tab === "upload" ? "Upload an image to use it" : "No selection"}</span>
+        <div className="detail-actions">
+          <button onClick={onCancel} type="button">
+            Cancel
+          </button>
+          <button disabled={!selectedId} onClick={() => onConfirm(selectedId)} type="button">
+            Use Selection
+          </button>
+        </div>
+      </footer>
+    </Modal>
   );
 }
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { ImageEditSourcePickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
@@ -206,6 +206,7 @@ export function ImageStudio() {
     purgeAsset,
     gpuOptions,
     imageModels,
+    importAsset,
     latestImageAssets,
     recentImageAssets,
     studioLaunch,
@@ -313,8 +314,22 @@ export function ImageStudio() {
   const [presetSaveMessage, setPresetSaveMessage] = useState({ tone: "neutral", text: "" });
   const presetDefaultSnapshots = useRef({});
   const editImageAssets = useMemo(
-    () => assets.filter((asset) => asset.type === "image" || asset.type === "frame"),
-    [assets],
+    () =>
+      assets.filter(
+        (asset) =>
+          (asset.type === "image" || asset.type === "frame") &&
+          asset.projectId === activeProject?.id &&
+          !asset.status?.trashed &&
+          !asset.status?.rejected,
+      ),
+    [assets, activeProject?.id],
+  );
+  const selectedAssetEditableSourceId = useMemo(
+    () =>
+      selectedAsset?.id && editImageAssets.some((asset) => asset.id === selectedAsset.id)
+        ? selectedAsset.id
+        : "",
+    [editImageAssets, selectedAsset?.id],
   );
 
   function handleModeChange(nextMode) {
@@ -335,10 +350,10 @@ export function ImageStudio() {
   }
 
   useEffect(() => {
-    if (mode === "edit_image" && selectedAsset?.id) {
-      setSourceAssetId(selectedAsset.id);
+    if (mode === "edit_image" && selectedAssetEditableSourceId) {
+      setSourceAssetId(selectedAssetEditableSourceId);
     }
-  }, [mode, selectedAsset?.id]);
+  }, [mode, selectedAssetEditableSourceId]);
 
   useEffect(() => {
     if (launchRequest?.view !== "Image") {
@@ -366,10 +381,10 @@ export function ImageStudio() {
     if (launchRequest.model) {
       setModel(launchRequest.model);
     }
-    if (launchRequest.mode === "edit_image" && selectedAsset?.id) {
-      setSourceAssetId(selectedAsset.id);
+    if (launchRequest.mode === "edit_image" && selectedAssetEditableSourceId) {
+      setSourceAssetId(selectedAssetEditableSourceId);
     }
-  }, [launchRequest?.id, selectedAsset?.id]);
+  }, [launchRequest?.id, selectedAsset?.id, selectedAssetEditableSourceId]);
 
   const availableModels = useMemo(
     () =>
@@ -1024,12 +1039,15 @@ export function ImageStudio() {
           <div className="studio-source-band">
             {mode === "edit_image" ? (
               <>
-                <AssetPickerField
+                <ImageEditSourcePickerField
                   assets={editImageAssets}
                   buttonLabel="Select image"
+                  characters={characters}
                   emptyLabel="No source image selected"
-                  label="Source"
+                  importAsset={importAsset}
+                  label="Source image"
                   onChange={setSourceAssetId}
+                  projectId={activeProject?.id}
                   value={sourceAssetId}
                 />
                 <FitModeControl

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -40,6 +40,7 @@ function baseContext(overrides = {}) {
     purgeAsset: vi.fn(),
     gpuOptions: [],
     imageModels: [Z_IMAGE],
+    importAsset: vi.fn(),
     latestImageAssets: [],
     recentImageAssets: [],
     studioLaunch: null,
@@ -68,6 +69,14 @@ function setInput(element, value) {
   const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
   setter.call(element, value);
   element.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+function setFileInput(element, files) {
+  Object.defineProperty(element, "files", {
+    configurable: true,
+    value: files,
+  });
+  element.dispatchEvent(new window.Event("change", { bubbles: true }));
 }
 
 const saveButton = (container) =>
@@ -147,5 +156,163 @@ describe("ImageStudio Save as Preset", () => {
 
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");
+  });
+});
+
+describe("ImageStudio edit source picker", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  async function openEditSourcePicker(context) {
+    await render(context);
+    await click([...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "Edit"));
+    await click([...container.querySelectorAll(".asset-picker-head button")].find((button) => button.textContent === "Select image"));
+    return container.querySelector('[role="dialog"]');
+  }
+
+  it("limits Image Edit source selection to active project images and shows the requested source tabs", async () => {
+    const active = { id: "asset-active", projectId: "project_1", type: "image", displayName: "Active Plate", status: { trashed: false } };
+    const trashed = { id: "asset-trashed", projectId: "project_1", type: "image", displayName: "Discarded Plate", status: { trashed: true } };
+    const rejected = { id: "asset-rejected", projectId: "project_1", type: "image", displayName: "Rejected Plate", status: { rejected: true } };
+    const otherProject = { id: "asset-other", projectId: "project_2", type: "image", displayName: "Other Project Plate", status: {} };
+    const video = { id: "asset-video", projectId: "project_1", type: "video", displayName: "Video Clip", status: {} };
+
+    const dialog = await openEditSourcePicker(
+      baseContext({
+        assets: [active, trashed, rejected, otherProject, video],
+        imageModels: [{ ...Z_IMAGE, capabilities: ["edit_image"] }],
+        selectedAsset: null,
+      }),
+    );
+
+    const sourceTabs = [...dialog.querySelectorAll('[role="tab"]')].map((button) => button.textContent.trim());
+    expect(sourceTabs).toEqual(["Assets1", "File Upload", "Character0"]);
+    expect(dialog.textContent).toContain("Active Plate");
+    expect(dialog.textContent).not.toContain("Discarded Plate");
+    expect(dialog.textContent).not.toContain("Rejected Plate");
+    expect(dialog.textContent).not.toContain("Other Project Plate");
+    expect(dialog.textContent).not.toContain("Video Clip");
+    expect(dialog.textContent).not.toContain("Renders");
+  });
+
+  it("filters the Character source tab by project, character, and active status", async () => {
+    const mira = { id: "char-1", name: "Mira", approvedReferences: [{ assetId: "ref-mira" }] };
+    const echo = { id: "char-2", name: "Echo", approvedReferences: [] };
+    const assets = [
+      { id: "ref-mira", projectId: "project_1", type: "image", displayName: "Mira Reference", status: {} },
+      {
+        id: "mira-render",
+        projectId: "project_1",
+        type: "image",
+        displayName: "Mira Render",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: {},
+      },
+      {
+        id: "mira-trash",
+        projectId: "project_1",
+        type: "image",
+        displayName: "Mira Discarded",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: { trashed: true },
+      },
+      {
+        id: "echo-render",
+        projectId: "project_1",
+        type: "image",
+        displayName: "Echo Render",
+        recipe: { normalizedSettings: { characterId: "char-2" } },
+        status: {},
+      },
+      {
+        id: "mira-other-project",
+        projectId: "project_2",
+        type: "image",
+        displayName: "Mira Elsewhere",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: {},
+      },
+    ];
+
+    const dialog = await openEditSourcePicker(
+      baseContext({
+        assets,
+        characters: [mira, echo],
+        imageModels: [{ ...Z_IMAGE, capabilities: ["edit_image"] }],
+        selectedAsset: null,
+      }),
+    );
+
+    await click([...dialog.querySelectorAll('[role="tab"]')].find((button) => button.textContent.includes("Character")));
+    expect(dialog.textContent).toContain("Mira Reference");
+    expect(dialog.textContent).toContain("Mira Render");
+    expect(dialog.textContent).not.toContain("Mira Discarded");
+    expect(dialog.textContent).not.toContain("Echo Render");
+    expect(dialog.textContent).not.toContain("Mira Elsewhere");
+
+    await act(async () => {
+      dialog.querySelector(".asset-picker-card").click();
+    });
+    await click([...dialog.querySelectorAll("button")].find((button) => button.textContent === "Use Selection"));
+
+    expect(container.textContent).toContain("Mira Reference");
+  });
+
+  it("imports a File Upload source and submits it as the edit source image", async () => {
+    const imported = {
+      id: "uploaded-source",
+      projectId: "project_1",
+      type: "image",
+      displayName: "uploaded.png",
+      status: {},
+    };
+    const importAsset = vi.fn(async () => imported);
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+
+    const dialog = await openEditSourcePicker(
+      baseContext({
+        assets: [],
+        createImageJob,
+        imageModels: [{ ...Z_IMAGE, capabilities: ["edit_image"] }],
+        importAsset,
+        selectedAsset: null,
+      }),
+    );
+
+    await click([...dialog.querySelectorAll('[role="tab"]')].find((button) => button.textContent === "File Upload"));
+    const file = new File(["image"], "source.png", { type: "image/png" });
+    await act(async () => setFileInput(dialog.querySelector('input[type="file"]'), [file]));
+    await act(async () => {});
+
+    expect(importAsset).toHaveBeenCalledWith(file, { throwOnError: true });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Generate"));
+    expect(createImageJob).toHaveBeenCalledWith(expect.objectContaining({ mode: "edit_image", sourceAssetId: "uploaded-source" }));
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the generic Image Edit source asset dialog with an Image Edit-specific picker: Assets, File Upload, and Character.
- Filters source candidates to active assets from the current project, excluding discarded/rejected entries and other projects.
- Scopes Character candidates by selected character while keeping upload selection wired into the edit source payload.

## Root Cause

Image Edit reused the broad asset picker against the in-memory asset catalog. App state intentionally includes trashed assets for Library Trashcan workflows, so the source picker could surface discarded assets and other stale/global-looking entries instead of only valid project edit sources.

## Validation

- npm test -- ImageStudio.test.jsx
- npm test
- Browser smoke against Vite at http://127.0.0.1:5173/; app rendered the expected API-offline state with the backend stopped.
