### PR TITLE
[codex] Move library assets to character assets

### DIFF
--- a/apps/web/src/components/DatasetAddDialog.jsx
+++ b/apps/web/src/components/DatasetAddDialog.jsx
@@ -6,14 +6,17 @@ import { Modal } from "./Modal.jsx";
 // (recipe.normalizedSettings.characterId) or generated referencing it
 // (metadata.characterReferences[].characterId). Mirrors the per-character
 // gallery filter so the Character tab surfaces the same images.
-export function assetMatchesCharacter(asset, characterId) {
+export function assetMatchesCharacter(asset, characterId, character = null) {
   if (!characterId) {
     return false;
   }
   if (asset?.recipe?.normalizedSettings?.characterId === characterId) {
     return true;
   }
-  return (asset?.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId);
+  if ((asset?.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId)) {
+    return true;
+  }
+  return (character?.references ?? []).some((reference) => (reference?.assetId ?? reference?.id) === asset?.id);
 }
 
 function assetTitle(asset) {
@@ -97,8 +100,11 @@ export function DatasetAddDialog({
   // Character tab: this character's images (including its Character Studio
   // outputs, which the Library tab hides), minus current members.
   const characterCandidates = useMemo(
-    () => assets.filter((asset) => assetMatchesCharacter(asset, characterId) && !memberSet.has(asset.id)),
-    [assets, characterId, memberSet],
+    () => {
+      const selectedCharacter = characters.find((character) => character.id === characterId) ?? null;
+      return assets.filter((asset) => assetMatchesCharacter(asset, characterId, selectedCharacter) && !memberSet.has(asset.id));
+    },
+    [assets, characterId, characters, memberSet],
   );
 
   function toggle(id) {

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -153,6 +153,96 @@ function AssetTags({ asset, availableTags = [], updateAssetTags = () => {} }) {
   );
 }
 
+function assetSupportsCharacterLink(asset) {
+  return (
+    ["image", "frame", "upload", "video"].includes(asset?.type) ||
+    asset?.file?.mimeType?.startsWith("image/") ||
+    asset?.file?.mimeType?.startsWith("video/")
+  );
+}
+
+function assetLinkedToCharacter(asset, character) {
+  const characterId = character?.id;
+  if (!asset?.id || !characterId) {
+    return false;
+  }
+  if (asset.recipe?.normalizedSettings?.characterId === characterId) {
+    return true;
+  }
+  if ((asset.metadata?.characterReferences ?? []).some((reference) => reference?.characterId === characterId)) {
+    return true;
+  }
+  return (character.references ?? []).some((reference) => (reference?.assetId ?? reference?.id) === asset.id);
+}
+
+function CharacterAssetLinker({ asset, characters = [], onMoveToCharacter }) {
+  const availableCharacters = React.useMemo(
+    () => characters.filter((character) => !character?.archived),
+    [characters],
+  );
+  const [characterId, setCharacterId] = React.useState(availableCharacters[0]?.id ?? "");
+  const [message, setMessage] = React.useState("");
+  const [moving, setMoving] = React.useState(false);
+
+  React.useEffect(() => {
+    setMessage("");
+    setMoving(false);
+  }, [asset?.id]);
+
+  React.useEffect(() => {
+    if (!availableCharacters.some((character) => character.id === characterId)) {
+      setCharacterId(availableCharacters[0]?.id ?? "");
+    }
+  }, [availableCharacters, characterId]);
+
+  if (!assetSupportsCharacterLink(asset) || !availableCharacters.length || typeof onMoveToCharacter !== "function") {
+    return null;
+  }
+
+  const selectedCharacter = availableCharacters.find((character) => character.id === characterId) ?? null;
+  const alreadyLinked = assetLinkedToCharacter(asset, selectedCharacter);
+
+  async function submit(event) {
+    event.preventDefault();
+    if (!selectedCharacter || alreadyLinked || moving) {
+      return;
+    }
+    setMoving(true);
+    setMessage("");
+    try {
+      await onMoveToCharacter(asset, selectedCharacter.id);
+      setMessage(`Added to ${selectedCharacter.name}'s assets.`);
+    } catch (err) {
+      setMessage(err?.message ?? "Could not add this asset to the character.");
+    } finally {
+      setMoving(false);
+    }
+  }
+
+  return (
+    <form className="character-asset-linker" onSubmit={submit}>
+      <label>
+        Character
+        <select aria-label="Target character" onChange={(event) => setCharacterId(event.target.value)} value={characterId}>
+          {availableCharacters.map((character) => (
+            <option key={character.id} value={character.id}>
+              {character.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        disabled={!selectedCharacter || alreadyLinked || moving}
+        title={alreadyLinked ? "Already in this character's assets" : undefined}
+        type="submit"
+      >
+        {moving ? "Moving..." : alreadyLinked ? "Already added" : "Move to Character"}
+      </button>
+      {message ? <p aria-live="polite">{message}</p> : null}
+    </form>
+  );
+}
+
 export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId }) {
   if (!assets.length) {
     return <div className="empty-panel">No assets in this view</div>;
@@ -254,6 +344,8 @@ export function AssetDetail({
   onSendImage,
   onSendVideo,
   onSendEditor,
+  characters = [],
+  onMoveToCharacter,
   updateAssetStatus,
   updateAssetTags,
   availableTags,
@@ -279,6 +371,7 @@ export function AssetDetail({
       <p>{asset.recipe?.prompt ?? "No prompt"}</p>
       <AssetTags asset={asset} availableTags={availableTags} updateAssetTags={updateAssetTags} />
       <RatingControl asset={asset} updateAssetStatus={updateAssetStatus} />
+      <CharacterAssetLinker asset={asset} characters={characters} onMoveToCharacter={onMoveToCharacter} />
       <div className="detail-actions">
         <button onClick={() => updateAssetStatus(asset, { favorite: !asset.status?.favorite })} type="button">
           {asset.status?.favorite ? "Unfavorite" : "Favorite"}

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -2338,6 +2338,72 @@ describe("SceneWorks app shell", () => {
     expect([...section.querySelectorAll("button")].some((button) => button.textContent.startsWith("Media (2)"))).toBe(true);
   });
 
+  it("surfaces assets moved from the Library in the Character Assets tab immediately", async () => {
+    const movedAsset = {
+      id: "asset-moved",
+      type: "image",
+      displayName: "Library Portrait",
+      projectId: "project-1",
+      recipe: { prompt: "library portrait" },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            addCharacterReference: () => {},
+            archiveCharacter: () => {},
+            assets: [movedAsset],
+            attachCharacterLora: () => {},
+            characters: [
+              {
+                id: "char-1",
+                name: "Mira",
+                type: "person",
+                references: [{ assetId: "asset-moved", role: "asset", approved: false }],
+                approvedReferences: [],
+                looks: [],
+                loras: [],
+              },
+            ],
+            createCharacter: () => {},
+            createCharacterLook: () => {},
+            createCharacterTestJob: () => {},
+            deleteAsset: () => {},
+            deleteCharacterLook: () => {},
+            detachCharacterLora: () => {},
+            imageModels: [],
+            latestImageAssets: [movedAsset],
+            loras: [],
+            setPreviewAsset: () => {},
+            sendCharacterToImage: () => {},
+            sendCharacterToVideo: () => {},
+            purgeAsset: () => {},
+            removeCharacterReference: () => {},
+            updateAssetStatus: () => {},
+            updateCharacter: () => {},
+            updateCharacterLook: () => {},
+            updateCharacterLora: () => {},
+            updateCharacterReference: () => {},
+          },
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    await act(async () => {
+      container.querySelector("#character-tab-assets").click();
+    });
+    const section = [...container.querySelectorAll(".character-section")].find(
+      (item) => item.querySelector(".eyebrow")?.textContent === "Character assets",
+    );
+    expect(section).toBeTruthy();
+    expect(section.textContent).toContain("Generated for Mira (1)");
+    expect(section.querySelectorAll(".character-asset-thumb")).toHaveLength(1);
+    expect([...section.querySelectorAll("button")].some((button) => button.textContent.startsWith("Media (1)"))).toBe(true);
+  });
+
   it("switches the active character via the compact selector (sc-2025)", async () => {
     const baseContext = {
       activeProject: { id: "project-1", name: "Noir" },
@@ -8415,6 +8481,123 @@ describe("SceneWorks app shell", () => {
       container.querySelector('button[aria-label="Remove portrait tag"]').click();
     });
     expect(updateAssetTags).toHaveBeenLastCalledWith(portrait, []);
+  });
+
+  it("moves a Library asset into a selected character's assets", async () => {
+    const addCharacterReference = vi.fn(async () => ({ id: "char-2", references: [] }));
+    const asset = {
+      id: "asset-portrait",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Portrait One",
+      recipe: { prompt: "studio portrait" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Characters" },
+            assets: [asset],
+            characters: [
+              { id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
+              { id: "char-2", name: "Dax", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
+            ],
+            addCharacterReference,
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: asset,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+            updateAssetTags: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    await changeField(container.querySelector('select[aria-label="Target character"]'), "char-2");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Move to Character").click();
+    });
+    await settle();
+
+    expect(addCharacterReference).toHaveBeenCalledWith("char-2", {
+      assetId: "asset-portrait",
+      approved: false,
+      role: "asset",
+      notes: "Added from Asset Library.",
+    });
+    expect(container.textContent).toContain("Added to Dax's assets.");
+  });
+
+  it("disables the Library move action for a character that already owns the asset", async () => {
+    const addCharacterReference = vi.fn();
+    const asset = {
+      id: "asset-portrait",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Portrait One",
+      recipe: { prompt: "studio portrait" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Characters" },
+            assets: [asset],
+            characters: [
+              {
+                id: "char-1",
+                name: "Mira",
+                type: "person",
+                references: [{ assetId: "asset-portrait", role: "asset" }],
+                approvedReferences: [],
+                looks: [],
+                loras: [],
+              },
+            ],
+            addCharacterReference,
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: asset,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+            updateAssetTags: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    const button = [...container.querySelectorAll("button")].find((item) => item.textContent === "Already added");
+    expect(button).toBeTruthy();
+    expect(button.disabled).toBe(true);
+    await act(async () => {
+      button.click();
+    });
+    expect(addCharacterReference).not.toHaveBeenCalled();
   });
 
   it("excludes Character Studio outputs from the Asset Library (sc-2024)", async () => {

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -160,7 +160,7 @@ export function CharacterStudio() {
   const characterImageAssetIds = useMemo(
     () =>
       selectedCharacter
-        ? imageAssets.filter((asset) => assetMatchesCharacter(asset, selectedCharacter.id)).map((asset) => asset.id)
+        ? imageAssets.filter((asset) => assetMatchesCharacter(asset, selectedCharacter.id, selectedCharacter)).map((asset) => asset.id)
         : [],
     [imageAssets, selectedCharacter?.id],
   );

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -13,6 +13,8 @@ export function LibraryScreen() {
     createVqaJob,
     deleteAsset,
     purgeAsset,
+    characters = [],
+    addCharacterReference,
     importAsset,
     setPreviewAsset,
     sendAssetToImage,
@@ -95,6 +97,19 @@ export function LibraryScreen() {
     await importAsset(file);
     setIsImporting(false);
     event.target.value = "";
+  }
+
+  async function moveAssetToCharacter(asset, characterId) {
+    const updated = await addCharacterReference?.(characterId, {
+      assetId: asset.id,
+      approved: false,
+      role: "asset",
+      notes: "Added from Asset Library.",
+    });
+    if (!updated) {
+      throw new Error("Could not add this asset to the character.");
+    }
+    return updated;
   }
 
   const imageCount = libraryAssets.filter((asset) => asset.type === "image").length;
@@ -190,6 +205,8 @@ export function LibraryScreen() {
           onSendImage={onSendImage}
           onSendVideo={onSendVideo}
           onSendEditor={onSendEditor}
+          characters={characters}
+          onMoveToCharacter={addCharacterReference ? moveAssetToCharacter : null}
           updateAssetStatus={updateAssetStatus}
           updateAssetTags={updateAssetTags}
           availableTags={availableTags}

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -713,6 +713,11 @@ export function CharacterAssets({
   if (!selectedCharacter) {
     return null;
   }
+  const referenceAssetIds = new Set(
+    (selectedCharacter.references ?? [])
+      .map((reference) => reference?.assetId ?? reference?.id)
+      .filter(Boolean),
+  );
   const scopedAssets = (assets ?? [])
     .filter(
       (asset) =>
@@ -720,7 +725,8 @@ export function CharacterAssets({
         // character's asset library (sc-2296) — the Assets tab is the home for
         // every piece of media made for or referencing this character.
         (asset.type === "image" || asset.type === "frame" || asset.type === "video") &&
-        (asset.recipe?.normalizedSettings?.characterId === characterId ||
+        (referenceAssetIds.has(asset.id) ||
+          asset.recipe?.normalizedSettings?.characterId === characterId ||
           (asset.metadata?.characterReferences ?? []).some((ref) => ref.characterId === characterId)),
     )
     .sort((left, right) => new Date(right.createdAt ?? 0) - new Date(left.createdAt ?? 0));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3105,6 +3105,53 @@ label {
   gap: 8px;
 }
 
+.character-asset-linker {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.character-asset-linker label {
+  display: grid;
+  gap: 6px;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.character-asset-linker button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13.5px;
+  font-weight: 500;
+  transition: background var(--t-fast), border-color var(--t-fast), transform var(--t-fast);
+}
+
+.character-asset-linker button:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.character-asset-linker button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.character-asset-linker p {
+  color: var(--text-muted);
+}
+
 .asset-tag-list,
 .asset-tile-tags {
   display: flex;


### PR DESCRIPTION
## Summary

- Add an Asset Library detail-panel control to move a selected asset into a character's assets.
- Reuse the existing character reference/link contract with `role: "asset"` and `approved: false`, so moved assets appear in the character gallery without becoming approved identity references.
- Teach character asset matching to trust the updated character reference list immediately, before the shared asset catalog refreshes.

## Validation

- `npm --prefix apps/web test -- main.test.jsx`
- `npm --prefix apps/web run build`

Note: `npm --prefix apps/web ci` in the clean worktree reported one existing critical audit issue; this PR does not change dependencies.
