### PR TITLE
Epic 3482 foundation: MLX-required routing + mlx_unsupported oracle + gap inventory (inert/observe-mode)

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -835,6 +835,13 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         // The catalog's install-state detection resolves the HF cache from this;
         // it must match the worker's download root or every model reads "missing".
         .env("HF_HOME", huggingface_home().to_string_lossy().to_string());
+    // Epic 3482 (Python Eradication) — macOS "MLX-required" mode is wired through the API
+    // (`Settings.mlx_required` ← `SCENEWORKS_MLX_REQUIRED`, sc-3483): the MPS worker never
+    // claims an MLX-eligible job and a job no live `mlx` worker takes fails `mlx_unavailable`
+    // instead of running on MPS. It ships default OFF (observe) so nothing is set here yet;
+    // the final cutover (sc-3492) flips it on for macOS at exactly this point —
+    //     #[cfg(target_os = "macos")] { command = command.env("SCENEWORKS_MLX_REQUIRED", "1"); }
+    // — once every Mac Python surface is ported or UI-gated.
     // The in-process utility worker shells out to ffmpeg; point it at the venv's
     // bundled binary since the desktop has no system ffmpeg on PATH.
     if let Some(ffmpeg) = resolve_bundled_ffmpeg() {

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -48,22 +48,55 @@ pub(crate) async fn claim_job(
     State(state): State<AppState>,
     ApiJson(payload): ApiJson<ClaimRequest>,
 ) -> Result<Json<ClaimResponse>, ApiError> {
-    let (response, decision) = store_call(state.clone(), move |store, timeout| {
+    let mlx_required = state.settings.mlx_required;
+    let (response, decision, stranded) = store_call(state.clone(), move |store, timeout| {
         store.mark_stale_workers_interrupted(timeout)?;
-        store.claim_next_job_routed(&payload.worker_id)
+        // macOS MLX-required (sc-3483): before claiming, fail any MLX-eligible job left
+        // stranded because no live `mlx` worker took it within the grace window — reusing
+        // the worker timeout as that window. A no-op when the flag is off, so cross-platform
+        // and Mac-pre-cutover behaviour is unchanged.
+        let stranded = store.fail_stranded_mlx_jobs(mlx_required, timeout)?;
+        let (job, decision) = store.claim_next_job_routed(&payload.worker_id, mlx_required)?;
+        Ok((job, decision, stranded))
     })
     .await?;
+    for job in &stranded {
+        emit_mlx_unavailable(job);
+        publish(&state, "job.updated", job);
+    }
     if let Some(decision) = &decision {
         emit_route_decision(decision);
     }
     if let Some(job) = &response {
         publish(&state, "job.updated", job);
+    }
+    if response.is_some() || !stranded.is_empty() {
         publish_queue(&state).await?;
     }
     Ok(Json(ClaimResponse {
         job: response,
         extra: Default::default(),
     }))
+}
+
+/// Emit the macOS `mlx_unavailable` terminal-routing event as a structured JSON line for
+/// the desktop's stdout capture + the headless `GET /api/v1/logs` buffer (sc-3447/3451/3453).
+/// Mirrors [`emit_route_decision`]: this is the System → Logs surface that turns "no MLX
+/// worker took the job" into a named, actionable line instead of a job silently stuck or
+/// run on MPS (sc-3483). `reason` carries the full actionable error set on the job.
+fn emit_mlx_unavailable(job: &JobSnapshot) {
+    let model = job.payload.get("model").and_then(Value::as_str);
+    let line = json!({
+        "event": "mlx_unavailable",
+        "reportedAt": now_rfc3339(),
+        "jobId": job.id,
+        "jobType": job.job_type.as_str(),
+        "model": model,
+        "reason": job.error,
+    })
+    .to_string();
+    println!("{line}");
+    record_api_event(&line);
 }
 
 /// Emit the MLX↔torch routing decision as a structured JSON line on the API's stdout

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -49,34 +49,75 @@ pub(crate) async fn claim_job(
     ApiJson(payload): ApiJson<ClaimRequest>,
 ) -> Result<Json<ClaimResponse>, ApiError> {
     let mlx_required = state.settings.mlx_required;
-    let (response, decision, stranded) = store_call(state.clone(), move |store, timeout| {
-        store.mark_stale_workers_interrupted(timeout)?;
-        // macOS MLX-required (sc-3483): before claiming, fail any MLX-eligible job left
-        // stranded because no live `mlx` worker took it within the grace window — reusing
-        // the worker timeout as that window. A no-op when the flag is off, so cross-platform
-        // and Mac-pre-cutover behaviour is unchanged.
-        let stranded = store.fail_stranded_mlx_jobs(mlx_required, timeout)?;
-        let (job, decision) = store.claim_next_job_routed(&payload.worker_id, mlx_required)?;
-        Ok((job, decision, stranded))
-    })
-    .await?;
+    let enforce_unsupported = state.settings.mlx_enforce_unsupported;
+    let (response, decision, stranded, unsupported) =
+        store_call(state.clone(), move |store, timeout| {
+            store.mark_stale_workers_interrupted(timeout)?;
+            // macOS MLX-required (sc-3483): before claiming, fail any MLX-eligible job left
+            // stranded because no live `mlx` worker took it within the grace window — reusing
+            // the worker timeout as that window. No-op when the flag is off.
+            let stranded = store.fail_stranded_mlx_jobs(mlx_required, timeout)?;
+            // macOS MLX-required + enforce (sc-3484): fail any queued job the Rust/MLX flow
+            // can't run. No-op in warn mode (the default) — the gap is logged at claim instead.
+            let unsupported = store.fail_unsupported_mlx_jobs(mlx_required, enforce_unsupported)?;
+            let (job, decision) = store.claim_next_job_routed(&payload.worker_id, mlx_required)?;
+            Ok((job, decision, stranded, unsupported))
+        })
+        .await?;
     for job in &stranded {
         emit_mlx_unavailable(job);
+        publish(&state, "job.updated", job);
+    }
+    for (job, reason) in &unsupported {
+        emit_mlx_unsupported(job, reason, "enforce");
         publish(&state, "job.updated", job);
     }
     if let Some(decision) = &decision {
         emit_route_decision(decision);
     }
     if let Some(job) = &response {
+        // Warn-only (sc-3484): an unsupported job the torch worker just claimed on a Mac —
+        // log the gap once so the inventory materializes while the job still runs on torch.
+        // In enforce mode such a job was already failed above and never reaches here.
+        if mlx_required && !enforce_unsupported {
+            if let Err(reason) = mac_rust_supported(job) {
+                emit_mlx_unsupported(job, &reason, "warn");
+            }
+        }
         publish(&state, "job.updated", job);
     }
-    if response.is_some() || !stranded.is_empty() {
+    if response.is_some() || !stranded.is_empty() || !unsupported.is_empty() {
         publish_queue(&state).await?;
     }
     Ok(Json(ClaimResponse {
         job: response,
         extra: Default::default(),
     }))
+}
+
+/// Emit the macOS `mlx_unsupported` gap event (epic 3482 / sc-3484) as a structured JSON line
+/// for the desktop stdout capture + headless `GET /api/v1/logs` buffer (sc-3447/3451/3453).
+/// `mode` is `"enforce"` (the job was failed terminal) or `"warn"` (logged but still run on
+/// torch). The body is the feature-precise [`UnsupportedReason`] — model/feature/detail/
+/// suggestedEpic — so the Logs surface and the gap inventory name the exact port-or-drop work.
+fn emit_mlx_unsupported(job: &JobSnapshot, reason: &UnsupportedReason, mode: &str) {
+    let mut value = serde_json::to_value(reason).unwrap_or_else(|_| json!({}));
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "event".to_owned(),
+            Value::String("mlx_unsupported".to_owned()),
+        );
+        object.insert("mode".to_owned(), Value::String(mode.to_owned()));
+        object.insert("reportedAt".to_owned(), Value::String(now_rfc3339()));
+        object.insert("jobId".to_owned(), Value::String(job.id.clone()));
+        object.insert(
+            "jobType".to_owned(),
+            Value::String(job.job_type.as_str().to_owned()),
+        );
+    }
+    let line = value.to_string();
+    println!("{line}");
+    record_api_event(&line);
 }
 
 /// Emit the macOS `mlx_unavailable` terminal-routing event as a structured JSON line for

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -148,6 +148,14 @@ pub struct Settings {
     pub worker_timeout_seconds: u64,
     pub jobs_db_path: PathBuf,
     pub run_utility_inprocess: bool,
+    /// Epic 3482 — macOS "MLX-required" mode. When set (the desktop sets it on macOS,
+    /// where it spawns the in-process `mlx` worker), the MPS torch worker never claims an
+    /// MLX-eligible job: it defers unconditionally to the `mlx` worker, and a job no live
+    /// `mlx` worker takes within the grace window fails terminal with `mlx_unavailable`
+    /// instead of silently falling back to MPS (sc-3483). Absent on Windows/Linux/Docker
+    /// (no `mlx` worker) → today's behaviour unchanged. Ships default OFF (observe); the
+    /// final cutover (sc-3492) flips it on for the packaged Mac build.
+    pub mlx_required: bool,
 }
 
 impl Settings {
@@ -184,6 +192,9 @@ impl Settings {
                 .unwrap_or(90),
             jobs_db_path,
             run_utility_inprocess: std::env::var("SCENEWORKS_RUN_UTILITY_INPROCESS")
+                .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True"))
+                .unwrap_or(false),
+            mlx_required: std::env::var("SCENEWORKS_MLX_REQUIRED")
                 .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True"))
                 .unwrap_or(false),
         }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -26,8 +26,8 @@ use sceneworks_core::contracts::{
     WorkerSnapshot, WorkerStatus,
 };
 use sceneworks_core::jobs_store::{
-    CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker, RetryJob,
-    RouteDecision, WorkerHeartbeat, JOB_STATUSES,
+    mac_rust_supported, CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate,
+    RegisterWorker, RetryJob, RouteDecision, UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
@@ -156,6 +156,14 @@ pub struct Settings {
     /// (no `mlx` worker) → today's behaviour unchanged. Ships default OFF (observe); the
     /// final cutover (sc-3492) flips it on for the packaged Mac build.
     pub mlx_required: bool,
+    /// Epic 3482 / sc-3484 — when MLX-required, what to do with a job the Rust/MLX flow can't
+    /// run (`mac_rust_supported` returns `Err`). **false = warn-only** (default): log a
+    /// structured `mlx_unsupported` gap event at claim time but still run the job on the
+    /// existing torch path, so flipping `mlx_required` on for observation materializes the gap
+    /// list without breaking anything. **true = enforce**: fail the job terminal with
+    /// `mlx_unsupported`. Read from `SCENEWORKS_MLX_UNSUPPORTED_MODE` (`enforce` vs anything
+    /// else). Irrelevant unless `mlx_required`.
+    pub mlx_enforce_unsupported: bool,
 }
 
 impl Settings {
@@ -196,6 +204,9 @@ impl Settings {
                 .unwrap_or(false),
             mlx_required: std::env::var("SCENEWORKS_MLX_REQUIRED")
                 .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True"))
+                .unwrap_or(false),
+            mlx_enforce_unsupported: std::env::var("SCENEWORKS_MLX_UNSUPPORTED_MODE")
+                .map(|value| value.trim().eq_ignore_ascii_case("enforce"))
                 .unwrap_or(false),
         }
     }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -194,6 +194,7 @@ fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         worker_timeout_seconds: 90,
         jobs_db_path: temp_dir.path().join("jobs.db"),
         run_utility_inprocess: false,
+        mlx_required: false,
     }
 }
 

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -195,6 +195,7 @@ fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         jobs_db_path: temp_dir.path().join("jobs.db"),
         run_utility_inprocess: false,
         mlx_required: false,
+        mlx_enforce_unsupported: false,
     }
 }
 

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1849,6 +1849,23 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
     }
 }
 
