### PR TITLE
sc-3345 + sc-3381: native InstantID full surface on Mac (identity + angle set + pose mode + face-restore)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee#ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee"
 dependencies = [
  "image",
  "inventory",
@@ -2953,7 +2953,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-face"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
@@ -2551,6 +2561,17 @@ dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
  "serde_json",
+]
+
+[[package]]
+name = "mlx-gen-instantid"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a67e8ed41f372e502ceb2128a140f24f8252248e#a67e8ed41f372e502ceb2128a140f24f8252248e"
+dependencies = [
+ "mlx-gen",
+ "mlx-gen-face",
+ "mlx-gen-sdxl",
+ "pmetal-mlx-rs",
 ]
 
 [[package]]
@@ -2932,7 +2953,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4204,8 +4225,10 @@ dependencies = [
  "imageproc",
  "mlx-gen",
  "mlx-gen-chroma",
+ "mlx-gen-face",
  "mlx-gen-flux",
  "mlx-gen-flux2",
+ "mlx-gen-instantid",
  "mlx-gen-joycaption",
  "mlx-gen-ltx",
  "mlx-gen-qwen-image",

--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -170,7 +170,10 @@ ANGLE_SET_ORDER: tuple[str, ...] = (
 # the kps-distortion rule). The face is small at full-body framing, so a face-restoration
 # pass re-imposes identity afterward (sc-2063 spike: ~0.38 -> ~0.88 ArcFace cosine).
 _POSE_SIZE: int = 1024
-_FACE_RESTORE_PROMPT = "close-up portrait of the woman's face, soft natural light, photorealistic, sharp focus"
+# Gender-neutral on purpose (sc-3381): this prompt is applied to EVERY character during the
+# face-restore re-render, so it must not assume a gender. (The native MLX engine's
+# `FACE_RESTORE_PROMPT` is the same neutral wording.)
+_FACE_RESTORE_PROMPT = "close-up portrait of the face, soft natural light, photorealistic, sharp focus"
 
 
 class InstantIDAdapter:

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2216,49 +2216,16 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             "the Qwen-Image-Edit model needs edit_image+sourceAssetId or character_image+referenceAssetId to route to MLX.",
             None,
         ),
-        // InstantID (sc-3345): single-identity + the 11-view angle set run on MLX. The remaining
-        // gaps are pose-library mode (engine sc-3117) and face-restore (engine sc-3380); a
-        // reference-less / non-character job has no InstantID path at all. Mirrors
-        // `instantid_mlx_eligible` so the named gap matches why routing refused it.
-        "instantid_realvisxl" => {
-            let advanced = payload.get("advanced").and_then(Value::as_object);
-            let has_poses = advanced
-                .and_then(|advanced| advanced.get("poses"))
-                .and_then(Value::as_array)
-                .map(|poses| poses.iter().filter(|pose| pose.is_object()).count())
-                .unwrap_or(0)
-                > 0;
-            let face_restore = match advanced.and_then(|advanced| advanced.get("faceRestore")) {
-                Some(Value::Bool(value)) => *value,
-                Some(Value::Number(number)) => {
-                    number.as_f64().map(|value| value != 0.0).unwrap_or(false)
-                }
-                Some(Value::String(value)) => !value.is_empty(),
-                _ => false,
-            };
-            if has_poses {
-                UnsupportedReason::new(
-                    Some(model),
-                    "InstantID pose-library mode",
-                    "InstantID single-identity + the 11-view angle set run on MLX (sc-3345); the pose-library MultiControlNet mode (IdentityNet + OpenPose) stays on the Python torch path until the engine pose port lands.",
-                    Some("sc-3117"),
-                )
-            } else if face_restore {
-                UnsupportedReason::new(
-                    Some(model),
-                    "InstantID face-restore",
-                    "InstantID identity + angle set run on MLX (sc-3345); the face-restore re-render pass stays on the Python torch path until it is ported.",
-                    Some("sc-3380"),
-                )
-            } else {
-                UnsupportedReason::new(
-                    Some(model),
-                    "InstantID without a character reference",
-                    "InstantID runs on MLX for character_image with a referenceAssetId (single identity + the 11-view angle set, sc-3345); a non-character / reference-less job has no InstantID path.",
-                    None,
-                )
-            }
-        }
+        // InstantID (sc-3345 + sc-3381): single identity, the 11-view angle set, pose-library mode
+        // (engine sc-3117) and face-restore (engine sc-3380) all run on MLX now. The only remaining
+        // non-MLX shape is a reference-less / non-character job, which has no InstantID path at all.
+        // Mirrors `instantid_mlx_eligible` so the named gap matches why routing refused it.
+        "instantid_realvisxl" => UnsupportedReason::new(
+            Some(model),
+            "InstantID without a character reference",
+            "InstantID runs on MLX for character_image with a referenceAssetId (identity, the 11-view angle set, pose-library mode, and face-restore, sc-3345 + sc-3381); a non-character / reference-less job has no InstantID path.",
+            None,
+        ),
         // flux2 / sdxl / realvisxl only fall out via LyCORIS (handled above) — defensive.
         _ => UnsupportedReason::new(
             Some(model),
@@ -2646,10 +2613,10 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux2_klein_9b_true_v2",
     "sdxl",
     "realvisxl",
-    // InstantID on RealVisXL (sc-3345): single-identity + the 11-view angle set route to the
-    // native `mlx-gen-instantid` provider. Pose-library + face-restore InstantID jobs are gated
-    // OUT by `instantid_mlx_eligible` and stay on the torch `InstantIDAdapter` (engine sc-3117 /
-    // sc-3380 not ported).
+    // InstantID on RealVisXL (sc-3345 + sc-3381): identity, the 11-view angle set, pose-library
+    // mode (MultiControlNet IdentityNet + OpenPose), and face-restore all route to the native
+    // `mlx-gen-instantid` provider. The torch `InstantIDAdapter` stays only off-Mac + as the
+    // mlx-down fallback.
     "instantid_realvisxl",
     "chroma1_hd",
     "chroma1_base",
@@ -2750,38 +2717,16 @@ fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
 }
 
-/// InstantID (`instantid_realvisxl`, sc-3345) MLX-routing conditions. The native
-/// `mlx-gen-instantid` provider serves single-identity `character_image` + the 11-view
-/// Character-Studio angle set on Mac. **Pose-library mode (`advanced.poses`) and face-restore
-/// (`advanced.faceRestore`) stay on the torch `InstantIDAdapter`** — the engine has neither
-/// (sc-3117 MultiControlNet pose + sc-3380 face-restore are not ported), so excluding them here
-/// keeps those jobs off the `mlx` worker and lets the torch worker claim them (the Decision-A
-/// fallback, per sc-3060). These exclusions MUST mirror the worker's `instantid_available` gate
-/// so the router and the worker never disagree (a job routed to `mlx` that the worker rejects
-/// would fall through to the procedural stub). Requires a reference face image.
+/// InstantID (`instantid_realvisxl`, sc-3345 + sc-3381) MLX-routing conditions. The native
+/// `mlx-gen-instantid` provider serves the full production surface on Mac: single-identity
+/// `character_image`, the 11-view Character-Studio angle set, pose-library mode (`advanced.poses`
+/// → MultiControlNet IdentityNet + OpenPose, engine sc-3117) and the optional face-restore
+/// re-render (`advanced.faceRestore`, engine sc-3380). So the only gate is a `character_image`
+/// job with a reference face — there is no remaining torch-only InstantID shape. This MUST mirror
+/// the worker's `instantid_available` gate so the router and the worker never disagree (a job
+/// routed to `mlx` that the worker rejects would fall through to the procedural stub).
 fn instantid_mlx_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) != Some("character_image") {
-        return false;
-    }
-    let advanced = payload.get("advanced").and_then(Value::as_object);
-    // Pose-library mode: any pose *object* in `advanced.poses` (mirrors the worker's
-    // `pose_entries`, which filters to objects) → torch.
-    let pose_objects = advanced
-        .and_then(|advanced| advanced.get("poses"))
-        .and_then(Value::as_array)
-        .map(|poses| poses.iter().filter(|pose| pose.is_object()).count())
-        .unwrap_or(0);
-    if pose_objects > 0 {
-        return false;
-    }
-    // Face-restore: truthy `advanced.faceRestore` (mirrors the worker's `advanced_flag`) → torch.
-    let face_restore = match advanced.and_then(|advanced| advanced.get("faceRestore")) {
-        Some(Value::Bool(value)) => *value,
-        Some(Value::Number(number)) => number.as_f64().map(|value| value != 0.0).unwrap_or(false),
-        Some(Value::String(value)) => !value.is_empty(),
-        _ => false,
-    };
-    if face_restore {
         return false;
     }
     payload
@@ -3675,7 +3620,7 @@ mod mlx_routing_tests {
     }
 
     #[test]
