### PR TITLE
sc-3521: replace_person worker cutover → native Wan-VACE

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1797,11 +1797,14 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
             Some("epic 3040"),
         )),
 
+        // replace_person → native Wan-VACE is MLX-eligible on the replace-capable models
+        // (handled by the early `job_is_any_mlx_eligible` Ok above, sc-3521). This arm is only
+        // reached for a replace_person job on a model with no MLX video engine — that stays torch.
         JobType::PersonReplace => Err(UnsupportedReason::new(
             model,
             "replace_person",
-            "person replacement is a torch-only advanced video mode (also depends on person detect/track).",
-            Some("epic 3040 (+ sc-3488)"),
+            "person replacement runs on native Wan-VACE only for the replace-capable MLX video models; this model has no MLX video engine, so it stays on the Python torch path.",
+            Some("epic 3040"),
         )),
 
         // Person detection + tracking are now ported to the Rust worker (epic 3482,
@@ -2119,8 +2122,9 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
     features.insert(
         "advancedVideoModes".to_owned(),
         MacFeatureSupport::unsupported(
-            "advanced video (extend / bridge / replace_person)",
-            "the advanced video job types and modes are torch-only.",
+            "advanced video (extend / bridge)",
+            "extend_clip / video_bridge are still torch-only; first_last_frame (sc-3520) and \
+             replace_person → Wan-VACE (sc-3521) now run on MLX.",
             "epic 3040",
         ),
     );
@@ -2232,11 +2236,13 @@ fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedReason {
         .get("mode")
         .and_then(Value::as_str)
         .unwrap_or("image_to_video");
-    if !matches!(mode, "text_to_video" | "image_to_video") {
+    if !video_mode_is_mlx_eligible(model, mode) {
         return UnsupportedReason::new(
             Some(model),
             "advanced video mode",
-            "advanced video_generate modes (first_last_frame / replace_person) are torch-only.",
+            "this video_generate mode is not MLX-eligible on this model (first_last_frame / \
+             replace_person route to MLX only on the capable engines; extend_clip / video_bridge \
+             stay torch).",
             Some("epic 3040"),
         );
     }
@@ -2788,19 +2794,23 @@ const VIDEO_MLX_ROUTED_MODELS: &[&str] = &[
 /// expressed by whether an `mlx` worker is registered and idle (see
 /// [`should_defer_video_to_mlx_worker`]).
 ///
-/// MLX covers `text_to_video` + `image_to_video` on Wan/LTX, plus `first_last_frame`
-/// on the FLF-capable engines (LTX + Wan TI2V-5B `wan_2_2`; sc-3055 cutover — see
-/// [`video_mode_is_mlx_eligible`]). Still on the Python torch path: the advanced job
-/// types (`video_extend`/`video_bridge`/`person_replace`) and the `replace_person`
-/// mode (a later Wan-VACE cutover slice), SVD (svd_xt not linked in the worker yet), and a
-/// non-MLX model. **Third-party LyCORIS (LoHa / non-peft LoKr) and LoKr-on-Wan now run on MLX**
+/// MLX covers `text_to_video` + `image_to_video` on Wan/LTX, plus `first_last_frame` on the
+/// FLF-capable engines (LTX + Wan TI2V-5B `wan_2_2`; sc-3520) and `replace_person` → native
+/// Wan-VACE (the `PersonReplace` job type, sc-3521 — see [`video_mode_is_mlx_eligible`]). Still
+/// on the Python torch path: the `video_extend`/`video_bridge` advanced job types (sc-3522),
+/// SVD (svd_xt not linked in the worker yet), and a non-MLX model. **Third-party LyCORIS (LoHa /
+/// non-peft LoKr) and LoKr-on-Wan now run on MLX**
 /// (epic 3641, sc-3671 + sc-3644): the Wan/LTX engine paths reconstruct + merge/residual the delta —
 /// the peft-LoKr-on-Wan merge has existed since sc-2393, and the old `create_video_adapter` torch
 /// gate was a routing caution, never an engine limit.
 fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
-    // Only the base video_generate job type is MLX-eligible; the advanced job types
-    // (extend/bridge/person-replace) are torch-only.
-    if !matches!(job.job_type, JobType::VideoGenerate) {
+    // The base `video_generate` job type plus `replace_person` (its dedicated `PersonReplace`
+    // job type, sc-3521 → Wan-VACE) are MLX-eligible; the `extend`/`bridge` advanced job
+    // types stay torch (sc-3522).
+    if !matches!(
+        job.job_type,
+        JobType::VideoGenerate | JobType::PersonReplace
+    ) {
         return false;
     }
     let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
@@ -2809,16 +2819,18 @@ fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     if !VIDEO_MLX_ROUTED_MODELS.contains(&model) {
         return false;
     }
-    // Mode defaults to `image_to_video`, mirroring `video_request_from_job`.
-    let mode = job
-        .payload
-        .get("mode")
-        .and_then(Value::as_str)
-        .unwrap_or("image_to_video");
-    if !video_mode_is_mlx_eligible(model, mode) {
-        return false;
-    }
-    true
+    // A `PersonReplace` job is always replace_person regardless of the payload mode; a
+    // `video_generate` job uses its mode (defaulting to `image_to_video`, mirroring
+    // `video_request_from_job`).
+    let mode = if matches!(job.job_type, JobType::PersonReplace) {
+        "replace_person"
+    } else {
+        job.payload
+            .get("mode")
+            .and_then(Value::as_str)
+            .unwrap_or("image_to_video")
+    };
+    video_mode_is_mlx_eligible(model, mode)
 }
 
 /// Which `video_generate` modes the in-process Rust MLX worker serves for `model`. Every
@@ -2826,12 +2838,17 @@ fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// is additionally MLX on the FLF-capable engines — LTX (`ltx_2_3`/`ltx_2_3_eros`, the
 /// reference-grounded `Keyframe` path, sc-3052) and Wan TI2V-5B (`wan_2_2`, the mask-blend
 /// multi-keyframe path, sc-3357). The 14B Wan MoE engines have no `Keyframe` path, so FLF on
-/// them stays torch. The advanced clip modes (`extend_clip`/`video_bridge`) + `replace_person`
-/// ride dedicated job types / the Wan-VACE path and are separate cutover slices (sc-3055).
+/// them stays torch. `replace_person` is MLX on the replace-capable models (→ native Wan-VACE,
+/// sc-3521). The advanced clip modes (`extend_clip`/`video_bridge`) ride dedicated job types
+/// and stay torch for now (sc-3522).
 fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
     match mode {
         "text_to_video" | "image_to_video" => true,
         "first_last_frame" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),
+        // replace_person → native Wan-VACE (sc-3521): the engine `wan_vace` provider serves it
+        // regardless of the user-picked replace-capable model (ltx_2_3 / ltx_2_3_eros / wan_2_2,
+        // the models that advertise the capability), so admit those.
+        "replace_person" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),
         _ => false,
     }
 }
@@ -3531,9 +3548,12 @@ mod mlx_routing_tests {
             "wan_2_2_i2v_14b",
             "first_last_frame"
         ));
-        // The advanced clip modes + replace_person are not video_generate-mode-eligible
-        // (they ride dedicated job types / the Wan-VACE path — separate cutover slices).
-        for mode in ["extend_clip", "video_bridge", "replace_person", "nonsense"] {
+        // replace_person → native Wan-VACE is MLX on the replace-capable models (sc-3521).
+        assert!(video_mode_is_mlx_eligible("ltx_2_3", "replace_person"));
+        assert!(video_mode_is_mlx_eligible("ltx_2_3_eros", "replace_person"));
+        assert!(video_mode_is_mlx_eligible("wan_2_2", "replace_person"));
+        // The advanced clip modes stay torch (separate cutover slice, sc-3522).
+        for mode in ["extend_clip", "video_bridge", "nonsense"] {
             assert!(!video_mode_is_mlx_eligible("ltx_2_3", mode));
         }
     }

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -9,10 +9,11 @@
 //!
 //! The advanced-mode asset ids (`last_frame` / `source_clip` / `bridge_right_clip`
 //! / `person_track`) are parsed and carried so the asset fact + routing layer see
