### PR TITLE
fix(desktop): grant get_session_logs Tauri ACL permission

### DIFF
--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -2,6 +2,7 @@ fn main() {
     tauri_build::try_build(tauri_build::Attributes::new().app_manifest(
         tauri_build::AppManifest::new().commands(&[
             "start_setup",
+            "get_session_logs",
             "get_app_settings",
             "get_storage_setup",
             "save_storage_setup",

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "allow-start-setup",
+    "allow-get-session-logs",
     "allow-get-app-settings",
     "allow-get-storage-setup",
     "allow-save-storage-setup",

--- a/apps/desktop/permissions/autogenerated/get_session_logs.toml
+++ b/apps/desktop/permissions/autogenerated/get_session_logs.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-get-session-logs"
+description = "Enables the get_session_logs command without any pre-configured scope."
+commands.allow = ["get_session_logs"]
+
+[[permission]]
+identifier = "deny-get-session-logs"
+description = "Denies the get_session_logs command without any pre-configured scope."
+commands.deny = ["get_session_logs"]


### PR DESCRIPTION
## Problem

The in-app **System → Logs** screen failed with:

> Couldn't load logs: Command `get_session_logs` not allowed by ACL

## Root cause

`get_session_logs` (added in sc-3451, epic 3447 observability) was wired into the `invoke_handler` in `apps/desktop/src/main.rs`, but the Tauri v2 ACL plumbing was never completed. Three parallel lists name every other desktop command and all omitted this one, so the command was rejected at the ACL layer before it could run.

## Fix (3 files)

- **`apps/desktop/build.rs`** — added `"get_session_logs"` to the `.commands(&[...])` list that drives permission autogeneration.
- **`apps/desktop/capabilities/default.json`** — granted `"allow-get-session-logs"` to the `main` window (the actual gate that rejected the call).
- **`apps/desktop/permissions/autogenerated/get_session_logs.toml`** — added the matching permission file (byte-for-byte identical to the build-script output; verified via empty `git diff`).

## Verification

`cargo check -p sceneworks-desktop` passes. `tauri_build` validates at compile time that every capability-referenced permission exists, so a green build confirms the ACL chain resolves end to end.

> Note: takes effect only in a **rebuilt** desktop app — the running shell has the old ACL baked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)