### PR TITLE
sc-3616 User-selectable accent color (7-palette picker)

### DIFF
--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -1,4 +1,5 @@
-//! UI preferences (theme, …) persisted as a small JSON file in the config dir.
+//! UI preferences (theme, accent, …) persisted as a small JSON file in the
+//! config dir.
 //! Served over plain HTTP because the bundled desktop UI runs at the API's
 //! `http://127.0.0.1:<port>` origin, where both Tauri IPC and origin-keyed
 //! `localStorage` are unreliable across launches (the port — and so the origin —
@@ -18,7 +19,15 @@ pub(crate) struct UiPreferences {
     /// Last-used UI theme (`"light"` or `"dark"`); absent until first set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     theme: Option<String>,
+    /// Last-used accent palette id (see `ACCENT_IDS`); absent until first set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    accent: Option<String>,
 }
+
+/// User-selectable accent palettes. Keep in sync with web/src/accents.js.
+const ACCENT_IDS: [&str; 7] = [
+    "teal", "indigo", "cobalt", "violet", "coral", "amber", "emerald",
+];
 
 fn preferences_path(state: &AppState) -> PathBuf {
     state.settings.config_dir.join(PREFERENCES_FILENAME)
@@ -49,6 +58,15 @@ fn normalize_theme(input: Option<&str>) -> Option<String> {
     }
 }
 
+/// The valid stored accent for `input`, or `None` if it isn't a known palette.
+fn normalize_accent(input: Option<&str>) -> Option<String> {
+    let value = input.map(str::trim)?;
+    ACCENT_IDS
+        .iter()
+        .find(|id| **id == value)
+        .map(|id| (*id).to_owned())
+}
+
 /// Current UI preferences (empty object on first run).
 pub(crate) async fn get_ui_preferences(
     State(state): State<AppState>,
@@ -66,6 +84,9 @@ pub(crate) async fn set_ui_preferences(
     if let Some(theme) = normalize_theme(payload.theme.as_deref()) {
         prefs.theme = Some(theme);
     }
+    if let Some(accent) = normalize_accent(payload.accent.as_deref()) {
+        prefs.accent = Some(accent);
+    }
     save_preferences(&state, &prefs)
         .map_err(|error| ApiError::internal(format!("Failed to save UI preferences: {error}")))?;
     Ok(Json(prefs))
@@ -73,7 +94,7 @@ pub(crate) async fn set_ui_preferences(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_theme;
+    use super::{normalize_accent, normalize_theme};
 
     #[test]
     fn normalize_theme_accepts_only_known_themes() {
@@ -81,5 +102,17 @@ mod tests {
         assert_eq!(normalize_theme(Some("dark")), Some("dark".to_owned()));
         assert_eq!(normalize_theme(Some("blue")), None);
         assert_eq!(normalize_theme(None), None);
+    }
+
+    #[test]
+    fn normalize_accent_accepts_only_known_palettes() {
+        assert_eq!(normalize_accent(Some("teal")), Some("teal".to_owned()));
+        assert_eq!(
+            normalize_accent(Some(" emerald ")),
+            Some("emerald".to_owned())
+        );
+        assert_eq!(normalize_accent(Some("amber")), Some("amber".to_owned()));
+        assert_eq!(normalize_accent(Some("fuchsia")), None);
+        assert_eq!(normalize_accent(None), None);
     }
 }

--- a/apps/web/public/theme-init.js
+++ b/apps/web/public/theme-init.js
@@ -1,9 +1,19 @@
-// Apply the persisted theme before first paint to avoid a flash. Kept as an
-// external script (not inline) so the served CSP can use a strict script-src 'self'.
+// Apply the persisted theme + accent before first paint to avoid a flash. Kept
+// as an external script (not inline) so the served CSP can use a strict
+// script-src 'self'.
 try {
-  const saved = window.localStorage.getItem("sceneworks-theme");
-  if (saved === "dark" || saved === "light") {
-    document.documentElement.setAttribute("data-theme", saved);
+  const root = document.documentElement;
+
+  const savedTheme = window.localStorage.getItem("sceneworks-theme");
+  if (savedTheme === "dark" || savedTheme === "light") {
+    root.setAttribute("data-theme", savedTheme);
+  }
+
+  // Keep this list in sync with web/src/accents.js (ACCENTS[].id).
+  const ACCENT_IDS = ["teal", "indigo", "cobalt", "violet", "coral", "amber", "emerald"];
+  const savedAccent = window.localStorage.getItem("sceneworks-accent");
+  if (savedAccent && ACCENT_IDS.indexOf(savedAccent) !== -1) {
+    root.setAttribute("data-accent", savedAccent);
   }
 } catch (_) {
   // ignore (private mode etc.)

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -28,6 +28,7 @@ import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
 import { AppContext } from "./context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
+import { ACCENTS, DEFAULT_ACCENT, isAccentId } from "./accents.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -214,6 +215,18 @@ function readStoredTheme() {
     return saved === "dark" || saved === "light" ? saved : "light";
   } catch {
     return "light";
+  }
+}
+
+function readStoredAccent() {
+  if (typeof window === "undefined") {
+    return DEFAULT_ACCENT;
+  }
+  try {
+    const saved = window.localStorage.getItem("sceneworks-accent");
+    return isAccentId(saved) ? saved : DEFAULT_ACCENT;
+  } catch {
+    return DEFAULT_ACCENT;
   }
 }
 
@@ -476,6 +489,17 @@ export function App() {
     apiFetch("/api/v1/ui-preferences", "", {
       method: "PUT",
       body: JSON.stringify({ theme: next }),
+    }).catch(() => {});
+  };
+  const [accent, setAccent] = useState(readStoredAccent);
+  // Same persistence contract as theme: instant localStorage cache + durable
+  // server copy. The PUT sends only the changed field, so the endpoint must
+  // MERGE partial updates (theme writes already rely on this).
+  const changeAccent = (next) => {
+    setAccent(next);
+    apiFetch("/api/v1/ui-preferences", "", {
+      method: "PUT",
+      body: JSON.stringify({ accent: next }),
     }).catch(() => {});
   };
   const activeProjectRef = useRef(null);
@@ -766,6 +790,18 @@ export function App() {
     }
   }, [theme]);
 
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    document.documentElement.setAttribute("data-accent", accent);
+    try {
+      window.localStorage.setItem("sceneworks-accent", accent);
+    } catch {
+      // ignore (private mode etc.)
+    }
+  }, [accent]);
+
   // Seed the theme from the server on launch (the durable copy; localStorage is
   // only an instant-paint cache). Each toggle persists itself via changeTheme,
   // so there's no save effect to race with this read.
