### PR TITLE
sc-3357: Wan-native extend_clip / video_bridge (single-frame boundary keyframe)

### DIFF
--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -78,14 +78,18 @@ describe("macGating helpers", () => {
     expect(macVideoModeBlock(video, gating, "replace_person")?.blocked).toBe(true);
   });
 
-  it("gates the LTX clip-conditioning modes per-model (sc-3773)", () => {
-    // extend_clip / video_bridge ride the LTX IC-LoRA path: enabled on LTX, blocked on Wan.
+  it("gates the clip-conditioning modes per-model (sc-3773 / sc-3357)", () => {
+    // extend_clip / video_bridge are MLX on LTX (IC-LoRA) and Wan TI2V-5B (boundary keyframe,
+    // sc-3357); the 14B Wan MoE engines have no keyframe path → blocked.
     const ltx = { id: "ltx_2_3", macSupport: { features: { videoModes: { extend_clip: true, video_bridge: true } } } };
-    const wan = { id: "wan_2_2", macSupport: { features: { videoModes: { extend_clip: false, video_bridge: false } } } };
+    const wan = { id: "wan_2_2", macSupport: { features: { videoModes: { extend_clip: true, video_bridge: true } } } };
+    const wanMoe = { id: "wan_2_2_t2v_14b", macSupport: { features: { videoModes: { extend_clip: false, video_bridge: false } } } };
     expect(macVideoModeBlock(ltx, gating, "extend_clip")).toBeNull();
     expect(macVideoModeBlock(ltx, gating, "video_bridge")).toBeNull();
-    expect(macVideoModeBlock(wan, gating, "extend_clip")?.blocked).toBe(true);
-    expect(macVideoModeBlock(wan, gating, "video_bridge")?.blocked).toBe(true);
+    expect(macVideoModeBlock(wan, gating, "extend_clip")).toBeNull();
+    expect(macVideoModeBlock(wan, gating, "video_bridge")).toBeNull();
+    expect(macVideoModeBlock(wanMoe, gating, "extend_clip")?.blocked).toBe(true);
+    expect(macVideoModeBlock(wanMoe, gating, "video_bridge")?.blocked).toBe(true);
   });
 
   it("falls back to the bare label when a reason is missing", () => {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1790,14 +1790,16 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
 
         JobType::VideoGenerate => Err(classify_video_gap(&job.payload)),
 
-        // Reached only for ineligible extend/bridge jobs (the eligible LTX IC-LoRA path
-        // early-returns `Ok` via `job_is_any_mlx_eligible`). The remaining gap is a
-        // non-LTX (Wan) engine, which has no IC-LoRA keyframe-append path (sc-3522).
+        // Reached only for ineligible extend/bridge jobs (the eligible LTX IC-LoRA path + the Wan
+        // TI2V-5B boundary-keyframe path early-return `Ok` via `job_is_any_mlx_eligible`). The
+        // remaining gap is an engine with no in-context / keyframe path: the 14B Wan MoE engines
+        // and any non-MLX video model (sc-3522 / sc-3357).
         JobType::VideoExtend | JobType::VideoBridge => Err(UnsupportedReason::new(
             model,
-            "extend / bridge on a non-LTX engine",
-            "extend_clip / video_bridge run on MLX only on the LTX IC-LoRA path (ltx_2_3 / ltx_2_3_eros); \
-             the Wan engines have no in-context keyframe-append path, so they stay on the Python torch path.",
+            "extend / bridge on this engine",
+            "extend_clip / video_bridge run on MLX on the LTX IC-LoRA path (ltx_2_3 / ltx_2_3_eros) \
+             and Wan TI2V-5B (wan_2_2, single-frame boundary keyframe conditioning); other engines \
+             (the 14B Wan MoE) have no keyframe path, so they stay on the Python torch path.",
             Some("epic 3040"),
         )),
 
@@ -2244,8 +2246,8 @@ fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             Some(model),
             "advanced video mode",
             "this video_generate mode is not MLX-eligible on this model (first_last_frame / \
-             replace_person route to MLX only on the capable engines; extend_clip / video_bridge \
-             stay torch).",
+             extend_clip / video_bridge / replace_person route to MLX only on the capable engines — \
+             LTX + Wan TI2V-5B for the keyframe/clip modes, Wan-VACE for replace_person).",
             Some("epic 3040"),
         );
     }
@@ -2801,10 +2803,11 @@ const VIDEO_MLX_ROUTED_MODELS: &[&str] = &[
 /// MLX covers `text_to_video` + `image_to_video` on Wan/LTX, `image_to_video` on SVD
 /// (`svd`→`svd_xt`, image-conditioned only — sc-3523), `first_last_frame` on the FLF-capable
 /// engines (LTX + Wan TI2V-5B `wan_2_2`; sc-3520), the clip-conditioning modes `extend_clip` /
-/// `video_bridge` on the LTX IC-LoRA path (sc-3522, the `VideoExtend` / `VideoBridge` job types),
-/// and `replace_person` → native Wan-VACE (the `PersonReplace` job type, sc-3521 — see
+/// `video_bridge` on the LTX IC-LoRA path **and Wan TI2V-5B** (sc-3522 / sc-3357, the `VideoExtend`
+/// / `VideoBridge` job types — Wan via single-frame boundary keyframe conditioning), and
+/// `replace_person` → native Wan-VACE (the `PersonReplace` job type, sc-3521 — see
 /// [`video_mode_is_mlx_eligible`]). Still on the Python torch path: a non-MLX model, and
-/// extend/bridge on the Wan engines (no IC-LoRA keyframe-append path).
+/// extend/bridge on the 14B Wan MoE engines (no `Keyframe` path).
 /// **Third-party LyCORIS (LoHa / non-peft LoKr) and LoKr-on-Wan now run on MLX**
 /// (epic 3641, sc-3671 + sc-3644): the Wan/LTX engine paths reconstruct + merge/residual the delta —
 /// the peft-LoKr-on-Wan merge has existed since sc-2393, and the old `create_video_adapter` torch
@@ -2857,10 +2860,13 @@ fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// multi-keyframe path, sc-3357). The 14B Wan MoE engines have no `Keyframe` path, so FLF on
 /// them stays torch. **SVD (`svd`) is image-conditioned only** — it serves `image_to_video`
 /// exclusively (no text→video, sc-3523). The clip-conditioning modes `extend_clip` /
-/// `video_bridge` are MLX on the **LTX** engines only (`ltx_2_3`/`ltx_2_3_eros`, the IC-LoRA
-/// keyframe-append path — sc-3522, engine `build_clips` sc-3052/3053); the Wan engines have no
-/// IC-LoRA path so they stay torch. `replace_person` is MLX on the replace-capable models
-/// (→ native Wan-VACE, sc-3521).
+/// `video_bridge` are MLX on the **LTX** engines (`ltx_2_3`/`ltx_2_3_eros`, the IC-LoRA
+/// multi-frame keyframe-append path — sc-3522, engine `build_clips` sc-3052/3053) **and Wan
+/// TI2V-5B** (`wan_2_2`, single-frame boundary `Keyframe` conditioning — sc-3357: extend pins the
+/// source clip's last frame, bridge pins the two boundary frames, the same mask-blend primitive as
+/// Wan FLF, matching the torch Wan reference which routed these to plain i2v). The 14B Wan MoE
+/// engines have no `Keyframe` path so they stay torch. `replace_person` is MLX on the
+/// replace-capable models (→ native Wan-VACE, sc-3521).
 fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
     if model == "svd" {
         return mode == "image_to_video";
@@ -2868,7 +2874,12 @@ fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
     match mode {
         "text_to_video" | "image_to_video" => true,
         "first_last_frame" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),
-        "extend_clip" | "video_bridge" => matches!(model, "ltx_2_3" | "ltx_2_3_eros"),
+        // extend_clip / video_bridge: LTX via the IC-LoRA multi-frame keyframe-append (sc-3522),
+        // and Wan TI2V-5B (`wan_2_2`) via single-frame boundary keyframe conditioning (sc-3357 —
+        // extend pins the source clip's last frame, bridge pins the two boundary frames, the same
+        // mask-blend `Keyframe` primitive as Wan FLF). The 14B Wan MoE engines have no `Keyframe`
+        // path, so extend/bridge on them stay torch.
+        "extend_clip" | "video_bridge" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),
         // replace_person → native Wan-VACE (sc-3521): the engine `wan_vace` provider serves it
         // regardless of the user-picked replace-capable model (ltx_2_3 / ltx_2_3_eros / wan_2_2,
         // the models that advertise the capability), so admit those.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3598,12 +3598,13 @@ mod mlx_routing_tests {
             "wan_2_2_i2v_14b",
             "first_last_frame"
         ));
