### PR TITLE
sc-3633: YOLO11 person detector (Rust worker) — decode verified, MLX backend port [draft]

### DIFF
--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -65,6 +65,11 @@ mod pose_jobs;
 // Real-ESRGAN / AuraSR path stays the Windows/Linux backend.
 #[cfg(target_os = "macos")]
 mod upscale_jobs;
+// YOLO11 person detection via onnxruntime/CoreML (epic 3482, sc-3488/sc-3633).
+// macOS-only like pose_jobs: the `ort` engine + CoreML EP only mean anything on
+// Apple Silicon, and the Python Ultralytics path stays the Windows/Linux backend.
+#[cfg(target_os = "macos")]
+mod person_jobs;
 use downloads::*;
 #[cfg(target_os = "macos")]
 use pose_jobs::*;

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -410,7 +410,43 @@ pub(crate) async fn run_person_detect(
     .await?;
     tokio::fs::rename(&temp_path, &media_path).await?;
 
-    let detections = candidate_people(1280, 720, source_asset_id, timestamp);
+    // Preview jobs (`preview: true`, claimed via the CPU worker's
+    // person_detect_preview capability) keep the procedural placeholder. Real
+    // jobs run the YOLO11 onnx detector (epic 3482, sc-3633) — model-backed,
+    // `personDetectionActive: true`, and erroring honestly when the detector
+    // can't run rather than silently degrading to boxes.
+    let is_preview = job
+        .payload
+        .get("preview")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let confidence = job
+        .payload
+        .get("advanced")
+        .and_then(|advanced| advanced.get("confidence"))
+        .or_else(|| job.payload.get("confidence"))
+        .map_or(0.25, |value| value_f64(value, 0.25))
+        .clamp(0.01, 1.0);
+    let (detections, detector_model, detector_adapter, detection_active, detector_meta) =
+        if is_preview {
+            (
+                candidate_people(1280, 720, source_asset_id, timestamp),
+                "procedural-person-detector".to_owned(),
+                "procedural_person_tracking",
+                false,
+                Value::Null,
+            )
+        } else {
+            let (boxes, device) =
+                run_yolo11_person_detect(settings, media_path.clone(), confidence).await?;
+            (
+                boxes,
+                "yolo11m".to_owned(),
+                "yolo11_ort",
+                true,
+                json!({ "backend": "ort", "device": device, "model": "yolo11m" }),
+            )
+        };
     let source_display_name = source_asset
         .get("displayName")
         .and_then(Value::as_str)
@@ -440,8 +476,8 @@ pub(crate) async fn run_person_detect(
         },
         "recipe": {
             "mode": "person_detect",
-            "model": "procedural-person-detector",
-            "adapter": "procedural_person_tracking",
+            "model": detector_model,
+            "adapter": detector_adapter,
             "prompt": "Detect selectable people in representative frame",
             "negativePrompt": "",
             "seed": 0,
@@ -450,7 +486,9 @@ pub(crate) async fn run_person_detect(
             "normalizedSettings": {
                 "sourceTimestamp": timestamp,
                 "detectionCount": detections.len(),
-                "personDetectionActive": false
+                "confidence": confidence,
+                "personDetectionActive": detection_active,
+                "detector": detector_meta
             },
             "rawAdapterSettings": { "sourcePath": source_rel }
         },
@@ -507,6 +545,10 @@ pub(crate) async fn run_person_detect(
     result.insert("sourceTimestamp".to_owned(), json!(timestamp));
     result.insert("detections".to_owned(), Value::Array(detections));
     result.insert(
+        "personDetectionActive".to_owned(),
+        Value::Bool(detection_active),
+    );
+    result.insert(
         "limits".to_owned(),
         json!({
             "maskStorage": "deferred",
@@ -514,6 +556,43 @@ pub(crate) async fn run_person_detect(
         }),
     );
     Ok(result)
+}
+
+/// Run the YOLO11 onnx person detector on a rendered frame, returning the
+/// normalized detection array (Python `run_person_detect` shape) + the device
+/// the model ran on. macOS-only: `ort`/CoreML is the Apple-Silicon backend
+/// (epic 3482, sc-3633); the Python Ultralytics path serves Windows/Linux.
+#[cfg(target_os = "macos")]
+async fn run_yolo11_person_detect(
+    settings: &Settings,
+    frame_path: PathBuf,
+    confidence: f64,
+) -> WorkerResult<(Vec<Value>, &'static str)> {
+    let onnx = crate::person_jobs::resolve_detector_onnx(settings).ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Person detector weights (yolo11m.onnx) are not provisioned on this worker.".to_owned(),
+        )
+    })?;
+    let conf = confidence as f32;
+    let result = tokio::task::spawn_blocking(move || {
+        crate::person_jobs::detect_people_blocking(onnx, frame_path, conf)
+    })
+    .await
+    .map_err(|error| WorkerError::InvalidPayload(format!("person detect task: {error}")))??;
+    let boxes =
+        crate::person_jobs::detections_to_json(&result.detections, result.width, result.height);
+    Ok((boxes, result.device))
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn run_yolo11_person_detect(
+    _settings: &Settings,
+    _frame_path: PathBuf,
+    _confidence: f64,
+) -> WorkerResult<(Vec<Value>, &'static str)> {
+    Err(WorkerError::InvalidPayload(
+        "Real person detection runs on the Python worker on this platform.".to_owned(),
+    ))
 }
 
 pub(crate) async fn run_person_track_job(

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -1,0 +1,396 @@
+//! YOLO11 person detection on the Rust worker (epic 3482, sc-3488 slice 1 / sc-3633).
+//!
+//! Ports the Python `scene_worker/person_adapters.py` `_UltralyticsDetector`
+//! (Ultralytics `yolo11m.pt`, COCO class 0) to Rust so the Replace-Person
+//! detection step runs on a Python-free Mac. Inference uses the `ort`
+//! (onnxruntime) + CoreML execution-provider scaffold proven by `pose_jobs.rs`
+//! (sc-3487): a process-wide cached `Session`, CoreML→CPU fallback, and all
+//! `ort` objects confined to a `spawn_blocking` closure.
+//!
+//! macOS-only in practice: the CoreML EP only matters on Apple Silicon, and the
+//! Python Ultralytics path stays the Windows/Linux detector. The pure detector
+//! math (letterbox / decode / NMS / box normalization) is unit-tested without
+//! the onnx weights; only the onnxruntime inference itself is gated.
+//!
+//! Pipeline (matched to the Ultralytics YOLO11 ONNX export — verified against the
+//! real `yolo11m.onnx` + `ultralytics.predict`):
+//!  - input `images` (1,3,640,640) f32: letterbox to 640 (ratio=min(640/w,640/h),
+//!    pad 114 centered), RGB channel order, divided by 255. cv2 INTER_LINEAR
+//!    half-pixel sampling.
+//!  - output `output0` (1,84,8400), channel-major: rows 0..4 = cx,cy,w,h in
+//!    letterbox px; rows 4..84 = 80 sigmoid class scores in [0,1] (no separate
+//!    objectness). Person = class 0 → channel 4.
+//!  - decode: keep anchors whose person score > conf, cx/cy/w/h → xyxy, subtract
+//!    the letterbox pad and divide by the ratio back into original px, clamp to
+//!    the frame, then greedy NMS at the Ultralytics default IoU 0.7.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use image::RgbImage;
+use ort::execution_providers::CoreMLExecutionProvider;
+use ort::session::Session;
+use ort::value::Tensor;
+use serde_json::{json, Value};
+
+use crate::{Settings, WorkerError, WorkerResult};
+
+/// Square detector input edge (the YOLO11 export is fixed 640×640).
+const DET: usize = 640;
+/// COCO "person" class index, matching Python `PERSON_CLASS_INDEX`.
+const PERSON_CLASS: usize = 0;
+/// Letterbox padding value (Ultralytics default), pre-`/255`.
+const PAD_VALUE: f32 = 114.0;
+/// Greedy-NMS IoU threshold — Ultralytics `predict` default (`iou=0.7`).
+const NMS_IOU: f32 = 0.7;
+/// The detector onnx filename in the app cache / model dir.
+const DET_FILE: &str = "yolo11m.onnx";
+
+// ---------------------------------------------------------------------------
+// pure detector math (unit-tested without weights)
+// ---------------------------------------------------------------------------
+
+/// One person box in the *original frame's* pixel coordinates.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct Detection {
+    pub x1: f32,
+    pub y1: f32,
+    pub x2: f32,
+    pub y2: f32,
+    pub score: f32,
+}
+
+impl Detection {
+    fn width(&self) -> f32 {
+        (self.x2 - self.x1).max(0.0)
+    }
+    fn height(&self) -> f32 {
+        (self.y2 - self.y1).max(0.0)
+    }
+    fn area(&self) -> f32 {
+        self.width() * self.height()
+    }
+}
+
+/// Letterbox geometry: the resize ratio and the centered left/top pad (px) in
+/// the 640 input. `un_letterbox` inverts it back to original-frame px.
+#[derive(Clone, Copy, Debug)]
+struct Letterbox {
+    ratio: f32,
+    pad_x: f32,
+    pad_y: f32,
+}
+
+impl Letterbox {
+    fn compute(w: u32, h: u32) -> Self {
+        let (w, h) = (w as f32, h as f32);
+        let ratio = (DET as f32 / w).min(DET as f32 / h);
+        let new_w = (w * ratio).round();
+        let new_h = (h * ratio).round();
+        // Ultralytics splits the pad in half with a -0.1 bias on the lead edge.
+        let pad_x = ((DET as f32 - new_w) / 2.0 - 0.1).round();
+        let pad_y = ((DET as f32 - new_h) / 2.0 - 0.1).round();
+        Self {
+            ratio,
+            pad_x,
+            pad_y,
+        }
+    }
+
+    /// Map a letterbox-space coordinate back into original-frame px.
+    fn un_x(&self, x: f32) -> f32 {
+        (x - self.pad_x) / self.ratio
+    }
+    fn un_y(&self, y: f32) -> f32 {
+        (y - self.pad_y) / self.ratio
+    }
+}
+
+/// Bilinear sample of an RGB channel (0=R,1=G,2=B) at (x,y); out-of-bounds →
+/// `border`. cv2 INTER_LINEAR half-pixel convention is applied by the caller.
+#[inline]
+fn sample_rgb(img: &RgbImage, x: f32, y: f32, c: usize, border: f32) -> f32 {
+    let (w, h) = (img.width() as i64, img.height() as i64);
+    let x0 = x.floor() as i64;
+    let y0 = y.floor() as i64;
+    let fx = x - x0 as f32;
+    let fy = y - y0 as f32;
+    let get = |xi: i64, yi: i64| -> f32 {
+        if xi < 0 || yi < 0 || xi >= w || yi >= h {
+            border
+        } else {
+            img.get_pixel(xi as u32, yi as u32)[c] as f32
+        }
+    };
+    let v00 = get(x0, y0);
+    let v10 = get(x0 + 1, y0);
+    let v01 = get(x0, y0 + 1);
+    let v11 = get(x0 + 1, y0 + 1);
+    let top = v00 * (1.0 - fx) + v10 * fx;
+    let bot = v01 * (1.0 - fx) + v11 * fx;
+    top * (1.0 - fy) + bot * fy
+}
+
+/// Build the (1,3,640,640) RGB `/255` letterboxed input and return the geometry.
+fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
+    let lb = Letterbox::compute(img.width(), img.height());
+    let (w, h) = (img.width() as f32, img.height() as f32);
+    let new_w = (w * lb.ratio).round();
+    let new_h = (h * lb.ratio).round();
+    let sx = w / new_w.max(1.0);
+    let sy = h / new_h.max(1.0);
+    let new_w = new_w as usize;
+    let new_h = new_h as usize;
+    let pad_x = lb.pad_x as usize;
+    let pad_y = lb.pad_y as usize;
+
+    let mut chw = vec![PAD_VALUE / 255.0; 3 * DET * DET];
+    for c in 0..3 {
+        let plane = c * DET * DET;
+        for dy in 0..new_h {
+            let src_y = (dy as f32 + 0.5) * sy - 0.5; // cv2 INTER_LINEAR half-pixel
+            let row = plane + (dy + pad_y) * DET + pad_x;
+            for dx in 0..new_w {
+                let src_x = (dx as f32 + 0.5) * sx - 0.5;
+                let v = sample_rgb(
+                    img,
+                    src_x.clamp(0.0, w - 1.0),
+                    src_y.clamp(0.0, h - 1.0),
+                    c,
+                    0.0,
+                );
+                chw[row + dx] = v / 255.0;
+            }
+        }
+    }
+    (chw, lb)
+}
+
+/// Decode the (1,84,8400) channel-major output into person boxes (original px),
+/// pre-NMS. `data` is laid out as `data[channel * anchors + anchor]`.
+fn decode(
+    data: &[f32],
+    shape: &[i64],
+    lb: &Letterbox,
+    conf: f32,
+    frame_w: u32,
+    frame_h: u32,
+) -> Vec<Detection> {
+    let channels = shape[1] as usize; // 84 = 4 box + 80 classes
+    let anchors = shape[2] as usize; // 8400
+    if channels < 5 {
+        return Vec::new();
+    }
+    let score_ch = 4 + PERSON_CLASS;
+    let (fw, fh) = (frame_w as f32, frame_h as f32);
+    let mut out = Vec::new();
+    for a in 0..anchors {
+        let score = data[score_ch * anchors + a];
+        if score <= conf {
+            continue;
+        }
+        let cx = data[a];
+        let cy = data[anchors + a];
+        let bw = data[2 * anchors + a];
+        let bh = data[3 * anchors + a];
+        let x1 = lb.un_x(cx - bw / 2.0).clamp(0.0, fw);
+        let y1 = lb.un_y(cy - bh / 2.0).clamp(0.0, fh);
+        let x2 = lb.un_x(cx + bw / 2.0).clamp(0.0, fw);
+        let y2 = lb.un_y(cy + bh / 2.0).clamp(0.0, fh);
+        out.push(Detection {
+            x1,
+            y1,
+            x2,
+            y2,
+            score,
+        });
+    }
+    out
+}
+
+fn iou(a: &Detection, b: &Detection) -> f32 {
+    let ix1 = a.x1.max(b.x1);
+    let iy1 = a.y1.max(b.y1);
+    let ix2 = a.x2.min(b.x2);
+    let iy2 = a.y2.min(b.y2);
+    let iw = (ix2 - ix1).max(0.0);
+    let ih = (iy2 - iy1).max(0.0);
+    let inter = iw * ih;
+    let union = a.area() + b.area() - inter;
+    if union > 0.0 {
+        inter / union
+    } else {
+        0.0
+    }
+}
+
+/// Greedy non-max suppression, score-descending, single (person) class.
+fn nms(mut dets: Vec<Detection>, iou_thr: f32) -> Vec<Detection> {
+    dets.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut keep: Vec<Detection> = Vec::new();
+    for det in dets {
+        if keep.iter().all(|k| iou(k, &det) <= iou_thr) {
+            keep.push(det);
+        }
+    }
+    keep
+}
+
+/// Convert NMS'd person boxes (original px) into the Python `run_person_detect`
+/// `detections` array shape: `{id,label,box{x,y,width,height},confidence,
+/// frameWidth,frameHeight,maskState}`, sorted confidence-descending, dropping
+/// degenerate boxes. Mirrors `PersonDetection.to_dict` + `xyxy_to_normalized`.
+pub(crate) fn detections_to_json(dets: &[Detection], frame_w: u32, frame_h: u32) -> Vec<Value> {
+    if frame_w == 0 || frame_h == 0 {
+        return Vec::new();
+    }
+    // Normalize in f64 to mirror Python `xyxy_to_normalized` (and avoid f32→f64
+    // widening artifacts in the emitted JSON numbers).
+    let (fw, fh) = (frame_w as f64, frame_h as f64);
+    let mut sorted = dets.to_vec();
+    sorted.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut out = Vec::new();
+    for det in sorted {
+        let x = (det.x1 as f64 / fw).clamp(0.0, 1.0);
+        let y = (det.y1 as f64 / fh).clamp(0.0, 1.0);
+        let width = (det.width() as f64 / fw).clamp(0.0, 1.0);
+        let height = (det.height() as f64 / fh).clamp(0.0, 1.0);
+        if width <= 0.0 || height <= 0.0 {
+            continue;
+        }
+        let index = out.len() + 1;
+        out.push(json!({
+            "id": format!("person_{index}"),
+            "label": format!("Person {index}"),
+            "box": { "x": x, "y": y, "width": width, "height": height },
+            "confidence": (det.score as f64 * 10000.0).round() / 10000.0,
+            "frameWidth": frame_w,
+            "frameHeight": frame_h,
+            "maskState": "missing",
+        }));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// onnxruntime detector (cached process-wide like Python's lazy model load)
+// ---------------------------------------------------------------------------
+
+struct Detector {
+    session: Session,
+    device: &'static str,
+}
+
+static DETECTOR: OnceLock<Mutex<Option<Detector>>> = OnceLock::new();
+
+fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
+    WorkerError::InvalidPayload(format!("onnxruntime: {e}"))
+}
+
+fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
+    let mut b = Session::builder().map_err(ort_err)?;
+    if coreml {
+        b = b
+            .with_execution_providers([CoreMLExecutionProvider::default().build()])
+            .map_err(ort_err)?;
+    }
+    b.commit_from_file(path).map_err(ort_err)
+}
+
+impl Detector {
+    fn load(path: &Path) -> WorkerResult<Self> {
+        match build_session(path, true) {
+            Ok(session) => Ok(Self {
+                session,
+                device: "coreml",
+            }),
+            Err(_) => Ok(Self {
+                session: build_session(path, false)?,
+                device: "cpu",
+            }),
+        }
+    }
+
+    fn detect(&mut self, img: &RgbImage, conf: f32) -> WorkerResult<Vec<Detection>> {
+        let (input, lb) = preprocess(img);
+        let tensor = Tensor::from_array(([1_i64, 3, DET as i64, DET as i64].to_vec(), input))
+            .map_err(ort_err)?;
+        let outputs = self.session.run(ort::inputs![tensor]).map_err(ort_err)?;
+        let (shp, data) = outputs[0].try_extract_tensor::<f32>().map_err(ort_err)?;
+        let shape = shp.to_vec();
+        let raw = decode(data, &shape, &lb, conf, img.width(), img.height());
+        Ok(nms(raw, NMS_IOU))
+    }
+}
+
+/// Person detections for one frame, plus the device the model ran on.
+pub(crate) struct DetectResult {
+    pub width: u32,
+    pub height: u32,
+    pub detections: Vec<Detection>,
+    pub device: &'static str,
+}
+
+/// Blocking person detection on a single rendered frame. All `ort` state lives
+/// inside this call (built once, cached process-wide) and never crosses an
+/// await; invoke via `spawn_blocking`.
+pub(crate) fn detect_people_blocking(
+    onnx_path: PathBuf,
+    image_path: PathBuf,
+    conf: f32,
+) -> WorkerResult<DetectResult> {
+    let img = image::open(&image_path)
+        .map_err(|e| WorkerError::InvalidPayload(format!("person frame open: {e}")))?
+        .to_rgb8();
+    let (width, height) = (img.width(), img.height());
+
+    let cell = DETECTOR.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().expect("person detector mutex poisoned");
+    if guard.is_none() {
+        *guard = Some(Detector::load(&onnx_path)?);
+    }
+    let detector = guard.as_mut().expect("detector loaded");
+    let device = detector.device;
+    let detections = detector.detect(&img, conf)?;
+    Ok(DetectResult {
+        width,
+        height,
+        detections,
+        device,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// weights resolution (download-on-first-use lands in slice 4 / sc-3636)
+// ---------------------------------------------------------------------------
+
+/// Resolve the detector onnx: explicit env pin (`SCENEWORKS_PERSON_DETECTOR_ONNX`),
+/// then the app cache `<data_dir>/cache/person-detect/`, then the model dir
+/// `<data_dir>/models/person-detect/`. Returns `None` when no weight is present
+/// (slice 4 adds download-on-first-use so the Mac is provisioned automatically).
+pub(crate) fn resolve_detector_onnx(settings: &Settings) -> Option<PathBuf> {
+    if let Ok(pinned) = std::env::var("SCENEWORKS_PERSON_DETECTOR_ONNX") {
+        let path = PathBuf::from(pinned);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    for sub in ["cache/person-detect", "models/person-detect"] {
+        let candidate = settings.data_dir.join(sub).join(DET_FILE);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -3,12 +3,14 @@
 //! Ports the Python `scene_worker/person_adapters.py` `_UltralyticsDetector`
 //! (Ultralytics `yolo11m.pt`, COCO class 0) to Rust so the Replace-Person
 //! detection step runs on a Python-free Mac. Inference uses the `ort`
-//! (onnxruntime) + CoreML execution-provider scaffold proven by `pose_jobs.rs`
-//! (sc-3487): a process-wide cached `Session`, CoreML→CPU fallback, and all
-//! `ort` objects confined to a `spawn_blocking` closure.
+//! (onnxruntime) scaffold proven by `pose_jobs.rs` (sc-3487): a process-wide
+//! cached `Session` and all `ort` objects confined to a `spawn_blocking`
+//! closure. Unlike `pose_jobs`, this runs on the **CPU EP by default** — the
+//! CoreML EP hangs in `commit_from_file` on the Ultralytics YOLO11 export (see
+//! `Detector::load`); CoreML is opt-in via `SCENEWORKS_PERSON_DETECTOR_COREML=1`.
 //!
-//! macOS-only in practice: the CoreML EP only matters on Apple Silicon, and the
-//! Python Ultralytics path stays the Windows/Linux detector. The pure detector
+//! macOS-only in practice: it gates with `pose_jobs`, and the Python Ultralytics
+//! path stays the Windows/Linux detector. The pure detector
 //! math (letterbox / decode / NMS / box normalization) is unit-tested without
 //! the onnx weights; only the onnxruntime inference itself is gated.
 //!
@@ -306,17 +308,30 @@ fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
 }
 
 impl Detector {
+    /// Build the cached detector. Unlike `pose_jobs` (YOLOX), the CoreML EP
+    /// *hangs* indefinitely in `commit_from_file` on the Ultralytics YOLO11
+    /// export — it never returns an error, so a try-CoreML-then-fall-back is
+    /// unsafe (it would deadlock the job). The CPU EP runs YOLO11m fine and is
+    /// what the Python reference (onnxruntime `CPUExecutionProvider`) used; for
+    /// a single representative frame / 2-fps tracking it's well within budget.
+    /// CoreML stays opt-in via `SCENEWORKS_PERSON_DETECTOR_COREML=1` for future
+    /// investigation (export-opset / MLProgram tweaks); see sc-3633 notes.
     fn load(path: &Path) -> WorkerResult<Self> {
-        match build_session(path, true) {
-            Ok(session) => Ok(Self {
-                session,
-                device: "coreml",
-            }),
-            Err(_) => Ok(Self {
-                session: build_session(path, false)?,
-                device: "cpu",
-            }),
+        let try_coreml = std::env::var("SCENEWORKS_PERSON_DETECTOR_COREML")
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if try_coreml {
+            if let Ok(session) = build_session(path, true) {
+                return Ok(Self {
+                    session,
+                    device: "coreml",
+                });
+            }
         }
+        Ok(Self {
+            session: build_session(path, false)?,
+            device: "cpu",
+        })
     }
 
     fn detect(&mut self, img: &RgbImage, conf: f32) -> WorkerResult<Vec<Detection>> {

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -1,0 +1,210 @@
+//! Unit tests for the YOLO11 person detector (sc-3633). The pure detector math
+//! (letterbox / decode / NMS / normalization) is covered without weights; the
+//! `#[ignore]` parity test runs the real `yolo11m.onnx` against a captured
+//! `ultralytics.predict` reference when the weights are staged in the app cache.
+
+use super::*;
+use std::path::PathBuf;
+
+#[test]
+fn letterbox_centers_pad_on_the_short_axis() {
+    // bus.jpg is 810×1080 (w×h): fit-by-height → 480×640, 80px pad each side in x.
+    let lb = Letterbox::compute(810, 1080);
+    assert!((lb.ratio - 0.59259).abs() < 1e-4, "ratio {}", lb.ratio);
+    assert_eq!(lb.pad_x, 80.0);
+    assert_eq!(lb.pad_y, 0.0);
+}
+
+#[test]
+fn un_letterbox_inverts_the_forward_mapping() {
+    let lb = Letterbox::compute(810, 1080);
+    // A point at original (300, 540) maps forward then back to itself.
+    let fx = 300.0 * lb.ratio + lb.pad_x;
+    let fy = 540.0 * lb.ratio + lb.pad_y;
+    assert!((lb.un_x(fx) - 300.0).abs() < 1e-3);
+    assert!((lb.un_y(fy) - 540.0).abs() < 1e-3);
+}
+
+#[test]
+fn decode_keeps_person_anchors_above_conf_and_builds_xyxy() {
+    // (1,6,2): 4 box channels + 2 class channels, 2 anchors, channel-major.
+    let shape = [1_i64, 6, 2];
+    // anchor0: strong person; anchor1: below conf.
+    let data = vec![
+        100.0, 200.0, // cx
+        100.0, 200.0, // cy
+        40.0, 10.0, // w
+        80.0, 10.0, // h
+        0.9, 0.1, // class0 = person
+        0.1, 0.05, // class1 = other
+    ];
+    let lb = Letterbox {
+        ratio: 1.0,
+        pad_x: 0.0,
+        pad_y: 0.0,
+    };
+    let dets = decode(&data, &shape, &lb, 0.25, 640, 640);
+    assert_eq!(dets.len(), 1, "only the above-conf person anchor survives");
+    let d = dets[0];
+    assert!((d.x1 - 80.0).abs() < 1e-3);
+    assert!((d.y1 - 60.0).abs() < 1e-3);
+    assert!((d.x2 - 120.0).abs() < 1e-3);
+    assert!((d.y2 - 140.0).abs() < 1e-3);
+    assert!((d.score - 0.9).abs() < 1e-6);
+}
+
+#[test]
+fn decode_clamps_boxes_to_the_frame() {
+    let shape = [1_i64, 5, 1];
+    // A box hanging off the top-left corner.
+    let data = vec![10.0, 10.0, 60.0, 60.0, 0.9];
+    let lb = Letterbox {
+        ratio: 1.0,
+        pad_x: 0.0,
+        pad_y: 0.0,
+    };
+    let dets = decode(&data, &shape, &lb, 0.25, 640, 640);
+    assert_eq!(dets.len(), 1);
+    assert_eq!(dets[0].x1, 0.0);
+    assert_eq!(dets[0].y1, 0.0);
+}
+
+#[test]
+fn nms_drops_high_overlap_keeps_disjoint() {
+    let strong = Detection {
+        x1: 0.0,
+        y1: 0.0,
+        x2: 100.0,
+        y2: 100.0,
+        score: 0.9,
+    };
+    let overlap = Detection {
+        x1: 5.0,
+        y1: 5.0,
+        x2: 105.0,
+        y2: 105.0,
+        score: 0.8,
+    };
+    let disjoint = Detection {
+        x1: 400.0,
+        y1: 400.0,
+        x2: 500.0,
+        y2: 500.0,
+        score: 0.7,
+    };
+    let kept = nms(vec![overlap, disjoint, strong], NMS_IOU);
+    assert_eq!(kept.len(), 2, "overlapping duplicate suppressed");
+    assert!((kept[0].score - 0.9).abs() < 1e-6, "highest score first");
+    assert!(kept.iter().any(|d| (d.score - 0.7).abs() < 1e-6));
+}
+
+#[test]
+fn detections_to_json_normalizes_orders_and_drops_degenerate() {
+    let dets = vec![
+        Detection {
+            x1: 64.0,
+            y1: 72.0,
+            x2: 320.0,
+            y2: 360.0,
+            score: 0.5,
+        },
+        Detection {
+            x1: 0.0,
+            y1: 0.0,
+            x2: 128.0,
+            y2: 72.0,
+            score: 0.95,
+        },
+        // degenerate (zero width) — dropped.
+        Detection {
+            x1: 10.0,
+            y1: 10.0,
+            x2: 10.0,
+            y2: 50.0,
+            score: 0.99,
+        },
+    ];
+    let json = detections_to_json(&dets, 640, 360);
+    assert_eq!(json.len(), 2, "degenerate box dropped");
+    // Confidence-descending: the 0.95 box becomes person_1.
+    assert_eq!(json[0]["id"], "person_1");
+    assert_eq!(json[0]["label"], "Person 1");
+    assert!((json[0]["confidence"].as_f64().unwrap() - 0.95).abs() < 1e-9);
+    let b = &json[0]["box"];
+    assert!((b["x"].as_f64().unwrap() - 0.0).abs() < 1e-9);
+    assert!((b["width"].as_f64().unwrap() - 0.2).abs() < 1e-9); // 128/640
+    assert!((b["height"].as_f64().unwrap() - 0.2).abs() < 1e-9); // 72/360
+    assert_eq!(json[1]["id"], "person_2");
+    assert_eq!(json[0]["frameWidth"], 640);
+    assert_eq!(json[0]["maskState"], "missing");
+}
+
+/// Cache fixtures staged during development (sc-3633): the exported detector,
+/// the bus.jpg test image, and the `ultralytics.predict` reference detections.
+fn cache_fixture(name: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let path = PathBuf::from(home)
+        .join("Library/Application Support/SceneWorks/cache/person-detect")
+        .join(name);
+    path.exists().then_some(path)
+}
+
+/// Real-weights parity: the Rust detector must reproduce `ultralytics.predict`
+/// on bus.jpg (4 people). Ignored by default — run with the model + fixtures
+/// staged in the app cache:
+///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
+#[test]
+#[ignore = "requires staged yolo11m.onnx + bus.jpg fixtures in the app cache"]
+fn yolo11_matches_ultralytics_reference_on_bus() {
+    let (Some(onnx), Some(image), Some(reference)) = (
+        cache_fixture("yolo11m.onnx"),
+        cache_fixture("people.jpg"),
+        cache_fixture("ref_people.json"),
+    ) else {
+        eprintln!("skipping: fixtures not staged");
+        return;
+    };
+
+    let result = detect_people_blocking(onnx, image, 0.25).expect("detection runs");
+    eprintln!(
+        "device={} detections={}",
+        result.device,
+        result.detections.len()
+    );
+    assert_eq!((result.width, result.height), (810, 1080), "bus.jpg dims");
+
+    let ref_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(reference).unwrap()).unwrap();
+    let ref_dets = ref_json["dets"].as_array().unwrap();
+    assert_eq!(
+        result.detections.len(),
+        ref_dets.len(),
+        "person count must match ultralytics ({} ref)",
+        ref_dets.len()
+    );
+
+    // Each reference box must have a Rust box within ~2px corners + ~0.02 conf.
+    let mut rust = result.detections.clone();
+    rust.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    for r in ref_dets {
+        let rb = r["xyxy"].as_array().unwrap();
+        let (rx1, ry1, rx2, ry2) = (
+            rb[0].as_f64().unwrap() as f32,
+            rb[1].as_f64().unwrap() as f32,
+            rb[2].as_f64().unwrap() as f32,
+            rb[3].as_f64().unwrap() as f32,
+        );
+        let rconf = r["conf"].as_f64().unwrap() as f32;
+        let matched = rust.iter().find(|d| {
+            (d.x1 - rx1).abs() < 2.0
+                && (d.y1 - ry1).abs() < 2.0
+                && (d.x2 - rx2).abs() < 2.0
+                && (d.y2 - ry2).abs() < 2.0
+                && (d.score - rconf).abs() < 0.02
+        });
+        assert!(
+            matched.is_some(),
+            "no Rust box matches ref [{rx1},{ry1},{rx2},{ry2}] conf {rconf}"
+        );
+    }
+}

--- a/docs/sc-3633-mlx-port.md
+++ b/docs/sc-3633-mlx-port.md
@@ -1,0 +1,68 @@
+# sc-3633 — YOLO11 person detector: MLX port plan (epic 3482 / sc-3488)
+
+**Decision (Michael, 2026-06-08):** the detector inference backend is **MLX (mlx-rs)**, not
+`ort`+CoreML. The whole Mac stack is MLX; and the CoreML EP *hangs indefinitely* in
+`commit_from_file` on the Ultralytics YOLO11 ONNX export (clean single-process repro,
+0% CPU at 180s, never errors → no fallback). The `ort` path is abandoned for this model.
+
+## What is already done + verified (committed on this branch)
+
+- `crates/sceneworks-worker/src/person_jobs.rs`: letterbox → decode → NMS → f64 normalize
+  (Python `run_person_detect` shape) + `media_jobs.rs` preview/real wiring. **Backend-agnostic.**
+- **Real-weights parity PASS:** the exact Rust letterbox+decode+NMS pipeline, replicated in
+  Python on the real `yolo11m.onnx`, reproduces `ultralytics.predict`'s 4 person boxes on
+  `bus.jpg` to ≤0.1px / 0.001 conf. So the decode that runs *on top of* the model output is proven.
+- The committed `Detector` (ort `Session`) is the only piece that gets replaced.
+
+## The MLX port: produce the same `(1,84,8400)` tensor, then existing decode runs unchanged
+
+### Weights (already converted + staged)
+`~/Library/Application Support/SceneWorks/cache/person-detect/yolo11m_fused_mlx.safetensors`
+- 225 tensors, **conv+BN fused** (via ultralytics `model.fuse()`), so the forward needs no BN.
+- Conv weights are **MLX layout `(out, kH, kW, in)`** (already transposed from torch `(o,i,kh,kw)`),
+  so load raw — do NOT run them through the engine's `conv2d_weight` (that would transpose again).
+- Keys mirror the fused torch state_dict (`model.<i>....conv.weight`/`.conv.bias`; bare detect
+  convs `model.23.cv2.*.2.{weight,bias}`, `model.23.cv3.*.2.*`, `model.23.dfl.conv.weight`).
+- Reproduce: `YOLO("yolo11m.pt").model.fuse()`, transpose 4-D weights `(0,2,3,1)`, save f32 safetensors.
+
+### Parity oracle (already captured)
+`…/cache/person-detect/refs.safetensors`: `input` (1,3,640,640, my exact letterbox of bus.jpg),
+plus block outputs `block4/10/16/19/22` and `final` (1,84,8400). Build the forward block-by-block
+and assert max-abs-diff vs these (NCHW; MLX runs NHWC → transpose for compare).
+
+### Dataflow (`…/cache/person-detect/dataflow.json`) — 24 blocks
+backbone: 0 Conv, 1 Conv, 2 C3k2, 3 Conv, 4 C3k2, 5 Conv, 6 C3k2, 7 Conv, 8 C3k2, 9 SPPF, 10 C2PSA;
+neck: 11 Upsample, 12 Concat[-1,6], 13 C3k2, 14 Upsample, 15 Concat[-1,4], 16 C3k2, 17 Conv,
+18 Concat[-1,13], 19 C3k2, 20 Conv, 21 Concat[-1,10], 22 C3k2; head: 23 Detect[16,19,22].
+Save-list outputs needed later for Concat: blocks 4, 6, 10, 13. (NHWC concat is on the channel axis = last.)
+
+### Module → engine-primitive mapping
+- **Conv** (ultralytics) = `mlx_gen::nn::conv2d(x, w, Some(b), stride, pad)` then `silu`. (k3s2p1 downsamples; k1s1p0 pointwise.)
+- **Bottleneck** = Conv(k3) → Conv(k3), optional residual add (`mlx_rs::ops::add`).
+- **C3k** = CSP: split cv1 output in half (channel), n× Bottleneck on one half, concat, cv2.
+- **C3k2** = C2f-style: cv1 → split → n× (C3k or Bottleneck) chained, concat all, cv2. (`c3k` flag per block; m-scale: blocks 2/4 use Bottleneck, 6/8/13/16/19/22 use C3k — confirm per `.m[*]` type at convert time and bake into config.)
+- **SPPF** = cv1 → x, p1=maxpool5(x), p2=maxpool5(p1), p3=maxpool5(p2) → concat[x,p1,p2,p3] → cv2.
+  maxpool 5×5 s1 p2: no pooling op in mlx_rs → `pad` by 2 with −inf then 24× `maximum` over shifts (or implement a small helper).
+- **C2PSA** = cv1 → split → PSABlock(attn + FFN) on one half → concat → cv2.
+  - Attention: qkv = conv1×1; split q,k,v; MHA with `matmul` + `softmax_axis(-1)`; proj conv. (head dim from `Attention` cfg.)
+- **Upsample** = `mlx_gen::nn::upsample_nearest(x, 2)`.
+- **Concat** = `mlx_rs::ops::concatenate_axis(&[...], -1)` (channel-last).
+- **Detect head (block 23)**: three branches (cv2 box-reg → 64ch, cv3 cls → 80ch). Then:
+  - DFL: box-reg reshape `(b, 4, 16, A)` → `softmax_axis(2)` → matmul with `[0..15]` → `(b,4,A)` distances.
+  - dist2bbox with **precomputed anchor points + strides** (grids at strides 8/16/32 for 640 → 80²+40²+20²=8400 anchors; anchor = cell center +0.5; ltrb → xywh in input px). Compute these as Rust constants.
+  - cls = `sigmoid`. Concat `[xywh(4), cls(80)]` on axis1 → `(1,84,8400)` == `refs.final`. Existing `decode()` consumes this.
+
+### Where it plugs in
+Replace `Detector`/`build_session`/ort imports in `person_jobs.rs` with a `YoloMlx` struct
+(load weights once, cached like the ort one), `detect(img)->Vec<Detection>` = preprocess (reuse
+existing letterbox, but emit NHWC f32 Array) → forward → existing `decode`+`nms`. Keep the
+`spawn_blocking` + process-wide cache. Drop the `ort`/`zip` use for person-detect (ort stays for pose_jobs).
+
+### Parity test
+`#[ignore]` test: load `refs.safetensors`, run forward, assert per-block + final max-abs-diff < ~1e-3
+(fused-conv fp32), then run `decode`+`nms` and assert the 4 bus.jpg boxes vs `ref_people.json` (≤2px).
+
+## Open API confirmations for the next session
+- The engine `Weights` loader: how to construct from a `.safetensors` path + `.require(name)->Array`
+  (used across mlx-gen; e.g. `mlx-gen-wan/tests/*` `fn load(name)->Weights`). Confirm the public path.
+- `Array` channel-split (`split`/slicing) + `transpose_axes` for the NCHW↔NHWC compares.


### PR DESCRIPTION
Slice 1 of sc-3488 (epic 3482, Python Eradication): port the Ultralytics YOLO11 person detector to the Rust worker so `person_detect` runs Python-free on Mac.

**Draft / checkpoint.** Banks the verified decode pipeline + worker wiring + the MLX-port plan; the native MLX forward pass lands as follow-up commits on this branch.

## What's here
- `person_jobs.rs`: letterbox → decode (`(1,84,8400)` channel-major, person=class 0) → NMS (iou 0.7) → f64 normalize (Python `run_person_detect` shape); process-wide cached `ort` Session via `spawn_blocking`.
- `media_jobs.rs`: `run_person_detect` branches preview→procedural / real→detector (macOS), erroring honestly when weights are absent rather than degrading silently.
- `lib.rs`: macOS-gated `person_jobs` module.
- `person_jobs/tests.rs`: pure-math unit tests + an `#[ignore]` real-weights parity test.
- `docs/sc-3633-mlx-port.md`: the MLX port plan (dataflow, fused-weight scheme, oracle, DFL/anchor decode).

## Backend: ort → MLX
The whole Mac stack is MLX, and the **ort CoreML EP hangs indefinitely** compiling the YOLO11 export (clean single-process repro: 0% CPU at 180s, never errors → no CoreML→CPU fallback can fire). This PR defaults the detector to the CPU EP (what the Python reference uses); the next commits replace `ort` with a native mlx-rs YOLO11 forward. The decode / NMS / letterbox + wiring + tests here are **backend-agnostic** and carry over unchanged — only the inference call swaps.

## Verification
- fmt clean · clippy `-D warnings` clean · 6/6 `person_jobs` unit tests pass.
- **Real-weights decode parity PASS:** the exact Rust pipeline replicated in Python on the real `yolo11m.onnx` reproduces `ultralytics.predict`'s 4 person boxes on bus.jpg to ≤0.1px / 0.001 conf.

## Caveats
- Delivers detector **infra only**; `replace_person` end-to-end on Mac still needs epic 3040 (video-gen/inpaint half), which is torch-only today.
- Branched off `dd429e7`; `main` has since advanced — may need a rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)