### PR TITLE
sc-3625: route FLUX.1 reference (XLabs IP-Adapter) to MLX on Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,10 +2521,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "inventory",
  "mlx-gen",
+ "mlx-gen-sdxl",
  "mlx-gen-z-image",
  "pmetal-mlx-rs",
 ]
@@ -2532,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2543,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2553,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "image",
  "inventory",
@@ -2565,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2575,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "image",
  "inventory",
@@ -2588,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "image",
  "inventory",
@@ -2602,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b85b07b5e62ddab38828e03e207b448a3fee9d4b#b85b07b5e62ddab38828e03e207b448a3fee9d4b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
 dependencies = [
  "image",
  "inventory",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2752,15 +2752,14 @@ fn qwen_edit_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// Python torch path (`FluxDiffusersAdapter`). A third-party LyCORIS LoRA also falls
 /// back to torch: the engine + the worker's `classify_adapter` apply LoRA and peft
 /// LoKr natively, but not arbitrary LyCORIS (which the worker would reject).
+/// FLUX.1 (`flux_schnell` / `flux_dev`) MLX-routing conditions. Text-to-image and
+/// **reference-image** (the XLabs IP-Adapter, epic 3621 — `referenceAssetId`, both
+/// variants: the Rust engine has no diffusers `load_ip_adapter` schnell limitation,
+/// so reference is native on schnell too). `edit_image` stays off — FLUX.1 has no
+/// edit path on any platform (a future Kontext epic, NOT a Python-eradication gap).
+/// A third-party LyCORIS LoRA falls back to torch; SceneWorks peft LoKr stays MLX.
 fn flux_mlx_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
-        return false;
-    }
-    let has_reference = payload
-        .get("referenceAssetId")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().is_empty());
-    if has_reference {
         return false;
     }
     !request_has_lycoris_lora(payload)
@@ -3391,20 +3390,31 @@ mod mlx_routing_tests {
     }
 
     #[test]
