### PR TITLE
sc-3385: correct stale per-mode video-routing comments (investigation closeout)

### DIFF
--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -2155,10 +2155,13 @@ def create_video_adapter(job: dict[str, Any] | None = None) -> VideoGenerationAd
         payload = (job or {}).get("payload", {})
         model = str(payload.get("model", "ltx_2_3"))
         target = model_target(model)
-        # Epic 3018 (sc-3036/sc-3037): MLX-eligible video (Wan/LTX text_to_video /
-        # image_to_video) is claimed by the in-process Rust GPU worker (gpu_id "mlx").
-        # The Python worker only receives torch-path jobs (advanced modes, SVD, non-MLX
-        # models, LoKr-on-Wan), so auto-dispatch routes straight to the native LTX /
+        # Epic 3018 (sc-3036/sc-3037) + the epic-3040 cutover: MLX-eligible video is
+        # claimed by the in-process Rust GPU worker (gpu_id "mlx") — Wan/LTX
+        # text_to_video / image_to_video, SVD image_to_video, first_last_frame (LTX +
+        # Wan TI2V-5B), extend_clip / video_bridge (LTX IC-LoRA) and replace_person
+        # (Wan-VACE). The Python worker receives the torch-path remainder (non-MLX
+        # models, Wan extend/bridge, LoKr-on-Wan) plus all video on Windows/Linux where
+        # there is no MLX worker, so auto-dispatch routes straight to the native LTX /
         # Diffusers torch adapters — the old MlxVideoAdapter path was removed at cutover.
         if target["adapter"] == "ltx_video":
             return LtxPipelinesVideoAdapter()

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3023,10 +3023,14 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         {
             return false;
         }
-        // Video (sc-3036): the mlx worker claims only MLX-eligible `video_generate`
-        // jobs (Wan/LTX text_to_video / image_to_video). The advanced video job types
-        // (extend / bridge / person-replace) and torch-only `video_generate` cases
-        // (advanced modes, SVD, non-MLX model, LoKr-on-Wan) stay on the Python worker.
+        // Video (sc-3036 + the epic-3040 cutover): the mlx worker claims MLX-eligible
+        // `video_generate` jobs (Wan/LTX text_to_video / image_to_video + SVD
+        // image_to_video) plus the advanced job types now ported to the Rust engine —
+        // `first_last_frame` (LTX + Wan TI2V-5B, sc-3520), `extend_clip` / `video_bridge`
+        // (LTX IC-LoRA, sc-3522), and `person_replace` → native Wan-VACE (sc-3521). The
+        // per-(model, mode) gate in `video_job_is_mlx_eligible` keeps each mode to its
+        // capable engines; everything it rejects — a non-MLX model, Wan extend/bridge
+        // (no IC-LoRA keyframe-append path), LoKr-on-Wan — stays on the Python worker.
         if matches!(
             job.job_type,
             JobType::VideoGenerate


### PR DESCRIPTION
## sc-3385 — Investigate + fix "all advanced video modes route to LTX" (per-mode model routing)

**Closeout of the investigation story.** Full re-audit against current `main` confirms the per-mode × per-model routing matrix is **already correctly implemented end-to-end** — the "fix" landed piecemeal through the four merged epic-3040 cutover slices:

- sc-3520 first_last_frame → LTX + Wan TI2V-5B (#466)
- sc-3522 extend_clip / video_bridge → LTX IC-LoRA (#492)
- sc-3521 replace_person → native Wan-VACE (#494)
- sc-3523 SVD → svd_xt, image_to_video only (#493)

### Audit result (no routing changes needed)
- **Rust** `video_job_is_mlx_eligible` / `video_mode_is_mlx_eligible` / `VIDEO_MLX_ROUTED_MODELS` / `classify_video_gap` encode the per-(model, mode) matrix precisely. Test-locked by the 11 `tests/jobs_store.rs` video tests (all green).
- **Python** `VIDEO_MODEL_TARGETS.capabilities` is per-model (no "everything on LTX"); `create_video_adapter` is model-driven; `_pipeline_kind` dispatches per-mode (replace_person→VACE on Wan, condition→LTX). No `_uses_ic_lora_pipeline` "force everything to LTX" — it is platform-correct torch-path routing for Windows/Linux.

### The one real defect found + fixed here
Two routing comments still claimed advanced modes + SVD "stay on the Python worker," which the cutover made false. Corrected both (`jobs_store.rs:worker_supports_job`, `video_adapters.py:create_video_adapter`) to describe the matrix actually enforced. **Doc-only; zero behavior change.**

### Surfaced for decision (not in scope here)
- **sc-3357** (Backlog): Wan-native extend/bridge is a lower-fidelity frame-conditioned approximation on torch (no IC-LoRA keyframe-append); MLX correctly routes Wan extend/bridge to torch. Whether to build true Wan-native clip conditioning is Michael's call.
- **sc-3055** (In Progress, separate umbrella): the final torch Mac-only adapter retirement, gated on a full in-app video parity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)