### PR TITLE
[codex] Route Qwen strict pose through MLX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "image",
  "inventory",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2565,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "image",
  "inventory",
@@ -2578,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "image",
  "inventory",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a93332e3ff5b6be683f3e094002a4ae99e024617#a93332e3ff5b6be683f3e094002a4ae99e024617"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
 dependencies = [
  "image",
  "inventory",
@@ -2888,7 +2888,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1877,7 +1877,7 @@ pub struct ModelMacSupport {
 #[serde(rename_all = "camelCase")]
 pub struct ModelMacFeatures {
     /// Pose conditioning (the pose picker): a non-empty `advanced.poses`, alone or with a
-    /// reference. `false` for base `qwen_image` (strict-pose ControlNet is torch-only, epic 3401).
+    /// reference. Base `qwen_image` strict-pose uses the MLX ControlNet path (epic 3401).
     pub pose: bool,
     /// Reference / IP-Adapter / `character_image` identity conditioning (`referenceAssetId`).
     pub reference: bool,
@@ -2178,24 +2178,12 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             Some("sc-3537"),
         );
     }
-    let has_poses = payload
-        .get("advanced")
-        .and_then(Value::as_object)
-        .and_then(|advanced| advanced.get("poses"))
-        .and_then(Value::as_array)
-        .is_some_and(|poses| !poses.is_empty());
     let is_edit = payload.get("mode").and_then(Value::as_str) == Some("edit_image");
     match model {
-        "qwen_image" if has_poses => UnsupportedReason::new(
-            Some(model),
-            "strict-pose ControlNet",
-            "Qwen strict-pose ControlNet (InstantX QwenImageControlNet) has no MLX port; the MLX path would silently drop the poses.",
-            Some("epic 3401"),
-        ),
         "qwen_image" => UnsupportedReason::new(
             Some(model),
             "reference / edit conditioning",
-            "base Qwen-Image reference / edit_image conditioning stays on the Python torch path.",
+            "base Qwen-Image reference / edit_image conditioning stays on the Python torch path unless it is the strict-pose ControlNet tier.",
             Some("epic 3401"),
         ),
         "flux_schnell" | "flux_dev" => UnsupportedReason::new(
@@ -2681,21 +2669,16 @@ fn flux2_mlx_eligible(payload: &Map<String, Value>) -> bool {
     !request_has_lycoris_lora(payload)
 }
 
-/// Qwen-Image (sc-3024) MLX-routing conditions, ported from `_should_route_qwen_to_mlx`:
-/// text-to-image only. A reference (character/edit flow) and `edit_image` stay on the
-/// Python torch path; a strict pose set stays on torch too — the Qwen strict-pose tier
-/// is a diffusers `QwenImageControlNet` (sc-2291), which the MLX path has no equivalent
-/// for (it would silently drop the poses). A third-party LyCORIS LoRA also falls back
-/// to torch (engine + worker apply LoRA + peft LoKr, but not arbitrary LyCORIS).
+/// Qwen-Image (sc-3024 / strict pose sc-3575) MLX-routing conditions: text-to-image,
+/// plus the base-Qwen strict pose tier (`advanced.poses`) handled by the `qwen_image_control`
+/// engine variant. A reference without poses (character/edit flow) and `edit_image` stay on
+/// the Python torch path. A third-party LyCORIS LoRA also falls back to torch (engine + worker
+/// apply LoRA + peft LoKr, but not arbitrary LyCORIS).
 fn qwen_mlx_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
     }
-    let has_reference = payload
-        .get("referenceAssetId")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().is_empty());
-    if has_reference {
+    if request_has_lycoris_lora(payload) {
         return false;
     }
     let has_poses = payload
@@ -2705,9 +2688,16 @@ fn qwen_mlx_eligible(payload: &Map<String, Value>) -> bool {
         .and_then(Value::as_array)
         .is_some_and(|poses| !poses.is_empty());
     if has_poses {
+        return true;
+    }
+    let has_reference = payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    if has_reference {
         return false;
     }
-    !request_has_lycoris_lora(payload)
+    true
 }
 
 /// Qwen-Image-Edit (sc-3397/sc-3398) MLX-routing conditions. The `qwen_image_edit` /
@@ -2718,7 +2708,7 @@ fn qwen_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// / best-effort-pose / angle-set flows — all reference-conditioned). The lightning distill
 /// (sc-3398) shares the same gate (its sampler + distill-LoRA are worker-local). A
 /// third-party LyCORIS LoRA falls back to torch (engine + worker apply LoRA + peft LoKr, but
-/// not arbitrary LyCORIS); base-Qwen strict pose stays on torch until epic 3401 lands.
+/// not arbitrary LyCORIS).
 fn qwen_edit_mlx_eligible(payload: &Map<String, Value>) -> bool {
     if request_has_lycoris_lora(payload) {
         return false;
@@ -3401,14 +3391,18 @@ mod mlx_routing_tests {
     }
 
     #[test]
-    fn qwen_edit_reference_poses_and_lycoris_fall_back_to_torch() {
+    fn qwen_edit_reference_and_lycoris_fall_back_but_pose_routes_mlx() {
         assert!(!qwen_mlx_eligible(&object(json!({ "mode": "edit_image" }))));
         assert!(!qwen_mlx_eligible(&object(
             json!({ "referenceAssetId": "asset_1" })
         )));
-        // Strict pose ControlNet (sc-2291) is torch-only for Qwen — unlike Z-Image,
-        // a pose set does NOT keep it on MLX.
-        assert!(!qwen_mlx_eligible(&object(json!({
+        // Strict pose ControlNet (sc-2291 / sc-3575) routes to MLX, even if a reference is
+        // present; the strict-pose tier is pose-from-prompt and ignores the reference.
+        assert!(qwen_mlx_eligible(&object(json!({
+            "advanced": { "poses": [{ "id": "p1" }] }
+        }))));
+        assert!(qwen_mlx_eligible(&object(json!({
+            "referenceAssetId": "asset_1",
             "advanced": { "poses": [{ "id": "p1" }] }
         }))));
         assert!(!qwen_mlx_eligible(&object(json!({

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1793,15 +1793,13 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
 #[test]
 fn mac_rust_supported_names_qwen_strict_pose_and_lycoris() {
     let store = store("oracle-features");
-    // Strict-pose ControlNet on Qwen → epic 3401.
+    // Strict-pose ControlNet on Qwen is now Rust/MLX (epic 3401 / sc-3575).
     let pose = job_of(
         &store,
         JobType::ImageGenerate,
         json!({ "model": "qwen_image", "prompt": "p", "advanced": { "poses": [{ "x": 1 }] } }),
     );
-    let pose_reason = mac_rust_supported(&pose).unwrap_err();
-    assert!(pose_reason.feature.contains("strict-pose"));
-    assert_eq!(pose_reason.suggested_epic.as_deref(), Some("epic 3401"));
+    assert!(mac_rust_supported(&pose).is_ok());
     // Third-party LyCORIS on an otherwise-MLX family → port-or-drop viability spike.
     let lycoris = job_of(
         &store,
@@ -1954,9 +1952,8 @@ fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
 
 #[test]
 fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
-    // Base Qwen strict-pose ControlNet is torch-only → pose control disabled; Z-Image /
-    // SDXL pose is MLX (Fun-CN / engine) → enabled.
-    assert!(!model_mac_support("qwen_image", "image").features.pose);
+    // Base Qwen strict-pose ControlNet, Z-Image, and SDXL pose are MLX → enabled.
+    assert!(model_mac_support("qwen_image", "image").features.pose);
     assert!(model_mac_support("z_image_turbo", "image").features.pose);
     assert!(model_mac_support("sdxl", "image").features.pose);
     // FLUX.1 reference/edit stay torch (viability spikes) → those controls disabled.
@@ -2840,7 +2837,7 @@ fn flux_reference_job_stays_on_torch() {
 }
 
 #[test]
-fn qwen_txt2img_routes_to_mlx_but_pose_stays_on_torch() {
+fn qwen_txt2img_and_strict_pose_route_to_mlx() {
     let store = store("mlx-routing-qwen");
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
@@ -2862,9 +2859,25 @@ fn qwen_txt2img_routes_to_mlx_but_pose_stays_on_torch() {
         .expect("mlx claims qwen txt2img");
     assert_eq!(claimed.id, txt2img.id);
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+    store
+        .update_job_progress(
+            &claimed.id,
+            ProgressUpdate {
+                status: JobStatus::Completed,
+                stage: ProgressStage::Completed,
+                progress: 1.0,
+                message: "Done".to_owned(),
+                error: None,
+                result: Some(object(json!({ "assetIds": ["asset-qwen"] }))),
+                eta_seconds: None,
+                peak_gpu_memory_pct: None,
+                peak_gpu_load_pct: None,
+                backend: None,
+            },
+        )
+        .expect("txt2img job completes");
 
-    // A strict-pose qwen job stays on the Python torch ControlNet path (sc-2291): the
-    // mlx worker refuses it, the torch worker claims it without deferral.
+    // A strict-pose qwen job routes to the MLX ControlNet path (epic 3401 / sc-3575).
     let pose = store
         .create_job(image_job_with(
             json!({
@@ -2875,16 +2888,12 @@ fn qwen_txt2img_routes_to_mlx_but_pose_stays_on_torch() {
             "auto",
         ))
         .expect("pose job creates");
-    assert!(store
+    let claimed = store
         .claim_next_job("worker-mlx")
         .expect("mlx claim ok")
-        .is_none());
-    let claimed = store
-        .claim_next_job("worker-torch")
-        .expect("torch claim ok")
-        .expect("torch claims qwen pose job");
+        .expect("mlx claims qwen pose job");
     assert_eq!(claimed.id, pose.id);
-    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
 }
 
 #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -76,34 +76,35 @@ mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/ml
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev a93332e3 (mlx-gen main): carries the LoRA/LoKr trainer surface (epic 3039),
+# Rev 0806c88e (mlx-gen main): carries Qwen-Image ControlNet strict pose (epic 3401),
+# the LoRA/LoKr trainer surface (epic 3039),
 # Wan/LTX converter stack, the Qwen modulation-LoRA routing fix (PR #160), and the
 # Wan-VACE provider (`wan_vace`) + per-request `control_scale` (epic 3040 sc-3388/3441/
 # 3467, the replace_person → VACE path) in one shared rev so MLX builds once with the
 # unchanged mlx-rs pin (e59ffd88, identical across the bump → no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a93332e3ff5b6be683f3e094002a4ae99e024617" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -8,7 +8,8 @@
 //! `assetWrites` per image is what streams results into the gallery as they land.
 //!
 //! On macOS, engine-backed families (`z_image_turbo` — sc-3022; `flux_schnell` /
-//! `flux_dev` — sc-3023) run **real** in-process inference via the linked mlx-gen
+//! `flux_dev` — sc-3023; `qwen_image` — sc-3024 / strict pose sc-3575) run **real**
+//! in-process inference via the linked mlx-gen
 //! engine; other models (and non-macOS) fall back to a procedural stub (sc-3020), so
 //! the pipeline stays cross-platform-testable and each new family just adds a row to
 //! the [`MLX_MODELS`] table + links its provider crate.
@@ -103,8 +104,9 @@ const MLX_MODELS: &[MlxModel] = &[
         // Non-distilled true-CFG base: 20 steps + guidance 4.0 + negative prompt
         // (Python MODEL_TARGETS / MlxQwenAdapter). mlx-gen's own default is 4 steps,
         // so steps are passed explicitly. Edit moves to MLX (sc-3397, the `qwen_image_edit`
-        // engine model below); base-Qwen strict-pose ControlNet stays on torch until the
-        // engine port lands (epic 3401).
+        // engine model below); base-Qwen strict-pose ControlNet routes to the
+        // `qwen_image_control` engine variant when `advanced.poses` is present
+        // (epic 3401 / sc-3575).
         sceneworks_id: "qwen_image",
         engine_id: "qwen_image",
         default_repo: "Qwen/Qwen-Image",
@@ -310,6 +312,19 @@ pub(crate) async fn run_image_generate_job(
     let handled = if zimage_control_available(&request, settings) {
         // Z-Image strict-pose (advanced.poses) → Fun-Controlnet-Union, one image per pose.
         generate_zimage_control_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if qwen_control_available(&request, settings) {
+        // Qwen strict-pose (advanced.poses) → InstantX ControlNet-Union, one image per pose.
+        generate_qwen_control_stream(
             api,
             settings,
             job,
@@ -1404,7 +1419,12 @@ fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool
 /// else defaults) to a single `.safetensors` in the HF cache. `None` when absent (the
 /// model-download flow fetches it ahead of generation, like base weights).
 #[cfg(target_os = "macos")]
-fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+fn resolve_control_weights_for(
+    request: &ImageRequest,
+    settings: &Settings,
+    default_repo: &'static str,
+    default_file: &'static str,
+) -> Option<PathBuf> {
     let control = request
         .advanced
         .get("controlWeights")
@@ -1418,11 +1438,17 @@ fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Optio
             .unwrap_or(default)
             .to_owned()
     };
-    let repo = str_field("repo", ZIMAGE_CONTROL_REPO);
-    let filename = str_field("filename", ZIMAGE_CONTROL_FILE);
+    let repo = str_field("repo", default_repo);
+    let filename = str_field("filename", default_file);
     let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo)?;
     let path = snapshot.join(filename);
     path.exists().then_some(path)
+}
+
+/// Resolve the Z-Image Fun-Controlnet-Union checkpoint.
+#[cfg(target_os = "macos")]
+fn resolve_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+    resolve_control_weights_for(request, settings, ZIMAGE_CONTROL_REPO, ZIMAGE_CONTROL_FILE)
 }
 
 /// Pose ControlNet lock strength: `advanced.controlScale` (default 0.9, clamp [0,2]).
@@ -2424,14 +2450,289 @@ async fn generate_flux2_edit_stream(
 }
 
 // ---------------------------------------------------------------------------
+// Qwen-Image strict-pose ControlNet (macOS, epic 3401 / sc-3575): the InstantX
+// `Qwen-Image-ControlNet-Union` variant registered in mlx-gen as `qwen_image_control`.
+// One image per library pose, shared seed, true CFG + character LoRA on the base Qwen model.
+// ---------------------------------------------------------------------------
+
+/// The engine registry id for the Qwen-Image ControlNet-Union variant.
+#[cfg(target_os = "macos")]
+const QWEN_CONTROL_ENGINE_ID: &str = "qwen_image_control";
+/// Default InstantX Qwen-Image-ControlNet-Union weights (Apache-2.0, DWPose-trained).
+#[cfg(target_os = "macos")]
+const QWEN_CONTROL_REPO: &str = "InstantX/Qwen-Image-ControlNet-Union";
+#[cfg(target_os = "macos")]
+const QWEN_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
+
+/// True when this is the base-Qwen strict-pose tier: `qwen_image` + non-empty object
+/// `advanced.poses`, not edit mode, and base weights available. A `referenceAssetId`, if present,
+/// is ignored for parity with the Python torch `QwenImageControlNetPipeline` path; identity comes
+/// from character LoRA adapters on the base transformer.
+#[cfg(target_os = "macos")]
+fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == "qwen_image"
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+        && resolve_weights_dir(request, settings).is_some()
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_qwen_control_weights(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+    resolve_control_weights_for(request, settings, QWEN_CONTROL_REPO, QWEN_CONTROL_FILE)
+}
+
+/// Load the Qwen-Image ControlNet-Union generator (base snapshot + InstantX control overlay).
+#[cfg(target_os = "macos")]
+fn qwen_control_load(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> WorkerResult<Box<dyn Generator>> {
+    let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
+        .with_control(WeightsSource::File(control_weights));
+    if let Some(quant) = quant {
+        spec = spec.with_quant(quant);
+    }
+    if !adapters.is_empty() {
+        spec = spec.with_adapters(adapters);
+    }
+    mlx_gen::load(QWEN_CONTROL_ENGINE_ID, &spec).map_err(|error| {
+        WorkerError::InvalidPayload(format!("Qwen strict-pose control load failed: {error}"))
+    })
+}
+
+/// Generate one Qwen strict-pose image: the pose skeleton drives the InstantX control branch at
+/// `control_scale`; prompt, true CFG, negative prompt, quant, and LoRA/LoKr mirror base Qwen.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn qwen_control_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    negative_prompt: Option<String>,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: f32,
+    control: Image,
+    control_scale: f32,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        negative_prompt,
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        guidance: Some(guidance),
+        conditioning: vec![Conditioning::Control {
+            image: control,
+            kind: ControlKind::Pose,
+            scale: control_scale,
+        }],
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator.generate(&request, on_progress).map_err(|error| {
+        WorkerError::InvalidPayload(format!("Qwen strict-pose generation failed: {error}"))
+    })?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::InvalidPayload(
+                    "Qwen strict-pose generator produced no image".to_owned(),
+                )
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::InvalidPayload(
+            "Qwen strict-pose generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn qwen_control_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: f32,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw.insert(
+        "controlEngine".to_owned(),
+        Value::String(QWEN_CONTROL_ENGINE_ID.to_owned()),
+    );
+    raw
+}
+
+/// Real Qwen strict-pose generation: one image per pose, each conditioned on a full DWPose
+/// skeleton. Mirrors the Python `_generate_pose_set` path: shared seed, full body/hands/face
+/// skeleton, `advanced.controlScale`, true CFG, and character LoRA identity.
+#[cfg(target_os = "macos")]
+async fn generate_qwen_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let qwen = mlx_model("qwen_image")
+        .ok_or_else(|| WorkerError::InvalidPayload("Qwen model row missing".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings)
+        .ok_or_else(|| WorkerError::InvalidPayload("Qwen-Image weights not found".to_owned()))?;
+    let control_weights = resolve_qwen_control_weights(request, settings).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Qwen strict-pose control weights not found (download {QWEN_CONTROL_REPO})."
+        ))
+    })?;
+    let (quant, quant_bits) = resolve_quant(request);
+    let steps = resolve_steps(request, qwen);
+    let guidance = resolve_guidance(request, qwen).unwrap_or(qwen.default_guidance);
+    let negative_prompt = resolve_negative_prompt(request, qwen);
+    let control_scale = resolve_control_scale(request);
+    let adapters = resolve_adapters(request)?;
+    let repo = model_repo(request, qwen);
+    let poses = parse_poses(request);
+    let count = poses.len();
+    let raw_settings = qwen_control_raw_settings(
+        request,
+        &repo,
+        steps,
+        quant_bits,
+        guidance,
+        control_scale,
+        count,
+    );
+    let seed = resolve_seed(request, 0);
+
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+
+    let blocking = {
+        let prompt = request.prompt.clone();
+        let (width, height) = (request.width, request.height);
+        let cancel = cancel.clone();
+        let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+        let job_id = job.id.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            let adapter_count = adapters.len();
+            emit_load_event(
+                "image_pipeline_load_start",
+                &job_id,
+                QWEN_CONTROL_ENGINE_ID,
+                adapter_count,
+            );
+            let generator = qwen_control_load(weights_dir, control_weights, quant, adapters)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                QWEN_CONTROL_ENGINE_ID,
+                adapter_count,
+            );
+            for (index, pose) in poses.into_iter().enumerate() {
+                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                    width,
+                    height,
+                    &pose.keypoints,
+                    pose.hands.as_deref(),
+                    pose.face.as_deref(),
+                    stickwidth,
+                );
+                let control = Image {
+                    width,
+                    height,
+                    pixels: skeleton.into_raw(),
+                };
+                let mut on_progress = |progress: Progress| {
+                    let event = match progress {
+                        Progress::Step { current, total } => GenEvent::Step {
+                            index,
+                            current,
+                            total,
+                        },
+                        Progress::Decoding => GenEvent::Decoding { index },
+                    };
+                    let _ = tx.blocking_send(event);
+                };
+                let (width, height, pixels) = qwen_control_generate_one(
+                    generator.as_ref(),
+                    &prompt,
+                    negative_prompt.clone(),
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
+                    control,
+                    control_scale,
+                    &cancel,
+                    &mut on_progress,
+                )?;
+                if tx
+                    .blocking_send(GenEvent::Image {
+                        index,
+                        seed,
+                        width,
+                        height,
+                        pixels,
+                    })
+                    .is_err()
+                {
+                    break; // receiver gone — stop generating.
+                }
+            }
+            Ok(())
+        })
+    };
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        "mlx_qwen",
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
 // Qwen-Image-Edit (macOS, sc-3397): the `qwen_image_edit` / `_2509` / `_2511` ids, all
 // served by the engine's single `qwen_image_edit` model (Reference/MultiReference
 // dual-latent). This is where Qwen edit/reference jobs run — `edit_image`, the
 // Character-Studio reference flow (subject variation), the 11-angle set, and the
 // best-effort pose tier (`[reference, skeleton]` multi-image). True CFG (negative prompt
 // + guidance from `trueCfgScale`), LoRA/LoKr, Q4/Q8, fit_image. Base-Qwen strict-pose
-// ControlNet stays on torch until the engine port lands (epic 3401); the `_2511_lightning`
-// distill (sampler + lightx2v LoRA) is sc-3398.
+// ControlNet is handled by the `qwen_image_control` path above; the `_2511_lightning` distill
+// (sampler + lightx2v LoRA) is sc-3398.
 // ---------------------------------------------------------------------------
 
 /// The engine edit-model id for a Qwen SceneWorks model, or `None` if it has no edit
@@ -4339,6 +4640,7 @@ mod tests {
             "flux1_schnell",
             "flux1_dev",
             "qwen_image",
+            "qwen_image_control",
             "qwen_image_edit",
             "flux2_klein_9b",
             "sdxl",
@@ -4601,6 +4903,28 @@ mod tests {
         assert_eq!(poses[0].keypoints[0], Some((0.5, 0.2)));
         assert!(poses[0].hands.is_some());
         assert!(poses[0].face.is_some());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn qwen_control_raw_settings_records_control_recipe() {
+        let req = request(json!({
+            "projectId": "p",
+            "model": "qwen_image",
+            "advanced": {
+                "poses": [{ "id": "pose_1" }],
+                "controlScale": 0.5
+            }
+        }));
+        let raw = qwen_control_raw_settings(&req, "Qwen/Qwen-Image", 20, Some(4), 4.0, 0.5, 1);
+        assert_eq!(
+            raw.get("controlEngine").and_then(Value::as_str),
+            Some(QWEN_CONTROL_ENGINE_ID)
+        );
+        assert_eq!(raw.get("controlScale"), Some(&json!(0.5)));
+        assert_eq!(raw.get("poseCount"), Some(&json!(1)));
+        assert_eq!(raw.get("guidanceScale"), Some(&json!(4.0)));
+        assert_eq!(raw.get("mlxQuantize"), Some(&json!(4)));
     }
 
     /// sc-3031 A/B dump (NOT a CI test): generate ONE image through the **real new-adapter
@@ -4893,6 +5217,87 @@ mod tests {
             control,
             0.9,
             None,
+            &cancel,
+            &mut |p| {
+                if let mlx_gen::Progress::Step { current, .. } = p {
+                    steps_seen = steps_seen.max(current);
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!((w, h), (512, 512));
+        assert_eq!(pixels.len(), 512 * 512 * 3);
+        assert!(steps_seen >= 1, "expected denoise step progress");
+        assert!(pixels.windows(2).any(|w| w[0] != w[1]));
+    }
+
+    /// Real-weights smoke: Qwen-Image strict-pose ControlNet. Loads the base
+    /// `Qwen/Qwen-Image` snapshot + the cached InstantX ControlNet-Union checkpoint,
+    /// renders one DWPose skeleton, and generates one image through `qwen_image_control`.
+    /// Needs both in the HF cache + a Metal device; run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored qwen_control_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real Qwen-Image + InstantX ControlNet weights + Metal device"]
+    fn qwen_control_real_weights_generates_one_pose() {
+        let base = hf_snapshot("models--Qwen--Qwen-Image");
+        let control = hf_snapshot("models--InstantX--Qwen-Image-ControlNet-Union")
+            .join(super::QWEN_CONTROL_FILE);
+        assert!(
+            control.exists(),
+            "Qwen control weights missing: {control:?}"
+        );
+
+        let generator =
+            qwen_control_load(base, control, Some(mlx_gen::Quant::Q8), Vec::new()).unwrap();
+
+        let kp = crate::openpose_skeleton::normalize_keypoints(&json!([
+            [0.5, 0.2],
+            [0.5, 0.35],
+            [0.42, 0.35],
+            [0.40, 0.5],
+            [0.40, 0.65],
+            [0.58, 0.35],
+            [0.60, 0.5],
+            [0.60, 0.65],
+            [0.45, 0.6],
+            [0.45, 0.8],
+            [0.45, 0.95],
+            [0.55, 0.6],
+            [0.55, 0.8],
+            [0.55, 0.95],
+            [0.48, 0.18],
+            [0.52, 0.18],
+            [0.46, 0.2],
+            [0.54, 0.2]
+        ]));
+        let skeleton = crate::openpose_skeleton::draw_wholebody(
+            512,
+            512,
+            &kp,
+            None,
+            None,
+            crate::openpose_skeleton::body_stickwidth(512, 512),
+        );
+        let control = mlx_gen::Image {
+            width: 512,
+            height: 512,
+            pixels: skeleton.into_raw(),
+        };
+
+        let cancel = mlx_gen::CancelFlag::new();
+        let mut steps_seen = 0u32;
+        let (w, h, pixels) = qwen_control_generate_one(
+            generator.as_ref(),
+            "a person standing in a meadow",
+            Some("blurry, low quality".to_owned()),
+            512,
+            512,
+            42,
+            4,
+            4.0,
+            control,
+            0.9,
             &cancel,
             &mut |p| {
                 if let mlx_gen::Progress::Step { current, .. } = p {


### PR DESCRIPTION
## Summary
- bump mlx-gen to the Qwen ControlNet-capable revision and link the qwen_image_control engine
- add the SceneWorks worker path that builds Conditioning::Control { Pose } for Qwen strict-pose jobs
- route base qwen_image + advanced.poses to the MLX worker while keeping edit/reference-only/LyCORIS cases on the existing Torch path

## Shortcut
- sc-3575: worker Qwen strict-pose MLX control path
- sc-3576: routing/support cutover
- Epic 3401

## Validation
- cargo test -p sceneworks-worker --lib qwen_control_raw_settings_records_control_recipe
- cargo test -p sceneworks-core --test jobs_store
- npm run rust:check
- Previously during implementation: cargo test -p sceneworks-worker --lib qwen_control_real_weights_generates_one_pose -- --ignored --nocapture