-        // extend_clip / video_bridge: MLX on the LTX IC-LoRA path only (sc-3522).
+        // extend_clip / video_bridge: MLX on the LTX IC-LoRA path (sc-3522) and Wan TI2V-5B
+        // (`wan_2_2`, single-frame boundary keyframe conditioning — sc-3357).
         for mode in ["extend_clip", "video_bridge"] {
             assert!(video_mode_is_mlx_eligible("ltx_2_3", mode));
             assert!(video_mode_is_mlx_eligible("ltx_2_3_eros", mode));
-            // No IC-LoRA keyframe-append path on the Wan engines → torch.
-            assert!(!video_mode_is_mlx_eligible("wan_2_2", mode));
+            assert!(video_mode_is_mlx_eligible("wan_2_2", mode));
+            // The 14B Wan MoE engines have no `Keyframe` path → torch.
             assert!(!video_mode_is_mlx_eligible("wan_2_2_t2v_14b", mode));
             assert!(!video_mode_is_mlx_eligible("wan_2_2_i2v_14b", mode));
         }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1884,9 +1884,13 @@ fn mac_rust_supported_names_infra_job_types() {
 #[test]
 fn mac_rust_supported_names_advanced_video_and_svd() {
     let store = store("oracle-video");
-    // extend / bridge on a non-LTX (Wan) engine: no IC-LoRA path → torch gap (sc-3522). The
-    // mode is derived from the job type, so a missing payload `mode` still classifies correctly.
-    let extend = job_of(&store, JobType::VideoExtend, json!({ "model": "wan_2_2" }));
+    // extend / bridge on a 14B Wan MoE engine: no `Keyframe` path → torch gap (sc-3522 / sc-3357).
+    // The mode is derived from the job type, so a missing payload `mode` still classifies correctly.
+    let extend = job_of(
+        &store,
+        JobType::VideoExtend,
+        json!({ "model": "wan_2_2_t2v_14b" }),
+    );
     assert_eq!(
         mac_rust_supported(&extend)
             .unwrap_err()
@@ -1894,7 +1898,10 @@ fn mac_rust_supported_names_advanced_video_and_svd() {
             .as_deref(),
         Some("epic 3040")
     );
-    // extend / bridge on the LTX IC-LoRA path are supported (sc-3522).
+    // extend / bridge on the LTX IC-LoRA path + Wan TI2V-5B boundary-keyframe path are supported
+    // (sc-3522 / sc-3357).
+    let wan_extend = job_of(&store, JobType::VideoExtend, json!({ "model": "wan_2_2" }));
+    assert!(mac_rust_supported(&wan_extend).is_ok());
     let ltx_extend = job_of(&store, JobType::VideoExtend, json!({ "model": "ltx_2_3" }));
     assert!(mac_rust_supported(&ltx_extend).is_ok());
     let ltx_bridge = job_of(
@@ -2053,9 +2060,9 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     assert_eq!(wan.get("image_to_video"), Some(&true));
     assert_eq!(wan.get("first_last_frame"), Some(&true)); // Wan TI2V-5B FLF is MLX
     assert_eq!(wan.get("replace_person"), Some(&true)); // → native Wan-VACE (sc-3521)
-                                                        // Wan has no IC-LoRA path → extend/bridge stay torch (sc-3773).
-    assert_eq!(wan.get("extend_clip"), Some(&false));
-    assert_eq!(wan.get("video_bridge"), Some(&false));
+                                                        // Wan TI2V-5B serves extend/bridge via single-frame boundary keyframe conditioning (sc-3357).
+    assert_eq!(wan.get("extend_clip"), Some(&true));
+    assert_eq!(wan.get("video_bridge"), Some(&true));
     // LTX serves the IC-LoRA clip-conditioning modes on MLX → extend/bridge enabled (sc-3522/3773).
     let ltx = model_mac_support("ltx_2_3", "video").features.video_modes;
     assert_eq!(ltx.get("extend_clip"), Some(&true));
@@ -2900,12 +2907,12 @@ fn mlx_worker_excluded_from_advanced_mode_video_job() {
     let store = store("mlx-video-routing-exclude");
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
-    // extend_clip / video_bridge are advanced modes that still ride the torch path (sc-3522);
-    // the mlx worker must not claim them even on a Wan model. (first_last_frame and
-    // replace_person are now MLX-eligible — see below.)
+    // extend_clip / video_bridge stay torch on engines with no keyframe path — the 14B Wan MoE
+    // here (sc-3522 / sc-3357: LTX + Wan TI2V-5B serve them on MLX, the MoE engines do not); the
+    // mlx worker must not claim this one.
     let job = store
         .create_job(video_job_with(
-            json!({ "model": "wan_2_2", "mode": "extend_clip" }),
+            json!({ "model": "wan_2_2_t2v_14b", "mode": "extend_clip" }),
             "auto",
         ))
         .expect("job creates");
@@ -3019,13 +3026,14 @@ fn flf_video_job_stays_on_torch_for_non_flf_capable_wan_moe() {
 
 #[test]
 fn clip_conditioning_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
-    // sc-3522 cutover: extend_clip / video_bridge are MLX-eligible on the LTX IC-LoRA path,
-    // so a torch worker defers the dedicated job types to an idle mlx worker.
+    // sc-3522 / sc-3357 cutover: extend_clip / video_bridge are MLX-eligible on the LTX IC-LoRA
+    // path and Wan TI2V-5B (`wan_2_2`, boundary-keyframe conditioning), so a torch worker defers
+    // the dedicated job types to an idle mlx worker.
     for (job_type, mode) in [
         (JobType::VideoExtend, "extend_clip"),
         (JobType::VideoBridge, "video_bridge"),
     ] {
-        for model in ["ltx_2_3", "ltx_2_3_eros"] {
+        for model in ["ltx_2_3", "ltx_2_3_eros", "wan_2_2"] {
             let store = store(&format!("mlx-video-routing-clip-{mode}-{model}"));
             register_gpu_worker(&store, "worker-torch", "mps", video_caps());
             register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
@@ -3059,20 +3067,21 @@ fn clip_conditioning_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
 }
 
 #[test]
-fn clip_conditioning_video_job_stays_on_torch_for_wan_engines() {
-    // extend_clip / video_bridge have no IC-LoRA keyframe-append path on Wan → stays torch,
-    // even though the mlx worker advertises the VideoExtend/VideoBridge capabilities.
+fn clip_conditioning_video_job_stays_on_torch_for_wan_moe_engines() {
+    // extend_clip / video_bridge have no `Keyframe` path on the 14B Wan MoE engines → stays torch,
+    // even though the mlx worker advertises the VideoExtend/VideoBridge capabilities. (Wan TI2V-5B
+    // `wan_2_2` IS MLX-eligible — sc-3357 — and is covered by the defer test above.)
     for (job_type, mode) in [
         (JobType::VideoExtend, "extend_clip"),
         (JobType::VideoBridge, "video_bridge"),
     ] {
-        let store = store(&format!("mlx-video-routing-clip-wan-{mode}"));
+        let store = store(&format!("mlx-video-routing-clip-wan-moe-{mode}"));
         register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
         let job = store
             .create_job(video_job_typed(
                 job_type.clone(),
-                json!({ "model": "wan_2_2", "mode": mode, "sourceClipAssetId": "left" }),
+                json!({ "model": "wan_2_2_t2v_14b", "mode": mode, "sourceClipAssetId": "left" }),
                 "auto",
             ))
             .expect("job creates");
@@ -3082,7 +3091,7 @@ fn clip_conditioning_video_job_stays_on_torch_for_wan_engines() {
                 .claim_next_job("worker-mlx")
                 .expect("mlx claim ok")
                 .is_none(),
-            "{mode}: mlx worker must not claim a Wan clip job"
+            "{mode}: mlx worker must not claim a 14B Wan MoE clip job"
         );
 
         register_gpu_worker(&store, "worker-torch", "mps", video_caps());

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1085,6 +1085,198 @@ fn resolve_wan_conditioning(
     }
 }
 
+/// Which boundary frame of a source clip to extract for Wan-native clip conditioning (sc-3357).
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ClipFramePosition {
+    /// The clip's first decoded frame (the right-side clip's head for `video_bridge`).
+    First,
+    /// The clip's last decoded frame (the source tail for `extend_clip` / the left-side clip).
+    Last,
+}
+
+/// Build the Wan-native boundary [`Conditioning::Keyframe`] set for extend_clip / video_bridge
+/// (sc-3357). Wan TI2V-5B has no in-context clip-append path (LTX's IC-LoRA `VideoClip`); its only
+/// clip primitive is the single-frame mask-blend `Keyframe` (the same one Wan FLF rides). So the
+/// faithful Wan-native form — matching the torch Wan reference, which routed these modes to plain
+/// i2v (`_pipeline_kind` → `"image"`, never IC-LoRA/VACE) — pins the clip *boundary* frame(s):
+/// - **extend_clip** → the source clip's last frame pinned at latent frame `0` (continue from it),
+///   strength `videoConditioningStrength`.
+/// - **video_bridge** → the left clip's last frame at `0` (`videoConditioningStrength`) + the right
+///   clip's first frame at latent frame `-1` (the engine's negative-from-end index), strength
+///   `bridgeRightVideoConditioningStrength`. Mechanically identical to first_last_frame.
+///
+/// Both strengths default to `1.0` (fully pinned), mirroring [`build_video_clip_conditioning`] and
+/// the torch `_advanced_float` defaults. This is the single-frame fidelity ceiling for Wan; richer
+/// motion-tail continuity is the LTX IC-LoRA path or native Wan-VACE (sc-3385 routing matrix).
+#[cfg(target_os = "macos")]
+fn build_wan_boundary_conditioning(
+    request: &VideoRequest,
+    left_frame: Image,
+    right_frame: Option<Image>,
+) -> WorkerResult<Vec<Conditioning>> {
+    let mut conditioning = vec![Conditioning::Keyframe {
+        image: left_frame,
+        frame_idx: 0,
+        strength: advanced_f32(request, "videoConditioningStrength", 1.0),
+    }];
+    if request.mode == "video_bridge" {
+        let right = right_frame.ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "video_bridge requires a right-side source clip (bridgeRightClipAssetId)."
+                    .to_owned(),
+            )
+        })?;
+        conditioning.push(Conditioning::Keyframe {
+            image: right,
+            frame_idx: -1,
+            strength: advanced_f32(request, "bridgeRightVideoConditioningStrength", 1.0),
+        });
+    }
+    Ok(conditioning)
+}
+
+/// Resolve extend_clip / video_bridge into Wan-native boundary [`Conditioning::Keyframe`]s
+/// (sc-3357). Wan-native clip conditioning is **only** the TI2V-5B mask-blend keyframe path, so
+/// guard the engine (the routing gate `video_mode_is_mlx_eligible` already restricts these to
+/// `wan_2_2`, but fail clearly here too if a 14B MoE job is mis-routed). Extracts the boundary
+/// frame(s) — the source clip's last frame (+ the right clip's first frame for bridge) — then maps
+/// them via [`build_wan_boundary_conditioning`]. Unlike the LTX path this needs **no** IC-LoRA.
+#[cfg(target_os = "macos")]
+async fn resolve_wan_clip_conditioning(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &str,
+) -> WorkerResult<Vec<Conditioning>> {
+    if engine_id != "wan2_2_ti2v_5b" {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{} is only supported on wan_2_2 (TI2V-5B), not {engine_id}.",
+            request.mode.replace('_', " ")
+        )));
+    }
+    let left_id = request.source_clip_asset_id.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "{} requires a source clip (sourceClipAssetId).",
+            request.mode.replace('_', " ")
+        ))
+    })?;
+    let left_frame = extract_clip_boundary_frame(
+        api,
+        settings,
+        job,
+        &request.project_id,
+        project_path,
+        left_id,
+        request.width,
+        request.height,
+        ClipFramePosition::Last,
+    )
+    .await?;
+    let right_frame = if request.mode == "video_bridge" {
+        let right_id = request
+            .bridge_right_clip_asset_id
+            .as_deref()
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(
+                    "video_bridge requires a right-side source clip (bridgeRightClipAssetId)."
+                        .to_owned(),
+                )
+            })?;
+        Some(
+            extract_clip_boundary_frame(
+                api,
+                settings,
+                job,
+                &request.project_id,
+                project_path,
+                right_id,
+                request.width,
+                request.height,
+                ClipFramePosition::First,
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+    build_wan_boundary_conditioning(request, left_frame, right_frame)
+}
+
+/// Decode a single boundary frame (first or last) of a source clip into an [`Image`], scaled to the
+/// output `width`×`height` (sc-3357, the Wan boundary-keyframe conditioning input). The last frame
+/// uses ffmpeg `-sseof` to seek near the end + `-update 1` so each decoded frame overwrites the lone
+/// output, leaving the final frame; the first frame is a plain `-frames:v 1`. Extracted via the
+/// shared [`run_ffmpeg`] (binary resolution + heartbeat/cancel), then loaded off the async runtime.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+async fn extract_clip_boundary_frame(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    project_id: &str,
+    project_path: &Path,
+    asset_id: &str,
+    width: u32,
+    height: u32,
+    position: ClipFramePosition,
+) -> WorkerResult<Image> {
+    let clip_path = resolve_clip_media_path(settings, project_id, asset_id, project_path)?;
+    let frames_dir = project_path
+        .join("assets")
+        .join(".cond_clips")
+        .join(Uuid::new_v4().simple().to_string());
+    tokio::fs::create_dir_all(&frames_dir).await?;
+    let out = frames_dir.join("boundary.png");
+    let mut args = vec!["ffmpeg".to_owned(), "-nostdin".to_owned(), "-y".to_owned()];
+    if position == ClipFramePosition::Last {
+        // Seek to ~2s before EOF; short clips clamp to the start (whole clip decoded). `-update 1`
+        // overwrites the single output per frame, so the final decoded frame is what remains.
+        args.push("-sseof".to_owned());
+        args.push("-2".to_owned());
+    }
+    args.push("-i".to_owned());
+    args.push(clip_path.display().to_string());
+    args.push("-vf".to_owned());
+    args.push(format!("scale={width}:{height}"));
+    if position == ClipFramePosition::Last {
+        args.push("-update".to_owned());
+        args.push("1".to_owned());
+    } else {
+        args.push("-frames:v".to_owned());
+        args.push("1".to_owned());
+    }
+    args.push(out.display().to_string());
+    let ctx = FfmpegContext::new(api, settings, &job.id, CANCEL_MESSAGE);
+    let result = run_ffmpeg(args, Some(ctx)).await;
+    let load = async {
+        result?;
+        let path = out.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<Image> {
+            let decoded = image::open(&path)
+                .map_err(|error| {
+                    WorkerError::InvalidPayload(format!(
+                        "boundary conditioning frame {}: {error}",
+                        path.display()
+                    ))
+                })?
+                .to_rgb8();
+            Ok(Image {
+                width: decoded.width(),
+                height: decoded.height(),
+                pixels: decoded.into_raw(),
+            })
+        })
+        .await
+        .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?
+    };
+    let frame = load.await;
+    let _ = tokio::fs::remove_dir_all(&frames_dir).await;
+    frame
+}
+
 /// Map `advanced.mlxQuantize` to a quant level (≤0 → dense, ≤4 → Q4, else Q8). Absent →
 /// `None`: dense bf16, or the engine builds it quantized from a pre-quantized snapshot.
 #[cfg(target_os = "macos")]
