### PR TITLE
sc-3755: wire video_bridge into Video Studio (mode + right-clip picker)

### DIFF
--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -219,9 +219,18 @@ export function VideoStudio() {
   const [ltxVideoCfg, setLtxVideoCfg] = useState(saved.videoCfgGuidanceScale ?? "");
   const [ltxVideoStg, setLtxVideoStg] = useState(saved.videoStgGuidanceScale ?? "");
   const [ltxVideoRescale, setLtxVideoRescale] = useState(saved.videoRescaleScale ?? "");
+  // Clip-conditioning strengths for the LTX IC-LoRA extend/bridge paths (sc-3522,
+  // sc-3755). The worker reads these from `advanced` (default 1.0 when absent):
+  // the source/left clip uses videoConditioningStrength, the bridge right clip
+  // uses bridgeRightVideoConditioningStrength.
+  const [videoConditioningStrength, setVideoConditioningStrength] = useState(saved.videoConditioningStrength ?? "");
+  const [bridgeRightVideoConditioningStrength, setBridgeRightVideoConditioningStrength] = useState(
+    saved.bridgeRightVideoConditioningStrength ?? "",
+  );
   const [sourceAssetId, setSourceAssetId] = useState(["image", "frame"].includes(selectedAsset?.type) ? selectedAsset.id : "");
   const [lastFrameAssetId, setLastFrameAssetId] = useState("");
   const [sourceClipAssetId, setSourceClipAssetId] = useState(selectedAsset?.type === "video" ? selectedAsset.id : "");
+  const [bridgeRightClipAssetId, setBridgeRightClipAssetId] = useState("");
   const [characterId, setCharacterId] = useState("");
   const [characterLookId, setCharacterLookId] = useState("");
   const [personTrackId, setPersonTrackId] = useState("");
@@ -250,7 +259,7 @@ export function VideoStudio() {
   // per-platform default (Q8_0 on MPS, Q4_K_M on CUDA).
   const quantVariants = Object.entries(selectedModel?.quantization?.variants ?? {});
   const supportsQuantization = quantVariants.length > 0;
-  const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "replace_person"].includes(mode);
+  const implementedMode = ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"].includes(mode);
   const {
     availablePresets,
     selectedPreset,
@@ -612,6 +621,8 @@ export function VideoStudio() {
     videoCfgGuidanceScale: ltxVideoCfg,
     videoStgGuidanceScale: ltxVideoStg,
     videoRescaleScale: ltxVideoRescale,
+    videoConditioningStrength,
+    bridgeRightVideoConditioningStrength,
   });
 
   useEffect(() => {
@@ -629,13 +640,16 @@ export function VideoStudio() {
     ["text_to_video", "Text → Video"],
     ["first_last_frame", "First → Last"],
     ["extend_clip", "Extend"],
+    ["video_bridge", "Bridge"],
     ["replace_person", "Replace person"],
   ];
   // Mac UI gating (sc-3486): disable the video modes that run on the Python torch path —
   // per-model FLF eligibility + the torch-only advanced modes (extend/bridge/replace).
   const macAdvancedVideoBlock = macFeatureBlock(macCapabilities, "advancedVideoModes");
+  // extend_clip + video_bridge share the IC-LoRA clip-conditioning path (sc-3522): both are
+  // gated by the `advancedVideoModes` capability the same way (MLX-eligible on LTX only).
   const macVideoModeBlockFor = (value) =>
-    value === "extend_clip"
+    value === "extend_clip" || value === "video_bridge"
       ? macAdvancedVideoBlock
       : macVideoModeBlock(selectedModel, macCapabilities, value);
   const matchingTracks = personTracks.filter((track) => track.sourceAssetId === sourceClipAssetId);
@@ -659,6 +673,7 @@ export function VideoStudio() {
     (mode === "image_to_video" && sourceAssetId) ||
     (mode === "first_last_frame" && sourceAssetId && lastFrameAssetId) ||
     (mode === "extend_clip" && sourceClipAssetId) ||
+    (mode === "video_bridge" && sourceClipAssetId && bridgeRightClipAssetId) ||
     (mode === "replace_person" && sourceClipAssetId && personTrackId && characterId);
   // Don't let Replace Person queue a job the readiness endpoint says no live
   // worker can run — that would sit unclaimable instead of honoring the gate.
@@ -724,7 +739,10 @@ export function VideoStudio() {
         characterLookId: characterLookId || null,
         sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,
         lastFrameAssetId: mode === "first_last_frame" ? lastFrameAssetId || null : null,
-        sourceClipAssetId: ["extend_clip", "replace_person"].includes(mode) ? sourceClipAssetId || null : null,
+        sourceClipAssetId: ["extend_clip", "replace_person", "video_bridge"].includes(mode)
+          ? sourceClipAssetId || null
+          : null,
+        bridgeRightClipAssetId: mode === "video_bridge" ? bridgeRightClipAssetId || null : null,
         personTrackId: mode === "replace_person" ? personTrackId || null : null,
         replacementMode: mode === "replace_person" ? replacementMode : "face_only",
         loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
@@ -761,6 +779,19 @@ export function VideoStudio() {
             : {}),
           ...(selectedModel?.adapter === "ltx_video" && ltxVideoRescale !== "" && Number.isFinite(Number(ltxVideoRescale))
             ? { videoRescaleScale: Number(ltxVideoRescale) }
+            : {}),
+          // LTX IC-LoRA clip-conditioning strengths (sc-3522, sc-3755). The worker
+          // reads these from `advanced`, defaulting to 1.0 when absent — extend uses
+          // the source-clip strength, bridge uses both left and right.
+          ...(["extend_clip", "video_bridge"].includes(mode) &&
+          videoConditioningStrength !== "" &&
+          Number.isFinite(Number(videoConditioningStrength))
+            ? { videoConditioningStrength: Number(videoConditioningStrength) }
+            : {}),
+          ...(mode === "video_bridge" &&
+          bridgeRightVideoConditioningStrength !== "" &&
+          Number.isFinite(Number(bridgeRightVideoConditioningStrength))
+            ? { bridgeRightVideoConditioningStrength: Number(bridgeRightVideoConditioningStrength) }
             : {}),
         },
       });
@@ -910,6 +941,27 @@ export function VideoStudio() {
                 onChange={setSourceClipAssetId}
                 value={sourceClipAssetId}
               />
+            ) : null}
+
+            {mode === "video_bridge" ? (
+              <>
+                <AssetPickerField
+                  assets={videoAssets}
+                  buttonLabel="Select clip"
+                  emptyLabel="No left clip selected"
+                  label="Left clip"
+                  onChange={setSourceClipAssetId}
+                  value={sourceClipAssetId}
+                />
+                <AssetPickerField
+                  assets={videoAssets}
+                  buttonLabel="Select clip"
+                  emptyLabel="No right clip selected"
+                  label="Right clip"
+                  onChange={setBridgeRightClipAssetId}
+                  value={bridgeRightClipAssetId}
+                />
+              </>
             ) : null}
 
             {mode === "replace_person" ? (
@@ -1326,6 +1378,36 @@ export function VideoStudio() {
                           value={ltxVideoRescale}
                         />
                       </label>
+                    </>
+                  ) : null}
+                  {["extend_clip", "video_bridge"].includes(mode) ? (
+                    <>
+                      <label>
+                        {mode === "video_bridge" ? "Left clip strength" : "Clip strength"}
+                        <input
+                          min="0"
+                          max="1"
+                          onChange={(event) => setVideoConditioningStrength(event.target.value)}
+                          placeholder="1.0"
+                          step="0.05"
+                          type="number"
+                          value={videoConditioningStrength}
+                        />
+                      </label>
+                      {mode === "video_bridge" ? (
+                        <label>
+                          Right clip strength
+                          <input
+                            min="0"
+                            max="1"
+                            onChange={(event) => setBridgeRightVideoConditioningStrength(event.target.value)}
+                            placeholder="1.0"
+                            step="0.05"
+                            type="number"
+                            value={bridgeRightVideoConditioningStrength}
+                          />
+                        </label>
+                      ) : null}
                     </>
                   ) : null}
                   {supportsQuantization ? (

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -70,6 +70,15 @@ async function click(element) {
   });
 }
 
+async function doubleClick(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("dblclick", { bubbles: true }));
+  });
+}
+
+const buttonWithText = (root, text) =>
+  [...root.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
+
 function setInput(element, value) {
   const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
   setter.call(element, value);
@@ -152,5 +161,88 @@ describe("VideoStudio Save as Preset", () => {
 
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");
+  });
+});
+
+describe("VideoStudio video_bridge", () => {
+  let container;
+  let root;
+
+  // A bridge-capable video model with a non-LTX id so the IC-LoRA preset gate
+  // (requiresLtxIcLora, which keys on ltx_2_3) doesn't block submission here —
+  // this test exercises the new input wiring, not the LTX IC-LoRA requirement.
+  const BRIDGE_MODEL = {
+    id: "bridge_model",
+    name: "Bridge Model",
+    type: "video",
+    family: "ltx-video",
+    capabilities: ["image_to_video", "text_to_video", "extend_clip", "video_bridge"],
+    defaults: { duration: 6, resolution: "768x512", fps: 25 },
+    limits: {},
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+
+  const leftClip = { id: "vid_left", type: "video", projectId: "project_1", displayName: "Left Clip" };
+  const rightClip = { id: "vid_right", type: "video", projectId: "project_1", displayName: "Right Clip" };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("submits both clip ids when bridging two clips", async () => {
+    const context = baseContext({
+      videoModels: [BRIDGE_MODEL],
+      assets: [leftClip, rightClip],
+      selectedAsset: leftClip,
+    });
+    await render(context);
+
+    // Switch to Bridge mode; the left clip is pre-filled from the selected asset.
+    const modeControl = container.querySelector(".mode-control");
+    await click(buttonWithText(modeControl, "Bridge"));
+
+    // Drive the right-clip picker (the only "Select clip" button; the left
+    // picker shows "Change" because it already has a value).
+    await click(buttonWithText(container, "Select clip"));
+    const modal = document.querySelector(".asset-picker-modal");
+    expect(modal).toBeTruthy();
+    const rightOption = [...modal.querySelectorAll('[role="option"]')].find((el) =>
+      el.textContent.includes("Right Clip"),
+    );
+    await doubleClick(rightOption);
+
+    // Render.
+    await click(buttonWithText(container, "Render clip"));
+
+    expect(context.createVideoJob).toHaveBeenCalledTimes(1);
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      mode: "video_bridge",
+      sourceClipAssetId: "vid_left",
+      bridgeRightClipAssetId: "vid_right",
+    });
   });
 });