-//! them, but the MLX video path (Wan / LTX text-or-image→video) does not consume
-//! them — those modes (first_last_frame / extend_clip / video_bridge /
-//! replace_person) stay on the Python torch worker (epic 3018 scope boundary;
-//! the MLX-vs-Python routing decision is sc-3036).
+//! them. The MLX video path now consumes them for the cutover modes: `first_last_frame`
+//! (two keyframes, sc-3520) and `replace_person` (the `source_clip` + `person_track` +
+//! character refs → native Wan-VACE, sc-3521). `extend_clip` / `video_bridge` still stay
+//! on the Python torch worker for now (sc-3522). The MLX-vs-Python routing decision is
+//! sc-3036.
 
 use serde_json::Value;
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1840,7 +1840,14 @@ fn mac_rust_supported_names_infra_job_types() {
     assert!(mac_rust_supported(&person_detect).is_ok());
     let person_track = job_of(&store, JobType::PersonTrack, json!({}));
     assert!(mac_rust_supported(&person_track).is_ok());
-    // replace_person stays a tracked torch gap (the video-gen/inpaint half, epic 3040).
+    // replace_person → native Wan-VACE is supported on a replace-capable MLX video model
+    // (sc-3521); a replace_person job on a model with no MLX video engine stays a torch gap.
+    let replace_mlx = job_of(
+        &store,
+        JobType::PersonReplace,
+        json!({ "model": "wan_2_2", "mode": "replace_person" }),
+    );
+    assert!(mac_rust_supported(&replace_mlx).is_ok());
     let replace = job_of(&store, JobType::PersonReplace, json!({}));
     let replace_reason = mac_rust_supported(&replace).unwrap_err();
     assert!(replace_reason
@@ -2021,13 +2028,13 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     assert!(qwen_edit.features.edit);
     // Third-party LyCORIS now applies on every MLX provider (epic 3641) → supported.
     assert!(model_mac_support("sdxl", "image").features.lycoris);
-    // Video models expose per-mode eligibility; advanced modes are torch-only.
+    // Video models expose per-mode eligibility; extend/bridge stay torch.
     let wan = model_mac_support("wan_2_2", "video").features.video_modes;
     assert_eq!(wan.get("text_to_video"), Some(&true));
     assert_eq!(wan.get("image_to_video"), Some(&true));
     assert_eq!(wan.get("first_last_frame"), Some(&true)); // Wan TI2V-5B FLF is MLX
-    assert_eq!(wan.get("replace_person"), Some(&false));
-    // The 14B Wan MoE engines have no FLF Keyframe path → torch.
+    assert_eq!(wan.get("replace_person"), Some(&true)); // → native Wan-VACE (sc-3521)
+                                                        // The 14B Wan MoE engines have no FLF Keyframe path → torch.
     assert_eq!(
         model_mac_support("wan_2_2_t2v_14b", "video")
             .features
@@ -2806,7 +2813,12 @@ fn ltx_training_is_mlx_worker_only_with_no_torch_fallback() {
 // --- Video routing (epic 3018, sc-3036) ---
 
 fn video_caps() -> Vec<WorkerCapability> {
-    vec![WorkerCapability::Gpu, WorkerCapability::VideoGenerate]
+    vec![
+        WorkerCapability::Gpu,
+        WorkerCapability::VideoGenerate,
+        // replace_person → Wan-VACE rides the `PersonReplace` job type (sc-3521).
+        WorkerCapability::PersonReplace,
+    ]
 }
 
 fn video_job_with(payload: Value, requested_gpu: &str) -> CreateJob {
@@ -2853,12 +2865,12 @@ fn mlx_worker_excluded_from_advanced_mode_video_job() {
     let store = store("mlx-video-routing-exclude");
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
-    // replace_person is an advanced mode that still rides the torch path at this point in
-    // the cutover (it routes to the Wan-VACE path in a later slice); the mlx worker must not
-    // claim it even on a Wan model. (first_last_frame is now MLX-eligible — see below.)
+    // extend_clip / video_bridge are advanced modes that still ride the torch path (sc-3522);
+    // the mlx worker must not claim them even on a Wan model. (first_last_frame and
+    // replace_person are now MLX-eligible — see below.)
     let job = store
         .create_job(video_job_with(
-            json!({ "model": "wan_2_2", "mode": "replace_person" }),
+            json!({ "model": "wan_2_2", "mode": "extend_clip" }),
             "auto",
         ))
         .expect("job creates");
@@ -2875,6 +2887,36 @@ fn mlx_worker_excluded_from_advanced_mode_video_job() {
         .expect("torch claims the job");
     assert_eq!(claimed.id, job.id);
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
+}
+
+#[test]
+fn replace_person_job_defers_from_torch_worker_to_idle_mlx_worker() {
+    // sc-3521 cutover: replace_person → native Wan-VACE is MLX-eligible on the replace-capable
+    // models, so a torch worker defers the `PersonReplace` job to an idle mlx worker.
+    let store = store("mlx-video-routing-replace");
+    register_gpu_worker(&store, "worker-torch", "mps", video_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
+
+    let mut payload = video_job_with(
+        json!({
+            "model": "wan_2_2", "mode": "replace_person",
+            "sourceClipAssetId": "clip", "personTrackId": "track_1", "characterId": "char_1"
+        }),
+        "auto",
+    );
+    payload.job_type = JobType::PersonReplace;
+    let job = store.create_job(payload).expect("job creates");
+
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    let claimed = store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .expect("mlx claims the replace_person job");
+    assert_eq!(claimed.id, job.id);
+    assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -399,6 +399,13 @@ pub(crate) fn mlx_gpu() -> DiscoveredGpu {
             // `image_detail` job runs in-process on the engine here too.
             WorkerCapability::ImageDetail,
             WorkerCapability::VideoGenerate,
+            // replace_person → native Wan-VACE (epic 3040, sc-3521): the `PersonReplace`
+            // job builds the masked control inputs (source clip + onnx-track mask + character
+            // refs) and runs the engine `wan_vace` provider in-process — the native
+            // equivalent of the torch `WanVACEPipeline` path. The API routes only
+            // MLX-eligible replace_person jobs here; non-VACE replacement + Windows/Linux
+            // keep the Python torch path.
+            WorkerCapability::PersonReplace,
             // Native Rust LoRA/LoKr training (epic 3039): plan validation +
             // real execution, both served in-process by `mlx_gen::load_trainer`.
             WorkerCapability::LoraTrain,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -45,6 +45,12 @@ mod image_jobs;
 use image_jobs::*;
 mod video_jobs;
 use video_jobs::*;
+// Replace-person mask pipeline (epic 3040, sc-3521): cross-platform mask rasterization /
+// resample / stored-seg-mask load, so the mask-port-vs-Python parity test runs on the
+// Linux CI lane. Its masks are consumed only by the macOS Wan-VACE path in `video_jobs`,
+// so off macOS the items are otherwise unused (the parity tests still build + run).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+mod person_replace;
 mod training_jobs;
 use training_jobs::*;
 mod caption_jobs;
@@ -568,6 +574,17 @@ async fn run_utility_job(
         JobType::VideoGenerate => run_video_generate_job(api, settings, &job)
             .await
             .map_err(|error| ("Video generation failed.", error)),
+        // replace_person → native Wan-VACE (epic 3040, sc-3521): the `PersonReplace` job
+        // type (and `video_generate` mode=`replace_person`) shares the video handler, which
+        // dispatches on `mode == "replace_person"` to the engine `wan_vace` provider — the
+        // native equivalent of the torch `WanVACEPipeline` path. The API routes only
+        // MLX-eligible replace_person jobs here (`jobs_store::video_job_is_mlx_eligible`);
+        // off macOS the `person_replace` capability is never advertised, so this arm only
+        // produces a real video on the macOS MLX worker (and the Python torch path serves
+        // Windows/Linux + non-VACE replacement).
+        JobType::PersonReplace => run_video_generate_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Person replacement failed.", error)),
         // Native MLX LoRA/LoKr training (epic 3039, sc-3043/3049), served in-process
         // by the linked mlx-gen engine on the macOS Apple-Silicon GPU worker. The API
         // routes only MLX-native families here (jobs_store::training_job_is_mlx_eligible);

--- a/crates/sceneworks-worker/src/person_replace.rs
+++ b/crates/sceneworks-worker/src/person_replace.rs
@@ -1,0 +1,440 @@
+//! Replace-person mask pipeline (epic 3040, sc-3521).
+//!
+//! The native-Rust port of the Python worker's replace_person mask preparation
+//! (`person_adapters.py` / `video_adapters.py`): turn a saved person track + its
+//! stored SAM2 segmentation masks into the per-frame binary masks the Wan-VACE
+//! engine consumes (`Conditioning::ControlClip { mask, .. }`; white = the person
+//! region to regenerate). Person detect/track/segment stays upstream (native MLX
+//! YOLO11 + SORT/ByteTrack + SAM2, sc-3633/3634/3709); only the rasterization /
+//! resample / stored-mask-load logic ports here.
+//!
+//! This module is **cross-platform** (no MLX / engine types) so it unit-tests on
+//! the Linux CI lane — the mask-port-vs-Python correctness gate. The engine call
+//! that consumes the masks lives in [`crate::video_jobs`] (macOS-only).
+//!
+//! Faithful ports (same arithmetic so the rasterized masks match the Python output
+//! for a fixture track):
+//!   * [`apply_track_corrections`] — `person_adapters.apply_track_corrections`
+//!   * [`resample_indices`] — `person_adapters._resample_indices`
+//!   * [`box_mask`] — `person_adapters._box_mask` (3% pad, PIL-inclusive rectangle)
+//!   * [`load_track_masks`] — `person_adapters.load_track_masks` (stored seg mask /
+//!     box fallback / `segmentation`|`degraded_box`|`mixed` mode)
+//!   * [`person_track_masks`] — `video_adapters.person_track_masks` (the
+//!     selected-detection single-frame fallback when a track has no frames)
+
+use std::path::Path;
+
+use image::RgbImage;
+use serde_json::{json, Value};
+
+use crate::{WorkerError, WorkerResult};
+
+/// The chosen mask source across the resampled frames (Python `load_track_masks` mode).
+pub(crate) const MODE_SEGMENTATION: &str = "segmentation";
+pub(crate) const MODE_DEGRADED_BOX: &str = "degraded_box";
+pub(crate) const MODE_MIXED: &str = "mixed";
+
+/// Clamp to `[0, 1]` (Python `safe_float(.., 0.0, 0.0, 1.0)`).
+fn clamp01(value: f64) -> f64 {
+    value.clamp(0.0, 1.0)
+}
+
+/// Round half-to-even (banker's rounding), matching Python's built-in `round` so the
+/// resampled frame indices match the Python worker exactly.
+fn python_round(value: f64) -> i64 {
+    let floor = value.floor();
+    let diff = value - floor;
+    if diff < 0.5 {
+        floor as i64
+    } else if diff > 0.5 {
+        floor as i64 + 1
+    } else {
+        // Exactly .5 → round to the even neighbour.
+        let f = floor as i64;
+        if f % 2 == 0 {
+            f
+        } else {
+            f + 1
+        }
+    }
+}
+
+/// Resampled frame indices mapping `count` output frames onto `total` track frames
+/// (Python `_resample_indices`): evenly spaced inclusive of both ends, clamped to the
+/// last index. `count <= 1` or `total <= 1` → all-zero (the single frame repeated).
+pub(crate) fn resample_indices(total: usize, count: usize) -> Vec<usize> {
+    if count <= 1 || total <= 1 {
+        return vec![0; count.max(1)];
+    }
+    (0..count)
+        .map(|index| {
+            let position = (total - 1) as f64 * index as f64 / (count - 1) as f64;
+            (python_round(position) as usize).min(total - 1)
+        })
+        .collect()
+}
+
+/// Apply persisted box/reject corrections to a track's frames (Python
+/// `apply_track_corrections`, sc-1485). Returns cloned frame objects with corrections
+/// applied — never mutating the sidecar:
+///   * a corrected box overrides the tracked box and clears that frame's stored mask
+///     (the old mask no longer matches the new box → the loader regenerates a box mask);
+///   * a rejected frame borrows the nearest accepted frame's box (mask cleared), so the
+///     mask never neutralizes a region the user flagged as wrong.
+///
+/// Corrections are keyed by `frameIndex`; out-of-range / malformed entries are ignored.
+pub(crate) fn apply_track_corrections(track: &Value) -> Vec<Value> {
+    let mut frames: Vec<Value> = track
+        .get("frames")
+        .and_then(Value::as_array)
+        .map(|frames| frames.iter().filter(|f| f.is_object()).cloned().collect())
+        .unwrap_or_default();
+    if frames.is_empty() {
+        return frames;
+    }
+
+    // Corrections keyed by frameIndex (bool is excluded — Python rejects `isinstance bool`).
+    let mut rejected = vec![false; frames.len()];
+    if let Some(corrections) = track.get("corrections").and_then(Value::as_array) {
+        for correction in corrections {
+            let Some(correction) = correction.as_object() else {
+                continue;
+            };
+            let index = match correction.get("frameIndex") {
+                Some(Value::Number(number)) => match number.as_i64() {
+                    Some(index) if (0..frames.len() as i64).contains(&index) => index as usize,
+                    _ => continue,
+                },
+                _ => continue,
+            };
+            if let Some(frame) = frames[index].as_object_mut() {
+                if let Some(box_value) = correction.get("box").filter(|b| b.is_object()) {
+                    frame.insert("box".to_owned(), box_value.clone());
+                    frame.insert("mask".to_owned(), Value::Null);
+                    frame.insert("corrected".to_owned(), Value::Bool(true));
+                }
+                if correction
+                    .get("rejected")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    rejected[index] = true;
+                    frame.insert("rejected".to_owned(), Value::Bool(true));
+                }
+            }
+        }
+    }
+
+    let accepted: Vec<usize> = (0..frames.len())
+        .filter(|index| !rejected[*index])
+        .collect();
+    if !accepted.is_empty() && accepted.len() < frames.len() {
+        let accepted_boxes: Vec<(usize, Value)> = accepted
+            .iter()
+            .map(|&index| {
+                (
+                    index,
+                    frames[index].get("box").cloned().unwrap_or(Value::Null),
+                )
+            })
+            .collect();
+        for index in 0..frames.len() {
+            if !rejected[index] {
+                continue;
+            }
+            // Nearest accepted frame, tie-broken toward the lower index (Python
+            // `min(accepted, key=lambda c: (abs(c - index), c))`).
+            let nearest = accepted_boxes
+                .iter()
+                .min_by_key(|(candidate, _)| (candidate.abs_diff(index), *candidate))
+                .map(|(_, box_value)| box_value.clone())
+                .unwrap_or(Value::Null);
+            if let Some(frame) = frames[index].as_object_mut() {
+                frame.insert("box".to_owned(), nearest);
+                frame.insert("mask".to_owned(), Value::Null);
+            }
+        }
+    }
+    frames
+}
+
+/// Rasterize a normalized `{x,y,width,height}` box to a binary `width × height` RGB mask
+/// (white = the person region to regenerate; black elsewhere) with a 3% pad on each side
+/// (Python `_box_mask`). A missing/empty box object → an all-black mask. The rectangle is
+/// PIL-inclusive of its far edge (matching `ImageDraw.rectangle`), clipped to the image.
+pub(crate) fn box_mask(box_value: Option<&Value>, width: u32, height: u32) -> RgbImage {
+    let mut mask = RgbImage::new(width, height);
+    let Some(object) = box_value.and_then(Value::as_object) else {
+        return mask;
+    };
+    if object.is_empty() {
+        return mask;
+    }
+    let get = |key: &str| clamp01(object.get(key).and_then(Value::as_f64).unwrap_or(0.0));
+    let (x, y, w, h) = (get("x"), get("y"), get("width"), get("height"));
+    let (wf, hf) = (width as f64, height as f64);
+    // int(..) truncates toward zero; x/y/w/h are in [0,1] so all products are non-negative.
+    let pad_x = (wf * 0.03) as i64;
+    let pad_y = (hf * 0.03) as i64;
+    let left = ((x * wf) as i64 - pad_x).max(0);
+    let top = ((y * hf) as i64 - pad_y).max(0);
+    let right = (((x + w) * wf) as i64 + pad_x).min(width as i64);
+    let bottom = (((y + h) * hf) as i64 + pad_y).min(height as i64);
+    // PIL rectangle fills both corners inclusively; clip the far edge to the last pixel.
+    let x1 = right.min(width as i64 - 1);
+    let y1 = bottom.min(height as i64 - 1);
+    for py in top..=y1 {
+        for px in left..=x1 {
+            mask.put_pixel(px as u32, py as u32, image::Rgb([255, 255, 255]));
+        }
+    }
+    mask
+}
+
+/// Load per-frame replacement masks for a track, resampled to `count` frames (Python
+/// `load_track_masks`). Corrections are applied first; then per frame a stored
+/// segmentation mask is used when its file still exists **and** the box was not corrected,
+/// otherwise a box mask is rasterized from the (possibly corrected) box. Returns the masks
+/// plus the source mode: [`MODE_SEGMENTATION`] (all stored), [`MODE_DEGRADED_BOX`] (all
+/// box-derived), or [`MODE_MIXED`].
+pub(crate) fn load_track_masks(
+    project_path: &Path,
+    track: &Value,
+    width: u32,
+    height: u32,
+    count: usize,
+) -> WorkerResult<(Vec<RgbImage>, &'static str)> {
+    let frames = apply_track_corrections(track);
+    if frames.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Person track has no frames; cannot build replacement masks.".to_owned(),
+        ));
+    }
+    let indices = resample_indices(frames.len(), count);
+    let mut masks = Vec::with_capacity(indices.len());
+    let mut segmentation = 0usize;
+    for index in &indices {
+        let frame = &frames[*index];
+        let stored = frame
+            .get("mask")
+            .and_then(Value::as_str)
+            .map(|rel| project_path.join(rel))
+            .filter(|path| path.exists());
+        match stored {
+            Some(path) => {
+                let loaded = image::open(&path)
+                    .map_err(|error| {
+                        WorkerError::InvalidPayload(format!(
+                            "replacement mask {}: {error}",
+                            path.display()
+                        ))
+                    })?
+                    .to_luma8();
+                // Match Pillow `convert("L").resize((w, h))` (default bilinear), then fan the
+                // single luma channel out to RGB (white = regenerate).
+                let resized = image::imageops::resize(
+                    &loaded,
+                    width,
+                    height,
+                    image::imageops::FilterType::Triangle,
+                );
+                let mut rgb = RgbImage::new(width, height);
+                for (dst, src) in rgb.pixels_mut().zip(resized.pixels()) {
+                    let value = src.0[0];
+                    *dst = image::Rgb([value, value, value]);
+                }
+                masks.push(rgb);
+                segmentation += 1;
+            }
+            None => masks.push(box_mask(frame.get("box"), width, height)),
+        }
+    }
+    let mode = if segmentation == indices.len() {
+        MODE_SEGMENTATION
+    } else if segmentation == 0 {
+        MODE_DEGRADED_BOX
+    } else {
+        MODE_MIXED
+    };
+    Ok((masks, mode))
+}
+
+/// Per-frame replacement masks for a track, with the selected-detection single-frame
+/// fallback (Python `video_adapters.person_track_masks`): a track with no frames but a
+/// `selectedDetection.box` is treated as a one-frame track from that box.
+pub(crate) fn person_track_masks(
+    project_path: &Path,
+    track: &Value,
+    width: u32,
+    height: u32,
+    count: usize,
+) -> WorkerResult<(Vec<RgbImage>, &'static str)> {
+    let has_frames = track
+        .get("frames")
+        .and_then(Value::as_array)
+        .is_some_and(|frames| !frames.is_empty());
+    if has_frames {
+        return load_track_masks(project_path, track, width, height, count);
+    }
+    let selected_box = track
+        .get("selectedDetection")
+        .and_then(|detection| detection.get("box"))
+        .filter(|box_value| box_value.is_object())
+        .cloned()
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Person track has no usable boxes.".to_owned())
+        })?;
+    let synthetic = json!({ "frames": [{ "box": selected_box, "mask": Value::Null }] });
+    load_track_masks(project_path, &synthetic, width, height, count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn white_pixels(mask: &RgbImage) -> usize {
+        mask.pixels().filter(|p| p.0[0] > 0).count()
+    }
+
+    #[test]
+    fn python_round_is_half_to_even() {
+        assert_eq!(python_round(0.5), 0);
+        assert_eq!(python_round(1.5), 2);
+        assert_eq!(python_round(2.5), 2);
+        assert_eq!(python_round(2.4), 2);
+        assert_eq!(python_round(2.6), 3);
+    }
+
+    #[test]
+    fn resample_indices_matches_python_formula() {
+        // count <= 1 or total <= 1 → repeated zero.
+        assert_eq!(resample_indices(10, 1), vec![0]);
+        assert_eq!(resample_indices(1, 4), vec![0, 0, 0, 0]);
+        // Evenly spaced inclusive of both ends.
+        assert_eq!(resample_indices(5, 5), vec![0, 1, 2, 3, 4]);
+        // Upsample: 3 track frames onto 5 outputs (round half-to-even at the .5 steps).
+        // positions: 0, 0.5, 1.0, 1.5, 2.0 → 0, 0, 1, 2, 2.
+        assert_eq!(resample_indices(3, 5), vec![0, 0, 1, 2, 2]);
+        // Downsample: 9 track frames onto 5 outputs → 0, 2, 4, 6, 8.
+        assert_eq!(resample_indices(9, 5), vec![0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn box_mask_pads_three_percent_and_fills_inclusive() {
+        // A centered half-size box at 100×100: pad = int(100*0.03) = 3 each side.
+        let box_value = json!({ "x": 0.25, "y": 0.25, "width": 0.5, "height": 0.5 });
+        let mask = box_mask(Some(&box_value), 100, 100);
+        // left=22, top=22, right=78, bottom=78 → inclusive 22..=78 = 57 px each axis.
+        assert_eq!(white_pixels(&mask), 57 * 57);
+        assert_eq!(mask.get_pixel(22, 22).0, [255, 255, 255]);
+        assert_eq!(mask.get_pixel(78, 78).0, [255, 255, 255]);
+        assert_eq!(mask.get_pixel(21, 21).0, [0, 0, 0]);
+        assert_eq!(mask.get_pixel(79, 79).0, [0, 0, 0]);
+    }
+
+    #[test]
+    fn box_mask_clips_to_image_bounds() {
+        // A full-frame box pads past the edges → the whole image is white, no panic.
+        let box_value = json!({ "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0 });
+        let mask = box_mask(Some(&box_value), 40, 24);
+        assert_eq!(white_pixels(&mask), 40 * 24);
+    }
+
+    #[test]
+    fn box_mask_missing_or_empty_is_black() {
+        assert_eq!(white_pixels(&box_mask(None, 16, 16)), 0);
+        let empty = json!({});
+        assert_eq!(white_pixels(&box_mask(Some(&empty), 16, 16)), 0);
+    }
+
+    #[test]
+    fn corrections_override_box_and_clear_mask() {
+        let track = json!({
+            "frames": [
+                { "box": { "x": 0.1, "y": 0.1, "width": 0.2, "height": 0.2 }, "mask": "m0.png" },
+                { "box": { "x": 0.5, "y": 0.5, "width": 0.2, "height": 0.2 }, "mask": "m1.png" }
+            ],
+            "corrections": [
+                { "frameIndex": 0, "box": { "x": 0.3, "y": 0.3, "width": 0.1, "height": 0.1 } }
+            ]
+        });
+        let frames = apply_track_corrections(&track);
+        assert_eq!(frames[0]["box"]["x"], json!(0.3));
+        assert_eq!(frames[0]["mask"], Value::Null);
+        assert_eq!(frames[0]["corrected"], json!(true));
+        // The untouched frame keeps its stored mask.
+        assert_eq!(frames[1]["mask"], json!("m1.png"));
+    }
+
+    #[test]
+    fn rejected_frame_borrows_nearest_accepted_box() {
+        let track = json!({
+            "frames": [
+                { "box": { "x": 0.1, "y": 0.1, "width": 0.2, "height": 0.2 }, "mask": "m0.png" },
+                { "box": { "x": 0.5, "y": 0.5, "width": 0.2, "height": 0.2 }, "mask": "m1.png" },
+                { "box": { "x": 0.8, "y": 0.8, "width": 0.1, "height": 0.1 }, "mask": "m2.png" }
+            ],
+            "corrections": [ { "frameIndex": 1, "rejected": true } ]
+        });
+        let frames = apply_track_corrections(&track);
+        // Frame 1 rejected → nearest accepted (0 and 2 are equidistant; tie → lower index 0).
+        assert_eq!(frames[1]["box"]["x"], json!(0.1));
+        assert_eq!(frames[1]["mask"], Value::Null);
+        assert_eq!(frames[1]["rejected"], json!(true));
+    }
+
+    #[test]
+    fn load_track_masks_degrades_to_box_when_no_stored_mask() {
+        let dir = std::env::temp_dir().join(format!("sw_masks_{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let track = json!({
+            "frames": [
+                { "box": { "x": 0.25, "y": 0.25, "width": 0.5, "height": 0.5 }, "mask": Value::Null }
+            ]
+        });
+        let (masks, mode) = load_track_masks(&dir, &track, 64, 64, 3).unwrap();
+        assert_eq!(masks.len(), 3);
+        assert_eq!(mode, MODE_DEGRADED_BOX);
+        assert!(white_pixels(&masks[0]) > 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_track_masks_uses_stored_segmentation_when_present() {
+        let dir = std::env::temp_dir().join(format!("sw_masks_{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // A real stored mask file: a 10×10 all-white luma PNG.
+        let stored = image::GrayImage::from_pixel(10, 10, image::Luma([255]));
+        stored.save(dir.join("seg0.png")).unwrap();
+        let track = json!({
+            "frames": [ { "box": { "x": 0.1, "y": 0.1, "width": 0.1, "height": 0.1 }, "mask": "seg0.png" } ]
+        });
+        let (masks, mode) = load_track_masks(&dir, &track, 32, 32, 1).unwrap();
+        assert_eq!(mode, MODE_SEGMENTATION);
+        // The stored all-white mask resizes to a fully-white 32×32 (not the small box).
+        assert_eq!(white_pixels(&masks[0]), 32 * 32);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn person_track_masks_falls_back_to_selected_detection() {
+        let dir = std::env::temp_dir().join(format!("sw_masks_{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let track = json!({
+            "frames": [],
+            "selectedDetection": { "box": { "x": 0.25, "y": 0.25, "width": 0.5, "height": 0.5 } }
+        });
+        let (masks, mode) = person_track_masks(&dir, &track, 64, 64, 2).unwrap();
+        assert_eq!(masks.len(), 2);
+        assert_eq!(mode, MODE_DEGRADED_BOX);
+        assert!(white_pixels(&masks[0]) > 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn person_track_masks_errors_without_frames_or_selection() {
+        let dir = std::env::temp_dir();
+        let track = json!({ "frames": [] });
+        assert!(person_track_masks(&dir, &track, 32, 32, 1).is_err());
+    }
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -32,13 +32,15 @@ use crate::media_jobs::{run_ffmpeg, FfmpegContext};
 use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
 #[cfg(target_os = "macos")]
 use mlx_gen::{
-    AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
-    LoadSpec, MoeExpert, Precision, Progress, Quant, WeightsSource,
+    AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Image,
+    LoadSpec, MoeExpert, Precision, Progress, Quant, ReplacementMode, WeightsSource,
 };
 #[cfg(target_os = "macos")]
 use mlx_gen_ltx as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_wan as _;
+#[cfg(target_os = "macos")]
+use sceneworks_core::character_store::CharacterStore;
 #[cfg(target_os = "macos")]
 use sceneworks_core::video_request::{ltx_frame_count, wan_frame_count};
 #[cfg(target_os = "macos")]
@@ -132,8 +134,22 @@ pub(crate) async fn run_video_generate_job(
     .await?;
     // Generate: real MLX on macOS for Wan (sc-3034) / LTX+audio (sc-3035) models with
     // resolvable weights, else the procedural stub (non-macOS or missing weights = stub).
+    // replace_person (sc-3521) always routes to the native Wan-VACE provider regardless of the
+    // user-picked (replace-capable) model — the native equivalent of the torch `WanVACEPipeline`
+    // path. It errors clearly if the VACE snapshot is unprovisioned rather than degrading to the
+    // procedural stub (a stubbed person-replace would be meaningless). It also reports the honest
+    // `replacementStatus` the asset sidecar folds in (project_store::build_video_sidecar_parts).
     #[cfg(target_os = "macos")]
-    let (decoded, adapter, raw_settings) = if let Some(engine_id) =
+    let (decoded, adapter, raw_settings, replacement_status) = if request.mode == "replace_person" {
+        let (decoded, status) =
+            generate_wan_vace(api, settings, job, &request, &project_path, backend).await?;
+        (
+            decoded,
+            WAN_VACE_ADAPTER,
+            wan_vace_raw_settings(&request),
+            Some(status),
+        )
+    } else if let Some(engine_id) =
         wan_engine_id(&request.model).filter(|_| wan_available(&request, settings))
     {
         (
@@ -149,6 +165,7 @@ pub(crate) async fn run_video_generate_job(
             .await?,
             WAN_ADAPTER,
             wan_raw_settings(&request),
+            None,
         )
     } else if let Some(engine_id) =
         ltx_engine_id(&request.model).filter(|_| ltx_available(&request, settings))
@@ -166,19 +183,22 @@ pub(crate) async fn run_video_generate_job(
             .await?,
             LTX_ADAPTER,
             ltx_raw_settings(&request),
+            None,
         )
     } else {
         (
             generate_stub_video(&request, seed),
             STUB_ADAPTER,
             stub_raw_settings(&request),
+            None,
         )
     };
     #[cfg(not(target_os = "macos"))]
-    let (decoded, adapter, raw_settings) = (
+    let (decoded, adapter, raw_settings, replacement_status) = (
         generate_stub_video(&request, seed),
         STUB_ADAPTER,
         stub_raw_settings(&request),
+        None::<Value>,
     );
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
 
@@ -199,7 +219,7 @@ pub(crate) async fn run_video_generate_job(
     let ctx = FfmpegContext::new(api, settings, &job.id, CANCEL_MESSAGE);
     encode_media(&plan.media_path, decoded, Some(ctx)).await?;
 
-    let fact = video_asset_fact(&plan, seed, adapter, raw_settings);
+    let fact = video_asset_fact(&plan, seed, adapter, raw_settings, replacement_status);
     let result = streaming_result(&plan, &fact, adapter);
     update_job(
         api,
@@ -624,7 +644,13 @@ async fn write_poster_frame(media_path: &Path) {
 /// is consumed by the API's video sidecar builder). Mirrors `video_generation_result`.
 /// `adapter` is the generating adapter id (`procedural_video` stub / `mlx_wan` real)
 /// and `raw_settings` its recorded knobs.
-fn video_asset_fact(plan: &VideoPlan, seed: i64, adapter: &str, raw_settings: Value) -> Value {
+fn video_asset_fact(
+    plan: &VideoPlan,
+    seed: i64,
+    adapter: &str,
+    raw_settings: Value,
+    replacement_status: Option<Value>,
+) -> Value {
     let request = &plan.request;
     let title: String = request.prompt.chars().take(56).collect();
     let title = title.trim();
@@ -638,7 +664,7 @@ fn video_asset_fact(plan: &VideoPlan, seed: i64, adapter: &str, raw_settings: Va
         .get("timelineContext")
         .cloned()
         .unwrap_or_else(|| json!({}));
-    json!({
+    let mut fact = json!({
         "type": "video",
         "assetId": plan.asset_id,
         "mediaPath": plan.media_rel,
@@ -668,7 +694,13 @@ fn video_asset_fact(plan: &VideoPlan, seed: i64, adapter: &str, raw_settings: Va
         "personTrackId": request.person_track_id,
         "replacementMode": request.replacement_mode,
         "timelineContext": timeline_context,
-    })
+    });
+    // replace_person reports its honest mask/track provenance (mirrors the torch
+    // `video_generation_result` `replacementStatus` fold; sc-3521).
+    if let (Some(status), Some(object)) = (replacement_status, fact.as_object_mut()) {
+        object.insert("replacementStatus".to_owned(), status);
+    }
+    fact
 }
 
 fn stub_raw_settings(request: &VideoRequest) -> Value {
@@ -1080,6 +1112,9 @@ struct VideoGenInput {
     steps: Option<u32>,
     guidance: Option<f32>,
     seed: u64,
+    /// Per-request control-clip conditioning scale (Wan-VACE `conditioning_scale`, sc-3441 /
+    /// sc-3521); `None` ⇒ the engine default (1.0). Unused by the non-control paths.
+    control_scale: Option<f32>,
     // LTX-only knobs (sc-3035); left at defaults by Wan + the other models.
     video_mode: Option<String>,
     enhance_prompt: bool,
@@ -1106,6 +1141,7 @@ impl Default for VideoGenInput {
             steps: None,
             guidance: None,
             seed: 0,
+            control_scale: None,
             video_mode: None,
             enhance_prompt: false,
             use_uncensored_enhancer: false,
@@ -1146,6 +1182,7 @@ fn run_video_generation(
         guidance: input.guidance,
         seed: Some(input.seed),
         conditioning: input.conditioning,
+        control_scale: input.control_scale,
         video_mode: input.video_mode,
         enhance_prompt: input.enhance_prompt,
         use_uncensored_enhancer: input.use_uncensored_enhancer,
@@ -1585,6 +1622,7 @@ async fn generate_ltx(
         steps: None,
         guidance: None,
         seed: resolve_video_seed(request) as u64,
+        control_scale: None,
         video_mode,
         enhance_prompt: advanced_bool(request, "enhancePrompt"),
         use_uncensored_enhancer: advanced_bool(request, "useUncensoredEnhancer"),
@@ -1592,6 +1630,480 @@ async fn generate_ltx(
         enhance_temperature,
     };
     generate_video(api, settings, job, backend, input).await
+}
+
+// ---------------------------------------------------------------------------
+// Real MLX Wan-VACE replace_person generation (macOS, via mlx-gen-wan, sc-3521):
+// route the `replace_person` mode / `PersonReplace` job to the native `wan_vace`
+// provider — the equivalent of the torch `DiffusersVideoAdapter` `WanVACEPipeline`
+// path. The worker builds the masked-control inputs (source clip frames + the
+// onnx-track person mask + character refs) and the engine does the
+// masking/neutralization + denoise. Person detect/track/segment stays upstream.
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real MLX Wan-VACE replace_person asset.
+#[cfg(target_os = "macos")]
+const WAN_VACE_ADAPTER: &str = "mlx_wan_vace";
+
+/// Letterbox pad colour for extracted source-clip frames — matches the Python `fit_frame`
+/// background (`0x12110f` = RGB 18,17,15) so the box masks (rasterized from the same
+/// normalized boxes at W×H) stay aligned with the control frames through the engine's
+/// identity-resize preprocess.
+#[cfg(target_os = "macos")]
+const FRAME_PAD_COLOR: &str = "0x12110f";
+
+/// Raw-settings recorded on a real Wan-VACE asset (`advanced` knobs + the real-inference
+/// markers; the engine id is `wan_vace`, not the user-picked replace-capable model).
+#[cfg(target_os = "macos")]
+fn wan_vace_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String("wan_vace".to_owned()));
+    raw.insert(
+        "frameCount".to_owned(),
+        json!(wan_frame_count(request.raw_frame_count())),
+    );
+    raw.insert("fps".to_owned(), json!(request.fps));
+    raw.insert(
+        "replacementMode".to_owned(),
+        Value::String(request.replacement_mode.clone()),
+    );
+    Value::Object(raw)
+}
+
+/// SceneWorks `replacementMode` string → engine [`ReplacementMode`] (default FaceOnly).
+#[cfg(target_os = "macos")]
+fn replacement_mode_from(value: &str) -> ReplacementMode {
+    match value {
+        "full_person_keep_outfit" => ReplacementMode::FullPersonKeepOutfit,
+        "full_person_replace_outfit" => ReplacementMode::FullPersonReplaceOutfit,
+        _ => ReplacementMode::FaceOnly,
+    }
+}
+
+/// Whether `dir` is a load-ready assembled Wan-VACE snapshot — the diffusers VACE
+/// `transformer/` plus the shared base-Wan UMT5/VAE/tokenizer that `mlx_gen::load("wan_vace")`
+/// reads (sc-3467 `assemble_wan_vace_snapshot` layout).
+#[cfg(target_os = "macos")]
+fn wan_vace_dir_is_complete(dir: &Path) -> bool {
+    dir.join("transformer").join("config.json").is_file()
+        && dir.join("t5_encoder.safetensors").is_file()
+        && dir.join("vae.safetensors").is_file()
+        && dir.join("tokenizer.json").is_file()
+}
+
+/// Resolve (assembling on first use) the converted Wan-VACE snapshot dir. Env override
+/// (`SCENEWORKS_MLX_WAN_VACE_DIR`) → the app-managed `<data>/models/mlx/wan_vace` → assemble
+/// it from the diffusers VACE transformer (HF `Wan-AI/Wan2.1-VACE-1.3B-diffusers`,
+/// `transformer/`) + a converted base-Wan 14B snapshot's shared UMT5/z16-VAE/tokenizer
+/// (sc-3467 `assemble_wan_vace_snapshot` — packaging, not conversion). Errors clearly when a
+/// component is missing rather than degrading to the stub.
+#[cfg(target_os = "macos")]
+fn resolve_wan_vace_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    if let Ok(override_dir) = std::env::var("SCENEWORKS_MLX_WAN_VACE_DIR") {
+        let path = PathBuf::from(override_dir.trim());
+        if wan_vace_dir_is_complete(&path) {
+            return Ok(path);
+        }
+    }
+    let out_dir = settings
+        .data_dir
+        .join("models")
+        .join("mlx")
+        .join("wan_vace");
+    if wan_vace_dir_is_complete(&out_dir) {
+        return Ok(out_dir);
+    }
+    // Assemble on first use: the VACE transformer is diffusers-layout (no conversion); the
+    // shared T5/VAE/tokenizer come from a converted base-Wan 14B snapshot (z16 VAE, shared
+    // with VACE since both are Wan2.1-based).
+    let vace_repo = "Wan-AI/Wan2.1-VACE-1.3B-diffusers";
+    let transformer_dir = huggingface_snapshot_dir(&settings.data_dir, vace_repo)
+        .map(|snapshot| snapshot.join("transformer"))
+        .filter(|dir| dir.join("config.json").is_file())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "replace_person: the Wan-VACE transformer ({vace_repo}) is not downloaded — \
+                 fetch it via the model manager."
+            ))
+        })?;
+    let base_wan = ["wan_2_2_t2v_14b", "wan_2_2_i2v_14b"]
+        .into_iter()
+        .find_map(|model| resolve_wan_model_dir(settings, model, model).ok())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "replace_person: Wan-VACE needs a converted base-Wan 14B snapshot (its shared \
+                 UMT5 text encoder + z16 VAE + tokenizer). Convert/download wan_2_2_t2v_14b or \
+                 wan_2_2_i2v_14b first."
+                    .to_owned(),
+            )
+        })?;
+    mlx_gen_wan::convert::assemble_wan_vace_snapshot(&out_dir, &transformer_dir, &base_wan, true)
+        .map_err(|error| {
+        WorkerError::InvalidPayload(format!(
+            "replace_person: failed to assemble the Wan-VACE snapshot: {error}"
+        ))
+    })?;
+    Ok(out_dir)
+}
+
+/// Decode the source clip into exactly `count` RGB frames at `width × height` (letterboxed,
+/// `FRAME_PAD_COLOR`), evenly resampled across the clip — the new shared frame-extraction
+/// helper (Python `load_source_video_frames`; also the seam extend/bridge will reuse). The
+/// frames are the (un-neutralized) Wan-VACE control video; the engine masks them.
+#[cfg(target_os = "macos")]
+async fn load_source_video_frames(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    count: usize,
+) -> WorkerResult<Vec<Image>> {
+    let asset_id = request.source_clip_asset_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "replace_person requires a source clip (sourceClipAssetId).".to_owned(),
+        )
+    })?;
+    let asset = ProjectStore::new(settings.data_dir.clone(), "worker")
+        .get_asset(&request.project_id, asset_id)
+        .map_err(|error| WorkerError::InvalidPayload(format!("source clip {asset_id}: {error}")))?;
+    let rel = asset
+        .get("file")
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!("source clip {asset_id} has no media path"))
+        })?;
+    let media_path = project_path.join(rel);
+    if !tokio::fs::try_exists(&media_path).await? {
+        return Err(WorkerError::InvalidPayload(format!(
+            "source clip file is missing: {}",
+            media_path.display()
+        )));
+    }
+
+    let work_dir = std::env::temp_dir().join(format!("sw-replace-frames-{}", job.id));
+    tokio::fs::create_dir_all(&work_dir).await?;
+    let pattern = work_dir.join("src_%05d.png");
+    let filters = format!(
+        "scale={width}:{height}:force_original_aspect_ratio=decrease,\
+         pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color={FRAME_PAD_COLOR},format=rgb24",
+        width = request.width,
+        height = request.height,
+    );
+    let ctx = FfmpegContext::new(api, settings, &job.id, CANCEL_MESSAGE);
+    let extract = run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            media_path.display().to_string(),
+            "-vf".to_owned(),
+            filters,
+            "-start_number".to_owned(),
+            "0".to_owned(),
+            pattern.display().to_string(),
+        ],
+        Some(ctx),
+    )
+    .await;
+    let frames = match extract {
+        Ok(()) => select_extracted_frames(work_dir.clone(), count).await,
+        Err(error) => Err(error),
+    };
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    frames
+}
+
+/// Collect the extracted PNG frames in `work_dir`, resample them to `count` evenly-spaced
+/// indices (Python `evenly_spaced_indices` — the same arithmetic as the mask resample), and
+/// decode the selected frames to engine [`Image`]s. Blocking IO/decoding runs off the runtime.
+#[cfg(target_os = "macos")]
+async fn select_extracted_frames(work_dir: PathBuf, count: usize) -> WorkerResult<Vec<Image>> {
+    tokio::task::spawn_blocking(move || -> WorkerResult<Vec<Image>> {
+        let mut paths: Vec<PathBuf> = std::fs::read_dir(&work_dir)?
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("png"))
+            .collect();
+        paths.sort();
+        if paths.is_empty() {
+            return Err(WorkerError::InvalidPayload(
+                "source clip produced no decodable frames".to_owned(),
+            ));
+        }
+        let indices = crate::person_replace::resample_indices(paths.len(), count);
+        indices
+            .into_iter()
+            .map(|index| {
+                let decoded = image::open(&paths[index])
+                    .map_err(|error| {
+                        WorkerError::InvalidPayload(format!(
+                            "source frame {}: {error}",
+                            paths[index].display()
+                        ))
+                    })?
+                    .to_rgb8();
+                Ok(Image {
+                    width: decoded.width(),
+                    height: decoded.height(),
+                    pixels: decoded.into_raw(),
+                })
+            })
+            .collect()
+    })
+    .await
+    .map_err(|error| WorkerError::InvalidPayload(format!("frame decode task: {error}")))?
+}
+
+/// The approved character reference images (≤4) for the replacement (Python
+/// `character_reference_images`): the selected look's `approvedReferenceIds`, else the
+/// character's approved `references`. Errors when none are readable (the torch
+/// `_validate_inputs` parity). The engine cover-fits each to the output size.
+#[cfg(target_os = "macos")]
+fn resolve_character_references(
+    settings: &Settings,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Image>> {
+    let character_id = request.character_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload("replace_person requires a character (characterId).".to_owned())
+    })?;
+    let character = CharacterStore::new(&settings.data_dir, project_path.to_path_buf())
+        .get_character(&request.project_id, character_id)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("character {character_id}: {error}"))
+        })?;
+    let mut ids: Vec<String> = Vec::new();
+    if let Some(look_id) = request.character_look_id.as_deref() {
+        if let Some(looks) = character.get("looks").and_then(Value::as_array) {
+            for look in looks {
+                if look.get("id").and_then(Value::as_str) == Some(look_id) {
+                    if let Some(approved) =
+                        look.get("approvedReferenceIds").and_then(Value::as_array)
+                    {
+                        ids.extend(approved.iter().filter_map(Value::as_str).map(str::to_owned));
+                    }
+                }
+            }
+        }
+    }
+    if ids.is_empty() {
+        if let Some(references) = character.get("references").and_then(Value::as_array) {
+            for reference in references {
+                if reference
+                    .get("approved")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    if let Some(asset_id) = reference.get("assetId").and_then(Value::as_str) {
+                        ids.push(asset_id.to_owned());
+                    }
+                }
+            }
+        }
+    }
+    let mut images = Vec::new();
+    for asset_id in ids.into_iter().filter(|id| !id.is_empty()).take(4) {
+        if let Ok(image) = load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            &asset_id,
+            project_path,
+        ) {
+            images.push(image);
+        }
+    }
+    if images.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Replace Person requires at least one approved character reference image.".to_owned(),
+        ));
+    }
+    Ok(images)
+}
+
+/// Convert an `image::RgbImage` (the rasterized mask) to an engine [`Image`].
+#[cfg(target_os = "macos")]
+fn rgb_image_to_engine(image: image::RgbImage) -> Image {
+    Image {
+        width: image.width(),
+        height: image.height(),
+        pixels: image.into_raw(),
+    }
+}
+
+/// Build the Wan-VACE conditioning: one [`Conditioning::ControlClip`] (source frames + the
+/// per-frame person mask; the engine neutralizes the masked region) plus one
+/// [`Conditioning::Reference`] per character reference image.
+#[cfg(target_os = "macos")]
+fn build_vace_conditioning(
+    frames: Vec<Image>,
+    masks: Vec<image::RgbImage>,
+    references: Vec<Image>,
+    masking_strength: f32,
+    mode: ReplacementMode,
+) -> WorkerResult<Vec<Conditioning>> {
+    if frames.len() != masks.len() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "replace_person: control frames ({}) and masks ({}) length mismatch",
+            frames.len(),
+            masks.len()
+        )));
+    }
+    let mask_images: Vec<Image> = masks.into_iter().map(rgb_image_to_engine).collect();
+    let mut conditioning = Vec::with_capacity(1 + references.len());
+    conditioning.push(Conditioning::ControlClip {
+        frames,
+        mask: mask_images,
+        masking_strength,
+        start_frame: 0,
+        mode,
+    });
+    for image in references {
+        conditioning.push(Conditioning::Reference {
+            image,
+            strength: None,
+        });
+    }
+    Ok(conditioning)
+}
+
+/// The honest `replacementStatus` recorded on the asset fact (mirrors the torch
+/// `replacement_status`); the API folds it into the video sidecar's normalizedSettings.
+#[cfg(target_os = "macos")]
+fn replacement_status_value(
+    track: &Value,
+    track_id: &str,
+    mask_mode: &str,
+    masking_strength: f32,
+    reference_count: usize,
+    frame_count: usize,
+) -> Value {
+    let status = track.get("status").and_then(Value::as_object);
+    let person_tracking_active = status
+        .and_then(|s| s.get("personTrackingActive"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let mask_state = status
+        .and_then(|s| s.get("maskState"))
+        .and_then(Value::as_str)
+        .unwrap_or("missing")
+        .to_owned();
+    let corrections = track.get("corrections").and_then(Value::as_array);
+    let correction_count = corrections.map(|list| list.len()).unwrap_or(0);
+    let resolved_track_id = track.get("id").and_then(Value::as_str).unwrap_or(track_id);
+    json!({
+        "personDetectionActive": true,
+        "personTrackingActive": person_tracking_active,
+        "replacementActive": true,
+        "replacementAdapter": WAN_VACE_ADAPTER,
+        "maskMode": mask_mode,
+        "maskState": mask_state,
+        "maskingStrength": masking_strength,
+        "personTrackId": resolved_track_id,
+        "characterReferenceCount": reference_count,
+        "controlFrameCount": frame_count,
+        "usedCorrections": correction_count > 0,
+        "correctionCount": correction_count,
+    })
+}
+
+/// Resolve a replace_person request into a Wan-VACE generation: assemble/resolve the snapshot,
+/// extract the source-clip control frames, build the per-frame person mask from the saved
+/// track (corrections applied), load the character refs, run the engine, and return the decoded
+/// video plus the honest `replacementStatus`. Person detect/track/segment stays upstream.
+#[cfg(target_os = "macos")]
+async fn generate_wan_vace(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    backend: &str,
+) -> WorkerResult<(DecodedVideo, Value)> {
+    let model_dir = resolve_wan_vace_model_dir(settings)?;
+    let track_id = request.person_track_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "replace_person requires a person track (personTrackId).".to_owned(),
+        )
+    })?;
+    let track = ProjectStore::new(settings.data_dir.clone(), "worker")
+        .get_person_track(&request.project_id, track_id)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("person track {track_id}: {error}"))
+        })?;
+
+    // Source frames + masks must match in count and be `1 + 4·k` (one z16 VAE temporal chunk),
+    // which `wan_frame_count` guarantees — the engine `validate()` enforces it too.
+    let frame_count = wan_frame_count(request.raw_frame_count()) as usize;
+    let frames =
+        load_source_video_frames(api, settings, job, request, project_path, frame_count).await?;
+    let (masks, mask_mode) = crate::person_replace::person_track_masks(
+        project_path,
+        &track,
+        request.width,
+        request.height,
+        frames.len(),
+    )?;
+    let references = resolve_character_references(settings, request, project_path)?;
+    let reference_count = references.len();
+    let frame_total = frames.len();
+
+    let masking_strength = advanced_f32(request, "maskingStrength", 1.0);
+    let conditioning = build_vace_conditioning(
+        frames,
+        masks,
+        references,
+        masking_strength,
+        replacement_mode_from(&request.replacement_mode),
+    )?;
+
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let steps = request.advanced.get("steps").and_then(|value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+            .map(|value| value as u32)
+    });
+    let guidance = request.advanced.get("guidanceScale").and_then(|value| {
+        value
+            .as_f64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+            .map(|value| value as f32)
+    });
+    let input = VideoGenInput {
+        engine_id: "wan_vace",
+        model_dir,
+        quant: resolve_wan_quant(request),
+        adapters: Vec::new(),
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: frame_count as u32,
+        fps: request.fps,
+        steps,
+        guidance,
+        seed: resolve_video_seed(request) as u64,
+        control_scale: Some(advanced_f32(request, "conditioningScale", 1.0)),
+        ..VideoGenInput::default()
+    };
+    let decoded = generate_video(api, settings, job, backend, input).await?;
+    let status = replacement_status_value(
+        &track,
+        track_id,
+        mask_mode,
+        masking_strength,
+        reference_count,
+        frame_total,
+    );
+    Ok((decoded, status))
 }
 
 #[cfg(test)]
