### PR TITLE
sc-3773: gate extend_clip / video_bridge per-model (LTX), drop global advancedVideoModes flag

### DIFF
--- a/apps/web/src/macGating.js
+++ b/apps/web/src/macGating.js
@@ -91,8 +91,9 @@ export function macVideoModeBlock(model, caps, mode) {
   return null;
 }
 
-// A non-model Python surface (lycoris, imageUpscale, poseFromPhoto, personDetect,
-// datasetCaptioning, advancedVideoModes). Returns `{ blocked, reason, text }` or `null`.
+// A non-model Python surface (imageUpscale, poseFromPhoto, personDetect, datasetCaptioning).
+// Returns `{ blocked, reason, text }` or `null`. Video modes are gated per-model via
+// macVideoModeBlock, not here (sc-3773).
 export function macFeatureBlock(caps, key) {
   if (!macGatingActive(caps)) return null;
   const feature = caps?.features?.[key];

--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -78,6 +78,16 @@ describe("macGating helpers", () => {
     expect(macVideoModeBlock(video, gating, "replace_person")?.blocked).toBe(true);
   });
 
+  it("gates the LTX clip-conditioning modes per-model (sc-3773)", () => {
+    // extend_clip / video_bridge ride the LTX IC-LoRA path: enabled on LTX, blocked on Wan.
+    const ltx = { id: "ltx_2_3", macSupport: { features: { videoModes: { extend_clip: true, video_bridge: true } } } };
+    const wan = { id: "wan_2_2", macSupport: { features: { videoModes: { extend_clip: false, video_bridge: false } } } };
+    expect(macVideoModeBlock(ltx, gating, "extend_clip")).toBeNull();
+    expect(macVideoModeBlock(ltx, gating, "video_bridge")).toBeNull();
+    expect(macVideoModeBlock(wan, gating, "extend_clip")?.blocked).toBe(true);
+    expect(macVideoModeBlock(wan, gating, "video_bridge")?.blocked).toBe(true);
+  });
+
   it("falls back to the bare label when a reason is missing", () => {
     expect(macReasonText(gating, null)).toBe("Not available on Mac (Rust/MLX only)");
   });

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -85,7 +85,6 @@ import {
   DEFAULT_MAC_CAPABILITIES,
   macAvailableModels,
   macBlockedModels,
-  macFeatureBlock,
   macVideoModeBlock,
 } from "../macGating.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
@@ -643,15 +642,12 @@ export function VideoStudio() {
     ["video_bridge", "Bridge"],
     ["replace_person", "Replace person"],
   ];
-  // Mac UI gating (sc-3486): disable the video modes that run on the Python torch path —
-  // per-model FLF eligibility + the torch-only advanced modes (extend/bridge/replace).
-  const macAdvancedVideoBlock = macFeatureBlock(macCapabilities, "advancedVideoModes");
-  // extend_clip + video_bridge share the IC-LoRA clip-conditioning path (sc-3522): both are
-  // gated by the `advancedVideoModes` capability the same way (MLX-eligible on LTX only).
-  const macVideoModeBlockFor = (value) =>
-    value === "extend_clip" || value === "video_bridge"
-      ? macAdvancedVideoBlock
-      : macVideoModeBlock(selectedModel, macCapabilities, value);
+  // Mac UI gating (sc-3486, sc-3773): every video mode is disabled per-model via the selected
+  // model's `macSupport.features.videoModes` — FLF on the non-Keyframe Wan MoE engines,
+  // replace_person on non-replace models, and the LTX IC-LoRA clip-conditioning modes
+  // (extend_clip / video_bridge) on non-LTX models. On LTX, extend/bridge stay enabled because
+  // the in-process Rust worker serves them, so the old coarse global flag is gone.
+  const macVideoModeBlockFor = (value) => macVideoModeBlock(selectedModel, macCapabilities, value);
   const matchingTracks = personTracks.filter((track) => track.sourceAssetId === sourceClipAssetId);
   const latestDetectionJob = jobs
     .filter(

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1997,11 +1997,15 @@ fn image_model_mac_support(model: &str) -> ModelMacSupport {
 }
 
 /// The `video_generate` modes the UI offers, in display order, so the gating mirrors
-/// [`video_mode_is_mlx_eligible`] for every mode a Mac user could pick.
+/// [`video_mode_is_mlx_eligible`] for every mode a Mac user could pick. The clip-conditioning
+/// modes `extend_clip` / `video_bridge` are included (sc-3773) so the Mac UI gates them
+/// per-model — MLX on the LTX IC-LoRA path, torch on Wan — rather than via a coarse global flag.
 const VIDEO_UI_MODES: &[&str] = &[
     "text_to_video",
     "image_to_video",
     "first_last_frame",
+    "extend_clip",
+    "video_bridge",
     "replace_person",
 ];
 
@@ -2108,8 +2112,8 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         // Person detection + tracking are ported to the Rust worker (sc-3488 /
         // sc-3633/3634/3709): native-MLX YOLO11 detection, SORT/ByteTrack track assembly,
         // and SAM2 per-frame segmentation all run in-process, so the Replace-Person
-        // detect → track → mask flow works on a Python-free Mac. (replace_person
-        // end-to-end still needs the video-gen/inpaint half — see `advancedVideoModes`.)
+        // detect → track → mask flow works on a Python-free Mac. (The replace_person
+        // video-gen half is gated per-model via each video model's `videoModes`.)
         "personDetect".to_owned(),
         MacFeatureSupport {
             supported: true,
@@ -2123,15 +2127,10 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
             reason: None,
         },
     );
-    features.insert(
-        "advancedVideoModes".to_owned(),
-        MacFeatureSupport::unsupported(
-            "advanced video (extend / bridge)",
-            "extend_clip / video_bridge are still torch-only; first_last_frame (sc-3520) and \
-             replace_person → Wan-VACE (sc-3521) now run on MLX.",
-            "epic 3040",
-        ),
-    );
+    // The former global `advancedVideoModes` flag is gone (sc-3773): every video mode — including
+    // the LTX IC-LoRA clip-conditioning modes extend_clip / video_bridge — is now gated per-model
+    // via each model's `macSupport.features.videoModes`, so a Mac user on LTX is no longer blocked
+    // from a mode the in-process Rust worker can run.
     MacCapabilities {
         platform: platform.to_owned(),
         mac_gating_active,

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2047,13 +2047,20 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     assert!(qwen_edit.features.edit);
     // Third-party LyCORIS now applies on every MLX provider (epic 3641) → supported.
     assert!(model_mac_support("sdxl", "image").features.lycoris);
-    // Video models expose per-mode eligibility; extend/bridge stay torch.
+    // Video models expose per-mode eligibility.
     let wan = model_mac_support("wan_2_2", "video").features.video_modes;
     assert_eq!(wan.get("text_to_video"), Some(&true));
     assert_eq!(wan.get("image_to_video"), Some(&true));
     assert_eq!(wan.get("first_last_frame"), Some(&true)); // Wan TI2V-5B FLF is MLX
     assert_eq!(wan.get("replace_person"), Some(&true)); // → native Wan-VACE (sc-3521)
-                                                        // The 14B Wan MoE engines have no FLF Keyframe path → torch.
+                                                        // Wan has no IC-LoRA path → extend/bridge stay torch (sc-3773).
+    assert_eq!(wan.get("extend_clip"), Some(&false));
+    assert_eq!(wan.get("video_bridge"), Some(&false));
+    // LTX serves the IC-LoRA clip-conditioning modes on MLX → extend/bridge enabled (sc-3522/3773).
+    let ltx = model_mac_support("ltx_2_3", "video").features.video_modes;
+    assert_eq!(ltx.get("extend_clip"), Some(&true));
+    assert_eq!(ltx.get("video_bridge"), Some(&true));
+    // The 14B Wan MoE engines have no FLF Keyframe path → torch.
     assert_eq!(
         model_mac_support("wan_2_2_t2v_14b", "video")
             .features
@@ -2090,7 +2097,9 @@ fn mac_capabilities_master_switch_and_infra_features() {
     assert_eq!(epic("datasetCaptioning"), None);
     // LyCORIS is ported to MLX (epic 3641) → no longer a capability gap entry at all.
     assert!(!mac.features.contains_key("lycoris"));
-    assert_eq!(epic("advancedVideoModes").as_deref(), Some("epic 3040"));
+    // The global advancedVideoModes flag is gone (sc-3773) — extend/bridge are gated per-model
+    // via each video model's macSupport.features.videoModes instead.
+    assert!(!mac.features.contains_key("advancedVideoModes"));
     assert!(mac.features["datasetCaptioning"].supported);
     // datasetCaptioning + imageUpscale + personDetect are the ported (supported) infra
     // features; the rest stay gated until their port lands.


### PR DESCRIPTION
## What & why

[sc-3773](https://app.shortcut.com/trefry/story/3773) — follow-up from [#495](https://github.com/michaeltrefry/SceneWorks/pull/495) (sc-3755).

On a gated Mac (`SCENEWORKS_MLX_REQUIRED`), `extend_clip` and `video_bridge` were disabled for **every** video model because both routed through the single global `advancedVideoModes` capability. But `video_mode_is_mlx_eligible` reports them **MLX-eligible on the LTX IC-LoRA path** (`ltx_2_3` / `ltx_2_3_eros`, sc-3522). So a Mac user on LTX was blocked from a mode the in-process Rust worker can actually run — the gate was coarser than the routing truth.

FLF and replace_person were already gated per-model (sc-3520 / sc-3521); this brings extend/bridge in line and retires the now-redundant global flag.

## Changes

**Backend — `crates/sceneworks-core/src/jobs_store.rs`**
- `VIDEO_UI_MODES` gains `extend_clip` + `video_bridge`, so each video model's `macSupport.features.videoModes` carries per-mode eligibility for them (driven by `video_mode_is_mlx_eligible`: `true` on LTX, `false` on Wan).
- Removed the dead global `advancedVideoModes` `MacFeatureSupport` entry — every video mode is now gated per-model.

**Frontend — `apps/web/src/screens/VideoStudio.jsx` / `macGating.js`**
- `macVideoModeBlockFor` routes `extend_clip` / `video_bridge` through the per-model `macVideoModeBlock` like every other mode; dropped `macAdvancedVideoBlock` and the now-unused `macFeatureBlock` import. Updated the `macFeatureBlock` docstring.

## Behavior

On a gated Mac: **Bridge/Extend enabled when LTX is selected, disabled on Wan** — matching `video_mode_is_mlx_eligible`. Non-Mac / observe-mode unchanged (every helper is inert).

## Tests
- `jobs_store`: assert per-model extend/bridge `videoModes` (false on `wan_2_2`, true on `ltx_2_3`) + that `advancedVideoModes` is no longer a capability key.
- `macGating`: new case asserting extend/bridge enabled on LTX, blocked on Wan.
- Rust: 96 jobs_store + 124 lib tests, `cargo fmt` + `clippy -D warnings` clean (sceneworks-core + rust-api). Web: **356/356** vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)