-    fn instantid_routes_identity_and_angle_set_but_pose_and_facerestore_stay_torch() {
+    fn instantid_routes_identity_angle_pose_and_facerestore_to_mlx() {
         // Single-identity character image → MLX (the native InstantID provider, sc-3345).
         let identity = object(json!({
             "model": "instantid_realvisxl",
@@ -3685,7 +3630,7 @@ mod mlx_routing_tests {
         assert!(instantid_mlx_eligible(&identity));
         assert!(image_request_mlx_eligible("instantid_realvisxl", &identity));
 
-        // The 11-view angle set is still MLX (angleSet is a worker-side grouping, not a gate).
+        // The 11-view angle set is MLX (angleSet is a worker-side grouping, not a gate).
         assert!(instantid_mlx_eligible(&object(json!({
             "model": "instantid_realvisxl",
             "mode": "character_image",
@@ -3693,20 +3638,20 @@ mod mlx_routing_tests {
             "advanced": { "angleSet": true }
         }))));
 
-        // Pose-library mode (engine sc-3117 not ported) → torch.
-        assert!(!instantid_mlx_eligible(&object(json!({
+        // Pose-library mode (engine sc-3117) → MLX (sc-3381).
+        assert!(instantid_mlx_eligible(&object(json!({
             "model": "instantid_realvisxl",
             "mode": "character_image",
             "referenceAssetId": "asset_1",
             "advanced": { "poses": [{ "id": "a" }] }
         }))));
 
-        // Face-restore (engine sc-3380 not ported) → torch.
-        assert!(!instantid_mlx_eligible(&object(json!({
+        // Face-restore (engine sc-3380) → MLX (sc-3381).
+        assert!(instantid_mlx_eligible(&object(json!({
             "model": "instantid_realvisxl",
             "mode": "character_image",
             "referenceAssetId": "asset_1",
-            "advanced": { "faceRestore": true }
+            "advanced": { "poses": [{ "id": "a" }], "faceRestore": true }
         }))));
 
         // No reference face → not eligible.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2155,7 +2155,10 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
 fn torch_only_image_model_epic(model: &str) -> Option<&'static str> {
     match model {
         "kolors" => Some("epic 3532"),
-        "instantid_realvisxl" => Some("epic 3109"),
+        // InstantID (instantid_realvisxl) was ported to MLX (epic 3109 engine / sc-3345) — it is
+        // now in `MLX_ROUTED_MODELS`, so it never reaches this torch-only classifier. Its
+        // remaining gaps (pose-library mode, face-restore) are named per-feature in
+        // `classify_image_gap`, not as a whole-model gap.
         "pulid_flux_dev" => Some("epic 3069"),
         "z_image_edit" => Some("epic 3529"),
         m if m.starts_with("sensenova") => Some("epic 3180"),
@@ -2213,6 +2216,49 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             "the Qwen-Image-Edit model needs edit_image+sourceAssetId or character_image+referenceAssetId to route to MLX.",
             None,
         ),
+        // InstantID (sc-3345): single-identity + the 11-view angle set run on MLX. The remaining
+        // gaps are pose-library mode (engine sc-3117) and face-restore (engine sc-3380); a
+        // reference-less / non-character job has no InstantID path at all. Mirrors
+        // `instantid_mlx_eligible` so the named gap matches why routing refused it.
+        "instantid_realvisxl" => {
+            let advanced = payload.get("advanced").and_then(Value::as_object);
+            let has_poses = advanced
+                .and_then(|advanced| advanced.get("poses"))
+                .and_then(Value::as_array)
+                .map(|poses| poses.iter().filter(|pose| pose.is_object()).count())
+                .unwrap_or(0)
+                > 0;
+            let face_restore = match advanced.and_then(|advanced| advanced.get("faceRestore")) {
+                Some(Value::Bool(value)) => *value,
+                Some(Value::Number(number)) => {
+                    number.as_f64().map(|value| value != 0.0).unwrap_or(false)
+                }
+                Some(Value::String(value)) => !value.is_empty(),
+                _ => false,
+            };
+            if has_poses {
+                UnsupportedReason::new(
+                    Some(model),
+                    "InstantID pose-library mode",
+                    "InstantID single-identity + the 11-view angle set run on MLX (sc-3345); the pose-library MultiControlNet mode (IdentityNet + OpenPose) stays on the Python torch path until the engine pose port lands.",
+                    Some("sc-3117"),
+                )
+            } else if face_restore {
+                UnsupportedReason::new(
+                    Some(model),
+                    "InstantID face-restore",
+                    "InstantID identity + angle set run on MLX (sc-3345); the face-restore re-render pass stays on the Python torch path until it is ported.",
+                    Some("sc-3380"),
+                )
+            } else {
+                UnsupportedReason::new(
+                    Some(model),
+                    "InstantID without a character reference",
+                    "InstantID runs on MLX for character_image with a referenceAssetId (single identity + the 11-view angle set, sc-3345); a non-character / reference-less job has no InstantID path.",
+                    None,
+                )
+            }
+        }
         // flux2 / sdxl / realvisxl only fall out via LyCORIS (handled above) — defensive.
         _ => UnsupportedReason::new(
             Some(model),
@@ -2600,6 +2646,11 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "flux2_klein_9b_true_v2",
     "sdxl",
     "realvisxl",
+    // InstantID on RealVisXL (sc-3345): single-identity + the 11-view angle set route to the
+    // native `mlx-gen-instantid` provider. Pose-library + face-restore InstantID jobs are gated
+    // OUT by `instantid_mlx_eligible` and stay on the torch `InstantIDAdapter` (engine sc-3117 /
+    // sc-3380 not ported).
+    "instantid_realvisxl",
     "chroma1_hd",
     "chroma1_base",
     "chroma1_flash",
@@ -2655,6 +2706,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
             flux2_mlx_eligible(payload)
         }
         "sdxl" | "realvisxl" => sdxl_mlx_eligible(payload),
+        "instantid_realvisxl" => instantid_mlx_eligible(payload),
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => chroma_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
@@ -2696,6 +2748,46 @@ fn job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// `image_detail` is a separate job type with its own routing (see `image_detail_mlx_eligible`).
 fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
+}
+
+/// InstantID (`instantid_realvisxl`, sc-3345) MLX-routing conditions. The native
+/// `mlx-gen-instantid` provider serves single-identity `character_image` + the 11-view
+/// Character-Studio angle set on Mac. **Pose-library mode (`advanced.poses`) and face-restore
+/// (`advanced.faceRestore`) stay on the torch `InstantIDAdapter`** — the engine has neither
+/// (sc-3117 MultiControlNet pose + sc-3380 face-restore are not ported), so excluding them here
+/// keeps those jobs off the `mlx` worker and lets the torch worker claim them (the Decision-A
+/// fallback, per sc-3060). These exclusions MUST mirror the worker's `instantid_available` gate
+/// so the router and the worker never disagree (a job routed to `mlx` that the worker rejects
+/// would fall through to the procedural stub). Requires a reference face image.
+fn instantid_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("character_image") {
+        return false;
+    }
+    let advanced = payload.get("advanced").and_then(Value::as_object);
+    // Pose-library mode: any pose *object* in `advanced.poses` (mirrors the worker's
+    // `pose_entries`, which filters to objects) → torch.
+    let pose_objects = advanced
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .map(|poses| poses.iter().filter(|pose| pose.is_object()).count())
+        .unwrap_or(0);
+    if pose_objects > 0 {
+        return false;
+    }
+    // Face-restore: truthy `advanced.faceRestore` (mirrors the worker's `advanced_flag`) → torch.
+    let face_restore = match advanced.and_then(|advanced| advanced.get("faceRestore")) {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Number(number)) => number.as_f64().map(|value| value != 0.0).unwrap_or(false),
+        Some(Value::String(value)) => !value.is_empty(),
+        _ => false,
+    };
+    if face_restore {
+        return false;
+    }
+    payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 /// FLUX.2-klein MLX-routing conditions. FLUX.2-klein is an **MLX-only** family (no torch backend),
@@ -3346,9 +3438,9 @@ fn sort_json_value(value: &mut Value) {
 #[cfg(test)]
 mod mlx_routing_tests {
     use super::{
-        flux2_mlx_eligible, flux_mlx_eligible, qwen_edit_mlx_eligible, qwen_mlx_eligible,
-        sdxl_mlx_eligible, video_mode_is_mlx_eligible, z_image_mlx_eligible,
-        VIDEO_MLX_ROUTED_MODELS,
+        flux2_mlx_eligible, flux_mlx_eligible, image_request_mlx_eligible, instantid_mlx_eligible,
+        qwen_edit_mlx_eligible, qwen_mlx_eligible, sdxl_mlx_eligible, video_mode_is_mlx_eligible,
+        z_image_mlx_eligible, VIDEO_MLX_ROUTED_MODELS,
     };
     use serde_json::{json, Map, Value};
 
@@ -3579,6 +3671,54 @@ mod mlx_routing_tests {
         assert!(sdxl_mlx_eligible(&object(json!({
             "mode": "edit_image",
             "loras": [{ "networkType": "lycoris" }]
+        }))));
+    }
+
+    #[test]
+    fn instantid_routes_identity_and_angle_set_but_pose_and_facerestore_stay_torch() {
+        // Single-identity character image → MLX (the native InstantID provider, sc-3345).
+        let identity = object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1"
+        }));
+        assert!(instantid_mlx_eligible(&identity));
+        assert!(image_request_mlx_eligible("instantid_realvisxl", &identity));
+
+        // The 11-view angle set is still MLX (angleSet is a worker-side grouping, not a gate).
+        assert!(instantid_mlx_eligible(&object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "angleSet": true }
+        }))));
+
+        // Pose-library mode (engine sc-3117 not ported) → torch.
+        assert!(!instantid_mlx_eligible(&object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "poses": [{ "id": "a" }] }
+        }))));
+
+        // Face-restore (engine sc-3380 not ported) → torch.
+        assert!(!instantid_mlx_eligible(&object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "faceRestore": true }
+        }))));
+
+        // No reference face → not eligible.
+        assert!(!instantid_mlx_eligible(&object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image"
+        }))));
+
+        // Non-character mode → not eligible (InstantID is a character flow).
+        assert!(!instantid_mlx_eligible(&object(json!({
+            "model": "instantid_realvisxl",
+            "mode": "text_to_image"
         }))));
     }
 

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1800,9 +1800,9 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
     let cases = [
         ("kolors", "epic 3532"),
         ("z_image_edit", "epic 3529"),
-        // instantid_realvisxl is NO LONGER wholly torch-only (sc-3345: identity + angle set run on
-        // MLX); its remaining per-feature gaps are covered by
-        // `mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped`.
+        // instantid_realvisxl is NOT torch-only — its full surface (identity, angle set, pose mode,
+        // face-restore) runs on MLX (sc-3345 + sc-3381); covered by
+        // `mac_rust_supported_instantid_identity_angle_pose_and_facerestore_ok`.
         ("sensenova_u1_8b", "epic 3180"),
         ("lens_turbo", "epic 3164"),
     ];
