### PR TITLE
sc-3537: third-party LyCORIS mlx-gen spike (GO) → port epic 3641

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2082,8 +2082,8 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         "lycoris".to_owned(),
         MacFeatureSupport::unsupported(
             "third-party LyCORIS LoRA",
-            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr).",
-            "sc-3537",
+            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr) — port pending (sc-3537 spike GO).",
+            "epic 3641",
         ),
     );
     features.insert(
@@ -2177,8 +2177,8 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
         return UnsupportedReason::new(
             Some(model),
             "third-party LyCORIS LoRA",
-            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr) — port-or-drop spike.",
-            Some("sc-3537"),
+            "the Rust engine/worker apply LoRA + peft LoKr, but not arbitrary third-party LyCORIS (LoHa / non-peft LoKr) — port pending (sc-3537 spike GO).",
+            Some("epic 3641"),
         );
     }
     let is_edit = payload.get("mode").and_then(Value::as_str) == Some("edit_image");
@@ -2250,8 +2250,8 @@ fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedReason {
         return UnsupportedReason::new(
             Some(model),
             "third-party LyCORIS LoRA",
-            "the mlx-video path can't apply arbitrary third-party LyCORIS adapters — port-or-drop spike.",
-            Some("sc-3537"),
+            "the mlx-video path can't apply arbitrary third-party LyCORIS adapters yet — port pending (sc-3537 spike GO).",
+            Some("epic 3641"),
         );
     }
     if is_wan_video_model(model) && request_has_lokr_lora(payload) {

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1800,7 +1800,7 @@ fn mac_rust_supported_names_qwen_strict_pose_and_lycoris() {
         json!({ "model": "qwen_image", "prompt": "p", "advanced": { "poses": [{ "x": 1 }] } }),
     );
     assert!(mac_rust_supported(&pose).is_ok());
-    // Third-party LyCORIS on an otherwise-MLX family → port-or-drop viability spike.
+    // Third-party LyCORIS on an otherwise-MLX family → port pending (sc-3537 spike GO → epic 3641).
     let lycoris = job_of(
         &store,
         JobType::ImageGenerate,
@@ -1808,7 +1808,7 @@ fn mac_rust_supported_names_qwen_strict_pose_and_lycoris() {
     );
     let lycoris_reason = mac_rust_supported(&lycoris).unwrap_err();
     assert!(lycoris_reason.feature.contains("LyCORIS"));
-    assert_eq!(lycoris_reason.suggested_epic.as_deref(), Some("sc-3537"));
+    assert_eq!(lycoris_reason.suggested_epic.as_deref(), Some("epic 3641"));
 }
 
 #[test]
@@ -2024,7 +2024,7 @@ fn mac_capabilities_master_switch_and_infra_features() {
     assert_eq!(epic("poseFromPhoto").as_deref(), Some("sc-3487"));
     assert_eq!(epic("personDetect").as_deref(), Some("sc-3488"));
     assert_eq!(epic("datasetCaptioning"), None);
-    assert_eq!(epic("lycoris").as_deref(), Some("sc-3537"));
+    assert_eq!(epic("lycoris").as_deref(), Some("epic 3641"));
     assert_eq!(epic("advancedVideoModes").as_deref(), Some("epic 3040"));
     assert!(mac.features["datasetCaptioning"].supported);
     assert!(mac

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -79,7 +79,7 @@ dropped — no silent drops.**
 | Reference (XLabs IP-Adapter) | `flux_schnell`, `flux_dev` | 🔵 Port (spike GO) | sc-3535 (spike) → **epic 3621** |
 | `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
 | reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
-| Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🔵 Port-or-drop spike | sc-3537 |
+| Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🔵 Port (spike GO) | sc-3537 (spike) → **epic 3641** |
 
 > **FLUX.1 `edit_image` is not an eradication gap (sc-3535).** The torch `FluxDiffusersAdapter`
 > hard-rejects `edit_image` ("does not support image editing") — FLUX.1 has no edit path on *any*
@@ -100,7 +100,7 @@ dropped — no silent drops.**
 | Advanced job types `video_extend`, `video_bridge` | 🔵 Port-pending | epic 3040 |
 | `person_replace` job type (replace_person) | 🔵 Port-pending | epic 3040 (+ sc-3488 person track) |
 | LoKr-on-Wan (Kronecker adapter on Wan) | 🔵 Port-pending | epic 3040 (LoKr-on-LTX already MLX) |
-| Third-party LyCORIS on video | 🔵 Port-or-drop spike | sc-3537 (shared image+video spike) |
+| Third-party LyCORIS on video | 🔵 Port (spike GO) | sc-3537 (spike) → **epic 3641** (shared image+video) |
 
 ## 4. Training (`lora_train`)
 


### PR DESCRIPTION
## Spike sc-3537 — third-party LyCORIS (LoHa / non-peft LoKr) in mlx-gen (image + video): **GO**

Decides **port vs drop** for applying third-party LyCORIS adapters on MLX-routed families. Outcome: **GO** (phased). This PR records the decision in the code-derived gap mapping; the engine + routing work is filed as **epic 3641** (sc-3642 / sc-3643 / sc-3644).

### Why GO (feasibility — HIGH confidence)
- **Non-peft / kohya LoKr:** mlx-gen's `reconstruct_lokr_delta` is **already general** (full + low-rank Kronecker factors, mirrors PEFT/LyCORIS `LoKrLayer.get_delta_weight`). The only gaps are detection/key-naming, not math: `is_lokr()` requires a `networkType=lokr` metadata stamp third-party files lack (→ key-sniff), kohya `lora_unet_<.→_>` flattening (→ reuse the existing `kohya_table`), and the `lokr_t2` tucker factor. ~90% there.
- **LoHa:** fully absent — a small net-new `reconstruct_loha_delta` (`ΔW=(α/r)·((w1_a@w1_b)⊙(w2_a@w2_b))`, + `hada_t1/t2`), `AdapterKind::Loha`, parse/detect/dispatch, conv2d variant. Mirrors the LoKr reconstruct.
- Conv2d targets + reversible per-adapter `spec.scale` are already reachable.
- Not "impossible" (the hard math is shipped) and aligns with epic 3482's zero-Python-on-Mac north star → GO, non-peft-LoKr first then LoHa.

### Caveats (recorded on the stories)
- **Parity runs live on the Mac.** torch 2.12 + MPS is installed at `~/mlx-flux-venv`, with peft 0.19.1 + lycoris-lora added for this harness — so LoKr/LoHa A/B parity is verified on-device against the real `lycoris`/`peft` reconstruction (no offline-goldens hand-wave).
- **Demand:** MEDIUM/reasoned (no live telemetry) — non-peft LoKr has a modest civitai footprint, LoHa rarer; SceneWorks' own trainer already emits MLX-native peft adapters. Low-moderate but nonzero, and a silent torch-only-on-Mac import is a parity wart.

### This PR (gap-mapping update only — mirrors the `sc-3535 → epic 3621` precedent)
- `docs/mac-rust-gaps.md` §2 (image) + §3 (video) LyCORIS rows: `Port-or-drop spike` → `Port (spike GO)`, pointing at **epic 3641**.
- `crates/sceneworks-core/src/jobs_store.rs`: `classify_image_gap` / `classify_video_gap` / `mac_capabilities` LyCORIS `suggested_epic` → `epic 3641`, reason reworded to "port pending (sc-3537 spike GO)". Still a gap (not yet ported) — routing behaviour unchanged.
- Tests updated to match (`crates/sceneworks-core/tests/jobs_store.rs`).

### Follow-up (epic 3641)
- **sc-3642** — mlx-gen non-peft/kohya LoKr (detection + key-naming + `lokr_t2` + conv2d)
- **sc-3643** — mlx-gen LoHa (`reconstruct_loha_delta` + `AdapterKind::Loha` + conv2d)
- **sc-3644** — SceneWorks routing flip + worker MLX-path apply + real-Mac E2E

### Tests
- `cargo test -p sceneworks-core --test jobs_store mac_rust_supported` → 7 passed.
- `cargo fmt -p sceneworks-core --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)