### PR TITLE
sc-3556: Wire JoyCaption MLX training caption jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-joycaption"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
@@ -4161,6 +4171,7 @@ dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
  "mlx-gen-flux2",
+ "mlx-gen-joycaption",
  "mlx-gen-ltx",
  "mlx-gen-qwen-image",
  "mlx-gen-sdxl",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -895,6 +895,7 @@ impl JobsStore {
         if should_defer_image_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
             || should_defer_video_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
             || should_defer_training_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
+            || should_defer_caption_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
         {
             // A non-mlx worker is yielding this MLX-eligible job to an idle mlx worker.
             let decision = RouteDecision::new(
@@ -1687,7 +1688,10 @@ impl RouteDecision {
 /// observability (sc-3449) and to identify the jobs the macOS grace sweep must fail when
 /// no `mlx` worker is alive (sc-3483).
 fn job_is_any_mlx_eligible(job: &JobSnapshot) -> bool {
-    job_is_mlx_eligible(job) || video_job_is_mlx_eligible(job) || training_job_is_mlx_eligible(job)
+    job_is_mlx_eligible(job)
+        || video_job_is_mlx_eligible(job)
+        || training_job_is_mlx_eligible(job)
+        || caption_job_is_mlx_eligible(job)
 }
 
 /// Actionable terminal error for an MLX-eligible job stranded on macOS with no live `mlx`
@@ -1842,8 +1846,8 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         JobType::TrainingCaption => Err(UnsupportedReason::new(
             None,
             "dataset captioning",
-            "automatic dataset captioning runs on the Python torch captioner.",
-            Some("sc-3490"),
+            "this dataset captioning job is not in the Rust/MLX JoyCaption flow.",
+            Some("sc-3556"),
         )),
     }
 }
@@ -2108,11 +2112,10 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
     );
     features.insert(
         "datasetCaptioning".to_owned(),
-        MacFeatureSupport::unsupported(
-            "dataset captioning",
-            "automatic dataset captioning runs on the Python torch captioner.",
-            "sc-3490",
-        ),
+        MacFeatureSupport {
+            supported: true,
+            reason: None,
+        },
     );
     features.insert(
         "advancedVideoModes".to_owned(),
@@ -2493,6 +2496,28 @@ fn should_defer_training_to_mlx_worker(
         return Ok(false);
     }
     // macOS MLX-required (sc-3483): yield unconditionally, same as the image sibling.
+    if mlx_required {
+        return Ok(true);
+    }
+    if job.requested_gpu != "auto" {
+        return Ok(false);
+    }
+    idle_mlx_worker_can_claim(connection, job, worker)
+}
+
+/// Captioning sibling of [`should_defer_image_to_mlx_worker`] (sc-3556): a non-mlx
+/// GPU worker defers JoyCaption dataset-caption jobs to an idle mlx worker, so the
+/// native Rust captioner (`mlx_gen::load_captioner`) can run them. Windows/Linux and
+/// explicit non-auto GPU requests keep the existing Python torch captioner fallback.
+fn should_defer_caption_to_mlx_worker(
+    connection: &Connection,
+    job: &JobSnapshot,
+    worker: &WorkerSnapshot,
+    mlx_required: bool,
+) -> JobsStoreResult<bool> {
+    if worker.gpu_id.eq_ignore_ascii_case("mlx") || !caption_job_is_mlx_eligible(job) {
+        return Ok(false);
+    }
     if mlx_required {
         return Ok(true);
     }
@@ -2945,6 +2970,18 @@ fn training_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     true
 }
 
+/// sc-3556 routing: SceneWorks training caption jobs keep their public
+/// `captioner=joy_caption` contract while the macOS mlx worker serves them through
+/// mlx-gen's JoyCaption provider. Other/unknown captioners stay off the mlx worker.
+fn caption_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
+    matches!(job.job_type, JobType::TrainingCaption)
+        && job
+            .payload
+            .get("captioner")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.trim() == "joy_caption")
+}
+
 /// Training kernels with NO non-Rust fallback — only the in-process Rust mlx worker
 /// can run them. `ltx_mlx_lora` was Apple-Silicon-only MLX-Python; epic 3039 (sc-3049)
 /// retired that Python trainer, leaving the native Rust LTX trainer as the sole path,
