### PR TITLE
sc-3625: bump mlx-gen pin to IP-Adapter parity fix + worker FLUX reference E2E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "image",
  "inventory",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "image",
  "inventory",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "image",
  "inventory",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0554ea16169abab721064261aa41e953a793fa05#0554ea16169abab721064261aa41e953a793fa05"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ee91754d8e8c962b24df806649a116c3522c885#0ee91754d8e8c962b24df806649a116c3522c885"
 dependencies = [
  "image",
  "inventory",
@@ -2899,7 +2899,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -83,33 +83,33 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # captioner registry/provider (epic 3550), plus Qwen Edit step eval boundaries for
 # Metal timeout avoidance, in one shared rev so MLX builds once with the unchanged
 # mlx-rs pin (e59ffd88, identical across the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0554ea16169abab721064261aa41e953a793fa05" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ee91754d8e8c962b24df806649a116c3522c885" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -6134,4 +6134,152 @@ mod tests {
         assert!((at(0, 8) - at(15, 8)).abs() < 1e-6);
         assert!((at(8, 0) - at(8, 15)).abs() < 1e-6);
     }
+
+    /// sc-3625 real-Mac E2E (epic 3621): drive the WORKER's FLUX.1 XLabs IP-Adapter reference path
+    /// end to end on real weights — `resolve_flux_ip_adapter_dir` staging from the real HF cache +
+    /// `mlx_load_with_ip` + a real `Conditioning::Reference` dev `true_cfg` render against the
+    /// pinned mlx-gen engine. Guards the worker plumbing the engine-side A/B can't: the staged-dir
+    /// contract + the dev reference render NOT regressing to the pre-#173 saturation (which
+    /// collapsed `true_cfg=4` to a near-uniform white frame). Run (needs FLUX.1-dev +
+    /// `XLabs-AI/flux-ip-adapter` + `openai/clip-vit-large-patch14` in the HF cache):
+    /// ```text
+    /// HF_HUB_CACHE=$HOME/.cache/huggingface/hub \
+    ///   cargo test -p sceneworks-worker --release flux_ip_reference_worker_e2e -- --ignored --nocapture
+    /// ```
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-Mac E2E: loads FLUX.1-dev + XLabs IP-Adapter + CLIP-ViT-L from the HF cache"]
+    fn flux_ip_reference_worker_e2e() {
+        fn hf_cache() -> String {
+            std::env::var("HF_HUB_CACHE").unwrap_or_else(|_| {
+                format!("{}/.cache/huggingface/hub", std::env::var("HOME").unwrap())
+            })
+        }
+        fn hf_snapshot(repo: &str, needs: &str) -> PathBuf {
+            let safe = repo.replace('/', "--");
+            let snaps = PathBuf::from(hf_cache())
+                .join(format!("models--{safe}"))
+                .join("snapshots");
+            std::fs::read_dir(&snaps)
+                .unwrap_or_else(|_| panic!("HF snapshot for {repo}"))
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .find(|p| p.is_dir() && p.join(needs).exists())
+                .unwrap_or_else(|| panic!("a complete {repo} snapshot with {needs}"))
+        }
+
+        // Point the worker's HF-cache resolver + Settings at the real cache + a temp data dir.
+        std::env::set_var("HF_HUB_CACHE", hf_cache());
+        let data = tempfile::tempdir().unwrap();
+        std::env::set_var("SCENEWORKS_DATA_DIR", data.path());
+        let settings = Settings::from_env();
+
+        // (1) The worker's OWN staging fn, against the real cache (the net-new sc-3625 fs logic).
+        let staged = resolve_flux_ip_adapter_dir(&settings).expect("stage flux ip-adapter dir");
+        assert!(
+            staged.join("ip_adapter.safetensors").exists(),
+            "staged ip_adapter.safetensors"
+        );
+        assert!(
+            staged.join("image_encoder/model.safetensors").exists(),
+            "staged image_encoder/model.safetensors"
+        );
+
+        // (2) Load FLUX.1-dev through the worker loader with the staged IP dir, resolving the
+        // engine id from the MLX_MODELS table exactly as the real dispatch does (model "flux_dev"
+        // → engine "flux1_dev").
+        let engine_id = mlx_model("flux_dev")
+            .expect("flux_dev in MLX_MODELS")
+            .engine_id;
+        let flux_dev = hf_snapshot("black-forest-labs/FLUX.1-dev", "transformer");
+        let generator = mlx_load_with_ip(engine_id, flux_dev, None, vec![], Some(staged))
+            .unwrap_or_else(|e| panic!("mlx_load_with_ip {engine_id} + ip: {e}"));
+
+        // (3) Reference render through the dev `true_cfg` path (white-dot garbage pre-#173).
+        let reference = {
+            let p = "/tmp/flux_ab/reference.png";
+            if std::path::Path::new(p).exists() {
+                let img = image::open(p).unwrap().to_rgb8();
+                Image {
+                    width: img.width(),
+                    height: img.height(),
+                    pixels: img.into_raw(),
+                }
+            } else {
+                // Synthetic fallback: a solid orange field (still drives the IP branch).
+                Image {
+                    width: 64,
+                    height: 64,
+                    pixels: [255u8, 140, 0]
+                        .iter()
+                        .cycle()
+                        .take(64 * 64 * 3)
+                        .copied()
+                        .collect(),
+                }
+            }
+        };
+        let req = |conditioning, true_cfg| GenerationRequest {
+            prompt: "an oil painting in the bold swirling brushstroke style of Van Gogh".into(),
+            width: 512,
+            height: 512,
+            seed: Some(2),
+            steps: Some(16),
+            true_cfg,
+            conditioning,
+            ..Default::default()
+        };
+        let run = |r: &GenerationRequest| match generator.generate(r, &mut |_| {}).unwrap() {
+            GenerationOutput::Images(mut v) => v.remove(0),
+            _ => unreachable!(),
+        };
+
+        let ref_out = run(&req(
+            vec![Conditioning::Reference {
+                image: reference,
+                strength: Some(0.7),
+            }],
+            Some(4.0),
+        ));
+        let plain = run(&req(vec![], None));
+
+        // Non-degenerate: the pre-#173 saturation collapsed dev true_cfg=4 to a near-uniform white.
+        let n = ref_out.pixels.len() as f64;
+        let mean = ref_out.pixels.iter().map(|&b| b as f64).sum::<f64>() / n;
+        let var = ref_out
+            .pixels
+            .iter()
+            .map(|&b| (b as f64 - mean).powi(2))
+            .sum::<f64>()
+            / n;
+        assert!(
+            var > 200.0,
+            "reference render near-uniform (var={var:.1}) — true_cfg saturation regression"
+        );
+        assert!(
+            mean < 245.0,
+            "reference render near-white (mean={mean:.1}) — true_cfg saturation regression"
+        );
+
+        // The reference actually changed the image vs plain txt2img (IP branch is applied).
+        let diff = ref_out
+            .pixels
+            .iter()
+            .zip(&plain.pixels)
+            .filter(|(a, b)| a != b)
+            .count();
+        assert!(
+            diff > ref_out.pixels.len() / 10,
+            "reference barely changed the render ({diff} px)"
+        );
+
+        if let Ok(p) = std::env::var("FLUX_IP_WORKER_OUT") {
+            image::RgbImage::from_raw(ref_out.width, ref_out.height, ref_out.pixels.clone())
+                .unwrap()
+                .save(&p)
+                .unwrap();
+            println!("[worker-e2e] wrote {p}");
+        }
+        println!("[worker-e2e] OK: staged dir contract + flux_dev load + dev true_cfg=4 reference render — var={var:.1} mean={mean:.1} diff-vs-txt2img={diff}px");
+    }
 }


