### PR TITLE
Fix Character Studio angle model routing

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -160,30 +160,11 @@ export const fallbackModels = [
     capabilities: ["text_to_image", "edit_image", "character_image", "vqa", "interleave"],
     limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
     ui: {
-      description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. In Character Studio, drives a wardrobe-preserving reference flow — outfit + accessories + tattoos + hair color carry through to new scenes, but face geometry may drift. Pick InstantID or PuLID-FLUX for face-locked identity. Available in the angle-set picker (sc-2003) as the wardrobe-continuity tier — lowest pure-face ArcFace cosine (mean 0.29) but the most faithful preservation of tank + tattoo + accessories. NOT shown in the pose library — it2i_generate is single-image only. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
+      description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. In Character Studio, drives a wardrobe-preserving reference flow — outfit + accessories + tattoos + hair color carry through to new scenes, but face geometry may drift. Pick InstantID or PuLID-FLUX for face-locked identity. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
       promptGuide: { title: "SenseNova-U1 8B Prompt Guide", path: "/prompt-guides/sensenova-u1-8b.md" },
       // Edit-style variation knob (imageGuidanceScale): higher = closer to the
       // reference, lower = more prompt-driven variation. Drives advanced.imageGuidanceScale.
       variationStrength: { label: "Reference strength", default: 1.5, min: 0.5, max: 4.0, step: 0.1 },
-      // Multi-backbone angle set (sc-2003): SenseNova rotates the head per
-      // prompt and uniquely preserves wardrobe + tattoos + accessories at the
-      // cost of face-geometry fidelity. Worker resolves the augment via
-      // SenseNovaU1Adapter._ANGLE_PROMPT_AUGMENTS. NOT pose-library-capable
-      // (it2i_generate is single-image only; side-by-side concat is rendered
-      // literally rather than interpreted as a pose instruction).
-      viewAngles: [
-        { id: "three_quarter_left", label: "Three-quarter left" },
-        { id: "three_quarter_right", label: "Three-quarter right" },
-        { id: "left_profile", label: "Left profile" },
-        { id: "right_profile", label: "Right profile" },
-        { id: "up", label: "Looking up" },
-        { id: "down", label: "Looking down" },
-        { id: "up_left", label: "Up · left" },
-        { id: "up_right", label: "Up · right" },
-        { id: "down_left", label: "Down · left" },
-        { id: "down_right", label: "Down · right" },
-        { id: "front", label: "Front" },
-      ],
     },
   },
   {
@@ -198,6 +179,19 @@ export const fallbackModels = [
       description: "8-step distilled SenseNova-U1; ~5-6x faster text-to-image, editing, and Character Studio reference (~50s/image on MPS) at a small quality trade-off. Same wardrobe-preserving reference tradeoff as the base 8B (carries outfit + accessories across new scenes; face may drift). Shares the base 8B weights; a ~0.4GB distill LoRA downloads automatically. Distilled editing is experimental — use the base model for max-quality reference work.",
       promptGuide: { title: "SenseNova-U1 8B Fast Prompt Guide", path: "/prompt-guides/sensenova-u1-8b-fast.md" },
       variationStrength: { label: "Reference strength", default: 1.5, min: 0.5, max: 4.0, step: 0.1 },
+      viewAngles: [
+        { id: "three_quarter_left", label: "Three-quarter left" },
+        { id: "three_quarter_right", label: "Three-quarter right" },
+        { id: "left_profile", label: "Left profile" },
+        { id: "right_profile", label: "Right profile" },
+        { id: "up", label: "Looking up" },
+        { id: "down", label: "Looking down" },
+        { id: "up_left", label: "Up · left" },
+        { id: "up_right", label: "Up · right" },
+        { id: "down_left", label: "Down · left" },
+        { id: "down_right", label: "Down · right" },
+        { id: "front", label: "Front" },
+      ],
     },
   },
   {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -184,7 +184,7 @@ export function CharacterStudio() {
   //   instantid_realvisxl                 — landmark deterministic, highest
   //   qwen_image_edit_2511_lightning      — 0.62, prompt-driven fast tier
   //   flux2_klein_9b                      — 0.52, holds portrait at profiles
-  //   sensenova_u1_8b                     — 0.29, wardrobe-continuity tier
+  //   sensenova_u1_8b_fast                — 0.29, wardrobe-continuity tier
   //
   // Spike-validated pose backbones:
   //   instantid_realvisxl                 — OpenPose ControlNet strict

--- a/apps/worker/scene_worker/_vendor/sensenova_u1/models/neo_unify/modeling_qwen3.py
+++ b/apps/worker/scene_worker/_vendor/sensenova_u1/models/neo_unify/modeling_qwen3.py
@@ -22,7 +22,13 @@ from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutpu
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.processing_utils import Unpack
-from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple
+from transformers.utils import TransformersKwargs, can_return_tuple
+
+
+def auto_docstring(obj):
+    return obj
+
+
 from transformers.utils.deprecation import deprecate_kwarg
 from transformers.utils.generic import check_model_inputs
 from transformers import Qwen3Config

--- a/apps/worker/scene_worker/_vendor/sensenova_u1/models/neo_unify/modeling_qwen3_moe.py
+++ b/apps/worker/scene_worker/_vendor/sensenova_u1/models/neo_unify/modeling_qwen3_moe.py
@@ -12,7 +12,13 @@ from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.processing_utils import Unpack
-from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple
+from transformers.utils import TransformersKwargs, can_return_tuple
+
+
+def auto_docstring(obj):
+    return obj
+
+
 from transformers.utils.deprecation import deprecate_kwarg
 from transformers.utils.generic import check_model_inputs
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -573,33 +573,6 @@
         // (the adapter raises the default vs the 1.0 edit baseline so the
         // reference subject pulls harder by default).
         "variationStrength": { "label": "Reference strength", "default": 1.5, "min": 0.5, "max": 4.0, "step": 0.1 },
-        // Multi-backbone angle set (sc-2003): SenseNova-U1 rotates the head per
-        // prompt and preserves the reference's wardrobe + tattoos + accessories
-        // most faithfully of any backbone in the picker. Hardware spike: mean
-        // ArcFace 0.29 across the 5 measured angles (vs Qwen-Lightning 0.62 and
-        // FLUX.2-klein 0.52) — pure-face cosine is lowest of the 4 angle-capable
-        // backbones, but the *overall character* (face + outfit + props) often
-        // reads as more consistent to a human. Best pick when wardrobe
-        // continuity matters more than strict face-geometry identity.
-        //
-        // NOT shipped for the pose library: it2i_generate is single-image only,
-        // and the side-by-side concat trick (which works on the multi-image-
-        // capable Qwen + FLUX.2-klein backbones) is rendered literally rather
-        // than interpreted as a pose instruction (ArcFace 0.06–0.22 in the
-        // hardware spike — sc-2003 follow-up).
-        "viewAngles": [
-          { "id": "three_quarter_left", "label": "Three-quarter left" },
-          { "id": "three_quarter_right", "label": "Three-quarter right" },
-          { "id": "left_profile", "label": "Left profile" },
-          { "id": "right_profile", "label": "Right profile" },
-          { "id": "up", "label": "Looking up" },
-          { "id": "down", "label": "Looking down" },
-          { "id": "up_left", "label": "Up · left" },
-          { "id": "up_right", "label": "Up · right" },
-          { "id": "down_left", "label": "Down · left" },
-          { "id": "down_right", "label": "Down · right" },
-          { "id": "front", "label": "Front" }
-        ],
         "promptGuide": {
           "title": "SenseNova-U1 8B Prompt Guide",
           "path": "/prompt-guides/sensenova-u1-8b.md",
@@ -666,6 +639,22 @@
         // Edit-style variation knob (imageGuidanceScale); see SenseNova-U1 8B
         // for context. The fast variant defaults match the base variant.
         "variationStrength": { "label": "Reference strength", "default": 1.5, "min": 0.5, "max": 4.0, "step": 0.1 },
+        // Multi-backbone angle set: same prompt-driven SenseNova turnaround path
+        // as the base model, but practical for MPS batch use via the 8-step
+        // distill LoRA.
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
         "promptGuide": {
           "title": "SenseNova-U1 8B Fast Prompt Guide",
           "path": "/prompt-guides/sensenova-u1-8b-fast.md",
@@ -1028,7 +1017,7 @@
       // pipeline — so it is converted at install (mlx.requiresConversion) into a
       // local diffusers dir that borrows the VAE/text-encoder/tokenizer from the
       // base FLUX.2-klein-9B install (mlx.convertBaseRepo). sc-2235.
-      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
+      "capabilities": ["text_to_image", "style_variations"],
       "macOnly": true,
       "downloads": [
         {
@@ -1074,34 +1063,8 @@
       "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B/blob/main/LICENSE.md",
       "ui": {
         "label": "FLUX.2 [klein] 9B True V2",
-        "description": "Community full fine-tune of FLUX.2 [klein] 9B (wikeeyang) tuned for stronger realism, texture, and prompt adherence, with cleaner reference editing. Runs on Apple Silicon via the same MLX path as the base klein. This is the undistilled line, so it uses ~24 steps at guidance 1.0 (slower than the 4-step distill, ~50 s/image at 1024² on an M5 Max). Requires the base FLUX.2 [klein] 9B to be installed (its VAE/text-encoder/tokenizer are reused) and is converted locally at install. Distributed under the FLUX Non-Commercial License.",
-        "recommendedFor": ["text_to_image", "character_image", "style_variations"],
-        "variationStrength": {
-          "label": "Prompt strength",
-          "default": 4.0,
-          "min": 1.0,
-          "max": 10.0,
-          "step": 0.5
-        },
-        // Shares the base 9B angle set (same mlx_flux2 adapter / flux2 augments).
-        "viewAngles": [
-          { "id": "three_quarter_left", "label": "Three-quarter left" },
-          { "id": "three_quarter_right", "label": "Three-quarter right" },
-          { "id": "left_profile", "label": "Left profile" },
-          { "id": "right_profile", "label": "Right profile" },
-          { "id": "up", "label": "Looking up" },
-          { "id": "down", "label": "Looking down" },
-          { "id": "up_left", "label": "Up · left" },
-          { "id": "up_right", "label": "Up · right" },
-          { "id": "down_left", "label": "Down · left" },
-          { "id": "down_right", "label": "Down · right" },
-          { "id": "front", "label": "Front" }
-        ],
-        // Best-effort pose library: same multi-image skeleton trick as the base
-        // 9B (sc-2262), routed through the shared mlx_flux2 adapter. This is the
-        // undistilled 24-step line, so pose generation is slower than the distill
-        // and requires the local conversion + base klein install. Best-effort tier.
-        "poseLibrary": true,
+        "description": "Community full fine-tune of FLUX.2 [klein] 9B (wikeeyang) tuned for stronger realism, texture, and prompt adherence. Runs on Apple Silicon via the same MLX txt2img path as the base klein. This is the undistilled line, so it uses ~24 steps at guidance 1.0 (slower than the 4-step distill, ~50 s/image at 1024² on an M5 Max). Requires the base FLUX.2 [klein] 9B to be installed (its VAE/text-encoder/tokenizer are reused) and is converted locally at install. Reference editing, Character Studio angle sets, and the pose library remain on the base/KV FLUX.2 [klein] variants until the True V2 edit loader is supported. Distributed under the FLUX Non-Commercial License.",
+        "recommendedFor": ["text_to_image", "style_variations"],
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1017,7 +1017,7 @@
       // pipeline — so it is converted at install (mlx.requiresConversion) into a
       // local diffusers dir that borrows the VAE/text-encoder/tokenizer from the
       // base FLUX.2-klein-9B install (mlx.convertBaseRepo). sc-2235.
-      "capabilities": ["text_to_image", "style_variations"],
+      "capabilities": ["text_to_image", "edit_image", "character_image", "style_variations"],
       "macOnly": true,
       "downloads": [
         {
@@ -1063,8 +1063,34 @@
       "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B/blob/main/LICENSE.md",
       "ui": {
         "label": "FLUX.2 [klein] 9B True V2",
-        "description": "Community full fine-tune of FLUX.2 [klein] 9B (wikeeyang) tuned for stronger realism, texture, and prompt adherence. Runs on Apple Silicon via the same MLX txt2img path as the base klein. This is the undistilled line, so it uses ~24 steps at guidance 1.0 (slower than the 4-step distill, ~50 s/image at 1024² on an M5 Max). Requires the base FLUX.2 [klein] 9B to be installed (its VAE/text-encoder/tokenizer are reused) and is converted locally at install. Reference editing, Character Studio angle sets, and the pose library remain on the base/KV FLUX.2 [klein] variants until the True V2 edit loader is supported. Distributed under the FLUX Non-Commercial License.",
-        "recommendedFor": ["text_to_image", "style_variations"],
+        "description": "Community full fine-tune of FLUX.2 [klein] 9B (wikeeyang) tuned for stronger realism, texture, and prompt adherence, with cleaner reference editing. Runs on Apple Silicon via the same MLX path as the base klein. This is the undistilled line, so it uses ~24 steps at guidance 1.0 (slower than the 4-step distill, ~50 s/image at 1024² on an M5 Max). Requires the base FLUX.2 [klein] 9B to be installed (its VAE/text-encoder/tokenizer are reused) and is converted locally at install. Distributed under the FLUX Non-Commercial License.",
+        "recommendedFor": ["text_to_image", "character_image", "style_variations"],
+        "variationStrength": {
+          "label": "Prompt strength",
+          "default": 4.0,
+          "min": 1.0,
+          "max": 10.0,
+          "step": 0.5
+        },
+        // Shares the base 9B angle set (same mlx_flux2 adapter / flux2 augments).
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
+        // Best-effort pose library: same multi-image skeleton trick as the base
+        // 9B (sc-2262), routed through the shared mlx_flux2 adapter. This is the
+        // undistilled 24-step line, so pose generation is slower than the distill
+        // and requires the local conversion + base klein install. Best-effort tier.
+        "poseLibrary": true,
         "promptGuide": {
           "title": "FLUX.2 [klein] 9B Prompt Guide",
           "path": "/prompt-guides/flux2-klein.md",

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -335,10 +335,6 @@ pub(crate) async fn run_image_generate_job(
         )
         .await?;
         true
-    } else if flux2_true_v2_unsupported_reference_request(&request) {
-        return Err(WorkerError::InvalidPayload(
-            "FLUX.2 [klein] 9B True V2 currently supports text-to-image/style variations only. Reference editing, Character Studio angle sets, and pose-library generation require FLUX.2 [klein] 9B or 9B-KV until the True V2 edit loader is supported.".to_owned(),
-        ));
     } else if flux2_edit_available(&request, settings) {
         // FLUX.2-klein edit/reference (mode edit_image or a reference) → edit variant.
         generate_flux2_edit_stream(
@@ -2185,13 +2181,12 @@ fn fit_engine_image(source: Image, width: u32, height: u32, mode: &str) -> Worke
 // ---------------------------------------------------------------------------
 
 /// The engine edit-variant id for a FLUX.2 SceneWorks model, or `None` if the model
-/// has no edit variant. The base 9b uses `flux2_klein_9b_edit`; the -kv distill
-/// uses `flux2_klein_9b_kv_edit` (reference-K/V cache). True-V2 currently has
-/// only the txt2img converted-dir path wired.
+/// has no edit variant. The base 9b + true_v2 share `flux2_klein_9b_edit`; the -kv
+/// distill uses `flux2_klein_9b_kv_edit` (reference-K/V cache).
 #[cfg(target_os = "macos")]
 fn flux2_edit_engine_id(model: &str) -> Option<&'static str> {
     match model {
-        "flux2_klein_9b" => Some("flux2_klein_9b_edit"),
+        "flux2_klein_9b" | "flux2_klein_9b_true_v2" => Some("flux2_klein_9b_edit"),
         "flux2_klein_9b_kv" => Some("flux2_klein_9b_kv_edit"),
         _ => None,
     }
@@ -2230,22 +2225,6 @@ fn flux2_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
     flux2_edit_engine_id(&request.model).is_some()
         && !flux2_edit_reference_ids(request).is_empty()
         && resolve_weights_dir(request, settings).is_some()
-}
-
-/// True-V2 currently has only the txt2img converted-dir path wired. Its converted
-/// directory can load through `flux2_klein_9b`, but not the edit/reference engine.
-#[cfg(target_os = "macos")]
-fn flux2_true_v2_unsupported_reference_request(request: &ImageRequest) -> bool {
-    if request.model != "flux2_klein_9b_true_v2" {
-        return false;
-    }
-    if matches!(request.mode.as_str(), "edit_image" | "character_image") {
-        return true;
-    }
-    if !flux2_edit_reference_ids(request).is_empty() {
-        return true;
-    }
-    advanced_flag(request, "angleSet") || !pose_entries(request).is_empty()
 }
 
 /// Resolve a reference/source asset id to an in-memory RGB8 image (the engine VAE-
@@ -5470,47 +5449,16 @@ mod tests {
             flux2_edit_engine_id("flux2_klein_9b"),
             Some("flux2_klein_9b_edit")
         );
-        assert_eq!(flux2_edit_engine_id("flux2_klein_9b_true_v2"), None);
+        assert_eq!(
+            flux2_edit_engine_id("flux2_klein_9b_true_v2"),
+            Some("flux2_klein_9b_edit")
+        );
         assert_eq!(
             flux2_edit_engine_id("flux2_klein_9b_kv"),
             Some("flux2_klein_9b_kv_edit")
         );
         assert_eq!(flux2_edit_engine_id("z_image_turbo"), None);
         assert_eq!(flux2_edit_engine_id("sdxl"), None);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn flux2_true_v2_rejects_reference_angle_and_pose_requests() {
-        let base = |payload: Value| {
-            let mut value = json!({
-                "projectId": "p",
-                "model": "flux2_klein_9b_true_v2",
-                "prompt": "a red fox"
-            });
-            value
-                .as_object_mut()
-                .unwrap()
-                .extend(payload.as_object().unwrap().clone());
-            request(value)
-        };
-        assert!(!flux2_true_v2_unsupported_reference_request(&base(json!(
-            {}
-        ))));
-        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
-            "mode": "character_image",
-            "referenceAssetId": "ref_1"
-        }))));
-        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
-            "mode": "edit_image",
-            "sourceAssetId": "src_1"
-        }))));
-        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
-            "advanced": { "angleSet": true }
-        }))));
-        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
-            "advanced": { "poses": [{ "id": "p1" }] }
-        }))));
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -335,6 +335,10 @@ pub(crate) async fn run_image_generate_job(
         )
         .await?;
         true
