### PR TITLE
sc-3489 follow-up: host Real-ESRGAN ONNX at SceneWorks/real-esrgan-onnx + wire default

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2256,12 +2256,23 @@
             "x2": {
               "repo": "nateraw/real-esrgan",
               "file": "RealESRGAN_x2plus.pth",
-              "originalUrl": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth"
+              "originalUrl": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.1/RealESRGAN_x2plus.pth",
+              // ONNX export for the Rust macOS upscaler (sc-3489): RRDBNet via
+              // onnxruntime/CoreML on a Python-free Mac. Reproducible from
+              // scripts/spikes/sc3489_export_reference.py.
+              "onnx": {
+                "repo": "SceneWorks/real-esrgan-onnx",
+                "file": "real_esrgan_x2.onnx"
+              }
             },
             "x4": {
               "repo": "nateraw/real-esrgan",
               "file": "RealESRGAN_x4plus.pth",
-              "originalUrl": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth"
+              "originalUrl": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth",
+              "onnx": {
+                "repo": "SceneWorks/real-esrgan-onnx",
+                "file": "real_esrgan_x4.onnx"
+              }
             }
           }
         }

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -43,12 +43,11 @@ use sceneworks_core::project_store::ProjectStore;
 const TILE_SIZE: usize = 512;
 const TILE_PAD: usize = 16;
 
-/// Default HuggingFace repo hosting the pre-exported ONNX (reproducible from
-/// `scripts/spikes/sc3489_export_reference.py`). Downloaded on first use, parity with
-/// sc-3487's rtmlib weights. NOTE: until this SceneWorks-owned repo is populated (needs
-/// a HF *write* token — see `docs/sc-3489/spike-findings.md`), provision via the env
-/// override `SCENEWORKS_REALESRGAN_X{2,4}_ONNX`.
-const ONNX_REPO: &str = "trefster/sceneworks-real-esrgan-onnx";
+/// SceneWorks-owned HuggingFace repo hosting the pre-exported ONNX (reproducible from
+/// `scripts/spikes/sc3489_export_reference.py`). Public; downloaded on first use,
+/// parity with sc-3487's rtmlib weights. Overridable via the manifest `onnx` resource
+/// or the env pin `SCENEWORKS_REALESRGAN_X{2,4}_ONNX`.
+const ONNX_REPO: &str = "SceneWorks/real-esrgan-onnx";
 
 fn onnx_file(factor: u8) -> String {
     format!("real_esrgan_x{factor}.onnx")

--- a/docs/sc-3489/spike-findings.md
+++ b/docs/sc-3489/spike-findings.md
@@ -94,16 +94,16 @@ get it **without torch**. Resolution order in the port mirrors Python's
 3. on-disk cache (`<data_dir>/cache/upscale/`);
 4. download-on-first-use from a HF repo (parity with sc-3487's rtmlib weights).
 
-**Hosting:** the export is fully reproducible from the committed script, but the two
-ONNX files (~67 MB each, fp32) must live at a stable URL for step 4. Consistent with
-the manifest convention (every other model is *downloaded*, not bundled) and with
-sc-3487, the right home is a **SceneWorks-controlled HF repo** (e.g.
-`trefster/sceneworks-real-esrgan-onnx`). This needs a HF **write** token — the token
-in this environment is read-only (`HF_READ_TOKEN_MAC`). **Action for Michael:** create
-the repo (or grant a write token) so the production default download URL can be wired;
-until then the port is fully testable via the env override. fp16 export (~33 MB each)
-is a viable size optimisation — CoreML runs fp16 internally anyway — but is left as a
-follow-up to keep parity numbers clean.
+**Hosting (DONE):** the two ONNX files (~67 MB each, fp32) are hosted at the public
+SceneWorks-owned repo **[`SceneWorks/real-esrgan-onnx`](https://huggingface.co/SceneWorks/real-esrgan-onnx)**
+(reproducible from the committed export script; model card records source-weight
+provenance + sha256). The worker downloads on first use from
+`https://huggingface.co/SceneWorks/real-esrgan-onnx/resolve/main/real_esrgan_x{2,4}.onnx`
+(public, no auth), and the manifest carries the `onnx` resource per the normal
+convention. Verified end-to-end: a fresh-cache worker (no env override) downloaded the
+x4 ONNX (sha256 match) and produced the upscaled output. fp16 export (~33 MB each) is a
+viable size optimisation — CoreML runs fp16 internally anyway — left as a follow-up to
+keep parity numbers clean.
 
 ## AuraSR
 


### PR DESCRIPTION
Follow-up to #480 (which merged the Real-ESRGAN Rust port). That PR shipped with a placeholder ONNX download repo and the env-override provisioning path. This wires the real hosting now that the **`SceneWorks` HF account exists**.

## What changed
- The two ONNX files are hosted at the public repo **[`SceneWorks/real-esrgan-onnx`](https://huggingface.co/SceneWorks/real-esrgan-onnx)** (model card records source-weight provenance — xinntao/nateraw RealESRGAN_x2plus/x4plus — + sha256; reproducible from the committed `scripts/spikes/sc3489_export_reference.py`).
- Worker default `ONNX_REPO` → `SceneWorks/real-esrgan-onnx` (was the `trefster/...` placeholder).
- Added the `onnx` resource to the `real-esrgan` upscaler manifest entry (x2/x4) per the normal provisioning convention, so `ensure_onnx` resolves it from the manifest too.

## Verified
- **Production download path end-to-end:** a fresh-cache mlx worker with **no env override** downloaded the x4 ONNX from HF (sha256 match `5c5866…`) and produced the 3072×3072 upscale.
- `npm run rust:check` green (the manifest `onnx` key deserializes cleanly).

Closes the last owed item from the sc-3489 spike (ONNX hosting). AuraSR Rust port remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)