@@ -1337,12 +1529,22 @@ async fn generate_wan(
         let trimmed = request.negative_prompt.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_owned())
     };
+    // extend_clip / video_bridge build single-frame boundary `Keyframe` conditioning from the
+    // source clip(s) (async ffmpeg frame extraction, sc-3357); every other mode resolves
+    // keyframe/reference conditioning synchronously from images.
+    let conditioning = match request.mode.as_str() {
+        "extend_clip" | "video_bridge" => {
+            resolve_wan_clip_conditioning(api, settings, job, request, project_path, engine_id)
+                .await?
+        }
+        _ => resolve_wan_conditioning(settings, request, project_path, engine_id)?,
+    };
     let input = VideoGenInput {
         engine_id,
         model_dir: resolve_wan_model_dir(settings, &request.model, engine_id)?,
         quant: resolve_wan_quant(request),
         adapters: resolve_wan_adapters(settings, request, engine_id)?,
-        conditioning: resolve_wan_conditioning(settings, request, project_path, engine_id)?,
+        conditioning,
         prompt: request.prompt.clone(),
         negative_prompt,
         width: request.width,
@@ -3555,6 +3757,80 @@ mod tests {
             "mode": "video_bridge"
         }));
         let err = build_video_clip_conditioning(&req, vec![pixel(1)], None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("right-side source clip"), "got: {err}");
