### PR TITLE
sc-3767: bundle ffmpeg as an app resource (decouple Rust worker from venv imageio-ffmpeg)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,8 @@ apps/desktop/binaries/
 apps/desktop/python-src/
 # onnxruntime dylib staged by build-sidecar.mjs for the Rust DWPose detector (sc-3487)
 apps/desktop/onnxruntime/
+# static ffmpeg staged by build-sidecar.mjs for the Rust worker (sc-3767)
+apps/desktop/ffmpeg/
 
 # SceneWorks local runtime data
 # user.*.jsonc manifests are rewritten by the SceneWorks API at runtime (local state, not source).

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -70,3 +70,27 @@ if (triple.includes("apple-darwin")) {
   );
   console.log(`build-sidecar: ${ortDir} placeholder (non-macOS, no DWPose dylib)`);
 }
+
+// The Rust worker shells out to ffmpeg (frame sampling, frame extract, timeline
+// export, video-gen audio mux) via SCENEWORKS_FFMPEG (set in setup.rs). The
+// desktop ships no system ffmpeg, and epic 3482 strips the Python venv it used to
+// borrow imageio-ffmpeg from — so we bundle a static ffmpeg as a Tauri resource
+// (tauri.conf.json `resources` -> `ffmpeg/**/*`). Like the onnxruntime dir above,
+// the `ffmpeg` dir must exist on EVERY platform (Tauri errors on an empty glob);
+// only macOS stages the real binary (Windows/Linux desktop + server/Docker use
+// PATH ffmpeg), other platforms ship a placeholder. GPLv3 — see
+// docs/sc-3767/ffmpeg-bundling.md.
+const ffmpegDir = join(desktopDir, "ffmpeg");
+mkdirSync(ffmpegDir, { recursive: true });
+if (triple.includes("apple-darwin")) {
+  const ffmpegDest = join(ffmpegDir, "ffmpeg");
+  const py = process.env.PYTHON || "python3";
+  run(py, ["apps/desktop/scripts/stage-ffmpeg.py", ffmpegDest]);
+  console.log(`build-sidecar: staged ${ffmpegDest}`);
+} else {
+  writeFileSync(
+    join(ffmpegDir, "README.txt"),
+    "Static ffmpeg is bundled on macOS only (sc-3767); Windows/Linux use PATH ffmpeg.\n",
+  );
+  console.log(`build-sidecar: ${ffmpegDir} placeholder (non-macOS, PATH ffmpeg)`);
+}

