### PR TITLE
sc-3523: SVD worker cutover → svd_xt (link mlx-gen-svd; image_to_video)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "image",
  "inventory",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "image",
  "inventory",
@@ -2598,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "image",
  "inventory",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
 dependencies = [
  "image",
  "inventory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "image",
  "inventory",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "image",
  "inventory",
@@ -2596,9 +2596,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-svd"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "mlx-gen-sdxl",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "image",
  "inventory",
@@ -2612,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0ed301962c9ec6e055b1cfeff2c75c7448006887#0ed301962c9ec6e055b1cfeff2c75c7448006887"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
 dependencies = [
  "image",
  "inventory",
@@ -2908,7 +2920,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4186,6 +4198,7 @@ dependencies = [
  "mlx-gen-qwen-image",
  "mlx-gen-sam2",
  "mlx-gen-sdxl",
+ "mlx-gen-svd",
  "mlx-gen-wan",
  "mlx-gen-z-image",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "image",
  "inventory",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "image",
  "inventory",
@@ -2598,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "image",
  "inventory",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=710fccd15d633e9140e93ee8d9850617cb095efb#710fccd15d633e9140e93ee8d9850617cb095efb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=29387635dcc3f7c1a036b69138c7a761b7592d82#29387635dcc3f7c1a036b69138c7a761b7592d82"
 dependencies = [
  "image",
  "inventory",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2496,8 +2496,8 @@ async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
     assert_eq!(kolors["macSupport"]["reason"]["suggestedEpic"], "epic 3532");
     // MLX-routed family → supported, stays in the picker.
     assert_eq!(by_id("z_image_turbo")["macSupport"]["supported"], true);
-    // Torch-only video model → unsupported.
-    assert_eq!(by_id("svd")["macSupport"]["supported"], false);
+    // SVD is now MLX-routed (sc-3523: `svd`→`svd_xt`, image→video only) → supported.
+    assert_eq!(by_id("svd")["macSupport"]["supported"], true);
 
     // Capabilities endpoint: gating active (mlx_required=true) + infra epics present.
     let (status, caps) = request(app, "GET", "/api/v1/capabilities/mac", Value::Null).await;

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2223,8 +2223,8 @@ fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedReason {
     if !VIDEO_MLX_ROUTED_MODELS.contains(&model) {
         return UnsupportedReason::new(
             Some(model),
-            "torch-only video model (incl. SVD)",
-            "this video model has no Rust/MLX engine (e.g. SVD); it runs on the Python torch path.",
+            "torch-only video model",
+            "this video model has no Rust/MLX engine; it runs on the Python torch path.",
             Some("epic 3040"),
         );
     }
@@ -2770,15 +2770,16 @@ fn z_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
 }
 
 /// Video models the in-process Rust MLX worker generates today (sc-3034 Wan2.2,
-/// sc-3035 LTX-2.3 + audio). Mirrors `MlxVideoAdapter._supported_models`. A model
-/// id absent here is never routed to the mlx worker — the Python torch path stays
-/// authoritative for it (and for SVD, which has no MLX crate).
+/// sc-3035 LTX-2.3 + audio, sc-3523 SVD-XT image→video). Mirrors
+/// `MlxVideoAdapter._supported_models`. A model id absent here is never routed to the
+/// mlx worker — the Python torch path stays authoritative for it.
 const VIDEO_MLX_ROUTED_MODELS: &[&str] = &[
     "ltx_2_3",
     "ltx_2_3_eros",
     "wan_2_2",
     "wan_2_2_t2v_14b",
     "wan_2_2_i2v_14b",
+    "svd",
 ];
 
 /// Epic 3018 routing (sc-3036, the video sibling of [`image_job_is_mlx_eligible`]):
@@ -2788,12 +2789,13 @@ const VIDEO_MLX_ROUTED_MODELS: &[&str] = &[
 /// expressed by whether an `mlx` worker is registered and idle (see
 /// [`should_defer_video_to_mlx_worker`]).
 ///
-/// MLX covers `text_to_video` + `image_to_video` on Wan/LTX, plus `first_last_frame`
-/// on the FLF-capable engines (LTX + Wan TI2V-5B `wan_2_2`; sc-3055 cutover — see
+/// MLX covers `text_to_video` + `image_to_video` on Wan/LTX, `image_to_video` on SVD
+/// (`svd`→`svd_xt`, image-conditioned only — sc-3523), plus `first_last_frame` on the
+/// FLF-capable engines (LTX + Wan TI2V-5B `wan_2_2`; sc-3055 cutover — see
 /// [`video_mode_is_mlx_eligible`]). Still on the Python torch path: the advanced job
 /// types (`video_extend`/`video_bridge`/`person_replace`) and the `replace_person`
-/// mode (a later Wan-VACE cutover slice), SVD (svd_xt not linked in the worker yet), and a
-/// non-MLX model. **Third-party LyCORIS (LoHa / non-peft LoKr) and LoKr-on-Wan now run on MLX**
+/// mode (a later Wan-VACE cutover slice), and a non-MLX model.
+/// **Third-party LyCORIS (LoHa / non-peft LoKr) and LoKr-on-Wan now run on MLX**
 /// (epic 3641, sc-3671 + sc-3644): the Wan/LTX engine paths reconstruct + merge/residual the delta —
 /// the peft-LoKr-on-Wan merge has existed since sc-2393, and the old `create_video_adapter` torch
 /// gate was a routing caution, never an engine limit.
@@ -2821,14 +2823,19 @@ fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     true
 }
 
-/// Which `video_generate` modes the in-process Rust MLX worker serves for `model`. Every
-/// routed model serves `text_to_video` + `image_to_video` (sc-3034/3035); `first_last_frame`
-/// is additionally MLX on the FLF-capable engines — LTX (`ltx_2_3`/`ltx_2_3_eros`, the
+/// Which `video_generate` modes the in-process Rust MLX worker serves for `model`. The Wan/LTX
+/// engines serve `text_to_video` + `image_to_video` (sc-3034/3035); `first_last_frame` is
+/// additionally MLX on the FLF-capable engines — LTX (`ltx_2_3`/`ltx_2_3_eros`, the
 /// reference-grounded `Keyframe` path, sc-3052) and Wan TI2V-5B (`wan_2_2`, the mask-blend
 /// multi-keyframe path, sc-3357). The 14B Wan MoE engines have no `Keyframe` path, so FLF on
-/// them stays torch. The advanced clip modes (`extend_clip`/`video_bridge`) + `replace_person`
-/// ride dedicated job types / the Wan-VACE path and are separate cutover slices (sc-3055).
+/// them stays torch. **SVD (`svd`) is image-conditioned only** — it serves `image_to_video`
+/// exclusively (no text→video, sc-3523). The advanced clip modes (`extend_clip`/`video_bridge`) +
+/// `replace_person` ride dedicated job types / the Wan-VACE path and are separate cutover slices
+/// (sc-3055).
 fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
+    if model == "svd" {
+        return mode == "image_to_video";
+    }
     match mode {
         "text_to_video" | "image_to_video" => true,
         "first_last_frame" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),
@@ -3510,10 +3517,25 @@ mod mlx_routing_tests {
 
     #[test]
     fn video_mode_eligibility_admits_flf_only_on_flf_capable_engines() {
-        // Base modes are MLX on every routed model.
+        // image_to_video is MLX on every routed model; text_to_video on every routed model
+        // EXCEPT SVD (image-conditioned only, sc-3523).
         for model in VIDEO_MLX_ROUTED_MODELS {
-            assert!(video_mode_is_mlx_eligible(model, "text_to_video"));
             assert!(video_mode_is_mlx_eligible(model, "image_to_video"));
+            assert_eq!(
+                video_mode_is_mlx_eligible(model, "text_to_video"),
+                *model != "svd",
+                "text_to_video eligibility for {model}"
+            );
+        }
+        // SVD serves image_to_video ONLY — no text_to_video, FLF, or anything else.
+        assert!(video_mode_is_mlx_eligible("svd", "image_to_video"));
+        for mode in [
+            "text_to_video",
+            "first_last_frame",
+            "replace_person",
+            "nonsense",
+        ] {
+            assert!(!video_mode_is_mlx_eligible("svd", mode));
         }
         // first_last_frame: MLX on LTX (base + eros) + Wan TI2V-5B (sc-3055 cutover).
         assert!(video_mode_is_mlx_eligible("ltx_2_3", "first_last_frame"));

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1886,18 +1886,25 @@ fn mac_rust_supported_names_advanced_video_and_svd() {
             .as_deref(),
         Some("epic 3040")
     );
-    // Torch-only video model (e.g. SVD) on the base video_generate type.
+    // SVD image→video is now MLX-supported (sc-3523: `svd`→`svd_xt`, image-conditioned only).
     let svd = job_of(
         &store,
         JobType::VideoGenerate,
         json!({ "model": "svd", "mode": "image_to_video" }),
     );
-    assert_eq!(
-        mac_rust_supported(&svd)
-            .unwrap_err()
-            .suggested_epic
-            .as_deref(),
-        Some("epic 3040")
+    assert!(
+        mac_rust_supported(&svd).is_ok(),
+        "svd image_to_video should be MLX-supported (sc-3523)"
+    );
+    // SVD is image-conditioned only — text→video on it is not in the Rust/MLX flow.
+    let svd_text = job_of(
+        &store,
+        JobType::VideoGenerate,
+        json!({ "model": "svd", "mode": "text_to_video" }),
+    );
+    assert!(
+        mac_rust_supported(&svd_text).is_err(),
+        "svd text_to_video is not MLX-eligible (image-conditioned only)"
     );
 }
 
@@ -1981,9 +1988,11 @@ fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
     let z_image = model_mac_support("z_image_turbo", "image");
     assert!(z_image.supported);
     assert!(z_image.reason.is_none());
-    // Torch-only video model (SVD) is hidden; Wan/LTX stay.
-    assert!(!model_mac_support("svd", "video").supported);
+    // SVD is now MLX-routed (sc-3523, image→video only) so it stays in the picker, like Wan/LTX;
+    // a genuinely engine-less video model id is still hidden.
+    assert!(model_mac_support("svd", "video").supported);
     assert!(model_mac_support("wan_2_2", "video").supported);
+    assert!(!model_mac_support("some_torch_only_video", "video").supported);
     // Utility/infra models are never hidden by model-level gating (their actions are
     // gated by mac_capabilities at the job-type level instead).
     assert!(model_mac_support("real_esrgan", "utility").supported);

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,18 +68,21 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 0ed3019 (mlx-gen main): adds the native-MLX SAM2 segmenter crate `mlx-gen-sam2`
-# (epic 3704, mlx-gen #176/#177/#179 — Hiera encoder + FPN neck + prompt encoder +
-# two-way mask decoder + box→mask segmenter), consumed by the Rust person-track
-# segmenter (sc-3709). On top of the prior rev's third-party LyCORIS (epic 3641,
-# #171/#172/#174), the core AdaptableHost loader (flux/flux2/qwen-image/z-image) plus
-# the SDXL merge path, the Wan in-place merge, the LTX forward residual, Qwen-Image
-# ControlNet strict pose (epic 3401), LoRA/LoKr trainer surface (epic 3039), Wan/LTX
-# converter stack, Wan-VACE provider + per-request control_scale (epic 3040), JoyCaption
-# captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621). One shared rev so
-# MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across the bump ->
-# no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+# Rev 710fccd (mlx-gen PR #180, branch claude/sc-3523-svd-motion-knobs — RE-PIN to the
+# squash-merged main SHA once #180 lands): exposes the SVD motion knobs on
+# `GenerationRequest` (`motion_bucket_id` / `noise_aug_strength` / `decode_chunk_size`),
+# read by the `svd_xt` provider, so the SVD worker cutover (sc-3523) can map them. On top
+# of the prior rev 0ed3019: the native-MLX SAM2 segmenter crate `mlx-gen-sam2` (epic 3704,
+# mlx-gen #176/#177/#179 — Hiera encoder + FPN neck + prompt encoder + two-way mask decoder
+# + box→mask segmenter), consumed by the Rust person-track segmenter (sc-3709); third-party
+# LyCORIS (epic 3641, #171/#172/#174); the core AdaptableHost loader
+# (flux/flux2/qwen-image/z-image) plus the SDXL merge path, the Wan in-place merge, the LTX
+# forward residual, Qwen-Image ControlNet strict pose (epic 3401), LoRA/LoKr trainer surface
+# (epic 3039), Wan/LTX converter stack, Wan-VACE provider + per-request control_scale
+# (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
+# One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
+# the bump -> no MLX rebuild).
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -87,38 +90,44 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+# Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
+# `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
+# `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
+# linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
+# other mlx-gen crates so MLX builds once.
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0ed301962c9ec6e055b1cfeff2c75c7448006887" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,12 +68,11 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 2938763 (mlx-gen PR #181, branch claude/sc-3764-svd-fps-decouple — RE-PIN to the
-# merged main SHA once #181 lands; it already includes the merged #180): exposes the SVD
-# motion knobs on `GenerationRequest` (`motion_bucket_id` / `noise_aug_strength` /
-# `decode_chunk_size`, #180) AND decouples the SVD motion-conditioning fps from the
-# output/playback fps via `conditioning_fps` (#181), both read by the `svd_xt` provider so
-# the SVD worker cutover (sc-3523 / sc-3764) can map them. On top of the prior rev 0ed3019:
+# Rev 13c0681 (mlx-gen main, merged PRs #180 + #181): exposes the SVD motion knobs on
+# `GenerationRequest` (`motion_bucket_id` / `noise_aug_strength` / `decode_chunk_size`, #180)
+# AND decouples the SVD motion-conditioning fps from the output/playback fps via
+# `conditioning_fps` (#181), both read by the `svd_xt` provider so the SVD worker cutover
+# (sc-3523 / sc-3764) can map them. On top of the prior rev 0ed3019:
 # the native-MLX SAM2 segmenter crate `mlx-gen-sam2` (epic 3704,
 # mlx-gen #176/#177/#179 — Hiera encoder + FPN neck + prompt encoder + two-way mask decoder
 # + box→mask segmenter), consumed by the Rust person-track segmenter (sc-3709); third-party
@@ -84,7 +83,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -92,44 +91,44 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,11 +68,13 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 710fccd (mlx-gen PR #180, branch claude/sc-3523-svd-motion-knobs — RE-PIN to the
-# squash-merged main SHA once #180 lands): exposes the SVD motion knobs on
-# `GenerationRequest` (`motion_bucket_id` / `noise_aug_strength` / `decode_chunk_size`),
-# read by the `svd_xt` provider, so the SVD worker cutover (sc-3523) can map them. On top
-# of the prior rev 0ed3019: the native-MLX SAM2 segmenter crate `mlx-gen-sam2` (epic 3704,
+# Rev 2938763 (mlx-gen PR #181, branch claude/sc-3764-svd-fps-decouple — RE-PIN to the
+# merged main SHA once #181 lands; it already includes the merged #180): exposes the SVD
+# motion knobs on `GenerationRequest` (`motion_bucket_id` / `noise_aug_strength` /
+# `decode_chunk_size`, #180) AND decouples the SVD motion-conditioning fps from the
+# output/playback fps via `conditioning_fps` (#181), both read by the `svd_xt` provider so
+# the SVD worker cutover (sc-3523 / sc-3764) can map them. On top of the prior rev 0ed3019:
+# the native-MLX SAM2 segmenter crate `mlx-gen-sam2` (epic 3704,
 # mlx-gen #176/#177/#179 — Hiera encoder + FPN neck + prompt encoder + two-way mask decoder
 # + box→mask segmenter), consumed by the Rust person-track segmenter (sc-3709); third-party
 # LyCORIS (epic 3641, #171/#172/#174); the core AdaptableHost loader
@@ -82,7 +84,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -90,44 +92,44 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d6
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "710fccd15d633e9140e93ee8d9850617cb095efb" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "29387635dcc3f7c1a036b69138c7a761b7592d82" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -38,6 +38,8 @@ use mlx_gen::{
 #[cfg(target_os = "macos")]
 use mlx_gen_ltx as _;
 #[cfg(target_os = "macos")]
+use mlx_gen_svd as _;
+#[cfg(target_os = "macos")]
 use mlx_gen_wan as _;
 #[cfg(target_os = "macos")]
 use sceneworks_core::video_request::{ltx_frame_count, wan_frame_count};
@@ -166,6 +168,23 @@ pub(crate) async fn run_video_generate_job(
             .await?,
             LTX_ADAPTER,
             ltx_raw_settings(&request),
+        )
+    } else if let Some(engine_id) =
+        svd_engine_id(&request.model).filter(|_| svd_available(&request, settings))
+    {
+        (
+            generate_svd(
+                api,
+                settings,
+                job,
+                &request,
+                &project_path,
+                engine_id,
+                backend,
+            )
+            .await?,
+            SVD_ADAPTER,
+            svd_raw_settings(&request),
         )
     } else {
         (
@@ -1086,6 +1105,10 @@ struct VideoGenInput {
     use_uncensored_enhancer: bool,
     enhance_max_tokens: Option<u32>,
     enhance_temperature: Option<f32>,
+    // SVD-only micro-conditioning knobs (sc-3523); `None` on the other models.
+    motion_bucket_id: Option<f32>,
+    noise_aug_strength: Option<f32>,
+    decode_chunk_size: Option<u32>,
 }
 
 #[cfg(target_os = "macos")]
@@ -1111,6 +1134,9 @@ impl Default for VideoGenInput {
             use_uncensored_enhancer: false,
             enhance_max_tokens: None,
             enhance_temperature: None,
+            motion_bucket_id: None,
+            noise_aug_strength: None,
+            decode_chunk_size: None,
         }
     }
 }
@@ -1151,6 +1177,9 @@ fn run_video_generation(
         use_uncensored_enhancer: input.use_uncensored_enhancer,
         enhance_max_tokens: input.enhance_max_tokens,
         enhance_temperature: input.enhance_temperature,
+        motion_bucket_id: input.motion_bucket_id,
+        noise_aug_strength: input.noise_aug_strength,
+        decode_chunk_size: input.decode_chunk_size,
         cancel: cancel.clone(),
         ..Default::default()
     };
@@ -1590,6 +1619,272 @@ async fn generate_ltx(
         use_uncensored_enhancer: advanced_bool(request, "useUncensoredEnhancer"),
         enhance_max_tokens,
         enhance_temperature,
+        ..VideoGenInput::default()
+    };
+    generate_video(api, settings, job, backend, input).await
+}
+
+// ---------------------------------------------------------------------------
+// Real MLX Stable Video Diffusion (SVD-XT) generation (macOS, via mlx-gen-svd, sc-3523):
+// image→video ONLY — animates one source image into a fixed ~25-frame burst (no text prompt,
+// no audio) via the `motion_bucket_id` / `noise_aug_strength` / conditioning-fps
+// micro-conditioning. One engine model `svd_xt`. Source-of-truth = the torch
+// `DiffusersVideoAdapter` `svd_video` path (`StableVideoDiffusionPipeline`, video_adapters.py).
+// The engine loads the stock diffusers fp16 snapshot directly (vae/ + unet/ + image_encoder/),
+// so there is no conversion step (unlike Wan/LTX).
+//
+// Divergence note: the engine uses one `fps` for BOTH the motion micro-conditioning
+// (`added_time_ids` = fps − 1) and the output mux. We pass the conditioning fps (manifest
+// `condFps`, default 7 — the value the model was trained on) so the MOTION is correct; the burst
+// therefore plays at that cadence. The torch path muxed the same 25-frame burst at the user's
+// playback `fps` instead — a cosmetic playback-speed difference, not a content one.
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real MLX SVD asset — matches the torch `svd_video` adapter id so the
+/// asset sidecar reads identically across the two backends.
+#[cfg(target_os = "macos")]
+const SVD_ADAPTER: &str = "svd_video";
+
+/// The diffusers SVD-XT repo the engine loads directly (fp16 `vae/` + `unet/` + `image_encoder/`).
+#[cfg(target_os = "macos")]
+const SVD_REPO: &str = "stabilityai/stable-video-diffusion-img2vid-xt";
+
+/// SceneWorks model id → mlx-gen registry id for the SVD family (only `svd` → `svd_xt`), or `None`.
+#[cfg(target_os = "macos")]
+fn svd_engine_id(model: &str) -> Option<&'static str> {
+    (model == "svd").then_some("svd_xt")
+}
+
+/// Whether the linked SVD engine can serve this request now (image→video with resolvable weights).
+/// SVD is image-conditioned only, so a request without a `sourceAssetId` can never run on it.
+#[cfg(target_os = "macos")]
+fn svd_available(request: &VideoRequest, settings: &Settings) -> bool {
+    svd_engine_id(&request.model).is_some()
+        && request.source_asset_id.is_some()
+        && resolve_svd_model_dir(settings).is_ok()
+}
+
+/// Whether `dir` is a usable SVD-XT snapshot — each component subdir carries the safetensors the
+/// engine reads (preferring the on-disk `.fp16` variant, else the full-precision file).
+#[cfg(target_os = "macos")]
+fn svd_dir_is_complete(dir: &Path) -> bool {
+    let has = |sub: &str, stem: &str| {
+        dir.join(sub)
+            .join(format!("{stem}.fp16.safetensors"))
+            .is_file()
+            || dir.join(sub).join(format!("{stem}.safetensors")).is_file()
+    };
+    has("vae", "diffusion_pytorch_model")
+        && has("unet", "diffusion_pytorch_model")
+        && has("image_encoder", "model")
+}
+
+/// Resolve the SVD-XT snapshot dir: env override (`SCENEWORKS_MLX_SVD_DIR`) → the cached HF snapshot
+/// of [`SVD_REPO`]. Only a dir carrying the three component subdirs ([`svd_dir_is_complete`]) counts.
+#[cfg(target_os = "macos")]
+fn resolve_svd_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    if let Ok(override_dir) = std::env::var("SCENEWORKS_MLX_SVD_DIR") {
+        let path = PathBuf::from(override_dir.trim());
+        if svd_dir_is_complete(&path) {
+            return Ok(path);
+        }
+    }
+    if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, SVD_REPO) {
+        if svd_dir_is_complete(&dir) {
+            return Ok(dir);
+        }
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "svd: no complete SVD-XT weights found (expected vae/ + unet/ + image_encoder/ under the \
+         cached {SVD_REPO} snapshot, or set $SCENEWORKS_MLX_SVD_DIR)"
+    )))
+}
+
+/// Read an SVD integer knob: `advanced[adv_key]` → `modelManifestEntry[manifest_key]` → `default`,
+/// then clamp to `[min, max]`. Mirrors the torch `safe_int(advanced.get(adv_key),
+/// target.get(manifest_key, default), min, max)` (advanced overrides the manifest, which overrides
+/// the builtin default; the resolved value is clamped).
+#[cfg(target_os = "macos")]
+fn svd_i32(
+    request: &VideoRequest,
+    adv_key: &str,
+    manifest_key: &str,
+    default: i32,
+    min: i32,
+    max: i32,
+) -> i32 {
+    request
+        .advanced
+        .get(adv_key)
+        .or_else(|| request.model_manifest_entry.get(manifest_key))
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .map(|v| v as i32)
+        .unwrap_or(default)
+        .clamp(min, max)
+}
+
+/// Read an SVD float knob: `advanced[adv_key]` → `modelManifestEntry[manifest_key]` → `default`
+/// (no clamp). Mirrors the torch `float(advanced.get(adv_key, target.get(manifest_key, default)))`.
+#[cfg(target_os = "macos")]
+fn svd_f32(request: &VideoRequest, adv_key: &str, manifest_key: &str, default: f32) -> f32 {
+    request
+        .advanced
+        .get(adv_key)
+        .or_else(|| request.model_manifest_entry.get(manifest_key))
+        .and_then(|v| v.as_f64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .map(|v| v as f32)
+        .unwrap_or(default)
+}
+
+/// Inference steps for an SVD request: `advanced.steps` → `modelManifestEntry.steps[quality]` (else
+/// its `balanced`) → the builtin quality ladder (fast 15 / balanced 25 / best 30), clamped 1..=80.
+/// Mirrors the torch `_num_inference_steps` for the `svd_video` adapter.
+#[cfg(target_os = "macos")]
+fn svd_steps(request: &VideoRequest) -> u32 {
+    let builtin = match request.quality.as_str() {
+        "fast" => 15,
+        "best" => 30,
+        _ => 25,
+    };
+    let manifest_default = request
+        .model_manifest_entry
+        .get("steps")
+        .and_then(Value::as_object)
+        .and_then(|steps| {
+            steps
+                .get(&request.quality)
+                .or_else(|| steps.get("balanced"))
+        })
+        .and_then(Value::as_i64)
+        .map(|v| v as i32)
+        .unwrap_or(builtin);
+    request
+        .advanced
+        .get("steps")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .map(|v| v as i32)
+        .unwrap_or(manifest_default)
+        .clamp(1, 80) as u32
+}
+
+/// The single `Reference` conditioning image (image→video source). SVD is image-conditioned only,
+/// so a missing `sourceAssetId` is a hard error (the routing gate [`svd_available`] already
+/// requires it; this guards the direct-call path).
+#[cfg(target_os = "macos")]
+fn resolve_svd_conditioning(
+    settings: &Settings,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Conditioning>> {
+    let asset_id = request.source_asset_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "svd image→video requires a source image (sourceAssetId).".to_owned(),
+        )
+    })?;
+    let image = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        asset_id,
+        project_path,
+    )?;
+    Ok(vec![Conditioning::Reference {
+        image,
+        strength: None,
+    }])
+}
+
+/// Raw-settings recorded on a real MLX SVD asset (the resolved knobs + real-inference markers).
+#[cfg(target_os = "macos")]
+fn svd_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert(
+        "numFrames".to_owned(),
+        json!(svd_i32(request, "numFrames", "numFrames", 25, 1, 25)),
+    );
+    raw.insert(
+        "motionBucketId".to_owned(),
+        json!(svd_i32(
+            request,
+            "motionBucketId",
+            "motionBucketId",
+            127,
+            1,
+            255
+        )),
+    );
+    raw.insert(
+        "conditioningFps".to_owned(),
+        json!(svd_i32(request, "conditioningFps", "condFps", 7, 1, 30)),
+    );
+    raw.insert(
+        "noiseAugStrength".to_owned(),
+        json!(svd_f32(
+            request,
+            "noiseAugStrength",
+            "noiseAugStrength",
+            0.02
+        )),
+    );
+    raw.insert(
+        "decodeChunkSize".to_owned(),
+        json!(svd_i32(
+            request,
+            "decodeChunkSize",
+            "decodeChunkSize",
+            8,
+            1,
+            64
+        )),
+    );
+    raw.insert("steps".to_owned(), json!(svd_steps(request)));
+    Value::Object(raw)
+}
+
+/// Resolve an SVD request into a [`VideoGenInput`] and run it (sc-3523). image→video only: no
+/// prompt / negative / guidance (the engine uses its frame-wise CFG ramp); `frames` is the
+/// model-fixed burst length (≤25); `fps` carries the motion-conditioning cadence (see the module
+/// note); `motion_bucket_id` / `noise_aug_strength` / `decode_chunk_size` drive the SVD knobs.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn generate_svd(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    let input = VideoGenInput {
+        engine_id,
+        model_dir: resolve_svd_model_dir(settings)?,
+        quant: None,
+        adapters: Vec::new(),
+        conditioning: resolve_svd_conditioning(settings, request, project_path)?,
+        prompt: String::new(),
+        negative_prompt: None,
+        width: request.width,
+        height: request.height,
+        frames: svd_i32(request, "numFrames", "numFrames", 25, 1, 25) as u32,
+        fps: svd_i32(request, "conditioningFps", "condFps", 7, 1, 30) as u32,
+        steps: Some(svd_steps(request)),
+        guidance: None,
+        seed: resolve_video_seed(request) as u64,
+        motion_bucket_id: Some(
+            svd_i32(request, "motionBucketId", "motionBucketId", 127, 1, 255) as f32,
+        ),
+        noise_aug_strength: Some(svd_f32(
+            request,
+            "noiseAugStrength",
+            "noiseAugStrength",
+            0.02,
+        )),
+        decode_chunk_size: Some(
+            svd_i32(request, "decodeChunkSize", "decodeChunkSize", 8, 1, 64) as u32,
+        ),
+        ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, input).await
 }
