### PR TITLE
sc-3055/sc-3520: advanced-video cutover — pin bump + FLF→Rust MLX worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "image",
  "inventory",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "image",
  "inventory",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "image",
  "inventory",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d233f231bc1c992e6bdd52ec9d4c880a1c8b352e#d233f231bc1c992e6bdd52ec9d4c880a1c8b352e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
 dependencies = [
  "image",
  "inventory",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1872,10 +1872,11 @@ fn is_wan_video_model(model: &str) -> bool {
 /// expressed by whether an `mlx` worker is registered and idle (see
 /// [`should_defer_video_to_mlx_worker`]).
 ///
-/// MLX covers **`text_to_video` + `image_to_video` on Wan/LTX only**. Everything
-/// else stays on the Python torch path: the advanced job types
-/// (`video_extend`/`video_bridge`/`person_replace`) and the advanced
-/// `video_generate` modes (`first_last_frame`/`replace_person`), SVD (no crate), a
+/// MLX covers `text_to_video` + `image_to_video` on Wan/LTX, plus `first_last_frame`
+/// on the FLF-capable engines (LTX + Wan TI2V-5B `wan_2_2`; sc-3055 cutover — see
+/// [`video_mode_is_mlx_eligible`]). Still on the Python torch path: the advanced job
+/// types (`video_extend`/`video_bridge`/`person_replace`) and the `replace_person`
+/// mode (a later Wan-VACE cutover slice), SVD (svd_xt not linked in the worker yet), a
 /// non-MLX model, a third-party LyCORIS LoRA (the mlx worker's `classify_adapter`
 /// rejects it), and **LoKr-on-Wan** (the diffusers-Wan path applies LoKr via PEFT;
 /// the mlx-video path can't — mirrors `create_video_adapter`). LoKr-on-LTX stays
@@ -1898,7 +1899,7 @@ fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
         .get("mode")
         .and_then(Value::as_str)
         .unwrap_or("image_to_video");
-    if !matches!(mode, "text_to_video" | "image_to_video") {
+    if !video_mode_is_mlx_eligible(model, mode) {
         return false;
     }
     if request_has_lycoris_lora(&job.payload) {
@@ -1908,6 +1909,21 @@ fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
         return false;
     }
     true
+}
+
+/// Which `video_generate` modes the in-process Rust MLX worker serves for `model`. Every
+/// routed model serves `text_to_video` + `image_to_video` (sc-3034/3035); `first_last_frame`
+/// is additionally MLX on the FLF-capable engines — LTX (`ltx_2_3`/`ltx_2_3_eros`, the
+/// reference-grounded `Keyframe` path, sc-3052) and Wan TI2V-5B (`wan_2_2`, the mask-blend
+/// multi-keyframe path, sc-3357). The 14B Wan MoE engines have no `Keyframe` path, so FLF on
+/// them stays torch. The advanced clip modes (`extend_clip`/`video_bridge`) + `replace_person`
+/// ride dedicated job types / the Wan-VACE path and are separate cutover slices (sc-3055).
+fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
+    match mode {
+        "text_to_video" | "image_to_video" => true,
+        "first_last_frame" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),
+        _ => false,
+    }
 }
 
 /// SceneWorks training kernels with a native mlx-gen Rust trainer (epic 3039):
