### PR TITLE
InstantID native-MLX on the Rust GPU worker (sc-3345 + sc-3381)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2531,9 +2531,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-face"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2545,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,9 +2564,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-instantid"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
+dependencies = [
+ "mlx-gen",
+ "mlx-gen-face",
+ "mlx-gen-sdxl",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2566,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2578,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2588,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2597,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2610,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2622,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2636,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2932,7 +2953,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4204,8 +4225,10 @@ dependencies = [
  "imageproc",
  "mlx-gen",
  "mlx-gen-chroma",
+ "mlx-gen-face",
  "mlx-gen-flux",
  "mlx-gen-flux2",
+ "mlx-gen-instantid",
  "mlx-gen-joycaption",
  "mlx-gen-ltx",
  "mlx-gen-qwen-image",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2155,7 +2155,10 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
 fn torch_only_image_model_epic(model: &str) -> Option<&'static str> {
     match model {
         "kolors" => Some("epic 3532"),
-        "instantid_realvisxl" => Some("epic 3109"),
+        // InstantID (instantid_realvisxl) was ported to MLX (epic 3109 engine / sc-3345) — it is
+        // now in `MLX_ROUTED_MODELS`, so it never reaches this torch-only classifier. Its
+        // remaining gaps (pose-library mode, face-restore) are named per-feature in
+        // `classify_image_gap`, not as a whole-model gap.
         "pulid_flux_dev" => Some("epic 3069"),
         "z_image_edit" => Some("epic 3529"),
         m if m.starts_with("sensenova") => Some("epic 3180"),
@@ -2211,6 +2214,15 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             Some(model),
             "edit without a reference/source image",
             "the Qwen-Image-Edit model needs edit_image+sourceAssetId or character_image+referenceAssetId to route to MLX.",
+            None,
+        ),
+        // InstantID (sc-3345 identity + angle set; sc-3381 pose mode + face-restore): the full
+        // surface runs on MLX for `character_image` + `referenceAssetId`. Only a non-character /
+        // reference-less job has no InstantID path. Mirrors `instantid_mlx_eligible`.
+        "instantid_realvisxl" => UnsupportedReason::new(
+            Some(model),
+            "InstantID without a character reference",
+            "InstantID runs on MLX for character_image with a referenceAssetId (single identity, the 11-view angle set, pose-library mode, and face-restore); a non-character / reference-less job has no InstantID path.",
             None,
         ),
         // flux2 / sdxl / realvisxl only fall out via LyCORIS (handled above) — defensive.
@@ -2600,6 +2612,11 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux2_klein_9b_true_v2",
     "sdxl",
     "realvisxl",
+    // InstantID on RealVisXL (sc-3345): single-identity + the 11-view angle set route to the
+    // native `mlx-gen-instantid` provider. Pose-library + face-restore InstantID jobs are gated
+    // OUT by `instantid_mlx_eligible` and stay on the torch `InstantIDAdapter` (engine sc-3117 /
+    // sc-3380 not ported).
+    "instantid_realvisxl",
     "chroma1_hd",
     "chroma1_base",
     "chroma1_flash",
@@ -2655,6 +2672,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
             flux2_mlx_eligible(payload)
         }
         "sdxl" | "realvisxl" => sdxl_mlx_eligible(payload),
+        "instantid_realvisxl" => instantid_mlx_eligible(payload),
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => chroma_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
@@ -2696,6 +2714,22 @@ fn job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// `image_detail` is a separate job type with its own routing (see `image_detail_mlx_eligible`).
 fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
+}
+
+/// InstantID (`instantid_realvisxl`) MLX-routing conditions. The native `mlx-gen-instantid`
+/// provider now serves the FULL surface on Mac: single-identity `character_image`, the 11-view
+/// Character-Studio angle set (sc-3345), AND pose-library mode + face-restore (sc-3381, on the
+/// #193 engine — `generate_pose` MultiControlNet IdentityNet+OpenPose / `restore_face`). So every
+/// `character_image` job with a reference face routes to MLX; only a non-character / reference-less
+/// job stays off. Mirrors the worker's `instantid_available` gate so the router and worker agree.
+fn instantid_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("character_image") {
+        return false;
+    }
+    payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 /// FLUX.2-klein MLX-routing conditions. FLUX.2-klein is an **MLX-only** family (no torch backend),
@@ -3346,9 +3380,9 @@ fn sort_json_value(value: &mut Value) {
 #[cfg(test)]
 mod mlx_routing_tests {
     use super::{
-        flux2_mlx_eligible, flux_mlx_eligible, qwen_edit_mlx_eligible, qwen_mlx_eligible,
-        sdxl_mlx_eligible, video_mode_is_mlx_eligible, z_image_mlx_eligible,
-        VIDEO_MLX_ROUTED_MODELS,
+        flux2_mlx_eligible, flux_mlx_eligible, image_request_mlx_eligible, instantid_mlx_eligible,
+        qwen_edit_mlx_eligible, qwen_mlx_eligible, sdxl_mlx_eligible, video_mode_is_mlx_eligible,
+        z_image_mlx_eligible, VIDEO_MLX_ROUTED_MODELS,
     };
     use serde_json::{json, Map, Value};
 
@@ -3579,6 +3613,40 @@ mod mlx_routing_tests {
         assert!(sdxl_mlx_eligible(&object(json!({
             "mode": "edit_image",
             "loras": [{ "networkType": "lycoris" }]
+        }))));
+    }
+
+    #[test]
+    fn instantid_routes_all_character_modes_to_mlx() {
+        // The full InstantID surface is native (sc-3345 identity + angle; sc-3381 pose + restore):
+        // every character_image + referenceAssetId shape routes to MLX.
+        for advanced in [
+            json!({}),
+            json!({ "angleSet": true }),
+            json!({ "poses": [{ "id": "a" }] }),
+            json!({ "faceRestore": true }),
+            json!({ "poses": [{ "id": "a" }], "faceRestore": true }),
+        ] {
+            let payload = object(json!({
+                "model": "instantid_realvisxl",
+                "mode": "character_image",
+                "referenceAssetId": "asset_1",
+                "advanced": advanced,
+            }));
+            assert!(instantid_mlx_eligible(&payload));
+            assert!(image_request_mlx_eligible("instantid_realvisxl", &payload));
+        }
+
+        // No reference face → not eligible.
+        assert!(!instantid_mlx_eligible(&object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image"
+        }))));
+
+        // Non-character mode → not eligible (InstantID is a character flow).
+        assert!(!instantid_mlx_eligible(&object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "text_to_image"
         }))));
     }
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1800,7 +1800,9 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
     let cases = [
         ("kolors", "epic 3532"),
         ("z_image_edit", "epic 3529"),
-        ("instantid_realvisxl", "epic 3109"),
+        // instantid_realvisxl is NO LONGER wholly torch-only (sc-3345: identity + angle set run on
+        // MLX); its remaining per-feature gaps are covered by
+        // `mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped`.
         ("sensenova_u1_8b", "epic 3180"),
         ("lens_turbo", "epic 3164"),
     ];
