### PR TITLE
feat(observability): image_pipeline_load events on MLX path (sc-3450)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1012,6 +1012,26 @@ fn mlx_load(
         .map_err(|error| WorkerError::InvalidPayload(format!("{engine_id} load failed: {error}")))
 }
 
+/// Emit an `image_pipeline_load_{start,complete}` event from inside a blocking
+/// generation closure (sc-3450), parity with the Python worker's pipeline-load
+/// events. On the MLX path `mlx_gen::load` is a single atomic call that also fuses
+/// any distill LoRA and applies user LoRAs (`spec.with_adapters`), so there is no
+/// separable fuse/apply step to bracket: the adapter total (`adapter_count` =
+/// distill + user) is reported here instead of via the torch worker's separate
+/// `image_distill_lora_fuse_*` / `image_lora_apply_*` sub-phase events. A `start`
+/// with no matching `complete` means the load failed (the error propagates via `?`).
+#[cfg(target_os = "macos")]
+fn emit_load_event(event: &str, job_id: &str, engine: &str, adapter_count: usize) {
+    emit_event(
+        event,
+        json!({
+            "jobId": job_id,
+            "engine": engine,
+            "adapterCount": adapter_count,
+        }),
+    );
+}
+
 /// Generate one image (RGB8) at the given seed; `on_progress` streams denoise steps.
 /// `guidance` is `None` for distilled variants (the engine rejects it on them).
 #[cfg(target_os = "macos")]
