### PR TITLE
sc-3715: wire SAM2 video propagation into person-track masks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "image",
  "inventory",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "image",
  "inventory",
@@ -2598,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "image",
  "inventory",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=13c0681d00cc2e3ec012e58b91de7887c3c928b7#13c0681d00cc2e3ec012e58b91de7887c3c928b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
 dependencies = [
  "image",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,11 +68,14 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 13c0681 (mlx-gen main, merged PRs #180 + #181): exposes the SVD motion knobs on
-# `GenerationRequest` (`motion_bucket_id` / `noise_aug_strength` / `decode_chunk_size`, #180)
-# AND decouples the SVD motion-conditioning fps from the output/playback fps via
-# `conditioning_fps` (#181), both read by the `svd_xt` provider so the SVD worker cutover
-# (sc-3523 / sc-3764) can map them. On top of the prior rev 0ed3019:
+# Rev 0d17c72 (mlx-gen main, merged PRs #182 + #183): completes the native-MLX SAM2 video
+# layer — the memory bank (memory encoder + memory attention, sc-3713 #182) and the
+# `Sam2VideoPredictor` propagation predictor (init_state / propagate, sc-3714 #183), consumed
+# by the Rust person-track segmenter's prompt-once + propagate path (sc-3715). On top of rev
+# 13c0681 (PRs #180 + #181): the SVD motion knobs on `GenerationRequest`
+# (`motion_bucket_id` / `noise_aug_strength` / `decode_chunk_size`, #180) AND the SVD
+# motion-conditioning fps decouple via `conditioning_fps` (#181), read by the `svd_xt`
+# provider for the SVD worker cutover (sc-3523 / sc-3764). And earlier:
 # the native-MLX SAM2 segmenter crate `mlx-gen-sam2` (epic 3704,
 # mlx-gen #176/#177/#179 — Hiera encoder + FPN neck + prompt encoder + two-way mask decoder
 # + box→mask segmenter), consumed by the Rust person-track segmenter (sc-3709); third-party
@@ -83,7 +86,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -91,44 +94,44 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00c
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "13c0681d00cc2e3ec012e58b91de7887c3c928b7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -759,14 +759,21 @@ async fn assemble_real_person_track(
     })
 }
 