+/// The dedicated MLX-porting epic for a torch-only image model (epic 3482 policy: every
+/// unported model gets its own port epic + is dropped on Mac until it lands). `None` = a
+/// model we don't have a port epic for yet, which the oracle reports as "needs an epic".
+/// Keep in sync with `docs/mac-rust-gaps.md` §1.
+fn torch_only_image_model_epic(model: &str) -> Option<&'static str> {
+    match model {
+        "kolors" => Some("epic 3532"),
+        "instantid_realvisxl" => Some("epic 3109"),
+        "pulid_flux_dev" => Some("epic 3069"),
+        "z_image_edit" => Some("epic 3529"),
+        m if m.starts_with("sensenova") => Some("epic 3180"),
+        m if m.starts_with("lens") => Some("epic 3164"),
+        m if m.starts_with("chroma") => Some("epic 3531"),
+        _ => None,
+    }
+}
+
 /// Name the precise gap for an ineligible `image_generate` / `image_edit` job: a torch-only
 /// model, or a torch-only feature on an otherwise-MLX family. Mirrors the per-family
 /// `*_mlx_eligible` gates so the reason matches why routing refused it.
@@ -1857,12 +1874,13 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
         return UnsupportedReason::new(None, "image generation", "no model specified.", None);
     };
     if !MLX_ROUTED_MODELS.contains(&model) {
-        return UnsupportedReason::new(
-            Some(model),
-            "torch-only image model",
-            "this model has no Rust/MLX engine; it runs on the Python torch path (InstantID / Kolors / PuLID / SenseNova / Lens / FLUX.2-dev family).",
-            Some("epic 3061"),
-        );
+        let epic = torch_only_image_model_epic(model);
+        let detail = if epic.is_some() {
+            "this model has no Rust/MLX engine yet; it runs on the Python torch path and is dropped on Mac until its port epic lands."
+        } else {
+            "this model has no Rust/MLX engine and no port epic yet — file a porting epic and drop it on Mac (epic 3482 policy)."
+        };
+        return UnsupportedReason::new(Some(model), "torch-only image model", detail, epic);
     }
     if request_has_lycoris_lora(&job.payload) {
         return UnsupportedReason::new(
@@ -1902,8 +1920,8 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
         "z_image_turbo" if is_edit => UnsupportedReason::new(
             Some(model),
             "edit_image",
-            "Z-Image img2img edit stays on the Python torch path.",
-            None,
+            "Z-Image img2img edit stays on the Python torch path (folds into the Z-Image-Edit port).",
+            Some("epic 3529"),
         ),
         "z_image_turbo" => UnsupportedReason::new(
             Some(model),

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -660,8 +660,109 @@ impl JobsStore {
         })
     }
 
+    /// macOS "MLX-required" grace sweep (epic 3482 / sc-3483). When `mlx_required`, the
+    /// non-mlx (MPS) worker never claims an MLX-eligible job — it defers unconditionally
+    /// to the in-process `mlx` worker (see `should_defer_*`). If no **live** `mlx` worker
+    /// claims such a job within the grace window — because the worker is down, never
+    /// started, or has been crashed longer than the supervisor's auto-restart can
+    /// self-heal — the job would otherwise sit queued forever. This fails those jobs
+    /// terminal (`status = failed`) with an actionable `mlx_unavailable` error naming the
+    /// model + job type, so the failure is loud and points at the real gap instead of
+    /// silently falling back to MPS.
+    ///
+    /// "Live `mlx` worker" = a `gpu_id = 'mlx'` worker that is not offline and has
+    /// heartbeat within the grace window. While one exists (even if it is merely busy),
+    /// this is a no-op and the job waits to be claimed; a transient `mlx` crash that the
+    /// supervisor restarts inside the window therefore never fails a job. `grace_seconds`
+    /// reuses the stale-worker timeout for exactly that reason.
+    ///
+    /// Off (`mlx_required == false`) it returns immediately, so Windows/Linux/Docker and
+    /// the Mac build before the final cutover (sc-3492) are completely unaffected. Returns
+    /// the jobs it failed so the caller can surface the structured event in System → Logs
+    /// and publish their updates.
+    pub fn fail_stranded_mlx_jobs(
+        &self,
+        mlx_required: bool,
+        grace_seconds: u64,
+    ) -> JobsStoreResult<Vec<JobSnapshot>> {
+        if !mlx_required {
+            return Ok(Vec::new());
+        }
+        let _guard = self.lock.lock();
+        let mut connection = self.connect()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let now = now_unix_seconds();
+        let grace = i64::try_from(grace_seconds.max(1)).unwrap_or(i64::MAX);
+        let cutoff = format_unix_seconds(now.saturating_sub(grace));
+
+        // A live `mlx` worker (not offline, heartbeat within the window) means MLX-eligible
+        // jobs should wait for it — it may simply be busy. Only when none has checked in
+        // within the window do we treat MLX as unavailable and fail the stranded jobs.
+        let live_mlx_worker = transaction
+            .query_row(
+                "
+                select 1 from workers
+                 where gpu_id = 'mlx'
+                   and status != 'offline'
+                   and last_seen_at >= ?1
+                 limit 1
+                ",
+                params![cutoff],
+                |_row| Ok(()),
+            )
+            .optional()?
+            .is_some();
+        if live_mlx_worker {
+            return Ok(Vec::new());
+        }
+
+        // Candidates: still queued and old enough to have outlived the grace window. A job
+        // newer than the cutoff keeps waiting (bounded), so a job created mid-outage isn't
+        // failed instantly — it gets the full window for an `mlx` worker to appear.
+        let mut statement = transaction.prepare(
+            "
+            select * from jobs
+             where status = 'queued'
+               and created_at < ?1
+             order by created_at asc
+            ",
+        )?;
+        let candidates = collect_jobs(statement.query_map(params![cutoff], row_to_job)?)?;
+        drop(statement);
+
+        let now_text = format_unix_seconds(now);
+        let mut failed_ids = Vec::new();
+        for job in candidates {
+            if !job_is_any_mlx_eligible(&job) {
+                continue;
+            }
+            let error = mlx_unavailable_error(&job, grace_seconds);
+            transaction.execute(
+                "
+                update jobs
+                   set status = 'failed',
+                       stage = 'failed',
+                       message = 'MLX worker unavailable.',
+                       error = ?2,
+                       completed_at = ?1,
+                       updated_at = ?1,
+                       worker_id = null
+                 where id = ?3 and status = 'queued'
+                ",
+                params![now_text, error, job.id],
+            )?;
+            failed_ids.push(job.id.clone());
+        }
+        let failed = failed_ids
+            .iter()
+            .map(|id| self.get_job_on_connection(&transaction, id))
+            .collect::<JobsStoreResult<Vec<_>>>()?;
+        transaction.commit()?;
+        Ok(failed)
+    }
+
     pub fn claim_next_job(&self, worker_id: &str) -> JobsStoreResult<Option<JobSnapshot>> {
-        Ok(self.claim_next_job_routed(worker_id)?.0)
+        Ok(self.claim_next_job_routed(worker_id, false)?.0)
     }
 
     /// Like [`Self::claim_next_job`], but also reports the MLX↔torch routing decision
@@ -673,6 +774,7 @@ impl JobsStore {
     pub fn claim_next_job_routed(
         &self,
         worker_id: &str,
+        mlx_required: bool,
     ) -> JobsStoreResult<(Option<JobSnapshot>, Option<RouteDecision>)> {
         let _guard = self.lock.lock();
         let mut connection = self.connect()?;
@@ -732,9 +834,9 @@ impl JobsStore {
         if should_defer_auto_gpu_claim(&transaction, &queued, &worker)? {
             return Ok((None, None));
         }
-        if should_defer_image_to_mlx_worker(&transaction, &queued, &worker)?
-            || should_defer_video_to_mlx_worker(&transaction, &queued, &worker)?
-            || should_defer_training_to_mlx_worker(&transaction, &queued, &worker)?
+        if should_defer_image_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
+            || should_defer_video_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
+            || should_defer_training_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
         {
             // A non-mlx worker is yielding this MLX-eligible job to an idle mlx worker.
             let decision = RouteDecision::new(
@@ -1522,6 +1624,33 @@ impl RouteDecision {
     }
 }
 
+/// True when *any* MLX-routing predicate (image/detail, video, or training) claims this
+/// job — the union an `mlx` worker would want. Used both to classify a claim for routing
+/// observability (sc-3449) and to identify the jobs the macOS grace sweep must fail when
+/// no `mlx` worker is alive (sc-3483).
+fn job_is_any_mlx_eligible(job: &JobSnapshot) -> bool {
+    job_is_mlx_eligible(job) || video_job_is_mlx_eligible(job) || training_job_is_mlx_eligible(job)
+}
+
+/// Actionable terminal error for an MLX-eligible job stranded on macOS with no live `mlx`
+/// worker (sc-3483). Names the model + job type so the job card and the System → Logs
+/// surface point at the real gap, never a generic failure. Prefixed `mlx_unavailable:` so
+/// the cause is greppable in logs and distinguishable from `mlx_unsupported` (sc-3484).
+fn mlx_unavailable_error(job: &JobSnapshot, grace_seconds: u64) -> String {
+    let model = job
+        .payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("(unknown)");
+    format!(
+        "mlx_unavailable: the MLX GPU worker is required on macOS but no live worker \
+         claimed this job within {grace_seconds}s (model={model}, type={job_type}). The \
+         Python/MPS fallback is disabled on Mac — check System → Logs and confirm the MLX \
+         worker is running.",
+        job_type = job.job_type.as_str()
+    )
+}
+
 /// Classify a *successful* claim for routing observability. `None` means the claim was
 /// routing-neutral (the job is not MLX-eligible, so no `mlx` worker would have wanted
 /// it). When a non-`mlx` worker claims an MLX-eligible job, the reason distinguishes a
@@ -1534,10 +1663,7 @@ fn route_decision_for_claim(
     gpu_id: &str,
     worker_id: &str,
 ) -> Option<RouteDecision> {
-    let mlx_eligible = job_is_mlx_eligible(job)
-        || video_job_is_mlx_eligible(job)
-        || training_job_is_mlx_eligible(job);
-    if !mlx_eligible {
+    if !job_is_any_mlx_eligible(job) {
         return None;
     }
     if gpu_id.eq_ignore_ascii_case("mlx") {
@@ -1629,11 +1755,24 @@ fn should_defer_image_to_mlx_worker(
     connection: &Connection,
     job: &JobSnapshot,
     worker: &WorkerSnapshot,
+    mlx_required: bool,
 ) -> JobsStoreResult<bool> {
-    if job.requested_gpu != "auto"
-        || worker.gpu_id.eq_ignore_ascii_case("mlx")
-        || !job_is_mlx_eligible(job)
-    {
+    if worker.gpu_id.eq_ignore_ascii_case("mlx") || !job_is_mlx_eligible(job) {
+        return Ok(false);
+    }
+    // macOS "MLX-required" (epic 3482 / sc-3483): the non-mlx (MPS) worker NEVER claims
+    // an MLX-eligible job — it yields unconditionally, even when no idle `mlx` worker is
+    // ready *right now*. The job waits for the `mlx` worker and, if none takes it within
+    // the grace window, `fail_stranded_mlx_jobs` fails it terminal with `mlx_unavailable`
+    // rather than letting MPS silently run it. This covers explicit-GPU pins too: "never
+    // MPS" is absolute on Mac.
+    if mlx_required {
+        return Ok(true);
+    }
+    // Off (Windows/Linux/Docker, and Mac pre-cutover): unchanged — defer only an `auto`
+    // job to an actually-idle `mlx` worker; otherwise the torch worker is the fallback and
+    // an explicit (non-`auto`) GPU choice is always honoured.
+    if job.requested_gpu != "auto" {
         return Ok(false);
     }
     idle_mlx_worker_can_claim(connection, job, worker)
@@ -1647,11 +1786,16 @@ fn should_defer_video_to_mlx_worker(
     connection: &Connection,
     job: &JobSnapshot,
     worker: &WorkerSnapshot,
+    mlx_required: bool,
 ) -> JobsStoreResult<bool> {
-    if job.requested_gpu != "auto"
-        || worker.gpu_id.eq_ignore_ascii_case("mlx")
-        || !video_job_is_mlx_eligible(job)
-    {
+    if worker.gpu_id.eq_ignore_ascii_case("mlx") || !video_job_is_mlx_eligible(job) {
+        return Ok(false);
+    }
+    // macOS MLX-required (sc-3483): yield unconditionally, same as the image sibling.
+    if mlx_required {
+        return Ok(true);
+    }
+    if job.requested_gpu != "auto" {
         return Ok(false);
     }
     idle_mlx_worker_can_claim(connection, job, worker)
@@ -1668,11 +1812,16 @@ fn should_defer_training_to_mlx_worker(
     connection: &Connection,
     job: &JobSnapshot,
     worker: &WorkerSnapshot,
+    mlx_required: bool,
 ) -> JobsStoreResult<bool> {
-    if job.requested_gpu != "auto"
-        || worker.gpu_id.eq_ignore_ascii_case("mlx")
-        || !training_job_is_mlx_eligible(job)
-    {
+    if worker.gpu_id.eq_ignore_ascii_case("mlx") || !training_job_is_mlx_eligible(job) {
+        return Ok(false);
+    }
+    // macOS MLX-required (sc-3483): yield unconditionally, same as the image sibling.
+    if mlx_required {
+        return Ok(true);
+    }
+    if job.requested_gpu != "auto" {
         return Ok(false);
     }
     idle_mlx_worker_can_claim(connection, job, worker)

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -761,6 +761,63 @@ impl JobsStore {
         Ok(failed)
     }
 
+    /// macOS "MLX-unsupported" enforce sweep (epic 3482 / sc-3484). When `mlx_required` AND
+    /// `enforce`, fails every queued job the Rust/MLX flow can't run (`mac_rust_supported`
+    /// returns `Err`) terminal with a feature-precise `mlx_unsupported` error — the forcing
+    /// function that turns "still on torch" into a loud, named failure instead of a silent
+    /// fallback. Unlike the stranded sweep there is no grace window: an unsupported job is
+    /// permanently unsupported until its surface is ported or dropped, so it fails immediately.
+    ///
+    /// Default mode is **warn** (`enforce == false`) → this is a no-op and the gap is logged
+    /// at claim time instead (the job still runs on torch), so flipping `mlx_required` on for
+    /// observation surfaces the gap list without breaking anything. Off (`!mlx_required`) →
+    /// immediate no-op, so Windows/Linux/Docker are unaffected. MLX-*eligible* jobs are
+    /// `Ok` here and handled by `fail_stranded_mlx_jobs`/routing — the two sweeps partition
+    /// the queue and never touch the same job. Returns `(job, reason)` pairs so the caller can
+    /// emit the structured event.
+    pub fn fail_unsupported_mlx_jobs(
+        &self,
+        mlx_required: bool,
+        enforce: bool,
+    ) -> JobsStoreResult<Vec<(JobSnapshot, UnsupportedReason)>> {
+        if !mlx_required || !enforce {
+            return Ok(Vec::new());
+        }
+        let _guard = self.lock.lock();
+        let mut connection = self.connect()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let mut statement = transaction
+            .prepare("select * from jobs where status = 'queued' order by created_at asc")?;
+        let candidates = collect_jobs(statement.query_map([], row_to_job)?)?;
+        drop(statement);
+
+        let now_text = format_unix_seconds(now_unix_seconds());
+        let mut failed = Vec::new();
+        for job in candidates {
+            let Err(reason) = mac_rust_supported(&job) else {
+                continue;
+            };
+            transaction.execute(
+                "
+                update jobs
+                   set status = 'failed',
+                       stage = 'failed',
+                       message = 'Not supported by the Rust/MLX flow on macOS.',
+                       error = ?2,
+                       completed_at = ?1,
+                       updated_at = ?1,
+                       worker_id = null
+                 where id = ?3 and status = 'queued'
+                ",
+                params![now_text, reason.error_message(), job.id],
+            )?;
+            let updated = self.get_job_on_connection(&transaction, &job.id)?;
+            failed.push((updated, reason));
+        }
+        transaction.commit()?;
+        Ok(failed)
+    }
+
     pub fn claim_next_job(&self, worker_id: &str) -> JobsStoreResult<Option<JobSnapshot>> {
         Ok(self.claim_next_job_routed(worker_id, false)?.0)
     }
@@ -1649,6 +1706,333 @@ fn mlx_unavailable_error(job: &JobSnapshot, grace_seconds: u64) -> String {
          worker is running.",
         job_type = job.job_type.as_str()
     )
+}
+
+/// Why the Rust/MLX flow can't run a job on macOS (epic 3482 / sc-3484) — the inverse of the
+/// `*_mlx_eligible` predicates, extended across every job type. Feature-precise so the
+/// `mlx_unsupported` Logs event + the gap inventory name the exact surface to port or drop.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnsupportedReason {
+    /// Model id involved, when the gap is model-specific (e.g. "kolors", "qwen_image").
+    pub model: Option<String>,
+    /// The specific capability that isn't in the Rust/MLX flow (e.g. "strict-pose ControlNet",
+    /// "third-party LyCORIS LoRA", "image_upscale (Real-ESRGAN)").
+    pub feature: String,
+    /// Actionable human-readable explanation.
+    pub detail: String,
+    /// Closing story/epic ("epic 3401", "sc-3489"), `"drop-candidate"`, or `None` when not yet
+    /// triaged — the roadmap pointer. "where known" per the story.
+    pub suggested_epic: Option<String>,
+}
+
+impl UnsupportedReason {
+    fn new(model: Option<&str>, feature: &str, detail: &str, suggested_epic: Option<&str>) -> Self {
+        Self {
+            model: model.map(str::to_owned),
+            feature: feature.to_owned(),
+            detail: detail.to_owned(),
+            suggested_epic: suggested_epic.map(str::to_owned),
+        }
+    }
+
+    /// Terminal job error for an enforced `mlx_unsupported` failure (sc-3484): greppable
+    /// prefix, names feature + model + roadmap pointer.
+    pub fn error_message(&self) -> String {
+        let model = self
+            .model
+            .as_deref()
+            .map(|m| format!(" ({m})"))
+            .unwrap_or_default();
+        let pointer = self
+            .suggested_epic
+            .as_deref()
+            .map(|epic| format!(" [{epic}]"))
+            .unwrap_or_default();
+        format!(
+            "mlx_unsupported: {feature}{model} is not in the Rust/MLX flow on macOS — {detail}{pointer}",
+            feature = self.feature,
+            detail = self.detail,
+        )
+    }
+}
+
+/// macOS "can the Rust/MLX flow run this?" oracle (sc-3484). `Ok(())` = the in-process mlx
+/// worker — or an MLX-agnostic in-process path (downloads, ffmpeg, prompt refine) — runs it
+/// with no Python torch dependency. `Err` names the exact Python-torch gap. This is the epic's
+/// *forcing function*: under mlx-required **enforce** mode an `Err` job fails terminal with
+/// `mlx_unsupported`, and the set of `Err`s IS the port-or-drop roadmap. Consistent with
+/// routing by construction — anything `job_is_any_mlx_eligible` accepts is `Ok`.
+pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
+    if job_is_any_mlx_eligible(job) {
+        return Ok(());
+    }
+    let model = job.payload.get("model").and_then(Value::as_str);
+    match job.job_type {
+        // MLX-agnostic job types: metadata/utility work, ffmpeg, and prompt refine run
+        // in-process on macOS with no Python torch dependency.
+        JobType::Placeholder
+        | JobType::ModelDownload
+        | JobType::ModelImport
+        | JobType::LoraImport
+        | JobType::FrameExtract
+        | JobType::TimelineExport
+        | JobType::PromptRefine => Ok(()),
+
+        // Forward-compat: an unrecognized job type isn't a known Python-torch gap, so don't
+        // enforce-fail it (it would otherwise break a newer job type this build doesn't model).
+        JobType::Unknown(_) => Ok(()),
+
+        JobType::ImageGenerate | JobType::ImageEdit => Err(classify_image_gap(job)),
+
+        JobType::ImageDetail => Err(UnsupportedReason::new(
+            model,
+            "non-SDXL tile-detail refine",
+            "image_detail is ported to MLX only for the SDXL/RealVisXL backbones (sc-3060); other models / third-party LyCORIS stay on the Python torch path.",
+            Some("epic 3041"),
+        )),
+
+        JobType::ImageVqa | JobType::ImageInterleave => Err(UnsupportedReason::new(
+            model,
+            "image understanding / interleave",
+            "image VQA / interleaved generation has no Rust/MLX engine path.",
+            None,
+        )),
+
+        JobType::VideoGenerate => Err(classify_video_gap(job)),
+
+        JobType::VideoExtend | JobType::VideoBridge => Err(UnsupportedReason::new(
+            model,
+            "advanced video (extend / bridge)",
+            "video_extend / video_bridge are torch-only advanced video modes.",
+            Some("epic 3040"),
+        )),
+
+        JobType::PersonReplace => Err(UnsupportedReason::new(
+            model,
+            "replace_person",
+            "person replacement is a torch-only advanced video mode (also depends on person detect/track).",
+            Some("epic 3040 (+ sc-3488)"),
+        )),
+
+        JobType::PersonDetect | JobType::PersonTrack => Err(UnsupportedReason::new(
+            None,
+            "person detect / track (YOLO/SAM2)",
+            "person detection/tracking runs on the Python onnxruntime/torch path.",
+            Some("sc-3488"),
+        )),
+
+        JobType::PoseDetect => Err(UnsupportedReason::new(
+            None,
+            "DWPose pose detection",
+            "photo→skeleton pose detection runs on Python onnxruntime (DWPose).",
+            Some("sc-3487"),
+        )),
+
+        JobType::ImageUpscale => Err(UnsupportedReason::new(
+            model,
+            "image_upscale (Real-ESRGAN)",
+            "standalone image upscaling runs on the Python torch Real-ESRGAN / AuraSR path.",
+            Some("sc-3489"),
+        )),
+
+        JobType::ModelConvert => classify_convert_gap(job),
+
+        JobType::LoraTrain => Err(classify_training_gap(job)),
+
+        JobType::TrainingCaption => Err(UnsupportedReason::new(
+            None,
+            "dataset captioning",
+            "automatic dataset captioning runs on the Python torch captioner.",
+            Some("sc-3490"),
+        )),
+    }
+}
+
+/// Name the precise gap for an ineligible `image_generate` / `image_edit` job: a torch-only
+/// model, or a torch-only feature on an otherwise-MLX family. Mirrors the per-family
+/// `*_mlx_eligible` gates so the reason matches why routing refused it.
+fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
+    let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
+        return UnsupportedReason::new(None, "image generation", "no model specified.", None);
+    };
+    if !MLX_ROUTED_MODELS.contains(&model) {
+        return UnsupportedReason::new(
+            Some(model),
+            "torch-only image model",
+            "this model has no Rust/MLX engine; it runs on the Python torch path (InstantID / Kolors / PuLID / SenseNova / Lens / FLUX.2-dev family).",
+            Some("epic 3061"),
+        );
+    }
+    if request_has_lycoris_lora(&job.payload) {
+        return UnsupportedReason::new(
+            Some(model),
+            "third-party LyCORIS LoRA",
+            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr).",
+            Some("drop-candidate"),
+        );
+    }
+    let has_poses = job
+        .payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty());
+    let is_edit = job.payload.get("mode").and_then(Value::as_str) == Some("edit_image");
+    match model {
+        "qwen_image" if has_poses => UnsupportedReason::new(
+            Some(model),
+            "strict-pose ControlNet",
+            "Qwen strict-pose ControlNet (InstantX QwenImageControlNet) has no MLX port; the MLX path would silently drop the poses.",
+            Some("epic 3401"),
+        ),
+        "qwen_image" => UnsupportedReason::new(
+            Some(model),
+            "reference / edit conditioning",
+            "base Qwen-Image reference / edit_image conditioning stays on the Python torch path.",
+            Some("epic 3401"),
+        ),
+        "flux_schnell" | "flux_dev" => UnsupportedReason::new(
+            Some(model),
+            "reference / IP-Adapter / edit",
+            "FLUX.1 reference / IP-Adapter / edit_image conditioning stays on the Python torch path.",
+            None,
+        ),
+        "z_image_turbo" if is_edit => UnsupportedReason::new(
+            Some(model),
+            "edit_image",
+            "Z-Image img2img edit stays on the Python torch path.",
+            None,
+        ),
+        "z_image_turbo" => UnsupportedReason::new(
+            Some(model),
+            "reference without a pose set",
+            "a Z-Image reference is only MLX-eligible alongside a strict pose set; reference-only stays on torch.",
+            None,
+        ),
+        "qwen_image_edit"
+        | "qwen_image_edit_2509"
+        | "qwen_image_edit_2511"
+        | "qwen_image_edit_2511_lightning" => UnsupportedReason::new(
+            Some(model),
+            "edit without a reference/source image",
+            "the Qwen-Image-Edit model needs edit_image+sourceAssetId or character_image+referenceAssetId to route to MLX.",
+            None,
+        ),
+        // flux2 / sdxl / realvisxl only fall out via LyCORIS (handled above) — defensive.
+        _ => UnsupportedReason::new(
+            Some(model),
+            "unsupported configuration",
+            "this model/feature combination is not in the Rust/MLX flow.",
+            None,
+        ),
+    }
+}
+
+/// Name the precise gap for an ineligible `video_generate` job: a torch-only model (incl. SVD),
+/// an advanced mode, a third-party LyCORIS, or LoKr-on-Wan. Mirrors `video_job_is_mlx_eligible`.
+fn classify_video_gap(job: &JobSnapshot) -> UnsupportedReason {
+    let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
+        return UnsupportedReason::new(None, "video generation", "no model specified.", None);
+    };
+    if !VIDEO_MLX_ROUTED_MODELS.contains(&model) {
+        return UnsupportedReason::new(
+            Some(model),
+            "torch-only video model (incl. SVD)",
+            "this video model has no Rust/MLX engine (e.g. SVD); it runs on the Python torch path.",
+            Some("epic 3040"),
+        );
+    }
+    let mode = job
+        .payload
+        .get("mode")
+        .and_then(Value::as_str)
+        .unwrap_or("image_to_video");
+    if !matches!(mode, "text_to_video" | "image_to_video") {
+        return UnsupportedReason::new(
+            Some(model),
+            "advanced video mode",
+            "advanced video_generate modes (first_last_frame / replace_person) are torch-only.",
+            Some("epic 3040"),
+        );
+    }
+    if request_has_lycoris_lora(&job.payload) {
+        return UnsupportedReason::new(
+            Some(model),
+            "third-party LyCORIS LoRA",
+            "the mlx-video path can't apply arbitrary third-party LyCORIS adapters.",
+            Some("drop-candidate"),
+        );
+    }
+    if is_wan_video_model(model) && request_has_lokr_lora(&job.payload) {
+        return UnsupportedReason::new(
+            Some(model),
+            "LoKr-on-Wan",
+            "the mlx Wan path can't merge a Kronecker (LoKr) adapter; LoKr-on-Wan stays on torch.",
+            Some("epic 3040"),
+        );
+    }
+    UnsupportedReason::new(
+        Some(model),
+        "unsupported video configuration",
+        "this video configuration is not in the Rust/MLX flow.",
+        None,
+    )
+}
+
+/// Name the precise gap for an ineligible `lora_train` job. Mirrors `training_job_is_mlx_eligible`:
+/// a kernel with no native mlx-gen Rust trainer, or LoKr-on-Wan.
+fn classify_training_gap(job: &JobSnapshot) -> UnsupportedReason {
+    let kernel = job
+        .payload
+        .get("plan")
+        .and_then(Value::as_object)
+        .and_then(|plan| plan.get("target"))
+        .and_then(Value::as_object)
+        .and_then(|target| target.get("kernel"))
+        .and_then(Value::as_str);
+    match kernel {
+        Some("kolors_lora") => UnsupportedReason::new(
+            None,
+            "Kolors LoRA training",
+            "the Kolors trainer (SDXL + ChatGLM3) has no mlx-gen Rust trainer.",
+            Some("epic 3039"),
+        ),
+        Some("lens_lora") => UnsupportedReason::new(
+            None,
+            "Lens LoRA training",
+            "the Lens trainer runs in a Python sidecar with no mlx-gen Rust trainer.",
+            Some("epic 3039"),
+        ),
+        Some("wan_lora") | Some("wan_moe_lora") => UnsupportedReason::new(
+            None,
+            "LoKr-on-Wan training",
+            "Wan LoKr training stays on torch (no Kronecker merge in the mlx Wan path).",
+            Some("epic 3039"),
+        ),
+        _ => UnsupportedReason::new(
+            None,
+            "LoRA/LoKr training",
+            "this training kernel has no native mlx-gen Rust trainer.",
+            Some("epic 3039"),
+        ),
+    }
+}
+
+/// `model_convert` is supported only for the in-process Rust FLUX.2-klein converter
+/// (`flux2_klein_diffusers`, sc-3136). The default/absent converter is the Python mlx-video
+/// Wan/LTX path (sc-3491 / sc-3224).
+fn classify_convert_gap(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
+    if job.payload.get("converter").and_then(Value::as_str) == Some("flux2_klein_diffusers") {
+        return Ok(());
+    }
+    Err(UnsupportedReason::new(
+        job.payload.get("model").and_then(Value::as_str),
+        "Wan/LTX model conversion (mlx_video)",
+        "installing a non-turnkey Wan/LTX checkpoint converts via the Python mlx_video path.",
+        Some("sc-3491 / sc-3224"),
+    ))
 }
 
 /// Classify a *successful* claim for routing observability. `None` means the claim was

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1795,8 +1795,8 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         JobType::ImageVqa | JobType::ImageInterleave => Err(UnsupportedReason::new(
             model,
             "image understanding / interleave",
-            "image VQA / interleaved generation has no Rust/MLX engine path.",
-            None,
+            "image VQA / interleaved generation is the SenseNova-U1 understanding surface; it lands with the SenseNova port.",
+            Some("epic 3180"),
         )),
 
         JobType::VideoGenerate => Err(classify_video_gap(job)),
@@ -1886,8 +1886,8 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
         return UnsupportedReason::new(
             Some(model),
             "third-party LyCORIS LoRA",
-            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr).",
-            Some("drop-candidate"),
+            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr) — port-or-drop spike.",
+            Some("sc-3537"),
         );
     }
     let has_poses = job
@@ -1914,8 +1914,8 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
         "flux_schnell" | "flux_dev" => UnsupportedReason::new(
             Some(model),
             "reference / IP-Adapter / edit",
-            "FLUX.1 reference / IP-Adapter / edit_image conditioning stays on the Python torch path.",
-            None,
+            "FLUX.1 reference / IP-Adapter / edit_image conditioning stays on the Python torch path — viability spike.",
+            Some("sc-3535"),
         ),
         "z_image_turbo" if is_edit => UnsupportedReason::new(
             Some(model),
@@ -1926,8 +1926,8 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
         "z_image_turbo" => UnsupportedReason::new(
             Some(model),
             "reference without a pose set",
-            "a Z-Image reference is only MLX-eligible alongside a strict pose set; reference-only stays on torch.",
-            None,
+            "a Z-Image reference is only MLX-eligible alongside a strict pose set; reference-only stays on torch — viability spike.",
+            Some("sc-3536"),
         ),
         "qwen_image_edit"
         | "qwen_image_edit_2509"
@@ -1979,8 +1979,8 @@ fn classify_video_gap(job: &JobSnapshot) -> UnsupportedReason {
         return UnsupportedReason::new(
             Some(model),
             "third-party LyCORIS LoRA",
-            "the mlx-video path can't apply arbitrary third-party LyCORIS adapters.",
-            Some("drop-candidate"),
+            "the mlx-video path can't apply arbitrary third-party LyCORIS adapters — port-or-drop spike.",
+            Some("sc-3537"),
         );
     }
     if is_wan_video_model(model) && request_has_lokr_lora(&job.payload) {

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1583,6 +1583,146 @@ fn mlx_eligible_image_job_falls_back_to_torch_when_no_mlx_worker() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("cuda:0"));
 }
 
+// epic 3482 / sc-3483 — macOS "MLX-required": the MPS worker never claims an MLX-eligible
+// job, and a job no live `mlx` worker takes within the grace window fails terminal with
+// `mlx_unavailable` rather than silently running on MPS. Ships behind a flag (default OFF);
+// the sibling `*_falls_back_to_torch_*` tests above pin the OFF behaviour.
+
+/// Backdate a job's `created_at` so the grace sweep treats it as having outlived the
+/// window (mirrors how `stale_sweep_*` backdates `last_seen_at`).
+fn backdate_job_created_at(store: &JobsStore, job_id: &str) {
+    let connection = Connection::open(store.db_path()).expect("db opens");
+    connection
+        .execute(
+            "update jobs set created_at = '2000-01-01T00:00:00Z' where id = ?1",
+            params![job_id],
+        )
+        .expect("job created_at backdates");
+}
+
+#[test]
+fn mlx_required_defers_eligible_job_even_with_no_idle_mlx_worker() {
+    let store = store("mlx-required-defer");
+    // Only an MPS worker is registered — no idle `mlx` worker to take the job. With the
+    // flag OFF this is exactly the torch fallback; with it ON the MPS worker yields
+    // unconditionally ("never MPS" on Mac).
+    register_gpu_worker(&store, "worker-mps", "mps", image_caps());
+    store
+        .create_job(image_job_with(
+            json!({ "model": "z_image_turbo", "prompt": "a misty fjord" }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    let (claimed, decision) = store
+        .claim_next_job_routed("worker-mps", true)
+        .expect("claim ok");
+    assert!(
+        claimed.is_none(),
+        "MPS worker must not claim the MLX-eligible job when mlx is required"
+    );
+    let decision = decision.expect("a routing decision is reported");
+    assert_eq!(decision.decision, "deferred_to_mlx");
+}
+
+#[test]
+fn mlx_required_fails_stranded_eligible_job_when_no_live_mlx_worker() {
+    let store = store("mlx-required-strand");
+    register_gpu_worker(&store, "worker-mps", "mps", image_caps());
+    let job = store
+        .create_job(image_job_with(
+            json!({ "model": "z_image_turbo", "prompt": "p" }),
+            "auto",
+        ))
+        .expect("job creates");
+    backdate_job_created_at(&store, &job.id);
+
+    let failed = store.fail_stranded_mlx_jobs(true, 90).expect("sweep ok");
+    assert_eq!(failed.len(), 1, "the stranded MLX-eligible job is failed");
+    assert_eq!(failed[0].id, job.id);
+    assert_eq!(failed[0].status, JobStatus::Failed);
+    assert!(
+        failed[0]
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("mlx_unavailable"),
+        "error names the mlx_unavailable cause: {:?}",
+        failed[0].error
+    );
+    // The terminal transition is persisted, not just reported.
+    assert_eq!(
+        store.get_job(&job.id).expect("job loads").status,
+        JobStatus::Failed
+    );
+}
+
+#[test]
+fn mlx_required_does_not_fail_when_a_live_mlx_worker_is_present() {
+    let store = store("mlx-required-live");
+    // A live `mlx` worker exists (just registered → recent heartbeat); the job waits for
+    // it instead of being failed — covers the "mlx worker merely busy" case.
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
+    let job = store
+        .create_job(image_job_with(
+            json!({ "model": "z_image_turbo", "prompt": "p" }),
+            "auto",
+        ))
+        .expect("job creates");
+    backdate_job_created_at(&store, &job.id);
+
+    let failed = store.fail_stranded_mlx_jobs(true, 90).expect("sweep ok");
+    assert!(failed.is_empty(), "a live mlx worker keeps the job queued");
+    assert_eq!(
+        store.get_job(&job.id).expect("job loads").status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
+fn fail_stranded_mlx_jobs_is_noop_when_not_required() {
+    let store = store("mlx-required-off");
+    register_gpu_worker(&store, "worker-mps", "mps", image_caps());
+    let job = store
+        .create_job(image_job_with(
+            json!({ "model": "z_image_turbo", "prompt": "p" }),
+            "auto",
+        ))
+        .expect("job creates");
+    backdate_job_created_at(&store, &job.id);
+
+    // Flag off (Windows/Linux/Docker, Mac pre-cutover): the sweep never fails anything.
+    let failed = store.fail_stranded_mlx_jobs(false, 90).expect("sweep ok");
+    assert!(failed.is_empty());
+    assert_eq!(
+        store.get_job(&job.id).expect("job loads").status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
+fn mlx_required_still_lets_mps_claim_a_non_eligible_model() {
+    // 3483 only kills the MPS fallback for MLX-*eligible* jobs. A torch-only model is not
+    // eligible, so it is NOT deferred and still runs on MPS — surfacing it as a loud
+    // `mlx_unsupported` failure is sc-3484's job, not this slice's.
+    let store = store("mlx-required-noneligible");
+    register_gpu_worker(&store, "worker-mps", "mps", image_caps());
+    let job = store
+        .create_job(image_job_with(
+            json!({ "model": "kolors", "prompt": "p" }),
+            "auto",
+        ))
+        .expect("job creates");
+
+    let claimed = store
+        .claim_next_job_routed("worker-mps", true)
+        .expect("claim ok")
+        .0
+        .expect("MPS claims the non-eligible job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
 // sc-3449 — claim_next_job_routed reports *why* an MLX-eligible job landed where it did.
 
 #[test]
@@ -1603,7 +1743,7 @@ fn routing_decision_reports_fell_back_to_torch_with_no_mlx_worker() {
         .expect("job creates");
 
     let (claimed, decision) = store
-        .claim_next_job_routed("worker-torch")
+        .claim_next_job_routed("worker-torch", false)
         .expect("torch claim ok");
     assert_eq!(claimed.expect("torch claims it").id, job.id);
     let decision = decision.expect("routing decision present");
@@ -1629,7 +1769,7 @@ fn routing_decision_reports_deferred_to_mlx_for_torch_worker() {
         .expect("job creates");
 
     let (claimed, decision) = store
-        .claim_next_job_routed("worker-torch")
+        .claim_next_job_routed("worker-torch", false)
         .expect("torch claim ok");
     assert!(claimed.is_none(), "torch defers to the idle mlx worker");
     let decision = decision.expect("routing decision present");
@@ -1649,7 +1789,7 @@ fn routing_decision_reports_claimed_by_mlx() {
         .expect("job creates");
 
     let (claimed, decision) = store
-        .claim_next_job_routed("worker-mlx")
+        .claim_next_job_routed("worker-mlx", false)
         .expect("mlx claim ok");
     assert_eq!(claimed.expect("mlx claims it").id, job.id);
     let decision = decision.expect("routing decision present");
@@ -1670,7 +1810,7 @@ fn routing_decision_is_none_for_non_mlx_model() {
         .expect("job creates");
 
     let (claimed, decision) = store
-        .claim_next_job_routed("worker-torch")
+        .claim_next_job_routed("worker-torch", false)
         .expect("torch claim ok");
     assert!(claimed.is_some(), "torch claims the torch-only job");
     assert!(
@@ -1771,7 +1911,7 @@ fn routing_decision_reports_claimed_by_mlx_for_image_edit() {
 
     // The fix makes the claim non-routing-neutral: an mlx_route_decision is now emitted.
     let (claimed, decision) = store
-        .claim_next_job_routed("worker-mlx")
+        .claim_next_job_routed("worker-mlx", false)
         .expect("mlx claim ok");
     assert_eq!(claimed.expect("mlx claims it").id, job.id);
     let decision = decision.expect("routing decision present");
@@ -1807,7 +1947,7 @@ fn torch_only_image_edit_model_stays_on_torch() {
     // A torch worker is the home for it, and the claim is routing-neutral (no event).
     register_gpu_worker(&store, "worker-torch", "mps", image_edit_caps());
     let (claimed, decision) = store
-        .claim_next_job_routed("worker-torch")
+        .claim_next_job_routed("worker-torch", false)
         .expect("torch claim ok");
     let claimed = claimed.expect("torch claims it");
     assert_eq!(claimed.id, job.id);

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1760,17 +1760,33 @@ fn mac_rust_supported_accepts_eligible_and_mlx_agnostic_jobs() {
 }
 
 #[test]
-fn mac_rust_supported_names_torch_only_image_model() {
+fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
     let store = store("oracle-torch-model");
-    let job = job_of(
-        &store,
-        JobType::ImageGenerate,
-        json!({ "model": "kolors", "prompt": "p" }),
-    );
-    let reason = mac_rust_supported(&job).unwrap_err();
-    assert_eq!(reason.model.as_deref(), Some("kolors"));
-    assert_eq!(reason.suggested_epic.as_deref(), Some("epic 3061"));
-    assert!(reason.error_message().starts_with("mlx_unsupported:"));
+    // Each torch-only model points at its dedicated MLX-porting epic (epic 3482 policy),
+    // not the generic done feasibility epic.
+    let cases = [
+        ("kolors", "epic 3532"),
+        ("chroma1_hd", "epic 3531"),
+        ("z_image_edit", "epic 3529"),
+        ("instantid_realvisxl", "epic 3109"),
+        ("sensenova_u1_8b", "epic 3180"),
+        ("lens_turbo", "epic 3164"),
+    ];
+    for (model, epic) in cases {
+        let job = job_of(
+            &store,
+            JobType::ImageGenerate,
+            json!({ "model": model, "prompt": "p" }),
+        );
+        let reason = mac_rust_supported(&job).unwrap_err();
+        assert_eq!(reason.model.as_deref(), Some(model));
+        assert_eq!(
+            reason.suggested_epic.as_deref(),
+            Some(epic),
+            "{model} → {epic}"
+        );
+        assert!(reason.error_message().starts_with("mlx_unsupported:"));
+    }
 }
 
 #[test]

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3,11 +3,12 @@ use std::path::PathBuf;
 
 use rusqlite::{params, Connection};
 use sceneworks_core::contracts::{
-    JobStatus, JobType, ProgressStage, WorkerCapability, WorkerStatus, WorkerUtilizationSnapshot,
+    JobSnapshot, JobStatus, JobType, ProgressStage, WorkerCapability, WorkerStatus,
+    WorkerUtilizationSnapshot,
 };
 use sceneworks_core::jobs_store::{
-    CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker, RetryJob,
-    WorkerHeartbeat, MAX_JOB_ATTEMPTS,
+    mac_rust_supported, CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate,
+    RegisterWorker, RetryJob, WorkerHeartbeat, MAX_JOB_ATTEMPTS,
 };
 use serde_json::{json, Map, Value};
 
@@ -1721,6 +1722,206 @@ fn mlx_required_still_lets_mps_claim_a_non_eligible_model() {
         .expect("MPS claims the non-eligible job");
     assert_eq!(claimed.id, job.id);
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
+// epic 3482 / sc-3484 — mac_rust_supported oracle (the inverse of the eligibility predicates)
+// + the enforce sweep that fails unsupported jobs terminal with `mlx_unsupported`.
+
+fn job_of(store: &JobsStore, job_type: JobType, payload: Value) -> JobSnapshot {
+    store
+        .create_job(CreateJob {
+            job_type,
+            project_id: Some("project-1".to_owned()),
+            project_name: Some("Project 1".to_owned()),
+            payload: object(payload),
+            requested_gpu: "auto".to_owned(),
+            source_job_id: None,
+            duplicate_of_job_id: None,
+            attempts: 1,
+        })
+        .expect("job creates")
+}
+
+#[test]
+fn mac_rust_supported_accepts_eligible_and_mlx_agnostic_jobs() {
+    let store = store("oracle-ok");
+    // MLX-eligible generation → supported (consistent with routing by construction).
+    let eligible = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "z_image_turbo", "prompt": "p" }),
+    );
+    assert!(mac_rust_supported(&eligible).is_ok());
+    // MLX-agnostic job types run in-process with no Python torch dependency.
+    let download = job_of(&store, JobType::ModelDownload, json!({ "repo": "x/y" }));
+    assert!(mac_rust_supported(&download).is_ok());
+    let refine = job_of(&store, JobType::PromptRefine, json!({ "prompt": "p" }));
+    assert!(mac_rust_supported(&refine).is_ok());
+}
+
+#[test]
+fn mac_rust_supported_names_torch_only_image_model() {
+    let store = store("oracle-torch-model");
+    let job = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "kolors", "prompt": "p" }),
+    );
+    let reason = mac_rust_supported(&job).unwrap_err();
+    assert_eq!(reason.model.as_deref(), Some("kolors"));
+    assert_eq!(reason.suggested_epic.as_deref(), Some("epic 3061"));
+    assert!(reason.error_message().starts_with("mlx_unsupported:"));
+}
+
+#[test]
+fn mac_rust_supported_names_qwen_strict_pose_and_lycoris() {
+    let store = store("oracle-features");
+    // Strict-pose ControlNet on Qwen → epic 3401.
+    let pose = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "qwen_image", "prompt": "p", "advanced": { "poses": [{ "x": 1 }] } }),
+    );
+    let pose_reason = mac_rust_supported(&pose).unwrap_err();
+    assert!(pose_reason.feature.contains("strict-pose"));
+    assert_eq!(pose_reason.suggested_epic.as_deref(), Some("epic 3401"));
+    // Third-party LyCORIS on an otherwise-MLX family → drop-candidate.
+    let lycoris = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "sdxl", "prompt": "p", "loras": [{ "networkType": "lycoris" }] }),
+    );
+    let lycoris_reason = mac_rust_supported(&lycoris).unwrap_err();
+    assert!(lycoris_reason.feature.contains("LyCORIS"));
+    assert_eq!(
+        lycoris_reason.suggested_epic.as_deref(),
+        Some("drop-candidate")
+    );
+}
+
+#[test]
+fn mac_rust_supported_names_infra_job_types() {
+    let store = store("oracle-infra");
+    let cases = [
+        (JobType::ImageUpscale, "sc-3489"),
+        (JobType::PoseDetect, "sc-3487"),
+        (JobType::PersonDetect, "sc-3488"),
+        (JobType::TrainingCaption, "sc-3490"),
+    ];
+    for (job_type, epic) in cases {
+        let job = job_of(&store, job_type, json!({}));
+        let reason = mac_rust_supported(&job).unwrap_err();
+        assert_eq!(
+            reason.suggested_epic.as_deref(),
+            Some(epic),
+            "job type maps to {epic}"
+        );
+    }
+}
+
+#[test]
+fn mac_rust_supported_names_advanced_video_and_svd() {
+    let store = store("oracle-video");
+    // Advanced video job type.
+    let extend = job_of(&store, JobType::VideoExtend, json!({ "model": "wan_2_2" }));
+    assert_eq!(
+        mac_rust_supported(&extend)
+            .unwrap_err()
+            .suggested_epic
+            .as_deref(),
+        Some("epic 3040")
+    );
+    // Torch-only video model (e.g. SVD) on the base video_generate type.
+    let svd = job_of(
+        &store,
+        JobType::VideoGenerate,
+        json!({ "model": "svd", "mode": "image_to_video" }),
+    );
+    assert_eq!(
+        mac_rust_supported(&svd)
+            .unwrap_err()
+            .suggested_epic
+            .as_deref(),
+        Some("epic 3040")
+    );
+}
+
+#[test]
+fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
+    let store = store("oracle-convert");
+    // The in-process Rust FLUX.2 converter is supported.
+    let flux2 = job_of(
+        &store,
+        JobType::ModelConvert,
+        json!({ "model": "flux2_klein_9b_true_v2", "converter": "flux2_klein_diffusers" }),
+    );
+    assert!(mac_rust_supported(&flux2).is_ok());
+    // The default/absent converter is the Python mlx-video Wan/LTX path → gap.
+    let wan = job_of(&store, JobType::ModelConvert, json!({ "model": "wan_2_2" }));
+    assert_eq!(
+        mac_rust_supported(&wan)
+            .unwrap_err()
+            .suggested_epic
+            .as_deref(),
+        Some("sc-3491 / sc-3224")
+    );
+}
+
+#[test]
+fn fail_unsupported_mlx_jobs_enforce_fails_only_unsupported() {
+    let store = store("oracle-enforce");
+    let unsupported = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "kolors", "prompt": "p" }),
+    );
+    let eligible = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "z_image_turbo", "prompt": "p" }),
+    );
+
+    let failed = store
+        .fail_unsupported_mlx_jobs(true, true)
+        .expect("sweep ok");
+    assert_eq!(failed.len(), 1, "only the unsupported job is failed");
+    assert_eq!(failed[0].0.id, unsupported.id);
+    assert_eq!(failed[0].0.status, JobStatus::Failed);
+    assert!(failed[0]
+        .0
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("mlx_unsupported"));
+    // The eligible job is untouched — it's routing/`fail_stranded`'s concern, not this sweep's.
+    assert_eq!(
+        store.get_job(&eligible.id).expect("loads").status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
+fn fail_unsupported_mlx_jobs_noop_when_warn_or_off() {
+    let store = store("oracle-warn-off");
+    let job = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "kolors", "prompt": "p" }),
+    );
+    // Warn-only (enforce=false): logged at claim time, never failed by the sweep.
+    assert!(store
+        .fail_unsupported_mlx_jobs(true, false)
+        .expect("ok")
+        .is_empty());
+    // Flag off (not mlx-required): never touches anything (Windows/Linux/Docker).
+    assert!(store
+        .fail_unsupported_mlx_jobs(false, true)
+        .expect("ok")
+        .is_empty());
+    assert_eq!(
+        store.get_job(&job.id).expect("loads").status,
+        JobStatus::Queued
+    );
 }
 
 // sc-3449 — claim_next_job_routed reports *why* an MLX-eligible job landed where it did.

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1801,7 +1801,7 @@ fn mac_rust_supported_names_qwen_strict_pose_and_lycoris() {
     let pose_reason = mac_rust_supported(&pose).unwrap_err();
     assert!(pose_reason.feature.contains("strict-pose"));
     assert_eq!(pose_reason.suggested_epic.as_deref(), Some("epic 3401"));
-    // Third-party LyCORIS on an otherwise-MLX family → drop-candidate.
+    // Third-party LyCORIS on an otherwise-MLX family → port-or-drop viability spike.
     let lycoris = job_of(
         &store,
         JobType::ImageGenerate,
@@ -1809,10 +1809,7 @@ fn mac_rust_supported_names_qwen_strict_pose_and_lycoris() {
     );
     let lycoris_reason = mac_rust_supported(&lycoris).unwrap_err();
     assert!(lycoris_reason.feature.contains("LyCORIS"));
-    assert_eq!(
-        lycoris_reason.suggested_epic.as_deref(),
-        Some("drop-candidate")
-    );
+    assert_eq!(lycoris_reason.suggested_epic.as_deref(), Some("sc-3537"));
 }
 
 #[test]
@@ -1880,6 +1877,50 @@ fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
             .suggested_epic
             .as_deref(),
         Some("sc-3491 / sc-3224")
+    );
+}
+
+#[test]
+fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
+    let store = store("oracle-feature-spikes");
+    // FLUX.1 reference/IP-Adapter → viability spike sc-3535.
+    let flux_ref = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "flux_dev", "prompt": "p", "referenceAssetId": "asset_1" }),
+    );
+    assert_eq!(
+        mac_rust_supported(&flux_ref)
+            .unwrap_err()
+            .suggested_epic
+            .as_deref(),
+        Some("sc-3535")
+    );
+    // Z-Image reference without a pose set → viability spike sc-3536.
+    let z_ref = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "z_image_turbo", "prompt": "p", "referenceAssetId": "asset_1" }),
+    );
+    assert_eq!(
+        mac_rust_supported(&z_ref)
+            .unwrap_err()
+            .suggested_epic
+            .as_deref(),
+        Some("sc-3536")
+    );
+    // Image understanding folds into the SenseNova port (epic 3180).
+    let vqa = job_of(
+        &store,
+        JobType::ImageVqa,
+        json!({ "model": "sensenova_u1_8b" }),
+    );
+    assert_eq!(
+        mac_rust_supported(&vqa)
+            .unwrap_err()
+            .suggested_epic
+            .as_deref(),
+        Some("epic 3180")
     );
 }
 

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -33,21 +33,25 @@ completes) or dropped (UI-gated, sc-3486).
 ## 1. Torch-only image models
 
 Image models in `MODEL_TARGETS` that are **not** in `MLX_ROUTED_MODELS` → the Python torch
