### PR TITLE
sc-3709: wire native-MLX SAM2 segmenter into person_track (segment_track + maskState)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "image",
  "inventory",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2574,9 +2574,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-sam2"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+dependencies = [
+ "mlx-gen",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "image",
  "inventory",
@@ -2589,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "image",
  "inventory",
@@ -2603,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6404de77ec82f5acaa370f487cb530c145345bb2#6404de77ec82f5acaa370f487cb530c145345bb2"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
 dependencies = [
  "image",
  "inventory",
@@ -4175,6 +4184,7 @@ dependencies = [
  "mlx-gen-joycaption",
  "mlx-gen-ltx",
  "mlx-gen-qwen-image",
+ "mlx-gen-sam2",
  "mlx-gen-sdxl",
  "mlx-gen-wan",
  "mlx-gen-z-image",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1804,12 +1804,13 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
             Some("epic 3040 (+ sc-3488)"),
         )),
 
-        JobType::PersonDetect | JobType::PersonTrack => Err(UnsupportedReason::new(
-            None,
-            "person detect / track (YOLO/SAM2)",
-            "person detection/tracking runs on the Python onnxruntime/torch path.",
-            Some("sc-3488"),
-        )),
+        // Person detection + tracking are now ported to the Rust worker (epic 3482,
+        // sc-3488): native-MLX YOLO11 detection (sc-3633), SORT/ByteTrack track assembly
+        // (sc-3634), and SAM2 per-frame segmentation (sc-3709) all run in-process on the
+        // macOS MLX worker, so the Replace-Person detect → track → mask flow is
+        // Python-free. (replace_person end-to-end still needs the video-gen/inpaint half,
+        // a tracked torch gap on `PersonReplace` below — epic 3040.)
+        JobType::PersonDetect | JobType::PersonTrack => Ok(()),
 
         // DWPose pose detection is now ported to the Rust worker (sc-3487): RTMW
         // whole-body via `ort`/CoreML on the macOS MLX worker, so the Pose Library