@@ -1736,7 +2248,13 @@ mod tests {
             "sourceAssetId": "asset_src", "personTrackId": "track_1"
         }));
         let plan = VideoPlan::new(&request, Path::new("/tmp/project"));
-        let fact = video_asset_fact(&plan, 42, "procedural_video", stub_raw_settings(&request));
+        let fact = video_asset_fact(
+            &plan,
+            42,
+            "procedural_video",
+            stub_raw_settings(&request),
+            None,
+        );
         assert_eq!(fact["type"], json!("video"));
         assert_eq!(fact["mimeType"], json!("video/mp4"));
         assert_eq!(fact["mediaPath"], json!(plan.media_rel));
@@ -1754,6 +2272,196 @@ mod tests {
         assert_eq!(result["adapter"], json!("procedural_video"));
         assert_eq!(result["assetWrites"].as_array().unwrap().len(), 1);
         assert_eq!(result["generationSet"]["count"], json!(1));
+    }
+
+    /// A replace_person asset fact carries the `replacementStatus` object the API folds into
+    /// the video sidecar (sc-3521); a non-replace fact omits it.
+    #[test]
+    fn asset_fact_embeds_replacement_status_when_present() {
+        let request = request(json!({
+            "projectId": "p", "model": "wan_2_2", "mode": "replace_person",
+            "prompt": "swap the hero", "personTrackId": "track_9"
+        }));
+        let plan = VideoPlan::new(&request, Path::new("/tmp/project"));
+        let status = json!({ "replacementActive": true, "maskMode": "segmentation" });
+        let fact = video_asset_fact(&plan, 7, "mlx_wan_vace", json!({}), Some(status));
+        assert_eq!(fact["replacementStatus"]["replacementActive"], json!(true));
+        assert_eq!(fact["replacementStatus"]["maskMode"], json!("segmentation"));
+        // Without a status the key is absent (the non-replace paths).
+        let bare = video_asset_fact(&plan, 7, "mlx_wan", json!({}), None);
+        assert!(bare.get("replacementStatus").is_none());
+    }
+
+    /// SceneWorks `replacementMode` strings → engine `ReplacementMode` (default FaceOnly).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn replacement_mode_maps_the_three_granularities() {
+        assert_eq!(
+            replacement_mode_from("face_only"),
+            ReplacementMode::FaceOnly
+        );
+        assert_eq!(
+            replacement_mode_from("full_person_keep_outfit"),
+            ReplacementMode::FullPersonKeepOutfit
+        );
+        assert_eq!(
+            replacement_mode_from("full_person_replace_outfit"),
+            ReplacementMode::FullPersonReplaceOutfit
+        );
+        assert_eq!(replacement_mode_from("nonsense"), ReplacementMode::FaceOnly);
+    }
+
+    /// The Wan-VACE conditioning is one ControlClip (frames + per-frame mask) followed by one
+    /// Reference per character image; mismatched frame/mask counts fail clearly.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn vace_conditioning_builds_control_clip_plus_references() {
+        let frame = |v: u8| Image {
+            width: 2,
+            height: 2,
+            pixels: vec![v; 12],
+        };
+        let mask = || image::RgbImage::from_pixel(2, 2, image::Rgb([255, 255, 255]));
+        let conditioning = build_vace_conditioning(
+            vec![frame(10), frame(20)],
+            vec![mask(), mask()],
+            vec![frame(30)],
+            0.75,
+            ReplacementMode::FullPersonKeepOutfit,
+        )
+        .expect("conditioning builds");
+        assert_eq!(conditioning.len(), 2); // 1 ControlClip + 1 Reference
+        match &conditioning[0] {
+            Conditioning::ControlClip {
+                frames,
+                mask,
+                masking_strength,
+                start_frame,
+                mode,
+            } => {
+                assert_eq!(frames.len(), 2);
+                assert_eq!(mask.len(), 2);
+                assert_eq!(*masking_strength, 0.75);
+                assert_eq!(*start_frame, 0);
+                assert_eq!(*mode, ReplacementMode::FullPersonKeepOutfit);
+            }
+            other => panic!("expected ControlClip, got {other:?}"),
+        }
+        assert!(matches!(conditioning[1], Conditioning::Reference { .. }));
+        // A frame/mask count mismatch is rejected.
+        assert!(build_vace_conditioning(
+            vec![frame(1)],
+            vec![mask(), mask()],
+            Vec::new(),
+            1.0,
+            ReplacementMode::FaceOnly,
+        )
+        .is_err());
+    }
+
+    /// `replacement_status_value` reports the honest mask/track provenance the sidecar folds in.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn replacement_status_reads_track_and_counts() {
+        let track = json!({
+            "id": "track_42",
+            "status": { "maskState": "active", "personTrackingActive": true },
+            "corrections": [ { "frameIndex": 0 }, { "frameIndex": 3 } ]
+        });
+        // 0.5 is exactly representable as f32 so the JSON widen to f64 is exact.
+        let status = replacement_status_value(&track, "ignored", "segmentation", 0.5, 2, 81);
+        assert_eq!(status["personDetectionActive"], json!(true));
+        assert_eq!(status["personTrackingActive"], json!(true));
+        assert_eq!(status["replacementActive"], json!(true));
+        assert_eq!(status["replacementAdapter"], json!("mlx_wan_vace"));
+        assert_eq!(status["maskMode"], json!("segmentation"));
+        assert_eq!(status["maskState"], json!("active"));
+        assert_eq!(status["maskingStrength"], json!(0.5));
+        assert_eq!(status["personTrackId"], json!("track_42"));
+        assert_eq!(status["characterReferenceCount"], json!(2));
+        assert_eq!(status["controlFrameCount"], json!(81));
+        assert_eq!(status["usedCorrections"], json!(true));
+        assert_eq!(status["correctionCount"], json!(2));
+    }
+
+    /// An assembled Wan-VACE snapshot dir if one is present (env override or the app-managed
+    /// default), else `None` so the real-weight smoke skips.
+    #[cfg(target_os = "macos")]
+    fn wan_vace_dir() -> Option<PathBuf> {
+        if let Ok(dir) = std::env::var("SCENEWORKS_MLX_WAN_VACE_DIR") {
+            let path = PathBuf::from(dir.trim());
+            if wan_vace_dir_is_complete(&path) {
+                return Some(path);
+            }
+        }
+        let home = std::env::var("HOME").ok()?;
+        let path = PathBuf::from(home)
+            .join("Library/Application Support/SceneWorks/data/models/mlx/wan_vace");
+        wan_vace_dir_is_complete(&path).then_some(path)
+    }
+
+    /// Real in-process Wan-VACE replace_person through the engine: load the assembled snapshot
+    /// and denoise a tiny 5-frame clip from a synthetic control clip (gray frames + a centered
+    /// box mask) + one reference, asserting frames come back RGB8-sized with streamed progress.
+    /// `#[ignore]` — the weights live outside CI; run manually on a Mac where the snapshot is
+    /// assembled (the real-Mac GPU parity gate, sc-3521).
+    #[cfg(target_os = "macos")]
+    #[ignore = "loads the real Wan-VACE snapshot; run manually on a Mac with it assembled"]
+    #[test]
+    fn wan_vace_real_weights() {
+        let Some(model_dir) = wan_vace_dir() else {
+            eprintln!("skipping wan_vace_real_weights: no assembled wan_vace snapshot found");
+            return;
+        };
+        let (w, h) = (256u32, 256u32);
+        let gray = || Image {
+            width: w,
+            height: h,
+            pixels: vec![118u8; (w * h * 3) as usize],
+        };
+        let frames: Vec<Image> = (0..5).map(|_| gray()).collect();
+        let masks: Vec<image::RgbImage> = (0..5)
+            .map(|_| {
+                crate::person_replace::box_mask(
+                    Some(&json!({ "x": 0.3, "y": 0.2, "width": 0.4, "height": 0.6 })),
+                    w,
+                    h,
+                )
+            })
+            .collect();
+        let conditioning =
+            build_vace_conditioning(frames, masks, vec![gray()], 1.0, ReplacementMode::FaceOnly)
+                .expect("conditioning builds");
+        let input = VideoGenInput {
+            engine_id: "wan_vace",
+            model_dir,
+            conditioning,
+            prompt: "a person walking, cinematic".to_owned(),
+            width: w,
+            height: h,
+            frames: 5,
+            fps: 16,
+            steps: Some(8),
+            seed: 7,
+            control_scale: Some(1.0),
+            ..VideoGenInput::default()
+        };
+        let cancel = CancelFlag::new();
+        let mut steps = 0u32;
+        let mut on_progress = |progress: Progress| {
+            if let Progress::Step { .. } = progress {
+                steps += 1;
+            }
+        };
+        let decoded =
+            run_video_generation(input, &cancel, &mut on_progress).expect("VACE generation");
+        assert!(decoded.fps >= 1);
+        assert!(decoded.audio.is_none(), "Wan-VACE emits no audio");
+        assert!(steps > 0, "denoise progress streamed");
+        assert!(decoded
+            .frames
+            .iter()
+            .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize));
     }
 
     /// Wan model-id → engine-id mapping + the family predicates that drive routing.