-adapter is authoritative on Mac. (`mac_rust_supported` → `epic 3061` by default; dispositions
-below are the per-model calls.)
+adapter is authoritative on Mac. **Policy (Michael, 2026-06-07): every unported model gets its
+own MLX-porting epic and is *dropped on Mac only* (UI-gated, sc-3486) until that port lands —
+Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust_supported` →
+`torch_only_image_model_epic(model)` names the specific epic below.
 
-| Model id | Family | Status | Closing work |
+| Model id | Family | Mac disposition | Porting epic |
 |---|---|---|---|
-| `kolors` | kolors | 🔵 Port-pending | epic 3061 (Kolors) |
-| `instantid_realvisxl` | sdxl (InstantID) | 🔵 Port-pending | epic 3061 (InstantID) |
-| `pulid_flux_dev` | flux (PuLID) | 🔵 Port-pending | epic 3061 (PuLID) |
-| `sensenova_u1_8b`, `sensenova_u1_8b_fast` | sensenova-u1 | 🟠 Drop-candidate | epic 3061 (SenseNova — likely drop) |
-| `lens`, `lens_turbo` | lens (Python sidecar `/opt/lens-venv`) | 🟠 Drop-candidate | epic 3061 (Lens) |
-| `chroma1_hd`, `chroma1_base`, `chroma1_flash` | chroma | ❓ Triage | **no epic yet** — surfaced by this audit; needs port-or-drop |
-| `z_image_edit` | z-image (edit) | ❓ Triage | **no epic yet** — Z-Image *edit* model is torch-only (txt2img `z_image_turbo` is ported) |
+| `kolors` | kolors (SDXL UNet + ChatGLM3) | 🔵 Port → drop-on-Mac until then | **epic 3532** |
+| `chroma1_hd`, `chroma1_base`, `chroma1_flash` | chroma (FLUX.1-schnell DiT) | 🔵 Port → drop-on-Mac until then | **epic 3531** |
+| `z_image_edit` | z-image (edit) | 🔵 Port → drop-on-Mac until then | **epic 3529** |
+| `instantid_realvisxl` | sdxl (InstantID) | 🔵 Port → drop-on-Mac until then | epic 3109 |
+| `pulid_flux_dev` | flux (PuLID) | 🔵 Port → drop-on-Mac until then | epic 3069 (engine done; owes SceneWorks routing) |
+| `sensenova_u1_8b`, `sensenova_u1_8b_fast` | sensenova-u1 | 🔵 Port → drop-on-Mac until then | epic 3180 |
+| `lens`, `lens_turbo` | lens (Python sidecar `/opt/lens-venv`) | 🔵 Port → drop-on-Mac until then | epic 3164 |
 
-> FLUX.2-**dev** is not in `MODEL_TARGETS` as a Mac target and is out of mlx-gen scope (likely
-> drop); third-party **LyCORIS** is a feature gap, see §2.
+> A torch-only image model with **no** porting epic yet → `torch_only_image_model_epic` returns
+> `None` and the oracle reports "needs a port epic (epic 3482 policy)"; file one + add it to the
+> match. FLUX.2-**dev** is not a Mac `MODEL_TARGETS` entry and is out of mlx-gen scope; third-party
+> **LyCORIS** is a feature gap, see §2.
 
 ## 2. Image feature gaps on MLX-routed families
 
@@ -59,7 +63,8 @@ exclusions). `mac_rust_supported` names each precisely.
 | Strict-pose ControlNet | `qwen_image` (+ `advanced.poses`) | 🔵 Port-pending | epic 3401 (Qwen ControlNet port) |
 | Reference / edit conditioning | base `qwen_image` (reference/`edit_image`) | 🔵 Port-pending | epic 3401 |
 | Reference / IP-Adapter / edit | `flux_schnell`, `flux_dev` | ❓ Triage | no epic — FLUX.1 reference/edit stays torch |
-| `edit_image` / reference-without-pose | `z_image_turbo` | ❓ Triage | no epic — Z-Image img2img-edit stays torch |
+| `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
+| reference-without-pose | `z_image_turbo` | ❓ Triage | no epic — reference-identity-only stays torch |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🟠 Drop-candidate | drop (engine applies LoRA + peft LoKr, not arbitrary LyCORIS) |
 
 ## 3. Video

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -1,0 +1,119 @@
+# macOS Python-dependency inventory (epic 3482)
+
+The triage table the Python-eradication cutover burns down. Every row is something that, on
+**macOS**, still reaches the Python torch/MPS worker — i.e. the in-process Rust/MLX flow can't
+run it yet. When the list is empty, the Mac build can stop shipping a Python venv/sidecar
+(sc-3492 / sc-3493).
+
+> **This table is code-derived.** Its executable form is
+> [`mac_rust_supported(job)`](../crates/sceneworks-core/src/jobs_store.rs) (sc-3484) — the
+> inverse of the `*_mlx_eligible` predicates. The same routing constants are the source of
+> truth: `MLX_ROUTED_MODELS`, `VIDEO_MLX_ROUTED_MODELS`, `MLX_ROUTED_TRAINING_KERNELS`, and the
+> per-family `*_mlx_eligible` gates in `crates/sceneworks-core/src/jobs_store.rs`; the model
+> registry is `MODEL_TARGETS` (`apps/worker/scene_worker/image_adapters.py` /
+> `video_adapters.py`); training kernels are the builtin targets in
+> `crates/sceneworks-core/src/training.rs`. **Keep this file in sync when a surface flips** —
+> when a model lands in a `*_ROUTED_*` set or an `*_mlx_eligible` gate opens, move its row to
+> *Done* and delete the gap. A row here that no longer matches the predicates is a bug.
+
+**Status legend**
+
+- ✅ **Done** — runs in the Rust/MLX flow on Mac (here for context; not a gap).
+- 🔵 **Port-pending (epic NNNN)** — Michael's decision is *port*; tracked by the linked story/epic.
+- 🟠 **Drop-candidate** — leaning *drop* (UI-gate/hide on Mac); needs Michael's confirm.
+- ❓ **Triage** — surfaced by the code, no port-or-drop decision yet.
+
+Rollout reminder: the cutover is staged (epic 3482). The `mlx_unsupported` oracle ships
+**warn-only** by default, so flipping `SCENEWORKS_MLX_REQUIRED=1` on a Mac logs every row below
+without breaking anything; each surface flips to enforce only once it's ported (its epic
+completes) or dropped (UI-gated, sc-3486).
+
+---
+
+## 1. Torch-only image models
+
+Image models in `MODEL_TARGETS` that are **not** in `MLX_ROUTED_MODELS` → the Python torch
+adapter is authoritative on Mac. (`mac_rust_supported` → `epic 3061` by default; dispositions
+below are the per-model calls.)
+
+| Model id | Family | Status | Closing work |
+|---|---|---|---|
+| `kolors` | kolors | 🔵 Port-pending | epic 3061 (Kolors) |
+| `instantid_realvisxl` | sdxl (InstantID) | 🔵 Port-pending | epic 3061 (InstantID) |
+| `pulid_flux_dev` | flux (PuLID) | 🔵 Port-pending | epic 3061 (PuLID) |
+| `sensenova_u1_8b`, `sensenova_u1_8b_fast` | sensenova-u1 | 🟠 Drop-candidate | epic 3061 (SenseNova — likely drop) |
+| `lens`, `lens_turbo` | lens (Python sidecar `/opt/lens-venv`) | 🟠 Drop-candidate | epic 3061 (Lens) |
+| `chroma1_hd`, `chroma1_base`, `chroma1_flash` | chroma | ❓ Triage | **no epic yet** — surfaced by this audit; needs port-or-drop |
+| `z_image_edit` | z-image (edit) | ❓ Triage | **no epic yet** — Z-Image *edit* model is torch-only (txt2img `z_image_turbo` is ported) |
+
+> FLUX.2-**dev** is not in `MODEL_TARGETS` as a Mac target and is out of mlx-gen scope (likely
+> drop); third-party **LyCORIS** is a feature gap, see §2.
+
+## 2. Image feature gaps on MLX-routed families
+
+Models that ARE MLX-routed but fall back to torch for a specific feature (the `*_mlx_eligible`
+exclusions). `mac_rust_supported` names each precisely.
+
+| Feature | Affected models | Status | Closing work |
+|---|---|---|---|
+| Strict-pose ControlNet | `qwen_image` (+ `advanced.poses`) | 🔵 Port-pending | epic 3401 (Qwen ControlNet port) |
+| Reference / edit conditioning | base `qwen_image` (reference/`edit_image`) | 🔵 Port-pending | epic 3401 |
+| Reference / IP-Adapter / edit | `flux_schnell`, `flux_dev` | ❓ Triage | no epic — FLUX.1 reference/edit stays torch |
+| `edit_image` / reference-without-pose | `z_image_turbo` | ❓ Triage | no epic — Z-Image img2img-edit stays torch |
+| Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🟠 Drop-candidate | drop (engine applies LoRA + peft LoKr, not arbitrary LyCORIS) |
+
+## 3. Video
+
+`video_generate` `text_to_video`/`image_to_video` on `VIDEO_MLX_ROUTED_MODELS`
+(`ltx_2_3`, `ltx_2_3_eros`, `wan_2_2`, `wan_2_2_t2v_14b`, `wan_2_2_i2v_14b`) is ported. Gaps:
+
+| Surface | Status | Closing work |
+|---|---|---|
+| `svd` model (Stable Video Diffusion, `svd_video` adapter — no MLX crate) | 🔵 Port-pending | epic 3040 |
+| Advanced `video_generate` modes (`first_last_frame`, `replace_person`) | 🔵 Port-pending | epic 3040 |
+| Advanced job types `video_extend`, `video_bridge` | 🔵 Port-pending | epic 3040 |
+| `person_replace` job type (replace_person) | 🔵 Port-pending | epic 3040 (+ sc-3488 person track) |
+| LoKr-on-Wan (Kronecker adapter on Wan) | 🔵 Port-pending | epic 3040 (LoKr-on-LTX already MLX) |
+| Third-party LyCORIS on video | 🟠 Drop-candidate | drop |
+
+## 4. Training (`lora_train`)
+
+`MLX_ROUTED_TRAINING_KERNELS` = `z_image_lora`, `sdxl_lora`, `wan_lora`, `wan_moe_lora`,
+`ltx_mlx_lora` (the last is MLX-only). Gaps:
+
+| Kernel | Status | Closing work |
+|---|---|---|
+| `kolors_lora` (SDXL + ChatGLM3, no mlx-gen trainer) | 🔵 Port-pending | epic 3039 |
+| `lens_lora` (Python sidecar trainer) | 🟠 Drop-candidate | epic 3039 (follows Lens model disposition) |
+| LoKr-on-Wan (`wan_lora` / `wan_moe_lora` + `networkType=lokr`) | 🔵 Port-pending | epic 3039 |
+
+## 5. Non-model Python infrastructure
+
+Job types / sub-systems that run on the Python worker (onnxruntime / torch / mlx_video) with no
+in-process Rust path. Per Michael's 2026-06-07 decision, all four spikes are **port** (not drop).
+
+| Surface | Job type(s) | Python backend | Status | Closing work |
+|---|---|---|---|---|
+| DWPose pose detection (photo→skeleton) | `pose_detect` | onnxruntime (RTMPose) | 🔵 Port-pending | sc-3487 |
+| Person detect / track | `person_detect`, `person_track` | YOLO / SAM2 | 🔵 Port-pending | sc-3488 |
+| Image upscaler (standalone) | `image_upscale` | Real-ESRGAN / AuraSR (torch) | 🔵 Port-pending | sc-3489 |
+| Dataset captioning | `training_caption` | torch captioner | 🔵 Port-pending | sc-3490 |
+| Wan/LTX model conversion | `model_convert` (non-`flux2_klein_diffusers` converter) | `mlx_video.convert_*` (Python) | 🔵 Port-pending | sc-3491 (= sc-3224) |
+| Image understanding / interleave | `image_vqa`, `image_interleave` | torch | ❓ Triage | no epic — verify Mac reachability |
+
+## 6. Already ported — NOT gaps (context)
+
+Listed so a reviewer doesn't re-file these. All run in the Rust/MLX flow on Mac.
+
+- Image base families: `z_image_turbo`, `flux_schnell`, `flux_dev`, `qwen_image` (txt2img),
+  `qwen_image_edit{,_2509,_2511,_2511_lightning}`, `flux2_klein_9b{,_kv,_true_v2}`, `sdxl`,
+  `realvisxl` (epic 3018).
+- SDXL advanced shapes — reference/IP-Adapter, `edit_image`, masked inpaint, outpaint, and
+  tile-detail (`image_detail` on `sdxl`/`realvisxl`) — epic 3041 / sc-3060.
+- FLUX.2-klein single-file conversion in-process Rust (`flux2_klein_diffusers`, sc-3136).
+- Video `text_to_video`/`image_to_video` on Wan2.2 + LTX-2.3 (+ synchronized audio), epic 3018.
+- Training: `z_image_lora`, `sdxl_lora`, `wan_lora`, `wan_moe_lora`, `ltx_mlx_lora` (epic 3039).
+
+---
+
+_Maintained under epic 3482 (sc-3485). Update alongside any change to the routing predicates._

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -19,9 +19,10 @@ run it yet. When the list is empty, the Mac build can stop shipping a Python ven
 **Status legend**
 
 - ✅ **Done** — runs in the Rust/MLX flow on Mac (here for context; not a gap).