@@ -2097,12 +2098,16 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         ),
     );
     features.insert(
+        // Person detection + tracking are ported to the Rust worker (sc-3488 /
+        // sc-3633/3634/3709): native-MLX YOLO11 detection, SORT/ByteTrack track assembly,
+        // and SAM2 per-frame segmentation all run in-process, so the Replace-Person
+        // detect → track → mask flow works on a Python-free Mac. (replace_person
+        // end-to-end still needs the video-gen/inpaint half — see `advancedVideoModes`.)
         "personDetect".to_owned(),
-        MacFeatureSupport::unsupported(
-            "person detect / track (YOLO/SAM2)",
-            "person detection/tracking runs on the Python onnxruntime/torch path.",
-            "sc-3488",
-        ),
+        MacFeatureSupport {
+            supported: true,
+            reason: None,
+        },
     );
     features.insert(
         "datasetCaptioning".to_owned(),

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1833,16 +1833,20 @@ fn mac_rust_supported_names_qwen_strict_pose_and_lycoris() {
 #[test]
 fn mac_rust_supported_names_infra_job_types() {
     let store = store("oracle-infra");
-    let cases = [(JobType::PersonDetect, "sc-3488")];
-    for (job_type, epic) in cases {
-        let job = job_of(&store, job_type, json!({}));
-        let reason = mac_rust_supported(&job).unwrap_err();
-        assert_eq!(
-            reason.suggested_epic.as_deref(),
-            Some(epic),
-            "job type maps to {epic}"
-        );
-    }
+    // Person detection + tracking are ported to the Rust worker (sc-3488 /
+    // sc-3633/3634/3709): native-MLX YOLO11 + SORT/ByteTrack + SAM2 segmentation → both
+    // supported. (replace_person end-to-end still needs epic 3040 — asserted below.)
+    let person_detect = job_of(&store, JobType::PersonDetect, json!({}));
+    assert!(mac_rust_supported(&person_detect).is_ok());
+    let person_track = job_of(&store, JobType::PersonTrack, json!({}));
+    assert!(mac_rust_supported(&person_track).is_ok());
+    // replace_person stays a tracked torch gap (the video-gen/inpaint half, epic 3040).
+    let replace = job_of(&store, JobType::PersonReplace, json!({}));
+    let replace_reason = mac_rust_supported(&replace).unwrap_err();
+    assert!(replace_reason
+        .suggested_epic
+        .as_deref()
+        .is_some_and(|epic| epic.contains("epic 3040")));
     // DWPose pose detection is ported to the Rust worker (sc-3487) → supported.
     let pose = job_of(&store, JobType::PoseDetect, json!({}));
     assert!(mac_rust_supported(&pose).is_ok());
@@ -2054,18 +2058,25 @@ fn mac_capabilities_master_switch_and_infra_features() {
     assert_eq!(epic("imageUpscale"), None);
     assert!(mac.features["imageUpscale"].supported);
     assert_eq!(epic("poseFromPhoto").as_deref(), Some("sc-3487"));
-    assert_eq!(epic("personDetect").as_deref(), Some("sc-3488"));
+    // Person detect/track is ported (sc-3488 / sc-3633/3634/3709) → supported, no epic.
+    assert_eq!(epic("personDetect"), None);
+    assert!(mac.features["personDetect"].supported);
     assert_eq!(epic("datasetCaptioning"), None);
     // LyCORIS is ported to MLX (epic 3641) → no longer a capability gap entry at all.
     assert!(!mac.features.contains_key("lycoris"));
     assert_eq!(epic("advancedVideoModes").as_deref(), Some("epic 3040"));
     assert!(mac.features["datasetCaptioning"].supported);
-    // datasetCaptioning + imageUpscale are the ported (supported) infra features; the
-    // rest stay gated until their port lands.
+    // datasetCaptioning + imageUpscale + personDetect are the ported (supported) infra
+    // features; the rest stay gated until their port lands.
     assert!(mac
         .features
         .iter()
-        .filter(|(key, _)| !matches!(key.as_str(), "datasetCaptioning" | "imageUpscale"))
+        .filter(|(key, _)| {
+            !matches!(
+                key.as_str(),
+                "datasetCaptioning" | "imageUpscale" | "personDetect"
+            )
+        })
         .all(|(_, f)| !f.supported));
     // Training kernels with a native Rust trainer stay enabled; LoKr-on-Wan does not.
     assert!(mac

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,16 +68,18 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 6404de7 (mlx-gen main): adds third-party LyCORIS (LoHa / non-peft kohya LoKr)
-# application across ALL providers (epic 3641, mlx-gen #171/#172/#174) — the core
-# AdaptableHost loader (flux/flux2/qwen-image/z-image) plus the SDXL merge path, the
-# Wan in-place merge, and the LTX forward residual. On top of the prior rev's
-# Qwen-Image ControlNet strict pose (epic 3401), LoRA/LoKr trainer surface (epic 3039),
-# Wan/LTX converter stack, Wan-VACE provider + per-request control_scale (epic 3040),
-# JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621). One
-# shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical
-# across the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+# Rev 0ed3019 (mlx-gen main): adds the native-MLX SAM2 segmenter crate `mlx-gen-sam2`
+# (epic 3704, mlx-gen #176/#177/#179 — Hiera encoder + FPN neck + prompt encoder +
+# two-way mask decoder + box→mask segmenter), consumed by the Rust person-track
+# segmenter (sc-3709). On top of the prior rev's third-party LyCORIS (epic 3641,
+# #171/#172/#174), the core AdaptableHost loader (flux/flux2/qwen-image/z-image) plus
+# the SDXL merge path, the Wan in-place merge, the LTX forward residual, Qwen-Image
+# ControlNet strict pose (epic 3401), LoRA/LoKr trainer surface (epic 3039), Wan/LTX
+# converter stack, Wan-VACE provider + per-request control_scale (epic 3040), JoyCaption
+# captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621). One shared rev so
+# MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across the bump ->
+# no MLX rebuild).
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -85,32 +87,38 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec8
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6404de77ec82f5acaa370f487cb530c145345bb2" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+# SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
+# crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
+# `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
+# masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
+# MLX builds once.
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -417,6 +417,15 @@ pub(crate) fn mlx_gpu() -> DiscoveredGpu {
             // works on a Python-free Mac. Only `engine=real-esrgan` (the default) is
             // served here; `aura-sr` stays on the Python worker (routing oracle).
             WorkerCapability::ImageUpscale,
+            // Real, model-backed person detection + tracking (epic 3482, sc-3488 /
+            // sc-3633/3634/3709): the native-MLX YOLO11 detector + SORT/ByteTrack tracker +
+            // SAM2 segmenter run in-process (`person_jobs` / `person_track` /
+            // `person_segment`), replacing the Python onnxruntime/torch path so the
+            // Replace-Person detect → track → mask flow works on a Python-free Mac. A
+            // `preview: true` job still routes to the CPU placeholder's procedural preview
+            // capability (`required_capability` in jobs_store).
+            WorkerCapability::PersonDetect,
+            WorkerCapability::PersonTrack,
         ],
         utilization: None,
     }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -72,6 +72,12 @@ mod upscale_jobs;
 mod person_jobs;
 #[cfg(target_os = "macos")]
 mod person_track;
+// Native-MLX SAM2 person segmentation (epic 3704, sc-3709): the `mlx-gen-sam2`
+// box-prompt segmenter generates per-frame masks in `run_person_track`. macOS-only
+// like person_jobs (mlx-gen builds MLX from source); the Python SAM2 path stays the
+// Windows/Linux backend.
+#[cfg(target_os = "macos")]
+mod person_segment;
 use downloads::*;
 #[cfg(target_os = "macos")]
 use pose_jobs::*;

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -601,7 +601,8 @@ async fn run_yolo11_person_detect(
 struct RealPersonTrack {
     frames: Vec<Value>,
     average_confidence: f64,
-    /// "degraded" for this slice (box-derived masks); SAM2 per-frame masks arrive in sc-3709.
+    /// Sidecar `maskState` from the SAM2 segmentation pass (sc-3709): active / generated /
+    /// degraded (segmenter unavailable → box-mask fallback) / missing (segmentation off).
     mask_state: &'static str,
     quality: Value,
     tracker_meta: Value,
@@ -618,11 +619,14 @@ async fn assemble_real_person_track(
     settings: &Settings,
     http_client: &reqwest::Client,
     job: &JobSnapshot,
+    project_path: &std::path::Path,
     source_media_path: &std::path::Path,
     detection: &Value,
+    track_id: &str,
     selected_timestamp: f64,
     duration: f64,
     confidence: f64,
+    segment_enabled: bool,
 ) -> WorkerResult<RealPersonTrack> {
     use crate::person_track as pt;
 
@@ -635,6 +639,10 @@ async fn assemble_real_person_track(
     tokio::fs::create_dir_all(&work_dir).await?;
 
     let mut device = "mlx";
+    // Keep each rendered frame (don't delete in-loop): the segmentation pass re-reads
+    // the detected target frames by the same sample index. They share the cadence, so
+    // assembly frame `i` ↔ `timestamps[i]` ↔ `frame_paths[i]`.
+    let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
     let mut per_frame: Vec<(f64, Vec<(pt::NormalizedBox, f64)>)> =
         Vec::with_capacity(timestamps.len());
     for (index, &timestamp) in timestamps.iter().enumerate() {
@@ -684,31 +692,152 @@ async fn assemble_real_person_track(
             })
             .collect::<Vec<_>>();
         per_frame.push((timestamp, boxes));
-        let _ = tokio::fs::remove_file(&frame_path).await;
+        frame_paths.push(frame_path);
     }
-    let _ = tokio::fs::remove_dir_all(&work_dir).await;
 
     let observations = pt::observe(per_frame);
     let assembly = pt::assemble_track(&observations, selected_box, selected_timestamp, &timestamps);
     if assembly.target_track_id.is_none() || assembly.detected_frames == 0 {
+        let _ = tokio::fs::remove_dir_all(&work_dir).await;
         return Err(WorkerError::InvalidPayload(
             "Selected person was not found in the source video. Re-run detection or adjust the selection."
                 .to_owned(),
         ));
     }
 
+    // SAM2 segmentation pass (sc-3709): write a per-frame mask for each detected target
+    // frame and fold the result into `maskState`. Any segmenter unavailability degrades
+    // gracefully to box-derived masks (handled by the replacement loader), never failing
+    // a track that already located the person.
+    let mut frames_json = pt::frames_to_json(&assembly.frames);
+    let mask_state = segment_assembly_frames(
+        api,
+        settings,
+        http_client,
+        job,
+        project_path,
+        track_id,
+        &assembly.frames,
+        &frame_paths,
+        &mut frames_json,
+        segment_enabled,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+
     Ok(RealPersonTrack {
-        frames: pt::frames_to_json(&assembly.frames),
+        frames: frames_json,
         average_confidence: pt::average_confidence(&assembly.frames),
-        mask_state: "degraded",
+        mask_state,
         quality: assembly.quality,
         tracker_meta: json!({
             "backend": "mlx",
             "device": device,
             "model": "yolo11m",
             "tracker": "sort_bytetrack",
+            "segmenter": if segment_enabled { "sam2.1_hiera_large" } else { "disabled" },
         }),
     })
+}
+
+/// Segment each detected target frame with the native-MLX SAM2 segmenter, write the
+/// masks under `person-tracks/{track_id}/masks/frame_{index:06}.png`, set each frame's
+/// `mask` path, and roll the outcome up into a `maskState` (Python `segment_track`):
+/// `missing` (segmentation disabled), `degraded` (segmenter/weights unavailable or every
+/// frame failed → box-mask fallback at replacement time), `generated` (some frames
+/// segmented), `active` (all detected frames segmented). Frame ordering matches the
+/// assembly: frame `i` reads `frame_paths[i]` and the mask filename is 1-based (`i + 1`),
+/// matching the Python sidecar.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn segment_assembly_frames(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+    project_path: &std::path::Path,
+    track_id: &str,
+    frames: &[crate::person_track::TrackFrame],
+    frame_paths: &[PathBuf],
+    frames_json: &mut [Value],
+    segment_enabled: bool,
+) -> &'static str {
+    let detected_total = frames.iter().filter(|frame| frame.detected).count();
+    if detected_total == 0 {
+        return "missing";
+    }
+    if !segment_enabled {
+        return "missing";
+    }
+
+    // Resolve/download the SAM2 weights once; any failure degrades to box masks.
+    let weights = match crate::person_segment::ensure_segmenter_weights(settings, http_client).await
+    {
+        Ok(path) => path,
+        Err(_) => return "degraded",
+    };
+    let masks_dir = project_path
+        .join("person-tracks")
+        .join(track_id)
+        .join("masks");
+    if tokio::fs::create_dir_all(&masks_dir).await.is_err() {
+        return "degraded";
+    }
+
+    let mut generated = 0usize;
+    for (index, frame) in frames.iter().enumerate() {
+        if !frame.detected {
+            continue;
+        }
+        let Some(frame_path) = frame_paths.get(index) else {
+            continue;
+        };
+        if check_cancel(
+            api,
+            &job.id,
+            "Person tracking canceled during segmentation.",
+        )
+        .await
+        .is_err()
+        {
+            // Cancellation surfaces through the outer job poll; stop segmenting and keep
+            // whatever masks were already written.
+            break;
+        }
+        let rel = format!("person-tracks/{track_id}/masks/frame_{:06}.png", index + 1);
+        let out_path = project_path.join(&rel);
+        let weights_for_task = weights.clone();
+        let frame_for_task = frame_path.clone();
+        let box_norm = (
+            frame.box_.x,
+            frame.box_.y,
+            frame.box_.width,
+            frame.box_.height,
+        );
+        let out_for_task = out_path.clone();
+        let segmented = tokio::task::spawn_blocking(move || {
+            crate::person_segment::segment_person_blocking(
+                weights_for_task,
+                frame_for_task,
+                box_norm,
+                out_for_task,
+            )
+        })
+        .await;
+        match segmented {
+            Ok(Ok(())) => {
+                if let Some(entry) = frames_json.get_mut(index) {
+                    entry["mask"] = Value::String(rel);
+                }
+                generated += 1;
+            }
+            // A single frame's failure is non-fatal (matches Python's per-frame `except:
+            // continue`); the frame keeps `mask: null` and falls back to a box mask.
+            _ => continue,
+        }
+    }
+
+    crate::person_segment::rollup_mask_state(generated, detected_total)
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -718,11 +847,14 @@ async fn assemble_real_person_track(
     _settings: &Settings,
     _http_client: &reqwest::Client,
     _job: &JobSnapshot,
+    _project_path: &std::path::Path,
     _source_media_path: &std::path::Path,
     _detection: &Value,
+    _track_id: &str,
     _selected_timestamp: f64,
     _duration: f64,
     _confidence: f64,
+    _segment_enabled: bool,
 ) -> WorkerResult<RealPersonTrack> {
     Err(WorkerError::InvalidPayload(
         "Real person tracking runs on the Python worker on this platform.".to_owned(),
@@ -846,10 +978,22 @@ pub(crate) async fn run_person_track(
         })
         .unwrap_or(0.0);
 
+    // Segmentation is on by default (Python `advanced.segment`); a per-frame SAM2 mask is
+    // written for each detected target frame. `segment: false` skips it (maskState=missing).
+    let segment_enabled = job
+        .payload
+        .get("advanced")
+        .and_then(|advanced| advanced.get("segment"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    // The track id is generated up front so the SAM2 segmentation pass can write masks under
+    // `person-tracks/{track_id}/masks/` before the sidecar is assembled.
+    let track_id = format!("track_{}", Uuid::new_v4().simple());
+
     // Preview jobs (CPU worker) keep the procedural placeholder. Real jobs run the native-MLX
-    // YOLO11 detector (sc-3633) per sampled frame + the SORT/ByteTrack tracker (sc-3634). maskState
-    // stays "degraded" (box-derived masks via `load_track_masks`) until the SAM2 segmenter is wired
-    // in (sc-3709).
+    // YOLO11 detector (sc-3633) per sampled frame + the SORT/ByteTrack tracker (sc-3634), then
+    // segment each detected frame with the native-MLX SAM2 segmenter (sc-3709) → maskState
+    // active / generated / degraded / missing.
     let (
         frames,
         average_confidence,
@@ -894,11 +1038,14 @@ pub(crate) async fn run_person_track(
             settings,
             http_client,
             job,
+            &project_path,
             &source_media_path,
             &detection,
+            &track_id,
             selected_timestamp,
             duration,
             confidence,
+            segment_enabled,
         )
         .await?;
         (
@@ -913,7 +1060,6 @@ pub(crate) async fn run_person_track(
         )
     };
 
-    let track_id = format!("track_{}", Uuid::new_v4().simple());
     let track_name =
         optional_payload_string(&job.payload, "trackName").unwrap_or("Selected person");
     let representative_frame_asset_id = job

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -1,0 +1,190 @@
+//! Native-MLX SAM2 person segmentation on the Rust worker (epic 3704, sc-3709;
+//! Slice 3 of sc-3488 / epic 3482).
+//!
+//! Ports the Python `scene_worker/person_adapters.py` `segment_track` /
+//! `_Sam2Segmenter` to Rust so the Replace-Person mask-generation step runs on a
+//! Python-free Mac. Each detected track frame is segmented with the native-MLX
+//! `mlx-gen-sam2` box-prompt segmenter (Hiera encoder + FPN neck + prompt encoder +
+//! two-way mask decoder, sc-3705/3706, GO at sc-3708) and the binary `L` mask is
+//! written under `person-tracks/{track_id}/masks/`.
+//!
+//! macOS-only, like `person_jobs`: `mlx-gen-sam2` builds Apple MLX from source and is
+//! meaningless off Apple Silicon. The Python SAM2 path stays the Windows/Linux backend.
+//!
+//! The orchestration (which frames to segment, the maskState rollup, the sidecar
+//! write) lives in `media_jobs::assemble_real_person_track`; this module owns only the
+//! weight resolution/download and the single-frame segment call.
+
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use image::GrayImage;
+
+use mlx_gen::weights::Weights;
+use mlx_gen_sam2::{Sam2ModelSize, Sam2Segmenter};
+
+use crate::{Settings, WorkerError, WorkerResult};
+
+/// The production SAM2 size (matches the spike + the `SceneWorks/sam2-mlx` upload).
+const SEG_FILE: &str = "sam2.1_hiera_large.safetensors";
+
+/// Download-on-first-use source: the converted MLX SAM2 weights owned by SceneWorks
+/// (sc-3707, uploaded from the official Meta `.pt` via `tools/convert_sam2_to_mlx.py`;
+/// bit-identical to the avbiswas reference). Public repo, so no credentials are needed —
+/// same shape as the YOLO11 detector weights (`person_jobs::DET_URL`).
+const SEG_URL: &str =
+    "https://huggingface.co/SceneWorks/sam2-mlx/resolve/main/sam2.1_hiera_large.safetensors";
+
+/// The SAM2 segmenter is loaded once and cached process-wide (like the YOLO detector
+/// and Python's lazy model load). Holds `None` until the first frame is segmented.
+static SEGMENTER: OnceLock<Mutex<Option<Sam2Segmenter>>> = OnceLock::new();
+
+/// Resolve already-present SAM2 weights: an explicit env pin
+/// (`SCENEWORKS_SAM2_WEIGHTS`), then the app cache `<data_dir>/cache/person-segment/`,
+/// then the model dir `<data_dir>/models/person-segment/`. Returns `None` when nothing
+/// is staged (then `ensure_segmenter_weights` downloads it).
+pub(crate) fn resolve_segmenter_weights(settings: &Settings) -> Option<PathBuf> {
+    if let Ok(pinned) = std::env::var("SCENEWORKS_SAM2_WEIGHTS") {
+        let path = PathBuf::from(pinned);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    for sub in ["cache/person-segment", "models/person-segment"] {
+        let candidate = settings.data_dir.join(sub).join(SEG_FILE);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Resolve the SAM2 weights, downloading them from HuggingFace on first use (into the
+/// app cache). Mirrors `person_jobs::ensure_detector_weights` — atomic `.tmp` + rename
+/// so a partial download is never mistaken for a complete one.
+pub(crate) async fn ensure_segmenter_weights(
+    settings: &Settings,
+    http_client: &reqwest::Client,
+) -> WorkerResult<PathBuf> {
+    if let Some(path) = resolve_segmenter_weights(settings) {
+        return Ok(path);
+    }
+    let cache = settings.data_dir.join("cache").join("person-segment");
+    tokio::fs::create_dir_all(&cache).await?;
+    let target = cache.join(SEG_FILE);
+    let bytes = http_client
+        .get(SEG_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    let tmp = target.with_extension("safetensors.tmp");
+    tokio::fs::write(&tmp, &bytes).await?;
+    tokio::fs::rename(&tmp, &target).await?;
+    Ok(target)
+}
+
+/// Scale a normalized `(x, y, width, height)` box to a pixel-space `[x1, y1, x2, y2]`
+/// corner box on a `width`×`height` frame, clamped to the frame. SAM2 takes the box as a
+/// corner-point prompt in original pixel space.
+pub(crate) fn box_norm_to_pixels(
+    box_norm: (f64, f64, f64, f64),
+    width: u32,
+    height: u32,
+) -> [f32; 4] {
+    let (bx, by, bw, bh) = box_norm;
+    let (w, h) = (width as f32, height as f32);
+    [
+        (bx as f32 * w).clamp(0.0, w),
+        (by as f32 * h).clamp(0.0, h),
+        ((bx + bw) as f32 * w).clamp(0.0, w),
+        ((by + bh) as f32 * h).clamp(0.0, h),
+    ]
+}
+
+/// Roll the per-frame segmentation outcome into the sidecar `maskState` (Python
+/// `segment_track`): `generated` masks out of `detected_total` detected target frames →
+/// `degraded` (none written → box-mask fallback at replacement time), `active` (every
+/// detected frame segmented), or `generated` (a partial subset).
+pub(crate) fn rollup_mask_state(generated: usize, detected_total: usize) -> &'static str {
+    if generated == 0 {
+        "degraded"
+    } else if generated >= detected_total {
+        "active"
+    } else {
+        "generated"
+    }
+}
+
+/// Segment one rendered frame to a binary person mask and write it to `out_path` as an
+/// `L` (8-bit grayscale) PNG (0 / 255). `box_norm` is the tracked box in normalized
+/// `(x, y, width, height)` space (0..1); it is scaled to the frame's pixel dimensions
+/// and passed to SAM2 as a corner-point box prompt. The MLX model is loaded once and
+/// cached process-wide (like the YOLO detector and Python's lazy model load); invoke via
+/// `spawn_blocking`. The image decode + GPU segment + PNG encode are all blocking work,
+/// so doing them together here keeps the mask off the async path entirely.
+pub(crate) fn segment_person_blocking(
+    weights_path: PathBuf,
+    image_path: PathBuf,
+    box_norm: (f64, f64, f64, f64),
+    out_path: PathBuf,
+) -> WorkerResult<()> {
+    let img = image::open(&image_path)
+        .map_err(|e| WorkerError::InvalidPayload(format!("person frame open: {e}")))?
+        .to_rgb8();
+    let (width, height) = (img.width(), img.height());
+    let box_xyxy = box_norm_to_pixels(box_norm, width, height);
+
+    let cell = SEGMENTER.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().expect("person segmenter mutex poisoned");
+    if guard.is_none() {
+        let weights = Weights::from_file(&weights_path)
+            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 weights load: {e}")))?;
+        let segmenter = Sam2Segmenter::from_weights_for_size(&weights, Sam2ModelSize::Large)
+            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 segmenter build: {e}")))?;
+        *guard = Some(segmenter);
+    }
+    let segmenter = guard.as_ref().expect("segmenter loaded");
+    let mask = segmenter
+        .segment(img.as_raw(), height, width, box_xyxy)
+        .map_err(|e| WorkerError::InvalidPayload(format!("sam2 segment: {e}")))?;
+    let pixels = mask.as_slice::<u8>().to_vec();
+    let gray = GrayImage::from_raw(width, height, pixels).ok_or_else(|| {
+        WorkerError::InvalidPayload("sam2 mask dimensions did not match the frame".to_owned())
+    })?;
+    gray.save(&out_path)
+        .map_err(|e| WorkerError::InvalidPayload(format!("sam2 mask save: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn box_norm_scales_and_clamps_to_the_frame() {
+        // A centered half-size box on a 1280×720 frame → [320,180,960,540].
+        let px = box_norm_to_pixels((0.25, 0.25, 0.5, 0.5), 1280, 720);
+        assert!((px[0] - 320.0).abs() < 1e-3);
+        assert!((px[1] - 180.0).abs() < 1e-3);
+        assert!((px[2] - 960.0).abs() < 1e-3);
+        assert!((px[3] - 540.0).abs() < 1e-3);
+        // A box that overflows the right/bottom edge clamps to the frame extent.
+        let clamped = box_norm_to_pixels((0.9, 0.9, 0.5, 0.5), 100, 100);
+        assert_eq!(clamped[2], 100.0);
+        assert_eq!(clamped[3], 100.0);
+    }
+
+    #[test]
+    fn mask_state_rollup_matches_python_segment_track() {
+        // No masks written → degraded (box-mask fallback).
+        assert_eq!(rollup_mask_state(0, 4), "degraded");
+        // Every detected frame segmented → active.
+        assert_eq!(rollup_mask_state(4, 4), "active");
+        // A partial subset → generated.
+        assert_eq!(rollup_mask_state(2, 4), "generated");
+        // A single detected frame, segmented → active (not generated).
+        assert_eq!(rollup_mask_state(1, 1), "active");
+    }
+}

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -448,6 +448,14 @@ fn mlx_gpu_advertises_generation_capabilities_only() {
     assert!(capabilities
         .iter()
         .any(|capability| capability.as_str() == "training_caption"));
+    // Real, model-backed person detect/track are ported to the MLX worker (sc-3709): the
+    // worker advertises the non-preview capabilities so the API routes real jobs here.
+    assert!(capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "person_detect"));
+    assert!(capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "person_track"));
     assert!(capabilities
         .iter()
         .any(|capability| capability.as_str() == "gpu"));

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -123,7 +123,7 @@ in-process Rust path. Per Michael's 2026-06-07 decision, all four spikes are **p
 | Surface | Job type(s) | Python backend | Status | Closing work |
 |---|---|---|---|---|
 | DWPose pose detection (photo→skeleton) | `pose_detect` | onnxruntime (RTMPose) | ✅ Ported (Rust `ort`/CoreML, macOS MLX worker) | sc-3487 |
-| Person detect / track | `person_detect`, `person_track` | YOLO / SAM2 | 🔵 Port-pending (all **MLX**) | sc-3488 → YOLO detect sc-3633 (ort→**MLX**, CoreML hangs), ByteTrack sc-3634, **SAM2 segmenter = MLX engine epic 3704** (spike sc-3635 GO→MLX; CoreML net-negative for the Hiera ViT) + wiring sc-3709, routing sc-3636 |
+| Person detect / track | `person_detect`, `person_track` | YOLO / SAM2 | ✅ Ported (all **native MLX**, macOS MLX worker) | sc-3488 → YOLO detect sc-3633 (native mlx-rs forward, CoreML/ort hangs), ByteTrack track assembly sc-3634, **SAM2 segmenter = MLX engine epic 3704** (spike sc-3635 GO→MLX; CoreML net-negative for the Hiera ViT) + wiring sc-3709 (capability advertise + `mac_rust_supported` flip). maskState active/generated/degraded/missing. **replace_person end-to-end still needs the video-gen/inpaint half — epic 3040** (see row above) |
 | Image upscaler (standalone) | `image_upscale` | Real-ESRGAN / AuraSR (torch) | ✅ Ported (Real-ESRGAN via Rust `ort`/CoreML, macOS MLX worker; **AuraSR** engine stays on Python) | sc-3489 |
 | Dataset captioning | `training_caption` | JoyCaption MLX provider (Python torch fallback off-MLX) | ✅ Ported (macOS MLX worker) | sc-3556 |
 | Wan/LTX model conversion | `model_convert` (non-`flux2_klein_diffusers` converter) | `mlx_video.convert_*` (Python) | 🔵 Port-pending | sc-3491 (= sc-3224) |


### PR DESCRIPTION
Completes **Slice 3 of sc-3488** (epic 3482 Python Eradication) / **Slice 5 of epic 3704**. The Replace-Person **detect → track → mask** flow now runs end-to-end on a Python-free Mac — native-MLX YOLO11 (sc-3633) + SORT/ByteTrack (sc-3634) + SAM2 (epic 3704), zero onnxruntime/torch.

### Engine
- Bump worker mlx-gen rev `6404de7 → 0ed3019` (mlx-gen main with the `mlx-gen-sam2` crate — #176/#177/#179) + add the `mlx-gen-sam2` dependency. **Same mlx-rs pin (`e59ffd88`) → MLX is not rebuilt.**

### Segmenter (`segment_track` port)
- New macOS module `person_segment.rs`: download-on-first-use of `sam2.1_hiera_large.safetensors` from the live `SceneWorks/sam2-mlx` HF repo (mirrors `person_jobs::ensure_detector_weights`), a process-wide `Sam2Segmenter` cache, and a blocking `segment(rgb, h, w, box) → L mask` that writes the PNG.
- `media_jobs::assemble_real_person_track` keeps each rendered frame and runs a SAM2 pass over the **detected target** frames: masks land at `person-tracks/{track_id}/masks/frame_{i:06}.png` (1-based), `frame.mask` is set, and **`maskState`** rolls up to `active` / `generated` / `degraded` (segmenter/weights unavailable → box-mask fallback at replacement time) / `missing` (`advanced.segment: false`). A single frame's failure is non-fatal (matches Python's per-frame `except: continue`).

### Routing flip (deferred from sc-3633/3634)
- `gpu.rs mlx_gpu()` advertises `PersonDetect` + `PersonTrack`; `jobs_store::mac_rust_supported` **and** `mac_capabilities` flip both to supported; `docs/mac-rust-gaps.md` updated.

### Coupling caveat
`replace_person` end-to-end still needs the video-gen/inpaint half (**epic 3040**, torch-only today); the `PersonReplace` job stays a tracked Mac gap (asserted in the oracle test).

### Verification
- `npm run rust:check` green — fmt + clippy `-D warnings` + all-crate tests + build.
- New pure unit tests: box→pixel scaling (`box_norm_to_pixels`) + the `maskState` rollup (`rollup_mask_state`).
- Real-Mac MLX E2E (detect → track → masks → `maskState=active`) is the remaining manual validation before **Done**.

Notes:
- sc-3707 PR [mlx-gen#178](https://github.com/michaeltrefry/mlx-gen/pull/178) (the Python converter + provisioning doc) is still open/In Review. It is **not** on the runtime path — the worker downloads the already-uploaded safetensors — so bumping to `0ed3019` (which excludes #178) is sufficient. Flagging so #178 still merges on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)