### PR TITLE
[codex] Fix Apple GPU queue contention

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -845,23 +845,7 @@ impl JobsStore {
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let worker = self.get_worker_on_connection(&transaction, worker_id)?;
         let worker_gpu_id = worker.gpu_id.clone();
-        let has_active_gpu_job = transaction
-            .query_row(
-                &format!(
-                    "
-                select id from jobs
-                 where assigned_gpu = ?1
-                   and status in ('preparing', 'downloading', 'loading_model', 'running', 'saving')
-                   and type not in ({})
-                 limit 1
-                ",
-                    non_gpu_job_types_sql()
-                ),
-                params![worker.gpu_id],
-                |_row| Ok(()),
-            )
-            .optional()?
-            .is_some();
+        let has_active_gpu_job = active_gpu_job_exists(&transaction, &worker.gpu_id)?;
 
         let mut statement = transaction.prepare(&format!(
             "
@@ -2549,6 +2533,25 @@ fn idle_mlx_worker_can_claim(
 }
 
 fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResult<bool> {
+    if is_apple_unified_gpu_id(gpu_id) {
+        return Ok(connection
+            .query_row(
+                &format!(
+                    "
+            select id from jobs
+             where lower(assigned_gpu) in ('mlx', 'mps')
+               and status in ('preparing', 'downloading', 'loading_model', 'running', 'saving')
+               and type not in ({})
+             limit 1
+            ",
+                    non_gpu_job_types_sql()
+                ),
+                [],
+                |_row| Ok(()),
+            )
+            .optional()?
+            .is_some());
+    }
     Ok(connection
         .query_row(
             &format!(
@@ -2566,6 +2569,10 @@ fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResu
         )
         .optional()?
         .is_some())
+}
+
+fn is_apple_unified_gpu_id(gpu_id: &str) -> bool {
+    gpu_id.eq_ignore_ascii_case("mlx") || gpu_id.eq_ignore_ascii_case("mps")
 }
 
 /// Models the in-process Rust MLX worker generates today, by id. This set grows

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1439,6 +1439,26 @@ fn image_edit_job_with(payload: Value, requested_gpu: &str) -> CreateJob {
     }
 }
 
+fn complete_job(store: &JobsStore, job_id: &str) {
+    store
+        .update_job_progress(
+            job_id,
+            ProgressUpdate {
+                status: JobStatus::Completed,
+                stage: ProgressStage::Completed,
+                progress: 1.0,
+                message: "Done".to_owned(),
+                error: None,
+                result: Some(Map::new()),
+                eta_seconds: None,
+                peak_gpu_memory_pct: None,
+                peak_gpu_load_pct: None,
+                backend: None,
+            },
+        )
+        .expect("job completes");
+}
+
 #[test]
 fn mlx_eligible_image_job_defers_from_torch_worker_to_idle_mlx_worker() {
     let store = store("mlx-routing-defer");
@@ -2271,6 +2291,112 @@ fn sdxl_masked_image_edit_job_type_defers_to_mlx_worker() {
         .expect("mlx claims the job");
     assert_eq!(claimed.id, job.id);
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn active_mlx_image_edit_blocks_mps_image_edit_claim() {
+    let store = store("mlx-mps-shared-gpu-active-mlx");
+    register_gpu_worker(&store, "worker-mps", "mps", image_edit_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+
+    let mlx_job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "qwen_image_edit_2511_lightning",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1",
+                "prompt": "make it a watercolor painting"
+            }),
+            "auto",
+        ))
+        .expect("mlx job creates");
+    let claimed_mlx = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the first job");
+    assert_eq!(claimed_mlx.id, mlx_job.id);
+    assert_eq!(claimed_mlx.assigned_gpu.as_deref(), Some("mlx"));
+
+    let mps_job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "z_image_edit",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_2",
+                "prompt": "p"
+            }),
+            "auto",
+        ))
+        .expect("mps job creates");
+
+    assert!(
+        store
+            .claim_next_job("worker-mps")
+            .expect("mps claim ok")
+            .is_none(),
+        "MPS must wait while the MLX worker is using the shared Apple GPU"
+    );
+
+    complete_job(&store, &claimed_mlx.id);
+    let claimed_mps = store
+        .claim_next_job("worker-mps")
+        .expect("mps claim ok")
+        .expect("mps claims once mlx completes");
+    assert_eq!(claimed_mps.id, mps_job.id);
+    assert_eq!(claimed_mps.assigned_gpu.as_deref(), Some("mps"));
+}
+
+#[test]
+fn active_mps_image_edit_blocks_mlx_image_edit_claim() {
+    let store = store("mlx-mps-shared-gpu-active-mps");
+    register_gpu_worker(&store, "worker-mps", "mps", image_edit_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+
+    let mps_job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "z_image_edit",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1",
+                "prompt": "p"
+            }),
+            "auto",
+        ))
+        .expect("mps job creates");
+    let claimed_mps = store
+        .claim_next_job("worker-mps")
+        .expect("mps claim ok")
+        .expect("mps claims the first job");
+    assert_eq!(claimed_mps.id, mps_job.id);
+    assert_eq!(claimed_mps.assigned_gpu.as_deref(), Some("mps"));
+
+    let mlx_job = store
+        .create_job(image_edit_job_with(
+            json!({
+                "model": "qwen_image_edit_2511_lightning",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_2",
+                "prompt": "make it a watercolor painting"
+            }),
+            "auto",
+        ))
+        .expect("mlx job creates");
+
+    assert!(
+        store
+            .claim_next_job("worker-mlx")
+            .expect("mlx claim ok")
+            .is_none(),
+        "MLX must wait while the MPS worker is using the shared Apple GPU"
+    );
+
+    complete_job(&store, &claimed_mps.id);
+    let claimed_mlx = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims once mps completes");
+    assert_eq!(claimed_mlx.id, mlx_job.id);
+    assert_eq!(claimed_mlx.assigned_gpu.as_deref(), Some("mlx"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Treat `mlx` and `mps` as a shared Apple unified GPU contention group during queue claim active-job checks.
- Keep exact `assigned_gpu` matching for other GPU IDs.
- Add Image Edit regressions for both directions: active MLX blocks MPS, and active MPS blocks MLX.

## Root Cause
The queue active-GPU guard only checked exact `assigned_gpu` equality. A running MLX job used `assigned_gpu = mlx`, so an idle MPS worker did not see that the same physical Apple GPU was already occupied and could claim a second Image Edit job immediately.

## Validation
- `cargo test -p sceneworks-core --test jobs_store image_edit_blocks`
- `cargo fmt --check`
- `cargo test -p sceneworks-core --test jobs_store`

Shortcut: sc-3648