-- 🔵 **Port-pending (epic NNNN)** — Michael's decision is *port*; tracked by the linked story/epic.
-- 🟠 **Drop-candidate** — leaning *drop* (UI-gate/hide on Mac); needs Michael's confirm.
-- ❓ **Triage** — surfaced by the code, no port-or-drop decision yet.
+- 🔵 **Port-pending (epic/story NNNN)** — has a tracked porting epic or story; ported, dropped on Mac until then.
+- 🔵 **Viability / port-or-drop spike (sc-NNNN)** — a spike decides port-vs-drop (the outcome is Michael's call); the model/feature is gated on Mac until it resolves.
+
+**No row is a bare "drop".** Per policy (Michael, 2026-06-07): every model gets a porting epic; every feature gap gets at least a viability spike. A *drop* is only ever the **outcome of a spike**, never a default — so there is no "drop-candidate" or untriaged state here. A code-surfaced gap with no tracked work is a bug in this table.
 
 Rollout reminder: the cutover is staged (epic 3482). The `mlx_unsupported` oracle ships
 **warn-only** by default, so flipping `SCENEWORKS_MLX_REQUIRED=1` on a Mac logs every row below
@@ -56,16 +57,18 @@ Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust
 ## 2. Image feature gaps on MLX-routed families
 
 Models that ARE MLX-routed but fall back to torch for a specific feature (the `*_mlx_eligible`
-exclusions). `mac_rust_supported` names each precisely.
+exclusions). `mac_rust_supported` names each precisely. **Policy: a feature gap on an
+already-ported model gets at least a viability spike (or an epic if large) before it's ported or
+dropped — no silent drops.**
 
 | Feature | Affected models | Status | Closing work |
 |---|---|---|---|
 | Strict-pose ControlNet | `qwen_image` (+ `advanced.poses`) | 🔵 Port-pending | epic 3401 (Qwen ControlNet port) |
 | Reference / edit conditioning | base `qwen_image` (reference/`edit_image`) | 🔵 Port-pending | epic 3401 |
