### PR TITLE
sc-3826: wire converted modelPath so FLUX.2 [klein] 9B True V2 loads

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -961,7 +961,40 @@ pub(crate) async fn resolve_model_manifest_entry(
             .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
             .cloned()
     };
-    Ok(merge_model_manifest_entry(find(&builtin), find(&user)))
+    let mut entry = merge_model_manifest_entry(find(&builtin), find(&user));
+    inject_converted_model_path(&mut entry, &state.settings.data_dir);
+    Ok(entry)
+}
+
+/// Populate the `modelPath` seam for convert-at-install MLX models. The worker's
+/// `resolve_weights_dir` loads such a model from the locally-assembled converted
+/// dir via `modelManifestEntry.modelPath`, but nothing else writes that key — the
+/// raw source repo is a single safetensors file with no diffusers layout, so
+/// without this the worker falls back to it and fails with "No such file or
+/// directory" (e.g. flux2_klein_9b_true_v2). `mlx_catalog_status` is the single
+/// source of truth for whether the conversion has produced a usable local dir.
+/// No-op when the model needs no conversion, is not yet converted, or the manifest
+/// already pins an explicit `modelPath`.
+pub(crate) fn inject_converted_model_path(entry: &mut Value, data_dir: &FsPath) {
+    let Some(object) = entry.as_object_mut() else {
+        return;
+    };
+    let already_set = object
+        .get("modelPath")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    if already_set {
+        return;
+    }
+    if let Some(converted) =
+        mlx_catalog_status(object, data_dir).and_then(|status| status.converted_path)
+    {
+        object.insert(
+            "modelPath".to_owned(),
+            Value::String(converted.display().to_string()),
+        );
+    }
 }
 
 /// One-level-deep merge of the builtin and user manifest entries for a single

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3,11 +3,11 @@ use super::events::{EventHub, EventMessage};
 use super::training::insufficient_disk_space;
 use super::workers::person_readiness_from_workers;
 use super::{
-    create_app, huggingface_repo_cache_path, inprocess_worker_gpu_id, lora_artifact_paths,
-    merge_model_manifest_entry, mlx_catalog_status, safe_download_dir, safe_repo_dir_name,
-    serialize_job_lora, strip_jsonc_comments, sweep_stale_lora_uploads_before, Settings,
-    WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, EVENT_BUFFER_SIZE,
-    HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    create_app, huggingface_repo_cache_path, inject_converted_model_path, inprocess_worker_gpu_id,
+    lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status, safe_download_dir,
+    safe_repo_dir_name, serialize_job_lora, strip_jsonc_comments, sweep_stale_lora_uploads_before,
+    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
+    EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -253,6 +253,68 @@ fn mlx_catalog_status_reports_turnkey_and_conversion_states() {
     assert_eq!(status.install_state, "installed");
     assert_eq!(status.conversion_state, "converted");
     assert_eq!(status.converted_path.unwrap(), converted);
+}
+
+#[test]
+fn inject_converted_model_path_populates_modelpath_seam_once_converted() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    // A convert-at-install model (e.g. flux2_klein_9b_true_v2) whose local MLX dir
+    // does not exist yet: leave `modelPath` unset so the worker reports the absent
+    // conversion rather than silently loading the wrong source repo.
+    let make_entry = || {
+        json!({
+            "id": "flux2_klein_9b_true_v2",
+            "mlx": {
+                "requiresConversion": true,
+                "converter": "flux2_klein_diffusers",
+                "convertSourceRepo": "wikeeyang/Flux2-Klein-9B-True-V2"
+            }
+        })
+    };
+    let mut entry = make_entry();
+    inject_converted_model_path(&mut entry, &data_dir);
+    assert!(
+        entry.get("modelPath").is_none(),
+        "modelPath must stay absent until the conversion has produced a local dir"
+    );
+
+    // Once the FLUX.2-klein converter has assembled the diffusers dir (marked by
+    // model_index.json), `modelPath` is injected so the worker's resolve_weights_dir
+    // loads the converted dir instead of falling back to the single-file source repo.
+    let converted = data_dir
+        .join("models")
+        .join("mlx")
+        .join("flux2_klein_9b_true_v2");
+    std::fs::create_dir_all(&converted).expect("create converted dir");
+    std::fs::write(converted.join("model_index.json"), "{}").expect("write model_index");
+    let mut entry = make_entry();
+    inject_converted_model_path(&mut entry, &data_dir);
+    assert_eq!(
+        entry.get("modelPath").and_then(Value::as_str),
+        Some(converted.display().to_string().as_str()),
+    );
+
+    // An explicit manifest `modelPath` is authoritative and never overwritten.
+    let mut pinned = make_entry();
+    pinned
+        .as_object_mut()
+        .unwrap()
+        .insert("modelPath".to_owned(), json!("/custom/path"));
+    inject_converted_model_path(&mut pinned, &data_dir);
+    assert_eq!(
+        pinned.get("modelPath").and_then(Value::as_str),
+        Some("/custom/path")
+    );
+
+    // A non-conversion model is untouched.
+    let mut turnkey = json!({
+        "id": "ltx_2_3",
+        "mlx": { "repo": "notapalindrome/ltx23-mlx-av-q4" }
+    });
+    inject_converted_model_path(&mut turnkey, &data_dir);
+    assert!(turnkey.get("modelPath").is_none());
 }
 
 fn write_test_safetensors(path: &std::path::Path) {


### PR DESCRIPTION
## Problem
Generating with **FLUX.2 [klein] 9B True V2** (`flux2_klein_9b_true_v2`) fails with:

```
flux2_klein_9b load failed: No such file or directory (os error 2)
```

## Root cause (regression from the epic-3018 native-Rust cutover)
`flux2_klein_9b_true_v2` is a convert-at-install model: install runs a `model_convert` job that assembles a diffusers dir at `<data>/models/mlx/flux2_klein_9b_true_v2`. Generation must be told where that dir is.

- The worker's `resolve_weights_dir` (`crates/sceneworks-worker/src/image_jobs.rs`) loads the model from `modelManifestEntry.modelPath` — the "modelPath seam" the comment on the `flux2_klein_9b_true_v2` `MlxModel` entry explicitly depends on — else it falls back to the raw HuggingFace snapshot of the source repo.
- **Nothing populated `modelPath`.** `resolve_model_manifest_entry` returned the raw manifest, which has no `modelPath`.
- So the worker fell through to the `wikeeyang/Flux2-Klein-9B-True-V2` snapshot — a single `.safetensors` file with **no diffusers layout** → "No such file or directory".

The original Python adapter (`mlx_flux_runner.py`, sc-2235) resolved this via a `_local_model_dir` resolver that threaded `<data>/models/mlx/<id>` in as `modelPath`. The epic-3018 generation cutover (sc-3037/sc-3032) deleted that adapter and carried over only the manifest seam, never the resolver — leaving it unwired. Converted **video** models avoided this because `resolve_ltx_model_dir` checks `<data>/models/mlx/<id>` directly; image generation had no equivalent.

## Fix
`resolve_model_manifest_entry` now calls a new `inject_converted_model_path`, which uses the existing single-source-of-truth `mlx_catalog_status` to detect a completed conversion and inject `modelPath` pointing at the converted dir. No-op when the model needs no conversion, isn't converted yet, or the manifest already pins an explicit `modelPath`. Populates the seam the worker already reads rather than adding a parallel resolution path.

## Tests / gates
- New unit test `inject_converted_model_path_populates_modelpath_seam_once_converted` (unset-until-converted, injected-after-converted, explicit-modelPath-preserved, non-conversion-untouched).
- `cargo test -p sceneworks-rust-api` — 102 pass; `cargo fmt --check` clean; `cargo clippy --all-targets -D warnings` clean.

## Not run here
- On-Mac end-to-end (install → convert → generate in Image Studio). The macOS-gated worker `resolve_weights_dir` consumer is unchanged and not compiled in the Linux parity lane, so the final live confirmation is still owed.

Story: [sc-3826](https://app.shortcut.com/trefry/story/3826)

🤖 Generated with [Claude Code](https://claude.com/claude-code)