### PR TITLE
sc-3857 fix: server manifest sampler menu + default negative, and guidance default 5.0→3.0

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -288,13 +288,14 @@ export const fallbackModels = [
     // Reference-driven only — appears solely in the "With character" picker.
     capabilities: ["character_image"],
     // UI-default seeds for the advanced panel's Guidance / Steps placeholders
-    // (sc-3857). These mirror the worker fallbacks (instantid_adapter.py
-    // _guidance_scale 5.0 / _num_inference_steps 30) so the form shows the real
-    // resolved default; leaving the field blank still defers to the worker.
-    // sampler/scheduler default to "default" (model-native) so behaviour is
-    // unchanged until the user picks — e.g. DPM++ SDE + Karras for sharper,
-    // less-saturated RealVisXL output.
-    defaults: { guidanceScale: 5.0, steps: 30, sampler: "default", scheduler: "default" },
+    // (sc-3857). These mirror the worker defaults (instantid_adapter.py
+    // _guidance_scale / _num_inference_steps) so the form shows the real resolved
+    // default; leaving the field blank still defers to the worker. Guidance 3.0
+    // (lowered from 5.0 per render tuning — RealVisXL is CFG-sensitive; 3.0 cuts
+    // the over-saturated/over-contrast look while holding identity). sampler/
+    // scheduler default to "default" (model-native) so behaviour is unchanged
+    // until the user picks — e.g. DPM++ SDE + Karras for sharper output.
+    defaults: { guidanceScale: 3.0, steps: 30, sampler: "default", scheduler: "default" },
     // SDXL/epsilon sampler menu (sc-3857). The worker registry routes this
     // epsilon pipe to standard solvers; dpmpp_sde + karras == "DPM++ SDE Karras".
     limits: {
@@ -302,7 +303,7 @@ export const fallbackModels = [
       schedulers: ["default", "karras", "exponential"],
     },
     ui: {
-      description: "Identity-preserving character generation — holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) + InstantID ArcFace embedding & landmark ControlNet; faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference, then raise Variations. ~30 steps at guidance 5.0, ~22GB peak.",
+      description: "Identity-preserving character generation — holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) + InstantID ArcFace embedding & landmark ControlNet; faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference, then raise Variations. ~30 steps at guidance 3.0, ~22GB peak.",
       promptGuide: { title: "InstantID (RealVisXL) Prompt Guide", path: "/prompt-guides/instantid-realvisxl.md" },
       // Per-model default negative prompt (sc-3857). Image Studio seeds this into
       // an empty negative box on entering character mode — RealVisXL otherwise ran

--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -588,12 +588,14 @@ MODEL_TARGETS = {
         # reference-driven character model (no plain text_to_image / edit_image).
         "family": "sdxl",
         "supportsEdit": False,
-        # Per the sc-2009 spike: ~30 steps at guidance 5.0; identity holds with
+        # ~30 steps; guidance lowered 5.0 -> 3.0 (sc-3857) after Michael's render
+        # tuning — RealVisXL is CFG-sensitive and 3.0 holds identity with markedly
+        # less of the over-saturated/over-contrast look. identity holds with
         # ip_adapter_scale ~0.8 and controlnet_conditioning_scale 0.45 (looser pose)
-        # .. 0.8 (frontal lock). Both ride advanced (ipAdapterScale /
+        # .. 0.8 (frontal lock). All ride advanced (guidanceScale / ipAdapterScale /
         # controlnetConditioningScale); the adapter defaults them when absent.
         "steps": 30,
-        "guidanceScale": 5.0,
+        "guidanceScale": 3.0,
         # RealVisXL ships fp16-variant weights; from_pretrained falls back to the
         # default precision if the variant is absent (see InstantIDAdapter).
         "variant": "fp16",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1489,12 +1489,14 @@
         "model": "${HF_CACHE}/SG161222/RealVisXL_V5.0"
       },
       "defaults": {
-        // sc-2009 spike: ~30 steps at guidance 5.0; identity scale 0.8, landmark
-        // scale 0.45 (looser pose) .. 0.8 (frontal lock). The reference-strength
-        // slider drives ipAdapterScale; controlnetConditioningScale rides advanced.
+        // ~30 steps; guidance 3.0 (lowered from 5.0 per sc-3857 render tuning —
+        // RealVisXL is CFG-sensitive and 3.0 holds identity with much less of the
+        // over-saturated/over-contrast look). identity scale 0.8, landmark scale
+        // 0.45 (looser pose) .. 0.8 (frontal lock). The reference-strength slider
+        // drives ipAdapterScale; controlnetConditioningScale rides advanced.
         "resolution": "1024x1024",
         "steps": 30,
-        "guidanceScale": 5.0,
+        "guidanceScale": 3.0,
         "count": 4,
         // sc-3857: sampler/scheduler default to model-native (apply_sampler no-op)
         // so behaviour is unchanged until the user picks from the menu below.
@@ -1520,7 +1522,7 @@
       },
       "ui": {
         "label": "InstantID (RealVisXL)",
-        "description": "Identity-preserving character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) with InstantID's ArcFace embedding + 5-point-landmark ControlNet — the sc-2009 winner for faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 5.0; ~22GB peak on Apple Silicon. Needs the InstantID weights (~4GB) + antelopev2 face pack, fetched on first use.",
+        "description": "Identity-preserving character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on RealVisXL_V5.0 (photoreal SDXL, openrail++ commercial-OK) with InstantID's ArcFace embedding + 5-point-landmark ControlNet — the sc-2009 winner for faithful likeness with scene freedom (vs IP-Adapter resemblance only). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 3.0; ~22GB peak on Apple Silicon. Needs the InstantID weights (~4GB) + antelopev2 face pack, fetched on first use.",
         "recommendedFor": ["character_image"],
         // InstantID identity tuning surfaced in the character-image picker. The
         // reference-strength slider drives ipAdapterScale (default raised to 0.8 for

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1495,13 +1495,22 @@
         "resolution": "1024x1024",
         "steps": 30,
         "guidanceScale": 5.0,
-        "count": 4
+        "count": 4,
+        // sc-3857: sampler/scheduler default to model-native (apply_sampler no-op)
+        // so behaviour is unchanged until the user picks from the menu below.
+        "sampler": "default",
+        "scheduler": "default"
       },
       "limits": {
         // Letterboxed to the output aspect before landmark detection, so any SDXL
         // bucket is safe (no face stretching — the sc-2009 kps-aspect fix).
         "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344"],
-        "count": [1, 2, 4]
+        "count": [1, 2, 4],
+        // sc-3857: SDXL/epsilon sampler menu. The worker registry routes this
+        // epsilon pipe to standard solvers; dpmpp_sde + karras == "DPM++ SDE
+        // Karras" (the RealVisXL-recommended, sharper/less-saturated combo).
+        "samplers": ["default", "euler", "euler_a", "dpmpp", "dpmpp_sde", "unipc"],
+        "schedulers": ["default", "karras", "exponential"]
       },
       "loraCompatibility": {
         // SDXL UNet, so sdxl-family LoRAs apply (per sc-1927 declare the real
@@ -1519,6 +1528,11 @@
         // controlnetConditioningScale (IdentityNet/landmark lock — the lever that
         // measurably trades pose freedom for face-geometry likeness, sc-2009 sweep).
         "referenceStrengthDefault": 0.8,
+        // sc-3857: per-model default negative prompt. Image Studio seeds this into
+        // an empty negative box on entering character mode (RealVisXL otherwise ran
+        // with NO negative there). Targets this model's failure modes — shiny/
+        // plastic skin and the over-saturated/over-contrasty look.
+        "defaultNegativePrompt": "plastic skin, airbrushed, oversaturated, overexposed, high contrast, cgi, 3d render, cartoon, anime, waxy, deformed, blurry, lowres",
         "identityStructure": {
           "label": "Identity structure",
           "default": 0.8,

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -144,7 +144,7 @@ def test_builtin_realvisxl_target_is_wired():
     assert target["supportsEdit"] is False
     assert target["repo"] == "SG161222/RealVisXL_V5.0"
     assert target["steps"] == 30
-    assert target["guidanceScale"] == 5.0
+    assert target["guidanceScale"] == 3.0
     instant = target["instantId"]
     assert instant["repo"] == "InstantX/InstantID"
     assert instant["controlnetSubfolder"] == "ControlNetModel"


### PR DESCRIPTION
Follow-up to [#508](https://github.com/michaeltrefry/SceneWorks/pull/508). Two things:

## 1. Make the sampler menu + default negative actually reach the running app
The sampler/scheduler dropdowns weren't showing in Character Studio (Michael's report) and Image Studio wasn't seeding the InstantID default negative. **Root cause:** #508 added `limits.samplers`/`schedulers`, `defaults.sampler`/`scheduler`, and `ui.defaultNegativePrompt` to the **web `constants.js` fallback only**. The running app sources its manifest from the **server** (`config/manifests/builtin.models.jsonc` → `/api/v1/models`); the fallback is used only when the server returns no models. Web tests passed because they exercise that fallback — which is why it slipped.

Fix: mirror those fields into the authoritative `instantid_realvisxl` entry in `builtin.models.jsonc` (sampler/scheduler default `"default"` → no-op until picked; SDXL sampler menu incl. `dpmpp_sde`; curated default negative). Schema already supported these (flow models declare `limits.samplers` today).

## 2. Lower the default guidance 5.0 → 3.0
Per Michael's render tuning, Guidance 3 / Steps 30 / native sampler is the sweet spot for InstantID RealVisXL (CFG-sensitive model; 3.0 holds identity with far less over-saturation/contrast). The **effective** render default is the worker's hardcoded `MODEL_TARGETS` dict (`image_adapters.py`) — the worker does NOT read the manifest — so that's the authoritative change; the manifest + web fallback are updated to match the UI placeholder, plus the adapter test + copy. Applies to all InstantID modes; overridable via the Guidance field.

## Validation
- `cargo test -p sceneworks-rust-api` manifest + catalog suites green (jsonc parses, catalog loads).
- `tests/test_instantid_adapter.py` (27) green with the new `guidanceScale == 3.0` assertion.
- Web suite (168) + `vite build` green.

Worker registry + frontend wiring from #508 already handle all these keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)