+    }
+
+    /// Wan extend_clip → one boundary `Keyframe` at latent frame 0 (the source clip's last frame),
+    /// strength `videoConditioningStrength` (default 1.0); the right frame is ignored (sc-3357).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_boundary_conditioning_extend_pins_last_frame_at_zero() {
+        let req = request(json!({
+            "projectId": "p", "model": "wan_2_2", "prompt": "extend it",
+            "mode": "extend_clip",
+            "advanced": { "videoConditioningStrength": 0.7 }
+        }));
+        let cond = build_wan_boundary_conditioning(&req, pixel(1), Some(pixel(2))).unwrap();
+        assert_eq!(cond.len(), 1);
+        match &cond[0] {
+            Conditioning::Keyframe {
+                frame_idx,
+                strength,
+                ..
+            } => {
+                assert_eq!(*frame_idx, 0);
+                assert_eq!(*strength, 0.7);
+            }
+            other => panic!("expected Keyframe, got {other:?}"),
+        }
+    }
+
+    /// Wan video_bridge → left clip's last frame at 0 (`videoConditioningStrength`) + right clip's
+    /// first frame at -1 (`bridgeRightVideoConditioningStrength`); mechanically FLF (sc-3357).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_boundary_conditioning_bridge_pins_both_boundaries() {
+        let req = request(json!({
+            "projectId": "p", "model": "wan_2_2", "prompt": "bridge them",
+            "mode": "video_bridge",
+            "advanced": { "bridgeRightVideoConditioningStrength": "0.5" }
+        }));
+        let cond = build_wan_boundary_conditioning(&req, pixel(1), Some(pixel(2))).unwrap();
+        assert_eq!(cond.len(), 2);
+        match (&cond[0], &cond[1]) {
+            (
+                Conditioning::Keyframe {
+                    frame_idx: left_idx,
+                    strength: left_strength,
+                    ..
+                },
+                Conditioning::Keyframe {
+                    frame_idx: right_idx,
+                    strength: right_strength,
+                    ..
+                },
+            ) => {
+                assert_eq!(*left_idx, 0);
+                assert_eq!(*left_strength, 1.0); // default
+                assert_eq!(*right_idx, -1); // engine negative-from-end
+                assert_eq!(*right_strength, 0.5); // numeric-string advanced knob
+            }
+            other => panic!("expected two Keyframes, got {other:?}"),
+        }
+    }
+
+    /// Wan video_bridge without the right boundary frame is a construction error (defence behind
+    /// the resolver's `bridgeRightClipAssetId` guard).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_boundary_conditioning_bridge_requires_right_frame() {
+        let req = request(json!({
+            "projectId": "p", "model": "wan_2_2", "prompt": "bridge them",
+            "mode": "video_bridge"
+        }));
+        let err = build_wan_boundary_conditioning(&req, pixel(1), None)
             .unwrap_err()
             .to_string();
         assert!(err.contains("right-side source clip"), "got: {err}");