@@ -1818,6 +1820,37 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
             "{model} → {epic}"
         );
         assert!(reason.error_message().starts_with("mlx_unsupported:"));
+    }
+}
+
+#[test]
+fn mac_rust_supported_instantid_full_surface_ok() {
+    let store = store("oracle-instantid");
+    // The full InstantID surface is native on Mac: identity (sc-3345), angle set (sc-3345),
+    // pose-library mode + face-restore (sc-3381, #193 engine). All character_image + reference
+    // shapes are supported.
+    for advanced in [
+        json!({}),
+        json!({ "angleSet": true }),
+        json!({ "poses": [{ "id": "a" }] }),
+        json!({ "faceRestore": true }),
+        json!({ "poses": [{ "id": "a" }], "faceRestore": true }),
+    ] {
+        let job = job_of(
+            &store,
+            JobType::ImageGenerate,
+            json!({
+                "model": "instantid_realvisxl",
+                "mode": "character_image",
+                "referenceAssetId": "asset_1",
+                "prompt": "p",
+                "advanced": advanced,
+            }),
+        );
+        assert!(
+            mac_rust_supported(&job).is_ok(),
+            "InstantID character_image should be MLX-supported"
+        );
     }
 }
 
@@ -3603,9 +3636,9 @@ fn non_mlx_model_image_job_is_not_routed_to_mlx_worker() {
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // A torch-only image model with no mlx-gen engine (e.g. kolors — InstantID/Kolors/
-    // PuLID/SenseNova have no MLX crate) stays on the Python path: the torch worker
-    // claims it without deferral, and the mlx worker would refuse it.
+    // A torch-only image model with no mlx-gen engine (e.g. kolors — Kolors/PuLID/SenseNova
+    // have no MLX crate; InstantID is now ported, sc-3345) stays on the Python path: the torch
+    // worker claims it without deferral, and the mlx worker would refuse it.
     let job = store
         .create_job(image_job_with(
             json!({ "model": "kolors", "prompt": "p" }),

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,11 +68,16 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev a67e8ed (mlx-gen main, merged PR #189, epic 3531): adds the native-MLX Chroma family
-# crate `mlx-gen-chroma` (chroma1_hd/base/flash — a FLUX.1-schnell-derived DiT + distilled-guidance
+# Rev ed8e6a1 (mlx-gen main, merged PR #193, epic 3109 / sc-3117+sc-3380): adds InstantID
+# pose mode (MultiControlNet IdentityNet + xinsir OpenPose, `InstantId::with_openpose` +
+# `generate_pose`, native skeleton rasterizer + no-face-visible branch) and the face-restore
+# pass (`restore_face`, ADetailer-style crop→re-render→feathered paste-back, gender-neutral
+# prompt), consumed by the SceneWorks InstantID pose/face-restore wiring (sc-3381). The mlx-rs
+# pin is unchanged (e59ffd88) so MLX core rebuilds nothing.
+# On top of rev a67e8ed (PR #189, epic 3531): the native-MLX Chroma family crate
+# `mlx-gen-chroma` (chroma1_hd/base/flash — a FLUX.1-schnell-derived DiT + distilled-guidance
 # Approximator, T5-only true-CFG conditioning, MMDiT attention masking; sc-3834..sc-3842), all
-# three variants at real-weight e2e parity vs diffusers plus Q4/Q8 + LoRA/LoKr. The mlx-rs pin is
-# unchanged (e59ffd88) and the core `mlx-gen` crate API is untouched, so MLX rebuilds nothing.
+# three variants at real-weight e2e parity vs diffusers plus Q4/Q8 + LoRA/LoKr.
 # On top of rev 0d17c72 (mlx-gen main, merged PRs #182 + #183): completes the native-MLX SAM2 video
 # layer — the memory bank (memory encoder + memory attention, sc-3713 #182) and the
 # `Sam2VideoPredictor` propagation predictor (init_state / propagate, sc-3714 #183), consumed
@@ -91,7 +96,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -99,49 +104,63 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f3
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
+# Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
+# (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
+# provider) consumed by the InstantID provider below to detect the reference face + produce
+# the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
+# InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
+# bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
+# `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
+# NOT an inventory-registered `Generator` — wired via a dedicated `generate_instantid_stream` in
+# image_jobs.rs (parallel to the sc-3060 SDXL-advanced path), not the MLX_MODELS table. Composes
+# mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
+# pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
+# + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -37,6 +37,18 @@ use mlx_gen_qwen_image as _;
 use mlx_gen_sdxl as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_z_image as _;
+// InstantID (sc-3345) is a bespoke provider, not an inventory-registered `Generator`, so it is
+// referenced by name (`InstantId::load`) rather than anchored with `as _;` — and the native face
+// stack it composes (`mlx-gen-face`, SCRFD + ArcFace) rides in transitively but is anchored here so
+// the direct dep the story adds is meaningful + survives any future unused-crate lint.
+#[cfg(target_os = "macos")]
+use mlx_gen::weights::Weights;
+#[cfg(target_os = "macos")]
+use mlx_gen_face as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_instantid::{
+    BodyPoint, InstantId, InstantIdPaths, InstantIdRequest, FACE_RESTORE_PROMPT,
+};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -394,6 +406,23 @@ pub(crate) async fn run_image_generate_job(
         // Qwen-Image-Edit (mode edit_image / Character-Studio reference / best-effort
         // pose / angle set) → the engine's `qwen_image_edit` model (sc-3397).
         generate_qwen_edit_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if instantid_available(&request, settings) {
+        // InstantID identity-preserving character image (sc-3345): single identity or the
+        // 11-view Character-Studio angle set, on RealVisXL + IdentityNet + the native face
+        // stack. Pose-library + faceRestore jobs are NOT eligible (kept on the torch
+        // adapter) — `instantid_available` gates them out so they fall through to the
+        // non-handled path and the torch worker claims them.
+        generate_instantid_stream(
             api,
             settings,
             job,
@@ -3109,7 +3138,9 @@ fn qwen_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
 /// streams against it). Qwen edit reuses the shared [`flux2_grouping`] decision.
 #[cfg(target_os = "macos")]
 fn grouped_image_count(request: &ImageRequest, settings: &Settings) -> u32 {
-    if qwen_edit_available(request, settings) {
+    if instantid_available(request, settings) {
+        instantid_image_count(request)
+    } else if qwen_edit_available(request, settings) {
         match flux2_grouping(request) {
             Flux2Grouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
             Flux2Grouping::Poses(count) => count as u32,
@@ -3969,6 +4000,690 @@ async fn generate_sdxl_advanced_stream(
         project_path,
         backend,
         adapter_label,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// InstantID identity-preserving character image (macOS, epic 3109 engine / sc-3345
+// integration): the production `instantid_realvisxl` model — InstantID on RealVisXL +
+// the stock SDXL IdentityNet ControlNet + the native MLX face stack (SCRFD + ArcFace),
+// all in-process with zero Python. Two modes only (torch parity): a single-identity
+// `character_image` (the reference's natural head pose) and the 11-view Character-Studio
+// angle set. Pose-library mode (`advanced.poses`) + face-restore (`advanced.faceRestore`)
+// are NOT handled here — they stay on the torch `InstantIDAdapter` (engine sc-3117 /
+// sc-3380 not yet ported), gated out by `instantid_available` so the torch worker claims
+// them. fp16 only for now (the validated envelope); Q8/Q4 ride explicit `mlxQuantize`
+// (unvalidated at 1024², gated by sc-3329 follow-up). The provider is the bespoke
+// `mlx_gen_instantid::InstantId` (not an inventory `Generator`), so this is a dedicated
+// stream parallel to `generate_sdxl_advanced_stream`, not an MLX_MODELS row.
+// ---------------------------------------------------------------------------
+
+/// The SceneWorks model id for native InstantID (production = InstantID on RealVisXL_V5.0).
+#[cfg(target_os = "macos")]
+const INSTANTID_MODEL: &str = "instantid_realvisxl";
+/// SDXL base for InstantID when the manifest omits `repo` (the photoreal production base).
+#[cfg(target_os = "macos")]
+const INSTANTID_SDXL_REPO: &str = "SG161222/RealVisXL_V5.0";
+/// Stock InstantID checkpoint repo — the IdentityNet `ControlNetModel/` lives here.
+#[cfg(target_os = "macos")]
+const INSTANTID_CONTROLNET_REPO: &str = "InstantX/InstantID";
+/// Converted-weights bundle (download-on-first-use): the MLX `ip-adapter.safetensors`
+/// (`tools/convert_instantid.py`) + the native face stack `scrfd_10g.safetensors`
+/// (`convert_scrfd.py`) + `arcface_iresnet100.safetensors` (`convert_glintr100.py`). Public
+/// repo, mirroring the YOLO11 / SAM2 `SceneWorks/*-mlx` uploads (sc-3633 / sc-3707).
+#[cfg(target_os = "macos")]
+const INSTANTID_MLX_REPO: &str = "SceneWorks/instantid-mlx";
+#[cfg(target_os = "macos")]
+const INSTANTID_IP_ADAPTER_FILE: &str = "ip-adapter.safetensors";
+#[cfg(target_os = "macos")]
+const INSTANTID_SCRFD_FILE: &str = "scrfd_10g.safetensors";
+#[cfg(target_os = "macos")]
+const INSTANTID_ARCFACE_FILE: &str = "arcface_iresnet100.safetensors";
+/// The IdentityNet weight file inside `ControlNetModel/` (a stock diffusers SDXL ControlNet).
+#[cfg(target_os = "macos")]
+const INSTANTID_CONTROLNET_FILES: [&str; 2] =
+    ["config.json", "diffusion_pytorch_model.safetensors"];
+/// Torch-parity defaults (the `instantid_realvisxl` MODEL_TARGETS): RealVisXL is tuned for a
+/// low CFG; the engine's own `InstantIdRequest::default` guidance (5.0) is for base SDXL.
+#[cfg(target_os = "macos")]
+const INSTANTID_DEFAULT_STEPS: u32 = 30;
+#[cfg(target_os = "macos")]
+const INSTANTID_DEFAULT_GUIDANCE: f32 = 3.0;
+#[cfg(target_os = "macos")]
+const INSTANTID_IP_SCALE: f32 = 0.8;
+#[cfg(target_os = "macos")]
+const INSTANTID_CONTROLNET_SCALE: f32 = 0.8;
+/// xinsir OpenPose-SDXL ControlNet (the pose-mode second branch, sc-3117). Loads via the stock
+/// `load_controlnet` (no conversion) — `image_adapters.py:615-617` parity.
+#[cfg(target_os = "macos")]
+const INSTANTID_OPENPOSE_REPO: &str = "xinsir/controlnet-openpose-sdxl-1.0";
+/// Torch-parity default OpenPose lock (`instantid_adapter.py::_openpose_scale`, default 0.7).
+#[cfg(target_os = "macos")]
+const INSTANTID_OPENPOSE_SCALE: f32 = 0.7;
+/// The face-restore re-render side (the engine's production crop size, sc-3380).
+#[cfg(target_os = "macos")]
+const INSTANTID_FACE_RESTORE_SIDE: u32 = 1024;
+
+/// How an InstantID character job batches its iterations (torch-parity precedence: a pose set
+/// wins over an angle set, which wins over plain identity — `instantid_adapter.py:655`).
+#[cfg(target_os = "macos")]
+enum InstantIdMode {
+    /// `count` images at the reference's natural head pose (engine `generate`, W×H letterboxed).
+    Identity,
+    /// The 11-view Character-Studio set, shared seed (engine `generate_angle`, square).
+    AngleSet,
+    /// `n` pose-library poses, shared seed — MultiControlNet IdentityNet + OpenPose (engine
+    /// `generate_pose`, square).
+    PoseSet(usize),
+}
+
+/// The 11-view Character-Studio angle set flag.
+#[cfg(target_os = "macos")]
+fn instantid_angle_set(request: &ImageRequest) -> bool {
+    advanced_flag(request, "angleSet")
+}
+
+/// Classify the InstantID iteration mode (pose set > angle set > plain identity).
+#[cfg(target_os = "macos")]
+fn instantid_mode(request: &ImageRequest) -> InstantIdMode {
+    let poses = pose_entries(request).len();
+    if poses > 0 {
+        InstantIdMode::PoseSet(poses)
+    } else if instantid_angle_set(request) {
+        InstantIdMode::AngleSet
+    } else {
+        InstantIdMode::Identity
+    }
+}
+
+/// Per-image InstantID action (the engine entry point this iteration calls). `Send` (it is moved
+/// into the blocking task): `BodyPoint = Option<(f64, f64)>`, `&'static str`, and the unit variant
+/// are all `Send`.
+#[cfg(target_os = "macos")]
+enum InstantIdAction {
+    /// `generate` — the reference's natural head pose, W×H letterboxed.
+    Identity,
+    /// `generate_angle` — a canonical Character-Studio view (square).
+    Angle(&'static str),
+    /// `generate_pose` — MultiControlNet IdentityNet + OpenPose on these COCO-18 keypoints (square).
+    Pose(Vec<BodyPoint>),
+}
+
+/// Bridge the worker's gallery-normalized keypoints (`openpose_skeleton::Keypoint = Option<(f32,
+/// f32)>`) to the engine's `BodyPoint = Option<(f64, f64)>`. `parse_poses` already applied the
+/// COCO-18 normalize + conf<=0 drop, so this is just the f32→f64 widening.
+#[cfg(target_os = "macos")]
+fn pose_to_body_points(keypoints: &[crate::openpose_skeleton::Keypoint]) -> Vec<BodyPoint> {
+    keypoints
+        .iter()
+        .map(|point| point.map(|(x, y)| (x as f64, y as f64)))
+        .collect()
+}
+
+/// Resolve the RealVisXL (SDXL) base snapshot for InstantID: an explicit `modelPath` dir
+/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
+/// RealVisXL_V5.0). The big base is staged by the normal model-download flow; `None` here
+/// means it is not present, so the job is not MLX-runnable (falls through to torch).
+#[cfg(target_os = "macos")]
+fn resolve_instantid_sdxl_base(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+    {
+        if path.is_dir() {
+            return Some(path);
+        }
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(INSTANTID_SDXL_REPO);
+    huggingface_snapshot_dir(&settings.data_dir, repo)
+}
+
+/// True when this is a native-MLX-eligible InstantID job: the production model in
+/// `character_image` mode with a reference face whose SDXL base resolves locally. ALL InstantID
+/// modes are now native (sc-3345 identity + angle set; sc-3381 pose mode + face-restore via the
+/// #193 engine). Mirrors `jobs_store::instantid_mlx_eligible` so the worker and the router agree.
+#[cfg(target_os = "macos")]
+fn instantid_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == INSTANTID_MODEL
+        && request.mode == "character_image"
+        && non_empty(&request.reference_asset_id)
+        && resolve_instantid_sdxl_base(request, settings).is_some()
+}
+
+/// The number of images an InstantID job produces: `n` for a pose set, 11 for an angle set, else
+/// `request.count`.
+#[cfg(target_os = "macos")]
+fn instantid_image_count(request: &ImageRequest) -> u32 {
+    match instantid_mode(request) {
+        InstantIdMode::PoseSet(count) => count as u32,
+        InstantIdMode::AngleSet => CHARACTER_ANGLE_SET_ORDER.len() as u32,
+        InstantIdMode::Identity => request.count,
+    }
+}
+
+/// Resolve InstantID denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` →
+/// the torch-parity default (30).
+#[cfg(target_os = "macos")]
+fn instantid_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 80) as u32)
+        .unwrap_or(INSTANTID_DEFAULT_STEPS)
+}
+
+/// Resolve InstantID guidance: `advanced.guidanceScale` → manifest `guidanceScale` → the
+/// RealVisXL-tuned default (3.0). Clamped to a sane CFG range.
+#[cfg(target_os = "macos")]
+fn instantid_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(INSTANTID_DEFAULT_GUIDANCE);
+    advanced_f32(request, "guidanceScale", manifest_default, 0.0, 30.0)
+}
+
+/// Resolve InstantID quantization. **fp16 (dense) is the default** — the validated identity
+/// envelope (ArcFace-cosine 0.82 @1024²); Q8/Q4 only on an explicit `advanced.mlxQuantize` /
+/// manifest opt-in (identity drops to ~0.64 @512² and full-res quant is unvalidated). Returns
+/// the engine `bits` (`Some(4)`/`Some(8)`/`None`) + the recipe bit count.
+#[cfg(target_os = "macos")]
+fn instantid_quant(request: &ImageRequest) -> (Option<i32>, Option<i64>) {
+    let raw = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(quant_int)
+        .or_else(|| {
+            request
+                .model_manifest_entry
+                .get("mlx")
+                .and_then(|mlx| mlx.get("quantize"))
+                .and_then(quant_int)
+        });
+    match raw {
+        Some(bits) if bits > 0 && bits <= 4 => (Some(4), Some(4)),
+        Some(bits) if bits > 4 => (Some(8), Some(8)),
+        // None / 0 / negative → fp16 (the default + the validated InstantID envelope).
+        _ => (None, None),
+    }
+}
+
+/// Flat telemetry recorded on InstantID assets (parity with `mlx_raw_settings` + the torch
+/// `InstantIDAdapter` recipe keys).
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn instantid_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: f32,
+    ip_scale: f32,
+    controlnet_scale: f32,
+    angle_set: bool,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert("ipAdapterScale".to_owned(), json!(ip_scale));
+    raw.insert(
+        "controlnetConditioningScale".to_owned(),
+        json!(controlnet_scale),
+    );
+    raw.insert(
+        "instantIdEngine".to_owned(),
+        Value::String("mlx_instantid".to_owned()),
+    );
+    if angle_set {
+        raw.insert("angleSet".to_owned(), Value::Bool(true));
+    }
+    raw
+}
+
+/// Resolve a single InstantID weight file: return it if already present in `dir`, else
+/// download `url` into `dir` (atomic `.tmp` + rename, so a partial download is never mistaken
+/// for a complete one — same shape as `person_segment::ensure_segmenter_weights`).
+#[cfg(target_os = "macos")]
+async fn ensure_instantid_file(
+    client: &reqwest::Client,
+    dir: &Path,
+    name: &str,
+    url: &str,
+) -> WorkerResult<PathBuf> {
+    let target = dir.join(name);
+    if target.exists() {
+        return Ok(target);
+    }
+    tokio::fs::create_dir_all(dir).await?;
+    let bytes = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!(
+                "InstantID weight download failed ({url}): {error}"
+            ))
+        })?
+        .bytes()
+        .await?;
+    let tmp = target.with_extension("download.tmp");
+    tokio::fs::write(&tmp, &bytes).await?;
+    tokio::fs::rename(&tmp, &target).await?;
+    Ok(target)
+}
+
+/// Resolve all InstantID weight inputs, downloading the small converted bundle + the stock
+/// IdentityNet on first use. Returns `(identitynet_dir, ip_adapter, scrfd, arcface)` — all
+/// `Send` paths; the `!Send` MLX load happens on the blocking thread. Resolution order favours
+/// an env override / the HF cache before any network fetch.
+#[cfg(target_os = "macos")]
+async fn ensure_instantid_weights(
+    settings: &Settings,
+) -> WorkerResult<(WeightsSource, PathBuf, PathBuf, PathBuf)> {
+    let client = reqwest::Client::new();
+
+    // Converted bundle (ip-adapter + face stack): an env-pinned dir (pre-staged for local
+    // validation) wins, else the app cache (download missing files from SceneWorks/instantid-mlx).
+    let bundle_dir = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| settings.data_dir.join("cache").join("instantid-mlx"));
+    let base = format!("https://huggingface.co/{INSTANTID_MLX_REPO}/resolve/main");
+    let ip_adapter = ensure_instantid_file(
+        &client,
+        &bundle_dir,
+        INSTANTID_IP_ADAPTER_FILE,
+        &format!("{base}/{INSTANTID_IP_ADAPTER_FILE}"),
+    )
+    .await?;
+    let scrfd = ensure_instantid_file(
+        &client,
+        &bundle_dir,
+        INSTANTID_SCRFD_FILE,
+        &format!("{base}/{INSTANTID_SCRFD_FILE}"),
+    )
+    .await?;
+    let arcface = ensure_instantid_file(
+        &client,
+        &bundle_dir,
+        INSTANTID_ARCFACE_FILE,
+        &format!("{base}/{INSTANTID_ARCFACE_FILE}"),
+    )
+    .await?;
+
+    // IdentityNet (stock InstantX ControlNetModel): env override → HF cache snapshot →
+    // download the two files into the app cache.
+    if let Ok(dir) = std::env::var("SCENEWORKS_INSTANTID_CONTROLNET") {
+        let dir = PathBuf::from(dir);
+        if dir.is_dir() {
+            return Ok((WeightsSource::Dir(dir), ip_adapter, scrfd, arcface));
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, INSTANTID_CONTROLNET_REPO)
+    {
+        let controlnet = snapshot.join("ControlNetModel");
+        if controlnet
+            .join("diffusion_pytorch_model.safetensors")
+            .exists()
+        {
+            return Ok((WeightsSource::Dir(controlnet), ip_adapter, scrfd, arcface));
+        }
+    }
+    let controlnet_dir = settings.data_dir.join("cache").join("instantid-controlnet");
+    let cn_base =
+        format!("https://huggingface.co/{INSTANTID_CONTROLNET_REPO}/resolve/main/ControlNetModel");
+    for file in INSTANTID_CONTROLNET_FILES {
+        ensure_instantid_file(&client, &controlnet_dir, file, &format!("{cn_base}/{file}")).await?;
+    }
+    Ok((
+        WeightsSource::Dir(controlnet_dir),
+        ip_adapter,
+        scrfd,
+        arcface,
+    ))
+}
+
+/// Resolve the xinsir OpenPose-SDXL ControlNet dir for pose mode: env override
+/// (`SCENEWORKS_INSTANTID_OPENPOSE`) → HF cache snapshot → download the two files on first use. A
+/// stock diffusers SDXL ControlNet (loads via `with_openpose`/`load_controlnet`, no conversion).
+#[cfg(target_os = "macos")]
+async fn ensure_instantid_openpose(settings: &Settings) -> WorkerResult<WeightsSource> {
+    if let Ok(dir) = std::env::var("SCENEWORKS_INSTANTID_OPENPOSE") {
+        let dir = PathBuf::from(dir);
+        if dir.is_dir() {
+            return Ok(WeightsSource::Dir(dir));
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, INSTANTID_OPENPOSE_REPO) {
+        if snapshot
+            .join("diffusion_pytorch_model.safetensors")
+            .exists()
+        {
+            return Ok(WeightsSource::Dir(snapshot));
+        }
+    }
+    let client = reqwest::Client::new();
+    let dir = settings.data_dir.join("cache").join("instantid-openpose");
+    let base = format!("https://huggingface.co/{INSTANTID_OPENPOSE_REPO}/resolve/main");
+    for file in INSTANTID_CONTROLNET_FILES {
+        ensure_instantid_file(&client, &dir, file, &format!("{base}/{file}")).await?;
+    }
+    Ok(WeightsSource::Dir(dir))
+}
+
+/// Real InstantID generation: resolve the reference + weights on the async side, then load the
+/// bespoke `InstantId` provider once + generate each image on the blocking thread (the MLX
+/// model is `!Send`). Three modes (torch parity): single identity (`generate`), the 11-view angle
+/// set (`generate_angle`), and the pose-library set (`generate_pose`, MultiControlNet IdentityNet
+/// with xinsir OpenPose — sc-3117). `advanced.faceRestore` adds the ADetailer-style re-render pass
+/// (`restore_face`, sc-3380) on each output. The engine `generate*` expose neither a step-progress
+/// callback nor a `CancelFlag`, so streaming is per-image (no `Step`/`Decoding` events) and
+/// cancellation is honoured between images. Reuses [`consume_gen_events`] for the asset writes.
+#[cfg(target_os = "macos")]
+async fn generate_instantid_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let sdxl_base = resolve_instantid_sdxl_base(request, settings).ok_or_else(|| {
+        WorkerError::InvalidPayload("InstantID base (RealVisXL) not found".to_owned())
+    })?;
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("InstantID requires a reference face image".to_owned())
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+
+    let (controlnet, ip_adapter, scrfd_path, arcface_path) =
+        ensure_instantid_weights(settings).await?;
+
+    let steps = instantid_steps(request);
+    let guidance = instantid_guidance(request);
+    let (quant_bits, recipe_bits) = instantid_quant(request);
+    let ip_scale = advanced_f32(request, "ipAdapterScale", INSTANTID_IP_SCALE, 0.0, 1.0);
+    let controlnet_scale = advanced_f32(
+        request,
+        "controlnetConditioningScale",
+        INSTANTID_CONTROLNET_SCALE,
+        0.0,
+        2.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(INSTANTID_SDXL_REPO)
+        .to_owned();
+    let mode = instantid_mode(request);
+    let angle_set = matches!(mode, InstantIdMode::AngleSet);
+    let pose_set = matches!(mode, InstantIdMode::PoseSet(_));
+    let openpose_scale = advanced_f32(request, "openPoseScale", INSTANTID_OPENPOSE_SCALE, 0.0, 2.0);
+    let face_restore = advanced_flag(request, "faceRestore");
+    // Load the xinsir OpenPose ControlNet only for pose mode (it is the MultiControlNet second
+    // branch; identity/angle modes don't need it).
+    let openpose = if pose_set {
+        Some(ensure_instantid_openpose(settings).await?)
+    } else {
+        None
+    };
+
+    let mut raw_settings = instantid_raw_settings(
+        request,
+        &repo,
+        steps,
+        recipe_bits,
+        guidance,
+        ip_scale,
+        controlnet_scale,
+        angle_set,
+    );
+    if pose_set {
+        raw_settings.insert("poseLibrary".to_owned(), Value::Bool(true));
+        raw_settings.insert("openPoseScale".to_owned(), json!(openpose_scale));
+    }
+    if face_restore {
+        raw_settings.insert("faceRestore".to_owned(), Value::Bool(true));
+    }
+
+    // Per-image work items: (seed, prompt, action). Pose + angle sets share one seed (only the
+    // pose changes across the set — noise-derived attributes stay constant); single identity is
+    // per-seed at the reference's natural pose.
+    let (width, height) = (request.width, request.height);
+    let work: Vec<(i64, String, InstantIdAction)> = match &mode {
+        InstantIdMode::PoseSet(_) => {
+            let set_seed = resolve_seed(request, 0);
+            parse_poses(request)
+                .into_iter()
+                .map(|pose| {
+                    (
+                        set_seed,
+                        request.prompt.clone(),
+                        InstantIdAction::Pose(pose_to_body_points(&pose.keypoints)),
+                    )
+                })
+                .collect()
+        }
+        InstantIdMode::AngleSet => {
+            let set_seed = resolve_seed(request, 0);
+            CHARACTER_ANGLE_SET_ORDER
+                .iter()
+                .map(|&angle| {
+                    (
+                        set_seed,
+                        augment_prompt_for_angle(&request.prompt, angle),
+                        InstantIdAction::Angle(angle),
+                    )
+                })
+                .collect()
+        }
+        InstantIdMode::Identity => (0..request.count as usize)
+            .map(|index| {
+                (
+                    resolve_seed(request, index),
+                    request.prompt.clone(),
+                    InstantIdAction::Identity,
+                )
+            })
+            .collect(),
+    };
+    let total = work.len();
+
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+
+    let blocking = {
+        let negative_prompt = request.negative_prompt.clone();
+        let cancel = cancel.clone();
+        let job_id = job.id.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            emit_load_event("image_pipeline_load_start", &job_id, "instantid", 0);
+            let paths = InstantIdPaths {
+                sdxl_base,
+                identitynet: controlnet,
+                ip_adapter,
+            };
+            let model = InstantId::load(&paths).map_err(|error| {
+                WorkerError::InvalidPayload(format!("InstantID load failed: {error}"))
+            })?;
+            // Attach OpenPose (pose mode) BEFORE quantize so it quantizes with the stack; quantize
+            // before with_face (the engine's documented order).
+            let model = match &openpose {
+                Some(source) => model.with_openpose(source).map_err(|error| {
+                    WorkerError::InvalidPayload(format!("InstantID OpenPose load failed: {error}"))
+                })?,
+                None => model,
+            };
+            let model = match quant_bits {
+                Some(bits) => model.quantize(bits).map_err(|error| {
+                    WorkerError::InvalidPayload(format!("InstantID quantize failed: {error}"))
+                })?,
+                None => model,
+            };
+            let scrfd = Weights::from_file(&scrfd_path).map_err(|error| {
+                WorkerError::InvalidPayload(format!(
+                    "InstantID SCRFD weights {scrfd_path:?}: {error}"
+                ))
+            })?;
+            let arcface = Weights::from_file(&arcface_path).map_err(|error| {
+                WorkerError::InvalidPayload(format!(
+                    "InstantID ArcFace weights {arcface_path:?}: {error}"
+                ))
+            })?;
+            let model = model.with_face(&scrfd, &arcface).map_err(|error| {
+                WorkerError::InvalidPayload(format!("InstantID face stack: {error}"))
+            })?;
+            // Face-restore needs the reference identity embedding (imposed on the re-rendered
+            // crop). Detect it once on the raw reference.
+            let restore_embedding = if face_restore {
+                Some(
+                    model
+                        .largest_face(
+                            &reference.pixels,
+                            reference.height as usize,
+                            reference.width as usize,
+                        )
+                        .map_err(|error| {
+                            WorkerError::InvalidPayload(format!(
+                                "InstantID face-restore reference: {error}"
+                            ))
+                        })?
+                        .embedding,
+                )
+            } else {
+                None
+            };
+            emit_load_event("image_pipeline_load_complete", &job_id, "instantid", 0);
+
+            for (index, (seed, prompt, action)) in work.into_iter().enumerate() {
+                if cancel.is_cancelled() {
+                    break;
+                }
+                // Angle + pose sets use a square canvas (the engine forces `req.height =
+                // req.width` for the canonical landmark/skeleton — the sc-2009 kps-aspect rule);
+                // single identity keeps the requested W×H (the engine letterboxes the reference).
+                let req = InstantIdRequest {
+                    prompt,
+                    negative: negative_prompt.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    ip_adapter_scale: ip_scale,
+                    controlnet_scale,
+                    openpose_scale,
+                    seed: seed as u64,
+                };
+                let mut out = match &action {
+                    InstantIdAction::Identity => model.generate(&req, &reference),
+                    InstantIdAction::Angle(angle) => model.generate_angle(&req, &reference, angle),
+                    InstantIdAction::Pose(keypoints) => {
+                        model.generate_pose(&req, &reference, keypoints)
+                    }
+                }
+                .map_err(|error| {
+                    WorkerError::InvalidPayload(format!("InstantID generation failed: {error}"))
+                })?;
+                // Optional ADetailer-style face-restore re-render (sc-3380), imposing the
+                // reference identity on the cropped face with the gender-neutral restore prompt.
+                if let Some(embedding) = &restore_embedding {
+                    let restore_req = InstantIdRequest {
+                        prompt: FACE_RESTORE_PROMPT.to_owned(),
+                        negative: negative_prompt.clone(),
+                        width: INSTANTID_FACE_RESTORE_SIDE,
+                        height: INSTANTID_FACE_RESTORE_SIDE,
+                        steps: steps as usize,
+                        guidance,
+                        ip_adapter_scale: ip_scale,
+                        controlnet_scale,
+                        openpose_scale,
+                        seed: seed as u64,
+                    };
+                    out = model
+                        .restore_face(&restore_req, &out, embedding)
+                        .map_err(|error| {
+                            WorkerError::InvalidPayload(format!(
+                                "InstantID face-restore failed: {error}"
+                            ))
+                        })?;
+                }
+                if tx
+                    .blocking_send(GenEvent::Image {
+                        index,
+                        seed,
+                        width: out.width,
+                        height: out.height,
+                        pixels: out.pixels,
+                    })
+                    .is_err()
+                {
+                    break; // receiver gone — stop generating.
+                }
+            }
+            Ok(())
+        })
+    };
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        "mlx_instantid",
         &raw_settings,
         total,
         rx,

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -54,7 +54,6 @@ Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust
 |---|---|---|---|
 | `kolors` | kolors (SDXL UNet + ChatGLM3) | 🔵 Port → drop-on-Mac until then | **epic 3532** |
 | `z_image_edit` | z-image (edit) | 🔵 Port → drop-on-Mac until then | **epic 3529** |
-| `instantid_realvisxl` | sdxl (InstantID) | 🔵 Port → drop-on-Mac until then | epic 3109 |
 | `pulid_flux_dev` | flux (PuLID) | 🔵 Port → drop-on-Mac until then | epic 3069 (engine done; owes SceneWorks routing) |
 | `sensenova_u1_8b`, `sensenova_u1_8b_fast` | sensenova-u1 | 🔵 Port → drop-on-Mac until then | epic 3180 |
 | `lens`, `lens_turbo` | lens (Python sidecar `/opt/lens-venv`) | 🔵 Port → drop-on-Mac until then | epic 3164 |
@@ -79,6 +78,7 @@ dropped — no silent drops.**
 | `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
 | reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🟢 Ported (MLX) | sc-3537 (spike) → epic 3641 (sc-3642/3643/3671 engine + sc-3644 routing) |
+| InstantID (identity, 11-view angle set, pose-library mode, face-restore) | `instantid_realvisxl` (`character_image` + `referenceAssetId`) | 🟢 Ported (MLX) | epic 3109 (engine: #153 identity/angle, #193 pose+restore — sc-3117/3380) → sc-3345 (identity+angle integration) + sc-3381 (pose+restore integration). Torch path kept as off-Mac + Mac-fallback (Decision-A); venv strip is the final epic-3482 step. |
 
 > **FLUX.1 `edit_image` is not an eradication gap (sc-3535).** The torch `FluxDiffusersAdapter`
 > hard-rejects `edit_image` ("does not support image editing") — FLUX.1 has no edit path on *any*


### PR DESCRIPTION
Brings the **full InstantID surface** onto the in-process Rust MLX worker on Mac (zero Python): single identity, the 11-view Character-Studio angle set, pose-library mode (MultiControlNet IdentityNet + OpenPose), and the ADetailer-style face-restore pass. `instantid_realvisxl` character jobs now route to the native `mlx-gen-instantid` provider; the torch `InstantIDAdapter` is kept as the off-Mac path + Mac fallback (Decision-A, per sc-3060). Part of epic 3018 / epic 3482 (Python eradication on Mac).

Two stories land together on this branch (tightly coupled — same files):

## sc-3345 — identity + 11-view angle set
- Add `mlx-gen-instantid` + `mlx-gen-face` (`cfg(macOS)`) worker deps.
- Dedicated `generate_instantid_stream` — the provider is the **bespoke `InstantId` API**, not an inventory `Generator`, so it gets its own stream parallel to the sc-3060 SDXL-advanced path (not an `MLX_MODELS` row). Reference-face payload, `ipAdapterScale`/`controlnetConditioningScale`, RealVisXL-tuned guidance(3.0)/steps(30) defaults, **fp16 default** (Q8/Q4 only on explicit `mlxQuantize`), engine-side letterbox, generation-set lineage + telemetry, per-image streaming.
- Download-on-first-use weight resolution (RealVisXL base + InstantX `ControlNetModel` + the converted `SceneWorks/instantid-mlx` bundle) with env overrides.
- Route `instantid_realvisxl` in `jobs_store` (`MLX_ROUTED_MODELS` + `instantid_mlx_eligible`).

## sc-3381 — pose-library mode + face-restore (engine PR #193)
- Bump worker `mlx-gen` pin `a67e8ed` → `ed8e6a1` (mlx-rs pin unchanged → no MLX-core churn).
- `InstantIdMode` dispatch (PoseSet > AngleSet > Identity, torch-parity precedence): pose set → `with_openpose(xinsir)` + `generate_pose` per pose (keypoints bridged from the existing `parse_poses`, `f32`→`f64` since engine `BodyPoint = Option<(f64,f64)>`); `advanced.faceRestore` → `restore_face` on each output with the reference embedding + gender-neutral prompt; `openPoseScale` default 0.7; xinsir OpenPose-SDXL download-on-first-use.
- Drop the pose/faceRestore routing exclusions; simplify the `classify_image_gap` arm; update the Mac-support oracle test + `docs/mac-rust-gaps.md` (full surface → Ported).

## Validation
- `cargo fmt --all --check` clean · `cargo clippy -p sceneworks-worker -p sceneworks-core --tests -- -D warnings` clean · worker **193** + core **125** tests · `sceneworks-rust-api` builds. Worker compiles against the new engine rev.
- **Real-weight RealVisXL_V5.0 @1024²/30** (in-process MLX, the exact engine entry points the worker calls):

  | Mode | ArcFace-cosine |
  |---|---|
  | identity (`generate`) | **0.8731** (≈ torch baseline 0.876) |
  | angle (`generate_angle`, ¾-right) | **0.8343** |
  | pose (`generate_pose`, full-body) | **0.7129** |
  | face-restore (`restore_face`) | base 0.7370 → **0.8338** |

## Reviewer notes
- **Torch path is NOT deleted** — it remains the off-Mac backend + Mac fallback-when-mlx-down. The actual venv/`requirements-instantid.txt` strip is the final epic-3482 step, not this PR.
- **Converted weights published**: public, ungated `SceneWorks/instantid-mlx` (ip-adapter + SCRFD + ArcFace + model card). ⚠️ **Licensing**: the ip-adapter is Apache-2.0 (InstantX/InstantID), but SCRFD + ArcFace derive from InsightFace `antelopev2` which is **non-commercial research only** — flagged on the model card; worth a product decision before commercial distribution.
- Engine API limits (acceptable for v1): `generate*` expose no mid-denoise progress/cancel → per-image streaming, cancellation honoured between images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)