@@ -3029,6 +3066,12 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         // `lens_lora` (no mlx-gen crate) and LoKr-on-Wan stay on the Python torch
         // worker. Applies to both dry-run and real runs.
         if matches!(job.job_type, JobType::LoraTrain) && !training_job_is_mlx_eligible(job) {
+            return false;
+        }
+        // Dataset captioning (sc-3556): the mlx worker claims only JoyCaption jobs
+        // backed by the mlx-gen provider. Any future non-JoyCaption captioner stays
+        // on the worker that advertises that capability.
+        if matches!(job.job_type, JobType::TrainingCaption) && !caption_job_is_mlx_eligible(job) {
             return false;
         }
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1817,7 +1817,6 @@ fn mac_rust_supported_names_infra_job_types() {
     let cases = [
         (JobType::ImageUpscale, "sc-3489"),
         (JobType::PersonDetect, "sc-3488"),
-        (JobType::TrainingCaption, "sc-3490"),
     ];
     for (job_type, epic) in cases {
         let job = job_of(&store, job_type, json!({}));
@@ -1831,6 +1830,16 @@ fn mac_rust_supported_names_infra_job_types() {
     // DWPose pose detection is ported to the Rust worker (sc-3487) → supported.
     let pose = job_of(&store, JobType::PoseDetect, json!({}));
     assert!(mac_rust_supported(&pose).is_ok());
+    // JoyCaption dataset captioning is ported to the Rust/MLX worker (sc-3556).
+    let caption = job_of(
+        &store,
+        JobType::TrainingCaption,
+        json!({ "captioner": "joy_caption" }),
+    );
+    assert!(mac_rust_supported(&caption).is_ok());
+    let unknown_caption = job_of(&store, JobType::TrainingCaption, json!({}));
+    let reason = mac_rust_supported(&unknown_caption).unwrap_err();
+    assert_eq!(reason.suggested_epic.as_deref(), Some("sc-3556"));
 }
 
 #[test]
@@ -1996,7 +2005,7 @@ fn mac_capabilities_master_switch_and_infra_features() {
     assert!(!inert.mac_gating_active);
     assert_eq!(inert.platform, "linux");
     assert_eq!(inert.not_available_label, MAC_NOT_AVAILABLE_LABEL);
-    // The infra surfaces all carry their port spike so the UI affordance can name it.
+    // Unsupported infra surfaces carry their port spike so the UI affordance can name it.
     let mac = mac_capabilities("macos", true);
     assert!(mac.mac_gating_active);
     let epic = |key: &str| {
@@ -2009,10 +2018,15 @@ fn mac_capabilities_master_switch_and_infra_features() {
     assert_eq!(epic("imageUpscale").as_deref(), Some("sc-3489"));
     assert_eq!(epic("poseFromPhoto").as_deref(), Some("sc-3487"));
     assert_eq!(epic("personDetect").as_deref(), Some("sc-3488"));
-    assert_eq!(epic("datasetCaptioning").as_deref(), Some("sc-3490"));
+    assert_eq!(epic("datasetCaptioning"), None);
     assert_eq!(epic("lycoris").as_deref(), Some("sc-3537"));
     assert_eq!(epic("advancedVideoModes").as_deref(), Some("epic 3040"));
-    assert!(mac.features.values().all(|f| !f.supported));
+    assert!(mac.features["datasetCaptioning"].supported);
+    assert!(mac
+        .features
+        .iter()
+        .filter(|(key, _)| key.as_str() != "datasetCaptioning")
+        .all(|(_, f)| !f.supported));
     // Training kernels with a native Rust trainer stay enabled; LoKr-on-Wan does not.
     assert!(mac
         .training
@@ -2375,6 +2389,92 @@ fn mlx_training_job(
         duplicate_of_job_id: None,
         attempts: 1,
     }
+}
+
+fn caption_caps() -> Vec<WorkerCapability> {
+    vec![WorkerCapability::Gpu, WorkerCapability::TrainingCaption]
+}
+
+fn joy_caption_job(requested_gpu: &str) -> CreateJob {
+    CreateJob {
+        job_type: JobType::TrainingCaption,
+        project_id: Some("project-1".to_owned()),
+        project_name: Some("Project 1".to_owned()),
+        payload: object(json!({
+            "provider": "training",
+            "kind": "training_caption",
+            "captioner": "joy_caption",
+            "modelNameOrPath": "fancyfeast/llama-joycaption-beta-one-hf-llava",
+            "projectId": "project-1",
+            "datasetId": "dataset-1",
+            "items": [{
+                "itemId": "item_0001",
+                "imagePath": "/tmp/item_0001.png",
+                "triggerWords": ["miraStyle"]
+            }]
+        })),
+        requested_gpu: requested_gpu.to_owned(),
+        source_job_id: None,
+        duplicate_of_job_id: None,
+        attempts: 1,
+    }
+}
+
+#[test]
+fn joy_caption_routes_to_idle_mlx_worker() {
+    let store = store("mlx-caption-routing");
+    register_gpu_worker(&store, "worker-torch", "mps", caption_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", caption_caps());
+
+    let job = store
+        .create_job(joy_caption_job("auto"))
+        .expect("caption job creates");
+
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims joy caption");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn joy_caption_falls_back_to_torch_when_no_mlx_worker() {
+    let store = store("mlx-caption-fallback");
+    register_gpu_worker(&store, "worker-torch", "cuda:0", caption_caps());
+
+    let job = store
+        .create_job(joy_caption_job("auto"))
+        .expect("caption job creates");
+
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims caption job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("cuda:0"));
+}
+
+#[test]
+fn explicit_gpu_joy_caption_is_not_deferred_to_mlx_worker() {
+    let store = store("mlx-caption-explicit-gpu");
+    register_gpu_worker(&store, "worker-torch", "mps", caption_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", caption_caps());
+
+    let job = store
+        .create_job(joy_caption_job("mps"))
+        .expect("caption job creates");
+
+    let claimed = store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .expect("torch claims explicit caption job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
 }
 
 #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -77,11 +77,11 @@ mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/ml
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Rev 0806c88e (mlx-gen main): carries Qwen-Image ControlNet strict pose (epic 3401),
-# the LoRA/LoKr trainer surface (epic 3039),
-# Wan/LTX converter stack, the Qwen modulation-LoRA routing fix (PR #160), and the
-# Wan-VACE provider (`wan_vace`) + per-request `control_scale` (epic 3040 sc-3388/3441/
-# 3467, the replace_person → VACE path) in one shared rev so MLX builds once with the
-# unchanged mlx-rs pin (e59ffd88, identical across the bump → no MLX rebuild).
+# the LoRA/LoKr trainer surface (epic 3039), Wan/LTX converter stack, the Qwen
+# modulation-LoRA routing fix (PR #160), the Wan-VACE provider (`wan_vace`) +
+# per-request `control_scale` (epic 3040 sc-3388/3441/3467), and the JoyCaption
+# captioner registry/provider (epic 3550) in one shared rev so MLX builds once with
+# the unchanged mlx-rs pin (e59ffd88, identical across the bump → no MLX rebuild).
 mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
@@ -105,6 +105,10 @@ mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
 mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+# JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
+# `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
+# registry for native dataset captioning on the macOS MLX worker.
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -1,0 +1,568 @@
+//! Native MLX dataset captioning (epic 3550, sc-3556).
+//!
+//! SceneWorks keeps the existing `training_caption` job contract and result shape,
+//! but the macOS `mlx` worker can now serve `captioner=joy_caption` in-process via
+//! mlx-gen's JoyCaption provider. The Python torch captioner remains the
+//! Windows/Linux path and the explicit non-MLX fallback.
+
+use super::*;
+
+#[cfg(target_os = "macos")]
+const JOY_CAPTION_MODEL: &str = "fancyfeast/llama-joycaption-beta-one-hf-llava";
+#[cfg(target_os = "macos")]
+const CANCEL_MESSAGE: &str = "Training captioning canceled by user.";
+
+#[cfg(target_os = "macos")]
+use mlx_gen::{
+    CancelFlag, CaptionOptions, CaptionRequest, CaptionSampling, Image, LoadSpec, Progress,
+    WeightsSource,
+};
+#[cfg(target_os = "macos")]
+use mlx_gen_joycaption as _;
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug)]
+struct CaptionItem {
+    item_id: String,
+    image_path: PathBuf,
+    trigger_words: Vec<String>,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug)]
+struct CaptionJobOptions {
+    options: CaptionOptions,
+    sampling: CaptionSampling,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+enum CaptionEvent {
+    Step {
+        index: usize,
+        current: u32,
+        total: u32,
+    },
+    Captioned {
+        index: usize,
+        item_id: String,
+        text: String,
+        trigger_words: Vec<String>,
+    },
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) async fn run_training_caption_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    if job
+        .payload
+        .get("captioner")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        != "joy_caption"
+    {
+        return Err(WorkerError::InvalidPayload(
+            "Unsupported training captioner for the MLX worker; use joy_caption.".to_owned(),
+        ));
+    }
+
+    let items = caption_items(&job.payload)?;
+    if items.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Training caption job has no items to caption.".to_owned(),
+        ));
+    }
+    let options = caption_job_options(&job.payload);
+    let model_name_or_path = job
+        .payload
+        .get("modelNameOrPath")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(JOY_CAPTION_MODEL)
+        .to_owned();
+    let weights_dir = resolve_caption_weights_dir(settings, &model_name_or_path)?;
+    let backend = backend_label(&settings.gpu_id);
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        caption_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.04,
+            "Preparing training caption job.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+
+    check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
+    update_job(
+        api,
+        &job.id,
+        caption_progress(
+            JobStatus::LoadingModel,
+            ProgressStage::LoadingModel,
+            0.08,
+            "Loading JoyCaption MLX model.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+
+    let cancel = CancelFlag::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<CaptionEvent>(64);
+    let blocking_cancel = cancel.clone();
+    let blocking_items = items.clone();
+    let blocking_options = options.clone();
+    let job_id = job.id.clone();
+    let blocking = tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+        emit_event(
+            "caption_pipeline_load_start",
+            json!({
+                "jobId": job_id,
+                "engine": JOY_CAPTION_MODEL,
+            }),
+        );
+        let captioner = mlx_gen::load_captioner(
+            JOY_CAPTION_MODEL,
+            &LoadSpec::new(WeightsSource::Dir(weights_dir)),
+        )
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("JoyCaption MLX load failed: {error}"))
+        })?;
+        emit_event(
+            "caption_pipeline_load_complete",
+            json!({
+                "jobId": job_id,
+                "engine": JOY_CAPTION_MODEL,
+            }),
+        );
+
+        for (index, item) in blocking_items.into_iter().enumerate() {
+            if blocking_cancel.is_cancelled() {
+                return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+            }
+            let image = load_caption_image(&item.image_path)?;
+            let mut request = CaptionRequest {
+                image,
+                options: blocking_options.options.clone(),
+                sampling: blocking_options.sampling,
+                trigger_words: item.trigger_words.clone(),
+                cancel: blocking_cancel.clone(),
+                ..Default::default()
+            };
+            request.prompt = request.options.custom_prompt.clone();
+            let mut on_progress = |progress: Progress| {
+                if let Progress::Step { current, total } = progress {
+                    let _ = tx.blocking_send(CaptionEvent::Step {
+                        index,
+                        current,
+                        total,
+                    });
+                }
+            };
+            let output = captioner
+                .caption(&request, &mut on_progress)
+                .map_err(|error| {
+                    WorkerError::InvalidPayload(format!(
+                        "JoyCaption MLX generation failed: {error}"
+                    ))
+                })?;
+            let text = mlx_gen::caption::joycaption::apply_trigger_words(
+                &output.text,
+                &item.trigger_words,
+            );
+            tx.blocking_send(CaptionEvent::Captioned {
+                index,
+                item_id: item.item_id,
+                text,
+                trigger_words: item.trigger_words,
+            })
+            .map_err(|_| WorkerError::Canceled(CANCEL_MESSAGE.to_owned()))?;
+        }
+        Ok(())
+    });
+
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut captions = Vec::with_capacity(items.len());
+    loop {
+        tokio::select! {
+            event = rx.recv() => {
+                match event {
+                    Some(CaptionEvent::Step { index, current, total }) => {
+                        let progress = caption_step_progress(index, current, total, items.len());
+                        update_job(
+                            api,
+                            &job.id,
+                            caption_progress(
+                                JobStatus::Running,
+                                ProgressStage::Running,
+                                progress,
+                                &format!("Captioning image {} of {}.", index + 1, items.len()),
+                                None,
+                                backend,
+                            ),
+                        )
+                        .await?;
+                    }
+                    Some(CaptionEvent::Captioned { index, item_id, text, trigger_words }) => {
+                        captions.push(json!({
+                            "itemId": item_id,
+                            "caption": {
+                                "text": text,
+                                "source": "auto",
+                                "triggerWords": trigger_words,
+                            }
+                        }));
+                        let progress = 0.12 + 0.76 * ((index + 1) as f64 / items.len() as f64);
+                        update_job(
+                            api,
+                            &job.id,
+                            caption_progress(
+                                JobStatus::Running,
+                                ProgressStage::Running,
+                                progress,
+                                &format!("Captioned image {} of {}.", index + 1, items.len()),
+                                None,
+                                backend,
+                            ),
+                        )
+                        .await?;
+                    }
+                    None => break,
+                }
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                match check_cancel(api, &job.id, CANCEL_MESSAGE).await {
+                    Ok(()) => {}
+                    Err(WorkerError::Canceled(_)) => cancel.cancel(),
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+    }
+
+    blocking.await.map_err(|error| {
+        WorkerError::InvalidPayload(format!("caption task panicked: {error}"))
+    })??;
+
+    update_job(
+        api,
+        &job.id,
+        caption_progress(
+            JobStatus::Saving,
+            ProgressStage::Saving,
+            0.94,
+            "Saving generated captions.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+    let project_id = required_payload_string(&job.payload, "projectId")?;
+    let dataset_id = required_payload_string(&job.payload, "datasetId")?;
+    let sidecars: Value = api
+        .post_json(
+            &format!(
+                "/api/v1/projects/{project_id}/training/datasets/{dataset_id}/caption-sidecars"
+            ),
+            &json!({ "items": captions }),
+        )
+        .await?;
+    update_job(
+        api,
+        &job.id,
+        caption_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            &format!("Created captions for {} training item(s).", items.len()),
+            Some(caption_result(
+                &model_name_or_path,
+                dataset_id,
+                items.len(),
+                sidecars,
+            )),
+            backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) async fn run_training_caption_job(
+    _api: &ApiClient,
+    _settings: &Settings,
+    _job: &JobSnapshot,
+) -> WorkerResult<()> {
+    Err(WorkerError::InvalidPayload(
+        "The Rust JoyCaption worker is macOS/MLX-only; use the Python torch captioner on this platform."
+            .to_owned(),
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn caption_progress(
+    status: JobStatus,
+    stage: ProgressStage,
+    progress: f64,
+    message: &str,
+    result: Option<JsonObject>,
+    backend: &str,
+) -> ProgressRequest {
+    ProgressRequest {
+        status,
+        stage,
+        progress: number_from_f64(progress),
+        message: message.to_owned(),
+        error: None,
+        result,
+        eta_seconds: None,
+        peak_gpu_memory_pct: None,
+        peak_gpu_load_pct: None,
+        backend: Some(backend.to_owned()),
+        extra: BTreeMap::new(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn caption_result(
+    model_name_or_path: &str,
+    dataset_id: &str,
+    captioned_count: usize,
+    sidecars: Value,
+) -> JsonObject {
+    let mut result = JsonObject::new();
+    result.insert("captioner".to_owned(), json!("joy_caption"));
+    result.insert("modelNameOrPath".to_owned(), json!(model_name_or_path));
+    result.insert("datasetId".to_owned(), json!(dataset_id));
+    result.insert(
+        "datasetVersion".to_owned(),
+        sidecars
+            .get("dataset")
+            .and_then(|dataset| dataset.get("version"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    result.insert("captionedItemCount".to_owned(), json!(captioned_count));
+    result.insert(
+        "sidecars".to_owned(),
+        sidecars
+            .get("sidecars")
+            .cloned()
+            .unwrap_or_else(|| json!([])),
+    );
+    result
+}
+
+#[cfg(target_os = "macos")]
+fn caption_items(payload: &JsonObject) -> WorkerResult<Vec<CaptionItem>> {
+    let items = payload
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Caption payload.items must be an array.".to_owned())
+        })?;
+    items
+        .iter()
+        .map(|item| {
+            let object = item.as_object().ok_or_else(|| {
+                WorkerError::InvalidPayload("Caption item must be an object.".to_owned())
+            })?;
+            let item_id = object
+                .get("itemId")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    WorkerError::InvalidPayload("Caption item is missing itemId.".to_owned())
+                })?
+                .to_owned();
+            let image_path = object
+                .get("imagePath")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    WorkerError::InvalidPayload(format!(
+                        "Caption item {item_id} is missing imagePath."
+                    ))
+                })?;
+            let trigger_words = object
+                .get("triggerWords")
+                .and_then(Value::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(str::to_owned)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            Ok(CaptionItem {
+                item_id,
+                image_path: PathBuf::from(image_path),
+                trigger_words,
+            })
+        })
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn caption_job_options(payload: &JsonObject) -> CaptionJobOptions {
+    let options = payload
+        .get("options")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    CaptionJobOptions {
+        options: CaptionOptions {
+            caption_type: option_string(&options, "captionType", "Descriptive"),
+            caption_length: option_string(&options, "captionLength", "long"),
+            extra_options: options
+                .get("extraOptions")
+                .and_then(Value::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            name_input: option_string(&options, "nameInput", ""),
+            custom_prompt: option_string(&options, "captionPrompt", ""),
+            low_vram: options
+                .get("lowVram")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        },
+        sampling: CaptionSampling {
+            temperature: value_f64(options.get("temperature").unwrap_or(&Value::Null), 0.6) as f32,
+            top_p: value_f64(options.get("topP").unwrap_or(&Value::Null), 0.9) as f32,
+            max_new_tokens: options
+                .get("maxNewTokens")
+                .and_then(Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+                .unwrap_or(256),
+        },
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn option_string(options: &JsonObject, key: &str, default: &str) -> String {
+    options
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or(default)
+        .to_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_caption_weights_dir(
+    settings: &Settings,
+    model_name_or_path: &str,
+) -> WorkerResult<PathBuf> {
+    let direct = PathBuf::from(model_name_or_path);
+    if direct.is_dir() {
+        return Ok(direct);
+    }
+    if direct.exists() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "JoyCaption model path must be a snapshot directory, not a file: {}",
+            direct.display()
+        )));
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, model_name_or_path) {
+        return Ok(snapshot);
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "JoyCaption model snapshot is not cached for {model_name_or_path}. Download/cache the model first or pass a local snapshot directory."
+    )))
+}
+
+#[cfg(target_os = "macos")]
+fn load_caption_image(path: &Path) -> WorkerResult<Image> {
+    let decoded = image::open(path)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("caption image {}: {error}", path.display()))
+        })?
+        .to_rgb8();
+    Ok(Image {
+        width: decoded.width(),
+        height: decoded.height(),
+        pixels: decoded.into_raw(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn caption_step_progress(index: usize, current: u32, total: u32, item_count: usize) -> f64 {
+    let item_count = item_count.max(1) as f64;
+    let within = if total > 0 {
+        (current as f64 / total as f64).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    (0.12 + 0.76 * ((index as f64 + within) / item_count)).min(0.9)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caption_job_options_preserve_training_surface() {
+        let options = caption_job_options(&serde_json::Map::from_iter([(
+            "options".to_owned(),
+            json!({
+                "captionType": "Straightforward",
+                "captionLength": "40",
+                "extraOptions": ["Mention lighting."],
+                "nameInput": "Mira",
+                "captionPrompt": "Use the custom prompt.",
+                "temperature": 0.5,
+                "topP": 0.8,
+                "maxNewTokens": 128,
+                "lowVram": true
+            }),
+        )]));
+        assert_eq!(options.options.caption_type, "Straightforward");
+        assert_eq!(options.options.caption_length, "40");
+        assert_eq!(options.options.extra_options, vec!["Mention lighting."]);
+        assert_eq!(options.options.name_input, "Mira");
+        assert_eq!(options.options.custom_prompt, "Use the custom prompt.");
+        assert!(options.options.low_vram);
+        assert_eq!(options.sampling.temperature, 0.5);
+        assert_eq!(options.sampling.top_p, 0.8);
+        assert_eq!(options.sampling.max_new_tokens, 128);
+    }
+
+    #[test]
+    fn caption_items_require_ids_and_paths() {
+        let payload = serde_json::Map::from_iter([(
+            "items".to_owned(),
+            json!([{
+                "itemId": "item_1",
+                "imagePath": "/tmp/image.png",
+                "triggerWords": ["miraStyle", ""]
+            }]),
+        )]);
+        let items = caption_items(&payload).expect("items parse");
+        assert_eq!(items[0].item_id, "item_1");
+        assert_eq!(items[0].image_path, PathBuf::from("/tmp/image.png"));
+        assert_eq!(items[0].trigger_words, vec!["miraStyle"]);
+    }
+}

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -376,6 +376,10 @@ pub(crate) fn cpu_gpu() -> DiscoveredGpu {
 /// when its torch backend is present. The API gates which `lora_train` jobs reach
 /// here to the MLX-native families (`jobs_store::training_job_is_mlx_eligible`);
 /// `kolors`/`lens` and LoKr-on-Wan stay on the Python torch worker.
+///
+/// Dataset captioning (sc-3556): JoyCaption is linked through mlx-gen's captioner
+/// registry and runs in-process on this worker; the Python captioner remains the
+/// Windows/Linux and explicit non-MLX fallback.
 #[cfg(target_os = "macos")]
 pub(crate) fn mlx_gpu() -> DiscoveredGpu {
     DiscoveredGpu {
@@ -399,6 +403,7 @@ pub(crate) fn mlx_gpu() -> DiscoveredGpu {
             // real execution, both served in-process by `mlx_gen::load_trainer`.
             WorkerCapability::LoraTrain,
             WorkerCapability::LoraTrainExecute,
+            WorkerCapability::TrainingCaption,
             // DWPose whole-body pose detection (epic 3482, sc-3487): RTMW via
             // onnxruntime/CoreML, served in-process by `pose_jobs::run_pose_detect_job`.
             // Replaces the Python rtmlib `pose_detect` path so the Pose Library

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -47,6 +47,8 @@ mod video_jobs;
 use video_jobs::*;
 mod training_jobs;
 use training_jobs::*;
+mod caption_jobs;
+use caption_jobs::*;
 mod downloads;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on other platforms it still builds + unit-tests (cross-platform
@@ -554,6 +556,12 @@ async fn run_utility_job(
         JobType::LoraTrain => run_lora_train_job(api, settings, &job)
             .await
             .map_err(|error| ("LoRA training failed.", error)),
+        // Native MLX JoyCaption dataset captioning (epic 3550, sc-3556). The API
+        // routes only `captioner=joy_caption` jobs here; Windows/Linux and
+        // explicit non-MLX GPU choices keep the Python torch captioner fallback.
+        JobType::TrainingCaption => run_training_caption_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Training captioning failed.", error)),
         JobType::ModelDownload => run_model_download_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Model download failed.", error)),

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -447,6 +447,9 @@ fn mlx_gpu_advertises_generation_capabilities_only() {
         .any(|capability| capability.as_str() == "video_generate"));
     assert!(capabilities
         .iter()
+        .any(|capability| capability.as_str() == "training_caption"));
+    assert!(capabilities
+        .iter()
         .any(|capability| capability.as_str() == "gpu"));
     // No CPU utility capabilities, even with utility jobs enabled — only the CPU
     // worker (which carries `Cpu`) gets those extended onto it.

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -116,7 +116,7 @@ in-process Rust path. Per Michael's 2026-06-07 decision, all four spikes are **p
 | DWPose pose detection (photo→skeleton) | `pose_detect` | onnxruntime (RTMPose) | ✅ Ported (Rust `ort`/CoreML, macOS MLX worker) | sc-3487 |
 | Person detect / track | `person_detect`, `person_track` | YOLO / SAM2 | 🔵 Port-pending | sc-3488 |
 | Image upscaler (standalone) | `image_upscale` | Real-ESRGAN / AuraSR (torch) | 🔵 Port-pending | sc-3489 |
-| Dataset captioning | `training_caption` | torch captioner | 🔵 Port-pending | sc-3490 |
+| Dataset captioning | `training_caption` | JoyCaption MLX provider (Python torch fallback off-MLX) | ✅ Ported (macOS MLX worker) | sc-3556 |
 | Wan/LTX model conversion | `model_convert` (non-`flux2_klein_diffusers` converter) | `mlx_video.convert_*` (Python) | 🔵 Port-pending | sc-3491 (= sc-3224) |
 | Image understanding / interleave | `image_vqa`, `image_interleave` | torch (SenseNova-U1) | 🔵 Port-pending | epic 3180 (SenseNova port — its understanding surface) |
 


### PR DESCRIPTION
## Summary
- route `training_caption` / `joy_caption` jobs to the macOS `mlx` worker while preserving Python torch fallback for non-MLX and explicit GPU requests
- add the Rust MLX JoyCaption caption runner that loads the cached snapshot, captions dataset items, writes caption sidecars, and returns the existing result shape
- bump SceneWorks macOS `mlx-gen` pins to `0806c88` and link `mlx-gen-joycaption`; update Mac capability/gap docs

## Validation
- `cargo test -p sceneworks-core --test jobs_store`
- `cargo check -p sceneworks-worker`
- `cargo test -p sceneworks-worker caption_`
- `cargo test -p sceneworks-worker mlx_gpu_advertises_generation_capabilities_only`
- `cargo test -p sceneworks-rust-api capabilities_mac_is_inert_when_mlx_not_required`
- `MLX_GEN_JOYCAPTION_SNAPSHOT="$HOME/.cache/huggingface/hub/models--fancyfeast--llama-joycaption-beta-one-hf-llava/snapshots/ebf414ea497a020da0f82df3913e5b6cb8e9663a" cargo test -p mlx-gen-joycaption --test generate_real_weights -- --ignored --nocapture`