### PR DESCRIPTION
Completes the last open slice of **sc-3357**. `first_last_frame` (mlx-gen PR #156) and `replace_person` (Wan-VACE, sc-3521) were already done; this routes **`extend_clip` / `video_bridge` on Wan TI2V-5B (`wan_2_2`)** to the in-process MLX worker.

## Approach
Worker-only — **no engine change**. Rides the already-validated Wan TI2V-5B `Keyframe` mask-blend path (the FLF primitive). This matches the torch Wan reference, which routed these modes to plain i2v (`_pipeline_kind` → `"image"`, never IC-LoRA/VACE) — so the single-frame boundary form is reference-grounded, not speculative:
- **extend_clip** → source clip's **last** frame pinned as `Keyframe@0` (continue from it).
- **video_bridge** → left clip's last frame `@0` + right clip's first frame `@-1` (mechanically `first_last_frame`).

## Changes
- **`sceneworks-core/jobs_store.rs`**: `video_mode_is_mlx_eligible` admits `wan_2_2` for extend/bridge (TI2V-5B only; the 14B Wan MoE has no `Keyframe` path → stays torch). Doc + `classify_unsupported`/`classify_video_gap` gap-reason updates. 4 tests retargeted from the old "Wan extend/bridge stays torch" contract to the 14B MoE.
- **`sceneworks-worker/video_jobs.rs`**: `generate_wan` routes extend/bridge to a new async `resolve_wan_clip_conditioning` → `build_wan_boundary_conditioning`; new `extract_clip_boundary_frame` ffmpeg helper (`-sseof -2` + `-update 1` for last frame, `-frames:v 1` for first). No IC-LoRA required (unlike the LTX path). Unit tests for the keyframe index/strength mapping.

## Scope boundary
Deliberately **not** built: speculative multi-frame mask-blend on TI2V-5B (no reference, redundant). Higher-fidelity Wan extend/bridge = native **Wan-VACE ControlClip** — that tier-C decision is tracked on **sc-3800** (research/decide) and **sc-3385** (routing matrix). The single-frame path here is the correct baseline/fallback regardless of that decision.

## Validation
No parity golden exists (the torch Wan reference for these modes is itself single-frame i2v), so validation is structural — the same bar as the FLF slice. Gates:
- `sceneworks-core` **96 passed**
- `sceneworks-worker` **189 + 3 new passed**
- clippy `-D warnings` clean, `cargo fmt` clean

**Owed:** real-Mac weight E2E (the `#[ignore]` tier), same as the sibling cutover slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)