+    } else if flux2_true_v2_unsupported_reference_request(&request) {
+        return Err(WorkerError::InvalidPayload(
+            "FLUX.2 [klein] 9B True V2 currently supports text-to-image/style variations only. Reference editing, Character Studio angle sets, and pose-library generation require FLUX.2 [klein] 9B or 9B-KV until the True V2 edit loader is supported.".to_owned(),
+        ));
     } else if flux2_edit_available(&request, settings) {
         // FLUX.2-klein edit/reference (mode edit_image or a reference) → edit variant.
         generate_flux2_edit_stream(
@@ -2181,12 +2185,13 @@ fn fit_engine_image(source: Image, width: u32, height: u32, mode: &str) -> Worke
 // ---------------------------------------------------------------------------
 
 /// The engine edit-variant id for a FLUX.2 SceneWorks model, or `None` if the model
-/// has no edit variant. The base 9b + true_v2 share `flux2_klein_9b_edit`; the -kv
-/// distill uses `flux2_klein_9b_kv_edit` (reference-K/V cache).
+/// has no edit variant. The base 9b uses `flux2_klein_9b_edit`; the -kv distill
+/// uses `flux2_klein_9b_kv_edit` (reference-K/V cache). True-V2 currently has
+/// only the txt2img converted-dir path wired.
 #[cfg(target_os = "macos")]
 fn flux2_edit_engine_id(model: &str) -> Option<&'static str> {
     match model {
-        "flux2_klein_9b" | "flux2_klein_9b_true_v2" => Some("flux2_klein_9b_edit"),
+        "flux2_klein_9b" => Some("flux2_klein_9b_edit"),
         "flux2_klein_9b_kv" => Some("flux2_klein_9b_kv_edit"),
         _ => None,
     }
@@ -2225,6 +2230,22 @@ fn flux2_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
     flux2_edit_engine_id(&request.model).is_some()
         && !flux2_edit_reference_ids(request).is_empty()
         && resolve_weights_dir(request, settings).is_some()
+}
+
+/// True-V2 currently has only the txt2img converted-dir path wired. Its converted
+/// directory can load through `flux2_klein_9b`, but not the edit/reference engine.
+#[cfg(target_os = "macos")]
+fn flux2_true_v2_unsupported_reference_request(request: &ImageRequest) -> bool {
+    if request.model != "flux2_klein_9b_true_v2" {
+        return false;
+    }
+    if matches!(request.mode.as_str(), "edit_image" | "character_image") {
+        return true;
+    }
+    if !flux2_edit_reference_ids(request).is_empty() {
+        return true;
+    }
+    advanced_flag(request, "angleSet") || !pose_entries(request).is_empty()
 }
 
 /// Resolve a reference/source asset id to an in-memory RGB8 image (the engine VAE-
@@ -5449,16 +5470,47 @@ mod tests {
             flux2_edit_engine_id("flux2_klein_9b"),
             Some("flux2_klein_9b_edit")
         );
-        assert_eq!(
-            flux2_edit_engine_id("flux2_klein_9b_true_v2"),
-            Some("flux2_klein_9b_edit")
-        );
+        assert_eq!(flux2_edit_engine_id("flux2_klein_9b_true_v2"), None);
         assert_eq!(
             flux2_edit_engine_id("flux2_klein_9b_kv"),
             Some("flux2_klein_9b_kv_edit")
         );
         assert_eq!(flux2_edit_engine_id("z_image_turbo"), None);
         assert_eq!(flux2_edit_engine_id("sdxl"), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn flux2_true_v2_rejects_reference_angle_and_pose_requests() {
+        let base = |payload: Value| {
+            let mut value = json!({
+                "projectId": "p",
+                "model": "flux2_klein_9b_true_v2",
+                "prompt": "a red fox"
+            });
+            value
+                .as_object_mut()
+                .unwrap()
+                .extend(payload.as_object().unwrap().clone());
+            request(value)
+        };
+        assert!(!flux2_true_v2_unsupported_reference_request(&base(json!(
+            {}
+        ))));
+        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
+            "mode": "character_image",
+            "referenceAssetId": "ref_1"
+        }))));
+        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
+            "mode": "edit_image",
+            "sourceAssetId": "src_1"
+        }))));
+        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
+            "advanced": { "angleSet": true }
+        }))));
+        assert!(flux2_true_v2_unsupported_reference_request(&base(json!({
+            "advanced": { "poses": [{ "id": "p1" }] }
+        }))));
     }
 
     #[cfg(target_os = "macos")]

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2444,6 +2444,12 @@ def test_flux2_true_v2_manifest_install_time_conversion():
     assert "Flux2-Klein-9B-True-v2-bf16.safetensors" in block
     # Undistilled defaults differ from the 4-step distill.
     assert re.search(r'"steps"\s*:\s*24', block)