@@ -1110,8 +1130,22 @@ async fn generate_mlx_stream(
         let (width, height) = (request.width, request.height);
         let seeds = seeds.clone();
         let cancel = cancel.clone();
+        let job_id = job.id.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let adapter_count = adapters.len();
+            emit_load_event(
+                "image_pipeline_load_start",
+                &job_id,
+                engine_id,
+                adapter_count,
+            );
             let generator = mlx_load(engine_id, weights_dir, quant, adapters)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                engine_id,
+                adapter_count,
+            );
             for (index, seed) in seeds.into_iter().enumerate() {
                 let mut on_progress = |progress: Progress| {
                     let event = match progress {
@@ -1587,8 +1621,22 @@ async fn generate_zimage_control_stream(
         let (width, height) = (request.width, request.height);
         let cancel = cancel.clone();
         let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+        let job_id = job.id.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let adapter_count = adapters.len();
+            emit_load_event(
+                "image_pipeline_load_start",
+                &job_id,
+                ZIMAGE_CONTROL_ENGINE_ID,
+                adapter_count,
+            );
             let generator = zimage_control_load(weights_dir, control_weights, quant, adapters)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                ZIMAGE_CONTROL_ENGINE_ID,
+                adapter_count,
+            );
             let identity_init = identity_init.as_ref();
             for (index, pose) in poses.into_iter().enumerate() {
                 let skeleton = crate::openpose_skeleton::draw_wholebody(
@@ -2271,8 +2319,22 @@ async fn generate_flux2_edit_stream(
         let (width, height) = (request.width, request.height);
         let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
         let cancel = cancel.clone();
+        let job_id = job.id.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let adapter_count = adapters.len();
+            emit_load_event(
+                "image_pipeline_load_start",
+                &job_id,
+                engine_id,
+                adapter_count,
+            );
             let generator = mlx_load(engine_id, weights_dir, quant, adapters)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                engine_id,
+                adapter_count,
+            );
             for (index, (seed, prompt)) in seeds.into_iter().zip(prompts).enumerate() {
                 // Pose tier: pair this pose's body-only skeleton (DWPose body, no
                 // hands/face — Python `draw_bodypose`) with the reference as a
@@ -2798,8 +2860,22 @@ async fn generate_qwen_edit_stream(
         let (width, height) = (request.width, request.height);
         let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
         let cancel = cancel.clone();
+        let job_id = job.id.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let adapter_count = adapters.len();
+            emit_load_event(
+                "image_pipeline_load_start",
+                &job_id,
+                engine_id,
+                adapter_count,
+            );
             let generator = mlx_load(engine_id, weights_dir, quant, adapters)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                engine_id,
+                adapter_count,
+            );
             for (index, (seed, prompt)) in seeds.into_iter().zip(prompts).enumerate() {
                 // Pose tier: pair the reference with this pose's body-only skeleton (DWPose
                 // body, no hands/face — Python `draw_bodypose`) as a `[reference, skeleton]`
@@ -3317,8 +3393,17 @@ async fn generate_sdxl_advanced_stream(
         let prompt = request.prompt.clone();
         let negative_prompt = negative_prompt.clone();
         let cancel = cancel.clone();
+        let job_id = job.id.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let adapter_count = adapters.len();
+            emit_load_event("image_pipeline_load_start", &job_id, "sdxl", adapter_count);
             let generator = sdxl_advanced_load(weights_dir, quant, adapters, ip_adapter_dir)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                "sdxl",
+                adapter_count,
+            );
             for (index, seed) in seeds.into_iter().enumerate() {
                 let mut on_progress = |progress: Progress| {
                     let event = match progress {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -71,10 +71,22 @@ Per-image lifecycle on the MLX path (parity with the Python worker), emitted fro
 shared streaming consumer (`image_jobs::consume_gen_events`): `jobId`, `imageIndex`,
 `imageCount`, `backend` (`mlx`). Confirms an MLX job is actually progressing image-by-image.
 
-> Not yet on the Rust path: `image_pipeline_load_start/complete`,
-> `image_distill_lora_fuse_start/complete`, `image_lora_apply_start/complete` — these run
-> inside the per-family blocking generation closures and need `jobId` threaded in
-> (tracked follow-up on sc-3450). The Python worker already emits them on the torch path.
+### Pipeline load — `image_pipeline_load_start` / `image_pipeline_load_complete` (Rust MLX worker, sc-3450)
+
+Brackets the engine load (`mlx_gen::load`) inside each per-family blocking generation
+closure (all five MLX image families): `jobId`, `engine` (the mlx-gen engine id, e.g.
+`qwen_image_edit`, `sdxl`, `z_image_turbo_control`), `adapterCount`. A `start` with **no
+matching `complete`** means the load failed (the job then errors). A long gap between the
+two is the signature of a cold-weight load — the prime suspect when an MLX job looks
+"stuck" before its first `image_inference_start`.
+
+> **No separate `image_distill_lora_fuse_*` / `image_lora_apply_*` events on the MLX path**
+> (the torch worker emits these as distinct phases). On MLX, `mlx_gen::load` is a single
+> atomic call that *also* fuses any distill LoRA and applies user LoRAs (`spec.with_adapters`),
+> so there is no separable fuse/apply step to bracket. The adapter total (distill + user) is
+> reported as `adapterCount` on the `image_pipeline_load_*` events instead — same diagnostic
+> information, accurate to the Rust engine's architecture, rather than fabricated
+> zero-duration sub-phase events.
 
 ## Diagnosing "MLX-eligible job ran on torch/MPS"
 


### PR DESCRIPTION
Completes the remaining **sc-3450** generation-event work (epic 3447). `image_inference_start/complete` already shipped in PR #462; this adds the pipeline-load phase.

## What
- `image_pipeline_load_start` / `image_pipeline_load_complete` now bracket the engine load (`mlx_gen::load`) inside **all 5 MLX image generation families** (base txt2img, Z-Image strict-pose control, FLUX.2 edit, Qwen edit, SDXL advanced), via a shared `emit_load_event` helper. Payload `{jobId, engine, adapterCount}`.
- Diagnostic value: a `start` with no matching `complete` = the load failed; a long gap between them = a cold-weight load (the prime suspect when an MLX job looks "stuck" before its first `image_inference_start`).

## Design decision (explicit)
I did **not** add `image_distill_lora_fuse_*` / `image_lora_apply_*` (which `docs/observability.md` previously listed as pending). On the MLX path `mlx_gen::load` is a single **atomic** call that also fuses the distill LoRA and applies user LoRAs (`spec.with_adapters`) — there is no separable fuse/apply step to bracket. Emitting zero-duration sub-phase brackets would be misleading observability (contrary to this epic's purpose), so the distill+user adapter total is reported as `adapterCount` on the load events instead. Same diagnostic information, accurate to the Rust engine's architecture. Documented in `docs/observability.md`.

## Validation
- `npm run rust:check` green (fmt + clippy `-D warnings` + 123 worker tests + core/api + nax guard + build).
- `cargo clippy -p sceneworks-worker -- -D warnings` on macOS exercises the new macOS-gated code (the Linux parity lane cfg-gates it out).
- Real-Mac runtime validation (events visible in System → Logs) folds into **sc-3454**.

## Files
- `crates/sceneworks-worker/src/image_jobs.rs` (+85): `emit_load_event` helper + bracketing in the 5 families; `job.id` cloned into each blocking closure.
- `docs/observability.md` (+20/-4): documents the new events + the fuse/apply folding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)