### PR TITLE
fix(routing): wire image_edit job type to MLX worker (sc-3513)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1759,7 +1759,16 @@ const MLX_ROUTED_MODELS: &[&str] = &[
 /// classifier (`image_jobs::classify_adapter`, sc-3022) is the backstop for an
 /// unstamped third-party LyCORIS file that slips through.
 fn image_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
-    if !matches!(job.job_type, JobType::ImageGenerate) {
+    // Both `image_generate` (text-to-image / character_image / reference) and the
+    // distinct `image_edit` job type (Image Studio/Editor "plain Image Edit":
+    // `mode=edit_image` + `sourceAssetId`, epic 2427) route through the same
+    // per-model predicates. The engine dispatches on payload model+mode, not job
+    // type (`run_image_generate_job`), and the per-model arms below already gate
+    // `edit_image` (qwen/flux2/sdxl edit → eligible; torch-only edit models aren't
+    // in `MLX_ROUTED_MODELS` → torch). Without `image_edit` in this gate, plain
+    // Image Edit fell through to torch silently with no `mlx_route_decision`
+    // (sc-3513).
+    if !matches!(job.job_type, JobType::ImageGenerate | JobType::ImageEdit) {
         return false;
     }
     let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
@@ -2141,9 +2150,14 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     // the Python worker. Non-mlx workers are unaffected here; the *preference* to route
     // eligible jobs to an idle mlx worker is a soft deferral in the claim path.
     if worker.gpu_id.eq_ignore_ascii_case("mlx") {
-        // Image: sc-3026 txt2img/LoRA + sc-3060 reference/edit/inpaint/outpaint + image_detail.
-        if matches!(job.job_type, JobType::ImageGenerate | JobType::ImageDetail)
-            && !job_is_mlx_eligible(job)
+        // Image: sc-3026 txt2img/LoRA + sc-3060 reference/edit/inpaint/outpaint +
+        // image_detail + sc-3513 the `image_edit` job type (plain Image Edit). A
+        // torch-only edit model (z_image_edit/kolors/sensenova/lens/pulid/instantid)
+        // is not MLX-eligible, so the mlx worker refuses it and it stays on torch.
+        if matches!(
+            job.job_type,
+            JobType::ImageGenerate | JobType::ImageEdit | JobType::ImageDetail
+        ) && !job_is_mlx_eligible(job)
         {
             return false;
         }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1411,6 +1411,32 @@ fn image_job_with(payload: Value, requested_gpu: &str) -> CreateJob {
     }
 }
 
+/// Capabilities a real image GPU worker advertises once it also serves the distinct
+/// `image_edit` job type (sc-3513) — both the Python torch worker (`IMAGE_JOB_TYPES`)
+/// and the macOS mlx worker (`gpu::mlx_gpu`) carry `image_edit` alongside `image_generate`.
+fn image_edit_caps() -> Vec<WorkerCapability> {
+    vec![
+        WorkerCapability::Gpu,
+        WorkerCapability::ImageGenerate,
+        WorkerCapability::ImageEdit,
+    ]
+}
+
+/// A `JobType::ImageEdit` job — "plain Image Edit" (Image Studio/Editor, epic 2427),
+/// the sibling of [`image_job_with`] for the edit job type the bug missed (sc-3513).
+fn image_edit_job_with(payload: Value, requested_gpu: &str) -> CreateJob {
+    CreateJob {
+        job_type: JobType::ImageEdit,
+        project_id: Some("project-1".to_owned()),
+        project_name: Some("Project 1".to_owned()),
+        payload: object(payload),
+        requested_gpu: requested_gpu.to_owned(),
+        source_job_id: None,
+        duplicate_of_job_id: None,
+        attempts: 1,
+    }
+}
+
 #[test]
 fn mlx_eligible_image_job_defers_from_torch_worker_to_idle_mlx_worker() {
     let store = store("mlx-routing-defer");
@@ -1650,6 +1676,145 @@ fn routing_decision_is_none_for_non_mlx_model() {
     assert!(
         decision.is_none(),
         "a non-MLX-eligible claim is routing-neutral (no event)"
+    );
+}
+
+// --- sc-3513: the `image_edit` job type (plain Image Edit) routes to MLX too ---
+//
+// "Plain Image Edit" is submitted as JobType::ImageEdit (mode=edit_image + sourceAssetId),
+// a *distinct* job type from the character/reference flow (JobType::ImageGenerate). The
+// engine dispatches edits on payload model+mode, not job type, so the edit-capable families
+// (qwen/flux2/sdxl) must route to the in-process mlx worker exactly like the generate flow;
+// torch-only edit models stay on torch. Before sc-3513 the routing gate excluded every
+// non-ImageGenerate type, so these jobs ran on torch silently with no `mlx_route_decision`.
+
+#[test]
+fn qwen_image_edit_job_type_defers_to_mlx_worker() {
+    let store = store("mlx-routing-image-edit-qwen");
+    register_gpu_worker(&store, "worker-torch", "mps", image_edit_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+
+    let job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "qwen_image_edit_2511_lightning",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1",
+                "prompt": "make it a watercolor painting"
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    // The torch worker defers the MLX-eligible edit to the idle mlx worker, which claims it.
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn sdxl_masked_image_edit_job_type_defers_to_mlx_worker() {
+    let store = store("mlx-routing-image-edit-sdxl-mask");
+    register_gpu_worker(&store, "worker-torch", "mps", image_edit_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+
+    // A masked inpaint is an image_edit job carrying a maskAssetId. Only SDXL/RealVisXL
+    // are image_inpaint-capable, and sc-3060's advanced SDXL stream handles masked
+    // inpaint/outpaint on the engine — so the mask is honoured on MLX, not dropped.
+    let job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "sdxl",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1",
+                "maskAssetId": "asset_mask",
+                "prompt": "replace the sky"
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn routing_decision_reports_claimed_by_mlx_for_image_edit() {
+    let store = store("route-decision-image-edit-mlx");
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+    let job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "flux2_klein_9b_true_v2",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1",
+                "prompt": "p"
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    // The fix makes the claim non-routing-neutral: an mlx_route_decision is now emitted.
+    let (claimed, decision) = store
+        .claim_next_job_routed("worker-mlx")
+        .expect("mlx claim ok");
+    assert_eq!(claimed.expect("mlx claims it").id, job.id);
+    let decision = decision.expect("routing decision present");
+    assert_eq!(decision.decision, "claimed_by_mlx");
+    assert_eq!(decision.reason, "mlx_worker");
+    assert_eq!(decision.gpu_id, "mlx");
+}
+
+#[test]
+fn torch_only_image_edit_model_stays_on_torch() {
+    let store = store("mlx-routing-image-edit-torch-only");
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+
+    // z_image_edit is NOT in MLX_ROUTED_MODELS (only z_image_turbo is), so the edit stays
+    // on the Python torch path. The mlx worker must refuse it.
+    let job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "z_image_edit",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1",
+                "prompt": "p"
+            }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+
+    // A torch worker is the home for it, and the claim is routing-neutral (no event).
+    register_gpu_worker(&store, "worker-torch", "mps", image_edit_caps());
+    let (claimed, decision) = store
+        .claim_next_job_routed("worker-torch")
+        .expect("torch claim ok");
+    let claimed = claimed.expect("torch claims it");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+    assert!(
+        decision.is_none(),
+        "a torch-only edit model is routing-neutral (no mlx_route_decision)"
     );
 }
 

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -360,7 +360,8 @@ pub(crate) fn cpu_gpu() -> DiscoveredGpu {
 }
 
 /// The Apple-Silicon native MLX GPU worker (epic 3018): advertises `image_generate`,
-/// `image_detail` (tile-ControlNet refine, sc-3060), `video_generate`, and LoRA/LoKr
+/// `image_edit` (plain Image Edit, sc-3513), `image_detail` (tile-ControlNet refine,
+/// sc-3060), `video_generate`, and LoRA/LoKr
 /// `lora_train` + `lora_train_execute` (epic 3039), served in-process by the linked
 /// mlx-gen engine. `Gpu` (not
 /// `Cpu`) so the API's `worker_supports_job` lets GPU jobs route here; it deliberately
@@ -383,6 +384,13 @@ pub(crate) fn mlx_gpu() -> DiscoveredGpu {
         capabilities: vec![
             WorkerCapability::Gpu,
             WorkerCapability::ImageGenerate,
+            // Plain Image Edit (sc-3513): the `image_edit` job type
+            // (`mode=edit_image` + `sourceAssetId`, epic 2427) runs the same engine
+            // edit paths as the `character_image` reference flow — qwen/flux2/sdxl
+            // edit dispatched by payload model+mode in `run_image_generate_job`. The
+            // API only routes MLX-eligible edit models here (`image_job_is_mlx_eligible`);
+            // torch-only edit models stay on the Python worker.
+            WorkerCapability::ImageEdit,
             // Tile-ControlNet detail refine (epic 3041, sc-3060) — the SDXL-family
             // `image_detail` job runs in-process on the engine here too.
             WorkerCapability::ImageDetail,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -517,6 +517,14 @@ async fn run_utility_job(
         JobType::ImageGenerate => run_image_generate_job(api, settings, &job)
             .await
             .map_err(|error| ("Image generation failed.", error)),
+        // Plain Image Edit (sc-3513): the distinct `image_edit` job type (`mode=edit_image`
+        // + `sourceAssetId`, epic 2427) shares the generate handler — it dispatches on
+        // payload model+mode (qwen/flux2/sdxl edit streams), not job type. The API only
+        // routes MLX-eligible edit models here (jobs_store::image_job_is_mlx_eligible); off
+        // macOS the `image_edit` capability is never advertised, so this arm is unreachable.
+        JobType::ImageEdit => run_image_generate_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Image edit failed.", error)),
         // Native MLX tile-ControlNet detail refine (epic 3041, sc-3060), served in-process
         // by the engine on the macOS Apple-Silicon GPU worker. Off macOS the capability is
         // never advertised, so this arm is unreachable there (image_detail runs on torch).

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -9,7 +9,7 @@ use axum::http::{HeaderMap, StatusCode as AxumStatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use sceneworks_core::contracts::WorkerUtilizationSnapshot;
+use sceneworks_core::contracts::{JobSnapshot, WorkerUtilizationSnapshot};
 use serde_json::{json, Value};
 use tempfile::tempdir;
 
@@ -423,10 +423,11 @@ fn rust_cpu_capabilities_do_not_claim_gpu_generation_jobs() {
         .any(|capability| capability.as_str() == "image_generate"));
 }
 
-/// The Apple-Silicon MLX GPU worker (epic 3018) advertises `image_generate` +
-/// `video_generate` so the API routes generation to it, but it must NOT pick up CPU
-/// utility jobs (those stay on the CPU worker) — the inverse of the CPU-worker
-/// contract above. `video_generate` lands with the video runtime (sc-3033).
+/// The Apple-Silicon MLX GPU worker (epic 3018) advertises `image_generate`,
+/// `image_edit` (sc-3513), + `video_generate` so the API routes generation/editing to
+/// it, but it must NOT pick up CPU utility jobs (those stay on the CPU worker) — the
+/// inverse of the CPU-worker contract above. `video_generate` lands with the video
+/// runtime (sc-3033).
 #[cfg(target_os = "macos")]
 #[test]
 fn mlx_gpu_advertises_generation_capabilities_only() {
@@ -436,6 +437,11 @@ fn mlx_gpu_advertises_generation_capabilities_only() {
     assert!(capabilities
         .iter()
         .any(|capability| capability.as_str() == "image_generate"));
+    // Plain Image Edit (sc-3513): without this the API's worker_supports_job would
+    // reject an `image_edit` claim and the job would silently fall back to torch.
+    assert!(capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "image_edit"));
     assert!(capabilities
         .iter()
         .any(|capability| capability.as_str() == "video_generate"));
@@ -458,6 +464,55 @@ fn mlx_gpu_advertises_generation_capabilities_only() {
             "MLX GPU worker should not advertise utility capability {utility}"
         );
     }
+}
+
+/// sc-3513: the worker's `JobType::ImageEdit` dispatch arm delegates to
+/// `run_image_generate_job` — the engine keys edits on payload model+mode, not job
+/// type. Feeding an `image_edit`-typed job into the handler proves it reaches the image
+/// pipeline (stopping at the payload's projectId guard) rather than the `run_utility_job`
+/// "unsupported job type" default — i.e. plain Image Edit is genuinely handled. The
+/// handler never reads `job_type`, so a missing projectId is its first stop (no network).
+#[tokio::test]
+async fn image_edit_job_dispatches_to_image_generate_handler() {
+    let settings = test_settings("http://127.0.0.1".to_owned(), None);
+    let api = ApiClient::new(&settings);
+    let job: JobSnapshot = serde_json::from_value(json!({
+        "id": "job-image-edit-1",
+        "type": "image_edit",
+        "status": "preparing",
+        "projectId": null,
+        "projectName": null,
+        "payload": { "model": "qwen_image_edit_2511", "mode": "edit_image" },
+        "result": {},
+        "requestedGpu": "auto",
+        "assignedGpu": null,
+        "workerId": null,
+        "progress": 0,
+        "stage": "preparing",
+        "message": "",
+        "error": null,
+        "etaSeconds": null,
+        "elapsedSeconds": null,
+        "attempts": 1,
+        "sourceJobId": null,
+        "duplicateOfJobId": null,
+        "cancelRequested": false,
+        "createdAt": "2026-06-07T00:00:00Z",
+        "updatedAt": "2026-06-07T00:00:00Z",
+        "startedAt": null,
+        "completedAt": null,
+        "canceledAt": null,
+        "lastHeartbeatAt": null
+    }))
+    .expect("image_edit job snapshot deserializes");
+
+    let error = super::image_jobs::run_image_generate_job(&api, &settings, &job)
+        .await
+        .expect_err("missing projectId is rejected by the image handler");
+    assert!(
+        matches!(&error, WorkerError::InvalidPayload(message) if message.contains("projectId")),
+        "expected a projectId payload error from the image handler, got {error:?}",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Plain **Image Edit** (Image Studio/Editor) is submitted as the `image_edit` job type (`mode=edit_image` + `sourceAssetId`), a distinct type from the character/reference flow (`image_generate`). That job type was **never wired into the Rust MLX worker**, so every plain edit claimed silently on torch/MPS with **no `mlx_route_decision`**, while *Image Edit with Character* (`image_generate`) correctly ran on MLX.

The engine already supports these edits — `run_image_generate_job` dispatches on payload **model+mode**, not job type, and already routes `mode=edit_image` to the qwen/flux2/sdxl edit streams. Only the `image_edit`-type plumbing was missing. Fixes [sc-3513](https://app.shortcut.com/trefry/story/3513) (epic 3018; concrete instance of the epic 3482 silent-torch-fallback North-Star violation).

## What changed (3 coordinated gaps)

1. **Routing** — `crates/sceneworks-core/src/jobs_store.rs`: `image_job_is_mlx_eligible` gate broadened `JobType::ImageGenerate` → `ImageGenerate | ImageEdit`. The existing per-model edit predicates (`qwen_edit_mlx_eligible` / `flux2_mlx_eligible` / `sdxl_mlx_eligible`, all handling `edit_image`) now decide eligibility, so `route_decision_for_claim` + `should_defer_image_to_mlx_worker` work for edits and the `mlx_route_decision` event fires.
2. **worker_supports_job** (same file) — `JobType::ImageEdit` added to the mlx family-gate so a torch-only edit model (`z_image_edit`/`kolors`/`sensenova`/`lens`/`pulid`/`instantid` — not in `MLX_ROUTED_MODELS`) is still refused and stays on torch.
3. **Capability** — `crates/sceneworks-worker/src/gpu.rs`: the `mlx` worker advertises `WorkerCapability::ImageEdit`.
4. **Dispatch** — `crates/sceneworks-worker/src/lib.rs`: `run_utility_job` gains `JobType::ImageEdit => run_image_generate_job(...)`.

## Mask flow (the gotcha) — handled, not dropped

Only `sdxl` + `realvisxl` carry the `image_inpaint` capability, and the web only sends `maskAssetId` for `image_inpaint`-capable models. Both are SDXL-family → MLX-eligible → `generate_sdxl_advanced_stream` handles masked inpaint **and** outpaint (sc-3060). So a masked edit only ever reaches the SDXL advanced stream; no mask is silently dropped. FLUX.2 has no inpaint-mask path on either backend (MLX-only family), so no behavior change.

## Tests

- `crates/sceneworks-core/tests/jobs_store.rs` (4): `qwen_image_edit_job_type_defers_to_mlx_worker`, `sdxl_masked_image_edit_job_type_defers_to_mlx_worker` (masked inpaint → mlx), `routing_decision_reports_claimed_by_mlx_for_image_edit` (the missing decision now fires), `torch_only_image_edit_model_stays_on_torch`.
- `crates/sceneworks-worker/src/tests.rs` (2): extended `mlx_gpu_advertises_generation_capabilities_only` to assert `image_edit`; new `image_edit_job_dispatches_to_image_generate_handler`.

## Verification (macOS)

- `cargo fmt --all --check`: clean
- `cargo clippy -p sceneworks-core -p sceneworks-worker --all-targets -- -D warnings`: exit 0 (macOS-gated engine code linted)
- `cargo clippy --workspace --exclude sceneworks-desktop --all-targets -- -D warnings`: clean
- `cargo test --workspace --exclude sceneworks-desktop`: exit 0 (core jobs_store 69/69 incl. 4 new; worker 124 + 2 new)
- `sceneworks-desktop` build fails only on the known fresh-worktree missing-sidecar staging issue (unrelated; this PR touches only `core` + `worker`).

## Reviewer notes / follow-up

- This is the routing/dispatch/capability fix. The empirical payoff — Michael's report that plain Image Edit has poor prompt adherence on torch — should improve because edits now run the tuned MLX `qwen_image_edit` engine (incl. the lightning distill) instead of the torch Qwen-edit adapter. That A/B (same edit + seed, before/after) needs a real Mac GPU run and is tracked as the remaining validation on sc-3513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)