-/// Segment each detected target frame with the native-MLX SAM2 segmenter, write the
-/// masks under `person-tracks/{track_id}/masks/frame_{index:06}.png`, set each frame's
-/// `mask` path, and roll the outcome up into a `maskState` (Python `segment_track`):
-/// `missing` (segmentation disabled), `degraded` (segmenter/weights unavailable or every
-/// frame failed → box-mask fallback at replacement time), `generated` (some frames
-/// segmented), `active` (all detected frames segmented). Frame ordering matches the
-/// assembly: frame `i` reads `frame_paths[i]` and the mask filename is 1-based (`i + 1`),
-/// matching the Python sidecar.
+/// Render dimensions of the sampled track frames (`render_frame_png` above), and therefore the
+/// size of the masks the SAM2 video predictor emits.
+#[cfg(target_os = "macos")]
+const TRACK_FRAME_SIZE: (u32, u32) = (1280, 720);
+
+/// Generate the selected person's track masks with the native-MLX SAM2 **video predictor**
+/// (sc-3715): prompt once on the first detected frame and propagate temporally-consistent masks
+/// across the `first..=last` detected span via the memory bank, so non-detected gap frames inside
+/// the span still get a mask (the "survives weak-detection frames" win). Masks are written under
+/// `person-tracks/{track_id}/masks/frame_{index:06}.png`, the frame's `mask` is set, and the
+/// outcome rolls up into a `maskState` (Python `segment_track`): `missing` (disabled / no detected
+/// frame), `degraded` (weights unavailable / propagation failed → box-mask fallback at replacement
+/// time), `generated` (some detected frames masked), `active` (all detected frames masked). The
+/// `generated`/`detected_total` rollup counts only detected frames, keeping the contract identical
+/// to the per-frame path; gap-frame masks are additive coverage.
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 async fn segment_assembly_frames(
@@ -782,10 +789,7 @@ async fn segment_assembly_frames(
     segment_enabled: bool,
 ) -> &'static str {
     let detected_total = frames.iter().filter(|frame| frame.detected).count();
-    if detected_total == 0 {
-        return "missing";
-    }
-    if !segment_enabled {
+    if detected_total == 0 || !segment_enabled {
         return "missing";
     }
 
@@ -803,60 +807,115 @@ async fn segment_assembly_frames(
         return "degraded";
     }
 
-    let mut generated = 0usize;
-    for (index, frame) in frames.iter().enumerate() {
-        if !frame.detected {
-            continue;
-        }
-        let Some(frame_path) = frame_paths.get(index) else {
-            continue;
-        };
-        if check_cancel(
-            api,
-            &job.id,
-            "Person tracking canceled during segmentation.",
-        )
-        .await
-        .is_err()
-        {
-            // Cancellation surfaces through the outer job poll; stop segmenting and keep
-            // whatever masks were already written.
-            break;
-        }
-        let rel = format!("person-tracks/{track_id}/masks/frame_{:06}.png", index + 1);
-        let out_path = project_path.join(&rel);
-        let weights_for_task = weights.clone();
-        let frame_for_task = frame_path.clone();
-        let box_norm = (
+    // The track spans first..=last detected frame. Propagate across that contiguous clip; frames
+    // outside it (before the person appears / after they leave) are left mask-less as before.
+    let Some(first) = frames.iter().position(|f| f.detected) else {
+        return "missing";
+    };
+    let last = frames.iter().rposition(|f| f.detected).unwrap_or(first);
+
+    // Clip frame paths + per-frame ByteTrack box anchors (None on the gap frames the predictor
+    // fills from memory). The shared sample index ties frame `i` ↔ `frame_paths[i]` ↔ mask `i + 1`.
+    if frame_paths.len() <= last {
+        return "degraded";
+    }
+    let mut clip_paths = Vec::with_capacity(last - first + 1);
+    let mut anchors = Vec::with_capacity(last - first + 1);
+    for (frame, path) in frames[first..=last].iter().zip(&frame_paths[first..=last]) {
+        clip_paths.push(path.clone());
+        anchors.push(frame.detected.then_some((
             frame.box_.x,
             frame.box_.y,
             frame.box_.width,
             frame.box_.height,
-        );
-        let out_for_task = out_path.clone();
-        let segmented = tokio::task::spawn_blocking(move || {
-            crate::person_segment::segment_person_blocking(
-                weights_for_task,
-                frame_for_task,
-                box_norm,
-                out_for_task,
-            )
+        )));
+    }
+
+    if check_cancel(
+        api,
+        &job.id,
+        "Person tracking canceled during segmentation.",
+    )
+    .await
+    .is_err()
+    {
+        return "degraded";
+    }
+
+    let weights_for_task = weights.clone();
+    let masks = match tokio::task::spawn_blocking(move || {
+        crate::person_segment::propagate_track_blocking(weights_for_task, clip_paths, anchors)
+    })
+    .await
+    {
+        Ok(Ok(masks)) => masks,
+        // Propagation failure degrades to box masks (handled by the replacement loader); a track
+        // that already located the person is never failed by the mask pass.
+        _ => return "degraded",
+    };
+
+    // Write every clip frame's non-empty mask (detected + gap) and set its sidecar `mask`. All the
+    // PNG encoding is blocking, so it runs in one `spawn_blocking`.
+    let pending: Vec<(usize, String, PathBuf, Vec<u8>)> = masks
+        .into_iter()
+        .enumerate()
+        .filter(|(_, pixels)| pixels.iter().any(|&p| p > 127))
+        .map(|(clip_idx, pixels)| {
+            let assembly_idx = first + clip_idx;
+            let rel = format!(
+                "person-tracks/{track_id}/masks/frame_{:06}.png",
+                assembly_idx + 1
+            );
+            let out_path = project_path.join(&rel);
+            (assembly_idx, rel, out_path, pixels)
         })
-        .await;
-        match segmented {
-            Ok(Ok(())) => {
-                if let Some(entry) = frames_json.get_mut(index) {
-                    entry["mask"] = Value::String(rel);
-                }
-                generated += 1;
-            }
-            // A single frame's failure is non-fatal (matches Python's per-frame `except:
-            // continue`); the frame keeps `mask: null` and falls back to a box mask.
-            _ => continue,
+        .collect();
+    let (width, height) = TRACK_FRAME_SIZE;
+    let written =
+        match tokio::task::spawn_blocking(move || write_track_mask_pngs(width, height, pending))
+            .await
+        {
+            Ok(written) => written,
+            Err(_) => return "degraded",
+        };
+
+    let mut generated = 0usize;
+    for (assembly_idx, rel) in written {
+        if let Some(entry) = frames_json.get_mut(assembly_idx) {
+            entry["mask"] = Value::String(rel);
+        }
+        if frames
+            .get(assembly_idx)
+            .map(|f| f.detected)
+            .unwrap_or(false)
+        {
+            generated += 1;
         }
     }
 
     crate::person_segment::rollup_mask_state(generated, detected_total)
+}
+
+/// Encode each `(assembly_idx, rel, out_path, pixels)` mask as an `L` (8-bit grayscale) PNG,
+/// returning the `(assembly_idx, rel)` of the frames that were written. A single frame's failure is
+/// non-fatal (matches Python's per-frame `except: continue`); it keeps `mask: null` and falls back
+/// to a box mask at replacement time.
+#[cfg(target_os = "macos")]
+fn write_track_mask_pngs(
+    width: u32,
+    height: u32,
+    pending: Vec<(usize, String, PathBuf, Vec<u8>)>,
+) -> Vec<(usize, String)> {
+    let mut written = Vec::with_capacity(pending.len());
+    for (assembly_idx, rel, out_path, pixels) in pending {
+        let Some(gray) = image::GrayImage::from_raw(width, height, pixels) else {
+            continue;
+        };
+        if gray.save(&out_path).is_ok() {
+            written.push((assembly_idx, rel));
+        }
+    }
+    written
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -2332,78 +2391,85 @@ mod person_track_e2e_tests {
                 .count();
             assert!(detected_total > 0, "no detected target frames to segment");
 
-            // 3. Provision the real SAM2 weights and segment every detected frame, writing
-            //    masks under `person-tracks/{track_id}/masks/` (the production layout).
+            // 3. Provision the real SAM2 weights and propagate the person's mask across the
+            //    detected span with the video predictor (sc-3715), writing masks under
+            //    `person-tracks/{track_id}/masks/` (the production layout).
             let seg_weights = crate::person_segment::ensure_segmenter_weights(&settings, &http)
                 .await
                 .expect("sam2 weights provisioned");
-            let track_id = "track_e2e";
-            let masks_dir = project_path
-                .join("person-tracks")
-                .join(track_id)
-                .join("masks");
-            std::fs::create_dir_all(&masks_dir).expect("masks dir");
 
+            let first = assembly
+                .frames
+                .iter()
+                .position(|f| f.detected)
+                .expect("a detected frame exists");
+            let last = assembly
+                .frames
+                .iter()
+                .rposition(|f| f.detected)
+                .unwrap_or(first);
+            let mut clip_paths = Vec::new();
+            let mut anchors = Vec::new();
+            for (frame, path) in assembly.frames[first..=last]
+                .iter()
+                .zip(&frame_paths[first..=last])
+            {
+                clip_paths.push(path.clone());
+                anchors.push(frame.detected.then(|| {
+                    let b = &frame.box_;
+                    (b.x, b.y, b.width, b.height)
+                }));
+            }
+            let gap_frames = anchors.iter().filter(|a| a.is_none()).count();
+
+            let masks = tokio::task::spawn_blocking(move || {
+                crate::person_segment::propagate_track_blocking(seg_weights, clip_paths, anchors)
+            })
+            .await
+            .expect("propagate task joins")
+            .expect("sam2 propagation runs");
+            assert_eq!(masks.len(), last - first + 1, "one mask per clip frame");
+
+            // Every detected frame's propagated mask is non-empty (SAM2 actually tracked the
+            // person, not a blank map); count detected frames masked for the rollup.
             let mut generated = 0usize;
-            for (index, frame) in assembly.frames.iter().enumerate() {
-                if !frame.detected {
-                    continue;
-                }
-                let out_path = masks_dir.join(format!("frame_{:06}.png", index + 1));
-                let box_norm = (
-                    frame.box_.x,
-                    frame.box_.y,
-                    frame.box_.width,
-                    frame.box_.height,
-                );
-                let weights_for_task = seg_weights.clone();
-                let frame_for_task = frame_paths[index].clone();
-                let out_for_task = out_path.clone();
-                tokio::task::spawn_blocking(move || {
-                    crate::person_segment::segment_person_blocking(
-                        weights_for_task,
-                        frame_for_task,
-                        box_norm,
-                        out_for_task,
-                    )
-                })
-                .await
-                .expect("segment task joins")
-                .expect("sam2 segmentation runs");
-
-                // The mask is a real binary `L` PNG aligned to the 1280×720 frame with a
-                // non-empty foreground (SAM2 actually selected the person, not a blank map).
-                let mask = image::open(&out_path).expect("mask PNG opens").to_luma8();
+            for (clip_idx, pixels) in masks.iter().enumerate() {
+                let assembly_idx = first + clip_idx;
+                let foreground = pixels.iter().filter(|&&p| p > 127).count();
                 assert_eq!(
-                    (mask.width(), mask.height()),
-                    (1280, 720),
+                    pixels.len(),
+                    (1280 * 720) as usize,
                     "mask must match the rendered frame size"
                 );
-                let foreground = mask.pixels().filter(|pixel| pixel.0[0] > 127).count();
-                assert!(
-                    foreground > 0,
-                    "frame {index} mask has no foreground — SAM2 produced an empty mask"
-                );
-                generated += 1;
+                if assembly.frames[assembly_idx].detected {
+                    assert!(
+                        foreground > 0,
+                        "frame {assembly_idx} mask has no foreground — propagation lost the person"
+                    );
+                    generated += 1;
+                }
             }
 
-            // 4. The maskState rollup must report `active` — every detected frame segmented —
-            //    which is the success signal `run_person_track` writes to the sidecar.
+            // 4. The maskState rollup must report `active` — every detected frame masked — which
+            //    is the success signal `run_person_track` writes to the sidecar.
             let mask_state = crate::person_segment::rollup_mask_state(generated, detected_total);
             eprintln!(
-                "person-track E2E: sampled={} detected={} segmented={} maskState={}",
+                "person-track E2E: sampled={} detected={} span={}..={} gapFrames={} segmented={} maskState={}",
                 timestamps.len(),
                 detected_total,
+                first,
+                last,
+                gap_frames,
                 generated,
                 mask_state
             );
             assert_eq!(
                 generated, detected_total,
-                "every detected frame should segment"
+                "every detected frame should be masked by propagation"
             );
             assert_eq!(
                 mask_state, "active",
-                "all detected frames segmented → maskState=active"
+                "all detected frames masked → maskState=active"
             );
         });
 

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -1,27 +1,28 @@
-//! Native-MLX SAM2 person segmentation on the Rust worker (epic 3704, sc-3709;
+//! Native-MLX SAM2 person segmentation on the Rust worker (epic 3704, sc-3709 → sc-3715;
 //! Slice 3 of sc-3488 / epic 3482).
 //!
-//! Ports the Python `scene_worker/person_adapters.py` `segment_track` /
-//! `_Sam2Segmenter` to Rust so the Replace-Person mask-generation step runs on a
-//! Python-free Mac. Each detected track frame is segmented with the native-MLX
-//! `mlx-gen-sam2` box-prompt segmenter (Hiera encoder + FPN neck + prompt encoder +
-//! two-way mask decoder, sc-3705/3706, GO at sc-3708) and the binary `L` mask is
-//! written under `person-tracks/{track_id}/masks/`.
+//! Ports the Python `scene_worker/person_adapters.py` `segment_track` to Rust so the
+//! Replace-Person mask-generation step runs on a Python-free Mac. **sc-3715** upgrades the
+//! per-frame box-prompt segmenter (sc-3709) to the native-MLX SAM2 **video predictor**
+//! (`mlx-gen-sam2` `Sam2VideoPredictor`, sc-3714): prompt SAM2 once on the selected track's
+//! first detected frame, then propagate temporally-consistent masks across the clip via the
+//! memory bank — so frames where the detector dropped out (occlusion / motion blur) still get
+//! a mask, and a detected frame that drifts is corrected back with its ByteTrack box. The
+//! binary `L` masks are written under `person-tracks/{track_id}/masks/`.
 //!
 //! macOS-only, like `person_jobs`: `mlx-gen-sam2` builds Apple MLX from source and is
-//! meaningless off Apple Silicon. The Python SAM2 path stays the Windows/Linux backend.
+//! meaningless off Apple Silicon. The Python SAM2 path stays the Windows/Linux backend (its
+//! per-frame quality gap is tracked in epic 3792 — backport video-SAM2 via candle-gen).
 //!
-//! The orchestration (which frames to segment, the maskState rollup, the sidecar
-//! write) lives in `media_jobs::assemble_real_person_track`; this module owns only the
-//! weight resolution/download and the single-frame segment call.
+//! The orchestration (which span to propagate, the maskState rollup, the sidecar write) lives
+//! in `media_jobs::assemble_real_person_track`; this module owns the weight
+//! resolution/download and the clip-level propagate call.
 
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
-use image::GrayImage;
-
 use mlx_gen::weights::Weights;
-use mlx_gen_sam2::{Sam2ModelSize, Sam2Segmenter};
+use mlx_gen_sam2::{Sam2ModelSize, Sam2VideoPredictor};
 
 use crate::{Settings, WorkerError, WorkerResult};
 
@@ -35,9 +36,18 @@ const SEG_FILE: &str = "sam2.1_hiera_large.safetensors";
 const SEG_URL: &str =
     "https://huggingface.co/SceneWorks/sam2-mlx/resolve/main/sam2.1_hiera_large.safetensors";
 
-/// The SAM2 segmenter is loaded once and cached process-wide (like the YOLO detector
-/// and Python's lazy model load). Holds `None` until the first frame is segmented.
-static SEGMENTER: OnceLock<Mutex<Option<Sam2Segmenter>>> = OnceLock::new();
+/// The SAM2 video predictor is loaded once and cached process-wide (weights load is the
+/// expensive part; the per-clip tracking state is built fresh each call). Holds `None` until
+/// the first track is propagated. Like the YOLO detector cache and Python's lazy model load.
+static PREDICTOR: OnceLock<Mutex<Option<Sam2VideoPredictor>>> = OnceLock::new();
+
+/// Minimum fraction of a propagated mask's foreground that must fall inside the frame's
+/// ByteTrack box for a detected frame to count as "on the person". Below this the propagation
+/// has drifted off the tracked person, so that frame is re-prompted with its box (2nd pass).
+const COVERAGE_MIN: f64 = 0.5;
+
+/// A normalized `(x, y, width, height)` box (0..1), the per-frame ByteTrack anchor.
+pub(crate) type BoxNorm = (f64, f64, f64, f64);
 
 /// Resolve already-present SAM2 weights: an explicit env pin
 /// (`SCENEWORKS_SAM2_WEIGHTS`), then the app cache `<data_dir>/cache/person-segment/`,
@@ -117,45 +127,139 @@ pub(crate) fn rollup_mask_state(generated: usize, detected_total: usize) -> &'st
     }
 }
 
-/// Segment one rendered frame to a binary person mask and write it to `out_path` as an
-/// `L` (8-bit grayscale) PNG (0 / 255). `box_norm` is the tracked box in normalized
-/// `(x, y, width, height)` space (0..1); it is scaled to the frame's pixel dimensions
-/// and passed to SAM2 as a corner-point box prompt. The MLX model is loaded once and
-/// cached process-wide (like the YOLO detector and Python's lazy model load); invoke via
-/// `spawn_blocking`. The image decode + GPU segment + PNG encode are all blocking work,
-/// so doing them together here keeps the mask off the async path entirely.
-pub(crate) fn segment_person_blocking(
-    weights_path: PathBuf,
-    image_path: PathBuf,
-    box_norm: (f64, f64, f64, f64),
-    out_path: PathBuf,
-) -> WorkerResult<()> {
-    let img = image::open(&image_path)
-        .map_err(|e| WorkerError::InvalidPayload(format!("person frame open: {e}")))?
-        .to_rgb8();
-    let (width, height) = (img.width(), img.height());
-    let box_xyxy = box_norm_to_pixels(box_norm, width, height);
+/// Fraction of a binary mask's foreground (`> 127`) that falls inside `box_norm` on a
+/// `width`×`height` frame. `0.0` when the mask is empty. Used to detect a propagated frame
+/// whose mask has drifted off the tracked person (low coverage → re-prompt with the box).
+pub(crate) fn mask_box_coverage(pixels: &[u8], box_norm: BoxNorm, width: u32, height: u32) -> f64 {
+    let [x1, y1, x2, y2] = box_norm_to_pixels(box_norm, width, height);
+    let (w, h) = (width as usize, height as usize);
+    let (mut fg, mut inside) = (0u64, 0u64);
+    for y in 0..h {
+        for x in 0..w {
+            if pixels[y * w + x] > 127 {
+                fg += 1;
+                if (x as f32) >= x1 && (x as f32) < x2 && (y as f32) >= y1 && (y as f32) < y2 {
+                    inside += 1;
+                }
+            }
+        }
+    }
+    if fg == 0 {
+        0.0
+    } else {
+        inside as f64 / fg as f64
+    }
+}
 
-    let cell = SEGMENTER.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().expect("person segmenter mutex poisoned");
+/// Propagate the selected person's mask across a clip with the native-MLX SAM2 **video
+/// predictor** (sc-3714). `clip_frame_paths` is the contiguous span the track spans (clip-local
+/// frame `0` = the first detected frame); `anchors[i]` is the frame's ByteTrack box in
+/// normalized `(x, y, width, height)` space when frame `i` was detected, else `None`. `anchors[0]`
+/// must be `Some` — it is the one-shot prompt.
+///
+/// Pass 1 prompts the first detected frame and propagates forward (the memory bank carries the
+/// person through the non-detected gap frames). Pass 2 (only if needed) re-prompts any **detected**
+/// frame whose mask drifted off its box (`mask_box_coverage < COVERAGE_MIN`) or came back empty,
+/// re-seeding those frames as box anchors so the track is corrected — this guards against a drifted
+/// propagated mask regressing vs the old per-frame box prompt.
+///
+/// Returns one binary mask (row-major `width*height`, `0`/`255`) per clip frame, in clip order.
+/// The model loads once and is cached process-wide; run under `spawn_blocking` (image decode + GPU
+/// propagation are blocking).
+pub(crate) fn propagate_track_blocking(
+    weights_path: PathBuf,
+    clip_frame_paths: Vec<PathBuf>,
+    anchors: Vec<Option<BoxNorm>>,
+) -> WorkerResult<Vec<Vec<u8>>> {
+    assert_eq!(
+        clip_frame_paths.len(),
+        anchors.len(),
+        "frames/anchors mismatch"
+    );
+    let prompt =
+        anchors.first().copied().flatten().ok_or_else(|| {
+            WorkerError::InvalidPayload("propagate clip needs a prompt frame".into())
+        })?;
+
+    // Decode every clip frame to RGB8; they share the rendered frame size.
+    let mut rgb: Vec<Vec<u8>> = Vec::with_capacity(clip_frame_paths.len());
+    let (mut width, mut height) = (0u32, 0u32);
+    for path in &clip_frame_paths {
+        let img = image::open(path)
+            .map_err(|e| WorkerError::InvalidPayload(format!("person frame open: {e}")))?
+            .to_rgb8();
+        if width == 0 {
+            (width, height) = (img.width(), img.height());
+        } else if img.width() != width || img.height() != height {
+            return Err(WorkerError::InvalidPayload(
+                "person clip frames are not all the same size".into(),
+            ));
+        }
+        rgb.push(img.into_raw());
+    }
+    let frame_refs: Vec<&[u8]> = rgb.iter().map(|f| f.as_slice()).collect();
+
+    let cell = PREDICTOR.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().expect("person predictor mutex poisoned");
     if guard.is_none() {
         let weights = Weights::from_file(&weights_path)
             .map_err(|e| WorkerError::InvalidPayload(format!("sam2 weights load: {e}")))?;
-        let segmenter = Sam2Segmenter::from_weights_for_size(&weights, Sam2ModelSize::Large)
-            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 segmenter build: {e}")))?;
-        *guard = Some(segmenter);
+        let predictor =
+            Sam2VideoPredictor::from_weights_for_size(&weights, Sam2ModelSize::Large)
+                .map_err(|e| WorkerError::InvalidPayload(format!("sam2 predictor build: {e}")))?;
+        *guard = Some(predictor);
     }
-    let segmenter = guard.as_ref().expect("segmenter loaded");
-    let mask = segmenter
-        .segment(img.as_raw(), height, width, box_xyxy)
-        .map_err(|e| WorkerError::InvalidPayload(format!("sam2 segment: {e}")))?;
-    let pixels = mask.as_slice::<u8>().to_vec();
-    let gray = GrayImage::from_raw(width, height, pixels).ok_or_else(|| {
-        WorkerError::InvalidPayload("sam2 mask dimensions did not match the frame".to_owned())
-    })?;
-    gray.save(&out_path)
-        .map_err(|e| WorkerError::InvalidPayload(format!("sam2 mask save: {e}")))?;
-    Ok(())
+    let predictor = guard.as_ref().expect("predictor loaded");
+
+    let run = |seeds: &[(usize, BoxNorm)]| -> WorkerResult<Vec<Vec<u8>>> {
+        let mut state = predictor
+            .init_state_from_frames(&frame_refs, height, width)
+            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 init_state: {e}")))?;
+        for &(idx, box_norm) in seeds {
+            predictor
+                .add_new_box(
+                    &mut state,
+                    idx as i32,
+                    box_norm_to_pixels(box_norm, width, height),
+                )
+                .map_err(|e| WorkerError::InvalidPayload(format!("sam2 add_box: {e}")))?;
+        }
+        let masks = predictor
+            .propagate(&mut state)
+            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 propagate: {e}")))?;
+        // `propagate` yields the prompt frame onward in order; build a dense per-clip-frame vec.
+        let mut out = vec![Vec::new(); clip_frame_paths.len()];
+        for (frame_idx, low) in &masks {
+            let mask = predictor
+                .mask_to_video_res(&state, low)
+                .map_err(|e| WorkerError::InvalidPayload(format!("sam2 mask resize: {e}")))?;
+            out[*frame_idx as usize] = mask.as_slice::<u8>().to_vec();
+        }
+        Ok(out)
+    };
+
+    // Pass 1: prompt once on the first detected frame.
+    let pass1 = run(&[(0, prompt)])?;
+
+    // Find detected frames whose propagated mask drifted off (or missed) the person.
+    let weak: Vec<(usize, BoxNorm)> = anchors
+        .iter()
+        .enumerate()
+        .skip(1)
+        .filter_map(|(i, anchor)| anchor.map(|b| (i, b)))
+        .filter(|&(i, b)| {
+            pass1.get(i).map(|m| !m.is_empty()).unwrap_or(false)
+                && mask_box_coverage(&pass1[i], b, width, height) < COVERAGE_MIN
+        })
+        .collect();
+    if weak.is_empty() {
+        return Ok(pass1);
+    }
+
+    // Pass 2: re-seed the prompt + every weak frame as box anchors and re-propagate.
+    let mut seeds = vec![(0usize, prompt)];
+    seeds.extend(weak);
+    run(&seeds)
 }
 
 #[cfg(test)]
@@ -174,6 +278,32 @@ mod tests {
         let clamped = box_norm_to_pixels((0.9, 0.9, 0.5, 0.5), 100, 100);
         assert_eq!(clamped[2], 100.0);
         assert_eq!(clamped[3], 100.0);
+    }
+
+    #[test]
+    fn mask_box_coverage_measures_foreground_inside_box() {
+        // 10×10 frame, a 4×4 foreground block at (2,2)..(6,6).
+        let (w, h) = (10u32, 10u32);
+        let mut pixels = vec![0u8; (w * h) as usize];
+        for y in 2..6 {
+            for x in 2..6 {
+                pixels[y * w as usize + x] = 255;
+            }
+        }
+        // A box covering the whole block → coverage 1.0.
+        let full = mask_box_coverage(&pixels, (0.2, 0.2, 0.4, 0.4), w, h);
+        assert!((full - 1.0).abs() < 1e-9, "full coverage was {full}");
+        // A box over the empty top-left corner → coverage 0.0 (none of the fg inside).
+        let none = mask_box_coverage(&pixels, (0.0, 0.0, 0.1, 0.1), w, h);
+        assert!(none.abs() < 1e-9, "disjoint coverage was {none}");
+        // An empty mask → 0.0, never a divide-by-zero.
+        assert_eq!(
+            mask_box_coverage(&[0u8; 100], (0.0, 0.0, 1.0, 1.0), w, h),
+            0.0
+        );
+        // A box over the left half of the block → ~half the foreground inside.
+        let half = mask_box_coverage(&pixels, (0.0, 0.0, 0.4, 1.0), w, h);
+        assert!((half - 0.5).abs() < 1e-9, "half coverage was {half}");
     }
 
     #[test]


### PR DESCRIPTION
Phase B (consumer) of [epic 3704](https://app.shortcut.com/trefry/epic/3704). Upgrades the macOS person-track mask pass from per-frame box-prompt SAM2 (sc-3709) to the native-MLX SAM2 **video predictor** (`Sam2VideoPredictor`, sc-3714, merged): prompt once on the selected track's first detected frame, then **propagate** temporally-consistent masks across the detected span via the memory bank.

## What changes
- **Bump** worker `mlx-gen*` pin `13c0681` → `0d17c72` (sc-3713 #182 + sc-3714 #183; same mlx-rs pin → no MLX rebuild).
- **`person_segment.rs`**: replace the per-frame `segment_person_blocking` with `propagate_track_blocking` — decode the clip → `init_state_from_frames` → `add_new_box` once on the first detected frame → `propagate` → `mask_to_video_res` per frame. A bounded **2nd pass** re-prompts any detected frame whose propagated mask drifts off its ByteTrack box (`mask_box_coverage < 0.5`) or comes back empty, re-seeding those as box anchors — the drift guard against regressing vs the per-frame path. Predictor cached process-wide.
- **`media_jobs.rs`**: `segment_assembly_frames` propagates the `first..=last` detected span and writes a mask for **every** clip frame — including previously-maskless **gap frames** inside the span (the "survives weak-detection frames" win) — setting `frame.mask`.

## Contract preserved (no regression)
`maskState` rollup unchanged — `generated` still counts detected frames with a non-empty mask → `active`/`generated`/`degraded`/`missing` as before. Mask output path `person-tracks/{id}/masks/frame_{index:06}.png` and `load_track_masks`/replace_person are untouched. Detected frames that drift are corrected back to box-prompt quality; gap-frame masks are purely additive; frames outside the detected span stay mask-less. Mac-first per the cross-platform decision on the story — the Windows/Linux torch path stays per-frame, backport tracked in [epic 3792](https://app.shortcut.com/trefry/epic/3792).

## Validation
- `npm run rust:check` green (fmt + clippy `-D warnings` + workspace test + build).
- **Real-Mac E2E** (sc-3753 harness, updated to drive propagate) on an 8s clip: `sampled=16 detected=4 span=12..=15 gapFrames=0 segmented=4 maskState=active` — propagate path runs end-to-end, all detected frames masked, no regression. (This clip's selected track has no gaps in-span; gap-filling is backed by the sc-3714 mlx-gen video parity: cosine 1.0, IoU 0.99982.)
- New unit test: `mask_box_coverage` (drift heuristic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)