### PR TITLE
sc-3843: route chroma1_* to in-process MLX on Mac (retire torch path)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2519,9 +2519,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-chroma"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "mlx-gen-flux",
+ "mlx-gen-z-image",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2544,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "image",
  "inventory",
@@ -2566,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2576,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2585,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "image",
  "inventory",
@@ -2598,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2610,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "image",
  "inventory",
@@ -2624,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=0d17c7279650903fca44fb62007970a8c33c90e7#0d17c7279650903fca44fb62007970a8c33c90e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
 dependencies = [
  "image",
  "inventory",
@@ -4191,6 +4203,7 @@ dependencies = [
  "image",
  "imageproc",
  "mlx-gen",
+ "mlx-gen-chroma",
  "mlx-gen-flux",
  "mlx-gen-flux2",
  "mlx-gen-joycaption",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2160,7 +2160,8 @@ fn torch_only_image_model_epic(model: &str) -> Option<&'static str> {
         "z_image_edit" => Some("epic 3529"),
         m if m.starts_with("sensenova") => Some("epic 3180"),
         m if m.starts_with("lens") => Some("epic 3164"),
-        m if m.starts_with("chroma") => Some("epic 3531"),
+        // Chroma (chroma1_*) was ported to MLX (epic 3531 / sc-3843) — it is now in
+        // `MLX_ROUTED_MODELS`, so it never reaches this torch-only gap classifier.
         _ => None,
     }
 }
@@ -2599,6 +2600,9 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux2_klein_9b_true_v2",
     "sdxl",
     "realvisxl",
+    "chroma1_hd",
+    "chroma1_base",
+    "chroma1_flash",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -2651,6 +2655,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
             flux2_mlx_eligible(payload)
         }
         "sdxl" | "realvisxl" => sdxl_mlx_eligible(payload),
+        "chroma1_hd" | "chroma1_base" | "chroma1_flash" => chroma_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
@@ -2777,6 +2782,17 @@ fn flux_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// img2img-edit stays on torch (epic 3529). Third-party LyCORIS now applies on the core MLX loader
 /// (epic 3641), so only `edit_image` keeps a Z-Image job off MLX.
 fn z_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