-| Reference / IP-Adapter / edit | `flux_schnell`, `flux_dev` | ❓ Triage | no epic — FLUX.1 reference/edit stays torch |
+| Reference / IP-Adapter / edit | `flux_schnell`, `flux_dev` | 🔵 Viability spike | sc-3535 |
 | `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
-| reference-without-pose | `z_image_turbo` | ❓ Triage | no epic — reference-identity-only stays torch |
-| Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🟠 Drop-candidate | drop (engine applies LoRA + peft LoKr, not arbitrary LyCORIS) |
+| reference-without-pose | `z_image_turbo` | 🔵 Viability spike | sc-3536 |
+| Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🔵 Port-or-drop spike | sc-3537 |
 
 ## 3. Video
 
@@ -79,7 +82,7 @@ exclusions). `mac_rust_supported` names each precisely.
 | Advanced job types `video_extend`, `video_bridge` | 🔵 Port-pending | epic 3040 |
 | `person_replace` job type (replace_person) | 🔵 Port-pending | epic 3040 (+ sc-3488 person track) |
 | LoKr-on-Wan (Kronecker adapter on Wan) | 🔵 Port-pending | epic 3040 (LoKr-on-LTX already MLX) |
-| Third-party LyCORIS on video | 🟠 Drop-candidate | drop |
+| Third-party LyCORIS on video | 🔵 Port-or-drop spike | sc-3537 (shared image+video spike) |
 
 ## 4. Training (`lora_train`)
 
@@ -89,7 +92,7 @@ exclusions). `mac_rust_supported` names each precisely.
 | Kernel | Status | Closing work |
 |---|---|---|
 | `kolors_lora` (SDXL + ChatGLM3, no mlx-gen trainer) | 🔵 Port-pending | epic 3039 |
-| `lens_lora` (Python sidecar trainer) | 🟠 Drop-candidate | epic 3039 (follows Lens model disposition) |
+| `lens_lora` (Python sidecar trainer) | 🔵 Port-pending | epic 3039 (follows Lens model port, epic 3164) |
 | LoKr-on-Wan (`wan_lora` / `wan_moe_lora` + `networkType=lokr`) | 🔵 Port-pending | epic 3039 |
 
 ## 5. Non-model Python infrastructure
@@ -104,7 +107,7 @@ in-process Rust path. Per Michael's 2026-06-07 decision, all four spikes are **p
 | Image upscaler (standalone) | `image_upscale` | Real-ESRGAN / AuraSR (torch) | 🔵 Port-pending | sc-3489 |
 | Dataset captioning | `training_caption` | torch captioner | 🔵 Port-pending | sc-3490 |
 | Wan/LTX model conversion | `model_convert` (non-`flux2_klein_diffusers` converter) | `mlx_video.convert_*` (Python) | 🔵 Port-pending | sc-3491 (= sc-3224) |
-| Image understanding / interleave | `image_vqa`, `image_interleave` | torch | ❓ Triage | no epic — verify Mac reachability |
+| Image understanding / interleave | `image_vqa`, `image_interleave` | torch (SenseNova-U1) | 🔵 Port-pending | epic 3180 (SenseNova port — its understanding surface) |
 
 ## 6. Already ported — NOT gaps (context)
 


### PR DESCRIPTION
## Epic 3482 — Python Eradication: backend foundation

Lands the **mechanism** for the macOS zero-Python rollout (epic [3482](https://app.shortcut.com/trefry/epic/3482)). Everything here ships **inert** — gated behind flags that default off / warn — so there is **no behavior change on any platform** until the cutover flips them. The point of this stack is to make "a job ran on torch/MPS instead of MLX on Mac" either impossible (for supported models) or a loud, named, actionable error (for unsupported ones), with the error list doubling as the port-or-drop roadmap.

Stacked, reviewable commit-by-commit:

### sc-3483 — kill the silent MPS fallback (`830b051`)
- `SCENEWORKS_MLX_REQUIRED` → `Settings.mlx_required` (default **false** = observe), mirroring `worker_timeout_seconds`.
- When required, a non-mlx (MPS) worker yields an MLX-**eligible** job **unconditionally** (drops the idle-mlx gate) — it never claims one. `claim_next_job` keeps the old behaviour (`false`) so cross-platform + ~40 existing call sites are untouched.
- New `JobsStore::fail_stranded_mlx_jobs(mlx_required, grace)` — if no **live** `mlx` worker takes an eligible job within the grace window (reuses the worker timeout, so a transient crash the supervisor restarts self-heals), the job fails terminal with an actionable `mlx_unavailable` error instead of hanging or silently running on MPS.

### sc-3484 — `mlx_unsupported` fast-fail + gap oracle (`bafd55f`)
- `pub fn mac_rust_supported(job) -> Result<(), UnsupportedReason>` — the inverse of every `*_mlx_eligible` predicate across all `JobType`s. `Ok` = the Rust/MLX flow (or an MLX-agnostic in-process path) runs it; `Err` names the exact Python-torch gap (model / feature / detail / suggestedEpic). Consistent with routing by construction.
- `pub fn fail_unsupported_mlx_jobs(mlx_required, enforce)` — enforce sweep fails queued unsupported jobs terminal; **default warn-only** logs the gap but still runs on torch. `SCENEWORKS_MLX_UNSUPPORTED_MODE`.
- `claim_job` emits structured `mlx_unsupported` Logs events (mirrors the sc-3449 route-decision line).

### sc-3485 — `docs/mac-rust-gaps.md` inventory (`63c70f5`)
- Code-derived triage table (traces to the routing constants + `MODEL_TARGETS` + training targets; names the oracle as its executable form, with a keep-in-sync contract). Surfaced two gaps the epic prose missed: the **Chroma** family and **`z_image_edit`**.

### Per-model port-epic wiring (`55eeada`)
- Policy (Michael): every unported model gets its own MLX-porting epic and is dropped on Mac only until it lands (Win/Linux keep torch). Created **epic 3531 (Chroma)**, **3529 (Z-Image-Edit)**, **3532 (Kolors)**; wired the oracle (`torch_only_image_model_epic`) + inventory to the specific per-model epics (InstantID 3109, PuLID 3069, SenseNova 3180, Lens 3164).

## Why inert / safe to merge

Both flags default off/warn. With `mlx_required` unset, the new routing branch and both sweeps are immediate no-ops; `setup.rs` does **not** set the flag on Mac yet (a comment marks the one-line sc-3492 cutover point). Nothing on Windows/Linux/Docker — which have no `mlx` worker — is reachable.

## Testing

`npm run rust:check` green (fmt + clippy `-D warnings` all-targets + workspace build + tests). 13 new core tests (5 routing/grace, 8 oracle/sweep). core jobs_store **82/82**, rust-api **98/98**.

## Reviewer notes

- **Scope boundaries** (flagged on the stories): 3483 governs MLX-*eligible* jobs only; a torch-only model on Mac still runs on MPS until 3484's enforce mode is turned on. "Two modes" = one global warn/enforce toggle (per-surface enforcement is operational via UI-gating + the final cutover). `setup.rs` is comment-only.
- **Not in this PR:** sc-3486 (Mac UI gating — the user-facing "drop"), and the final cutover stories (sc-3492/3493).
- **Owes before the stories close:** real-Mac enforce-mode E2E (no hardware in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