--- a/apps/desktop/scripts/stage-ffmpeg.py
+++ b/apps/desktop/scripts/stage-ffmpeg.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Stage the static ffmpeg binary for the Rust worker (sc-3767, epic 3482).
+
+The Rust worker shells out to ffmpeg for frame sampling (person-track), frame
+extraction, timeline export, and video-gen audio mux — all via
+`media_jobs::run_ffmpeg`, which honors `SCENEWORKS_FFMPEG` (set by the desktop
+`setup.rs`) else falls back to `ffmpeg` on PATH. The desktop ships no system
+ffmpeg, so for a packaged, Python-free Mac (epic 3482's venv strip) we must
+bundle the binary as an app resource rather than resolving it from the venv's
+imageio-ffmpeg.
+
+We stage the *exact* binary the desktop runs today: imageio-ffmpeg's bundled
+`ffmpeg-macos-aarch64-vX` (an evermeet.cx GPLv3 static build). The macOS arm64
+imageio-ffmpeg wheel is platform-tagged (`py3-none-macosx_*_arm64`) and bundles
+the binary at `imageio_ffmpeg/binaries/ffmpeg-*`, so we pip-download that wheel
+(a zip) and extract it. Pinned to a known version so the bundle is deterministic.
+
+LICENSING: the extracted ffmpeg is GPLv3 (configured `--enable-gpl` +
+`--enable-libx264/x265`, which the worker's libx264 mp4 encode requires — an
+LGPL build is not an option). See docs/sc-3767/ffmpeg-bundling.md for provenance
+and GPL compliance. Invoked by build-sidecar.mjs on macOS only.
+
+USAGE: python3 stage-ffmpeg.py <dest-binary-path>
+"""
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+# Pin to the version the desktop venv currently resolves (imageio-ffmpeg 0.6.0 →
+# ffmpeg 7.1 macos-aarch64). Bump in lockstep with requirements-mlx.txt so the
+# bundled binary matches what dev/pre-bundle runs.
+IMAGEIO_FFMPEG_VERSION = "0.6.0"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: stage-ffmpeg.py <dest-binary-path>", file=sys.stderr)
+        return 2
+    dest = sys.argv[1]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Let pip pick the wheel matching this (macOS arm64) build host; the
+        # binary is bundled inside the platform-tagged wheel.
+        subprocess.run(
+            [
+                sys.executable, "-m", "pip", "download",
+                f"imageio-ffmpeg=={IMAGEIO_FFMPEG_VERSION}",
+                "--only-binary=:all:", "--no-deps", "-d", tmp,
+            ],
+            check=True,
+        )
+        wheels = glob.glob(os.path.join(tmp, "imageio_ffmpeg-*.whl"))
+        if not wheels:
+            print("stage-ffmpeg: no imageio-ffmpeg wheel downloaded", file=sys.stderr)
+            return 1
+        with zipfile.ZipFile(wheels[0]) as zf:
+            bins = [
+                n for n in zf.namelist()
+                if "imageio_ffmpeg/binaries/ffmpeg" in n and not n.endswith("/")
+            ]
+            if not bins:
+                print("stage-ffmpeg: wheel has no ffmpeg binary", file=sys.stderr)
+                return 1
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with zf.open(bins[0]) as src, open(dest, "wb") as out:
+                out.write(src.read())
+        os.chmod(dest, 0o755)
+    print(f"stage-ffmpeg: staged {dest} (imageio-ffmpeg {IMAGEIO_FFMPEG_VERSION})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -775,11 +775,27 @@ async fn provision_lens_venv(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Resolve the ffmpeg binary bundled with the venv's imageio-ffmpeg, used by the
-/// API's in-process utility worker for timeline export / frame extraction. The
-/// desktop ships no system ffmpeg, so without this those jobs fail. Returns None
-/// if the venv or imageio-ffmpeg isn't available yet.
-fn resolve_bundled_ffmpeg() -> Option<String> {
+/// Resolve the ffmpeg binary the Rust worker shells out to (frame sampling,
+/// frame extract, timeline export, video-gen audio mux — all via
+/// `media_jobs::run_ffmpeg`, which honors `SCENEWORKS_FFMPEG`). The desktop ships
+/// no system ffmpeg, so without this those jobs fail. Prefers the static ffmpeg
+/// bundled next to the app (staged by build-sidecar.mjs into the `ffmpeg` resource
+/// dir, so a packaged Python-free Mac still works — epic 3482, sc-3767); falls
+/// back to the venv's imageio-ffmpeg only in dev / pre-bundle. Returns None when
+/// neither is available (Windows/Linux desktop pre-bundle, or after the venv strip
+/// with no resource — caller then leaves `SCENEWORKS_FFMPEG` unset → PATH ffmpeg).
+fn resolve_bundled_ffmpeg(app: &AppHandle) -> Option<String> {
+    if let Ok(resources) = app.path().resource_dir() {
+        let bundled = resources.join("ffmpeg").join(if cfg!(windows) {
+            "ffmpeg.exe"
+        } else {
+            "ffmpeg"
+        });
+        if bundled.exists() {
+            return Some(bundled.to_string_lossy().to_string());
+        }
+    }
+    // Dev / pre-bundle fallback: the venv's imageio-ffmpeg binary.
     let python = venv_python(&venv_dir());
     if !python.exists() {
         return None;
@@ -877,9 +893,9 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
     // the final cutover (sc-3492) flips it on for macOS at exactly this point —
     //     #[cfg(target_os = "macos")] { command = command.env("SCENEWORKS_MLX_REQUIRED", "1"); }
     // — once every Mac Python surface is ported or UI-gated.
-    // The in-process utility worker shells out to ffmpeg; point it at the venv's
-    // bundled binary since the desktop has no system ffmpeg on PATH.
-    if let Some(ffmpeg) = resolve_bundled_ffmpeg() {
+    // The in-process utility worker shells out to ffmpeg; point it at the bundled
+    // static binary (sc-3767) since the desktop has no system ffmpeg on PATH.
+    if let Some(ffmpeg) = resolve_bundled_ffmpeg(app) {
         command = command.env("SCENEWORKS_FFMPEG", ffmpeg);
     }
     // DWPose pose detection (sc-3487) loads onnxruntime dynamically; point `ort` at
@@ -1206,7 +1222,7 @@ fn supervise_mlx_worker(app: AppHandle, api_port: u16) {
                 );
             // The worker muxes generated video with ffmpeg; the desktop ships no
             // system ffmpeg, so point it at the bundled binary (as spawn_api does).
-            if let Some(ffmpeg) = resolve_bundled_ffmpeg() {
+            if let Some(ffmpeg) = resolve_bundled_ffmpeg(&app) {
                 command = command.env("SCENEWORKS_FFMPEG", ffmpeg);
             }
             // This is the worker that advertises `pose_detect` (epic 3482, sc-3487);

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -28,7 +28,7 @@
     "active": true,
     "targets": "all",
     "externalBin": ["binaries/sceneworks-api", "binaries/uv"],
-    "resources": ["python-src/**/*", "onnxruntime/**/*"],
+    "resources": ["python-src/**/*", "onnxruntime/**/*", "ffmpeg/**/*"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/docs/sc-3767/ffmpeg-bundling.md
+++ b/docs/sc-3767/ffmpeg-bundling.md
@@ -1,0 +1,82 @@
+# sc-3767 — Bundled ffmpeg: provenance & licensing
+
+Epic 3482 (Python Eradication). The Rust worker shells out to `ffmpeg` for frame
+sampling (person-track), frame extraction, timeline export, and video-gen audio
+mux — all through `media_jobs::run_ffmpeg`, which uses `SCENEWORKS_FFMPEG` when set
+else `ffmpeg` on PATH. The desktop ships no system ffmpeg and used to borrow the
+venv's `imageio-ffmpeg` binary; once the Mac Python venv is stripped (sc-3492) that
+source disappears, so we bundle a static ffmpeg as an app resource instead — the
+same pattern as the onnxruntime dylib (sc-3487).
+
+## What we ship
+
+- **Binary:** `ffmpeg` 7.1, macОS arm64 (Mach-O, links only system frameworks +
+  `libc++`/`libSystem` — no bundled third-party dylibs).
+- **Source:** the binary bundled inside the `imageio-ffmpeg==0.6.0` macOS arm64
+  wheel (`imageio_ffmpeg/binaries/ffmpeg-macos-aarch64-v7.1`), staged by
+  `apps/desktop/scripts/stage-ffmpeg.py` (invoked from `build-sidecar.mjs` on macOS
+  only) into the `apps/desktop/ffmpeg/` Tauri resource dir.
+- **Identity:** this is the **exact** binary the desktop already runs today via the
+  venv — sha256 `6d175a4743ca50256e89a8cdd731100f9cee33bd79aeea46894d209410dc6617`
+  (wheel-RECORD base64 `bRdaR0PKUCVuiajN1zEQD5zuM715rupGiU0glBDcZhc=`). Bundling
+  changes only *where* it resolves from, not *what* runs — zero behavior change.
+- **Upstream provenance:** imageio-ffmpeg's macOS builds come from
+  [evermeet.cx](https://evermeet.cx/ffmpeg/). Build configuration (from
+  `ffmpeg -version`):
+  `--enable-gpl --enable-libx264 --enable-libx265 --enable-libvmaf --enable-libvidstab
+  --enable-libaom --enable-libsvtav1 --enable-libopus --enable-libmp3lame --enable-libvpx
+  --enable-libwebp --enable-libass --enable-libfreetype ...`
+
+## Licensing — GPLv3
+
+This is a **GPLv3** build, not LGPL: `--enable-gpl` plus GPL-licensed components
+(libx264, libx265, libvidstab) place the combined ffmpeg binary under GPLv3.
+
+**An LGPL build is not an option for SceneWorks:** the video-gen encode path
+hard-requires `libx264` for H.264 mp4 output (`crates/sceneworks-worker/src/
+video_jobs.rs` — `-c:v libx264`), which only exists in a GPL build. Dropping to
+LGPL would break video generation and timeline export.
+
+SceneWorks invokes ffmpeg as a **separate executable** over a command-line
+interface (`std::process::Command`), at arm's length — the GPL'd ffmpeg is an
+independent aggregated program, not linked into the app, so its copyleft does not
+extend to SceneWorks' own code.
+
+### Redistribution obligations (now that we bundle it)
+
+Today the GPL binary is pip-downloaded onto the user's machine at first-run; once
+it's an app resource, **we redistribute it**, which triggers GPLv3 §6:
+
+- **License text:** ship the GPL v3 license alongside the binary (ffmpeg's own
+  `COPYING.GPLv3`).
+- **Corresponding source / written offer:** the exact source is FFmpeg 7.1 from
+  <https://ffmpeg.org/releases/> (`ffmpeg-7.1.tar.xz`) built per the evermeet
+  configuration above; evermeet publishes its build scripts at
+  <https://evermeet.cx/ffmpeg/>. Provide this as a written offer in the app's
+  third-party notices / About → Licenses.
+- The `imageio-ffmpeg` *wrapper* (the Python package the wheel comes from) is
+  BSD-2-Clause — relevant only as the delivery vehicle; it imposes no extra
+  obligation on the binary.
+
+> **Action for packaging (tracked, not yet wired):** the desktop's third-party
+> license bundle / About screen must include the ffmpeg GPLv3 text + the written
+> offer above before the bundled-ffmpeg build ships to users. This doc is the
+> source of truth for that notice.
+
+## Cross-platform
+
+- **macOS desktop:** bundled static ffmpeg (this doc).
+- **Windows / Linux desktop:** `build-sidecar.mjs` writes a placeholder into the
+  `ffmpeg/` resource dir (Tauri errors on a resource glob matching no files); no
+  binary is staged. `resolve_bundled_ffmpeg()` finds no resource and no
+  imageio-ffmpeg → returns `None` → `SCENEWORKS_FFMPEG` stays unset → PATH ffmpeg.
+- **Server / Docker:** never run `setup.rs`; always PATH ffmpeg. Unchanged.
+
+## Resolution order (`apps/desktop/src/setup.rs::resolve_bundled_ffmpeg`)
+
+1. Bundled resource `…/Resources/ffmpeg/ffmpeg` (packaged app) — **preferred**.
+2. Venv `imageio-ffmpeg` binary (dev / pre-bundle fallback).
+3. Neither → `None` → caller leaves `SCENEWORKS_FFMPEG` unset → worker uses PATH.
+
+The `SCENEWORKS_FFMPEG` override contract is unchanged, so no Rust-worker change is
+needed — `media_jobs::run_ffmpeg` already honors it.


### PR DESCRIPTION
[sc-3767](https://app.shortcut.com/trefry/story/3767) — epic 3482 (Python Eradication) hard blocker.

## Problem
The desktop's ffmpeg came **only** from the Python venv's `imageio-ffmpeg`: `setup.rs::resolve_bundled_ffmpeg()` ran the venv Python (`imageio_ffmpeg.get_ffmpeg_exe()`) and returned a path inside the venv. When epic 3482 strips the Mac venv (sc-3492), that resolves to `None` → `SCENEWORKS_FFMPEG` unset → `media_jobs::run_ffmpeg` falls back to `ffmpeg` on PATH → not found → **every** Rust-worker ffmpeg job fails (frame sampling for person-track, frame extract, timeline export, video-gen audio mux).

## Fix — mirror the onnxruntime precedent (sc-3487)
Stage a static ffmpeg as a Tauri resource at build time and prefer it at runtime, keeping the venv probe only as a dev/pre-bundle fallback. The worker already honors `SCENEWORKS_FFMPEG`, so there is **no Rust-worker change**.

- **`apps/desktop/scripts/stage-ffmpeg.py`** (new) — pip-downloads `imageio-ffmpeg==0.6.0` (the macOS arm64 wheel bundles the binary) and extracts `imageio_ffmpeg/binaries/ffmpeg-*`. Ships the **exact** ffmpeg 7.1 the desktop runs today.
- **`build-sidecar.mjs`** — stages the real binary into `apps/desktop/ffmpeg/ffmpeg` on macOS; writes a placeholder README on other platforms (Tauri errors on a resource glob matching no files).
- **`tauri.conf.json`** — adds `ffmpeg/**/*` to `resources`; **`.gitignore`** ignores `apps/desktop/ffmpeg/`.
- **`setup.rs::resolve_bundled_ffmpeg(&AppHandle)`** — prefers the bundled resource (`resource_dir()/ffmpeg/ffmpeg`), falls back to the venv's imageio-ffmpeg only in dev/pre-bundle. Both spawn sites updated to pass the `AppHandle`.
- **`docs/sc-3767/ffmpeg-bundling.md`** (new) — provenance + GPLv3 compliance.

## Cross-platform
Windows/Linux desktop + server/Docker are unchanged — they ship no bundled binary, leave `SCENEWORKS_FFMPEG` unset, and use PATH ffmpeg.

## Licensing (GPLv3)
The bundled binary is an evermeet.cx GPLv3 build (`--enable-gpl` + libx264/x265). An LGPL build is **not** an option: the worker's H.264 mp4 encode hard-requires `libx264` (`video_jobs.rs` `-c:v libx264`). Today the GPL binary is pip-downloaded onto the user's machine; bundling means **we redistribute** it → GPLv3 §6 obligations (license text + written source offer). The app has no third-party-notices surface yet, so filed **[sc-3778](https://app.shortcut.com/trefry/story/3778)** (blocks sc-3492) to wire that notice before the bundled build ships.

## Verification
- ✅ Staging produces a **bit-identical** binary: sha256 `6d175a47…dc6617` matches the wheel RECORD. ffmpeg 7.1 arm64; `libx264` + `aac` present.
- ✅ **Real worker encode job passes driven by the staged binary**: `SCENEWORKS_FFMPEG=<staged> cargo test -p sceneworks-worker encode_stub_to_mp4_with_audio_and_poster` → frames→mp4 (libx264) + AAC mux + poster all succeed via `media_jobs::run_ffmpeg`.
- ✅ `cargo check` + `cargo clippy -D warnings` on `sceneworks-desktop` clean.

## Reviewer note
A literal packaged `tauri build` + venv-removed launch was **not** run this session (heavyweight bundle/signing). The runtime resource lookup type-checks and mirrors the already-proven onnxruntime resolver, and the ffmpeg job is proven against the staged binary — but the packaged-resource resolution at runtime is unverified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)