@@ -773,9 +809,14 @@ export function App() {
     let cancelled = false;
     apiFetch("/api/v1/ui-preferences", "")
       .then((prefs) => {
-        const stored = prefs?.theme;
-        if (!cancelled && (stored === "dark" || stored === "light")) {
-          setTheme(stored);
+        if (cancelled) {
+          return;
+        }
+        if (prefs?.theme === "dark" || prefs?.theme === "light") {
+          setTheme(prefs.theme);
+        }
+        if (isAccentId(prefs?.accent)) {
+          setAccent(prefs.accent);
         }
       })
       .catch(() => {});
@@ -1718,6 +1759,20 @@ export function App() {
           <button className="icon-btn" title="Notifications" type="button">
             <Icon.Bell />
           </button>
+          <div className="accent-picker" role="group" aria-label="Accent color">
+            {ACCENTS.map((option) => (
+              <button
+                aria-label={option.name}
+                aria-pressed={accent === option.id}
+                className={accent === option.id ? "accent-swatch active" : "accent-swatch"}
+                key={option.id}
+                onClick={() => changeAccent(option.id)}
+                style={{ "--sw": option.swatch }}
+                title={option.name}
+                type="button"
+              />
+            ))}
+          </div>
           <button
             className="icon-btn"
             onClick={() => changeTheme(theme === "light" ? "dark" : "light")}

--- a/apps/web/src/accents.js
+++ b/apps/web/src/accents.js
@@ -1,0 +1,22 @@
+// User-selectable accent palettes (sc-accent). Each entry maps to a
+// `[data-accent="<id>"]` block in styles.css that sets the accent + secondary
+// hue; the light/dark ramps in :root / [data-theme="dark"] consume those hues,
+// so flipping the attribute recolors the whole app. `swatch` is the dot shown
+// in the topbar picker. "teal" is the default brand accent.
+export const ACCENTS = [
+  { id: "teal", name: "Teal", swatch: "oklch(0.60 0.13 178)" },
+  { id: "indigo", name: "Indigo", swatch: "oklch(0.55 0.16 274)" },
+  { id: "cobalt", name: "Cobalt", swatch: "oklch(0.55 0.16 252)" },
+  { id: "violet", name: "Violet", swatch: "oklch(0.55 0.18 305)" },
+  { id: "coral", name: "Coral", swatch: "oklch(0.64 0.16 28)" },
+  { id: "amber", name: "Amber", swatch: "oklch(0.72 0.13 80)" },
+  { id: "emerald", name: "Emerald", swatch: "oklch(0.58 0.14 152)" },
+];
+
+export const DEFAULT_ACCENT = "teal";
+
+const ACCENT_IDS = new Set(ACCENTS.map((accent) => accent.id));
+
+export function isAccentId(value) {
+  return typeof value === "string" && ACCENT_IDS.has(value);
+}

--- a/apps/web/src/components/Logo.jsx
+++ b/apps/web/src/components/Logo.jsx
@@ -3,8 +3,10 @@ import React, { useId } from "react";
 /**
  * SceneWorks mark — "scene cut" (D1). A rounded square split by a diagonal
  * seam: teal triangle over a solid ground. Colors come from CSS variables
- * (--logo-ground / --logo-seam) so it tracks the active theme; teal is fixed
- * brand color and does not follow the user-selectable accent.
+ * (--logo-ground / --logo-seam) so it tracks the active theme; the triangle is
+ * --teal, which now follows the user-selectable accent (sc-accent) — the teal
+ * palette keeps the fixed #2fa193 brand color, the other palettes derive a
+ * matching --teal.
  */
 export function Logo({ size = 32, title = "SceneWorks", className }) {
   const clipId = useId();

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -39,9 +39,13 @@
   --text-muted: oklch(0.5 0.012 240);
   --text-faint: oklch(0.66 0.01 240);
 
-  --accent: oklch(0.66 0.11 178);
-  --accent-strong: oklch(0.55 0.13 178);
-  --accent-soft: oklch(0.94 0.04 178);
+  /* Accent is hue-driven so one [data-accent] swap recolors the whole app.
+     --accent-h / --warm-h are set per palette at the bottom of this block;
+     teal (178 / 235) is the default. */
+  --accent-h: 178;
+  --accent: oklch(0.66 0.11 var(--accent-h));
+  --accent-strong: oklch(0.55 0.13 var(--accent-h));
+  --accent-soft: oklch(0.94 0.04 var(--accent-h));
   --accent-fg: #ffffff;
 
   /* Brand palette — fixed brand colors, theme-independent. */
@@ -55,8 +59,9 @@
   --logo-seam: var(--paper);
   --wordmark-strong: var(--ink);
 
-  --warm: oklch(0.72 0.11 235);
-  --warm-soft: oklch(0.95 0.03 235);
+  --warm-h: 235;
+  --warm: oklch(0.72 0.11 var(--warm-h));
+  --warm-soft: oklch(0.95 0.03 var(--warm-h));
   --danger: oklch(0.62 0.18 25);
   --danger-soft: oklch(0.95 0.04 25);
   --success: oklch(0.62 0.13 155);
@@ -82,9 +87,9 @@
   --text-muted: oklch(0.72 0.012 240);
   --text-faint: oklch(0.56 0.012 240);
 
-  --accent: oklch(0.74 0.11 178);
-  --accent-strong: oklch(0.82 0.12 178);
-  --accent-soft: oklch(0.3 0.06 178);
+  --accent: oklch(0.74 0.11 var(--accent-h));
+  --accent-strong: oklch(0.82 0.12 var(--accent-h));
+  --accent-soft: oklch(0.3 0.06 var(--accent-h));
   --accent-fg: oklch(0.16 0.012 240);
 
   /* On dark: mark ground → mist (full square reads), seam → ink, wordmark → paper. */
@@ -92,8 +97,8 @@
   --logo-seam: var(--ink);
   --wordmark-strong: var(--paper);
 
-  --warm: oklch(0.78 0.11 235);
-  --warm-soft: oklch(0.32 0.05 235);
+  --warm: oklch(0.78 0.11 var(--warm-h));
+  --warm-soft: oklch(0.32 0.05 var(--warm-h));
   --danger-soft: oklch(0.3 0.06 25);
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
@@ -101,6 +106,21 @@
   --shadow-lg: 0 30px 60px rgba(0, 0, 0, 0.55), 0 4px 12px rgba(0, 0, 0, 0.4);
   color-scheme: dark;
 }
+
+/* ---------- Accent palettes (user-selectable, sc-accent) ----------
+   Each sets the accent + secondary hue; the light/dark ramps above consume them.
+   `teal` keeps the fixed #2fa193 brand mark; the rest derive a matching --teal. */
+[data-accent="teal"]    { --accent-h: 178; --warm-h: 235; }
+[data-accent="indigo"]  { --accent-h: 274; --warm-h: 320; --teal: oklch(0.58 0.16 274); }
+[data-accent="cobalt"]  { --accent-h: 252; --warm-h: 205; --teal: oklch(0.55 0.16 252); }
+[data-accent="violet"]  { --accent-h: 305; --warm-h: 268; --teal: oklch(0.55 0.18 305); }
+[data-accent="coral"]   { --accent-h: 28;  --warm-h: 350; --teal: oklch(0.62 0.16 28); }
+[data-accent="amber"]   { --accent-h: 80;  --warm-h: 45;  --teal: oklch(0.72 0.13 80);
+                          --accent-fg: oklch(0.24 0.03 80); }
+[data-accent="emerald"] { --accent-h: 152; --warm-h: 128; --teal: oklch(0.56 0.14 152); }
+/* Amber's accent is bright enough to need dark text on chips/buttons in light mode;
+   in dark mode the default ink fg is already correct, so restore it. */
+[data-theme="dark"][data-accent="amber"] { --accent-fg: oklch(0.16 0.012 240); }
 
 /* ---------- Reset ---------- */
 * {
@@ -829,6 +849,32 @@ button:focus-visible {
 
 [data-theme="dark"] .icon-btn.active {
   color: var(--accent);
+}
+
+/* Accent picker — topbar swatch row */
+.accent-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+}
+
+.accent-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  background: var(--sw);
+  border: 1.5px solid var(--border);
+  transition: transform var(--t-fast) var(--ease-out), box-shadow var(--t-fast);
+}
+
+.accent-swatch:hover {
+  transform: translateY(-1px);
+}
+
+.accent-swatch.active {
+  border-color: var(--sw);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--sw) 38%, transparent);
 }
 
 .dot {


### PR DESCRIPTION
## What

Adds a **user-selectable accent color** — a 7-option picker (Teal · Indigo · Cobalt · Violet · Coral · Amber · Emerald) in the topbar, left of the theme toggle. Implements the Claude Design *SceneWorks Accent Explorer* handoff (`accent-patch/APPLY.md`).

## Why

The design exploration (chat transcript) landed on: explore all 7 palettes, surface them as a topbar swatch row, recolor the logo to match, and persist the choice like the theme. The user couldn't pick one favorite, so all 7 ship as a setting.

## How

Mirrors the existing **theme** pattern exactly:
- A single `data-accent` attribute on `<html>`, persisted to **localStorage + `/api/v1/ui-preferences`**, applied **pre-paint** by `theme-init.js` (no flash).
- Accent + secondary (`--warm`) tokens are made **hue-driven** (`--accent-h` / `--warm-h`), so flipping `[data-accent]` recolors the whole app with **zero call-site changes** — every rule already reads `var(--accent*)`/`var(--warm*)`/`var(--teal)`.
- The in-app logo follows automatically (its triangle is `var(--teal)`); non-teal palettes derive a matching `--teal`. The teal palette keeps the fixed `#2fa193` brand mark.

## Files

- `apps/web/src/accents.js` *(new)* — `ACCENTS`, `DEFAULT_ACCENT`, `isAccentId`.
- `apps/web/public/theme-init.js` — apply saved `data-accent` pre-paint.
- `apps/web/src/styles.css` — hue-driven accent/warm tokens (light + dark), 7 `[data-accent]` palette blocks (+ amber light/dark `--accent-fg` override), `.accent-picker`/`.accent-swatch` styles.
- `apps/web/src/App.jsx` — accent state, `changeAccent`, `data-accent` effect, server seed, topbar swatch row.
- `apps/web/src/components/Logo.jsx` — comment only (teal now follows the accent).
- `apps/rust-api/src/preferences.rs` — `accent` field + `normalize_accent` whitelist on the merging GET/PUT, with a unit test.

## Verification

- `vite build` clean · **354/354** web vitest pass
- `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean on rust-api · **2/2** `preferences` unit tests
- Browser preview: 7 swatches render, Teal default active; clicking Violet flips `data-accent`, recolors `--accent`→hue 305, derives `--teal`, recolors logo + Generate button + active nav, and persists to localStorage.

## Reviewer notes

- **Accepted limitation** (per design): the static favicon `sceneworks-logo.svg` stays teal; the in-app `<Logo>` follows the accent.
- Backend persistence is **best-effort** — the picker works fully via localStorage even if the server write fails (graceful `.catch`); you'd only lose cross-device / desktop-relaunch persistence.
- The `accent` field was validated client-side + by unit test; a real round-trip against a running rust-api hasn't been exercised (preview had no backend).

Shortcut: [sc-3616](https://app.shortcut.com/trefry/story/3616)

🤖 Generated with [Claude Code](https://claude.com/claude-code)