### PR TITLE
sc-3633: native MLX YOLO11 person detector forward pass + download-on-first-use

### DIFF
--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -33,14 +33,6 @@ uuid = { version = "1.11", features = ["v4"] }
 axum = "0.7"
 tower = { version = "0.5", features = ["util"] }
 
-# macOS NAX-presence guard (tests/nax_guard.rs): exercises a 16-bit fused SDPA op
-# directly against mlx-rs to prove the workspace .cargo/config.toml deployment-target
-# pin is in effect. Pinned to the SAME rev mlx-gen uses so Cargo builds MLX once
-# (a different rev would compile pmetal-mlx-sys twice). mlx-gen itself is already a
-# (macOS) dependency above and is usable from integration tests as-is.
-[target.'cfg(target_os = "macos")'.dev-dependencies]
-mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-
 # Native MLX image+video inference engine (epic 2337), linked in-process so the
 # Rust GPU worker dispatches generation with no Python adapter/sidecar (epic 3018).
 # macOS-only: mlx-gen builds Apple MLX from source and is meaningless off Apple
@@ -86,6 +78,13 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical
 # across the bump -> no MLX rebuild).
 mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+# `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
+# detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
+# not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
+# and the DFL/anchor decode. Pinned to the SAME rev mlx-gen uses so MLX builds once
+# (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
+# guard test (tests/nax_guard.rs).
+mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
 mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -592,7 +592,7 @@ async fn run_utility_job(
         JobType::TimelineExport => run_timeline_export_job(api, settings, &job)
             .await
             .map_err(|error| ("Timeline export failed.", error)),
-        JobType::PersonDetect => run_person_detect_job(api, settings, &job)
+        JobType::PersonDetect => run_person_detect_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Person detection failed.", error)),
         // DWPose whole-body pose detection (epic 3482, sc-3487): RTMW via

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -442,9 +442,9 @@ pub(crate) async fn run_person_detect(
             (
                 boxes,
                 "yolo11m".to_owned(),
-                "yolo11_ort",
+                "yolo11_mlx",
                 true,
-                json!({ "backend": "ort", "device": device, "model": "yolo11m" }),
+                json!({ "backend": "mlx", "device": device, "model": "yolo11m" }),
             )
         };
     let source_display_name = source_asset
@@ -558,9 +558,9 @@ pub(crate) async fn run_person_detect(
     Ok(result)
 }
 
-/// Run the YOLO11 onnx person detector on a rendered frame, returning the
+/// Run the native MLX YOLO11 person detector on a rendered frame, returning the
 /// normalized detection array (Python `run_person_detect` shape) + the device
-/// the model ran on. macOS-only: `ort`/CoreML is the Apple-Silicon backend
+/// the model ran on. macOS-only: MLX (mlx-rs) is the Apple-Silicon backend
 /// (epic 3482, sc-3633); the Python Ultralytics path serves Windows/Linux.
 #[cfg(target_os = "macos")]
 async fn run_yolo11_person_detect(
@@ -568,14 +568,15 @@ async fn run_yolo11_person_detect(
     frame_path: PathBuf,
     confidence: f64,
 ) -> WorkerResult<(Vec<Value>, &'static str)> {
-    let onnx = crate::person_jobs::resolve_detector_onnx(settings).ok_or_else(|| {
+    let weights = crate::person_jobs::resolve_detector_weights(settings).ok_or_else(|| {
         WorkerError::InvalidPayload(
-            "Person detector weights (yolo11m.onnx) are not provisioned on this worker.".to_owned(),
+            "Person detector weights (yolo11m_fused_mlx.safetensors) are not provisioned on this worker."
+                .to_owned(),
         )
     })?;
     let conf = confidence as f32;
     let result = tokio::task::spawn_blocking(move || {
-        crate::person_jobs::detect_people_blocking(onnx, frame_path, conf)
+        crate::person_jobs::detect_people_blocking(weights, frame_path, conf)
     })
     .await
     .map_err(|error| WorkerError::InvalidPayload(format!("person detect task: {error}")))??;

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -288,6 +288,7 @@ pub(crate) async fn run_frame_extract(
 pub(crate) async fn run_person_detect_job(
     api: &ApiClient,
     settings: &Settings,
+    http_client: &reqwest::Client,
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
@@ -326,7 +327,7 @@ pub(crate) async fn run_person_detect_job(
         ),
     )
     .await?;
-    let result = run_person_detect(api, settings, job).await?;
+    let result = run_person_detect(api, settings, http_client, job).await?;
     update_job(
         api,
         &job.id,
@@ -347,6 +348,7 @@ pub(crate) async fn run_person_detect_job(
 pub(crate) async fn run_person_detect(
     api: &ApiClient,
     settings: &Settings,
+    http_client: &reqwest::Client,
     job: &JobSnapshot,
 ) -> WorkerResult<JsonObject> {
     let project_id = required_payload_string(&job.payload, "projectId")?;
@@ -438,7 +440,8 @@ pub(crate) async fn run_person_detect(
             )
         } else {
             let (boxes, device) =
-                run_yolo11_person_detect(settings, media_path.clone(), confidence).await?;
+                run_yolo11_person_detect(settings, http_client, media_path.clone(), confidence)
+                    .await?;
             (
                 boxes,
                 "yolo11m".to_owned(),
@@ -565,15 +568,11 @@ pub(crate) async fn run_person_detect(
 #[cfg(target_os = "macos")]
 async fn run_yolo11_person_detect(
     settings: &Settings,
+    http_client: &reqwest::Client,
     frame_path: PathBuf,
     confidence: f64,
 ) -> WorkerResult<(Vec<Value>, &'static str)> {
-    let weights = crate::person_jobs::resolve_detector_weights(settings).ok_or_else(|| {
-        WorkerError::InvalidPayload(
-            "Person detector weights (yolo11m_fused_mlx.safetensors) are not provisioned on this worker."
-                .to_owned(),
-        )
-    })?;
+    let weights = crate::person_jobs::ensure_detector_weights(settings, http_client).await?;
     let conf = confidence as f32;
     let result = tokio::task::spawn_blocking(move || {
         crate::person_jobs::detect_people_blocking(weights, frame_path, conf)
@@ -588,6 +587,7 @@ async fn run_yolo11_person_detect(
 #[cfg(not(target_os = "macos"))]
 async fn run_yolo11_person_detect(
     _settings: &Settings,
+    _http_client: &reqwest::Client,
     _frame_path: PathBuf,
     _confidence: f64,
 ) -> WorkerResult<(Vec<Value>, &'static str)> {

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -61,6 +61,11 @@ const PAD_VALUE: f32 = 114.0;
 const NMS_IOU: f32 = 0.7;
 /// The fused MLX-layout detector weights in the app cache / model dir.
 const DET_FILE: &str = "yolo11m_fused_mlx.safetensors";
+/// HuggingFace download URL for the fused weights (download-on-first-use, slice 4 /
+/// sc-3636). Public repo, so no credentials are needed — same shape as the DWPose
+/// openmmlab bundles (`pose_jobs`).
+const DET_URL: &str =
+    "https://huggingface.co/SceneWorks/yolo11m-person-detect-mlx/resolve/main/yolo11m_fused_mlx.safetensors";
 
 // ---------------------------------------------------------------------------
 // pure detector math (unit-tested without weights)
@@ -710,14 +715,14 @@ pub(crate) fn detect_people_blocking(
 }
 
 // ---------------------------------------------------------------------------
-// weights resolution (download-on-first-use lands in slice 4 / sc-3636)
+// weights resolution + download-on-first-use
 // ---------------------------------------------------------------------------
 
-/// Resolve the fused MLX detector weights: explicit env pin
+/// Resolve already-present fused MLX detector weights: explicit env pin
 /// (`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`), then the app cache
 /// `<data_dir>/cache/person-detect/`, then the model dir
-/// `<data_dir>/models/person-detect/`. Returns `None` when no weight is present
-/// (slice 4 adds download-on-first-use so the Mac is provisioned automatically).
+/// `<data_dir>/models/person-detect/`. Returns `None` when nothing is staged (then
+/// `ensure_detector_weights` downloads it).
 pub(crate) fn resolve_detector_weights(settings: &Settings) -> Option<PathBuf> {
     if let Ok(pinned) = std::env::var("SCENEWORKS_PERSON_DETECTOR_WEIGHTS") {
         let path = PathBuf::from(pinned);
@@ -732,6 +737,32 @@ pub(crate) fn resolve_detector_weights(settings: &Settings) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Resolve the fused MLX detector weights, downloading them from HuggingFace on first
+/// use (into the app cache). Mirrors `pose_jobs::ensure_one` — atomic `.tmp` + rename so
+/// a partial download is never mistaken for a complete one.
+pub(crate) async fn ensure_detector_weights(
+    settings: &Settings,
+    http_client: &reqwest::Client,
+) -> WorkerResult<PathBuf> {
+    if let Some(path) = resolve_detector_weights(settings) {
+        return Ok(path);
+    }
+    let cache = settings.data_dir.join("cache").join("person-detect");
+    tokio::fs::create_dir_all(&cache).await?;
+    let target = cache.join(DET_FILE);
+    let bytes = http_client
+        .get(DET_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    let tmp = target.with_extension("safetensors.tmp");
+    tokio::fs::write(&tmp, &bytes).await?;
+    tokio::fs::rename(&tmp, &target).await?;
+    Ok(target)
 }
 
 #[cfg(test)]

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -2,51 +2,65 @@
 //!
 //! Ports the Python `scene_worker/person_adapters.py` `_UltralyticsDetector`
 //! (Ultralytics `yolo11m.pt`, COCO class 0) to Rust so the Replace-Person
-//! detection step runs on a Python-free Mac. Inference uses the `ort`
-//! (onnxruntime) scaffold proven by `pose_jobs.rs` (sc-3487): a process-wide
-//! cached `Session` and all `ort` objects confined to a `spawn_blocking`
-//! closure. Unlike `pose_jobs`, this runs on the **CPU EP by default** — the
-//! CoreML EP hangs in `commit_from_file` on the Ultralytics YOLO11 export (see
-//! `Detector::load`); CoreML is opt-in via `SCENEWORKS_PERSON_DETECTOR_COREML=1`.
+//! detection step runs on a Python-free Mac.
 //!
-//! macOS-only in practice: it gates with `pose_jobs`, and the Python Ultralytics
-//! path stays the Windows/Linux detector. The pure detector
-//! math (letterbox / decode / NMS / box normalization) is unit-tested without
-//! the onnx weights; only the onnxruntime inference itself is gated.
+//! **Backend = native MLX (mlx-rs), not `ort`+CoreML** (Michael's call, 2026-06-08).
+//! The whole Mac stack is MLX (mlx-gen); and the `ort` CoreML EP *hangs indefinitely*
+//! in `commit_from_file` on the Ultralytics YOLO11 ONNX export, so the `ort` path was
+//! abandoned for this model. The YOLO11m forward pass is assembled here directly from
+//! `mlx_gen::nn` primitives (`conv2d`/`silu`/`upsample_nearest`) plus `mlx_rs::ops` for
+//! the CSP splits, depthwise convs, SPPF max-pool, C2PSA attention, and the DFL/anchor
+//! decode head — mirroring how DWPose (`pose_jobs`) lives in the worker rather than a
+//! new mlx-gen crate. Weights are the conv+BN-fused `yolo11m_fused_mlx.safetensors`
+//! (MLX `(out, kH, kW, in)` layout — loaded raw, no further transpose).
 //!
-//! Pipeline (matched to the Ultralytics YOLO11 ONNX export — verified against the
-//! real `yolo11m.onnx` + `ultralytics.predict`):
-//!  - input `images` (1,3,640,640) f32: letterbox to 640 (ratio=min(640/w,640/h),
-//!    pad 114 centered), RGB channel order, divided by 255. cv2 INTER_LINEAR
-//!    half-pixel sampling.
-//!  - output `output0` (1,84,8400), channel-major: rows 0..4 = cx,cy,w,h in
+//! macOS-only in practice: it gates with `pose_jobs`, and the Python Ultralytics path
+//! stays the Windows/Linux detector. The pure detector math (letterbox / decode / NMS /
+//! box normalization) is unit-tested without the weights; the forward pass is covered
+//! by an `#[ignore]` parity test against a captured per-block reference oracle.
+//!
+//! Pipeline (matched to the Ultralytics YOLO11 export — verified against the real
+//! `yolo11m.onnx` + `ultralytics.predict`):
+//!  - input `images` (1,640,640,3) f32 NHWC: letterbox to 640 (ratio=min(640/w,640/h),
+//!    pad 114 centered), RGB channel order, divided by 255. cv2 INTER_LINEAR half-pixel
+//!    sampling.
+//!  - the forward produces `(1,84,8400)` channel-major: rows 0..4 = cx,cy,w,h in
 //!    letterbox px; rows 4..84 = 80 sigmoid class scores in [0,1] (no separate
 //!    objectness). Person = class 0 → channel 4.
-//!  - decode: keep anchors whose person score > conf, cx/cy/w/h → xyxy, subtract
-//!    the letterbox pad and divide by the ratio back into original px, clamp to
-//!    the frame, then greedy NMS at the Ultralytics default IoU 0.7.
+//!  - decode: keep anchors whose person score > conf, cx/cy/w/h → xyxy, subtract the
+//!    letterbox pad and divide by the ratio back into original px, clamp to the frame,
+//!    then greedy NMS at the Ultralytics default IoU 0.7.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use image::RgbImage;
-use ort::execution_providers::CoreMLExecutionProvider;
-use ort::session::Session;
-use ort::value::Tensor;
 use serde_json::{json, Value};
+
+use mlx_gen::nn::{conv2d, silu, upsample_nearest};
+use mlx_gen::weights::Weights;
+use mlx_gen::Result as MlxResult;
+use mlx_rs::ops::indexing::TryIndexOp;
+use mlx_rs::ops::{
+    add, concatenate_axis, matmul, maximum, multiply, pad, sigmoid, softmax_axis, split,
+    split_sections, subtract, sum_axis,
+};
+use mlx_rs::Array;
 
 use crate::{Settings, WorkerError, WorkerResult};
 
 /// Square detector input edge (the YOLO11 export is fixed 640×640).
 const DET: usize = 640;
+/// Total anchor count across the three detect scales (80²+40²+20²).
+const ANCHORS: i32 = 8400;
 /// COCO "person" class index, matching Python `PERSON_CLASS_INDEX`.
 const PERSON_CLASS: usize = 0;
 /// Letterbox padding value (Ultralytics default), pre-`/255`.
 const PAD_VALUE: f32 = 114.0;
 /// Greedy-NMS IoU threshold — Ultralytics `predict` default (`iou=0.7`).
 const NMS_IOU: f32 = 0.7;
-/// The detector onnx filename in the app cache / model dir.
-const DET_FILE: &str = "yolo11m.onnx";
+/// The fused MLX-layout detector weights in the app cache / model dir.
+const DET_FILE: &str = "yolo11m_fused_mlx.safetensors";
 
 // ---------------------------------------------------------------------------
 // pure detector math (unit-tested without weights)
@@ -74,8 +88,8 @@ impl Detection {
     }
 }
 
-/// Letterbox geometry: the resize ratio and the centered left/top pad (px) in
-/// the 640 input. `un_letterbox` inverts it back to original-frame px.
+/// Letterbox geometry: the resize ratio and the centered left/top pad (px) in the 640
+/// input. `un_x`/`un_y` invert it back to original-frame px.
 #[derive(Clone, Copy, Debug)]
 struct Letterbox {
     ratio: f32,
@@ -108,8 +122,8 @@ impl Letterbox {
     }
 }
 
-/// Bilinear sample of an RGB channel (0=R,1=G,2=B) at (x,y); out-of-bounds →
-/// `border`. cv2 INTER_LINEAR half-pixel convention is applied by the caller.
+/// Bilinear sample of an RGB channel (0=R,1=G,2=B) at (x,y); out-of-bounds → `border`.
+/// cv2 INTER_LINEAR half-pixel convention is applied by the caller.
 #[inline]
 fn sample_rgb(img: &RgbImage, x: f32, y: f32, c: usize, border: f32) -> f32 {
     let (w, h) = (img.width() as i64, img.height() as i64);
@@ -133,7 +147,8 @@ fn sample_rgb(img: &RgbImage, x: f32, y: f32, c: usize, border: f32) -> f32 {
     top * (1.0 - fy) + bot * fy
 }
 
-/// Build the (1,3,640,640) RGB `/255` letterboxed input and return the geometry.
+/// Build the (1,640,640,3) RGB `/255` letterboxed input in **NHWC** order (the layout
+/// `mlx_gen::nn::conv2d` expects) and return the geometry.
 fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
     let lb = Letterbox::compute(img.width(), img.height());
     let (w, h) = (img.width() as f32, img.height() as f32);
@@ -146,14 +161,15 @@ fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
     let pad_x = lb.pad_x as usize;
     let pad_y = lb.pad_y as usize;
 
-    let mut chw = vec![PAD_VALUE / 255.0; 3 * DET * DET];
-    for c in 0..3 {
-        let plane = c * DET * DET;
-        for dy in 0..new_h {
-            let src_y = (dy as f32 + 0.5) * sy - 0.5; // cv2 INTER_LINEAR half-pixel
-            let row = plane + (dy + pad_y) * DET + pad_x;
-            for dx in 0..new_w {
-                let src_x = (dx as f32 + 0.5) * sx - 0.5;
+    // NHWC: hwc[(y * DET + x) * 3 + c].
+    let mut hwc = vec![PAD_VALUE / 255.0; DET * DET * 3];
+    for dy in 0..new_h {
+        let src_y = (dy as f32 + 0.5) * sy - 0.5; // cv2 INTER_LINEAR half-pixel
+        let row = ((dy + pad_y) * DET + pad_x) * 3;
+        for dx in 0..new_w {
+            let src_x = (dx as f32 + 0.5) * sx - 0.5;
+            let base = row + dx * 3;
+            for c in 0..3 {
                 let v = sample_rgb(
                     img,
                     src_x.clamp(0.0, w - 1.0),
@@ -161,11 +177,11 @@ fn preprocess(img: &RgbImage) -> (Vec<f32>, Letterbox) {
                     c,
                     0.0,
                 );
-                chw[row + dx] = v / 255.0;
+                hwc[base + c] = v / 255.0;
             }
         }
     }
-    (chw, lb)
+    (hwc, lb)
 }
 
 /// Decode the (1,84,8400) channel-major output into person boxes (original px),
@@ -283,68 +299,380 @@ pub(crate) fn detections_to_json(dets: &[Detection], frame_w: u32, frame_h: u32)
 }
 
 // ---------------------------------------------------------------------------
-// onnxruntime detector (cached process-wide like Python's lazy model load)
+// native MLX YOLO11m forward pass
 // ---------------------------------------------------------------------------
+//
+// The module tree (every C3k2 here is c3k=True, n=1 with an inner C3k of n=2 — read
+// straight from the fused state-dict) maps to these primitives:
+//   Conv        = conv2d(NHWC, [out,kH,kW,in] weight + bias) then SiLU
+//   Bottleneck  = Conv(k3) → Conv(k3), + residual (shortcut, c1==c2)
+//   C3k (n=2)   = cv1‖cv2 split, n× Bottleneck on cv1, cat[m, cv2], cv3
+//   C3k2 (n=1)  = cv1 → chunk(2), C3k on the 2nd half, cat[a, b, m], cv2
+//   SPPF        = cv1 → 3× maxpool5(s1,p2) → cat[x,p1,p2,p3] → cv2
+//   C2PSA       = cv1 → split, PSABlock(attn + ffn), cat, cv2
+//   Detect      = per-scale cv2(box64)/cv3(cls80) → DFL → dist2bbox(anchors) → sigmoid
 
-struct Detector {
-    session: Session,
-    device: &'static str,
+/// Captured forward outputs: the final `(1,84,8400)` plus the per-block reference
+/// points the parity oracle (`refs.safetensors`) checks. Block tensors stay NHWC; the
+/// oracle is NCHW, so the test transposes before comparing. The block fields exist only
+/// for the parity test — the production `detect_people` path reads `output` alone.
+pub(crate) struct YoloForward {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub block4: Array,
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub block10: Array,
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub block16: Array,
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub block19: Array,
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub block22: Array,
+    pub output: Array,
 }
 
-static DETECTOR: OnceLock<Mutex<Option<Detector>>> = OnceLock::new();
-
-fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
-    WorkerError::InvalidPayload(format!("onnxruntime: {e}"))
+/// Loaded YOLO11m detector: the fused MLX weights plus the precomputed detect anchors
+/// and strides (constant for the fixed 640 input).
+struct Yolo {
+    weights: Weights,
+    anchor_x: Array,
+    anchor_y: Array,
+    stride: Array,
 }
 
-fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
-    let mut b = Session::builder().map_err(ort_err)?;
-    if coreml {
-        b = b
-            .with_execution_providers([CoreMLExecutionProvider::default().build()])
-            .map_err(ort_err)?;
-    }
-    b.commit_from_file(path).map_err(ort_err)
-}
-
-impl Detector {
-    /// Build the cached detector. Unlike `pose_jobs` (YOLOX), the CoreML EP
-    /// *hangs* indefinitely in `commit_from_file` on the Ultralytics YOLO11
-    /// export — it never returns an error, so a try-CoreML-then-fall-back is
-    /// unsafe (it would deadlock the job). The CPU EP runs YOLO11m fine and is
-    /// what the Python reference (onnxruntime `CPUExecutionProvider`) used; for
-    /// a single representative frame / 2-fps tracking it's well within budget.
-    /// CoreML stays opt-in via `SCENEWORKS_PERSON_DETECTOR_COREML=1` for future
-    /// investigation (export-opset / MLProgram tweaks); see sc-3633 notes.
+impl Yolo {
     fn load(path: &Path) -> WorkerResult<Self> {
-        let try_coreml = std::env::var("SCENEWORKS_PERSON_DETECTOR_COREML")
-            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        if try_coreml {
-            if let Ok(session) = build_session(path, true) {
-                return Ok(Self {
-                    session,
-                    device: "coreml",
-                });
-            }
-        }
+        let weights = Weights::from_file(path)
+            .map_err(|e| WorkerError::InvalidPayload(format!("yolo11m weights load: {e}")))?;
+        let (ax, ay, st) = Self::build_anchors();
         Ok(Self {
-            session: build_session(path, false)?,
-            device: "cpu",
+            weights,
+            anchor_x: Array::from_slice(&ax, &[1, ANCHORS, 1]),
+            anchor_y: Array::from_slice(&ay, &[1, ANCHORS, 1]),
+            stride: Array::from_slice(&st, &[1, ANCHORS, 1]),
         })
     }
 
-    fn detect(&mut self, img: &RgbImage, conf: f32) -> WorkerResult<Vec<Detection>> {
+    /// Detect-head anchor centers (cell + 0.5) and per-anchor strides, row-major over
+    /// the three feature grids (80²@8, 40²@16, 20²@32) — the order the Detect head
+    /// flattens and concatenates its scales.
+    fn build_anchors() -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+        let mut ax = Vec::with_capacity(ANCHORS as usize);
+        let mut ay = Vec::with_capacity(ANCHORS as usize);
+        let mut st = Vec::with_capacity(ANCHORS as usize);
+        for (grid, stride) in [(80usize, 8.0f32), (40, 16.0), (20, 32.0)] {
+            for gy in 0..grid {
+                for gx in 0..grid {
+                    ax.push(gx as f32 + 0.5);
+                    ay.push(gy as f32 + 0.5);
+                    st.push(stride);
+                }
+            }
+        }
+        (ax, ay, st)
+    }
+
+    fn w(&self, key: &str) -> MlxResult<&Array> {
+        self.weights.require(key)
+    }
+
+    /// Ultralytics `Conv` (fused conv+BN): `conv2d` over a `<prefix>.conv.weight/bias`
+    /// pair, optionally followed by SiLU.
+    fn conv(
+        &self,
+        x: &Array,
+        prefix: &str,
+        stride: i32,
+        padding: i32,
+        act: bool,
+    ) -> MlxResult<Array> {
+        let w = self.w(&format!("{prefix}.conv.weight"))?;
+        let b = self.w(&format!("{prefix}.conv.bias"))?;
+        let y = conv2d(x, w, Some(b), stride, padding)?;
+        if act {
+            silu(&y)
+        } else {
+            Ok(y)
+        }
+    }
+
+    /// A bare `nn.Conv2d` (the Detect head's `cv2.*.2` / `cv3.*.2` leaves): plain
+    /// `<prefix>.weight/bias`, no activation.
+    fn conv_raw(&self, x: &Array, prefix: &str, stride: i32, padding: i32) -> MlxResult<Array> {
+        let w = self.w(&format!("{prefix}.weight"))?;
+        let b = self.w(&format!("{prefix}.bias"))?;
+        conv2d(x, w, Some(b), stride, padding)
+    }
+
+    /// Depthwise 3×3 conv (stride 1, pad 1) over NHWC `x`, from a `<prefix>.conv` pair
+    /// with a `[C,3,3,1]` weight. `mlx_rs` conv2d only supports `groups=1`, so this is
+    /// the 9-tap shift-multiply-accumulate equivalent: zero-pad by 1, then for each
+    /// kernel tap broadcast the per-channel weight over a shifted slice and sum.
+    fn depthwise3x3(&self, x: &Array, prefix: &str, act: bool) -> MlxResult<Array> {
+        let w = self.w(&format!("{prefix}.conv.weight"))?; // (C,3,3,1)
+        let b = self.w(&format!("{prefix}.conv.bias"))?; // (C,)
+        let sh = x.shape();
+        let (h, wd, c) = (sh[1], sh[2], sh[3]);
+        // Per-channel taps from the host buffer: layout (C,3,3,1) → idx = cc*9 + ky*3 + kx.
+        let wdat = w.as_slice::<f32>();
+        let xp = pad(x, &[(0, 0), (1, 1), (1, 1), (0, 0)][..], None, None)?;
+        let mut acc: Option<Array> = None;
+        for ky in 0..3i32 {
+            for kx in 0..3i32 {
+                let tap: Vec<f32> = (0..c as usize)
+                    .map(|cc| wdat[cc * 9 + (ky * 3 + kx) as usize])
+                    .collect();
+                let tap = Array::from_slice(&tap, &[1, 1, 1, c]);
+                let sl = xp.try_index((.., ky..ky + h, kx..kx + wd, ..))?;
+                let term = multiply(&sl, &tap)?;
+                acc = Some(match acc {
+                    Some(a) => add(&a, &term)?,
+                    None => term,
+                });
+            }
+        }
+        let y = add(acc.expect("3x3 kernel has taps"), b)?;
+        if act {
+            silu(&y)
+        } else {
+            Ok(y)
+        }
+    }
+
+    /// Ultralytics `Bottleneck`: Conv(k3) → Conv(k3) with an optional residual add
+    /// (all callers here have `c1 == c2`, so the add is gated only by `shortcut`).
+    fn bottleneck(&self, x: &Array, prefix: &str, shortcut: bool) -> MlxResult<Array> {
+        let y = self.conv(x, &format!("{prefix}.cv1"), 1, 1, true)?;
+        let y = self.conv(&y, &format!("{prefix}.cv2"), 1, 1, true)?;
+        if shortcut {
+            Ok(add(x, &y)?)
+        } else {
+            Ok(y)
+        }
+    }
+
+    /// Ultralytics `C3k` (n=2): `cv3(cat(m(cv1(x)), cv2(x)))`.
+    fn c3k(&self, x: &Array, prefix: &str, shortcut: bool) -> MlxResult<Array> {
+        let p1 = self.conv(x, &format!("{prefix}.cv1"), 1, 0, true)?;
+        let p2 = self.conv(x, &format!("{prefix}.cv2"), 1, 0, true)?;
+        let q = self.bottleneck(&p1, &format!("{prefix}.m.0"), shortcut)?;
+        let q = self.bottleneck(&q, &format!("{prefix}.m.1"), shortcut)?;
+        let cat = concatenate_axis(&[&q, &p2], 3)?;
+        self.conv(&cat, &format!("{prefix}.cv3"), 1, 0, true)
+    }
+
+    /// Ultralytics `C3k2` (n=1, c3k=True): split cv1 in half, run a C3k on the second
+    /// half, then `cv2(cat(a, b, m))`.
+    fn c3k2(&self, x: &Array, i: usize, shortcut: bool) -> MlxResult<Array> {
+        let cv1 = self.conv(x, &format!("model.{i}.cv1"), 1, 0, true)?;
+        let parts = split(&cv1, 2, 3)?;
+        let (a, b) = (parts[0].clone(), parts[1].clone());
+        let m = self.c3k(&b, &format!("model.{i}.m.0"), shortcut)?;
+        let cat = concatenate_axis(&[&a, &b, &m], 3)?;
+        self.conv(&cat, &format!("model.{i}.cv2"), 1, 0, true)
+    }
+
+    /// Ultralytics `SPPF`: cv1 → three chained 5×5 max-pools (s1,p2) → cat → cv2.
+    fn sppf(&self, x: &Array, i: usize) -> MlxResult<Array> {
+        let y = self.conv(x, &format!("model.{i}.cv1"), 1, 0, true)?;
+        let p1 = Self::maxpool5(&y)?;
+        let p2 = Self::maxpool5(&p1)?;
+        let p3 = Self::maxpool5(&p2)?;
+        let cat = concatenate_axis(&[&y, &p1, &p2, &p3], 3)?;
+        self.conv(&cat, &format!("model.{i}.cv2"), 1, 0, true)
+    }
+
+    /// 5×5 max-pool, stride 1, pad 2 — `-inf` pad then elementwise max over the 25
+    /// shifted windows (mlx_rs has no pooling op).
+    fn maxpool5(x: &Array) -> MlxResult<Array> {
+        let sh = x.shape();
+        let (h, wd) = (sh[1], sh[2]);
+        let ninf = Array::from_f32(f32::NEG_INFINITY);
+        let xp = pad(x, &[(0, 0), (2, 2), (2, 2), (0, 0)][..], Some(ninf), None)?;
+        let mut acc: Option<Array> = None;
+        for ky in 0..5i32 {
+            for kx in 0..5i32 {
+                let sl = xp.try_index((.., ky..ky + h, kx..kx + wd, ..))?;
+                acc = Some(match acc {
+                    Some(a) => maximum(&a, &sl)?,
+                    None => sl,
+                });
+            }
+        }
+        Ok(acc.expect("5x5 window has taps"))
+    }
+
+    /// Ultralytics `C2PSA` (block 10): cv1 → split, PSABlock on the second half, cat, cv2.
+    fn c2psa(&self, x: &Array, i: usize) -> MlxResult<Array> {
+        let cv1 = self.conv(x, &format!("model.{i}.cv1"), 1, 0, true)?;
+        let parts = split(&cv1, 2, 3)?;
+        let (a, b) = (parts[0].clone(), parts[1].clone());
+        let b = self.psablock(&b, &format!("model.{i}.m.0"))?;
+        let cat = concatenate_axis(&[&a, &b], 3)?;
+        self.conv(&cat, &format!("model.{i}.cv2"), 1, 0, true)
+    }
+
+    /// `PSABlock`: `x = x + attn(x); x = x + ffn(x)` (ffn = Conv(k1,SiLU) → Conv(k1,no act)).
+    fn psablock(&self, x: &Array, prefix: &str) -> MlxResult<Array> {
+        let a = self.attention(x, &format!("{prefix}.attn"))?;
+        let b1 = add(x, &a)?;
+        let f = self.conv(&b1, &format!("{prefix}.ffn.0"), 1, 0, true)?;
+        let f = self.conv(&f, &format!("{prefix}.ffn.1"), 1, 0, false)?;
+        Ok(add(&b1, &f)?)
+    }
+
+    /// Ultralytics `Attention` (num_heads=4, key_dim=32, head_dim=64): 1×1 qkv conv,
+    /// per-head scaled-dot-product attention, plus the depthwise positional-encoding of
+    /// `v`, then a 1×1 projection. Operates with the spatial map flattened to N=H·W
+    /// tokens; channels are head-major (`head*128 + d`) exactly as the torch `view` lays
+    /// them out.
+    fn attention(&self, x: &Array, prefix: &str) -> MlxResult<Array> {
+        let sh = x.shape();
+        let (h, wd, c) = (sh[1], sh[2], sh[3]);
+        let n = h * wd;
+        let (nh, kd, hd) = (4i32, 32i32, 64i32);
+
+        let qkv = self.conv(x, &format!("{prefix}.qkv"), 1, 0, false)?; // (1,H,W,512)
+        let qkv = qkv.reshape(&[n, nh, 2 * kd + hd])?; // (N,4,128)
+        let parts = split_sections(&qkv, &[kd, 2 * kd], 2)?; // q(32), k(32), v(64)
+        let (q, k, v) = (&parts[0], &parts[1], &parts[2]);
+
+        let qh = q.transpose_axes(&[1, 0, 2])?; // (4,N,32)
+        let kh = k.transpose_axes(&[1, 2, 0])?; // (4,32,N)
+        let scale = Array::from_f32((kd as f32).powf(-0.5));
+        let attn = multiply(&matmul(&qh, &kh)?, &scale)?; // (4,N,N)
+        let attn = softmax_axis(&attn, -1, true)?;
+        let vh = v.transpose_axes(&[1, 0, 2])?; // (4,N,64)
+        let out = matmul(&attn, &vh)?.transpose_axes(&[1, 0, 2])?; // (N,4,64)
+        let x_attn = out.reshape(&[1, h, wd, c])?; // channel = head*64 + d
+
+        let v_nhwc = v.reshape(&[1, h, wd, c])?; // v as a feature map for the PE conv
+        let pe = self.depthwise3x3(&v_nhwc, &format!("{prefix}.pe"), false)?;
+        let x = add(&x_attn, &pe)?;
+        self.conv(&x, &format!("{prefix}.proj"), 1, 0, false)
+    }
+
+    /// One Detect scale: box branch (cv2 → 64 = 4·reg_max) and class branch (cv3 → 80),
+    /// concatenated and flattened to `(1, Hi·Wi, 144)` (row-major, matching the anchors).
+    fn detect_scale(&self, x: &Array, i: usize) -> MlxResult<Array> {
+        let bx = self.conv(x, &format!("model.23.cv2.{i}.0"), 1, 1, true)?;
+        let bx = self.conv(&bx, &format!("model.23.cv2.{i}.1"), 1, 1, true)?;
+        let bx = self.conv_raw(&bx, &format!("model.23.cv2.{i}.2"), 1, 0)?; // 64
+
+        let cx = self.depthwise3x3(x, &format!("model.23.cv3.{i}.0.0"), true)?;
+        let cx = self.conv(&cx, &format!("model.23.cv3.{i}.0.1"), 1, 0, true)?;
+        let cx = self.depthwise3x3(&cx, &format!("model.23.cv3.{i}.1.0"), true)?;
+        let cx = self.conv(&cx, &format!("model.23.cv3.{i}.1.1"), 1, 0, true)?;
+        let cx = self.conv_raw(&cx, &format!("model.23.cv3.{i}.2"), 1, 0)?; // 80
+
+        let cat = concatenate_axis(&[&bx, &cx], 3)?; // (1,Hi,Wi,144)
+        let sh = cat.shape();
+        Ok(cat.reshape(&[1, sh[1] * sh[2], 144])?)
+    }
+
+    /// Detect head: assemble the three scales, DFL-decode the box distances, project to
+    /// xywh via the precomputed anchors/strides, sigmoid the classes, and emit the
+    /// `(1,84,8400)` channel-major tensor the `decode()` consumer expects.
+    fn detect(&self, p3: &Array, p4: &Array, p5: &Array) -> MlxResult<Array> {
+        let s0 = self.detect_scale(p3, 0)?;
+        let s1 = self.detect_scale(p4, 1)?;
+        let s2 = self.detect_scale(p5, 2)?;
+        let cat = concatenate_axis(&[&s0, &s1, &s2], 1)?; // (1,8400,144)
+        let parts = split_sections(&cat, &[64], 2)?; // box(64), cls(80)
+        let (box_, cls) = (&parts[0], &parts[1]);
+
+        // DFL: per side, softmax over 16 bins then expected value (the bin indices live
+        // in the conv weight, [0..15]).
+        let bins = self
+            .w("model.23.dfl.conv.weight")?
+            .reshape(&[1, 1, 1, 16])?;
+        let probs = softmax_axis(&box_.reshape(&[1, ANCHORS, 4, 16])?, 3, true)?;
+        let dist = sum_axis(&multiply(&probs, &bins)?, 3, false)?; // (1,8400,4) = l,t,r,b
+        let d = split_sections(&dist, &[1, 2, 3], 2)?;
+        let (l, t, r, b) = (&d[0], &d[1], &d[2], &d[3]);
+
+        // dist2bbox(xywh) * stride, with anchor centers (cell + 0.5).
+        let x1 = subtract(&self.anchor_x, l)?;
+        let y1 = subtract(&self.anchor_y, t)?;
+        let x2 = add(&self.anchor_x, r)?;
+        let y2 = add(&self.anchor_y, b)?;
+        let half = Array::from_f32(0.5);
+        let cx = multiply(&multiply(&add(&x1, &x2)?, &half)?, &self.stride)?;
+        let cy = multiply(&multiply(&add(&y1, &y2)?, &half)?, &self.stride)?;
+        let bw = multiply(&subtract(&x2, &x1)?, &self.stride)?;
+        let bh = multiply(&subtract(&y2, &y1)?, &self.stride)?;
+        let dbox = concatenate_axis(&[&cx, &cy, &bw, &bh], 2)?; // (1,8400,4)
+
+        let cls = sigmoid(cls)?;
+        let hwc = concatenate_axis(&[&dbox, &cls], 2)?; // (1,8400,84)
+        Ok(hwc.transpose_axes(&[0, 2, 1])?) // (1,84,8400) channel-major
+    }
+
+    /// Full YOLO11m forward, capturing the oracle block points. Shortcut residuals are
+    /// on for every C3k2 (the C3k2 default; the yaml never overrides it).
+    fn run(&self, x: &Array) -> MlxResult<YoloForward> {
+        // backbone
+        let x = self.conv(x, "model.0", 2, 1, true)?; // 320,64
+        let x = self.conv(&x, "model.1", 2, 1, true)?; // 160,128
+        let x = self.c3k2(&x, 2, true)?; // 160,256
+        let x = self.conv(&x, "model.3", 2, 1, true)?; // 80,256
+        let x = self.c3k2(&x, 4, true)?; // 80,512
+        let block4 = x.clone();
+        let x = self.conv(&x, "model.5", 2, 1, true)?; // 40,512
+        let x = self.c3k2(&x, 6, true)?; // 40,512
+        let b6 = x.clone();
+        let x = self.conv(&x, "model.7", 2, 1, true)?; // 20,512
+        let x = self.c3k2(&x, 8, true)?; // 20,512
+        let x = self.sppf(&x, 9)?; // 20,512
+        let x = self.c2psa(&x, 10)?; // 20,512
+        let block10 = x.clone();
+        let b10 = x.clone();
+        // neck (PANet)
+        let x = upsample_nearest(&x, 2)?; // 40,512
+        let x = concatenate_axis(&[&x, &b6], 3)?; // 40,1024
+        let x = self.c3k2(&x, 13, true)?; // 40,512
+        let b13 = x.clone();
+        let x = upsample_nearest(&x, 2)?; // 80,512
+        let x = concatenate_axis(&[&x, &block4], 3)?; // 80,1024
+        let p3 = self.c3k2(&x, 16, true)?; // 80,256  → P3
+        let x = self.conv(&p3, "model.17", 2, 1, true)?; // 40,256
+        let x = concatenate_axis(&[&x, &b13], 3)?; // 40,768
+        let p4 = self.c3k2(&x, 19, true)?; // 40,512  → P4
+        let x = self.conv(&p4, "model.20", 2, 1, true)?; // 20,512
+        let x = concatenate_axis(&[&x, &b10], 3)?; // 20,1024
+        let p5 = self.c3k2(&x, 22, true)?; // 20,512  → P5
+
+        let output = self.detect(&p3, &p4, &p5)?;
+        Ok(YoloForward {
+            block4,
+            block10,
+            block16: p3,
+            block19: p4,
+            block22: p5,
+            output,
+        })
+    }
+
+    fn detect_people(&self, img: &RgbImage, conf: f32) -> WorkerResult<Vec<Detection>> {
         let (input, lb) = preprocess(img);
-        let tensor = Tensor::from_array(([1_i64, 3, DET as i64, DET as i64].to_vec(), input))
-            .map_err(ort_err)?;
-        let outputs = self.session.run(ort::inputs![tensor]).map_err(ort_err)?;
-        let (shp, data) = outputs[0].try_extract_tensor::<f32>().map_err(ort_err)?;
-        let shape = shp.to_vec();
+        let x = Array::from_slice(&input, &[1, DET as i32, DET as i32, 3]);
+        let out = self
+            .run(&x)
+            .map_err(|e| WorkerError::InvalidPayload(format!("yolo11m forward: {e}")))?
+            .output;
+        // The head ends in a transpose, so `out` is a non-contiguous view; `as_slice`
+        // would hand back the *physical* (pre-transpose) buffer. Flatten first to force a
+        // logical-order copy → the `(1,84,8400)` channel-major layout `decode` indexes.
+        let out = out
+            .reshape(&[-1])
+            .map_err(|e| WorkerError::InvalidPayload(format!("yolo11m output reshape: {e}")))?;
+        let data = out.as_slice::<f32>();
+        let shape = [1_i64, 84, ANCHORS as i64];
         let raw = decode(data, &shape, &lb, conf, img.width(), img.height());
         Ok(nms(raw, NMS_IOU))
     }
 }
+
+static DETECTOR: OnceLock<Mutex<Option<Yolo>>> = OnceLock::new();
 
 /// Person detections for one frame, plus the device the model ran on.
 pub(crate) struct DetectResult {
@@ -354,11 +682,10 @@ pub(crate) struct DetectResult {
     pub device: &'static str,
 }
 
-/// Blocking person detection on a single rendered frame. All `ort` state lives
-/// inside this call (built once, cached process-wide) and never crosses an
-/// await; invoke via `spawn_blocking`.
+/// Blocking person detection on a single rendered frame. The MLX model is loaded once
+/// and cached process-wide (like Python's lazy model load); invoke via `spawn_blocking`.
 pub(crate) fn detect_people_blocking(
-    onnx_path: PathBuf,
+    weights_path: PathBuf,
     image_path: PathBuf,
     conf: f32,
 ) -> WorkerResult<DetectResult> {
@@ -370,16 +697,15 @@ pub(crate) fn detect_people_blocking(
     let cell = DETECTOR.get_or_init(|| Mutex::new(None));
     let mut guard = cell.lock().expect("person detector mutex poisoned");
     if guard.is_none() {
-        *guard = Some(Detector::load(&onnx_path)?);
+        *guard = Some(Yolo::load(&weights_path)?);
     }
-    let detector = guard.as_mut().expect("detector loaded");
-    let device = detector.device;
-    let detections = detector.detect(&img, conf)?;
+    let detector = guard.as_ref().expect("detector loaded");
+    let detections = detector.detect_people(&img, conf)?;
     Ok(DetectResult {
         width,
         height,
         detections,
-        device,
+        device: "mlx",
     })
 }
 
@@ -387,12 +713,13 @@ pub(crate) fn detect_people_blocking(
 // weights resolution (download-on-first-use lands in slice 4 / sc-3636)
 // ---------------------------------------------------------------------------
 
-/// Resolve the detector onnx: explicit env pin (`SCENEWORKS_PERSON_DETECTOR_ONNX`),
-/// then the app cache `<data_dir>/cache/person-detect/`, then the model dir
+/// Resolve the fused MLX detector weights: explicit env pin
+/// (`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`), then the app cache
+/// `<data_dir>/cache/person-detect/`, then the model dir
 /// `<data_dir>/models/person-detect/`. Returns `None` when no weight is present
 /// (slice 4 adds download-on-first-use so the Mac is provisioned automatically).
-pub(crate) fn resolve_detector_onnx(settings: &Settings) -> Option<PathBuf> {
-    if let Ok(pinned) = std::env::var("SCENEWORKS_PERSON_DETECTOR_ONNX") {
+pub(crate) fn resolve_detector_weights(settings: &Settings) -> Option<PathBuf> {
+    if let Ok(pinned) = std::env::var("SCENEWORKS_PERSON_DETECTOR_WEIGHTS") {
         let path = PathBuf::from(pinned);
         if path.exists() {
             return Some(path);

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -1,9 +1,12 @@
 //! Unit tests for the YOLO11 person detector (sc-3633). The pure detector math
 //! (letterbox / decode / NMS / normalization) is covered without weights; the
-//! `#[ignore]` parity test runs the real `yolo11m.onnx` against a captured
-//! `ultralytics.predict` reference when the weights are staged in the app cache.
+//! `#[ignore]` parity tests run the native MLX forward against a captured per-block
+//! reference oracle (`refs.safetensors`) and reproduce `ultralytics.predict`'s boxes,
+//! when the fused MLX weights + fixtures are staged in the app cache.
 
 use super::*;
+use mlx_gen::weights::Weights;
+use mlx_rs::Array;
 use std::path::PathBuf;
 
 #[test]
@@ -149,15 +152,109 @@ fn cache_fixture(name: &str) -> Option<PathBuf> {
     path.exists().then_some(path)
 }
 
-/// Real-weights parity: the Rust detector must reproduce `ultralytics.predict`
-/// on bus.jpg (4 people). Ignored by default — run with the model + fixtures
-/// staged in the app cache:
+/// Flatten an array to a contiguous f32 vec in logical row-major order (forces a copy
+/// of a transposed view), so two arrays of equal shape compare element-by-element.
+fn flat(a: &Array) -> Vec<f32> {
+    a.reshape(&[-1])
+        .expect("flatten")
+        .as_slice::<f32>()
+        .to_vec()
+}
+
+/// Max absolute difference between two equally-shaped arrays.
+fn max_abs_diff(got: &Array, want: &Array) -> f32 {
+    assert_eq!(got.shape(), want.shape(), "shape mismatch");
+    flat(got)
+        .iter()
+        .zip(flat(want))
+        .map(|(g, w)| (g - w).abs())
+        .fold(0.0f32, f32::max)
+}
+
+/// Per-block + final parity: the native MLX forward, fed the oracle's exact letterboxed
+/// input, must match the captured reference (`refs.safetensors`) block-for-block. This is
+/// the make-or-break correctness gate for the port — it isolates the forward pass from
+/// the (separately-verified) letterbox/decode/NMS math. Ignored by default — run with the
+/// fused weights + oracle staged in the app cache:
 ///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
 #[test]
-#[ignore = "requires staged yolo11m.onnx + bus.jpg fixtures in the app cache"]
-fn yolo11_matches_ultralytics_reference_on_bus() {
-    let (Some(onnx), Some(image), Some(reference)) = (
-        cache_fixture("yolo11m.onnx"),
+#[ignore = "requires staged yolo11m_fused_mlx.safetensors + refs.safetensors in the app cache"]
+fn yolo11_mlx_forward_matches_reference_oracle() {
+    let (Some(weights), Some(refs)) = (
+        cache_fixture("yolo11m_fused_mlx.safetensors"),
+        cache_fixture("refs.safetensors"),
+    ) else {
+        eprintln!("skipping: fixtures not staged");
+        return;
+    };
+
+    let model = Yolo::load(&weights).expect("weights load");
+    let oracle = Weights::from_file(&refs).expect("refs load");
+    // The oracle input is NCHW (1,3,640,640); the forward runs NHWC.
+    let input = oracle
+        .require("input")
+        .expect("input tensor")
+        .transpose_axes(&[0, 2, 3, 1])
+        .expect("nhwc");
+    let fwd = model.run(&input).expect("forward runs");
+
+    // Block tensors are NHWC; the oracle is NCHW — transpose back before comparing.
+    // block4 is near-bit-exact (proves the whole backbone CSP assembly). The deeper
+    // blocks accumulate fp32 backend drift (MLX/Metal vs the torch oracle, ~1e-2 by the
+    // neck — first jumping at the C2PSA softmax/matmul); that drift is benign and proven
+    // not to move results by the box/class assertions below + the e2e box parity test.
+    let checks = [
+        ("block4", &fwd.block4, 1e-3f32),
+        ("block10", &fwd.block10, 2e-2),
+        ("block16", &fwd.block16, 2e-2),
+        ("block19", &fwd.block19, 2e-2),
+        ("block22", &fwd.block22, 2e-2),
+    ];
+    for (name, got_nhwc, tol) in checks {
+        let got = got_nhwc.transpose_axes(&[0, 3, 1, 2]).expect("nchw");
+        let diff = max_abs_diff(&got, oracle.require(name).expect(name));
+        eprintln!("{name}: max|Δ| = {diff:.3e} (tol {tol:.0e})");
+        assert!(diff < tol, "{name} max|Δ| {diff:.3e} exceeds {tol:.0e}");
+    }
+
+    // The head output `(1,84,8400)`: rows 0..4 are box geometry in letterbox px, rows
+    // 4..84 are class probabilities. Assert them separately — box error is a sub-pixel
+    // tolerance, class error a tight probability tolerance.
+    let want_final = oracle.require("final").expect("final");
+    let gf = flat(&fwd.output);
+    let wf = flat(want_final);
+    let (mut box_d, mut cls_d) = (0.0f32, 0.0f32);
+    for r in 0..84usize {
+        for a in 0..8400usize {
+            let d = (gf[r * 8400 + a] - wf[r * 8400 + a]).abs();
+            if r < 4 {
+                box_d = box_d.max(d);
+            } else {
+                cls_d = cls_d.max(d);
+            }
+        }
+    }
+    eprintln!("final box-rows(0..4) max|Δ| = {box_d:.3e} px");
+    eprintln!("final cls-rows(4..84) max|Δ| = {cls_d:.3e}");
+    assert!(
+        box_d < 2.0,
+        "final box rows max|Δ| {box_d:.3e} px exceeds 2px"
+    );
+    assert!(
+        cls_d < 5e-3,
+        "final class rows max|Δ| {cls_d:.3e} exceeds 5e-3"
+    );
+}
+
+/// End-to-end parity: the full detector (letterbox → MLX forward → decode → NMS) must
+/// reproduce `ultralytics.predict`'s 4 people on the staged photo. Ignored by default —
+/// run with the model + fixtures staged in the app cache:
+///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
+#[test]
+#[ignore = "requires staged yolo11m_fused_mlx.safetensors + people.jpg fixtures in the app cache"]
+fn yolo11_matches_ultralytics_reference_on_photo() {
+    let (Some(weights), Some(image), Some(reference)) = (
+        cache_fixture("yolo11m_fused_mlx.safetensors"),
         cache_fixture("people.jpg"),
         cache_fixture("ref_people.json"),
     ) else {
@@ -165,13 +262,17 @@ fn yolo11_matches_ultralytics_reference_on_bus() {
         return;
     };
 
-    let result = detect_people_blocking(onnx, image, 0.25).expect("detection runs");
+    let result = detect_people_blocking(weights, image, 0.25).expect("detection runs");
     eprintln!(
         "device={} detections={}",
         result.device,
         result.detections.len()
     );
-    assert_eq!((result.width, result.height), (810, 1080), "bus.jpg dims");
+    assert_eq!(
+        (result.width, result.height),
+        (810, 1080),
+        "people.jpg dims"
+    );
 
     let ref_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(reference).unwrap()).unwrap();

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -309,3 +309,50 @@ fn yolo11_matches_ultralytics_reference_on_photo() {
         );
     }
 }
+
+/// Provisioning parity: download the fused weights from the public HuggingFace URL
+/// (`DET_URL`) into a throwaway dir, then prove a fresh download loads and detects the 4
+/// reference people. Validates the URL + that the hosted artifact is the right weights.
+/// Ignored by default (network); run with the people.jpg fixture staged:
+///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
+#[test]
+#[ignore = "network: downloads the fused weights from HuggingFace"]
+fn yolo11_downloads_and_detects_from_huggingface() {
+    let Some(image) = cache_fixture("people.jpg") else {
+        eprintln!("skipping: people.jpg not staged");
+        return;
+    };
+    let dir = std::env::temp_dir().join("sceneworks-person-detect-dl-test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let target = dir.join("yolo11m_fused_mlx.safetensors");
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let client = reqwest::Client::new();
+        let bytes = client
+            .get(DET_URL)
+            .send()
+            .await
+            .expect("GET weights")
+            .error_for_status()
+            .expect("200 OK")
+            .bytes()
+            .await
+            .expect("body");
+        tokio::fs::write(&target, &bytes).await.unwrap();
+    });
+    eprintln!(
+        "downloaded {} bytes → {}",
+        std::fs::metadata(&target).unwrap().len(),
+        target.display()
+    );
+
+    let result =
+        detect_people_blocking(target, image, 0.25).expect("detection runs on downloaded weights");
+    assert_eq!(
+        result.detections.len(),
+        4,
+        "4 people from downloaded weights"
+    );
+}

--- a/docs/sc-3633-mlx-port.md
+++ b/docs/sc-3633-mlx-port.md
@@ -66,3 +66,48 @@ existing letterbox, but emit NHWC f32 Array) → forward → existing `decode`+`
 - The engine `Weights` loader: how to construct from a `.safetensors` path + `.require(name)->Array`
   (used across mlx-gen; e.g. `mlx-gen-wan/tests/*` `fn load(name)->Weights`). Confirm the public path.
 - `Array` channel-split (`split`/slicing) + `transpose_axes` for the NCHW↔NHWC compares.
+
+## DONE — native mlx-rs YOLO11m forward implemented + parity-verified (2026-06-09)
+
+The full forward is in `crates/sceneworks-worker/src/person_jobs.rs` (`Yolo`/`YoloForward`),
+built from `mlx_gen::nn::{conv2d,silu,upsample_nearest}` + `mlx_rs::ops`. The `ort` `Detector`,
+`build_session`, and the `ort`/`zip` imports are gone from the person-detect path (`ort` stays
+for `pose_jobs`). `mlx-rs` (pmetal-mlx-rs, same rev mlx-gen pins) is now a first-class macOS
+dependency. `media_jobs.rs` reports `backend:"mlx"`, adapter `yolo11_mlx`, device `mlx`.
+
+### Architecture, straight from the fused state-dict (authoritative source of truth)
+- **Every** C3k2 block (2/4/6/8/13/16/19/22) is `c3k=True, n=1` with an inner `C3k(n=2)` — the
+  `model.<i>.m.0.cv3` + `m.0.m.{0,1}` keys prove it. So all eight are structurally identical,
+  differing only in channel dims (read from the weights). The standard-YAML "c3k=False for early/
+  neck blocks" does NOT hold for this checkpoint — trust the weights, not the yaml.
+- Bottleneck residual is on everywhere: C3k2 defaults `shortcut=True` and the yaml never overrides
+  it; all inner bottlenecks have `c1==c2`. (Confirmed: block4 parity is near-bit-exact.)
+- C2PSA (block 10): `num_heads=4, key_dim=32, head_dim=64`, scale `32^-0.5`; PE is a depthwise 3×3
+  on `v` reshaped to a feature map; ffn.1 has no activation.
+- Detect: DFL bin indices are read straight from `model.23.dfl.conv.weight` ([0..15]); anchors are
+  cell-center (+0.5) row-major over 80²@8 / 40²@16 / 20²@32; output assembled `[xywh, sigmoid(cls)]`
+  → transposed to `(1,84,8400)` channel-major for the existing `decode()`.
+
+### Two implementation gotchas
+- **`mlx_rs::ops::conv2d` only supports `groups=1`** → depthwise convs (C2PSA `pe`, Detect `cv3`
+  DWConv, all `[C,3,3,1]`) are a manual 9-tap shift/multiply/accumulate (pad-by-1, per-channel tap
+  broadcast over a `try_index` range slice). SPPF 5×5 max-pool uses the same shift trick (−inf pad,
+  25-tap elementwise `maximum`).
+- **`Array::as_slice` returns the PHYSICAL buffer, not the logical order.** The head ends in a
+  `transpose_axes`, so the `(1,84,8400)` output is a non-contiguous view; calling `as_slice` on it
+  directly hands back the pre-transpose `(1,8400,84)` data → `decode` reads scrambled rows (the
+  symptom was 327 post-NMS boxes). Fix: `reshape(&[-1])` first to force a logical-order copy. (The
+  oracle test's `flat()` already did this, which is why per-block parity passed while the e2e path
+  failed — a useful tell.)
+
+### Parity results (`cargo test -p sceneworks-worker person_jobs -- --include-ignored --test-threads=1`)
+Run MLX tests single-threaded — concurrent MLX forwards across test threads corrupt results.
+- Per-block vs `refs.safetensors`: block4 **1.7e-5** (near-bit-exact → backbone correct); block10
+  6.8e-3, block16 5.4e-3, block19 1.3e-2, block22 7.7e-3 — accumulated fp32 backend drift (MLX/Metal
+  vs the torch oracle), first jumping at the C2PSA softmax/matmul. Benign.
+- Final head: class rows **1.98e-3**, box rows **<1px**.
+- End-to-end (letterbox→forward→decode→NMS) reproduces `ultralytics.predict`'s **4 people on
+  people.jpg to ≤2px / 0.02 conf** (0.917/0.907/0.906/0.778). Decode/NMS already verified in #485.
+
+Weight provisioning (download-on-first-use, HF host) is still slice 4 / sc-3636 — the resolver reads
+the staged `yolo11m_fused_mlx.safetensors` from the app cache / model dir for now.


### PR DESCRIPTION
Completes the body of **sc-3633** (epic 3482 Python Eradication / sc-3488 slice 1): the native **mlx-rs YOLO11m forward pass** that replaces the `ort` `Detector`. The decode/NMS/letterbox foundation merged in #485 runs on top unchanged.

## What changed
- **`person_jobs.rs`** — the full YOLO11m forward in MLX (`mlx_gen::nn::{conv2d,silu,upsample_nearest}` + `mlx_rs::ops`): backbone (Conv/C3k2/C3k/Bottleneck/SPPF/C2PSA) + PANet neck + Detect head (DFL → dist2bbox with precomputed anchors/strides + sigmoid cls) → `(1,84,8400)`. The `ort` `Session`/CoreML path (which hangs on the YOLO11 export) and the `ort`/`zip` imports are gone from the person-detect path (`ort` stays for `pose_jobs`).
- **`mlx-rs`** (pmetal-mlx-rs, same rev mlx-gen pins → MLX builds once) promoted to a first-class macOS dependency.
- **Download-on-first-use** — `ensure_detector_weights` fetches the fused `yolo11m_fused_mlx.safetensors` from a public HuggingFace repo into the app cache (atomic `.tmp`+rename), mirroring `pose_jobs::ensure_one`; `http_client` threaded through the PersonDetect job chain like PoseDetect/ImageUpscale.
- **`media_jobs.rs`** reports `backend:"mlx"` / adapter `yolo11_mlx` / device `mlx`.

## Architecture notes (from the fused state-dict, the authoritative source — not the stock YAML)
- Every C3k2 block (2/4/6/8/13/16/19/22) is `c3k=True, n=1` with an inner `C3k(n=2)` (the `m.0.cv3` + `m.0.m.{0,1}` keys prove it) → all eight structurally identical. Bottleneck residual is on everywhere (C3k2 default `shortcut=True`, never overridden).
- C2PSA: 4 heads, key_dim 32, head_dim 64, scale `32^-0.5`, depthwise PE on `v`.
- Two MLX gotchas: `mlx_rs::ops::conv2d` is `groups=1`-only → depthwise convs are a manual 9-tap shift/mul/add (SPPF maxpool same trick); and `Array::as_slice` returns the **physical** buffer, so the transposed head output is `reshape(&[-1])`'d before decode (else scrambled → 327 spurious boxes).

## Parity (ignored tests, real weights, single-threaded)
- per-block vs `refs.safetensors`: **block4 1.7e-5** (backbone near-bit-exact); deeper blocks 5e-3..1.3e-2 (benign fp32 Metal-vs-torch drift). Final **class rows 2.0e-3, box rows <1px**.
- end-to-end reproduces `ultralytics.predict`'s **4 people on people.jpg to ≤2px / 0.02 conf**.

## Gate
Workspace `cargo fmt --check`, `clippy -D warnings`, `build`, full `cargo test` all green on macOS (the MLX-gated module included). The two real-weight parity tests pass; the network download test passes once the HF repo is live.

Plan/results: `docs/sc-3633-mlx-port.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)