### PR TITLE
sc-3381: fix gender-hardcoded InstantID _FACE_RESTORE_PROMPT

### DIFF
--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -170,7 +170,10 @@ ANGLE_SET_ORDER: tuple[str, ...] = (
 # the kps-distortion rule). The face is small at full-body framing, so a face-restoration
 # pass re-imposes identity afterward (sc-2063 spike: ~0.38 -> ~0.88 ArcFace cosine).
 _POSE_SIZE: int = 1024
-_FACE_RESTORE_PROMPT = "close-up portrait of the woman's face, soft natural light, photorealistic, sharp focus"
+# Gender-neutral on purpose (sc-3381): this prompt is applied to EVERY character during the
+# face-restore re-render, so it must not assume a gender. (The native MLX engine's
+# `FACE_RESTORE_PROMPT` is the same neutral wording.)
+_FACE_RESTORE_PROMPT = "close-up portrait of the face, soft natural light, photorealistic, sharp focus"
 
 
 class InstantIDAdapter:


### PR DESCRIPTION
The torch `InstantIDAdapter` face-restore pass applies `_FACE_RESTORE_PROMPT` to **every** character, but it was hardcoded `"close-up portrait of the woman's face, ..."` — a latent bug that biases every restored face female regardless of the subject. This neutralizes it to `"the face"`, matching the native MLX engine's `FACE_RESTORE_PROMPT` verbatim.

## Why a separate one-line PR

Fixing this prompt is an explicit acceptance item of **[sc-3381](https://app.shortcut.com/trefry/story/3381)** ("Worker-side bug to fix here too: the gender-hardcoded `_FACE_RESTORE_PROMPT`"). PR #514 (`59f81d8`) landed the native pose-mode + face-restore Rust wiring for sc-3345 + sc-3381 but **missed this Python fix**. Rather than re-open a conflicting duplicate of the (already-merged) Rust work, this lands just the remaining piece.

## Scope

- One line + an explanatory comment in `apps/worker/scene_worker/instantid_adapter.py`.
- Affects the **off-Mac torch path** and the **Mac mlx-down fallback** (the native MLX path already uses a neutral prompt). Python parses clean; no behavior change beyond the prompt text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)