-    fn flux_edit_reference_and_lycoris_fall_back_to_torch() {
-        // edit_image, reference (IP-Adapter), and third-party LyCORIS all stay on Python.
-        assert!(!flux_mlx_eligible(&object(json!({ "mode": "edit_image" }))));
-        assert!(!flux_mlx_eligible(&object(
+    fn flux_reference_is_eligible() {
+        // Reference (XLabs IP-Adapter, epic 3621) now routes to MLX on both variants —
+        // the Rust engine has no diffusers schnell limitation.
+        assert!(flux_mlx_eligible(&object(
             json!({ "referenceAssetId": "asset_1" })
         )));
+        // A reference + LoRA is still fine.
+        assert!(flux_mlx_eligible(&object(json!({
+            "referenceAssetId": "asset_1",
+            "loras": [{ "networkType": "lora" }]
+        }))));
+    }
+
+    #[test]
+    fn flux_edit_and_lycoris_fall_back_to_torch() {
+        // edit_image (no FLUX.1 edit on any platform — future Kontext) and third-party
+        // LyCORIS stay on Python. Reference does NOT fall back anymore (see above).
+        assert!(!flux_mlx_eligible(&object(json!({ "mode": "edit_image" }))));
         assert!(!flux_mlx_eligible(&object(json!({
             "loras": [{ "networkType": "lycoris" }]
         }))));
-        // Unlike Z-Image, a pose set does NOT rescue a reference: FLUX.1 has no MLX
-        // reference path here, so reference always falls back.
+        // A reference with a LyCORIS LoRA still falls back (LyCORIS forces torch).
         assert!(!flux_mlx_eligible(&object(json!({
             "referenceAssetId": "asset_1",
-            "advanced": { "poses": [{ "id": "p1" }] }
+            "loras": [{ "networkType": "lycoris" }]
         }))));
     }
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1893,19 +1893,17 @@ fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
 #[test]
 fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
     let store = store("oracle-feature-spikes");
-    // FLUX.1 reference (XLabs IP-Adapter) → spike sc-3535 (GO) resolved into the MLX port
-    // epic 3621; still a torch-fallback gap until that engine work lands.
+    // FLUX.1 reference (XLabs IP-Adapter) is now ported to MLX (spike sc-3535 → epic 3621,
+    // sc-3625): the Rust engine drives the IP-Adapter natively on both schnell + dev, so it is
+    // supported on the Rust/MLX worker rather than a torch-fallback gap.
     let flux_ref = job_of(
         &store,
         JobType::ImageGenerate,
         json!({ "model": "flux_dev", "prompt": "p", "referenceAssetId": "asset_1" }),
     );
-    assert_eq!(
-        mac_rust_supported(&flux_ref)
-            .unwrap_err()
-            .suggested_epic
-            .as_deref(),
-        Some("epic 3621")
+    assert!(
+        mac_rust_supported(&flux_ref).is_ok(),
+        "FLUX.1 reference (IP-Adapter) should be MLX-supported (epic 3621)"
     );
     // Z-Image reference without a pose set is now ported to MLX (sc-3536 spike → sc-3619):
     // the base engine's plain img2img-init path drives the reference identity natively, so
@@ -1970,10 +1968,14 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     let z_image = model_mac_support("z_image_turbo", "image");
     assert!(z_image.features.reference);
     assert!(!z_image.features.edit);
-    // FLUX.1 reference/edit stay torch (viability spikes) → those controls disabled.
+    // FLUX.1 reference (XLabs IP-Adapter) is ported to MLX (epic 3621) → reference enabled on
+    // both variants; edit_image stays off (no FLUX.1 edit on any platform — future Kontext).
     let flux = model_mac_support("flux_dev", "image");
-    assert!(!flux.features.reference);
+    assert!(flux.features.reference);
     assert!(!flux.features.edit);
+    let flux_schnell = model_mac_support("flux_schnell", "image");
+    assert!(flux_schnell.features.reference);
+    assert!(!flux_schnell.features.edit);
     // SDXL + FLUX.2 do reference/edit on MLX (epic 3041 / MLX-only family) → enabled.
     let sdxl = model_mac_support("sdxl", "image");
     assert!(sdxl.features.reference);
@@ -2916,11 +2918,13 @@ fn flux_schnell_txt2img_routes_to_mlx_worker() {
 }
 
 #[test]
-fn flux_reference_job_stays_on_torch() {
+fn flux_reference_job_routes_to_mlx() {
     let store = store("mlx-routing-flux-reference");
+    register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // FLUX.1 reference/IP-Adapter stays on the Python torch path → mlx refuses it.
+    // FLUX.1 reference/IP-Adapter (epic 3621) now runs natively on the Rust/MLX worker →
+    // torch refuses it, mlx claims it.
     let job = store
         .create_job(image_job_with(
             json!({ "model": "flux_dev", "prompt": "p", "referenceAssetId": "asset_1" }),
@@ -2928,17 +2932,15 @@ fn flux_reference_job_stays_on_torch() {
         ))
         .expect("job creates");
     assert!(store
-        .claim_next_job("worker-mlx")
-        .expect("mlx claim ok")
-        .is_none());
-
-    register_gpu_worker(&store, "worker-torch", "mps", image_caps());
-    let claimed = store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
-        .expect("torch claims flux reference job");
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims flux reference job");
     assert_eq!(claimed.id, job.id);
-    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
 }
 
 #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -83,33 +83,33 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # captioner registry/provider (epic 3550), plus Qwen Edit step eval boundaries for
 # Metal timeout avoidance, in one shared rev so MLX builds once with the unchanged
 # mlx-rs pin (e59ffd88, identical across the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b85b07b5e62ddab38828e03e207b448a3fee9d4b" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1019,6 +1019,20 @@ fn mlx_load(
     quant: Option<Quant>,
     adapters: Vec<AdapterSpec>,
 ) -> WorkerResult<Box<dyn Generator>> {
+    mlx_load_with_ip(engine_id, weights_dir, quant, adapters, None)
+}
+
+/// As [`mlx_load`], but optionally installing an IP-Adapter from `ip_adapter_dir`
+/// (`LoadSpec::with_ip_adapter`). Used by the FLUX.1 XLabs IP-Adapter reference path
+/// (epic 3621): the engine then treats a `Conditioning::Reference` as the image prompt.
+#[cfg(target_os = "macos")]
+fn mlx_load_with_ip(
+    engine_id: &str,
+    weights_dir: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+    ip_adapter_dir: Option<PathBuf>,
+) -> WorkerResult<Box<dyn Generator>> {
     let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir));
     if let Some(quant) = quant {
         spec = spec.with_quant(quant);
@@ -1026,8 +1040,71 @@ fn mlx_load(
     if !adapters.is_empty() {
         spec = spec.with_adapters(adapters);
     }
+    if let Some(dir) = ip_adapter_dir {
+        spec = spec.with_ip_adapter(WeightsSource::Dir(dir));
+    }
     mlx_gen::load(engine_id, &spec)
         .map_err(|error| WorkerError::InvalidPayload(format!("{engine_id} load failed: {error}")))
+}
+
+/// XLabs FLUX IP-Adapter repos (epic 3621). The torch `flux_dev` path already declares +
+/// downloads these (the `ipAdapter` block in `image_adapters`); the MLX path reuses the same
+/// HF-cache snapshots — there is no new weight to ship.
+#[cfg(target_os = "macos")]
+const FLUX_IP_ADAPTER_REPO: &str = "XLabs-AI/flux-ip-adapter";
+#[cfg(target_os = "macos")]
+const FLUX_IP_IMAGE_ENCODER_REPO: &str = "openai/clip-vit-large-patch14";
+/// IP-Adapter scale when the request omits `ipAdapterScale` (XLabs resemblance tier 0.7, matching
+/// the torch `FluxDiffusersAdapter`).
+#[cfg(target_os = "macos")]
+const FLUX_IP_SCALE: f32 = 0.7;
+/// `trueCfgScale` default for the FLUX.1-dev IP-Adapter path (real CFG; torch default ~4.0).
+#[cfg(target_os = "macos")]
+const FLUX_IP_TRUE_CFG: f32 = 4.0;
+
+/// The FLUX.1 engine families that carry the XLabs IP-Adapter (both variants — the Rust engine has
+/// no diffusers `load_ip_adapter` schnell limitation).
+#[cfg(target_os = "macos")]
+fn is_flux_model(model: &str) -> bool {
+    matches!(model, "flux_schnell" | "flux_dev")
+}
+
+/// Stage the engine's IP-Adapter dir contract from the two cached HF snapshots:
+/// `<staged>/ip_adapter.safetensors` (XLabs) + `<staged>/image_encoder/model.safetensors`
+/// (openai CLIP-ViT-L). Errors loudly if either snapshot is missing — mirrors the SDXL IP path
+/// (`resolve_ip_adapter_dir`); the repos reach the cache via the model-download flow / the torch
+/// `flux_dev` path, not a new provisioning step.
+#[cfg(target_os = "macos")]
+fn resolve_flux_ip_adapter_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    let missing = || {
+        WorkerError::InvalidPayload(format!(
+            "FLUX IP-Adapter weights not found (download {FLUX_IP_ADAPTER_REPO} + {FLUX_IP_IMAGE_ENCODER_REPO})."
+        ))
+    };
+    let adapter_snap =
+        crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, FLUX_IP_ADAPTER_REPO)
+            .ok_or_else(missing)?;
+    let clip_snap =
+        crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, FLUX_IP_IMAGE_ENCODER_REPO)
+            .ok_or_else(missing)?;
+    let ip_file = adapter_snap.join("ip_adapter.safetensors");
+    let clip_file = clip_snap.join("model.safetensors");
+    if !ip_file.exists() || !clip_file.exists() {
+        return Err(missing());
+    }
+    let staged = settings.data_dir.join("staged").join("flux-ip-adapter");
+    let encoder_dir = staged.join("image_encoder");
+    std::fs::create_dir_all(&encoder_dir)
+        .map_err(|e| WorkerError::InvalidPayload(format!("stage flux ip-adapter dir: {e}")))?;
+    // Re-link each call: the HF-cache targets are immutable, so a stable staged dir is reusable.
+    let link = |src: &Path, dst: PathBuf| -> WorkerResult<()> {
+        let _ = std::fs::remove_file(&dst);
+        std::os::unix::fs::symlink(src, &dst)
+            .map_err(|e| WorkerError::InvalidPayload(format!("stage flux ip-adapter link: {e}")))
+    };
+    link(&ip_file, staged.join("ip_adapter.safetensors"))?;
+    link(&clip_file, encoder_dir.join("model.safetensors"))?;
+    Ok(staged)
 }
 
 /// Emit an `image_pipeline_load_{start,complete}` event from inside a blocking
@@ -1069,6 +1146,7 @@ fn mlx_generate_one(
     guidance: Option<f32>,
     negative_prompt: Option<String>,
     reference: Option<&(Image, f32)>,
+    true_cfg: Option<f32>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -1088,6 +1166,7 @@ fn mlx_generate_one(
         seed: Some(seed as u64),
         steps: Some(steps),
         guidance,
+        true_cfg,
         conditioning,
         cancel: cancel.clone(),
         ..Default::default()
@@ -1153,13 +1232,46 @@ async fn generate_mlx_stream(
     let seeds: Vec<i64> = (0..count)
         .map(|index| resolve_seed(request, index))
         .collect();
-    // Reference-identity img2img-init (sc-3619): only Z-Image reaches this plain path with a
-    // reference (FLUX is ineligible→torch, Qwen/SDXL divert to their own edit/advanced branches).
-    // Resolve once — the identity is constant across the set — and seed each image's denoise.
-    let identity_init = if request.model == "z_image_turbo" {
-        resolve_zimage_identity_init(request, settings, project_path)?
+    // Reference conditioning for the base MLX path, resolved once (constant across the set):
+    //  • Z-Image reference-identity img2img-init (sc-3619), and
+    //  • FLUX.1 XLabs IP-Adapter (epic 3621 — both schnell + dev; `strength = ipAdapterScale`, plus
+    //    real CFG via `trueCfgScale` on dev). Qwen/SDXL reference divert to their own advanced
+    //    branches before reaching here.
+    let has_reference = request
+        .reference_asset_id
+        .as_deref()
+        .is_some_and(|id| !id.trim().is_empty());
+    let (identity_init, flux_ip_dir, flux_true_cfg): (
+        Option<(Image, f32)>,
+        Option<PathBuf>,
+        Option<f32>,
+    ) = if request.model == "z_image_turbo" {
+        (
+            resolve_zimage_identity_init(request, settings, project_path)?,
+            None,
+            None,
+        )
+    } else if is_flux_model(&request.model) && has_reference && request.mode != "edit_image" {
+        let reference_id = request
+            .reference_asset_id
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_owned();
+        let image = load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            &reference_id,
+            project_path,
+        )?;
+        let scale = advanced_f32(request, "ipAdapterScale", FLUX_IP_SCALE, 0.0, 1.0);
+        let ip_dir = resolve_flux_ip_adapter_dir(settings)?;
+        // Real CFG only on dev (schnell is distilled — no CFG).
+        let true_cfg = (request.model == "flux_dev")
+            .then(|| advanced_f32(request, "trueCfgScale", FLUX_IP_TRUE_CFG, 1.0, 10.0));
+        (Some((image, scale)), Some(ip_dir), true_cfg)
     } else {
-        None
+        (None, None, None)
     };
 
     let cancel = CancelFlag::new();
@@ -1171,7 +1283,8 @@ async fn generate_mlx_stream(
         let seeds = seeds.clone();
         let cancel = cancel.clone();
         let job_id = job.id.clone();
-        // `identity_init` is moved into the closure below (the `move` captures it by value).
+        // `identity_init` + `flux_ip_dir` + `flux_true_cfg` are moved into the closure (the `move`
+        // captures them by value).
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
             let adapter_count = adapters.len();
             emit_load_event(
@@ -1180,7 +1293,7 @@ async fn generate_mlx_stream(
                 engine_id,
                 adapter_count,
             );
-            let generator = mlx_load(engine_id, weights_dir, quant, adapters)?;
+            let generator = mlx_load_with_ip(engine_id, weights_dir, quant, adapters, flux_ip_dir)?;
             emit_load_event(
                 "image_pipeline_load_complete",
                 &job_id,
@@ -1209,6 +1322,7 @@ async fn generate_mlx_stream(
                     guidance,
                     negative_prompt.clone(),
                     identity_init.as_ref(),
+                    flux_true_cfg,
                     &cancel,
                     &mut on_progress,
                 )?;
@@ -4715,6 +4829,7 @@ mod tests {
             guidance,
             negative_prompt,
             None,
+            None,
             &cancel,
             &mut |p| {
                 if let mlx_gen::Progress::Step { current, .. } = p {
@@ -4994,6 +5109,7 @@ mod tests {
             steps,
             guidance,
             negative,
+            None,
             None,
             &cancel,
             &mut |_| {},

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -76,7 +76,7 @@ dropped — no silent drops.**
 |---|---|---|---|
 | Strict-pose ControlNet | `qwen_image` (+ `advanced.poses`) | 🔵 Port-pending | epic 3401 (Qwen ControlNet port) |
 | Reference / edit conditioning | base `qwen_image` (reference/`edit_image`) | 🔵 Port-pending | epic 3401 |
-| Reference (XLabs IP-Adapter) | `flux_schnell`, `flux_dev` | 🔵 Port (spike GO) | sc-3535 (spike) → **epic 3621** |
+| Reference (XLabs IP-Adapter) | `flux_schnell`, `flux_dev` | 🟢 Ported (MLX) | sc-3535 (spike) → epic 3621 (sc-3622–3625) |
 | `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
 | reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🔵 Port-or-drop spike | sc-3537 |
@@ -86,7 +86,9 @@ dropped — no silent drops.**
 > platform, so it reaches no Python worker to retire. It's a universal product gap (a future
 > FLUX.1-Kontext capability), not a Mac-vs-torch gap, and is intentionally absent from this table.
 > Likewise, FLUX.1 reference = the **XLabs IP-Adapter** (not VAE img2img-init), which is why it
-> needs the engine port in epic 3621 rather than a gate-flip like Z-Image's sc-3619.
+> needed a real engine port in epic 3621 (now landed — CLIP-ViT-L encoder + decoupled cross-attn in
+> `mlx-gen-flux`, sc-3622–3625) rather than a gate-flip like Z-Image's sc-3619. Both schnell + dev
+> route reference to MLX — the Rust engine has no diffusers `load_ip_adapter` schnell limitation.
 
 ## 3. Video
 


### PR DESCRIPTION
Closes the SceneWorks routing for the FLUX.1 XLabs IP-Adapter port (epic 3621). The engine work (sc-3622/3623/3624) landed in [mlx-gen#170](https://github.com/michaeltrefry/mlx-gen/pull/170); this opens the Mac routing so FLUX.1 reference jobs run in the in-process Rust/MLX worker instead of the torch `FluxDiffusersAdapter`. Mirrors the Z-Image gate-open sc-3619.

## Changes
- **Gate** (`jobs_store.rs` `flux_mlx_eligible`): drop the `has_reference → false` exclusion (keep `edit_image` + LyCORIS). Opens reference for **both** `flux_schnell` + `flux_dev` — the Rust engine has no diffusers `load_ip_adapter` schnell limitation (the e2e proved schnell works). `model_mac_support` `features.reference` auto-flips via the probe.
- **Worker** (`image_jobs.rs`): `resolve_flux_ip_adapter_dir` stages the engine's IP-adapter dir contract (`ip_adapter.safetensors` + `image_encoder/model.safetensors`) by symlinking the **two cached HF snapshots** — `XLabs-AI/flux-ip-adapter` + `openai/clip-vit-large-patch14`, the same repos the torch `flux_dev` path already declares/downloads (**nothing new to ship**; errors loudly if absent, mirroring the SDXL IP path). `generate_mlx_stream` threads a single `Conditioning::Reference { image, strength = ipAdapterScale }` into the FLUX MLX render via `mlx_load_with_ip` (`LoadSpec::with_ip_adapter`) + `true_cfg` (`trueCfgScale`, dev only).
- **Pin**: bump `mlx-gen` rev to the #170 merge (`0554ea1`).
- **Docs**: `mac-rust-gaps.md` §2 FLUX reference row → 🟢 Ported (MLX); `edit_image` stays a universal product gap (future Kontext).
- Routing + feature-flag tests flipped (flux reference now routes to MLX / is supported).

## Verification
- `npm run rust:check` green — `clippy -D warnings` clean + core/worker/api suites (125 / 91 / 101 / 138 …).
- Engine side already e2e-verified on real FLUX.1-schnell (#170): IP scale=0 == txt2img byte-identical, scale>0 conditions the image.

## Owes
Real-Mac E2E (no GPU/weights in CI): a `flux_dev`/`flux_schnell` `character_image` job with `referenceAssetId` rendering the IP-Adapter result on the Mac worker. The XLabs + CLIP repos must be in the HF cache (same as the torch path / SDXL IP).

Part of epic 3621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)