@@ -1879,6 +2174,166 @@ mod tests {
         assert_eq!(ltx_engine_id("ltx_2_3_eros"), Some("ltx_2_3"));
         assert_eq!(ltx_engine_id("wan_2_2"), None);
         assert_eq!(ltx_engine_id("z_image_turbo"), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn svd_engine_id_maps_only_svd() {
+        assert_eq!(svd_engine_id("svd"), Some("svd_xt"));
+        assert_eq!(svd_engine_id("ltx_2_3"), None);
+        assert_eq!(svd_engine_id("wan_2_2"), None);
+        assert_eq!(svd_engine_id("svd_xt"), None);
+    }
+
+    /// SVD knobs resolve advanced → manifest entry → builtin default, then clamp; `conditioningFps`
+    /// reads the `condFps` manifest key. Mirrors the torch `svd_video` `_pipeline_kwargs` mapping.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn svd_knobs_resolve_advanced_over_manifest_over_default() {
+        // Bare request → builtin defaults.
+        let bare = request(json!({ "projectId": "p", "model": "svd", "sourceAssetId": "a" }));
+        assert_eq!(svd_i32(&bare, "numFrames", "numFrames", 25, 1, 25), 25);
+        assert_eq!(
+            svd_i32(&bare, "motionBucketId", "motionBucketId", 127, 1, 255),
+            127
+        );
+        assert_eq!(svd_i32(&bare, "conditioningFps", "condFps", 7, 1, 30), 7);
+        assert_eq!(
+            svd_i32(&bare, "decodeChunkSize", "decodeChunkSize", 8, 1, 64),
+            8
+        );
+        assert_eq!(
+            svd_f32(&bare, "noiseAugStrength", "noiseAugStrength", 0.02),
+            0.02
+        );
+        assert_eq!(svd_steps(&bare), 25); // balanced
+
+        // Manifest entry overrides the builtin default; advanced overrides the manifest.
+        let layered = request(json!({
+            "projectId": "p", "model": "svd", "sourceAssetId": "a", "quality": "fast",
+            "modelManifestEntry": {
+                "motionBucketId": 180, "condFps": 6, "noiseAugStrength": 0.1,
+                "steps": { "fast": 12, "balanced": 25, "best": 30 }
+            },
+            "advanced": { "motionBucketId": 200, "decodeChunkSize": "16" }
+        }));
+        // advanced wins for motionBucketId; manifest wins for condFps + noiseAug.
+        assert_eq!(
+            svd_i32(&layered, "motionBucketId", "motionBucketId", 127, 1, 255),
+            200
+        );
+        assert_eq!(svd_i32(&layered, "conditioningFps", "condFps", 7, 1, 30), 6);
+        assert_eq!(
+            svd_f32(&layered, "noiseAugStrength", "noiseAugStrength", 0.02),
+            0.1
+        );
+        // numeric string parses.
+        assert_eq!(
+            svd_i32(&layered, "decodeChunkSize", "decodeChunkSize", 8, 1, 64),
+            16
+        );
+        // steps from manifest's quality ladder (fast).
+        assert_eq!(svd_steps(&layered), 12);
+
+        // Out-of-range values clamp to the engine-safe bounds.
+        let extreme = request(json!({
+            "projectId": "p", "model": "svd", "sourceAssetId": "a",
+            "advanced": { "motionBucketId": 999, "numFrames": 99, "decodeChunkSize": 0 }
+        }));
+        assert_eq!(
+            svd_i32(&extreme, "motionBucketId", "motionBucketId", 127, 1, 255),
+            255
+        );
+        assert_eq!(svd_i32(&extreme, "numFrames", "numFrames", 25, 1, 25), 25);
+        assert_eq!(
+            svd_i32(&extreme, "decodeChunkSize", "decodeChunkSize", 8, 1, 64),
+            1
+        );
+    }
+
+    /// Locate the cached SVD-XT diffusers snapshot (the stock HF repo the engine loads directly), or
+    /// `None` if absent — `$SCENEWORKS_MLX_SVD_DIR` else the default HF hub cache.
+    #[cfg(target_os = "macos")]
+    fn svd_real_dir() -> Option<PathBuf> {
+        if let Ok(dir) = std::env::var("SCENEWORKS_MLX_SVD_DIR") {
+            let path = PathBuf::from(dir.trim());
+            if svd_dir_is_complete(&path) {
+                return Some(path);
+            }
+        }
+        let snaps = PathBuf::from(std::env::var("HOME").ok()?)
+            .join(".cache/huggingface/hub")
+            .join("models--stabilityai--stable-video-diffusion-img2vid-xt")
+            .join("snapshots");
+        std::fs::read_dir(&snaps)
+            .ok()?
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| svd_dir_is_complete(path))
+    }
+
+    /// Real in-process SVD-XT image→video through the engine: load the stock diffusers snapshot,
+    /// animate a synthetic reference image into a tiny clip, and assert the decode seam returns the
+    /// requested RGB8 frames at the conditioning fps with NO audio and streamed denoise progress.
+    /// Exercises the worker's `run_video_generation` path (with the sc-3523 motion knobs) end to end.
+    /// `#[ignore]` — the weights live outside CI; run manually where the checkpoint is cached.
+    #[cfg(target_os = "macos")]
+    #[ignore = "loads the real SVD-XT weights; run manually on a Mac with the checkpoint cached"]
+    #[test]
+    fn svd_real_weights_image_to_video() {
+        let Some(model_dir) = svd_real_dir() else {
+            eprintln!("skipping svd_real_weights_image_to_video: no SVD-XT checkpoint found");
+            return;
+        };
+        let (w, h) = (64u32, 64u32);
+        let mut pixels = vec![0u8; (w * h * 3) as usize];
+        for y in 0..h {
+            for x in 0..w {
+                let i = ((y * w + x) * 3) as usize;
+                pixels[i] = (x * 255 / w) as u8;
+                pixels[i + 1] = (y * 255 / h) as u8;
+                pixels[i + 2] = 128;
+            }
+        }
+        let input = VideoGenInput {
+            engine_id: "svd_xt",
+            model_dir,
+            width: 256,
+            height: 256,
+            frames: 4,
+            fps: 7,
+            steps: Some(2),
+            seed: 7,
+            conditioning: vec![Conditioning::Reference {
+                image: mlx_gen::Image {
+                    width: w,
+                    height: h,
+                    pixels,
+                },
+                strength: None,
+            }],
+            motion_bucket_id: Some(127.0),
+            noise_aug_strength: Some(0.02),
+            decode_chunk_size: Some(2),
+            ..VideoGenInput::default()
+        };
+        let cancel = CancelFlag::new();
+        let mut steps = 0u32;
+        let mut on_progress = |progress: Progress| {
+            if let Progress::Step { .. } = progress {
+                steps += 1;
+            }
+        };
+        let decoded =
+            run_video_generation(input, &cancel, &mut on_progress).expect("svd i2v generation");
+        assert_eq!(decoded.frames.len(), 4, "4 frames");
+        assert_eq!(decoded.fps, 7, "output fps = conditioning fps");
+        assert!(decoded.audio.is_none(), "SVD emits no audio");
+        assert!(steps > 0, "denoise progress streamed");
+        assert!(decoded
+            .frames
+            .iter()
+            .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize));
     }
 
     /// `advanced.noAudio` maps to the engine's `video_mode = "no_audio"`; enhance flags

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1109,6 +1109,8 @@ struct VideoGenInput {
     motion_bucket_id: Option<f32>,
     noise_aug_strength: Option<f32>,
     decode_chunk_size: Option<u32>,
+    // SVD motion-conditioning fps, decoupled from the output `fps` (sc-3764); `None` elsewhere.
+    conditioning_fps: Option<u32>,
 }
 
 #[cfg(target_os = "macos")]