@@ -1824,7 +1824,7 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
 }
 
 #[test]
-fn mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped() {
+fn mac_rust_supported_instantid_identity_angle_pose_and_facerestore_ok() {
     let store = store("oracle-instantid");
     // Single-identity InstantID character image → supported (the native provider, sc-3345).
     let identity = job_of(
@@ -1852,7 +1852,7 @@ fn mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped() {
     );
     assert!(mac_rust_supported(&angle_set).is_ok());
 
-    // Pose-library mode is still a tracked gap → engine sc-3117.
+    // Pose-library mode now runs natively (engine sc-3117 → sc-3381).
     let pose = job_of(
         &store,
         JobType::ImageGenerate,
@@ -1863,11 +1863,9 @@ fn mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped() {
             "advanced": { "poses": [{ "id": "a" }] }
         }),
     );
-    let pose_reason = mac_rust_supported(&pose).unwrap_err();
-    assert_eq!(pose_reason.model.as_deref(), Some("instantid_realvisxl"));
-    assert_eq!(pose_reason.suggested_epic.as_deref(), Some("sc-3117"));
+    assert!(mac_rust_supported(&pose).is_ok());
 
-    // Face-restore is still a tracked gap → engine sc-3380.
+    // Pose + face-restore now runs natively (engine sc-3380 → sc-3381).
     let face_restore = job_of(
         &store,
         JobType::ImageGenerate,
@@ -1875,12 +1873,23 @@ fn mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped() {
             "model": "instantid_realvisxl",
             "mode": "character_image",
             "referenceAssetId": "asset_1",
-            "advanced": { "faceRestore": true }
+            "advanced": { "poses": [{ "id": "a" }], "faceRestore": true }
         }),
     );
-    let fr_reason = mac_rust_supported(&face_restore).unwrap_err();
-    assert_eq!(fr_reason.model.as_deref(), Some("instantid_realvisxl"));
-    assert_eq!(fr_reason.suggested_epic.as_deref(), Some("sc-3380"));
+    assert!(mac_rust_supported(&face_restore).is_ok());
+
+    // A character job WITHOUT a reference face has no InstantID path → the one remaining gap.
+    let no_reference = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "prompt": "p"
+        }),
+    );
+    let reason = mac_rust_supported(&no_reference).unwrap_err();
+    assert_eq!(reason.model.as_deref(), Some("instantid_realvisxl"));
 }
 
 #[test]

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1800,7 +1800,9 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
     let cases = [
         ("kolors", "epic 3532"),
         ("z_image_edit", "epic 3529"),
-        ("instantid_realvisxl", "epic 3109"),
+        // instantid_realvisxl is NO LONGER wholly torch-only (sc-3345: identity + angle set run on
+        // MLX); its remaining per-feature gaps are covered by
+        // `mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped`.
         ("sensenova_u1_8b", "epic 3180"),
         ("lens_turbo", "epic 3164"),
     ];
@@ -1819,6 +1821,66 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
         );
         assert!(reason.error_message().starts_with("mlx_unsupported:"));
     }
+}
+
+#[test]
+fn mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped() {
+    let store = store("oracle-instantid");
+    // Single-identity InstantID character image → supported (the native provider, sc-3345).
+    let identity = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "prompt": "p"
+        }),
+    );
+    assert!(mac_rust_supported(&identity).is_ok());
+
+    // The 11-view angle set is also supported.
+    let angle_set = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "angleSet": true }
+        }),
+    );
+    assert!(mac_rust_supported(&angle_set).is_ok());
+
+    // Pose-library mode is still a tracked gap → engine sc-3117.
+    let pose = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "poses": [{ "id": "a" }] }
+        }),
+    );
+    let pose_reason = mac_rust_supported(&pose).unwrap_err();
+    assert_eq!(pose_reason.model.as_deref(), Some("instantid_realvisxl"));
+    assert_eq!(pose_reason.suggested_epic.as_deref(), Some("sc-3117"));
+
+    // Face-restore is still a tracked gap → engine sc-3380.
+    let face_restore = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({
+            "model": "instantid_realvisxl",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "faceRestore": true }
+        }),
+    );
+    let fr_reason = mac_rust_supported(&face_restore).unwrap_err();
+    assert_eq!(fr_reason.model.as_deref(), Some("instantid_realvisxl"));
+    assert_eq!(fr_reason.suggested_epic.as_deref(), Some("sc-3380"));
 }
 
 #[test]
