### PR TITLE
sc-3486: Mac UI gating — hide/disable models + features not in the Rust/MLX flow

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -26,8 +26,9 @@ use sceneworks_core::contracts::{
     WorkerSnapshot, WorkerStatus,
 };
 use sceneworks_core::jobs_store::{
-    mac_rust_supported, CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate,
-    RegisterWorker, RetryJob, RouteDecision, UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
+    mac_capabilities, mac_rust_supported, model_mac_support, CreateJob, DuplicateJob, JobsStore,
+    JobsStoreError, MacCapabilities, ProgressUpdate, RegisterWorker, RetryJob, RouteDecision,
+    UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
@@ -727,6 +728,7 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
             "/api/v1/capabilities/person",
             get(person_capability_readiness),
         )
+        .route("/api/v1/capabilities/mac", get(mac_capability_support))
         .route("/api/v1/workers/register", post(register_worker))
         .route(
             "/api/v1/workers/:worker_id/heartbeat",

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -876,6 +876,23 @@ pub(crate) async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiErr
                 credential_host.map(Value::String).unwrap_or(Value::Null),
             );
         }
+        // Mac UI gating (sc-3486): per-model Rust/MLX support so the web client can
+        // hide/disable a torch-only model in the pickers and disable the feature
+        // controls a supported model can't run on MLX. Computed from the same routing
+        // predicates as the `mac_rust_supported` oracle, and platform-independent (a
+        // fact about the Rust flow) — the client only acts on it when the capabilities
+        // endpoint reports `macGatingActive`, so non-Mac pickers are untouched.
+        let mac_support = {
+            let id = object.get("id").and_then(Value::as_str).unwrap_or_default();
+            let model_type = object
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            model_mac_support(id, model_type)
+        };
+        if let Ok(mac_support) = serde_json::to_value(mac_support) {
+            object.insert("macSupport".to_owned(), mac_support);
+        }
         // macOS Model Manager: MLX availability + conversion status for models that
         // declare an `mlx` variant. Additive fields the web/Docker build ignores; the
         // probes are cheap and portable, so a const `cfg!` check gates them rather

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2448,6 +2448,92 @@ async fn timeline_routes_persist_and_create_worker_jobs() {
 }
 
 #[tokio::test]
+async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
+    // sc-3486: the catalog stamps per-model `macSupport`, and the capabilities endpoint
+    // carries the master switch (`macGatingActive` = mlx_required) + infra gating.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            { "id": "z_image_turbo", "name": "Z-Image-Turbo", "family": "z-image", "type": "image",
+              "adapter": "z_image_diffusers", "capabilities": ["text_to_image"], "downloads": [],
+              "paths": {}, "defaults": {}, "limits": {}, "loraCompatibility": { "families": [], "types": [] }, "ui": {} },
+            { "id": "kolors", "name": "Kolors", "family": "kolors", "type": "image",
+              "adapter": "kolors_diffusers", "capabilities": ["text_to_image"], "downloads": [],
+              "paths": {}, "defaults": {}, "limits": {}, "loraCompatibility": { "families": [], "types": [] }, "ui": {} },
+            { "id": "svd", "name": "SVD", "family": "svd", "type": "video",
+              "adapter": "svd_video", "capabilities": ["image_to_video"], "downloads": [],
+              "paths": {}, "defaults": {}, "limits": {}, "loraCompatibility": { "families": [], "types": [] }, "ui": {} }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+
+    let mut settings = test_settings(&temp_dir);
+    settings.mlx_required = true;
+    let app = create_app(settings).expect("app creates");
+
+    let (status, models) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    let by_id = |id: &str| {
+        models
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["id"] == id)
+            .cloned()
+            .unwrap_or(Value::Null)
+    };
+    // Torch-only image model → unsupported on Mac, names its port epic.
+    let kolors = by_id("kolors");
+    assert_eq!(kolors["macSupport"]["supported"], false);
+    assert_eq!(kolors["macSupport"]["reason"]["suggestedEpic"], "epic 3532");
+    // MLX-routed family → supported, stays in the picker.
+    assert_eq!(by_id("z_image_turbo")["macSupport"]["supported"], true);
+    // Torch-only video model → unsupported.
+    assert_eq!(by_id("svd")["macSupport"]["supported"], false);
+
+    // Capabilities endpoint: gating active (mlx_required=true) + infra epics present.
+    let (status, caps) = request(app, "GET", "/api/v1/capabilities/mac", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(caps["macGatingActive"], true);
+    assert_eq!(
+        caps["notAvailableLabel"],
+        "Not available on Mac (Rust/MLX only)"
+    );
+    assert_eq!(
+        caps["features"]["imageUpscale"]["reason"]["suggestedEpic"],
+        "sc-3489"
+    );
+    assert_eq!(
+        caps["features"]["poseFromPhoto"]["reason"]["suggestedEpic"],
+        "sc-3487"
+    );
+    assert!(caps["training"]["supportedKernels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|k| k == "z_image_lora"));
+}
+
+#[tokio::test]
+async fn capabilities_mac_is_inert_when_mlx_not_required() {
+    // The default (observe mode / Windows / Linux) reports gating inactive, so the client
+    // applies no gating at all.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, caps) = request(app, "GET", "/api/v1/capabilities/mac", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(caps["macGatingActive"], false);
+}
+
+#[tokio::test]
 async fn image_job_route_threads_upscale_contract_when_enabled() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/rust-api/src/workers.rs
+++ b/apps/rust-api/src/workers.rs
@@ -61,6 +61,19 @@ pub(crate) async fn person_capability_readiness(
     ))
 }
 
+/// Mac UI gating capabilities (sc-3486): the master switch (`macGatingActive`, the
+/// `SCENEWORKS_MLX_REQUIRED` rollout flag) plus every non-model Python surface the web client
+/// disables on Mac (LyCORIS, upscale, pose-from-photo, person detect/track, captioning, advanced
+/// video, training kernels). Platform is the API host's OS, so a Docker/Windows/Linux client reads
+/// `macGatingActive=false` and applies no gating at all. Per-model support rides on
+/// `GET /api/v1/models` (`macSupport`); this endpoint carries the global/feature half.
+pub(crate) async fn mac_capability_support(State(state): State<AppState>) -> Json<MacCapabilities> {
+    Json(mac_capabilities(
+        std::env::consts::OS,
+        state.settings.mlx_required,
+    ))
+}
+
 pub(crate) async fn register_worker(
     State(state): State<AppState>,
     ApiJson(payload): ApiJson<WorkerRegisterRequest>,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -27,6 +27,7 @@ import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
 import { AppContext } from "./context/AppContext.js";
+import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -420,6 +421,8 @@ export function App() {
   const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [], document: [] });
   const [workers, setWorkers] = useState([]);
   const [queueSummary, setQueueSummary] = useState(null);
+  // Mac UI gating (sc-3486): inert until the capabilities endpoint reports macGatingActive.
+  const [macCapabilities, setMacCapabilities] = useState(DEFAULT_MAC_CAPABILITIES);
   const [trainingTargets, setTrainingTargets] = useState({ schemaVersion: 1, targets: [] });
   const [trainingPresets, setTrainingPresets] = useState({ schemaVersion: 1, presets: [] });
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
@@ -994,6 +997,10 @@ export function App() {
         fetchInitial("Training targets", "/api/v1/training/targets", { schemaVersion: 1, targets: [] }),
         fetchInitial("Training presets", "/api/v1/training/presets", { schemaVersion: 1, presets: [] }),
       ]);
+    // Mac UI gating (sc-3486): optional + non-fatal — a fetch failure leaves gating inert.
+    fetchInitial("Mac capabilities", "/api/v1/capabilities/mac", DEFAULT_MAC_CAPABILITIES, true)
+      .then((result) => setMacCapabilities(result.value ?? DEFAULT_MAC_CAPABILITIES))
+      .catch(() => {});
     const projectItems = projectsResult.value;
     setProjects(projectItems);
     setProjectsLoaded(true);
