### PR TITLE
sc-3619 route Z-Image reference-identity (no pose) to MLX

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1931,8 +1931,8 @@ fn image_model_mac_support(model: &str) -> ModelMacSupport {
         };
     }
     // "Available in some MLX config" probes — bias toward not-disabling so a valid combination
-    // (e.g. a Z-Image reference *with* a pose set) is never blocked. The residual config-only dead
-    // ends (a Z-Image reference *without* a pose) surface as the `mlx_unsupported` submit affordance.
+    // (e.g. a Z-Image reference, with or without a pose set — sc-3619) is never blocked. Any
+    // residual config-only dead ends surface as the `mlx_unsupported` submit affordance.
     let pose = image_request_mlx_eligible(
         model,
         &probe_payload(model, &[("advanced", json!({ "poses": [{}] }))]),
@@ -2200,12 +2200,6 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             "edit_image",
             "Z-Image img2img edit stays on the Python torch path (folds into the Z-Image-Edit port).",
             Some("epic 3529"),
-        ),
-        "z_image_turbo" => UnsupportedReason::new(
-            Some(model),
-            "reference without a pose set",
-            "a Z-Image reference is only MLX-eligible alongside a strict pose set; reference-only stays on torch — viability spike.",
-            Some("sc-3536"),
         ),
         "qwen_image_edit"
         | "qwen_image_edit_2509"
@@ -2773,27 +2767,15 @@ fn flux_mlx_eligible(payload: &Map<String, Value>) -> bool {
 }
 
 /// Z-Image (sc-3022) MLX-routing conditions, ported from
-/// `_should_route_z_image_to_mlx`: text-to-image only; a reference asset is
-/// allowed only alongside a strict pose set (the Fun-ControlNet pose tier lives
-/// only on MLX — sc-2257/sc-2328, so a reference+pose job must NOT divert to
-/// torch, which would honour count while dropping the poses); a third-party
-/// LyCORIS LoRA falls back to torch while SceneWorks peft LoKr stays on MLX
-/// (sc-2216).
+/// `_should_route_z_image_to_mlx`: text-to-image, reference-identity img2img-init
+/// (sc-3619 — `referenceAssetId` without a pose set, the plain img2img path the
+/// base engine already supports), and reference+pose (the Fun-ControlNet pose tier
+/// lives only on MLX — sc-2257/sc-2328, so a reference+pose job must NOT divert to
+/// torch, which would honour count while dropping the poses). `edit_image`
+/// img2img-edit stays on torch (epic 3529); a third-party LyCORIS LoRA falls back
+/// to torch while SceneWorks peft LoKr stays on MLX (sc-2216).
 fn z_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
-        return false;
-    }
-    let has_reference = payload
-        .get("referenceAssetId")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().is_empty());
-    let has_poses = payload
-        .get("advanced")
-        .and_then(Value::as_object)
-        .and_then(|advanced| advanced.get("poses"))
-        .and_then(Value::as_array)
-        .is_some_and(|poses| !poses.is_empty());
-    if has_reference && !has_poses {
         return false;
     }
     !request_has_lycoris_lora(payload)
@@ -3357,15 +3339,23 @@ mod mlx_routing_tests {
     }
 
     #[test]