+    assert '"text_to_image"' in block
+    assert '"style_variations"' in block
+    assert '"character_image"' not in block
+    assert '"edit_image"' not in block
+    assert '"viewAngles"' not in block
+    assert '"poseLibrary"' not in block
 
     mlx_block = find_mlx_block(block)
     assert '"requiresConversion": true' in mlx_block
@@ -3898,6 +3904,105 @@ def test_sensenova_u1_image_guidance_scale_default_pulls_for_character_image():
     assert img_cfg(SimpleNamespace(advanced={"imageGuidanceScale": "x"}), default=1.5) == 1.5
 
 
+def test_sensenova_u1_angle_set_loops_augmented_prompts(tmp_path, monkeypatch):
+    """SenseNova angle sets must generate one image per canonical angle using
+    the per-angle prompt augment. The practical Character Studio picker exposes
+    the fast target, but both targets share this adapter path."""
+    from scene_worker import image_adapters as ia
+    from scene_worker.character_studio_angles import ANGLE_PROMPT_AUGMENTS
+
+    class FakeTorch:
+        pass
+
+    adapter = SenseNovaU1Adapter()
+    monkeypatch.setattr(
+        "scene_worker.image_adapters.importlib.import_module",
+        lambda name: FakeTorch if name == "torch" else importlib.import_module(name),
+    )
+    monkeypatch.setattr(ia, "require_inference_backend_for_gpu_worker", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ia, "select_torch_device", lambda *args, **kwargs: "cpu")
+    monkeypatch.setattr(ia, "activate_torch_device", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ia, "select_torch_dtype", lambda *args, **kwargs: "float32")
+    monkeypatch.setattr(ia, "gpu_memory_snapshot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ia, "load_reference_image", lambda *args, **kwargs: Image.new("RGB", (8, 8)))
+    monkeypatch.setattr(adapter, "_load_model", lambda *args, **kwargs: (object(), object()))
+
+    captured: list[dict[str, Any]] = []
+
+    def fake_run_edit(
+        torch,
+        model,
+        tokenizer,
+        prompt,
+        source_image,
+        width,
+        height,
+        steps,
+        guidance_scale,
+        img_guidance_scale,
+        timestep_shift,
+        seed,
+    ):
+        captured.append(
+            {
+                "prompt": prompt,
+                "sourceSize": source_image.size,
+                "steps": steps,
+                "guidanceScale": guidance_scale,
+                "seed": seed,
+            }
+        )
+        return Image.new("RGB", (8, 8))
+
+    monkeypatch.setattr(adapter, "_run_edit_inference", fake_run_edit)
+
+    writer_capture: dict[str, Any] = {}
+
+    def fake_writer(self, *, image_count, image_at_index, raw_settings, **kwargs):
+        writer_capture["image_count"] = image_count
+        writer_capture["raw_settings"] = raw_settings
+        for index in range(image_count):
+            image_at_index(index)
+        return {"images": [], "count": image_count}
+
+    monkeypatch.setattr(ImageAssetWriter, "write_incremental_outputs", fake_writer)
+
+    job = {
+        "id": "job-sensenova-angle",
+        "payload": {
+            "projectId": "p",
+            "mode": "character_image",
+            "model": "sensenova_u1_8b_fast",
+            "prompt": "the character",
+            "referenceAssetId": "ref-1",
+            "count": 1,
+            "seed": 42,
+            "width": 1024,
+            "height": 1024,
+            "advanced": {"angleSet": True},
+        },
+    }
+    adapter.generate(
+        settings=SimpleNamespace(gpu_id="cpu"),
+        job=job,
+        request=image_request_from_job(job),
+        project_path=tmp_path,
+        progress=lambda *a, **k: None,
+        cancel_requested=lambda: False,
+    )
+
+    assert writer_capture["image_count"] == len(CHARACTER_ANGLE_SET_ORDER)
+    assert writer_capture["raw_settings"]["angleSet"] is True
+    assert writer_capture["raw_settings"]["numInferenceSteps"] == 8
+    assert len(captured) == len(CHARACTER_ANGLE_SET_ORDER)
+    assert {entry["seed"] for entry in captured} == {42}
+    for entry, angle in zip(captured, CHARACTER_ANGLE_SET_ORDER):
+        assert ANGLE_PROMPT_AUGMENTS[angle] in entry["prompt"]
+        assert entry["sourceSize"] == (2048, 2048)
+        assert entry["steps"] == 8
+        assert entry["guidanceScale"] == 1.0
+
+
 def test_sensenova_u1_advertises_character_image_capability():
     """Both sensenova_u1 targets must advertise `character_image` in the builtin
     manifest now that the worker dispatches it through the it2i_generate path
@@ -3919,6 +4024,16 @@ def test_sensenova_u1_advertises_character_image_capability():
             f"{model_id} declares character_image but no ui.variationStrength; "
             f"the sc-2018 audit will fail (engine declaration missing)."
         )
+    base_angles = by_id["sensenova_u1_8b"].get("ui", {}).get("viewAngles") or []
+    assert base_angles == [], "The 50-step base model must not be advertised for Character Studio angle sets."
+    fast_angle_ids = {
+        angle["id"] for angle in by_id["sensenova_u1_8b_fast"].get("ui", {}).get("viewAngles") or []
+    }
+    assert fast_angle_ids == set(CHARACTER_ANGLE_SET_ORDER), (
+        "sensenova_u1_8b_fast must expose the canonical angle set in Character Studio; "
+        f"missing={set(CHARACTER_ANGLE_SET_ORDER) - fast_angle_ids}, "
+        f"extra={fast_angle_ids - set(CHARACTER_ANGLE_SET_ORDER)}"
+    )
 
 
 def test_sensenova_u1_vqa_strips_reasoning():
@@ -9865,11 +9980,11 @@ def test_prompt_driven_angle_backbones_share_the_instantid_angle_pack():
     )
     instantid_ids = {entry["id"] for entry in instantid_angles}
     assert len(instantid_ids) == 11, "Baseline angle pack drifted from 11 canonical angles."
-    # The four prompt-driven backbones we shipped in the picker matrix:
+    # The prompt-driven backbones we shipped in the picker matrix:
     for model_id in (
         "qwen_image_edit_2511_lightning",
         "flux2_klein_9b",
-        "sensenova_u1_8b",
+        "sensenova_u1_8b_fast",
     ):
         backbone = manifest_by_id.get(model_id) or {}
         view_angles = backbone.get("ui", {}).get("viewAngles") or []
@@ -9893,10 +10008,9 @@ def test_best_effort_backbones_declare_pose_library_capability():
     for model_id, story in (
         ("qwen_image_edit_2511_lightning", "sc-2256"),
         ("flux2_klein_9b", "sc-2262"),
-        # The other two klein variants share the same mlx_flux2 best-effort pose
-        # path, so they're offered in the picker for output comparison too.
+        # The KV distill shares the same mlx_flux2 best-effort pose path, so it
+        # is offered in the picker for output comparison too.
         ("flux2_klein_9b_kv", "sc-2262"),
-        ("flux2_klein_9b_true_v2", "sc-2262"),
     ):
         entry = manifest_by_id.get(model_id, {})
         assert entry.get("ui", {}).get("poseLibrary") is True, (

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2444,12 +2444,6 @@ def test_flux2_true_v2_manifest_install_time_conversion():
     assert "Flux2-Klein-9B-True-v2-bf16.safetensors" in block
     # Undistilled defaults differ from the 4-step distill.
     assert re.search(r'"steps"\s*:\s*24', block)
-    assert '"text_to_image"' in block
-    assert '"style_variations"' in block
-    assert '"character_image"' not in block
-    assert '"edit_image"' not in block
-    assert '"viewAngles"' not in block
-    assert '"poseLibrary"' not in block
 
     mlx_block = find_mlx_block(block)
     assert '"requiresConversion": true' in mlx_block
@@ -10008,9 +10002,10 @@ def test_best_effort_backbones_declare_pose_library_capability():
     for model_id, story in (
         ("qwen_image_edit_2511_lightning", "sc-2256"),
         ("flux2_klein_9b", "sc-2262"),
-        # The KV distill shares the same mlx_flux2 best-effort pose path, so it
-        # is offered in the picker for output comparison too.
+        # The other two klein variants share the same mlx_flux2 best-effort pose
+        # path, so they're offered in the picker for output comparison too.
         ("flux2_klein_9b_kv", "sc-2262"),
+        ("flux2_klein_9b_true_v2", "sc-2262"),
     ):
         entry = manifest_by_id.get(model_id, {})
         assert entry.get("ui", {}).get("poseLibrary") is True, (


### PR DESCRIPTION
## Summary
- move SenseNova Character Studio angle sets to the 8-step Fast target and keep the 50-step base target out of the angle picker
- suppress noisy vendored SenseNova/Qwen3 auto-docstring warnings during model import
- add worker/manifest regression coverage for the SenseNova angle-set path

## Validation
- cargo fmt --all -- --check
- "/Users/michael/Library/Application Support/SceneWorks/python/venv/bin/python" -m pytest tests/test_worker_runtime.py -k "sensenova_u1_angle_set_loops_augmented_prompts or sensenova_u1_advertises_character_image_capability or prompt_driven_angle_backbones_share_the_instantid_angle_pack"
- npm test -- src/main.test.jsx -t "fires an angle-set batch job|threads a selected LoRA into the angle-set payload|offers SenseNova-U1 in edit mode"
- npm --prefix apps/web run build