@@ -1137,6 +1139,7 @@ impl Default for VideoGenInput {
             motion_bucket_id: None,
             noise_aug_strength: None,
             decode_chunk_size: None,
+            conditioning_fps: None,
         }
     }
 }
@@ -1180,6 +1183,7 @@ fn run_video_generation(
         motion_bucket_id: input.motion_bucket_id,
         noise_aug_strength: input.noise_aug_strength,
         decode_chunk_size: input.decode_chunk_size,
+        conditioning_fps: input.conditioning_fps,
         cancel: cancel.clone(),
         ..Default::default()
     };
@@ -1633,11 +1637,11 @@ async fn generate_ltx(
 // The engine loads the stock diffusers fp16 snapshot directly (vae/ + unet/ + image_encoder/),
 // so there is no conversion step (unlike Wan/LTX).
 //
-// Divergence note: the engine uses one `fps` for BOTH the motion micro-conditioning
-// (`added_time_ids` = fps − 1) and the output mux. We pass the conditioning fps (manifest
-// `condFps`, default 7 — the value the model was trained on) so the MOTION is correct; the burst
-// therefore plays at that cadence. The torch path muxed the same 25-frame burst at the user's
-// playback `fps` instead — a cosmetic playback-speed difference, not a content one.
+// fps (sc-3764): the engine decouples the two cadences — the motion micro-conditioning fps
+// (`added_time_ids` = fps − 1) rides `conditioning_fps` (manifest `condFps`, default 7 — the value
+// the model was trained on, so MOTION stays correct), while the output/playback fps is the user's
+// `request.fps` (mirroring the torch `export_to_video(fps=request.fps)`). So the burst now plays at
+// the requested cadence with correct motion — full parity with the torch `svd_video` path.
 // ---------------------------------------------------------------------------
 
 /// Adapter id recorded on a real MLX SVD asset — matches the torch `svd_video` adapter id so the
@@ -1818,6 +1822,8 @@ fn svd_raw_settings(request: &VideoRequest) -> Value {
         "conditioningFps".to_owned(),
         json!(svd_i32(request, "conditioningFps", "condFps", 7, 1, 30)),
     );
+    // The output/playback cadence (decoupled from conditioningFps; sc-3764).
+    raw.insert("fps".to_owned(), json!(request.fps));
     raw.insert(
         "noiseAugStrength".to_owned(),
         json!(svd_f32(
@@ -1868,7 +1874,9 @@ async fn generate_svd(
         width: request.width,
         height: request.height,
         frames: svd_i32(request, "numFrames", "numFrames", 25, 1, 25) as u32,
-        fps: svd_i32(request, "conditioningFps", "condFps", 7, 1, 30) as u32,
+        // Output/playback cadence = the user's `fps` (mirrors the torch `export_to_video(fps=request.fps)`);
+        // the motion cadence rides `conditioning_fps` below (sc-3764).
+        fps: request.fps,
         steps: Some(svd_steps(request)),
         guidance: None,
         seed: resolve_video_seed(request) as u64,
@@ -1884,6 +1892,7 @@ async fn generate_svd(
         decode_chunk_size: Some(
             svd_i32(request, "decodeChunkSize", "decodeChunkSize", 8, 1, 64) as u32,
         ),
+        conditioning_fps: Some(svd_i32(request, "conditioningFps", "condFps", 7, 1, 30) as u32),
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, input).await
@@ -2274,9 +2283,9 @@ mod tests {
 
     /// Real in-process SVD-XT image→video through the engine: load the stock diffusers snapshot,
     /// animate a synthetic reference image into a tiny clip, and assert the decode seam returns the
-    /// requested RGB8 frames at the conditioning fps with NO audio and streamed denoise progress.
-    /// Exercises the worker's `run_video_generation` path (with the sc-3523 motion knobs) end to end.
-    /// `#[ignore]` — the weights live outside CI; run manually where the checkpoint is cached.
+    /// requested RGB8 frames at the OUTPUT/playback fps (decoupled from the conditioning fps; sc-3764)
+    /// with NO audio and streamed denoise progress. Exercises the worker's `run_video_generation`
+    /// path (with the sc-3523 motion knobs) end to end. `#[ignore]` — the weights live outside CI.
     #[cfg(target_os = "macos")]
     #[ignore = "loads the real SVD-XT weights; run manually on a Mac with the checkpoint cached"]
     #[test]
@@ -2301,7 +2310,8 @@ mod tests {
             width: 256,
             height: 256,
             frames: 4,
-            fps: 7,
+            // Playback fps (24) distinct from the conditioning fps (7) to prove the decouple (sc-3764).
+            fps: 24,
             steps: Some(2),
             seed: 7,
             conditioning: vec![Conditioning::Reference {
@@ -2315,6 +2325,7 @@ mod tests {
             motion_bucket_id: Some(127.0),
             noise_aug_strength: Some(0.02),
             decode_chunk_size: Some(2),
+            conditioning_fps: Some(7),
             ..VideoGenInput::default()
         };
         let cancel = CancelFlag::new();
@@ -2327,7 +2338,10 @@ mod tests {
         let decoded =
             run_video_generation(input, &cancel, &mut on_progress).expect("svd i2v generation");
         assert_eq!(decoded.frames.len(), 4, "4 frames");
-        assert_eq!(decoded.fps, 7, "output fps = conditioning fps");
+        assert_eq!(
+            decoded.fps, 24,
+            "output fps follows the playback fps, not the conditioning fps (sc-3764)"
+        );
         assert!(decoded.audio.is_none(), "SVD emits no audio");
         assert!(steps > 0, "denoise progress streamed");
         assert!(decoded


### PR DESCRIPTION
Worker-cutover slice of [sc-3055](https://app.shortcut.com/trefry/story/3055) (epic 3040). Routes the `svd` model (Stable Video Diffusion img2vid-XT) to the in-process Rust MLX engine `svd_xt`, replacing the torch `DiffusersVideoAdapter` `svd_video` path on Mac. SVD is image-conditioned only: a fixed ~25-frame burst from one source image, no text prompt, no audio.

## Verify-first finding (drove the scope)
The `svd_xt` engine's `GenerationRequest` only exposed `frames`/`steps`/`fps`/`guidance`/`seed` + a `Reference` image — `motion_bucket_id` / `noise_aug_strength` (SVD's primary **motion** controls, feeding `added_time_ids`) and `decode_chunk_size` were hardcoded to the reference defaults, so a worker-only cutover would silently ignore the user's motion sliders. Closing that gap needed a small engine change: **[mlx-gen #180](https://github.com/michaeltrefry/mlx-gen/pull/180)** adds those three as optional request fields.

## Worker (`video_jobs.rs`)
- Link `mlx-gen-svd` + `use mlx_gen_svd as _;`.
- `svd_engine_id` / `svd_available` + `generate_svd`: resolve the stock diffusers `stabilityai/stable-video-diffusion-img2vid-xt` snapshot (loaded directly — no conversion), single source image → `Conditioning::Reference`, no prompt/negative/guidance.
- Map knobs advanced→manifest→default (clamped), mirroring the torch `_pipeline_kwargs`: `numFrames` 25, `motionBucketId` 127, `conditioningFps`/`condFps` 7, `noiseAugStrength` 0.02, `decodeChunkSize` 8, quality→steps.

## Routing (`jobs_store.rs`)
- `svd` added to `VIDEO_MLX_ROUTED_MODELS`; `video_mode_is_mlx_eligible` constrains SVD to **`image_to_video` only**. Gap classifier + UI-gating tests + the rust-api catalog test updated (SVD now `macSupport.supported = true`).

## Pin
Bumps mlx-gen `0ed3019` → `710fccd` (the #180 branch commit, so this builds/reviews now). **Re-pin to the squash-merged main SHA once #180 lands** (noted in `crates/sceneworks-worker/Cargo.toml`).

## ⚠️ Known divergence (for review)
The engine conflates the motion-conditioning fps and the output-mux fps into one `req.fps`. I pass the **conditioning fps** (`condFps`, default 7) so the motion is correct (diffusers-canonical) — the burst therefore plays at ~7fps. The torch path muxed the same 25 frames at the user's playback `fps` instead. This is a cosmetic playback-speed difference, not a content one; if exact torch playback-fps parity is wanted, it's a small follow-up (engine: decouple conditioning fps from output fps).

## Verification (M-series GPU, real SVD-XT weights)
- mlx-gen: `svd_provider_generates_video` + new `svd_request_knobs_drive_generation` (motion change ⇒ different frames; chunk override ⇒ all frames).
- worker: `svd_real_weights_image_to_video` (`run_video_generation` i2v: 4 frames, fps 7, no audio, streamed progress) — all `#[ignore]`, run locally.
- `cargo fmt --all --check` / `cargo clippy --all-targets -D warnings` / full `cargo test` green.

Gate: real-Mac GPU parity ✅ + SVD weight provisioning (checkpoint resolves from the HF cache / `$SCENEWORKS_MLX_SVD_DIR`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)