### PR TITLE
[codex] bump mlx-gen for Qwen LoRA routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "image",
  "inventory",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "image",
  "inventory",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "image",
  "inventory",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4#4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
 dependencies = [
  "image",
  "inventory",
@@ -2783,7 +2783,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -60,33 +60,32 @@ mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/ml
 # stories (sc-3022..3035) add their provider here; this scaffold links Z-Image
 # (sc-3022, next) to prove the cross-crate registry path end to end.
 [target.'cfg(target_os = "macos")'.dependencies]
-# Rev 4ea5d86 (mlx-gen main): the LoRA/LoKr trainer surface (epic 3039, PRs #142–147)
-# layered on top of the sc-3224 Wan/LTX converters (PR #140, rev 01bf6259) the base
-# branch pinned — 4ea5d86 is a strict superset, so it carries BOTH the converters and
-# the trainers in a single rev (and MLX still builds once with the unchanged mlx-rs pin).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+# Rev d233f23 (mlx-gen main): carries the LoRA/LoKr trainer surface (epic 3039),
+# Wan/LTX converter stack, and the Qwen modulation-LoRA routing fix (PR #160) in one
+# shared rev so MLX builds once with the unchanged mlx-rs pin.
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4ea5d8653b9cdc84997bc97dfdb0e5a0fa62fda4" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Bumps the SceneWorks worker's pinned `mlx-gen-*` dependencies from `4ea5d865...` to `d233f231...`.

That upstream rev includes `mlx-gen` PR #160, which fixes Qwen-Image / Qwen-Image-Edit MLX adapter routing for LoRAs that target Diffusers modulation linears like `transformer_blocks.N.img_mod.1` and `transformer_blocks.N.txt_mod.1`.

## Changes

- Update all macOS `mlx-gen-*` git dependency revs in `crates/sceneworks-worker/Cargo.toml`.
- Refresh `Cargo.lock` to resolve those packages at `d233f231...`.
- Preserve the existing lockfile resolver update to `proc-macro-crate 2.0.2` for `num_enum_derive`.

## Validation

- `cargo check -p sceneworks-worker`