### PR DESCRIPTION
## What & why

[sc-3755](https://app.shortcut.com/trefry/story/3755) — Video Studio had no way to create a `video_bridge` job even though the backend supports it end-to-end (sc-3522, [#492](https://github.com/michaeltrefry/SceneWorks/pull/492)): the API maps `video_bridge → JobType::VideoBridge` and validates `sourceClipAssetId` + `bridgeRightClipAssetId`, and the Rust MLX worker builds the LTX IC-LoRA left@0 / right@-1 `VideoClip` conditioning. This wires the UI inputs.

## Changes — `apps/web/src/screens/VideoStudio.jsx`

- **Mode option**: `modeOptions` gains `["video_bridge", "Bridge"]`; `implementedMode` includes it.
- **Right-clip picker**: bridge mode shows two pickers — "Left clip" (existing `sourceClipAssetId`) + a new "Right clip" bound to `bridgeRightClipAssetId`, mirroring the extend_clip picker.
- **Submit**: sets `sourceClipAssetId` for bridge too and emits top-level `bridgeRightClipAssetId`. `createVideoJob` spreads `...payload`, so the new field flows through untouched.
- **Readiness**: `hasInputs` requires both `sourceClipAssetId` AND `bridgeRightClipAssetId` for bridge.
- **Mac gating** (sc-3486): bridge shares extend_clip's `advancedVideoModes` capability gate via `macVideoModeBlockFor`. `ltxIcLoraRequiredModes` already included `video_bridge`, so the IC-LoRA preset requirement was already wired.
- **Optional advanced knobs** (worker already reads them, default 1.0): "Left clip strength" (`videoConditioningStrength`, extend + bridge) and "Right clip strength" (`bridgeRightVideoConditioningStrength`, bridge-only), persisted via `useStudioSettingsWriter`.

## Tests

Added a `VideoStudio video_bridge` integration test that renders the real component, switches to Bridge, drives the actual right-clip `AssetPicker` modal, submits, and asserts the payload carries both clip ids. **Web suite: 355/355 green** (`vitest run --environment jsdom`).

## Out of scope (unchanged)

Worker/engine path (sc-3522) and real-Mac IC-LoRA parity. Follow-up filed for tightening the Mac bridge/extend gate to per-model LTX eligibility (the `advancedVideoModes` capability is still globally `unsupported`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)