@@ -1575,6 +1582,8 @@ export function App() {
     imageModels,
     videoModels,
     models,
+    // Mac UI gating (sc-3486)
+    macCapabilities,
     loras,
     deleteLora,
     deleteModel,

--- a/apps/web/src/macGating.js
+++ b/apps/web/src/macGating.js
@@ -1,0 +1,123 @@
+// Mac UI gating (sc-3486, epic 3482). The API's GET /api/v1/capabilities/mac surfaces the
+// `mac_rust_supported` oracle to the client: a master switch (`macGatingActive`, the
+// SCENEWORKS_MLX_REQUIRED rollout flag) plus per-feature support for the non-model Python
+// surfaces, and each model on GET /api/v1/models carries a `macSupport` block. When gating is
+// active (a Mac in MLX-required mode) the studios hide/disable models and feature controls that
+// can only run on the Python torch path, so a Mac user never reaches a `mlx_unsupported` error
+// after submit. On Windows/Linux (and a Mac still in observe mode) `macGatingActive` is false and
+// every helper here is a no-op, so non-Mac pickers are untouched.
+
+export const MAC_NOT_AVAILABLE_LABEL = "Not available on Mac (Rust/MLX only)";
+
+// The inert default used until the capabilities endpoint responds (and the permanent value on
+// non-Mac / observe-mode deployments). Every helper below short-circuits to "not blocked".
+export const DEFAULT_MAC_CAPABILITIES = {
+  macGatingActive: false,
+  platform: "",
+  notAvailableLabel: MAC_NOT_AVAILABLE_LABEL,
+  features: {},
+  training: { supportedKernels: [], lokrOnWanSupported: false },
+};
+
+function label(caps) {
+  return caps?.notAvailableLabel || MAC_NOT_AVAILABLE_LABEL;
+}
+
+// Compose the user-facing affordance text from a backend UnsupportedReason
+// ({ feature, detail, suggestedEpic }).
+export function macReasonText(caps, reason) {
+  const base = label(caps);
+  if (!reason) return base;
+  const detail = reason.detail || reason.feature || "";
+  const epic = reason.suggestedEpic ? ` (${reason.suggestedEpic})` : "";
+  return detail ? `${base} — ${detail}${epic}` : base;
+}
+
+function featureLabel(feature) {
+  switch (feature) {
+    case "pose":
+      return "pose conditioning";
+    case "reference":
+      return "reference / identity conditioning";
+    case "edit":
+      return "image editing";
+    case "lycoris":
+      return "third-party LyCORIS LoRA";
+    default:
+      return feature;
+  }
+}
+
+// Whether gating is engaged at all (a Mac in MLX-required mode).
+export function macGatingActive(caps) {
+  return Boolean(caps?.macGatingActive);
+}
+
+// A whole model that can't run in the Rust/MLX flow on Mac (torch-only) → hidden/disabled in
+// pickers. Returns `{ blocked, reason, text }` or `null`.
+export function macModelBlock(model, caps) {
+  if (!macGatingActive(caps)) return null;
+  if (model?.macSupport?.supported === false) {
+    const reason = model.macSupport.reason ?? null;
+    return { blocked: true, reason, text: macReasonText(caps, reason) };
+  }
+  return null;
+}
+
+// A per-model feature control (pose / reference / edit / lycoris) the model can't run on MLX.
+// Returns `{ blocked, text }` or `null`.
+export function macModelFeatureBlock(model, caps, feature) {
+  if (!macGatingActive(caps)) return null;
+  const features = model?.macSupport?.features;
+  if (features && features[feature] === false) {
+    return {
+      blocked: true,
+      text: `${label(caps)} — this model's ${featureLabel(feature)} runs on the Python torch path.`,
+    };
+  }
+  return null;
+}
+
+// Whether a video_generate mode routes to MLX for the given (supported) video model.
+export function macVideoModeBlock(model, caps, mode) {
+  if (!macGatingActive(caps)) return null;
+  const modes = model?.macSupport?.features?.videoModes;
+  if (modes && modes[mode] === false) {
+    return {
+      blocked: true,
+      text: `${label(caps)} — this mode is a torch-only advanced video mode.`,
+    };
+  }
+  return null;
+}
+
+// A non-model Python surface (lycoris, imageUpscale, poseFromPhoto, personDetect,
+// datasetCaptioning, advancedVideoModes). Returns `{ blocked, reason, text }` or `null`.
+export function macFeatureBlock(caps, key) {
+  if (!macGatingActive(caps)) return null;
+  const feature = caps?.features?.[key];
+  if (feature && feature.supported === false) {
+    const reason = feature.reason ?? null;
+    return { blocked: true, reason, text: macReasonText(caps, reason) };
+  }
+  return null;
+}
+
+// Whether a training kernel has no native Rust trainer (so its base model is gated in Training).
+export function macTrainingKernelBlocked(caps, kernel) {
+  if (!macGatingActive(caps) || !kernel) return false;
+  const supported = caps?.training?.supportedKernels ?? [];
+  return !supported.includes(kernel);
+}
+
+// Partition a model list into the Mac-available ones (for the picker) — a no-op when gating is off.
+export function macAvailableModels(models, caps) {
+  if (!macGatingActive(caps)) return models ?? [];
+  return (models ?? []).filter((model) => model?.macSupport?.supported !== false);
+}
+
+// The models hidden from a picker on Mac, so a screen can show a "N unavailable" affordance.
+export function macBlockedModels(models, caps) {
+  if (!macGatingActive(caps)) return [];
+  return (models ?? []).filter((model) => model?.macSupport?.supported === false);
+}

--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAC_CAPABILITIES,
+  macAvailableModels,
+  macBlockedModels,
+  macFeatureBlock,
+  macModelBlock,
+  macModelFeatureBlock,
+  macReasonText,
+  macTrainingKernelBlocked,
+  macVideoModeBlock,
+} from "./macGating.js";
+
+const gating = {
+  macGatingActive: true,
+  platform: "macos",
+  notAvailableLabel: "Not available on Mac (Rust/MLX only)",
+  features: {
+    imageUpscale: {
+      supported: false,
+      reason: { feature: "image_upscale (Real-ESRGAN)", detail: "torch path.", suggestedEpic: "sc-3489" },
+    },
+    lycoris: { supported: true },
+  },
+  training: { supportedKernels: ["z_image_lora", "sdxl_lora"], lokrOnWanSupported: false },
+};
+
+const torchModel = { id: "kolors", macSupport: { supported: false, reason: { detail: "no MLX engine.", suggestedEpic: "epic 3532" } } };
+const mlxModel = { id: "z_image_turbo", macSupport: { supported: true, features: { pose: true, reference: false, edit: false, lycoris: false } } };
+
+describe("macGating helpers", () => {
+  it("are all inert when gating is not active (Windows/Linux/observe mode)", () => {
+    const caps = DEFAULT_MAC_CAPABILITIES;
+    expect(macModelBlock(torchModel, caps)).toBeNull();
+    expect(macModelFeatureBlock(mlxModel, caps, "reference")).toBeNull();
+    expect(macFeatureBlock(caps, "imageUpscale")).toBeNull();
+    expect(macTrainingKernelBlocked(caps, "kolors_lora")).toBe(false);
+    expect(macAvailableModels([torchModel, mlxModel], caps)).toHaveLength(2);
+    expect(macBlockedModels([torchModel, mlxModel], caps)).toHaveLength(0);
+  });
+
+  it("blocks a torch-only model and names its port epic when gating is active", () => {
+    const block = macModelBlock(torchModel, gating);
+    expect(block?.blocked).toBe(true);
+    expect(block?.text).toContain("Not available on Mac (Rust/MLX only)");
+    expect(block?.text).toContain("epic 3532");
+    expect(macModelBlock(mlxModel, gating)).toBeNull();
+  });
+
+  it("partitions a model list into available/blocked", () => {
+    expect(macAvailableModels([torchModel, mlxModel], gating).map((m) => m.id)).toEqual(["z_image_turbo"]);
+    expect(macBlockedModels([torchModel, mlxModel], gating).map((m) => m.id)).toEqual(["kolors"]);
+  });
+
+  it("blocks a per-model feature only when its flag is false", () => {
+    expect(macModelFeatureBlock(mlxModel, gating, "pose")).toBeNull();
+    const refBlock = macModelFeatureBlock(mlxModel, gating, "reference");
+    expect(refBlock?.blocked).toBe(true);
+    expect(refBlock?.text).toContain("torch path");
+  });
+
+  it("blocks a global feature and surfaces its reason text", () => {
+    const block = macFeatureBlock(gating, "imageUpscale");
+    expect(block?.blocked).toBe(true);
+    expect(block?.text).toContain("sc-3489");
+    // A supported feature is not blocked.
+    expect(macFeatureBlock(gating, "lycoris")).toBeNull();
+  });
+
+  it("blocks a training kernel without a native Rust trainer", () => {
+    expect(macTrainingKernelBlocked(gating, "kolors_lora")).toBe(true);
+    expect(macTrainingKernelBlocked(gating, "z_image_lora")).toBe(false);
+  });
+
+  it("blocks a torch-only video mode by per-model eligibility", () => {
+    const video = { id: "wan_2_2", macSupport: { features: { videoModes: { image_to_video: true, replace_person: false } } } };
+    expect(macVideoModeBlock(video, gating, "image_to_video")).toBeNull();
+    expect(macVideoModeBlock(video, gating, "replace_person")?.blocked).toBe(true);
+  });
+
+  it("falls back to the bare label when a reason is missing", () => {
+    expect(macReasonText(gating, null)).toBe("Not available on Mac (Rust/MLX only)");
+  });
+});

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -15,6 +15,7 @@ import { assetMatchesCharacter } from "../components/DatasetAddDialog.jsx";
 import { extractFamilies } from "../presetUtils.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { useAppContext } from "../context/AppContext.js";