@@ -3603,9 +3665,9 @@ fn non_mlx_model_image_job_is_not_routed_to_mlx_worker() {
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // A torch-only image model with no mlx-gen engine (e.g. kolors — InstantID/Kolors/
-    // PuLID/SenseNova have no MLX crate) stays on the Python path: the torch worker
-    // claims it without deferral, and the mlx worker would refuse it.
+    // A torch-only image model with no mlx-gen engine (e.g. kolors — Kolors/PuLID/SenseNova
+    // have no MLX crate; InstantID is now ported, sc-3345) stays on the Python path: the torch
+    // worker claims it without deferral, and the mlx worker would refuse it.
     let job = store
         .create_job(image_job_with(
             json!({ "model": "kolors", "prompt": "p" }),

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,7 +68,13 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev a67e8ed (mlx-gen main, merged PR #189, epic 3531): adds the native-MLX Chroma family
+# Rev ed8e6a1 (mlx-gen main, merged PR #193, epic 3109 / sc-3117 + sc-3380): adds the native
+# InstantID pose mode (MultiControlNet IdentityNet + OpenPose, `InstantId::with_openpose` /
+# `generate_pose`) and the ADetailer-style face-restore pass (`InstantId::restore_face`), consumed
+# by the `instantid_realvisxl` pose-library + face-restore cutover (sc-3381). The mlx-rs pin is
+# unchanged (e59ffd88, identical at this rev) and only the `mlx-gen-instantid` crate gained API, so
+# MLX rebuilds nothing and the other families are byte-for-byte the prior `a67e8ed` tree + #190..#193.
+# On top of rev a67e8ed (merged PR #189, epic 3531): adds the native-MLX Chroma family
 # crate `mlx-gen-chroma` (chroma1_hd/base/flash — a FLUX.1-schnell-derived DiT + distilled-guidance
 # Approximator, T5-only true-CFG conditioning, MMDiT attention masking; sc-3834..sc-3842), all
 # three variants at real-weight e2e parity vs diffusers plus Q4/Q8 + LoRA/LoKr. The mlx-rs pin is
@@ -91,7 +97,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -99,54 +105,54 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f3
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face(scrfd, arcface)` → `generate`/`generate_angle`), NOT an inventory-registered
@@ -154,7 +160,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8e
 # to the sc-3060 SDXL-advanced path), not the MLX_MODELS table. Composes mlx-gen-sdxl (UNet +
 # IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. Same git rev (already
 # contains PR #153 + the sc-3329 quant fix #155) + mlx-rs pin so MLX builds once.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ed8e6a116422da1f3ad1b5ca1ecfd28cfd4a14ee" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -142,6 +142,19 @@ mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
 mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+# Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
+# (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
+# provider) consumed by the InstantID provider below to detect the reference face + produce
+# the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
+# InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
+# bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
+# `.with_face(scrfd, arcface)` → `generate`/`generate_angle`), NOT an inventory-registered
+# `Generator` — wired via a dedicated `generate_instantid_stream` in image_jobs.rs (parallel
+# to the sc-3060 SDXL-advanced path), not the MLX_MODELS table. Composes mlx-gen-sdxl (UNet +
+# IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. Same git rev (already
+# contains PR #153 + the sc-3329 quant fix #155) + mlx-rs pin so MLX builds once.
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a67e8ed41f372e502ceb2128a140f24f8252248e" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -46,7 +46,11 @@ use mlx_gen::weights::Weights;
 #[cfg(target_os = "macos")]
 use mlx_gen_face as _;
 #[cfg(target_os = "macos")]
-use mlx_gen_instantid::{InstantId, InstantIdPaths, InstantIdRequest};
+use mlx_gen_instantid::{
+    letterbox as instantid_letterbox, normalize_keypoints as instantid_normalize_keypoints,
+    BodyPoint, InstantId, InstantIdPaths, InstantIdRequest, DEFAULT_OPENPOSE_SCALE,
+    FACE_RESTORE_PROMPT,
+};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -415,11 +419,11 @@ pub(crate) async fn run_image_generate_job(
         .await?;
         true
     } else if instantid_available(&request, settings) {
-        // InstantID identity-preserving character image (sc-3345): single identity or the
-        // 11-view Character-Studio angle set, on RealVisXL + IdentityNet + the native face
-        // stack. Pose-library + faceRestore jobs are NOT eligible (kept on the torch
-        // adapter) — `instantid_available` gates them out so they fall through to the
-        // non-handled path and the torch worker claims them.
+        // InstantID identity-preserving character image (sc-3345 + sc-3381): single identity,
+        // the 11-view Character-Studio angle set, pose-library mode (MultiControlNet IdentityNet +
+        // OpenPose), and the optional face-restore re-render — all on RealVisXL + the native face
+        // stack, zero Python. The torch `InstantIDAdapter` stays only for off-Mac + the mlx-down
+        // fallback (Decision-A).
         generate_instantid_stream(
             api,
             settings,
@@ -4009,18 +4013,18 @@ async fn generate_sdxl_advanced_stream(
 }
 
 // ---------------------------------------------------------------------------
-// InstantID identity-preserving character image (macOS, epic 3109 engine / sc-3345
-// integration): the production `instantid_realvisxl` model — InstantID on RealVisXL +
-// the stock SDXL IdentityNet ControlNet + the native MLX face stack (SCRFD + ArcFace),
-// all in-process with zero Python. Two modes only (torch parity): a single-identity
-// `character_image` (the reference's natural head pose) and the 11-view Character-Studio
-// angle set. Pose-library mode (`advanced.poses`) + face-restore (`advanced.faceRestore`)
-// are NOT handled here — they stay on the torch `InstantIDAdapter` (engine sc-3117 /
-// sc-3380 not yet ported), gated out by `instantid_available` so the torch worker claims
-// them. fp16 only for now (the validated envelope); Q8/Q4 ride explicit `mlxQuantize`
-// (unvalidated at 1024², gated by sc-3329 follow-up). The provider is the bespoke
-// `mlx_gen_instantid::InstantId` (not an inventory `Generator`), so this is a dedicated
-// stream parallel to `generate_sdxl_advanced_stream`, not an MLX_MODELS row.
+// InstantID identity-preserving character image (macOS, epic 3109 engine / sc-3345 + sc-3381
+// integration): the production `instantid_realvisxl` model — InstantID on RealVisXL + the stock
+// SDXL IdentityNet ControlNet + the native MLX face stack (SCRFD + ArcFace), all in-process with
+// zero Python. The FULL torch surface (sc-3381): single-identity `character_image` (the
+// reference's natural head pose), the 11-view Character-Studio angle set, pose-library mode
+// (`advanced.poses` → MultiControlNet IdentityNet + the xinsir OpenPose-SDXL ControlNet, engine
+// sc-3117), and the optional face-restore re-render (`advanced.faceRestore`, engine sc-3380). The
+// torch `InstantIDAdapter` is kept only off-Mac + as the mlx-down fallback (Decision-A). fp16 by
+// default (the validated envelope); Q8/Q4 ride explicit `mlxQuantize` (unvalidated at 1024²,
+// gated by sc-3329 follow-up). The provider is the bespoke `mlx_gen_instantid::InstantId` (not an
+// inventory `Generator`), so this is a dedicated stream parallel to `generate_sdxl_advanced_stream`,
+// not an MLX_MODELS row.
 // ---------------------------------------------------------------------------
 
 /// The SceneWorks model id for native InstantID (production = InstantID on RealVisXL_V5.0).
@@ -4058,12 +4062,66 @@ const INSTANTID_DEFAULT_GUIDANCE: f32 = 3.0;
 const INSTANTID_IP_SCALE: f32 = 0.8;
 #[cfg(target_os = "macos")]
 const INSTANTID_CONTROLNET_SCALE: f32 = 0.8;
+/// The xinsir OpenPose-SDXL ControlNet (Apache-2.0) that drives the body skeleton in pose mode
+/// (`MODEL_TARGETS["instantid_realvisxl"]["openPose"]["repo"]`). Loaded as a stock diffusers SDXL
+/// ControlNet — the engine reads only the safetensors (`config.json` is unused; its config is
+/// fixed to `UNetConfig::sdxl_base()`).
+#[cfg(target_os = "macos")]
+const INSTANTID_OPENPOSE_REPO: &str = "xinsir/controlnet-openpose-sdxl-1.0";
+#[cfg(target_os = "macos")]
+const INSTANTID_OPENPOSE_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// Pose-mode canvas side — the production `_POSE_SIZE` (square 1024); the engine `generate_pose`
+/// uses `req.width` as the square side and renders the skeleton + re-placed face landmarks on it.
+#[cfg(target_os = "macos")]
+const INSTANTID_POSE_SIZE: u32 = 1024;
 
-/// True when this job carries a pose-library set (`advanced.poses`) — InstantID pose mode is
-/// torch-only (engine sc-3117 not ported), so these are excluded from the MLX path.
+/// True when this job carries a pose-library set (`advanced.poses`) — InstantID pose mode
+/// (MultiControlNet IdentityNet + OpenPose, engine sc-3117) now runs natively (sc-3381).
 #[cfg(target_os = "macos")]
 fn instantid_pose_set(request: &ImageRequest) -> bool {
     !pose_entries(request).is_empty()
+}
+
+/// One InstantID render in a job's set: a single identity (the reference's natural head pose), a
+/// canonical Character-Studio view angle, or a library pose (COCO-18 keypoints driving OpenPose).
+#[cfg(target_os = "macos")]
+enum InstantIdShot {
+    Identity,
+    Angle(&'static str),
+    Pose(Vec<BodyPoint>),
+}
+
+/// COCO-18 keypoints for one `advanced.poses` gallery entry, parsed to the engine's `BodyPoint`
+/// (normalized `[0,1]`; `None` for absent / zero-confidence joints) via the engine's own
+/// `normalize_keypoints` — the exact coercion the production `openpose_skeleton.py::normalize_keypoints`
+/// applies (`[x,y]` / `[x,y,conf<=0 → drop]` / `null`, truncated/padded to 18). f64 throughout, so the
+/// engine's bit-exact `draw_bodypose` port renders the same skeleton as the Python path.
+#[cfg(target_os = "macos")]
+fn instantid_pose_keypoints(entry: &Value) -> Vec<BodyPoint> {
+    let raw: Vec<Option<(f64, f64, Option<f64>)>> = entry
+        .get("keypoints")
+        .and_then(Value::as_array)
+        .map(|points| {
+            points
+                .iter()
+                .map(|point| {
+                    let point = point.as_array()?;
+                    let x = point.first()?.as_f64()?;
+                    let y = point.get(1)?.as_f64()?;
+                    Some((x, y, point.get(2).and_then(Value::as_f64)))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    instantid_normalize_keypoints(&raw)
+}
+
+/// The OpenPose `controlnet_conditioning_scale` for pose mode (`advanced.openPoseScale`, default
+/// 0.7 — the production default; no web control today, carried verbatim per sc-3381). The
+/// no-face-visible boost to ≥0.85 is applied engine-side.
+#[cfg(target_os = "macos")]
+fn instantid_openpose_scale(request: &ImageRequest) -> f32 {
+    advanced_f32(request, "openPoseScale", DEFAULT_OPENPOSE_SCALE, 0.0, 2.0)
 }
 
 /// The 11-view Character-Studio angle set vs the single-identity path.
@@ -4102,23 +4160,25 @@ fn resolve_instantid_sdxl_base(request: &ImageRequest, settings: &Settings) -> O
 }
 
 /// True when this is a native-MLX-eligible InstantID job: the production model in
-/// `character_image` mode with a reference face, NOT a pose set and NOT face-restore (both
-/// torch-only), whose SDXL base resolves locally. The pose/face-restore exclusions mirror the
-/// `jobs_store::instantid_mlx_eligible` routing predicate so the worker and the router agree.
+/// `character_image` mode with a reference face whose SDXL base resolves locally. Identity, the
+/// 11-view angle set, pose-library mode (`advanced.poses`), and face-restore (`advanced.faceRestore`)
+/// all run natively now (sc-3381). Mirrors the `jobs_store::instantid_mlx_eligible` routing
+/// predicate so the worker and the router agree.
 #[cfg(target_os = "macos")]
 fn instantid_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.model == INSTANTID_MODEL
         && request.mode == "character_image"
         && non_empty(&request.reference_asset_id)
-        && !instantid_pose_set(request)
-        && !advanced_flag(request, "faceRestore")
         && resolve_instantid_sdxl_base(request, settings).is_some()
 }
 
-/// The number of images an InstantID job produces: 11 for an angle set, else `request.count`.
+/// The number of images an InstantID job produces: one per pose for a pose set, 11 for an angle
+/// set, else `request.count`.
 #[cfg(target_os = "macos")]
 fn instantid_image_count(request: &ImageRequest) -> u32 {
-    if instantid_angle_set(request) {
+    if instantid_pose_set(request) {
+        pose_entries(request).len() as u32
+    } else if instantid_angle_set(request) {
         CHARACTER_ANGLE_SET_ORDER.len() as u32
     } else {
         request.count
@@ -4198,6 +4258,9 @@ fn instantid_raw_settings(
     ip_scale: f32,
     controlnet_scale: f32,
     angle_set: bool,
+    pose_set: bool,
+    face_restore: bool,
+    openpose_scale: f32,
 ) -> JsonObject {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
@@ -4219,6 +4282,12 @@ fn instantid_raw_settings(
     );
     if angle_set {
         raw.insert("angleSet".to_owned(), Value::Bool(true));
+    }
+    // Pose mode telemetry (parity with the torch `_run_pose` recipe keys): the OpenPose strength
+    // and whether the face-restore re-render ran.
+    if pose_set {
+        raw.insert("openPoseScale".to_owned(), json!(openpose_scale));
+        raw.insert("faceRestore".to_owned(), Value::Bool(face_restore));
     }
     raw
 }
@@ -4326,11 +4395,49 @@ async fn ensure_instantid_weights(
     ))
 }
 
+/// Resolve the xinsir OpenPose-SDXL ControlNet for pose mode (sc-3381): env override
+/// (`SCENEWORKS_INSTANTID_OPENPOSE`, a dir or file) → HF cache snapshot → download-on-first-use
+/// into the app cache. The engine loads only the safetensors (its ControlNet config is fixed to
+/// `sdxl_base`), so a `File` source is sufficient.
+#[cfg(target_os = "macos")]
+async fn ensure_instantid_openpose(settings: &Settings) -> WorkerResult<WeightsSource> {
+    if let Ok(path) = std::env::var("SCENEWORKS_INSTANTID_OPENPOSE") {
+        let path = PathBuf::from(path);
+        if path.is_dir() {
+            return Ok(WeightsSource::Dir(path));
+        }
+        if path.is_file() {
+            return Ok(WeightsSource::File(path));
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, INSTANTID_OPENPOSE_REPO) {
+        let file = snapshot.join(INSTANTID_OPENPOSE_FILE);
+        if file.exists() {
+            return Ok(WeightsSource::File(file));
+        }
+    }
+    let dir = settings.data_dir.join("cache").join("instantid-openpose");
+    let client = reqwest::Client::new();
+    let file = ensure_instantid_file(
+        &client,
+        &dir,
+        INSTANTID_OPENPOSE_FILE,
+        &format!(
+            "https://huggingface.co/{INSTANTID_OPENPOSE_REPO}/resolve/main/{INSTANTID_OPENPOSE_FILE}"
+        ),
+    )
+    .await?;
+    Ok(WeightsSource::File(file))
+}
+
 /// Real InstantID generation: resolve the reference + weights on the async side, then load the
 /// bespoke `InstantId` provider once + generate each image on the blocking thread (the MLX
-/// model is `!Send`). The engine `generate`/`generate_angle` expose neither a step-progress
-/// callback nor a `CancelFlag`, so streaming is per-image (no `Step`/`Decoding` events) and
-/// cancellation is honoured between images. Reuses [`consume_gen_events`] for the asset writes.
+/// model is `!Send`). Covers all four production modes — single identity, the 11-view angle set,
+/// pose-library mode (`advanced.poses` → MultiControlNet IdentityNet + OpenPose, sc-3117), and the
+/// optional face-restore re-render (`advanced.faceRestore`, sc-3380) — with zero Python (sc-3381).
+/// The engine `generate*` expose neither a step-progress callback nor a `CancelFlag`, so streaming
+/// is per-image (no `Step`/`Decoding` events) and cancellation is honoured between images. Reuses
+/// [`consume_gen_events`] for the asset writes.
 #[cfg(target_os = "macos")]
 async fn generate_instantid_stream(
     api: &ApiClient,
@@ -4383,6 +4490,9 @@ async fn generate_instantid_stream(
         .unwrap_or(INSTANTID_SDXL_REPO)
         .to_owned();
     let angle_set = instantid_angle_set(request);
+    let pose_set = instantid_pose_set(request);
+    let face_restore = advanced_flag(request, "faceRestore");
+    let openpose_scale = instantid_openpose_scale(request);
     let raw_settings = instantid_raw_settings(
         request,
         &repo,
@@ -4392,13 +4502,38 @@ async fn generate_instantid_stream(
         ip_scale,
         controlnet_scale,
         angle_set,
+        pose_set,
+        face_restore,
+        openpose_scale,
     );
 
-    // Per-image work items: (seed, prompt, optional canonical view angle). The angle set is a
-    // shared seed (only the head pose changes across the 11 views — noise-derived attributes
-    // stay constant); single identity is per-seed at the reference's natural pose.
+    // Pose mode additionally needs the xinsir OpenPose-SDXL ControlNet; face-restore reuses the
+    // already-resolved native face stack. Resolved only when a pose set is present.
+    let openpose = if pose_set {
+        Some(ensure_instantid_openpose(settings).await?)
+    } else {
+        None
+    };
+
+    // Per-image work items: (seed, prompt, shot). Pose + angle sets share ONE seed so the
+    // noise-derived attributes InstantID does not lock (hair, wardrobe, lighting) stay constant
+    // across the set — only the head pose changes; single identity is per-seed at the reference's
+    // natural pose. Pose mode keeps the literal prompt (no angle augment) and carries each pose's
+    // COCO-18 keypoints.
     let (width, height) = (request.width, request.height);
-    let work: Vec<(i64, String, Option<&'static str>)> = if angle_set {
+    let work: Vec<(i64, String, InstantIdShot)> = if pose_set {
+        let set_seed = resolve_seed(request, 0);
+        pose_entries(request)
+            .into_iter()
+            .map(|entry| {
+                (
+                    set_seed,
+                    request.prompt.clone(),
+                    InstantIdShot::Pose(instantid_pose_keypoints(entry)),
+                )
+            })
+            .collect()
+    } else if angle_set {
         let set_seed = resolve_seed(request, 0);
         CHARACTER_ANGLE_SET_ORDER
             .iter()
@@ -4406,13 +4541,19 @@ async fn generate_instantid_stream(
                 (
                     set_seed,
                     augment_prompt_for_angle(&request.prompt, angle),
-                    Some(angle),
+                    InstantIdShot::Angle(angle),
                 )
             })
             .collect()
     } else {
         (0..request.count as usize)
-            .map(|index| (resolve_seed(request, index), request.prompt.clone(), None))
+            .map(|index| {
+                (
+                    resolve_seed(request, index),
+                    request.prompt.clone(),
+                    InstantIdShot::Identity,
+                )
+            })
             .collect()
     };
     let total = work.len();
@@ -4439,6 +4580,12 @@ async fn generate_instantid_stream(
                     WorkerError::InvalidPayload(format!("InstantID quantize failed: {error}"))
                 })?;
             }
+            // Attach the OpenPose ControlNet for pose mode (quantizes with the stack if quant is on).
+            if let Some(openpose) = &openpose {
+                model = model.with_openpose(openpose).map_err(|error| {
+                    WorkerError::InvalidPayload(format!("InstantID OpenPose ControlNet: {error}"))
+                })?;
+            }
             let scrfd = Weights::from_file(&scrfd_path).map_err(|error| {
                 WorkerError::InvalidPayload(format!(
                     "InstantID SCRFD weights {scrfd_path:?}: {error}"
@@ -4452,33 +4599,81 @@ async fn generate_instantid_stream(
             let model = model.with_face(&scrfd, &arcface).map_err(|error| {
                 WorkerError::InvalidPayload(format!("InstantID face stack: {error}"))
             })?;
+
+            // Face-restore (pose mode only, mirroring `_run_pose`) re-imposes the reference identity
+            // on the small full-body face. Compute the reference ArcFace embedding ONCE, from the
+            // same square-letterboxed reference the pose render detects on, so the restore identity
+            // matches the generation identity.
+            let restore_embedding = if face_restore && pose_set {
+                let canvas =
+                    instantid_letterbox(&reference, INSTANTID_POSE_SIZE, INSTANTID_POSE_SIZE);
+                let face = model
+                    .largest_face(
+                        &canvas.pixels,
+                        INSTANTID_POSE_SIZE as usize,
+                        INSTANTID_POSE_SIZE as usize,
+                    )
+                    .map_err(|error| {
+                        WorkerError::InvalidPayload(format!(
+                            "InstantID face-restore reference: {error}"
+                        ))
+                    })?;
+                Some(face.embedding)
+            } else {
+                None
+            };
             emit_load_event("image_pipeline_load_complete", &job_id, "instantid", 0);
 
-            for (index, (seed, prompt, angle)) in work.into_iter().enumerate() {
+            for (index, (seed, prompt, shot)) in work.into_iter().enumerate() {
                 if cancel.is_cancelled() {
                     break;
                 }
-                // Angle set uses a square canvas (the engine forces `req.height = req.width`
-                // for the canonical landmark pack — the sc-2009 kps-aspect rule); single
-                // identity keeps the requested W×H (the engine letterboxes the reference).
+                // Pose mode renders on a square `_POSE_SIZE` canvas (the engine places the skeleton
+                // + re-placed face landmarks there); identity/angle keep the requested W×H (the
+                // engine letterboxes the reference / squares the canonical landmark pack).
+                let (req_w, req_h) = match &shot {
+                    InstantIdShot::Pose(_) => (INSTANTID_POSE_SIZE, INSTANTID_POSE_SIZE),
+                    _ => (width, height),
+                };
                 let req = InstantIdRequest {
                     prompt,
                     negative: negative_prompt.clone(),
-                    width,
-                    height,
+                    width: req_w,
+                    height: req_h,
                     steps: steps as usize,
                     guidance,
                     ip_adapter_scale: ip_scale,
                     controlnet_scale,
+                    openpose_scale,
                     seed: seed as u64,
                 };
-                let out = match angle {
-                    Some(angle) => model.generate_angle(&req, &reference, angle),
-                    None => model.generate(&req, &reference),
+                let mut out = match &shot {
+                    InstantIdShot::Angle(angle) => model.generate_angle(&req, &reference, angle),
+                    InstantIdShot::Pose(keypoints) => {
+                        model.generate_pose(&req, &reference, keypoints)
+                    }
+                    InstantIdShot::Identity => model.generate(&req, &reference),
                 }
                 .map_err(|error| {
                     WorkerError::InvalidPayload(format!("InstantID generation failed: {error}"))
                 })?;
+                // Face-restore pass (pose mode + faceRestore). A no-op engine-side on a back/occluded
+                // view (no face detected in the render), mirroring the torch `face_box is not None`
+                // gate. Uses the gender-neutral `FACE_RESTORE_PROMPT` (the Python `_FACE_RESTORE_PROMPT`
+                // gender bug is fixed worker-side too, sc-3381).
+                if let (InstantIdShot::Pose(_), Some(embedding)) = (&shot, &restore_embedding) {
+                    let restore_req = InstantIdRequest {
+                        prompt: FACE_RESTORE_PROMPT.to_owned(),
+                        ..req.clone()
+                    };
+                    out = model
+                        .restore_face(&restore_req, &out, embedding)
+                        .map_err(|error| {
+                            WorkerError::InvalidPayload(format!(
+                                "InstantID face-restore failed: {error}"
+                            ))
+                        })?;
+                }
                 if tx
                     .blocking_send(GenEvent::Image {
                         index,

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -37,6 +37,16 @@ use mlx_gen_qwen_image as _;
 use mlx_gen_sdxl as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_z_image as _;
+// InstantID (sc-3345) is a bespoke provider, not an inventory-registered `Generator`, so it is
+// referenced by name (`InstantId::load`) rather than anchored with `as _;` — and the native face
+// stack it composes (`mlx-gen-face`, SCRFD + ArcFace) rides in transitively but is anchored here so
+// the direct dep the story adds is meaningful + survives any future unused-crate lint.
+#[cfg(target_os = "macos")]
+use mlx_gen::weights::Weights;
+#[cfg(target_os = "macos")]
+use mlx_gen_face as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_instantid::{InstantId, InstantIdPaths, InstantIdRequest};
 
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
@@ -394,6 +404,23 @@ pub(crate) async fn run_image_generate_job(
         // Qwen-Image-Edit (mode edit_image / Character-Studio reference / best-effort
         // pose / angle set) → the engine's `qwen_image_edit` model (sc-3397).
         generate_qwen_edit_stream(
+            api,
+            settings,
+            job,
+            &plan,
+            &project_path,
+            backend,
+            &mut asset_writes,
+        )
+        .await?;
+        true
+    } else if instantid_available(&request, settings) {
+        // InstantID identity-preserving character image (sc-3345): single identity or the
+        // 11-view Character-Studio angle set, on RealVisXL + IdentityNet + the native face
+        // stack. Pose-library + faceRestore jobs are NOT eligible (kept on the torch
+        // adapter) — `instantid_available` gates them out so they fall through to the
+        // non-handled path and the torch worker claims them.
+        generate_instantid_stream(
             api,
             settings,
             job,
@@ -3109,7 +3136,9 @@ fn qwen_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
 /// streams against it). Qwen edit reuses the shared [`flux2_grouping`] decision.
 #[cfg(target_os = "macos")]
 fn grouped_image_count(request: &ImageRequest, settings: &Settings) -> u32 {
-    if qwen_edit_available(request, settings) {
+    if instantid_available(request, settings) {
+        instantid_image_count(request)
+    } else if qwen_edit_available(request, settings) {
         match flux2_grouping(request) {
             Flux2Grouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
             Flux2Grouping::Poses(count) => count as u32,
@@ -3969,6 +3998,512 @@ async fn generate_sdxl_advanced_stream(
         project_path,
         backend,
         adapter_label,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// InstantID identity-preserving character image (macOS, epic 3109 engine / sc-3345
+// integration): the production `instantid_realvisxl` model — InstantID on RealVisXL +
+// the stock SDXL IdentityNet ControlNet + the native MLX face stack (SCRFD + ArcFace),
+// all in-process with zero Python. Two modes only (torch parity): a single-identity
+// `character_image` (the reference's natural head pose) and the 11-view Character-Studio
+// angle set. Pose-library mode (`advanced.poses`) + face-restore (`advanced.faceRestore`)
+// are NOT handled here — they stay on the torch `InstantIDAdapter` (engine sc-3117 /
+// sc-3380 not yet ported), gated out by `instantid_available` so the torch worker claims
+// them. fp16 only for now (the validated envelope); Q8/Q4 ride explicit `mlxQuantize`
+// (unvalidated at 1024², gated by sc-3329 follow-up). The provider is the bespoke
+// `mlx_gen_instantid::InstantId` (not an inventory `Generator`), so this is a dedicated
+// stream parallel to `generate_sdxl_advanced_stream`, not an MLX_MODELS row.
+// ---------------------------------------------------------------------------
+
+/// The SceneWorks model id for native InstantID (production = InstantID on RealVisXL_V5.0).
+#[cfg(target_os = "macos")]
+const INSTANTID_MODEL: &str = "instantid_realvisxl";
+/// SDXL base for InstantID when the manifest omits `repo` (the photoreal production base).
+#[cfg(target_os = "macos")]
+const INSTANTID_SDXL_REPO: &str = "SG161222/RealVisXL_V5.0";
+/// Stock InstantID checkpoint repo — the IdentityNet `ControlNetModel/` lives here.
+#[cfg(target_os = "macos")]
+const INSTANTID_CONTROLNET_REPO: &str = "InstantX/InstantID";
+/// Converted-weights bundle (download-on-first-use): the MLX `ip-adapter.safetensors`
+/// (`tools/convert_instantid.py`) + the native face stack `scrfd_10g.safetensors`
+/// (`convert_scrfd.py`) + `arcface_iresnet100.safetensors` (`convert_glintr100.py`). Public
+/// repo, mirroring the YOLO11 / SAM2 `SceneWorks/*-mlx` uploads (sc-3633 / sc-3707).
+#[cfg(target_os = "macos")]
+const INSTANTID_MLX_REPO: &str = "SceneWorks/instantid-mlx";
+#[cfg(target_os = "macos")]
+const INSTANTID_IP_ADAPTER_FILE: &str = "ip-adapter.safetensors";
+#[cfg(target_os = "macos")]
+const INSTANTID_SCRFD_FILE: &str = "scrfd_10g.safetensors";
+#[cfg(target_os = "macos")]
+const INSTANTID_ARCFACE_FILE: &str = "arcface_iresnet100.safetensors";
+/// The IdentityNet weight file inside `ControlNetModel/` (a stock diffusers SDXL ControlNet).
+#[cfg(target_os = "macos")]
+const INSTANTID_CONTROLNET_FILES: [&str; 2] =
+    ["config.json", "diffusion_pytorch_model.safetensors"];
+/// Torch-parity defaults (the `instantid_realvisxl` MODEL_TARGETS): RealVisXL is tuned for a
+/// low CFG; the engine's own `InstantIdRequest::default` guidance (5.0) is for base SDXL.
+#[cfg(target_os = "macos")]
+const INSTANTID_DEFAULT_STEPS: u32 = 30;
+#[cfg(target_os = "macos")]
+const INSTANTID_DEFAULT_GUIDANCE: f32 = 3.0;
+#[cfg(target_os = "macos")]
+const INSTANTID_IP_SCALE: f32 = 0.8;
+#[cfg(target_os = "macos")]
+const INSTANTID_CONTROLNET_SCALE: f32 = 0.8;
+
+/// True when this job carries a pose-library set (`advanced.poses`) — InstantID pose mode is
+/// torch-only (engine sc-3117 not ported), so these are excluded from the MLX path.
+#[cfg(target_os = "macos")]
+fn instantid_pose_set(request: &ImageRequest) -> bool {
+    !pose_entries(request).is_empty()
+}
+
+/// The 11-view Character-Studio angle set vs the single-identity path.
+#[cfg(target_os = "macos")]
+fn instantid_angle_set(request: &ImageRequest) -> bool {
+    advanced_flag(request, "angleSet")
+}
+
+/// Resolve the RealVisXL (SDXL) base snapshot for InstantID: an explicit `modelPath` dir
+/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
+/// RealVisXL_V5.0). The big base is staged by the normal model-download flow; `None` here
+/// means it is not present, so the job is not MLX-runnable (falls through to torch).
+#[cfg(target_os = "macos")]
+fn resolve_instantid_sdxl_base(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+    {
+        if path.is_dir() {
+            return Some(path);
+        }
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(INSTANTID_SDXL_REPO);
+    huggingface_snapshot_dir(&settings.data_dir, repo)
+}
+
+/// True when this is a native-MLX-eligible InstantID job: the production model in
+/// `character_image` mode with a reference face, NOT a pose set and NOT face-restore (both
+/// torch-only), whose SDXL base resolves locally. The pose/face-restore exclusions mirror the
+/// `jobs_store::instantid_mlx_eligible` routing predicate so the worker and the router agree.
+#[cfg(target_os = "macos")]
+fn instantid_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == INSTANTID_MODEL
+        && request.mode == "character_image"
+        && non_empty(&request.reference_asset_id)
+        && !instantid_pose_set(request)
+        && !advanced_flag(request, "faceRestore")
+        && resolve_instantid_sdxl_base(request, settings).is_some()
+}
+
+/// The number of images an InstantID job produces: 11 for an angle set, else `request.count`.
+#[cfg(target_os = "macos")]
+fn instantid_image_count(request: &ImageRequest) -> u32 {
+    if instantid_angle_set(request) {
+        CHARACTER_ANGLE_SET_ORDER.len() as u32
+    } else {
+        request.count
+    }
+}
+
+/// Resolve InstantID denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` →
+/// the torch-parity default (30).
+#[cfg(target_os = "macos")]
+fn instantid_steps(request: &ImageRequest) -> u32 {
+    let parse = |value: &Value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    };
+    request
+        .advanced
+        .get("steps")
+        .and_then(parse)
+        .or_else(|| request.model_manifest_entry.get("steps").and_then(parse))
+        .map(|steps| steps.clamp(1, 80) as u32)
+        .unwrap_or(INSTANTID_DEFAULT_STEPS)
+}
+
+/// Resolve InstantID guidance: `advanced.guidanceScale` → manifest `guidanceScale` → the
+/// RealVisXL-tuned default (3.0). Clamped to a sane CFG range.
+#[cfg(target_os = "macos")]
+fn instantid_guidance(request: &ImageRequest) -> f32 {
+    let manifest_default = request
+        .model_manifest_entry
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(INSTANTID_DEFAULT_GUIDANCE);
+    advanced_f32(request, "guidanceScale", manifest_default, 0.0, 30.0)
+}
+
+/// Resolve InstantID quantization. **fp16 (dense) is the default** — the validated identity
+/// envelope (ArcFace-cosine 0.82 @1024²); Q8/Q4 only on an explicit `advanced.mlxQuantize` /
+/// manifest opt-in (identity drops to ~0.64 @512² and full-res quant is unvalidated). Returns
+/// the engine `bits` (`Some(4)`/`Some(8)`/`None`) + the recipe bit count.
+#[cfg(target_os = "macos")]
+fn instantid_quant(request: &ImageRequest) -> (Option<i32>, Option<i64>) {
+    let raw = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(quant_int)
+        .or_else(|| {
+            request
+                .model_manifest_entry
+                .get("mlx")
+                .and_then(|mlx| mlx.get("quantize"))
+                .and_then(quant_int)
+        });
+    match raw {
+        Some(bits) if bits > 0 && bits <= 4 => (Some(4), Some(4)),
+        Some(bits) if bits > 4 => (Some(8), Some(8)),
+        // None / 0 / negative → fp16 (the default + the validated InstantID envelope).
+        _ => (None, None),
+    }
+}
+
+/// Flat telemetry recorded on InstantID assets (parity with `mlx_raw_settings` + the torch
+/// `InstantIDAdapter` recipe keys).
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn instantid_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: f32,
+    ip_scale: f32,
+    controlnet_scale: f32,
+    angle_set: bool,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert("ipAdapterScale".to_owned(), json!(ip_scale));
+    raw.insert(
+        "controlnetConditioningScale".to_owned(),
+        json!(controlnet_scale),
+    );
+    raw.insert(
+        "instantIdEngine".to_owned(),
+        Value::String("mlx_instantid".to_owned()),
+    );
+    if angle_set {
+        raw.insert("angleSet".to_owned(), Value::Bool(true));
+    }
+    raw
+}
+
+/// Resolve a single InstantID weight file: return it if already present in `dir`, else
+/// download `url` into `dir` (atomic `.tmp` + rename, so a partial download is never mistaken
+/// for a complete one — same shape as `person_segment::ensure_segmenter_weights`).
+#[cfg(target_os = "macos")]
+async fn ensure_instantid_file(
+    client: &reqwest::Client,
+    dir: &Path,
+    name: &str,
+    url: &str,
+) -> WorkerResult<PathBuf> {
+    let target = dir.join(name);
+    if target.exists() {
+        return Ok(target);
+    }
+    tokio::fs::create_dir_all(dir).await?;
+    let bytes = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!(
+                "InstantID weight download failed ({url}): {error}"
+            ))
+        })?
+        .bytes()
+        .await?;
+    let tmp = target.with_extension("download.tmp");
+    tokio::fs::write(&tmp, &bytes).await?;
+    tokio::fs::rename(&tmp, &target).await?;
+    Ok(target)
+}
+
+/// Resolve all InstantID weight inputs, downloading the small converted bundle + the stock
+/// IdentityNet on first use. Returns `(identitynet_dir, ip_adapter, scrfd, arcface)` — all
+/// `Send` paths; the `!Send` MLX load happens on the blocking thread. Resolution order favours
+/// an env override / the HF cache before any network fetch.
+#[cfg(target_os = "macos")]
+async fn ensure_instantid_weights(
+    settings: &Settings,
+) -> WorkerResult<(WeightsSource, PathBuf, PathBuf, PathBuf)> {
+    let client = reqwest::Client::new();
+
+    // Converted bundle (ip-adapter + face stack): an env-pinned dir (pre-staged for local
+    // validation) wins, else the app cache (download missing files from SceneWorks/instantid-mlx).
+    let bundle_dir = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| settings.data_dir.join("cache").join("instantid-mlx"));
+    let base = format!("https://huggingface.co/{INSTANTID_MLX_REPO}/resolve/main");
+    let ip_adapter = ensure_instantid_file(
+        &client,
+        &bundle_dir,
+        INSTANTID_IP_ADAPTER_FILE,
+        &format!("{base}/{INSTANTID_IP_ADAPTER_FILE}"),
+    )
+    .await?;
+    let scrfd = ensure_instantid_file(
+        &client,
+        &bundle_dir,
+        INSTANTID_SCRFD_FILE,
+        &format!("{base}/{INSTANTID_SCRFD_FILE}"),
+    )
+    .await?;
+    let arcface = ensure_instantid_file(
+        &client,
+        &bundle_dir,
+        INSTANTID_ARCFACE_FILE,
+        &format!("{base}/{INSTANTID_ARCFACE_FILE}"),
+    )
+    .await?;
+
+    // IdentityNet (stock InstantX ControlNetModel): env override → HF cache snapshot →
+    // download the two files into the app cache.
+    if let Ok(dir) = std::env::var("SCENEWORKS_INSTANTID_CONTROLNET") {
+        let dir = PathBuf::from(dir);
+        if dir.is_dir() {
+            return Ok((WeightsSource::Dir(dir), ip_adapter, scrfd, arcface));
+        }
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, INSTANTID_CONTROLNET_REPO)
+    {
+        let controlnet = snapshot.join("ControlNetModel");
+        if controlnet
+            .join("diffusion_pytorch_model.safetensors")
+            .exists()
+        {
+            return Ok((WeightsSource::Dir(controlnet), ip_adapter, scrfd, arcface));
+        }
+    }
+    let controlnet_dir = settings.data_dir.join("cache").join("instantid-controlnet");
+    let cn_base =
+        format!("https://huggingface.co/{INSTANTID_CONTROLNET_REPO}/resolve/main/ControlNetModel");
+    for file in INSTANTID_CONTROLNET_FILES {
+        ensure_instantid_file(&client, &controlnet_dir, file, &format!("{cn_base}/{file}")).await?;
+    }
+    Ok((
+        WeightsSource::Dir(controlnet_dir),
+        ip_adapter,
+        scrfd,
+        arcface,
+    ))
+}
+
+/// Real InstantID generation: resolve the reference + weights on the async side, then load the
+/// bespoke `InstantId` provider once + generate each image on the blocking thread (the MLX
+/// model is `!Send`). The engine `generate`/`generate_angle` expose neither a step-progress
+/// callback nor a `CancelFlag`, so streaming is per-image (no `Step`/`Decoding` events) and
+/// cancellation is honoured between images. Reuses [`consume_gen_events`] for the asset writes.
+#[cfg(target_os = "macos")]
+async fn generate_instantid_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let sdxl_base = resolve_instantid_sdxl_base(request, settings).ok_or_else(|| {
+        WorkerError::InvalidPayload("InstantID base (RealVisXL) not found".to_owned())
+    })?;
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("InstantID requires a reference face image".to_owned())
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+
+    let (controlnet, ip_adapter, scrfd_path, arcface_path) =
+        ensure_instantid_weights(settings).await?;
+
+    let steps = instantid_steps(request);
+    let guidance = instantid_guidance(request);
+    let (quant_bits, recipe_bits) = instantid_quant(request);
+    let ip_scale = advanced_f32(request, "ipAdapterScale", INSTANTID_IP_SCALE, 0.0, 1.0);
+    let controlnet_scale = advanced_f32(
+        request,
+        "controlnetConditioningScale",
+        INSTANTID_CONTROLNET_SCALE,
+        0.0,
+        2.0,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(INSTANTID_SDXL_REPO)
+        .to_owned();
+    let angle_set = instantid_angle_set(request);
+    let raw_settings = instantid_raw_settings(
+        request,
+        &repo,
+        steps,
+        recipe_bits,
+        guidance,
+        ip_scale,
+        controlnet_scale,
+        angle_set,
+    );
+
+    // Per-image work items: (seed, prompt, optional canonical view angle). The angle set is a
+    // shared seed (only the head pose changes across the 11 views — noise-derived attributes
+    // stay constant); single identity is per-seed at the reference's natural pose.
+    let (width, height) = (request.width, request.height);
+    let work: Vec<(i64, String, Option<&'static str>)> = if angle_set {
+        let set_seed = resolve_seed(request, 0);
+        CHARACTER_ANGLE_SET_ORDER
+            .iter()
+            .map(|&angle| {
+                (
+                    set_seed,
+                    augment_prompt_for_angle(&request.prompt, angle),
+                    Some(angle),
+                )
+            })
+            .collect()
+    } else {
+        (0..request.count as usize)
+            .map(|index| (resolve_seed(request, index), request.prompt.clone(), None))
+            .collect()
+    };
+    let total = work.len();
+
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+
+    let blocking = {
+        let negative_prompt = request.negative_prompt.clone();
+        let cancel = cancel.clone();
+        let job_id = job.id.clone();
+        tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+            emit_load_event("image_pipeline_load_start", &job_id, "instantid", 0);
+            let paths = InstantIdPaths {
+                sdxl_base,
+                identitynet: controlnet,
+                ip_adapter,
+            };
+            let mut model = InstantId::load(&paths).map_err(|error| {
+                WorkerError::InvalidPayload(format!("InstantID load failed: {error}"))
+            })?;
+            if let Some(bits) = quant_bits {
+                model = model.quantize(bits).map_err(|error| {
+                    WorkerError::InvalidPayload(format!("InstantID quantize failed: {error}"))
+                })?;
+            }
+            let scrfd = Weights::from_file(&scrfd_path).map_err(|error| {
+                WorkerError::InvalidPayload(format!(
+                    "InstantID SCRFD weights {scrfd_path:?}: {error}"
+                ))
+            })?;
+            let arcface = Weights::from_file(&arcface_path).map_err(|error| {
+                WorkerError::InvalidPayload(format!(
+                    "InstantID ArcFace weights {arcface_path:?}: {error}"
+                ))
+            })?;
+            let model = model.with_face(&scrfd, &arcface).map_err(|error| {
+                WorkerError::InvalidPayload(format!("InstantID face stack: {error}"))
+            })?;
+            emit_load_event("image_pipeline_load_complete", &job_id, "instantid", 0);
+
+            for (index, (seed, prompt, angle)) in work.into_iter().enumerate() {
+                if cancel.is_cancelled() {
+                    break;
+                }
+                // Angle set uses a square canvas (the engine forces `req.height = req.width`
+                // for the canonical landmark pack — the sc-2009 kps-aspect rule); single
+                // identity keeps the requested W×H (the engine letterboxes the reference).
+                let req = InstantIdRequest {
+                    prompt,
+                    negative: negative_prompt.clone(),
+                    width,
+                    height,
+                    steps: steps as usize,
+                    guidance,
+                    ip_adapter_scale: ip_scale,
+                    controlnet_scale,
+                    seed: seed as u64,
+                };
+                let out = match angle {
+                    Some(angle) => model.generate_angle(&req, &reference, angle),
+                    None => model.generate(&req, &reference),
+                }
+                .map_err(|error| {
+                    WorkerError::InvalidPayload(format!("InstantID generation failed: {error}"))
+                })?;
+                if tx
+                    .blocking_send(GenEvent::Image {
+                        index,
+                        seed,
+                        width: out.width,
+                        height: out.height,
+                        pixels: out.pixels,
+                    })
+                    .is_err()
+                {
+                    break; // receiver gone — stop generating.
+                }
+            }
+            Ok(())
+        })
+    };
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        "mlx_instantid",
         &raw_settings,
         total,
         rx,

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -79,8 +79,8 @@ dropped — no silent drops.**
 | reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🟢 Ported (MLX) | sc-3537 (spike) → epic 3641 (sc-3642/3643/3671 engine + sc-3644 routing) |
 | InstantID identity + 11-view angle set | `instantid_realvisxl` (`character_image` + `referenceAssetId`) | 🟢 Ported (MLX) | epic 3109 (engine) → sc-3345 (worker integration + routing) |
-| InstantID pose-library mode | `instantid_realvisxl` (`advanced.poses`) | 🔵 Port-pending | sc-3117 (engine MultiControlNet pose) → sc-3381 (torch retirement) |
-| InstantID face-restore | `instantid_realvisxl` (`advanced.faceRestore`) | 🔵 Port-pending | sc-3380 (engine face-restore re-render) → sc-3381 |
+| InstantID pose-library mode | `instantid_realvisxl` (`advanced.poses`) | 🟢 Ported (MLX) | sc-3117 (engine MultiControlNet pose) → sc-3381 (worker integration + routing) |
+| InstantID face-restore | `instantid_realvisxl` (`advanced.faceRestore`) | 🟢 Ported (MLX) | sc-3380 (engine face-restore re-render) → sc-3381 (worker integration + routing) |
 
 > **FLUX.1 `edit_image` is not an eradication gap (sc-3535).** The torch `FluxDiffusersAdapter`
 > hard-rejects `edit_image` ("does not support image editing") — FLUX.1 has no edit path on *any*

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -54,7 +54,6 @@ Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust
 |---|---|---|---|
 | `kolors` | kolors (SDXL UNet + ChatGLM3) | 🔵 Port → drop-on-Mac until then | **epic 3532** |
 | `z_image_edit` | z-image (edit) | 🔵 Port → drop-on-Mac until then | **epic 3529** |
-| `instantid_realvisxl` | sdxl (InstantID) | 🔵 Port → drop-on-Mac until then | epic 3109 |
 | `pulid_flux_dev` | flux (PuLID) | 🔵 Port → drop-on-Mac until then | epic 3069 (engine done; owes SceneWorks routing) |
 | `sensenova_u1_8b`, `sensenova_u1_8b_fast` | sensenova-u1 | 🔵 Port → drop-on-Mac until then | epic 3180 |
 | `lens`, `lens_turbo` | lens (Python sidecar `/opt/lens-venv`) | 🔵 Port → drop-on-Mac until then | epic 3164 |
@@ -79,6 +78,9 @@ dropped — no silent drops.**
 | `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
 | reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🟢 Ported (MLX) | sc-3537 (spike) → epic 3641 (sc-3642/3643/3671 engine + sc-3644 routing) |
+| InstantID identity + 11-view angle set | `instantid_realvisxl` (`character_image` + `referenceAssetId`) | 🟢 Ported (MLX) | epic 3109 (engine) → sc-3345 (worker integration + routing) |
+| InstantID pose-library mode | `instantid_realvisxl` (`advanced.poses`) | 🔵 Port-pending | sc-3117 (engine MultiControlNet pose) → sc-3381 (torch retirement) |
+| InstantID face-restore | `instantid_realvisxl` (`advanced.faceRestore`) | 🔵 Port-pending | sc-3380 (engine face-restore re-render) → sc-3381 |
 
 > **FLUX.1 `edit_image` is not an eradication gap (sc-3535).** The torch `FluxDiffusersAdapter`
 > hard-rejects `edit_image` ("does not support image editing") — FLUX.1 has no edit path on *any*


### PR DESCRIPTION
Brings the **full production InstantID surface** (`instantid_realvisxl`) onto the in-process Rust MLX engine on Mac, with zero Python: single identity, the 11-view Character-Studio angle set, pose-library mode (MultiControlNet IdentityNet + OpenPose), and the face-restore re-render. Completes the torch retirement for this model on Mac (epic 3018 / [epic 3482](https://app.shortcut.com/trefry/epic/3482)).

Stories: **[sc-3345](https://app.shortcut.com/trefry/story/3345)** (identity + angle set, base) + **[sc-3381](https://app.shortcut.com/trefry/story/3381)** (pose mode + face-restore).

## ⚠️ For reviewers: this PR carries two stories

`sc-3345` (the base-identity cutover) was marked *In Review* but had **never been committed or PR'd** — it lived only as uncommitted edits in another worktree. `sc-3381` builds directly on its `generate_instantid_stream` and can't compile without it. So commit `66af9b3` brings the sc-3345 work forward onto current `main` as the base, and `d4ff12f` layers sc-3381 on top. Reviewable as two commits.

## What changed

**Engine pin bump** `a67e8ed → ed8e6a1` (mlx-gen PR #193 = sc-3117 pose + sc-3380 restore). The `mlx-rs` pin is **identical** at both revs → MLX/Metal rebuilds nothing; only the `mlx-gen-instantid` provider crate gains API.

**Worker** (`crates/sceneworks-worker/src/image_jobs.rs`) — `generate_instantid_stream` drives an `InstantIdShot {Identity, Angle, Pose}` work model:
- **Pose mode** — `ensure_instantid_openpose` resolves the xinsir OpenPose-SDXL ControlNet (env → HF cache → download-on-first-use; the engine reads only the safetensors, its ControlNet config is fixed to `sdxl_base`). Gallery `advanced.poses` COCO-18 keypoints are parsed to the engine's `BodyPoint` via the engine's **own** `normalize_keypoints` (f64, bit-exact with the production `openpose_skeleton.py`). Square 1024 `_POSE_SIZE` canvas. The no-face / back-view IdentityNet+IP zeroing + OpenPose boost is handled engine-side.
- **Face-restore** — pose-mode-only (mirrors the torch `_run_pose` `face_box is not None and faceRestore` gate); runs `restore_face` with the reference ArcFace embedding computed once from the **same square-letterboxed reference the pose render detects on**, so the restore identity matches the generation identity. Gender-neutral `FACE_RESTORE_PROMPT`. A no-op engine-side on back views.
- `openPoseScale` knob carried (default 0.7; no web control — kept verbatim). Pose count folded into `instantid_image_count`; telemetry adds `openPoseScale` / `faceRestore`.

**Routing** (`crates/sceneworks-core/src/jobs_store.rs`) — `instantid_mlx_eligible` now admits poses + faceRestore; the only gate is `character_image` + a reference face. Gap classifier simplified to the one remaining (reference-less) case; routing + oracle tests flipped.

**Python** (`apps/worker/scene_worker/instantid_adapter.py`) — fix the gender-hardcoded `_FACE_RESTORE_PROMPT` (`"the woman's face" → "the face"`), which was applied to every character. Now matches the engine's neutral prompt verbatim; benefits the off-Mac torch path too.

## Scope note — "retire torch" = Mac routing flip, not Python deletion

The torch `InstantIDAdapter` stays for **Windows/Linux** and as the **mlx-down fallback** (Decision-A); `openpose_skeleton.py` is shared by the Z-Image/Qwen strict-pose tiers. Mac `requirements-instantid.txt` is **not** dropped here — `insightface`/`onnxruntime`/`einops` are shared with PuLID-FLUX (`pulid_flux_dev`, still torch-only on Mac); that drop belongs to the final venv-strip (sc-3492).

## Validation

**Real-weight RealVisXL_V5.0 @1024², in-process MLX, zero Python** — the exact engine entry points the worker calls (`with_openpose` → `generate_pose` → `restore_face`, `dance_01` gallery pose):
- Pose mode: ArcFace-cosine(ref, generated) = **0.7129** (> the 0.6895 base-SDXL baseline; identity holds, pose followed, square non-degenerate output).
- Face-restore: base **0.7370 → restored 0.8338** (clear identity recovery, seamless feathered paste-back).

`npm run rust:check` **fully green**: fmt + clippy `--all-targets -D warnings` + `cargo test` (all crates) + `cargo build`. Worker 194 + core 30 tests pass, including the updated InstantID routing + Mac-support-oracle tests.

The converted weights bundle `SceneWorks/instantid-mlx` is already published (public, model card, 3 files). Remaining follow-up: live app-stack smoke through `image_job → mlx worker → provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)