### PR DESCRIPTION
Closes out the FLUX.1 XLabs IP-Adapter reference path (epic [3621](https://app.shortcut.com/trefry/epic/3621)) now that the engine parity fix has landed.

## What
- **Bump mlx-gen pin** `0554ea1` → `0ee9175` (merge of [mlx-gen#173](https://github.com/michaeltrefry/mlx-gen/pull/173)). That engine PR fixes the IP residual placement — added **raw/ungated after the FF** (diffusers `hidden_states = hidden_states + ip_attn_output`) instead of folded pre-`gate_msa` — which resolved **both** the weak-resemblance and the dev `true_cfg=4` saturation the prior pin (`0554ea1`, shipped via #478) produced. mlx-rs pin unchanged; all 9 `mlx-gen*` crate deps moved together.
- **Worker real-Mac E2E** (`flux_ip_reference_worker_e2e`, macOS `#[ignore]`): drives the worker's *own* path end to end on real weights — `resolve_flux_ip_adapter_dir` staging from the HF cache → `mlx_load_with_ip` (engine id resolved via `MLX_MODELS`, `flux_dev`→`flux1_dev`) → a `Conditioning::Reference` dev `true_cfg=4` render. Asserts non-degenerate output (var/mean guard against the pre-#173 white-frame saturation) and that it differs from plain txt2img.

## Verified on this M-series Mac
`flux_ip_reference_worker_e2e` passes: staged-dir contract OK, render = a clean orange tabby in Van Gogh style — **var=4990.6, mean=115.4, 782351px differ vs txt2img** (the saturated frame would have been near-uniform white). Engine-side A/B (mlx-gen#173): CLIP resemblance-to-ref MLX 0.7847 vs torch 0.8066, |Δ|=0.022 MATCH.

`npm run rust:check` green (fmt + clippy + tests + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)