-    fn z_image_reference_without_poses_falls_back_to_torch() {
-        // A plain reference (no poses) has no Z-Image path on MLX → torch.
-        assert!(!z_image_mlx_eligible(&object(
+    fn z_image_reference_without_poses_is_eligible() {
+        // sc-3619: reference-identity img2img-init (no pose) now routes to MLX — the
+        // base engine already supports the plain img2img path, and torch dropped the
+        // reference entirely (it was a no-op on the fallback).
+        assert!(z_image_mlx_eligible(&object(
             json!({ "referenceAssetId": "asset_1" })
         )));
-        // Empty/whitespace reference id is treated as absent → eligible.
+        // Empty/whitespace reference id is treated as absent → plain txt2img, eligible.
         assert!(z_image_mlx_eligible(&object(
             json!({ "referenceAssetId": "   " })
         )));
+        // A reference with empty poses is still reference-only → eligible (not the
+        // pose tier, which needs a non-empty pose set).
+        assert!(z_image_mlx_eligible(&object(json!({
+            "referenceAssetId": "asset_1",
+            "advanced": { "poses": [] }
+        }))));
     }
 
     #[test]
@@ -3375,11 +3365,6 @@ mod mlx_routing_tests {
         assert!(z_image_mlx_eligible(&object(json!({
             "referenceAssetId": "asset_1",
             "advanced": { "poses": [{ "id": "pose_1" }] }
-        }))));
-        // Poses present but empty array → not a pose request → reference falls back.
-        assert!(!z_image_mlx_eligible(&object(json!({
-            "referenceAssetId": "asset_1",
-            "advanced": { "poses": [] }
         }))));
     }
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1906,18 +1906,17 @@ fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
             .as_deref(),
         Some("sc-3535")
     );
-    // Z-Image reference without a pose set → viability spike sc-3536.
+    // Z-Image reference without a pose set is now ported to MLX (sc-3536 spike → sc-3619):
+    // the base engine's plain img2img-init path drives the reference identity natively, so
+    // it is supported on the Rust/MLX worker rather than a torch-fallback gap.
     let z_ref = job_of(
         &store,
         JobType::ImageGenerate,
         json!({ "model": "z_image_turbo", "prompt": "p", "referenceAssetId": "asset_1" }),
     );
-    assert_eq!(
-        mac_rust_supported(&z_ref)
-            .unwrap_err()
-            .suggested_epic
-            .as_deref(),
-        Some("sc-3536")
+    assert!(
+        mac_rust_supported(&z_ref).is_ok(),
+        "z-image reference-without-pose should be MLX-supported (sc-3619)"
     );
     // Image understanding folds into the SenseNova port (epic 3180).
     let vqa = job_of(
@@ -1965,6 +1964,11 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     assert!(model_mac_support("qwen_image", "image").features.pose);
     assert!(model_mac_support("z_image_turbo", "image").features.pose);
     assert!(model_mac_support("sdxl", "image").features.pose);
+    // Z-Image reference-identity (no pose) is ported to MLX (sc-3619) → the reference control
+    // is enabled; edit_image still stays torch (epic 3529).
+    let z_image = model_mac_support("z_image_turbo", "image");
+    assert!(z_image.features.reference);
+    assert!(!z_image.features.edit);
     // FLUX.1 reference/edit stay torch (viability spikes) → those controls disabled.
     let flux = model_mac_support("flux_dev", "image");
     assert!(!flux.features.reference);

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1052,6 +1052,11 @@ fn emit_load_event(event: &str, job_id: &str, engine: &str, adapter_count: usize
 
 /// Generate one image (RGB8) at the given seed; `on_progress` streams denoise steps.
 /// `guidance` is `None` for distilled variants (the engine rejects it on them).
+///
+/// `reference` is the optional identity img2img-init (sc-3619): `(image, strength)` adds a
+/// `Reference` conditioning that seeds the denoise from the reference latents — the plain
+/// (no-ControlNet) Z-Image reference-without-pose path, reusing the same engine img2img the
+/// strict-pose tier already drives. `None` → plain txt2img.
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 fn mlx_generate_one(
@@ -1063,9 +1068,17 @@ fn mlx_generate_one(
     steps: u32,
     guidance: Option<f32>,
     negative_prompt: Option<String>,
+    reference: Option<&(Image, f32)>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let conditioning = match reference {
+        Some((image, strength)) => vec![Conditioning::Reference {
+            image: image.clone(),
+            strength: Some(*strength),
+        }],
+        None => Vec::new(),
+    };
     let request = GenerationRequest {
         prompt: prompt.to_owned(),
         negative_prompt,
@@ -1075,6 +1088,7 @@ fn mlx_generate_one(
         seed: Some(seed as u64),
         steps: Some(steps),
         guidance,
+        conditioning,
         cancel: cancel.clone(),
         ..Default::default()
     };
@@ -1139,6 +1153,14 @@ async fn generate_mlx_stream(
     let seeds: Vec<i64> = (0..count)
         .map(|index| resolve_seed(request, index))
         .collect();
+    // Reference-identity img2img-init (sc-3619): only Z-Image reaches this plain path with a
+    // reference (FLUX is ineligible→torch, Qwen/SDXL divert to their own edit/advanced branches).
+    // Resolve once — the identity is constant across the set — and seed each image's denoise.
+    let identity_init = if request.model == "z_image_turbo" {
+        resolve_zimage_identity_init(request, settings, project_path)?
+    } else {
+        None
+    };
 
     let cancel = CancelFlag::new();
     let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
@@ -1149,6 +1171,7 @@ async fn generate_mlx_stream(
         let seeds = seeds.clone();
         let cancel = cancel.clone();
         let job_id = job.id.clone();
+        // `identity_init` is moved into the closure below (the `move` captures it by value).
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
             let adapter_count = adapters.len();
             emit_load_event(
@@ -1185,6 +1208,7 @@ async fn generate_mlx_stream(
                     steps,
                     guidance,
                     negative_prompt.clone(),
+                    identity_init.as_ref(),
                     &cancel,
                     &mut on_progress,
                 )?;
@@ -4690,6 +4714,7 @@ mod tests {
             steps,
             guidance,
             negative_prompt,
+            None,
             &cancel,
             &mut |p| {
                 if let mlx_gen::Progress::Step { current, .. } = p {
@@ -4969,6 +4994,7 @@ mod tests {
             steps,
             guidance,
             negative,
+            None,
             &cancel,
             &mut |_| {},
         )

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -78,7 +78,7 @@ dropped — no silent drops.**
 | Reference / edit conditioning | base `qwen_image` (reference/`edit_image`) | 🔵 Port-pending | epic 3401 |
 | Reference / IP-Adapter / edit | `flux_schnell`, `flux_dev` | 🔵 Viability spike | sc-3535 |
 | `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
-| reference-without-pose | `z_image_turbo` | 🔵 Viability spike | sc-3536 |
+| reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🔵 Port-or-drop spike | sc-3537 |
 
 ## 3. Video


### PR DESCRIPTION
Closes the epic 3482 gap surfaced by the **sc-3536** viability spike (GO). Routes `z_image_turbo` reference-identity-without-pose natively on the Mac MLX/Rust path instead of the Python torch fallback.

## Why

A reference-without-pose Z-Image job (`referenceAssetId` present, no `advanced.poses`, not `edit_image`) was routed to torch — where `ZImageDiffusersAdapter` has **no `referenceAssetId`/`character_image` handling at all** and silently dropped the reference, producing a plain txt2img. Meanwhile the mlx-gen `z_image_turbo` **base** engine already fully supports plain img2img reference-init (`descriptor()` advertises `ConditioningKind::Reference`; `generate()` resolves a single `Conditioning::Reference` → `init_time_step` → VAE-encode init → blend with seeded noise → denoise from the init step — the parity-proven mflux path, the same conditioning the strict-pose tier already passes). So the gap closes with just the eligibility gate + plain-path wiring, and the result is strictly better than the prior torch no-op.

Unlike the strict-pose tier (sc-2328 "identity init fights the pose lock" caveat), reference-only is the clean img2img case — no pose to conflict with.

## What changed (4 files, +59/−44)

- **`crates/sceneworks-core/src/jobs_store.rs`** — opened `z_image_mlx_eligible` for reference-without-pose (kept `edit_image` → torch for epic 3529, third-party LyCORIS → torch for sc-3537); dropped the matching `classify_image_gap` arm. `model_mac_support` `features.reference` for z-image auto-flips `true` via the same predicate (self-healing UI un-gate, sc-3486 — no separate frontend change).
- **`crates/sceneworks-worker/src/image_jobs.rs`** — `mlx_generate_one` takes `reference: Option<&(Image, f32)>` and adds a `Conditioning::Reference` to the plain `GenerationRequest`; `generate_mlx_stream` resolves the identity init once via the existing `resolve_zimage_identity_init` (z_image_turbo only — FLUX is ineligible→torch, Qwen/SDXL divert to their own branches) and threads it to each image.
- **`crates/sceneworks-core/tests/jobs_store.rs`** — flipped the oracle assertion (z-image reference now `mac_rust_supported().is_ok()`), flipped the eligibility unit test, added a `model_mac_support` feature-flag assertion.
- **`docs/mac-rust-gaps.md`** §2 — reference-without-pose row → 🟢 Ported (MLX).

## Behavior note

The img2img init engages on the existing opt-in convention: `advanced.referenceStrength > 0` + `referenceAssetId` (reuses `zimage_identity_strength`, clamp `[0.05, 1.0]`). A reference **without** a strength still routes to MLX but renders plain txt2img — same as the torch fallback's old no-op, so no regression; strictly better when a strength is set. Possible tuning follow-up (left out to avoid an unvalidated default): default a non-zero `referenceStrength` for reference-only Z-Image, since there's no pose to fight.

## Validation

- `cargo clippy --workspace --exclude sceneworks-desktop --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace --exclude sceneworks-desktop` — 0 failed (core 124 routing + 91 integration; worker 138)
- `sceneworks-desktop` excluded: fresh-worktree sidecar-staging limitation, unrelated (no desktop code touched).
- **Real-Mac MLX E2E owed** (no GPU/weights in CI) — same as sibling sc-2257/2328/3146. Validate: a `z_image_turbo` `character_image` job with `referenceAssetId` + `referenceStrength` renders identity img2img on the mlx worker (`mlx-worker.log` shows the base `z_image_turbo` engine, not torch).

Stories: sc-3536 (spike, Done) → sc-3619 (port, this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)