### PR DESCRIPTION
Worker-side cutover routing `replace_person` (the `PersonReplace` job type + `video_generate` mode=`replace_person`) to the native engine `wan_vace` provider on the macOS MLX worker — the native equivalent of the torch `DiffusersVideoAdapter` `WanVACEPipeline` path. The engine provider + snapshot assembler + per-request `control_scale` already merged (sc-3388 / sc-3467 / sc-3441); the worker mlx-gen pin already carries them. This is purely the worker wiring.

Story: [sc-3521](https://app.shortcut.com/trefry/story/3521). Follows the FLF slice [#466](https://github.com/michaeltrefry/SceneWorks/pull/466) (sc-3520); routing matrix per sc-3385 (replace_person → Wan-VACE primary).

## What changed

- **Mask pipeline port** — new cross-platform `crates/sceneworks-worker/src/person_replace.rs`: faithful ports of `apply_track_corrections` (corrected-box override + clear-mask; rejected-frame nearest-accepted-box borrow), `_resample_indices` (banker's `python_round` so indices match Python exactly), `_box_mask` (3% pad, PIL-inclusive far edge, empty-vs-missing box distinction), `load_track_masks` (stored seg-mask load → RGB fan-out, box fallback, `segmentation`/`degraded_box`/`mixed` mode), and `person_track_masks` (selectedDetection single-frame fallback). The module is cross-platform so its 11 unit tests run on the Linux CI lane — the **mask-port-vs-Python correctness gate**.
- **Wan-VACE generation** (`video_jobs.rs`, macOS): `run_video_generate_job` gains a `replace_person` branch → `generate_wan_vace`. New shared ffmpeg source-frame extractor (`load_source_video_frames`, same scale+pad `0x12110f` filter as the track-detect frames so masks stay aligned), character refs (≤4), then `Conditioning::ControlClip { frames, mask, masking_strength, start_frame: 0, mode }` + one `Reference` per ref — the engine does the masking/neutralization. Frame count = `wan_frame_count` (1+4·k); `conditioningScale` → `control_scale` (added to `VideoGenInput`). Snapshot resolved/assembled on first use via `mlx_gen_wan::convert::assemble_wan_vace_snapshot` (VACE transformer HF `Wan-AI/Wan2.1-VACE-1.3B-diffusers` + a converted base-Wan 14B's shared UMT5/z16-VAE/tokenizer), erroring clearly when a component is missing rather than degrading to the stub. Honest `replacementStatus` reported on the asset fact (the API folds it into the video sidecar).
- **Dispatch / capability / routing**: `lib.rs` dispatches `JobType::PersonReplace` → the video handler; `gpu.rs` advertises `WorkerCapability::PersonReplace` on the mlx worker; `jobs_store.rs` `video_job_is_mlx_eligible` + `video_mode_is_mlx_eligible` admit `replace_person` (→ Wan-VACE, model-independent, on the replace-capable models `ltx_2_3`/`ltx_2_3_eros`/`wan_2_2`); `classify_video_gap`, the mac-support oracle, and the feature flags updated. `extend_clip`/`video_bridge` stay torch (sc-3522).

## Frame-count note (sc-3467)

The Rust Wan z16 decode is non-causal (`4·t_lat`), engine-wide, so VACE `replace_person` returns +3 frames vs the torch causal `WanVACEPipeline` — consistent with the other Rust Wan paths (epic 3018). Not a blocker.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test`, `cargo build` — all green.
- Tests: core 124 unit + 94 jobs_store (incl. a new replace_person → mlx defer test), rust-api 101, worker 173 (incl. 11 person_replace + 22 video_jobs).
- Added an `#[ignore]` `wan_vace_real_weights` engine smoke for the manual run.

## Reviewer notes / remaining gate

- **Real-Mac GPU E2E parity is the one remaining gate** — not runnable in CI. Run `wan_vace_real_weights` (and a full replace_person job) on a Mac with the assembled `wan_vace` snapshot before merge.
- Person detect/track/segment stays upstream (native YOLO11 + SORT/ByteTrack + SAM2); only the mask rasterization/decode + the video-gen half ported here.
- Windows/Linux keep the Python torch path (mlx-gen is macOS-only); the LTX IC-LoRA replace_person remains the torch-family option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)