### PR TITLE
sc-3535 FLUX.1 reference/IP-Adapter spike (GO) — align oracle + docs to epic 3621

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2191,9 +2191,9 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
         ),
         "flux_schnell" | "flux_dev" => UnsupportedReason::new(
             Some(model),
-            "reference / IP-Adapter / edit",
-            "FLUX.1 reference / IP-Adapter / edit_image conditioning stays on the Python torch path — viability spike.",
-            Some("sc-3535"),
+            "reference (XLabs IP-Adapter)",
+            "FLUX.1 reference is the XLabs IP-Adapter (not img2img-init); it stays on the Python torch path until the MLX port lands. (FLUX.1 edit_image has no torch path on any platform — a future Kontext capability, not an eradication gap; see sc-3535.)",
+            Some("epic 3621"),
         ),
         "z_image_turbo" if is_edit => UnsupportedReason::new(
             Some(model),

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1893,7 +1893,8 @@ fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
 #[test]
 fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
     let store = store("oracle-feature-spikes");
-    // FLUX.1 reference/IP-Adapter → viability spike sc-3535.
+    // FLUX.1 reference (XLabs IP-Adapter) → spike sc-3535 (GO) resolved into the MLX port
+    // epic 3621; still a torch-fallback gap until that engine work lands.
     let flux_ref = job_of(
         &store,
         JobType::ImageGenerate,
@@ -1904,7 +1905,7 @@ fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
             .unwrap_err()
             .suggested_epic
             .as_deref(),
-        Some("sc-3535")
+        Some("epic 3621")
     );
     // Z-Image reference without a pose set is now ported to MLX (sc-3536 spike → sc-3619):
     // the base engine's plain img2img-init path drives the reference identity natively, so

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -76,10 +76,17 @@ dropped — no silent drops.**
 |---|---|---|---|
 | Strict-pose ControlNet | `qwen_image` (+ `advanced.poses`) | 🔵 Port-pending | epic 3401 (Qwen ControlNet port) |
 | Reference / edit conditioning | base `qwen_image` (reference/`edit_image`) | 🔵 Port-pending | epic 3401 |
-| Reference / IP-Adapter / edit | `flux_schnell`, `flux_dev` | 🔵 Viability spike | sc-3535 |
+| Reference (XLabs IP-Adapter) | `flux_schnell`, `flux_dev` | 🔵 Port (spike GO) | sc-3535 (spike) → **epic 3621** |
 | `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
 | reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🔵 Port-or-drop spike | sc-3537 |
+
+> **FLUX.1 `edit_image` is not an eradication gap (sc-3535).** The torch `FluxDiffusersAdapter`
+> hard-rejects `edit_image` ("does not support image editing") — FLUX.1 has no edit path on *any*
+> platform, so it reaches no Python worker to retire. It's a universal product gap (a future
+> FLUX.1-Kontext capability), not a Mac-vs-torch gap, and is intentionally absent from this table.
+> Likewise, FLUX.1 reference = the **XLabs IP-Adapter** (not VAE img2img-init), which is why it
+> needs the engine port in epic 3621 rather than a gate-flip like Z-Image's sc-3619.
 
 ## 3. Video
 


### PR DESCRIPTION
Resolves the **sc-3535** viability spike (epic 3482 Python Eradication, `docs/mac-rust-gaps.md` §2): assess porting FLUX.1 (`flux_schnell`/`flux_dev`) reference / IP-Adapter / edit conditioning into `mlx-gen-flux` so it routes natively on Mac instead of the Python torch `FluxDiffusersAdapter`.

## Verdict: GO (port) — tracked in [epic 3621](https://app.shortcut.com/trefry/epic/3621) (sc-3622 → sc-3625)

Unlike its Z-Image sibling (sc-3536/[#475](https://github.com/michaeltrefry/SceneWorks/pull/475)), this is a **real engine port, not a gate-flip**.

### Two reframing findings
1. **FLUX.1 "reference" is the XLabs IP-Adapter, not VAE img2img-init.** The torch `FluxDiffusersAdapter` routes `referenceAssetId` through `XLabs-AI/flux-ip-adapter` (`load_ip_adapter`, `set_ip_adapter_scale`, `ip_adapter_image=`, `true_cfg_scale`). So it needs a CLIP image encoder + IP-Adapter projection + decoupled cross-attn — it can't be opened with a predicate.
2. **`edit_image` is out of scope — not a Mac-vs-torch gap.** `FluxDiffusersAdapter.generate` hard-rejects `edit_image` ("does not support image editing"; future FLUX.1-Kontext). FLUX.1 has no edit path on *any* platform → no Python worker to retire → universal product gap, removed from the inventory table.

### Feasibility GREEN — every piece has an in-tree MLX precedent
- Injection seam `mlx_gen_flux::transformer::DitImageInjector` (model-agnostic; already used by PuLID's `ca.rs`)
- IP-Adapter-behind-`Conditioning::Reference` template `mlx-gen-sdxl/src/ip_adapter.rs` (no separate `IpAdapter` kind → the eventual SceneWorks wiring is identical to sc-3619)
- CLIP-ViT-L/14 tower reusable from `mlx-gen-svd` / `mlx-gen-pulid`
- Real CFG already present: `Flux1::generate_with_injector_cfg`

Distinct from PuLID-FLUX (epic 3069, faithful face identity) — the two reference tiers are not folded.

## What's in this PR (docs/oracle only — no routing behavior change)
The `flux_mlx_eligible` gate **stays closed** until the engine port lands; reference jobs still correctly fall back to torch.

- `docs/mac-rust-gaps.md` §2 — FLUX row → "Reference (XLabs IP-Adapter) · 🔵 Port (spike GO) · sc-3535 → epic 3621"; added a note clarifying FLUX `edit_image` is not an eradication gap.
- `crates/sceneworks-core/src/jobs_store.rs` — `mac_rust_supported` FLUX reason now points at epic 3621 (was sc-3535) and clarifies reference=IP-Adapter / edit=universal.
- `crates/sceneworks-core/tests/jobs_store.rs` — oracle test updated to assert `epic 3621`.

## Tests
Core green (91 integration + 15 lib routing), `cargo fmt` clean. The `flux_edit_reference_and_lycoris_fall_back_to_torch` gate test still passes, confirming the gate is correctly left closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)