### PR TITLE
[codex] Bump mlx-gen for Qwen edit timeout fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "image",
  "inventory",
@@ -2565,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "image",
  "inventory",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "image",
  "inventory",
@@ -2602,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0806c88e618d5b84d474cd2ec5df5a06db1bca54#0806c88e618d5b84d474cd2ec5df5a06db1bca54"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
 dependencies = [
  "image",
  "inventory",
@@ -2898,7 +2898,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -76,39 +76,40 @@ mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/ml
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 0806c88e (mlx-gen main): carries Qwen-Image ControlNet strict pose (epic 3401),
+# Rev b85b07b5 (mlx-gen main): carries Qwen-Image ControlNet strict pose (epic 3401),
 # the LoRA/LoKr trainer surface (epic 3039), Wan/LTX converter stack, the Qwen
 # modulation-LoRA routing fix (PR #160), the Wan-VACE provider (`wan_vace`) +
 # per-request `control_scale` (epic 3040 sc-3388/3441/3467), and the JoyCaption
-# captioner registry/provider (epic 3550) in one shared rev so MLX builds once with
-# the unchanged mlx-rs pin (e59ffd88, identical across the bump → no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+# captioner registry/provider (epic 3550), plus Qwen Edit step eval boundaries for
+# Metal timeout avoidance, in one shared rev so MLX builds once with the unchanged
+# mlx-rs pin (e59ffd88, identical across the bump -> no MLX rebuild).
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0806c88e618d5b84d474cd2ec5df5a06db1bca54" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Bump all SceneWorks worker mlx-gen package pins to b85b07b5e62ddab38828e03e207b448a3fee9d4b.
- Update Cargo.lock so the macOS MLX worker consumes the Qwen Edit timeout fix from michaeltrefry/mlx-gen#169.

## Why
The macOS image generation path must stay Rust/MLX-only. This pulls in the upstream MLX-side fix for intermittent Qwen Edit Lightning + user LoRA Metal command-buffer timeouts without adding any Torch fallback behavior.

## Validation
- cargo fmt --check
- cargo check -p sceneworks-worker
- cargo test -p sceneworks-worker --lib qwen_edit_lightning_model_row_is_cfg_off_4step_distill -- --nocapture