+}
+
+/// Chroma (epic 3531, sc-3843) MLX-routing conditions. Chroma is **text-to-image only**
+/// (`text_to_image` + `style_variations`; no edit / reference / ControlNet — those would be
+/// later engine ports), so every non-edit `image_generate` job routes to the in-process Rust
+/// `mlx-gen-chroma` worker on Mac. An `edit_image` mode — which Chroma has no path for on any
+/// platform — stays off MLX (defensive; the UI never offers edit for Chroma). All three variants
+/// (`chroma1_hd` / `chroma1_base` / `chroma1_flash`) share this gate. Third-party LyCORIS and peft
+/// LoKr apply on the core MLX loader (epic 3641 / sc-3842), so a LoRA never forces torch.
+fn chroma_mlx_eligible(payload: &Map<String, Value>) -> bool {
     payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1773,6 +1773,18 @@ fn mac_rust_supported_accepts_eligible_and_mlx_agnostic_jobs() {
         json!({ "model": "z_image_turbo", "prompt": "p" }),
     );
     assert!(mac_rust_supported(&eligible).is_ok());
+    // Chroma text-to-image (epic 3531 / sc-3843) is now MLX-eligible on every variant.
+    for id in ["chroma1_hd", "chroma1_base", "chroma1_flash"] {
+        let chroma = job_of(
+            &store,
+            JobType::ImageGenerate,
+            json!({ "model": id, "prompt": "p" }),
+        );
+        assert!(
+            mac_rust_supported(&chroma).is_ok(),
+            "{id} should be MLX-eligible"
+        );
+    }
     // MLX-agnostic job types run in-process with no Python torch dependency.
     let download = job_of(&store, JobType::ModelDownload, json!({ "repo": "x/y" }));
     assert!(mac_rust_supported(&download).is_ok());
@@ -1787,7 +1799,6 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
     // not the generic done feasibility epic.
     let cases = [
         ("kolors", "epic 3532"),
-        ("chroma1_hd", "epic 3531"),
         ("z_image_edit", "epic 3529"),
         ("instantid_realvisxl", "epic 3109"),
         ("sensenova_u1_8b", "epic 3180"),
@@ -2012,6 +2023,13 @@ fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
     let z_image = model_mac_support("z_image_turbo", "image");
     assert!(z_image.supported);
     assert!(z_image.reason.is_none());
+    // Chroma (epic 3531 / sc-3843) is now MLX-routed — all three variants stay in the picker
+    // and no longer report an `mlx_unsupported` port-epic gap.
+    for id in ["chroma1_hd", "chroma1_base", "chroma1_flash"] {
+        let chroma = model_mac_support(id, "image");
+        assert!(chroma.supported, "{id} should be MLX-supported");
+        assert!(chroma.reason.is_none(), "{id} should carry no gap reason");
+    }
     // SVD is now MLX-routed (sc-3523, image→video only) so it stays in the picker, like Wan/LTX;
     // a genuinely engine-less video model id is still hidden.
     assert!(model_mac_support("svd", "video").supported);

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,7 +68,12 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 0d17c72 (mlx-gen main, merged PRs #182 + #183): completes the native-MLX SAM2 video
+# Rev a67e8ed (mlx-gen main, merged PR #189, epic 3531): adds the native-MLX Chroma family
+# crate `mlx-gen-chroma` (chroma1_hd/base/flash — a FLUX.1-schnell-derived DiT + distilled-guidance
+# Approximator, T5-only true-CFG conditioning, MMDiT attention masking; sc-3834..sc-3842), all
+# three variants at real-weight e2e parity vs diffusers plus Q4/Q8 + LoRA/LoKr. The mlx-rs pin is
+# unchanged (e59ffd88) and the core `mlx-gen` crate API is untouched, so MLX rebuilds nothing.
+# On top of rev 0d17c72 (mlx-gen main, merged PRs #182 + #183): completes the native-MLX SAM2 video
 # layer — the memory bank (memory encoder + memory attention, sc-3713 #182) and the
 # `Sam2VideoPredictor` propagation predictor (init_state / propagate, sc-3714 #183), consumed
 # by the Rust person-track segmenter's prompt-once + propagate path (sc-3715). On top of rev
@@ -86,7 +91,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -94,44 +99,49 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c727965
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+# Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
+# `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
+# when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
+# other mlx-gen crates so MLX builds once.
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "0d17c7279650903fca44fb62007970a8c33c90e7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -26,6 +26,8 @@ use mlx_gen::{
     GenerationRequest, Generator, Image, LoadSpec, Progress, Quant, WeightsSource,
 };
 #[cfg(target_os = "macos")]
+use mlx_gen_chroma as _;
+#[cfg(target_os = "macos")]
 use mlx_gen_flux as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_flux2 as _;
@@ -237,6 +239,46 @@ const MLX_MODELS: &[MlxModel] = &[
         default_guidance: 7.0,
         supports_negative_prompt: true,
         adapter_label: "mlx_sdxl",
+    },
+    // Chroma (epic 3531, sc-3843) — FLUX.1-schnell-derived DiT, T5-only conditioning. The engine
+    // is a TRUE-CFG family: its descriptor advertises `supports_guidance=false` +
+    // `supports_negative_prompt=true`, so the CFG scale is forwarded as `true_cfg` (NOT the
+    // distilled `guidance` scalar, which the engine rejects) — see [`uses_true_cfg`] /
+    // [`resolve_true_cfg`]. HD/Base are full true-CFG (the manifest pre-fills 40 steps + guidance
+    // 3.0; the engine's own defaults are 28 steps + 4.0 — the request carries the manifest values).
+    // Each SceneWorks id maps 1:1 to the engine registry id of the same name.
+    MlxModel {
+        sceneworks_id: "chroma1_hd",
+        engine_id: "chroma1_hd",
+        default_repo: "lodestones/Chroma1-HD",
+        default_steps: 40,
+        supports_guidance: false,
+        default_guidance: 3.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_chroma",
+    },
+    MlxModel {
+        sceneworks_id: "chroma1_base",
+        engine_id: "chroma1_base",
+        default_repo: "lodestones/Chroma1-Base",
+        default_steps: 40,
+        supports_guidance: false,
+        default_guidance: 3.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_chroma",
+    },
+    // Flash is the few-step distilled checkpoint: ~8 steps, CFG baked toward 1.0 (single forward —
+    // the negative prompt is effectively inert at true_cfg≈1). It shares the true-CFG descriptor,
+    // so `true_cfg` still carries the scale (default 1.0).
+    MlxModel {
+        sceneworks_id: "chroma1_flash",
+        engine_id: "chroma1_flash",
+        default_repo: "lodestones/Chroma1-Flash",
+        default_steps: 8,
+        supports_guidance: false,
+        default_guidance: 1.0,
+        supports_negative_prompt: true,
+        adapter_label: "mlx_chroma",
     },
 ];
 
@@ -870,6 +912,38 @@ fn resolve_guidance(request: &ImageRequest, model: &MlxModel) -> Option<f32> {
     Some(scale)
 }
 
+/// True for a TRUE-CFG family whose engine reads the CFG scale from `true_cfg` (with a real
+/// negative prompt) and **rejects** the distilled `guidance` scalar — i.e. Chroma (epic 3531),
+/// uniquely identified by `supports_guidance=false` + `supports_negative_prompt=true`. The
+/// guidance-distilled families (`z_image_turbo`, `flux_schnell`) are `false`/`false` (no CFG at
+/// all), and the `guidance`-scalar families (qwen / sdxl / flux2 …) are `true`/*. For a true-CFG
+/// family the worker forwards `advanced.guidanceScale` as `true_cfg`, not `guidance`.
+#[cfg(target_os = "macos")]
+fn uses_true_cfg(model: &MlxModel) -> bool {
+    !model.supports_guidance && model.supports_negative_prompt
+}
+
+/// Resolve the true-CFG scale for a true-CFG family (Chroma). `None` for every other family
+/// (their CFG, if any, flows through [`resolve_guidance`]). The scale is `advanced.guidanceScale`
+/// (the same user knob) else the family default — forwarded to the engine as `GenerationRequest.true_cfg`.
+#[cfg(target_os = "macos")]
+fn resolve_true_cfg(request: &ImageRequest, model: &MlxModel) -> Option<f32> {
+    if !uses_true_cfg(model) {
+        return None;
+    }
+    let scale = request
+        .advanced
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(model.default_guidance);
+    Some(scale)
+}
+
 /// The negative prompt to pass to the engine. `None` for variants without true CFG
 /// (the engine rejects `negative_prompt` on the distilled families) and for an empty
 /// prompt (the true-CFG engines fall back to their own neutral negative).
@@ -1208,10 +1282,19 @@ async fn generate_mlx_stream(
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, model);
     let guidance = resolve_guidance(request, model);
+    // True-CFG families (Chroma) carry the CFG scale in `true_cfg`, not `guidance` (which their
+    // engine rejects); `None` for every other family. The recipe records the effective CFG knob.
+    let model_true_cfg = resolve_true_cfg(request, model);
     let negative_prompt = resolve_negative_prompt(request, model);
     let adapters = resolve_adapters(request)?;
     let repo = model_repo(request, model);
-    let raw_settings = mlx_raw_settings(request, &repo, steps, quant_bits, guidance);
+    let raw_settings = mlx_raw_settings(
+        request,
+        &repo,
+        steps,
+        quant_bits,
+        guidance.or(model_true_cfg),
+    );
     let engine_id = model.engine_id;
     let adapter_label = model.adapter_label;
     let count = request.count as usize;
@@ -1259,6 +1342,10 @@ async fn generate_mlx_stream(
     } else {
         (None, None, None)
     };
+    // The CFG scale passed to the engine as `true_cfg`: the FLUX.1-dev reference path's scale if
+    // present, otherwise the true-CFG family scale (Chroma). `None` for the guidance-scalar and
+    // distilled families, which carry CFG (if any) through `guidance` instead.
+    let true_cfg = flux_true_cfg.or(model_true_cfg);
 
     let cancel = CancelFlag::new();
     let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
@@ -1269,7 +1356,7 @@ async fn generate_mlx_stream(
         let seeds = seeds.clone();
         let cancel = cancel.clone();
         let job_id = job.id.clone();
-        // `identity_init` + `flux_ip_dir` + `flux_true_cfg` are moved into the closure (the `move`
+        // `identity_init` + `flux_ip_dir` + `true_cfg` are moved into the closure (the `move`
         // captures them by value).
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
             let adapter_count = adapters.len();
@@ -1308,7 +1395,7 @@ async fn generate_mlx_stream(
                     guidance,
                     negative_prompt.clone(),
                     identity_init.as_ref(),
-                    flux_true_cfg,
+                    true_cfg,
                     &cancel,
                     &mut on_progress,
                 )?;
@@ -4768,6 +4855,9 @@ mod tests {
             "qwen_image_edit",
             "flux2_klein_9b",
             "sdxl",
+            "chroma1_hd",
+            "chroma1_base",
+            "chroma1_flash",
         ] {
             assert!(ids.contains(&id), "registry missing {id}");
         }

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -53,7 +53,6 @@ Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust
 | Model id | Family | Mac disposition | Porting epic |
 |---|---|---|---|
 | `kolors` | kolors (SDXL UNet + ChatGLM3) | 🔵 Port → drop-on-Mac until then | **epic 3532** |
-| `chroma1_hd`, `chroma1_base`, `chroma1_flash` | chroma (FLUX.1-schnell DiT) | 🔵 Port → drop-on-Mac until then | **epic 3531** |
 | `z_image_edit` | z-image (edit) | 🔵 Port → drop-on-Mac until then | **epic 3529** |
 | `instantid_realvisxl` | sdxl (InstantID) | 🔵 Port → drop-on-Mac until then | epic 3109 |
 | `pulid_flux_dev` | flux (PuLID) | 🔵 Port → drop-on-Mac until then | epic 3069 (engine done; owes SceneWorks routing) |
@@ -136,6 +135,8 @@ Listed so a reviewer doesn't re-file these. All run in the Rust/MLX flow on Mac.
 - Image base families: `z_image_turbo`, `flux_schnell`, `flux_dev`, `qwen_image` (txt2img),
   `qwen_image_edit{,_2509,_2511,_2511_lightning}`, `flux2_klein_9b{,_kv,_true_v2}`, `sdxl`,
   `realvisxl` (epic 3018).
+- Chroma text-to-image: `chroma1_hd`, `chroma1_base`, `chroma1_flash` (FLUX.1-schnell-derived
+  DiT, T5-only true-CFG; `mlx-gen-chroma`) — epic 3531 / sc-3843.
 - SDXL advanced shapes — reference/IP-Adapter, `edit_image`, masked inpaint, outpaint, and
   tile-detail (`image_detail` on `sdxl`/`realvisxl`) — epic 3041 / sc-3060.
 - FLUX.2-klein single-file conversion in-process Rust (`flux2_klein_diffusers`, sc-3136).


### PR DESCRIPTION
Cross-repo cutover for **sc-3843** (epic 3531), consuming the merged [mlx-gen#189](https://github.com/michaeltrefry/mlx-gen/pull/189) (`a67e8ed4`). Chroma1-HD/Base/Flash now run on the in-process Rust MLX worker on macOS; **Windows/Linux/Docker keep the Python torch `ChromaDiffusersAdapter` unchanged**.

## Changes
- **Routing** (`crates/sceneworks-core/src/jobs_store.rs`): added `chroma1_hd`/`chroma1_base`/`chroma1_flash` to `MLX_ROUTED_MODELS`, a text-to-image-only `chroma_mlx_eligible` gate + dispatch arm (Chroma has no edit/reference/ControlNet path — `edit_image` stays off), and removed the now-stale `chroma → epic 3531` arm from `torch_only_image_model_epic` so Chroma no longer reports `mlx_unsupported`.
- **Engine dep** (`crates/sceneworks-worker/Cargo.toml`): bumped all mlx-gen deps `0d17c72 → a67e8ed4` and added the `mlx-gen-chroma` provider crate. The mlx-rs pin (`e59ffd88`) and core `mlx-gen` API are unchanged, so MLX rebuilds nothing.
- **Worker** (`crates/sceneworks-worker/src/image_jobs.rs`): `use mlx_gen_chroma as _;` for inventory self-registration; three `MlxModel` rows (engine ids `chroma1_hd`/`base`/`flash`); and a **true-CFG** path. Chroma's engine advertises `supports_guidance=false` + `supports_true_cfg=true` + `supports_negative_prompt=true`, so the CFG knob (`advanced.guidanceScale`) is forwarded as `GenerationRequest.true_cfg`, **not** the distilled `guidance` scalar the engine rejects (new `uses_true_cfg`/`resolve_true_cfg`, keyed by `!supports_guidance && supports_negative_prompt`).
- **Docs** (`docs/mac-rust-gaps.md`): moved Chroma out of §1 (torch-only) into §6 (already-ported).

## Validation (real macOS build)
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean on `sceneworks-core` / `sceneworks-worker` / `sceneworks-rust-api`.
- Worker compiles with `mlx-gen-chroma` linked; the registry-link test confirms all three `chroma1_*` ids self-register via `inventory`.
- Tests: core `jobs_store` 96, worker 193 (+ nax_guard), rust-api 102 — all pass. Added Chroma positive coverage to `mac_rust_supported` + `model_mac_support`; removed `chroma1_hd` from the torch-only-gap test.

## Not covered here
- Real-weight Chroma generation E2E on Mac hardware (needs the ~45GB `lodestones/Chroma1-*` snapshots). Engine-side parity was already proven in mlx-gen#189 (sc-3840).
- The `sceneworks-desktop` Tauri bundle build fails on a **pre-existing** missing staged sidecar binary (`apps/desktop/binaries/sceneworks-api-aarch64-apple-darwin`, gitignored, produced by `build-sidecar.mjs`) — independent of this change; the desktop crate links only `sceneworks-core`, not the worker/engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)