@@ -2297,7 +2313,8 @@ fn sort_json_value(value: &mut Value) {
 mod mlx_routing_tests {
     use super::{
         flux2_mlx_eligible, flux_mlx_eligible, qwen_edit_mlx_eligible, qwen_mlx_eligible,
-        request_has_lycoris_lora, sdxl_mlx_eligible, z_image_mlx_eligible,
+        request_has_lycoris_lora, sdxl_mlx_eligible, video_mode_is_mlx_eligible,
+        z_image_mlx_eligible, VIDEO_MLX_ROUTED_MODELS,
     };
     use serde_json::{json, Map, Value};
 
@@ -2533,5 +2550,35 @@ mod mlx_routing_tests {
         assert!(!request_has_lycoris_lora(&object(json!({
             "loras": [{ "path": "unstamped.safetensors" }]
         }))));
+    }
+
+    #[test]
+    fn video_mode_eligibility_admits_flf_only_on_flf_capable_engines() {
+        // Base modes are MLX on every routed model.
+        for model in VIDEO_MLX_ROUTED_MODELS {
+            assert!(video_mode_is_mlx_eligible(model, "text_to_video"));
+            assert!(video_mode_is_mlx_eligible(model, "image_to_video"));
+        }
+        // first_last_frame: MLX on LTX (base + eros) + Wan TI2V-5B (sc-3055 cutover).
+        assert!(video_mode_is_mlx_eligible("ltx_2_3", "first_last_frame"));
+        assert!(video_mode_is_mlx_eligible(
+            "ltx_2_3_eros",
+            "first_last_frame"
+        ));
+        assert!(video_mode_is_mlx_eligible("wan_2_2", "first_last_frame"));
+        // FLF stays torch on the 14B Wan MoE engines (no engine Keyframe path).
+        assert!(!video_mode_is_mlx_eligible(
+            "wan_2_2_t2v_14b",
+            "first_last_frame"
+        ));
+        assert!(!video_mode_is_mlx_eligible(
+            "wan_2_2_i2v_14b",
+            "first_last_frame"
+        ));
+        // The advanced clip modes + replace_person are not video_generate-mode-eligible
+        // (they ride dedicated job types / the Wan-VACE path — separate cutover slices).
+        for mode in ["extend_clip", "video_bridge", "replace_person", "nonsense"] {
+            assert!(!video_mode_is_mlx_eligible("ltx_2_3", mode));
+        }
     }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1834,11 +1834,74 @@ fn mlx_worker_excluded_from_advanced_mode_video_job() {
     let store = store("mlx-video-routing-exclude");
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
-    // first_last_frame is an advanced mode — torch-only even on a Wan model (MLX
-    // covers only text_to_video / image_to_video).
+    // replace_person is an advanced mode that still rides the torch path at this point in
+    // the cutover (it routes to the Wan-VACE path in a later slice); the mlx worker must not
+    // claim it even on a Wan model. (first_last_frame is now MLX-eligible — see below.)
     let job = store
         .create_job(video_job_with(
-            json!({ "model": "wan_2_2", "mode": "first_last_frame" }),
+            json!({ "model": "wan_2_2", "mode": "replace_person" }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+
+    register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims the job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
+#[test]
+fn flf_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
+    // sc-3055 cutover: first_last_frame is MLX-eligible on the FLF-capable engines (LTX +
+    // Wan TI2V-5B `wan_2_2`), so a torch worker defers it to an idle mlx worker.
+    for model in ["ltx_2_3", "wan_2_2"] {
+        let store = store(&format!("mlx-video-routing-flf-{model}"));
+        register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+        register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+        let job = store
+            .create_job(video_job_with(
+                json!({
+                    "model": model, "mode": "first_last_frame",
+                    "sourceAssetId": "a", "lastFrameAssetId": "b"
+                }),
+                "auto",
+            ))
+            .expect("job creates");
+
+        assert!(
+            store
+                .claim_next_job("worker-torch")
+                .expect("torch claim ok")
+                .is_none(),
+            "{model}: torch defers FLF to the idle mlx worker"
+        );
+        let claimed = store
+            .claim_next_job("worker-mlx")
+            .expect("mlx claim ok")
+            .expect("mlx claims the FLF job");
+        assert_eq!(claimed.id, job.id);
+        assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+    }
+}
+
+#[test]
+fn flf_video_job_stays_on_torch_for_non_flf_capable_wan_moe() {
+    // FLF on the 14B Wan MoE engines has no engine Keyframe path → stays torch.
+    let store = store("mlx-video-routing-flf-moe");
+    register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+    let job = store
+        .create_job(video_job_with(
+            json!({ "model": "wan_2_2_t2v_14b", "mode": "first_last_frame" }),
             "auto",
         ))
         .expect("job creates");

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -60,32 +60,34 @@ mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/ml
 # stories (sc-3022..3035) add their provider here; this scaffold links Z-Image
 # (sc-3022, next) to prove the cross-crate registry path end to end.
 [target.'cfg(target_os = "macos")'.dependencies]
-# Rev d233f23 (mlx-gen main): carries the LoRA/LoKr trainer surface (epic 3039),
-# Wan/LTX converter stack, and the Qwen modulation-LoRA routing fix (PR #160) in one
-# shared rev so MLX builds once with the unchanged mlx-rs pin.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+# Rev a93332e3 (mlx-gen main): carries the LoRA/LoKr trainer surface (epic 3039),
+# Wan/LTX converter stack, the Qwen modulation-LoRA routing fix (PR #160), and the
+# Wan-VACE provider (`wan_vace`) + per-request `control_scale` (epic 3040 sc-3388/3441/
+# 3467, the replace_person → VACE path) in one shared rev so MLX builds once with the
+# unchanged mlx-rs pin (e59ffd88, identical across the bump → no MLX rebuild).
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d233f231bc1c992e6bdd52ec9d4c880a1c8b352e" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -996,6 +996,17 @@ fn resolve_wan_conditioning(
     project_path: &Path,
     engine_id: &str,
 ) -> WorkerResult<Vec<Conditioning>> {
+    // first_last_frame is Wan-native only on the TI2V-5B mask-blend keyframe path (sc-3357);
+    // the routing gate (`video_mode_is_mlx_eligible`) already restricts FLF to `wan_2_2`, but
+    // guard here too so a mis-routed 14B MoE job fails clearly instead of silently dropping it.
+    if request.mode == "first_last_frame" {
+        if engine_id != "wan2_2_ti2v_5b" {
+            return Err(WorkerError::InvalidPayload(format!(
+                "first_last_frame is only supported on wan_2_2 (TI2V-5B), not {engine_id}."
+            )));
+        }
+        return resolve_keyframe_conditioning(settings, request, project_path);
+    }
     let required = engine_id == "wan2_2_i2v_14b";
     let accepts = required || engine_id == "wan2_2_ti2v_5b";
     if !accepts {
@@ -1402,13 +1413,17 @@ fn resolve_ltx_adapters(request: &VideoRequest) -> WorkerResult<Vec<AdapterSpec>
 }
 
 /// Optional I2V conditioning for LTX: a `source_asset_id` → a single `Reference` image
-/// (image→video); absent → pure text→video. (Audio is produced either way.)
+/// (image→video); absent → pure text→video. `first_last_frame` → two `Keyframe`s (sc-3055).
+/// (Audio is produced either way.)
 #[cfg(target_os = "macos")]
 fn resolve_ltx_conditioning(
     settings: &Settings,
     request: &VideoRequest,
     project_path: &Path,
 ) -> WorkerResult<Vec<Conditioning>> {
+    if request.mode == "first_last_frame" {
+        return resolve_keyframe_conditioning(settings, request, project_path);
+    }
     match request.source_asset_id.as_deref() {
         Some(asset_id) => {
             let image = load_reference_image(
@@ -1434,6 +1449,87 @@ fn advanced_bool(request: &VideoRequest, key: &str) -> bool {
         .get(key)
         .and_then(Value::as_bool)
         .unwrap_or(false)
+}
+
+/// Read an `advanced` float (JSON number or numeric string), default `fallback` — mirrors the
+/// Python `_advanced_float`.
+#[cfg(target_os = "macos")]
+fn advanced_f32(request: &VideoRequest, key: &str, fallback: f32) -> f32 {
+    request
+        .advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(fallback)
+}
+
+/// Read an `advanced` integer (JSON int or numeric string), default `fallback`.
+#[cfg(target_os = "macos")]
+fn advanced_i32(request: &VideoRequest, key: &str, fallback: i32) -> i32 {
+    request
+        .advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as i32)
+        .unwrap_or(fallback)
+}
+
+/// First/last-frame conditioning (sc-3055 cutover): two [`Conditioning::Keyframe`]s — the source
+/// image pinned at latent frame 0 and the last-frame image at latent frame `-1` (the engine's
+/// Python-style negative-from-end index, so the worker needs no latent-frame math; the engine
+/// bounds-checks it). Mirrors the torch `_ltx_conditioning_images` first_last_frame path: first @
+/// `imageConditioningStrength`, last @ `lastFrameConditioningStrength` (both default 1.0 = fully
+/// pinned). Shared by LTX (`ltx_2_3`) and Wan TI2V-5B (`wan_2_2`), the engines whose providers
+/// advertise `Keyframe`. `imageFrameIndex` (default 0) is forwarded as the first keyframe's latent
+/// index — for the universal FLF case (0) latent 0 == output 0.
+#[cfg(target_os = "macos")]
+fn resolve_keyframe_conditioning(
+    settings: &Settings,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Conditioning>> {
+    let first_id = request.source_asset_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "first_last_frame requires a source image (sourceAssetId).".to_owned(),
+        )
+    })?;
+    let last_id = request.last_frame_asset_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "first_last_frame requires a last-frame image (lastFrameAssetId).".to_owned(),
+        )
+    })?;
+    let first = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        first_id,
+        project_path,
+    )?;
+    let last = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        last_id,
+        project_path,
+    )?;
+    Ok(vec![
+        Conditioning::Keyframe {
+            image: first,
+            frame_idx: advanced_i32(request, "imageFrameIndex", 0),
+            strength: advanced_f32(request, "imageConditioningStrength", 1.0),
+        },
+        Conditioning::Keyframe {
+            image: last,
+            frame_idx: -1,
+            strength: advanced_f32(request, "lastFrameConditioningStrength", 1.0),
+        },
+    ])
 }
 
 /// Raw-settings recorded on a real MLX LTX asset (`advanced` knobs + real-inference markers).
@@ -1799,6 +1895,79 @@ mod tests {
         // LTX adapters: a plain user LoRA is uniform (no per-pass schedule, no moe tag).
         let none = resolve_ltx_adapters(&req).unwrap();
         assert!(none.is_empty());
+    }
+
+    /// The FLF keyframe knobs (sc-3055) parse from JSON numbers + numeric strings and fall back
+    /// to their defaults — these drive the two `Keyframe` strengths + the first keyframe's index.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn advanced_numeric_helpers_parse_flf_keyframe_knobs() {
+        let req = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "a fox",
+            "mode": "first_last_frame",
+            "advanced": {
+                "imageConditioningStrength": 0.8,        // JSON number
+                "lastFrameConditioningStrength": "0.65",  // numeric string
+                "imageFrameIndex": 2
+            }
+        }));
+        assert_eq!(advanced_f32(&req, "imageConditioningStrength", 1.0), 0.8);
+        assert_eq!(
+            advanced_f32(&req, "lastFrameConditioningStrength", 1.0),
+            0.65
+        );
+        assert_eq!(advanced_i32(&req, "imageFrameIndex", 0), 2);
+        // Absent keys → the fully-pinned defaults (strength 1.0, first index 0).
+        let bare = request(json!({ "projectId": "p", "model": "ltx_2_3", "prompt": "a fox" }));
+        assert_eq!(advanced_f32(&bare, "imageConditioningStrength", 1.0), 1.0);
+        assert_eq!(
+            advanced_f32(&bare, "lastFrameConditioningStrength", 1.0),
+            1.0
+        );
+        assert_eq!(advanced_i32(&bare, "imageFrameIndex", 0), 0);
+    }
+
+    /// `resolve_keyframe_conditioning` fails clearly when an FLF source/last-frame asset id is
+    /// missing (the guards run before any project/image IO, so no fixture is needed).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn keyframe_conditioning_requires_both_frame_assets() {
+        let settings = Settings::from_env();
+        // No sourceAssetId.
+        let no_first = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "a fox",
+            "mode": "first_last_frame", "lastFrameAssetId": "asset_last"
+        }));
+        let err = resolve_keyframe_conditioning(&settings, &no_first, Path::new("/tmp/p"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("source image"), "got: {err}");
+        // sourceAssetId but no lastFrameAssetId.
+        let no_last = request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "a fox",
+            "mode": "first_last_frame", "sourceAssetId": "asset_first"
+        }));
+        let err = resolve_keyframe_conditioning(&settings, &no_last, Path::new("/tmp/p"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("last-frame image"), "got: {err}");
+    }
+
+    /// FLF on a 14B Wan MoE engine is rejected at the conditioning resolver (defence-in-depth
+    /// behind the routing gate, which already restricts FLF to `wan_2_2`/TI2V-5B).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_flf_rejected_on_non_ti2v_engine() {
+        let settings = Settings::from_env();
+        let req = request(json!({
+            "projectId": "p", "model": "wan_2_2_t2v_14b", "prompt": "a fox",
+            "mode": "first_last_frame",
+            "sourceAssetId": "a", "lastFrameAssetId": "b"
+        }));
+        let err = resolve_wan_conditioning(&settings, &req, Path::new("/tmp/p"), "wan2_2_t2v_14b")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("TI2V-5B"), "got: {err}");
     }
 
     /// An LTX-2.3 snapshot **complete for the current engine** ([`ltx_dir_is_complete`]),