+import { DEFAULT_MAC_CAPABILITIES, macAvailableModels } from "../macGating.js";
 
 const characterTypes = [
   ["person", "Person"],
@@ -75,8 +76,14 @@ export function CharacterStudio() {
     trainingDatasetsProjectId,
     createTrainingDataset,
     openDatasetInLibrary,
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
   const latestAssets = latestImageAssets;
+  // Mac UI gating (sc-3486): hide torch-only models from the angle/pose/test pickers.
+  const macImageModels = useMemo(
+    () => macAvailableModels(imageModels, macCapabilities),
+    [imageModels, macCapabilities],
+  );
   const onPreview = setPreviewAsset;
   // Job callbacks for character generation cards (Angle Set / Pose Library).
   // jobAction may be missing in test contexts that wrap CharacterStudio with a
@@ -188,12 +195,12 @@ export function CharacterStudio() {
   // single-image only (side-by-side concat is rendered literally, not
   // interpreted as a pose instruction).
   const angleModels = useMemo(
-    () => imageModels.filter((item) => Array.isArray(item.ui?.viewAngles) && item.ui.viewAngles.length > 0),
-    [imageModels],
+    () => macImageModels.filter((item) => Array.isArray(item.ui?.viewAngles) && item.ui.viewAngles.length > 0),
+    [macImageModels],
   );
   const poseModels = useMemo(
-    () => imageModels.filter((item) => item.ui?.poseLibrary),
-    [imageModels],
+    () => macImageModels.filter((item) => item.ui?.poseLibrary),
+    [macImageModels],
   );
   // Default selection: the first registered backbone (manifest order keeps
   // InstantID first so the existing strict tier remains the default).
@@ -228,10 +235,10 @@ export function CharacterStudio() {
   }, [selectedCharacter?.id, selectedCharacter?.updatedAt]);
 
   useEffect(() => {
-    if (!imageModels.some((item) => item.id === testModel)) {
-      setTestModel(imageModels[0]?.id ?? "z_image_turbo");
+    if (!macImageModels.some((item) => item.id === testModel)) {
+      setTestModel(macImageModels[0]?.id ?? "z_image_turbo");
     }
-  }, [imageModels, testModel]);
+  }, [macImageModels, testModel]);
 
   // Create a draft character straight from the selector's "+ New character"
   // item (sc-2025) — name and type are then edited in the detail form, mirroring

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -3,6 +3,7 @@ import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "reac
 import { apiFetch } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
+import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
@@ -342,7 +343,11 @@ export function ImageEditor() {
     purgeAsset,
     registerLeaveGuard,
     imageModels,
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
+  // Mac UI gating (sc-3486): the standalone upscaler runs on the Python torch Real-ESRGAN /
+  // AuraSR path (no in-process Rust path yet, sc-3489), so disable the tool on a gated Mac.
+  const macUpscaleBlock = macFeatureBlock(macCapabilities, "imageUpscale");
 
   // The working-image session: the single bitmap every tool operates on, plus its
   // provenance. This state is the contract consumed by crop/upscale/save and the
@@ -1250,9 +1255,9 @@ export function ImageEditor() {
             </button>
             <button
               className={tool === "upscale" ? "image-editor-tool active" : "image-editor-tool"}
-              disabled={!!aiOp}
+              disabled={!!aiOp || Boolean(macUpscaleBlock)}
               onClick={() => setTool("upscale")}
-              title="Upscale"
+              title={macUpscaleBlock ? macUpscaleBlock.text : "Upscale"}
               type="button"
             >
               Upscale

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -84,6 +84,12 @@ import {
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import {
+  DEFAULT_MAC_CAPABILITIES,
+  macAvailableModels,
+  macBlockedModels,
+  macModelFeatureBlock,
+} from "../macGating.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import {
@@ -221,6 +227,7 @@ export function ImageStudio() {
     selectedAsset,
     setRequestedGpu,
     updateAssetStatus,
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
   // Recent Assets list (sc-2088). When the new context value is available, use
   // the bounded 20-most-recent list; fall back to the legacy single-generation
@@ -386,9 +393,19 @@ export function ImageStudio() {
     }
   }, [launchRequest?.id, selectedAsset?.id, selectedAssetEditableSourceId]);
 
+  // Mac UI gating (sc-3486): on a Mac in MLX-required mode, hide torch-only models from the
+  // picker so the user can't select something that would only error. Inert elsewhere.
+  const macImageModels = useMemo(
+    () => macAvailableModels(imageModels, macCapabilities),
+    [imageModels, macCapabilities],
+  );
+  const macHiddenImageModels = useMemo(
+    () => macBlockedModels(imageModels, macCapabilities),
+    [imageModels, macCapabilities],
+  );
   const availableModels = useMemo(
     () =>
-      imageModels.filter((item) => {
+      macImageModels.filter((item) => {
         const caps = item.capabilities ?? [];
         if (mode === "edit_image") {
           return caps.includes("edit_image") || caps.includes("image_edit");
@@ -400,7 +417,7 @@ export function ImageStudio() {
         }
         return item.type === "image";
       }),
-    [imageModels, mode],
+    [macImageModels, mode],
   );
   // When the mode change filters out the current model (e.g. Lens-Turbo is the
   // text default but isn't edit-capable), snap to the first available model so
@@ -429,6 +446,16 @@ export function ImageStudio() {
   const viewAngles = Array.isArray(selectedModel?.ui?.viewAngles) ? selectedModel.ui.viewAngles : null;
   // Whether the model supports the OpenPose pose library (InstantID).
   const poseLibrary = Boolean(selectedModel?.ui?.poseLibrary);
+  // Mac UI gating (sc-3486): disable the per-model feature controls the selected model can't run
+  // in the Rust/MLX flow on Mac, so the user never reaches a `mlx_unsupported` error after submit.
+  const macEditBlock = macModelFeatureBlock(selectedModel, macCapabilities, "edit");
+  const macReferenceBlock = macModelFeatureBlock(selectedModel, macCapabilities, "reference");
+  const macPoseBlock = macModelFeatureBlock(selectedModel, macCapabilities, "pose");
+  const macModeBlock = (value) => {
+    if (value === "edit_image") return macEditBlock;
+    if (value === "character_image" || value === "style_variations") return macReferenceBlock;
+    return null;
+  };
   // Variation slider spec (FLUX / Qwen). When declared, the model exposes a
   // trueCfgScale knob alongside (FLUX) or instead of (Qwen, via hideReferenceStrength)
   // the IP-Adapter reference-strength slider (sc-2017).
@@ -973,17 +1000,22 @@ export function ImageStudio() {
                 ["edit_image", "Edit"],
                 ["character_image", "With character"],
                 ["style_variations", "Variations"],
-              ].map(([value, label]) => (
-                <button
-                  className={mode === value ? "active" : ""}
-                  key={value}
-                  onClick={() => handleModeChange(value)}
-                  type="button"
-                >
-                  {value === "text_to_image" ? <Icon.Sparkle size={13} /> : null}
-                  {label}
-                </button>
-              ))}
+              ].map(([value, label]) => {
+                const macBlock = macModeBlock(value);
+                return (
+                  <button
+                    className={mode === value ? "active" : ""}
+                    key={value}
+                    onClick={() => handleModeChange(value)}
+                    type="button"
+                    disabled={Boolean(macBlock)}
+                    title={macBlock ? macBlock.text : undefined}
+                  >
+                    {value === "text_to_image" ? <Icon.Sparkle size={13} /> : null}
+                    {label}
+                  </button>
+                );
+              })}
             </div>
             <div className="prompt-hero-links">
               <button className="hero-link" onClick={() => setGuideOpen(true)} type="button">
@@ -1160,7 +1192,9 @@ export function ImageStudio() {
                           </select>
                         </label>
                       ) : null}
-                      {poseLibrary ? (
+                      {poseLibrary && macPoseBlock ? (
+                        <p className="mac-gating-note">{macPoseBlock.text}</p>
+                      ) : poseLibrary ? (
                         <details className="pose-library-details">
                           <summary>
                             Pose library{selectedPoseIds.length ? ` · ${selectedPoseIds.length} selected` : ""}
@@ -1268,13 +1302,20 @@ export function ImageStudio() {
             <label>
               Model
               <select onChange={(event) => setModel(event.target.value)} value={model}>
-                {(availableModels.length ? availableModels : imageModels).map((item) => (
+                {(availableModels.length ? availableModels : macImageModels).map((item) => (
                   <option key={item.id} value={item.id}>
                     {item.name}
                   </option>
                 ))}
               </select>
             </label>
+            {macHiddenImageModels.length ? (
+              <p className="mac-gating-note">
+                {macHiddenImageModels.length} model
+                {macHiddenImageModels.length === 1 ? "" : "s"} unavailable on Mac (Rust/MLX only) —
+                see Models for details.
+              </p>
+            ) : null}
 
             <div className="style-preset-strip">
               <span className="style-preset-label">Style preset</span>

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -4,6 +4,7 @@ import { terminalStatuses } from "../constants.js";
 import { hasPresentCredential, loadCredentials } from "../credentials.js";
 import { extractFamilies, modelLoraFamilies, presetLoraId, presetLoras } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
+import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock, macModelBlock } from "../macGating.js";
 
 // Wan A14B is a two-expert mixture; its LoRAs come as a high/low-noise pair. These
 // base models accept the optional low-noise expert upload (sc-1991). The 5B model
@@ -201,7 +202,10 @@ export function ModelManagerScreen() {
     createLoraImportJob,
     createModelImportJob,
     presets: recipePresets = [],
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
+  // Mac UI gating (sc-3486): third-party LyCORIS adapters never run in the Rust/MLX flow (sc-3537).
+  const macLycorisBlock = macFeatureBlock(macCapabilities, "lycoris");
   const onCancelJob = (job) => jobAction(job, "cancel");
   const onResumeDownloadJob = (job, payload) => jobAction(job, "retry", { body: payload ?? {} });
   const onFreshDownloadJob = (job, payload) => jobAction(job, "retry", { body: payload ?? {} });
@@ -539,6 +543,11 @@ export function ModelManagerScreen() {
             needs family
           </span>
         ) : null}
+        {macModelBlock(model, macCapabilities) ? (
+          <span className="status-badge warning" title={macModelBlock(model, macCapabilities).text}>
+            not on Mac
+          </span>
+        ) : null}
         {capabilities.length ? (
           <ul className="model-capabilities">
             {capabilities.map((capability) => (
@@ -827,6 +836,7 @@ export function ModelManagerScreen() {
             <strong>Import LoRA</strong>
             <span>{importForm.family || "auto-detect"}</span>
           </div>
+          {macLycorisBlock ? <p className="mac-gating-note">{macLycorisBlock.text}</p> : null}
           <div className="segmented-control compact-segment" aria-label="LoRA import source">
             <button
               className={importForm.mode === "url" ? "active" : ""}

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -4,6 +4,7 @@ import { AssetDetail, AssetGrid, FullscreenPreview, emptyTrash } from "../compon
 import { AssetThumbnail } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { GLOBAL_POSES_PROJECT_ID } from "../poseLibrary.js";
 
@@ -414,7 +415,10 @@ function PoseCreatePanel({ hidden, categories, onSaved, existingPoses }) {
 }
 
 export function PoseLibraryScreen() {
-  const { token } = useAppContext();
+  const { token, macCapabilities = DEFAULT_MAC_CAPABILITIES } = useAppContext();
+  // Mac UI gating (sc-3486): photo→skeleton pose detection runs on Python onnxruntime (DWPose),
+  // with no in-process Rust path yet (sc-3487), so the Create tab is disabled on a gated Mac.
+  const macPoseDetectBlock = macFeatureBlock(macCapabilities, "poseFromPhoto");
   const [activeTab, setActiveTab] = useState("poses");
   const [poses, setPoses] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -531,20 +535,25 @@ export function PoseLibraryScreen() {
           </p>
         </div>
         <div className="segmented-control" role="tablist" aria-label="Pose Library sections">
-          {TABS.map(([id, label]) => (
-            <button
-              aria-controls={`pose-library-panel-${id}`}
-              aria-selected={activeTab === id}
-              className={activeTab === id ? "active" : ""}
-              id={`pose-library-tab-${id}`}
-              key={id}
-              onClick={() => setActiveTab(id)}
-              role="tab"
-              type="button"
-            >
-              {label}
-            </button>
-          ))}
+          {TABS.map(([id, label]) => {
+            const macBlock = id === "create" ? macPoseDetectBlock : null;
+            return (
+              <button
+                aria-controls={`pose-library-panel-${id}`}
+                aria-selected={activeTab === id}
+                className={activeTab === id ? "active" : ""}
+                disabled={Boolean(macBlock)}
+                id={`pose-library-tab-${id}`}
+                key={id}
+                onClick={() => setActiveTab(id)}
+                role="tab"
+                title={macBlock ? macBlock.text : undefined}
+                type="button"
+              >
+                {label}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useAppContext } from "../context/AppContext.js";
+import { DEFAULT_MAC_CAPABILITIES, macTrainingKernelBlocked } from "../macGating.js";
 import { API_BASE_URL } from "../api.js";
 import { AssetThumbnail, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { CompactSelector } from "../components/CompactSelector.jsx";
@@ -883,6 +884,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     trainingTargetsError = "",
     setActiveView,
     studioLaunch,
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
   const datasets = trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [];
   const datasetsError = trainingDatasetsError;
@@ -1019,10 +1021,20 @@ export function TrainingStudio({ mode = "training" } = {}) {
     (!activeDataset || dirty);
   const displayedCaptionPrompt = captionSettings.captionPrompt || buildJoyCaptionPrompt(captionSettings);
   const firstTarget = trainingTargets[0] ?? null;
+  // Mac UI gating (sc-3486): a target whose kernel has no native mlx-gen Rust trainer
+  // (kolors_lora / lens_lora) can't train on a gated Mac — disable it and snap off it.
+  const macTargetBlocked = (target) => macTrainingKernelBlocked(macCapabilities, target?.kernel);
   const selectedTarget = useMemo(
     () => trainingTargets.find((target) => target.id === selectedTargetId) ?? firstTarget,
     [firstTarget, selectedTargetId, trainingTargets],
   );
+  useEffect(() => {
+    if (selectedTarget && macTargetBlocked(selectedTarget)) {
+      const fallback = trainingTargets.find((target) => !macTargetBlocked(target));
+      if (fallback) setSelectedTargetId(fallback.id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTarget?.id, trainingTargets, macCapabilities]);
   const targetPresets = useMemo(
     () => presetsForTarget(trainingPresets, selectedTarget?.id),
     [selectedTarget?.id, trainingPresets],
@@ -1053,6 +1065,18 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const networkTypeOptions = rangeOptions(selectedTarget?.limits, "networkTypes");
   const showNetworkType = networkTypeOptions.length > 1;
   const isLokrNetwork = asText(configDraft.networkType).trim() === "lokr";
+  // Mac UI gating (sc-3486): the mlx Wan trainer can't merge a Kronecker (LoKr) adapter, so
+  // disable the LoKr network type for Wan targets on a gated Mac (LoKr on Z-Image/SDXL/LTX is fine).
+  const macLokrOnWanBlocked =
+    Boolean(macCapabilities?.macGatingActive) &&
+    (selectedTarget?.kernel ?? "").startsWith("wan") &&
+    macCapabilities?.training?.lokrOnWanSupported === false;
+  useEffect(() => {
+    if (macLokrOnWanBlocked && isLokrNetwork) {
+      updateConfigDraft("networkType", "lora");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [macLokrOnWanBlocked, isLokrNetwork]);
   const lrSchedulerLimitOptions = rangeOptions(selectedTarget?.limits, "lrSchedulers");
   const lrSchedulerSelectOptions = lrSchedulerLimitOptions.length ? lrSchedulerLimitOptions : lrSchedulerOptions;
   const visibleLrSchedulerOptions =
@@ -1893,11 +1917,15 @@ export function TrainingStudio({ mode = "training" } = {}) {
                         <label>
                           Target
                           <select onChange={(event) => setSelectedTargetId(event.target.value)} value={selectedTarget.id}>
-                            {trainingTargets.map((target) => (
-                              <option key={target.id} value={target.id}>
-                                {target.ui?.label ?? target.name}
-                              </option>
-                            ))}
+                            {trainingTargets.map((target) => {
+                              const blocked = macTargetBlocked(target);
+                              return (
+                                <option key={target.id} value={target.id} disabled={blocked}>
+                                  {target.ui?.label ?? target.name}
+                                  {blocked ? " — not on Mac (Rust/MLX only)" : ""}
+                                </option>
+                              );
+                            })}
                           </select>
                         </label>
                         <label>
@@ -2037,11 +2065,15 @@ export function TrainingStudio({ mode = "training" } = {}) {
                                 onChange={(event) => updateConfigDraft("networkType", event.target.value)}
                                 value={configDraft.networkType ?? "lora"}
                               >
-                                {networkTypeOptions.map((option) => (
-                                  <option key={option} value={option}>
-                                    {networkTypeLabel(option)}
-                                  </option>
-                                ))}
+                                {networkTypeOptions.map((option) => {
+                                  const blocked = option === "lokr" && macLokrOnWanBlocked;
+                                  return (
+                                    <option key={option} value={option} disabled={blocked}>
+                                      {networkTypeLabel(option)}
+                                      {blocked ? " — not on Mac (Rust/MLX only)" : ""}
+                                    </option>
+                                  );
+                                })}
                               </select>
                             </label>
                           ) : null}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -81,6 +81,13 @@ import {
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import {
+  DEFAULT_MAC_CAPABILITIES,
+  macAvailableModels,
+  macBlockedModels,
+  macFeatureBlock,
+  macVideoModeBlock,
+} from "../macGating.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { qualityChoices } from "../jobTypes.js";
 import {
@@ -134,6 +141,7 @@ export function VideoStudio() {
     setRequestedGpu,
     updateAssetStatus,
     videoModels,
+    macCapabilities = DEFAULT_MAC_CAPABILITIES,
   } = useAppContext();
   // Recent Assets (sc-2089) — 20 most recent video assets in the active
   // project. Falls back to the legacy single-generation list for test
@@ -171,6 +179,20 @@ export function VideoStudio() {
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
   const [model, setModel] = useState(saved.model ?? videoModels[0]?.id ?? ltxVideoModelId);
   const [guideOpen, setGuideOpen] = useState(false);
+  // Mac UI gating (sc-3486): hide torch-only video models (e.g. SVD) and snap off one if selected.
+  const macVideoModels = useMemo(
+    () => macAvailableModels(videoModels, macCapabilities),
+    [videoModels, macCapabilities],
+  );
+  const macHiddenVideoModels = useMemo(
+    () => macBlockedModels(videoModels, macCapabilities),
+    [videoModels, macCapabilities],
+  );
+  useEffect(() => {
+    if (macVideoModels.length && !macVideoModels.some((item) => item.id === model)) {
+      setModel(macVideoModels[0].id);
+    }
+  }, [macVideoModels, model]);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
   // Prompt guide for the selected model; fall back to the generic video guide
   // when a model declares none, so the button is always useful (sc-1817).
@@ -609,6 +631,13 @@ export function VideoStudio() {
     ["extend_clip", "Extend"],
     ["replace_person", "Replace person"],
   ];
+  // Mac UI gating (sc-3486): disable the video modes that run on the Python torch path —
+  // per-model FLF eligibility + the torch-only advanced modes (extend/bridge/replace).
+  const macAdvancedVideoBlock = macFeatureBlock(macCapabilities, "advancedVideoModes");
+  const macVideoModeBlockFor = (value) =>
+    value === "extend_clip"
+      ? macAdvancedVideoBlock
+      : macVideoModeBlock(selectedModel, macCapabilities, value);
   const matchingTracks = personTracks.filter((track) => track.sourceAssetId === sourceClipAssetId);
   const latestDetectionJob = jobs
     .filter(
@@ -774,16 +803,21 @@ export function VideoStudio() {
         <div className="surface-header hero studio-prompt-hero video-prompt-hero">
           <div className="prompt-hero-top">
             <div className="segmented-control mode-control" role="tablist" aria-label="Video mode">
-              {modeOptions.map(([value, label]) => (
-                <button
-                  className={mode === value ? "active" : ""}
-                  key={value}
-                  onClick={() => setMode(value)}
-                  type="button"
-                >
-                  {label}
-                </button>
-              ))}
+              {modeOptions.map(([value, label]) => {
+                const macBlock = macVideoModeBlockFor(value);
+                return (
+                  <button
+                    className={mode === value ? "active" : ""}
+                    key={value}
+                    onClick={() => setMode(value)}
+                    type="button"
+                    disabled={Boolean(macBlock)}
+                    title={macBlock ? macBlock.text : undefined}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
             </div>
             <div className="prompt-hero-links">
               <button className="hero-link" onClick={() => setGuideOpen(true)} type="button">
@@ -1064,13 +1098,19 @@ export function VideoStudio() {
               <label>
                 Model
                 <select onChange={(event) => setModel(event.target.value)} value={model}>
-                  {videoModels.map((item) => (
+                  {(macVideoModels.length ? macVideoModels : videoModels).map((item) => (
                     <option key={item.id} value={item.id}>
                       {item.name}
                     </option>
                   ))}
                 </select>
               </label>
+              {macHiddenVideoModels.length ? (
+                <p className="mac-gating-note">
+                  {macHiddenVideoModels.length} model
+                  {macHiddenVideoModels.length === 1 ? "" : "s"} unavailable on Mac (Rust/MLX only).
+                </p>
+              ) : null}
 
               <div className="style-preset-strip">
                 <span className="style-preset-label">Style preset</span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4853,6 +4853,15 @@ label {
   background: var(--warm-soft);
 }
 
+/* Mac UI gating affordance (sc-3486): the small "unavailable on Mac (Rust/MLX only)" note
+   shown under a gated picker/control. Muted so it reads as guidance, not an error. */
+.mac-gating-note {
+  margin: 6px 0 0;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: var(--text-muted);
+}
+
 .inline-success {
   border-color: transparent;
   background: var(--accent-soft);

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -8,7 +9,7 @@ use rusqlite::{
     params, params_from_iter, Connection, OptionalExtension, Row, ToSql, TransactionBehavior,
 };
 use serde::de::DeserializeOwned;
-use serde_json::{Map, Number, Value};
+use serde_json::{json, Map, Number, Value};
 
 use crate::contracts::{
     ContractNumber, JobSnapshot, JobStatus, JobType, ProgressStage, QueueSummary, WorkerCapability,
@@ -1711,7 +1712,7 @@ fn mlx_unavailable_error(job: &JobSnapshot, grace_seconds: u64) -> String {
 /// Why the Rust/MLX flow can't run a job on macOS (epic 3482 / sc-3484) — the inverse of the
 /// `*_mlx_eligible` predicates, extended across every job type. Feature-precise so the
 /// `mlx_unsupported` Logs event + the gap inventory name the exact surface to port or drop.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnsupportedReason {
     /// Model id involved, when the gap is model-specific (e.g. "kolors", "qwen_image").
@@ -1783,7 +1784,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // enforce-fail it (it would otherwise break a newer job type this build doesn't model).
         JobType::Unknown(_) => Ok(()),
 
-        JobType::ImageGenerate | JobType::ImageEdit => Err(classify_image_gap(job)),
+        JobType::ImageGenerate | JobType::ImageEdit => Err(classify_image_gap(&job.payload)),
 
         JobType::ImageDetail => Err(UnsupportedReason::new(
             model,
@@ -1799,7 +1800,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
             Some("epic 3180"),
         )),
 
-        JobType::VideoGenerate => Err(classify_video_gap(job)),
+        JobType::VideoGenerate => Err(classify_video_gap(&job.payload)),
 
         JobType::VideoExtend | JobType::VideoBridge => Err(UnsupportedReason::new(
             model,
@@ -1836,9 +1837,9 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
             Some("sc-3489"),
         )),
 
-        JobType::ModelConvert => classify_convert_gap(job),
+        JobType::ModelConvert => classify_convert_gap(&job.payload),
 
-        JobType::LoraTrain => Err(classify_training_gap(job)),
+        JobType::LoraTrain => Err(classify_training_gap(&job.payload)),
 
         JobType::TrainingCaption => Err(UnsupportedReason::new(
             None,
@@ -1846,6 +1847,295 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
             "automatic dataset captioning runs on the Python torch captioner.",
             Some("sc-3490"),
         )),
+    }
+}
+
+/// The user-facing affordance prefix the Mac UI shows in place of a torch-only control
+/// (sc-3486). Centralised so the API, the web client, and the gap docs read identically.
+pub const MAC_NOT_AVAILABLE_LABEL: &str = "Not available on Mac (Rust/MLX only)";
+
+/// UI-facing per-model macOS support (sc-3486), derived from the same `*_mlx_eligible` routing
+/// predicates as the [`mac_rust_supported`] job oracle — one source of truth, so what the UI
+/// hides can never drift from what routing refuses. `supported` = at least one generation config
+/// for this model routes to the in-process Rust/MLX flow on macOS, so the model stays in the
+/// picker; `false` = a torch-only model the Mac UI hides/disables once gating is active (its
+/// `reason` names the porting epic). The per-feature flags use "available in *some* MLX config"
+/// semantics (they never over-gate a valid combination) so a control is disabled only when the
+/// model can't use it on MLX at all; residual config-specific dead ends are caught by the
+/// `mlx_unsupported` affordance at submit.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelMacSupport {
+    pub supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<UnsupportedReason>,
+    pub features: ModelMacFeatures,
+}
+
+/// Per-feature macOS support for a model (sc-3486). Each flag mirrors the routing predicate for
+/// that feature with "eligible in at least one config" semantics; `false` → disable that control
+/// on Mac when gating is active. `video_modes` is populated only for video models.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelMacFeatures {
+    /// Pose conditioning (the pose picker): a non-empty `advanced.poses`, alone or with a
+    /// reference. `false` for base `qwen_image` (strict-pose ControlNet is torch-only, epic 3401).
+    pub pose: bool,
+    /// Reference / IP-Adapter / `character_image` identity conditioning (`referenceAssetId`).
+    pub reference: bool,
+    /// img2img `edit_image` (`mode=edit_image` + a source/reference image).
+    pub edit: bool,
+    /// Third-party LyCORIS (LoHa / non-peft LoKr) adapters — never in the Rust flow yet (sc-3537).
+    pub lycoris: bool,
+    /// Video-only: which `video_generate` modes route to MLX. Empty for non-video models.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub video_modes: BTreeMap<String, bool>,
+}
+
+/// Build a synthetic generation payload (`{ "model": ..., <entries> }`) for probing the routing
+/// predicates without a full [`JobSnapshot`] — the UI-gating sibling of how the oracle reads a
+/// real job's payload.
+fn probe_payload(model: &str, entries: &[(&str, Value)]) -> Map<String, Value> {
+    let mut payload = Map::new();
+    payload.insert("model".to_owned(), Value::String(model.to_owned()));
+    for (key, value) in entries {
+        payload.insert((*key).to_owned(), value.clone());
+    }
+    payload
+}
+
+/// UI gating support for a model id of the given catalog `model_type` ("image" / "video" / other).
+/// Non-image/video types (utility/infra: upscalers, captioners) are reported `supported` — their
+/// Python-only *actions* are gated by [`mac_capabilities`] at the job-type level, not by hiding
+/// the model from a picker. Same source of truth as [`mac_rust_supported`].
+pub fn model_mac_support(model_id: &str, model_type: &str) -> ModelMacSupport {
+    match model_type {
+        "image" => image_model_mac_support(model_id),
+        "video" => video_model_mac_support(model_id),
+        _ => ModelMacSupport {
+            supported: true,
+            reason: None,
+            features: ModelMacFeatures::default(),
+        },
+    }
+}
+
+fn image_model_mac_support(model: &str) -> ModelMacSupport {
+    if !MLX_ROUTED_MODELS.contains(&model) {
+        return ModelMacSupport {
+            supported: false,
+            reason: Some(classify_image_gap(&probe_payload(model, &[]))),
+            features: ModelMacFeatures::default(),
+        };
+    }
+    // "Available in some MLX config" probes — bias toward not-disabling so a valid combination
+    // (e.g. a Z-Image reference *with* a pose set) is never blocked. The residual config-only dead
+    // ends (a Z-Image reference *without* a pose) surface as the `mlx_unsupported` submit affordance.
+    let pose = image_request_mlx_eligible(
+        model,
+        &probe_payload(model, &[("advanced", json!({ "poses": [{}] }))]),
+    ) || image_request_mlx_eligible(
+        model,
+        &probe_payload(
+            model,
+            &[
+                ("mode", json!("character_image")),
+                ("referenceAssetId", json!("probe")),
+                ("advanced", json!({ "poses": [{}] })),
+            ],
+        ),
+    );
+    let reference = image_request_mlx_eligible(
+        model,
+        &probe_payload(model, &[("referenceAssetId", json!("probe"))]),
+    ) || image_request_mlx_eligible(
+        model,
+        &probe_payload(
+            model,
+            &[
+                ("mode", json!("character_image")),
+                ("referenceAssetId", json!("probe")),
+            ],
+        ),
+    ) || image_request_mlx_eligible(
+        model,
+        &probe_payload(
+            model,
+            &[
+                ("referenceAssetId", json!("probe")),
+                ("advanced", json!({ "poses": [{}] })),
+            ],
+        ),
+    );
+    let edit = image_request_mlx_eligible(
+        model,
+        &probe_payload(
+            model,
+            &[
+                ("mode", json!("edit_image")),
+                ("sourceAssetId", json!("probe")),
+            ],
+        ),
+    );
+    ModelMacSupport {
+        supported: true,
+        reason: None,
+        features: ModelMacFeatures {
+            pose,
+            reference,
+            edit,
+            lycoris: false,
+            video_modes: BTreeMap::new(),
+        },
+    }
+}
+
+/// The `video_generate` modes the UI offers, in display order, so the gating mirrors
+/// [`video_mode_is_mlx_eligible`] for every mode a Mac user could pick.
+const VIDEO_UI_MODES: &[&str] = &[
+    "text_to_video",
+    "image_to_video",
+    "first_last_frame",
+    "replace_person",
+];
+
+fn video_model_mac_support(model: &str) -> ModelMacSupport {
+    if !VIDEO_MLX_ROUTED_MODELS.contains(&model) {
+        return ModelMacSupport {
+            supported: false,
+            reason: Some(classify_video_gap(&probe_payload(model, &[]))),
+            features: ModelMacFeatures::default(),
+        };
+    }
+    let video_modes = VIDEO_UI_MODES
+        .iter()
+        .map(|mode| ((*mode).to_owned(), video_mode_is_mlx_eligible(model, mode)))
+        .collect();
+    ModelMacSupport {
+        supported: true,
+        reason: None,
+        features: ModelMacFeatures {
+            video_modes,
+            ..ModelMacFeatures::default()
+        },
+    }
+}
+
+/// macOS support for a non-model feature/sub-system (sc-3486): the infra job types that have no
+/// in-process Rust path. `supported=false` carries the `reason` (the same `UnsupportedReason` the
+/// `mlx_unsupported` event uses); when one of these is ported its flag flips to `true`.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MacFeatureSupport {
+    pub supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<UnsupportedReason>,
+}
+
+impl MacFeatureSupport {
+    fn unsupported(feature: &str, detail: &str, suggested_epic: &str) -> Self {
+        Self {
+            supported: false,
+            reason: Some(UnsupportedReason::new(
+                None,
+                feature,
+                detail,
+                Some(suggested_epic),
+            )),
+        }
+    }
+}
+
+/// macOS training support (sc-3486): the kernels with a native mlx-gen Rust trainer, so the
+/// Training studio can disable a base model whose kernel only runs on the Python torch trainer.
+/// `lokr_on_wan_supported=false` mirrors the LoKr-on-Wan routing caveat.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MacTrainingSupport {
+    pub supported_kernels: Vec<String>,
+    pub lokr_on_wan_supported: bool,
+}
+
+/// What the Mac UI needs to gate every non-model Python surface plus the master switch
+/// (sc-3486). `mac_gating_active` is the rollout flag (`SCENEWORKS_MLX_REQUIRED`): when `false`
+/// (Windows/Linux, or a Mac still in observe mode) the client applies no gating at all, so
+/// non-Mac pickers are untouched. The per-feature entries are facts about the Rust flow
+/// independent of the flag; the client only acts on them when `mac_gating_active`.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MacCapabilities {
+    pub platform: String,
+    pub mac_gating_active: bool,
+    pub not_available_label: String,
+    pub features: BTreeMap<String, MacFeatureSupport>,
+    pub training: MacTrainingSupport,
+}
+
+/// Build the [`MacCapabilities`] surface for the given platform + gating flag. The feature set is
+/// the non-model half of `docs/mac-rust-gaps.md` §5 (infra) plus the global feature gaps; keep it
+/// in sync with the oracle's job-type arms.
+pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilities {
+    let mut features = BTreeMap::new();
+    features.insert(
+        "lycoris".to_owned(),
+        MacFeatureSupport::unsupported(
+            "third-party LyCORIS LoRA",
+            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr).",
+            "sc-3537",
+        ),
+    );
+    features.insert(
+        "imageUpscale".to_owned(),
+        MacFeatureSupport::unsupported(
+            "image_upscale (Real-ESRGAN)",
+            "standalone image upscaling runs on the Python torch Real-ESRGAN / AuraSR path.",
+            "sc-3489",
+        ),
+    );
+    features.insert(
+        "poseFromPhoto".to_owned(),
+        MacFeatureSupport::unsupported(
+            "DWPose pose detection",
+            "photo→skeleton pose detection runs on Python onnxruntime (DWPose).",
+            "sc-3487",
+        ),
+    );
+    features.insert(
+        "personDetect".to_owned(),
+        MacFeatureSupport::unsupported(
+            "person detect / track (YOLO/SAM2)",
+            "person detection/tracking runs on the Python onnxruntime/torch path.",
+            "sc-3488",
+        ),
+    );
+    features.insert(
+        "datasetCaptioning".to_owned(),
+        MacFeatureSupport::unsupported(
+            "dataset captioning",
+            "automatic dataset captioning runs on the Python torch captioner.",
+            "sc-3490",
+        ),
+    );
+    features.insert(
+        "advancedVideoModes".to_owned(),
+        MacFeatureSupport::unsupported(
+            "advanced video (extend / bridge / replace_person)",
+            "the advanced video job types and modes are torch-only.",
+            "epic 3040",
+        ),
+    );
+    MacCapabilities {
+        platform: platform.to_owned(),
+        mac_gating_active,
+        not_available_label: MAC_NOT_AVAILABLE_LABEL.to_owned(),
+        features,
+        training: MacTrainingSupport {
+            supported_kernels: MLX_ROUTED_TRAINING_KERNELS
+                .iter()
+                .map(|kernel| (*kernel).to_owned())
+                .collect(),
+            lokr_on_wan_supported: false,
+        },
     }
 }
 
@@ -1869,8 +2159,8 @@ fn torch_only_image_model_epic(model: &str) -> Option<&'static str> {
 /// Name the precise gap for an ineligible `image_generate` / `image_edit` job: a torch-only
 /// model, or a torch-only feature on an otherwise-MLX family. Mirrors the per-family
 /// `*_mlx_eligible` gates so the reason matches why routing refused it.
-fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
-    let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
+fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
+    let Some(model) = payload.get("model").and_then(Value::as_str) else {
         return UnsupportedReason::new(None, "image generation", "no model specified.", None);
     };
     if !MLX_ROUTED_MODELS.contains(&model) {
@@ -1882,7 +2172,7 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
         };
         return UnsupportedReason::new(Some(model), "torch-only image model", detail, epic);
     }
-    if request_has_lycoris_lora(&job.payload) {
+    if request_has_lycoris_lora(payload) {
         return UnsupportedReason::new(
             Some(model),
             "third-party LyCORIS LoRA",
@@ -1890,14 +2180,13 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
             Some("sc-3537"),
         );
     }
-    let has_poses = job
-        .payload
+    let has_poses = payload
         .get("advanced")
         .and_then(Value::as_object)
         .and_then(|advanced| advanced.get("poses"))
         .and_then(Value::as_array)
         .is_some_and(|poses| !poses.is_empty());
-    let is_edit = job.payload.get("mode").and_then(Value::as_str) == Some("edit_image");
+    let is_edit = payload.get("mode").and_then(Value::as_str) == Some("edit_image");
     match model {
         "qwen_image" if has_poses => UnsupportedReason::new(
             Some(model),
@@ -1950,8 +2239,8 @@ fn classify_image_gap(job: &JobSnapshot) -> UnsupportedReason {
 
 /// Name the precise gap for an ineligible `video_generate` job: a torch-only model (incl. SVD),
 /// an advanced mode, a third-party LyCORIS, or LoKr-on-Wan. Mirrors `video_job_is_mlx_eligible`.
-fn classify_video_gap(job: &JobSnapshot) -> UnsupportedReason {
-    let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
+fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedReason {
+    let Some(model) = payload.get("model").and_then(Value::as_str) else {
         return UnsupportedReason::new(None, "video generation", "no model specified.", None);
     };
     if !VIDEO_MLX_ROUTED_MODELS.contains(&model) {
@@ -1962,8 +2251,7 @@ fn classify_video_gap(job: &JobSnapshot) -> UnsupportedReason {
             Some("epic 3040"),
         );
     }
-    let mode = job
-        .payload
+    let mode = payload
         .get("mode")
         .and_then(Value::as_str)
         .unwrap_or("image_to_video");
@@ -1975,7 +2263,7 @@ fn classify_video_gap(job: &JobSnapshot) -> UnsupportedReason {
             Some("epic 3040"),
         );
     }
-    if request_has_lycoris_lora(&job.payload) {
+    if request_has_lycoris_lora(payload) {
         return UnsupportedReason::new(
             Some(model),
             "third-party LyCORIS LoRA",
@@ -1983,7 +2271,7 @@ fn classify_video_gap(job: &JobSnapshot) -> UnsupportedReason {
             Some("sc-3537"),
         );
     }
-    if is_wan_video_model(model) && request_has_lokr_lora(&job.payload) {
+    if is_wan_video_model(model) && request_has_lokr_lora(payload) {
         return UnsupportedReason::new(
             Some(model),
             "LoKr-on-Wan",
@@ -2001,9 +2289,8 @@ fn classify_video_gap(job: &JobSnapshot) -> UnsupportedReason {
 
 /// Name the precise gap for an ineligible `lora_train` job. Mirrors `training_job_is_mlx_eligible`:
 /// a kernel with no native mlx-gen Rust trainer, or LoKr-on-Wan.
-fn classify_training_gap(job: &JobSnapshot) -> UnsupportedReason {
-    let kernel = job
-        .payload
+fn classify_training_gap(payload: &Map<String, Value>) -> UnsupportedReason {
+    let kernel = payload
         .get("plan")
         .and_then(Value::as_object)
         .and_then(|plan| plan.get("target"))
@@ -2041,12 +2328,12 @@ fn classify_training_gap(job: &JobSnapshot) -> UnsupportedReason {
 /// `model_convert` is supported only for the in-process Rust FLUX.2-klein converter
 /// (`flux2_klein_diffusers`, sc-3136). The default/absent converter is the Python mlx-video
 /// Wan/LTX path (sc-3491 / sc-3224).
-fn classify_convert_gap(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
-    if job.payload.get("converter").and_then(Value::as_str) == Some("flux2_klein_diffusers") {
+fn classify_convert_gap(payload: &Map<String, Value>) -> Result<(), UnsupportedReason> {
+    if payload.get("converter").and_then(Value::as_str) == Some("flux2_klein_diffusers") {
         return Ok(());
     }
     Err(UnsupportedReason::new(
-        job.payload.get("model").and_then(Value::as_str),
+        payload.get("model").and_then(Value::as_str),
         "Wan/LTX model conversion (mlx_video)",
         "installing a non-turnkey Wan/LTX checkpoint converts via the Python mlx_video path.",
         Some("sc-3491 / sc-3224"),
@@ -2325,21 +2612,28 @@ fn image_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
         return false;
     };
+    image_request_mlx_eligible(model, &job.payload)
+}
+
+/// Per-model image MLX-eligibility dispatch, factored out of [`image_job_is_mlx_eligible`] so the
+/// UI gating oracle ([`model_mac_support`], sc-3486) can probe the same per-family predicates with
+/// synthetic payloads — one dispatch table, no divergence between routing and what the UI hides.
+fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool {
     if !MLX_ROUTED_MODELS.contains(&model) {
         return false;
     }
     match model {
-        "z_image_turbo" => z_image_mlx_eligible(&job.payload),
-        "flux_schnell" | "flux_dev" => flux_mlx_eligible(&job.payload),
-        "qwen_image" => qwen_mlx_eligible(&job.payload),
+        "z_image_turbo" => z_image_mlx_eligible(payload),
+        "flux_schnell" | "flux_dev" => flux_mlx_eligible(payload),
+        "qwen_image" => qwen_mlx_eligible(payload),
         "qwen_image_edit"
         | "qwen_image_edit_2509"
         | "qwen_image_edit_2511"
-        | "qwen_image_edit_2511_lightning" => qwen_edit_mlx_eligible(&job.payload),
+        | "qwen_image_edit_2511_lightning" => qwen_edit_mlx_eligible(payload),
         "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" => {
-            flux2_mlx_eligible(&job.payload)
+            flux2_mlx_eligible(payload)
         }
-        "sdxl" | "realvisxl" => sdxl_mlx_eligible(&job.payload),
+        "sdxl" | "realvisxl" => sdxl_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -7,8 +7,9 @@ use sceneworks_core::contracts::{
     WorkerUtilizationSnapshot,
 };
 use sceneworks_core::jobs_store::{
-    mac_rust_supported, CreateJob, DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate,
-    RegisterWorker, RetryJob, WorkerHeartbeat, MAX_JOB_ATTEMPTS,
+    mac_capabilities, mac_rust_supported, model_mac_support, CreateJob, DuplicateJob, JobsStore,
+    JobsStoreError, ProgressUpdate, RegisterWorker, RetryJob, WorkerHeartbeat,
+    MAC_NOT_AVAILABLE_LABEL, MAX_JOB_ATTEMPTS,
 };
 use serde_json::{json, Map, Value};
 
@@ -1922,6 +1923,109 @@ fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
             .as_deref(),
         Some("epic 3180")
     );
+}
+
+#[test]
+fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
+    // sc-3486: the picker-gating view of the same routing predicates. Torch-only image
+    // models are unsupported (hidden/disabled on Mac) and carry their port epic.
+    let kolors = model_mac_support("kolors", "image");
+    assert!(!kolors.supported);
+    assert_eq!(
+        kolors
+            .reason
+            .as_ref()
+            .and_then(|r| r.suggested_epic.as_deref()),
+        Some("epic 3532")
+    );
+    // An MLX-routed base family stays in the picker.
+    let z_image = model_mac_support("z_image_turbo", "image");
+    assert!(z_image.supported);
+    assert!(z_image.reason.is_none());
+    // Torch-only video model (SVD) is hidden; Wan/LTX stay.
+    assert!(!model_mac_support("svd", "video").supported);
+    assert!(model_mac_support("wan_2_2", "video").supported);
+    // Utility/infra models are never hidden by model-level gating (their actions are
+    // gated by mac_capabilities at the job-type level instead).
+    assert!(model_mac_support("real_esrgan", "utility").supported);
+}
+
+#[test]
+fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
+    // Base Qwen strict-pose ControlNet is torch-only → pose control disabled; Z-Image /
+    // SDXL pose is MLX (Fun-CN / engine) → enabled.
+    assert!(!model_mac_support("qwen_image", "image").features.pose);
+    assert!(model_mac_support("z_image_turbo", "image").features.pose);
+    assert!(model_mac_support("sdxl", "image").features.pose);
+    // FLUX.1 reference/edit stay torch (viability spikes) → those controls disabled.
+    let flux = model_mac_support("flux_dev", "image");
+    assert!(!flux.features.reference);
+    assert!(!flux.features.edit);
+    // SDXL + FLUX.2 do reference/edit on MLX (epic 3041 / MLX-only family) → enabled.
+    let sdxl = model_mac_support("sdxl", "image");
+    assert!(sdxl.features.reference);
+    assert!(sdxl.features.edit);
+    let flux2 = model_mac_support("flux2_klein_9b", "image");
+    assert!(flux2.features.reference);
+    assert!(flux2.features.edit);
+    // Qwen-Image-Edit conditions reference/edit on its modes → both enabled (no over-gate).
+    let qwen_edit = model_mac_support("qwen_image_edit_2511", "image");
+    assert!(qwen_edit.features.reference);
+    assert!(qwen_edit.features.edit);
+    // LyCORIS is never in the Rust flow yet, for every family.
+    assert!(!model_mac_support("sdxl", "image").features.lycoris);
+    // Video models expose per-mode eligibility; advanced modes are torch-only.
+    let wan = model_mac_support("wan_2_2", "video").features.video_modes;
+    assert_eq!(wan.get("text_to_video"), Some(&true));
+    assert_eq!(wan.get("image_to_video"), Some(&true));
+    assert_eq!(wan.get("first_last_frame"), Some(&true)); // Wan TI2V-5B FLF is MLX
+    assert_eq!(wan.get("replace_person"), Some(&false));
+    // The 14B Wan MoE engines have no FLF Keyframe path → torch.
+    assert_eq!(
+        model_mac_support("wan_2_2_t2v_14b", "video")
+            .features
+            .video_modes
+            .get("first_last_frame"),
+        Some(&false)
+    );
+}
+
+#[test]
+fn mac_capabilities_master_switch_and_infra_features() {
+    // On a non-Mac host (or a Mac still in observe mode) the gating is inert.
+    let inert = mac_capabilities("linux", false);
+    assert!(!inert.mac_gating_active);
+    assert_eq!(inert.platform, "linux");
+    assert_eq!(inert.not_available_label, MAC_NOT_AVAILABLE_LABEL);
+    // The infra surfaces all carry their port spike so the UI affordance can name it.
+    let mac = mac_capabilities("macos", true);
+    assert!(mac.mac_gating_active);
+    let epic = |key: &str| {
+        mac.features
+            .get(key)
+            .and_then(|f| f.reason.as_ref())
+            .and_then(|r| r.suggested_epic.as_deref())
+            .map(str::to_owned)
+    };
+    assert_eq!(epic("imageUpscale").as_deref(), Some("sc-3489"));
+    assert_eq!(epic("poseFromPhoto").as_deref(), Some("sc-3487"));
+    assert_eq!(epic("personDetect").as_deref(), Some("sc-3488"));
+    assert_eq!(epic("datasetCaptioning").as_deref(), Some("sc-3490"));
+    assert_eq!(epic("lycoris").as_deref(), Some("sc-3537"));
+    assert_eq!(epic("advancedVideoModes").as_deref(), Some("epic 3040"));
+    assert!(mac.features.values().all(|f| !f.supported));
+    // Training kernels with a native Rust trainer stay enabled; LoKr-on-Wan does not.
+    assert!(mac
+        .training
+        .supported_kernels
+        .iter()
+        .any(|k| k == "z_image_lora"));
+    assert!(mac
+        .training
+        .supported_kernels
+        .iter()
+        .any(|k| k == "sdxl_lora"));
+    assert!(!mac.training.lokr_on_wan_supported);
 }
 
 #[test]

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -29,6 +29,17 @@ Rollout reminder: the cutover is staged (epic 3482). The `mlx_unsupported` oracl
 without breaking anything; each surface flips to enforce only once it's ported (its epic
 completes) or dropped (UI-gated, sc-3486).
 
+> **UI gating (sc-3486).** The same oracle is surfaced to the web client so a Mac user never
+> reaches a `mlx_unsupported` error after submit. `GET /api/v1/models` stamps each model with
+> `macSupport { supported, reason, features { pose, reference, edit, lycoris, videoModes } }`
+> (`model_mac_support`), and `GET /api/v1/capabilities/mac` carries the master switch
+> (`macGatingActive` = `SCENEWORKS_MLX_REQUIRED`), the infra feature gaps below (§5), and the
+> supported training kernels (§4). The client (`apps/web/src/macGating.js`) hides torch-only
+> models from the studio pickers and disables the feature controls in this table — but only when
+> `macGatingActive`, so Windows/Linux (and an observe-mode Mac) are untouched. When a surface
+> here flips to *Done*, its `macSupport`/capability flag flips to supported automatically (same
+> predicates), and the UI stops gating it — no separate UI change needed.
+
 ---
 
 ## 1. Torch-only image models

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2159,6 +2159,21 @@
           "z-image"
         ]
       },
+      "macSupport": {
+        "features": {
+          "edit": false,
+          "lycoris": false,
+          "pose": false,
+          "reference": false
+        },
+        "reason": {
+          "detail": "this model has no Rust/MLX engine and no port epic yet \u2014 file a porting epic and drop it on Mac (epic 3482 policy).",
+          "feature": "torch-only image model",
+          "model": "base-model",
+          "suggestedEpic": null
+        },
+        "supported": false
+      },
       "missingRequiredFiles": [],
       "name": "User Model",
       "paths": {},
@@ -2197,6 +2212,15 @@
         "families": [
           "z-image"
         ]
+      },
+      "macSupport": {
+        "features": {
+          "edit": false,
+          "lycoris": false,
+          "pose": true,
+          "reference": true
+        },
+        "supported": true
       },
       "missingRequiredFiles": [],
       "name": "Z-Image Turbo",


### PR DESCRIPTION
Foundation slice 4 of **epic 3482 (Python Eradication)**. Surfaces the `mac_rust_supported` oracle (sc-3484) to the web client so a Mac user in MLX-required mode never reaches an `mlx_unsupported` error after submit — the user-facing "drop". **Ships inert** (`SCENEWORKS_MLX_REQUIRED` default off); Windows/Linux and an observe-mode Mac are untouched.

## Backend — one source of truth
Same routing predicates as the oracle, so what the UI hides can never drift from what routing refuses.

- **`jobs_store.rs`**: refactor `classify_{image,video,training,convert}_gap` to take `&payload`, and extract `image_request_mlx_eligible` so the UI gating reuses the exact per-family eligibility dispatch.
  - `model_mac_support(id, type)` → `{ supported, reason, features { pose, reference, edit, lycoris, videoModes } }`. Feature flags use **"eligible in *some* MLX config"** semantics, so a valid combination (e.g. a Z-Image reference *with* a pose) is never blocked; residual config-only dead ends fall through to the submit affordance.
  - `mac_capabilities(platform, gating)` → master switch + the non-model infra gaps (upscale/pose-from-photo/person/captioning/LyCORIS/advanced-video) + the supported training kernels.
  - `UnsupportedReason` derives `PartialEq`.
- **`rust-api`**: stamp `macSupport` onto every `/api/v1/models` entry; new `GET /api/v1/capabilities/mac` (`macGatingActive` = `SCENEWORKS_MLX_REQUIRED`).

## Frontend — `apps/web/src/macGating.js` (no-op unless `macGatingActive`)
- App threads `macCapabilities` through context.
- **Pickers** (Image / Video / Character): torch-only models hidden + a "N unavailable on Mac" note; a hidden selection snaps to the first available model.
- **ImageStudio**: Edit / With-character modes + the pose picker disabled per the selected model's feature flags (e.g. base `qwen_image` strict pose → epic 3401).
- **VideoStudio**: advanced / torch-only modes disabled per `(model, mode)` (SVD hidden; extend/bridge/replace torch-only → epic 3040).
- **TrainingStudio**: targets whose kernel has no native Rust trainer (kolors/lens) disabled; LoKr disabled for Wan targets.
- **ImageEditor**: standalone upscaler disabled (sc-3489). **PoseLibrary**: photo→skeleton Create tab disabled (sc-3487). **ModelManager**: LyCORIS-upload note (sc-3537) + a "not on Mac" badge on torch-only rows.
- A "Not available on Mac (Rust/MLX only) — <reason>" affordance throughout.

When a gap flips to *Done*, its `macSupport`/capability flag flips to supported automatically (same predicates) — the UI stops gating it with no separate change.

## Verification
- `npm run rust:check` green — core `jobs_store` **88** (+3), rust-api **100** (+2).
- web **vitest 354** (+8 `macGating` unit tests) + clean production build (216 modules).
- `docs/mac-rust-gaps.md` records the UI-surface contract.
- **Owes**: real-Mac enforce-mode E2E (no Mac hardware in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)