### PR DESCRIPTION
First verified increment of the **epic 3040 worker cutover** (sc-3055). Lands the engine pin bump + the **first_last_frame (FLF)** routing slice ([sc-3520](https://app.shortcut.com/trefry/story/3520)). Because real-Mac GPU parity can't run in CI, the cutover is landing as verified increments — each routing flip is validated on a Mac before deploy (the pattern every prior cutover story in this program followed).

## What changed

**1. Engine pin bump → `a93332e3`** (`crates/sceneworks-worker/Cargo.toml`)
- All 8 `mlx-gen*` deps `d233f23 → a93332e3` (the merged mlx-gen `#163`/`#164`). `mlx-rs` rev is unchanged, so MLX builds once and stays cached.
- The bump's *only* delta vs the old pin is the **Wan-VACE provider** (`wan_vace` + per-request `control_scale`) — i.e. it specifically unlocks the upcoming `replace_person → VACE` slice (sc-3521). The conditioning framework (Keyframe/VideoClip/ControlClip), LTX advanced modes, `svd_xt`, and Wan FLF were already at the old pin.

**2. FLF cutover (sc-3520)**
- `crates/sceneworks-core/src/jobs_store.rs`: new pure helper `video_mode_is_mlx_eligible(model, mode)` admits `first_last_frame` on the FLF-capable engines only — LTX (`ltx_2_3`/`ltx_2_3_eros`, sc-3052) + Wan TI2V-5B (`wan_2_2`, sc-3357). The 14B Wan MoE engines have no engine Keyframe path, so FLF on them stays torch. `video_job_is_mlx_eligible` delegates the mode check to it.
- `crates/sceneworks-worker/src/video_jobs.rs`: shared `resolve_keyframe_conditioning` → two `Conditioning::Keyframe` — source @ latent frame `imageFrameIndex` (default 0, `imageConditioningStrength`) and the last-frame image @ latent frame **`-1`** (`lastFrameConditioningStrength`). Wired into both `resolve_ltx_conditioning` + `resolve_wan_conditioning` (Wan guarded to `wan2_2_ti2v_5b`). New `advanced_f32`/`advanced_i32` helpers mirror the Python `_advanced_float`.

## Why `-1` for the last frame (verified against engine source)

mlx-gen-ltx `build_keyframes`/`build_clips` resolve `Conditioning::Keyframe`/`VideoClip` `frame_idx` as a **latent** index with Python-style negative-from-end indexing (`frame_idx < 0 → lf + frame_idx`), bounds-checked engine-side. So the worker passes `-1` for "last frame" and needs no latent-frame math. Source-of-truth = the torch `_ltx_conditioning_images` first_last_frame path (first @ index/strength, last @ `num_frames-1`/strength).

## Tests (all green; `npm run rust:check` passes)

- `crates/sceneworks-core/tests/jobs_store.rs`: `flf_video_job_defers_from_torch_worker_to_idle_mlx_worker` (LTX + Wan), `flf_video_job_stays_on_torch_for_non_flf_capable_wan_moe`, and the repurposed `mlx_worker_excluded_from_advanced_mode_video_job` (now uses `replace_person`, which still rides torch).
- core unit `video_mode_eligibility_admits_flf_only_on_flf_capable_engines`; worker units `advanced_numeric_helpers_parse_flf_keyframe_knobs`, `keyframe_conditioning_requires_both_frame_assets`, `wan_flf_rejected_on_non_ti2v_engine`.

## Reviewer notes / scope boundaries

- **Validation gate:** the routing flip is included here but is gated on a real-Mac FLF parity pass before deploy (no special weights needed — LTX byte-validated per sc-3052, Wan structural per sc-3357). Treat as "code-complete, owes real-Mac E2E," like prior cutover stories.
- **Untouched:** person detect/track (ONNX) and the Windows/Linux torch video paths (`LtxPipelinesVideoAdapter`/`DiffusersVideoAdapter`) — mlx-gen is macOS-only, so torch stays the cross-platform path.
- **Remaining cutover slices** (filed, blocking sc-3055): sc-3521 `replace_person → Wan-VACE` (next), sc-3522 extend/bridge (blocked on IC-LoRA weights), sc-3523 SVD, then the torch Mac-path retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)