### PR TITLE
feat(z-image): port Z-Image-Edit to MLX on macOS (epic 3529)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2157,7 +2157,8 @@ fn torch_only_image_model_epic(model: &str) -> Option<&'static str> {
         "kolors" => Some("epic 3532"),
         "instantid_realvisxl" => Some("epic 3109"),
         "pulid_flux_dev" => Some("epic 3069"),
-        "z_image_edit" => Some("epic 3529"),
+        // z_image_edit was ported to MLX (epic 3529 / sc-3923) — it is now in
+        // `MLX_ROUTED_MODELS`, so it never reaches this torch-only gap classifier.
         m if m.starts_with("sensenova") => Some("epic 3180"),
         m if m.starts_with("lens") => Some("epic 3164"),
         // Chroma (chroma1_*) was ported to MLX (epic 3531 / sc-3843) — it is now in
@@ -2184,7 +2185,6 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
     }
     // Third-party LyCORIS (LoHa / non-peft LoKr) now applies on every MLX provider (epic 3641,
     // sc-3642/3643/3671), so it is no longer an image gap.
-    let is_edit = payload.get("mode").and_then(Value::as_str) == Some("edit_image");
     match model {
         "qwen_image" => UnsupportedReason::new(
             Some(model),
@@ -2197,12 +2197,6 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             "reference (XLabs IP-Adapter)",
             "FLUX.1 reference is the XLabs IP-Adapter (not img2img-init); it stays on the Python torch path until the MLX port lands. (FLUX.1 edit_image has no torch path on any platform — a future Kontext capability, not an eradication gap; see sc-3535.)",
             Some("epic 3621"),
-        ),
-        "z_image_turbo" if is_edit => UnsupportedReason::new(
-            Some(model),
-            "edit_image",
-            "Z-Image img2img edit stays on the Python torch path (folds into the Z-Image-Edit port).",
-            Some("epic 3529"),
         ),
         "qwen_image_edit"
         | "qwen_image_edit_2509"
@@ -2588,6 +2582,7 @@ fn is_apple_unified_gpu_id(gpu_id: &str) -> bool {
 /// mlx worker, so the Python torch path stays authoritative for it.
 const MLX_ROUTED_MODELS: &[&str] = &[
     "z_image_turbo",
+    "z_image_edit",
     "flux_schnell",
     "flux_dev",
     "qwen_image",
@@ -2644,7 +2639,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         return false;
     }
     match model {
-        "z_image_turbo" => z_image_mlx_eligible(payload),
+        "z_image_turbo" | "z_image_edit" => z_image_mlx_eligible(payload),
         "flux_schnell" | "flux_dev" => flux_mlx_eligible(payload),
         "qwen_image" => qwen_mlx_eligible(payload),
         "qwen_image_edit"
@@ -2776,13 +2771,22 @@ fn flux_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// Z-Image (sc-3022) MLX-routing conditions, ported from
 /// `_should_route_z_image_to_mlx`: text-to-image, reference-identity img2img-init
 /// (sc-3619 — `referenceAssetId` without a pose set, the plain img2img path the
-/// base engine already supports), and reference+pose (the Fun-ControlNet pose tier
+/// base engine already supports), reference+pose (the Fun-ControlNet pose tier
 /// lives only on MLX — sc-2257/sc-2328, so a reference+pose job must NOT divert to
-/// torch, which would honour count while dropping the poses). `edit_image`
-/// img2img-edit stays on torch (epic 3529). Third-party LyCORIS now applies on the core MLX loader
-/// (epic 3641), so only `edit_image` keeps a Z-Image job off MLX.
+/// torch, which would honour count while dropping the poses), and `edit_image`
+/// img2img-edit (epic 3529 — the engine's `Conditioning::Reference` img2img path with a
+/// `sourceAssetId` init, shared by `z_image_turbo` edit_image mode and the `z_image_edit`
+/// model, both on Turbo weights). An `edit_image` without a source asset has nothing to
+/// edit, so it stays off MLX. Third-party LyCORIS now applies on the core MLX loader
+/// (epic 3641), so a LoRA never forces torch.
 fn z_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
-    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return payload
+            .get("sourceAssetId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.trim().is_empty());
+    }
+    true
 }
 
 /// Chroma (epic 3531, sc-3843) MLX-routing conditions. Chroma is **text-to-image only**
@@ -3043,8 +3047,9 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     if worker.gpu_id.eq_ignore_ascii_case("mlx") {
         // Image: sc-3026 txt2img/LoRA + sc-3060 reference/edit/inpaint/outpaint +
         // image_detail + sc-3513 the `image_edit` job type (plain Image Edit). A
-        // torch-only edit model (z_image_edit/kolors/sensenova/lens/pulid/instantid)
-        // is not MLX-eligible, so the mlx worker refuses it and it stays on torch.
+        // torch-only edit model (kolors/sensenova/lens/pulid/instantid) is not
+        // MLX-eligible, so the mlx worker refuses it and it stays on torch.
+        // (z_image_edit was ported to MLX, epic 3529 / sc-3923.)
         if matches!(
             job.job_type,
             JobType::ImageGenerate | JobType::ImageEdit | JobType::ImageDetail
@@ -3365,10 +3370,25 @@ mod mlx_routing_tests {
     }
 
     #[test]
-    fn z_image_edit_mode_is_not_eligible() {
+    fn z_image_edit_mode_with_source_is_eligible() {
+        // epic 3529: img2img-edit (sourceAssetId) now routes to MLX via the engine's
+        // `Conditioning::Reference` img2img path.
+        assert!(z_image_mlx_eligible(&object(json!({
+            "mode": "edit_image",
+            "sourceAssetId": "asset_1"
+        }))));
+    }
+
+    #[test]
+    fn z_image_edit_mode_without_source_is_not_eligible() {
+        // An edit with nothing to edit (no/blank sourceAssetId) stays off MLX.
         assert!(!z_image_mlx_eligible(&object(
             json!({ "mode": "edit_image" })
         )));
+        assert!(!z_image_mlx_eligible(&object(json!({
+            "mode": "edit_image",
+            "sourceAssetId": "   "
+        }))));
     }
 
     #[test]

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1797,9 +1797,9 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
     let store = store("oracle-torch-model");
     // Each torch-only model points at its dedicated MLX-porting epic (epic 3482 policy),
     // not the generic done feasibility epic.
+    // (z_image_edit was ported to MLX, epic 3529 / sc-3923 — no longer torch-only.)
     let cases = [
         ("kolors", "epic 3532"),
-        ("z_image_edit", "epic 3529"),
         ("instantid_realvisxl", "epic 3109"),
         ("sensenova_u1_8b", "epic 3180"),
         ("lens_turbo", "epic 3164"),
@@ -2046,11 +2046,15 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     assert!(model_mac_support("qwen_image", "image").features.pose);
     assert!(model_mac_support("z_image_turbo", "image").features.pose);
     assert!(model_mac_support("sdxl", "image").features.pose);
-    // Z-Image reference-identity (no pose) is ported to MLX (sc-3619) → the reference control
-    // is enabled; edit_image still stays torch (epic 3529).
+    // Z-Image reference-identity (no pose) is ported to MLX (sc-3619) → reference enabled;
+    // img2img-edit is now ported too (epic 3529 / sc-3923) → edit enabled.
     let z_image = model_mac_support("z_image_turbo", "image");
     assert!(z_image.features.reference);
-    assert!(!z_image.features.edit);
+    assert!(z_image.features.edit);
+    // The dedicated z_image_edit model is supported on Mac with edit enabled (no dead-end).
+    let z_image_edit = model_mac_support("z_image_edit", "image");
+    assert!(z_image_edit.supported);
+    assert!(z_image_edit.features.edit);
     // FLUX.1 reference (XLabs IP-Adapter) is ported to MLX (epic 3621) → reference enabled on
     // both variants; edit_image stays off (no FLUX.1 edit on any platform — future Kontext).
     let flux = model_mac_support("flux_dev", "image");
@@ -2403,10 +2407,12 @@ fn active_mlx_image_edit_blocks_mps_image_edit_claim() {
     assert_eq!(claimed_mlx.id, mlx_job.id);
     assert_eq!(claimed_mlx.assigned_gpu.as_deref(), Some("mlx"));
 
+    // A torch-only edit model (kolors) is the MPS job — it stays on the torch worker, so it
+    // exercises the shared-GPU exclusion without being soft-deferred to the idle mlx worker.
     let mps_job = store
         .create_job(image_edit_job_with(
             json!({
-                "model": "z_image_edit",
+                "model": "kolors",
                 "mode": "edit_image",
                 "sourceAssetId": "asset_2",
                 "prompt": "p"
@@ -2438,10 +2444,11 @@ fn active_mps_image_edit_blocks_mlx_image_edit_claim() {
     register_gpu_worker(&store, "worker-mps", "mps", image_edit_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
+    // A torch-only edit model (kolors) is the MPS job (it isn't soft-deferred to the mlx worker).
     let mps_job = store
         .create_job(image_edit_job_with(
             json!({
-                "model": "z_image_edit",
+                "model": "kolors",
                 "mode": "edit_image",
                 "sourceAssetId": "asset_1",
                 "prompt": "p"
@@ -2517,12 +2524,13 @@ fn torch_only_image_edit_model_stays_on_torch() {
     let store = store("mlx-routing-image-edit-torch-only");
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
-    // z_image_edit is NOT in MLX_ROUTED_MODELS (only z_image_turbo is), so the edit stays
-    // on the Python torch path. The mlx worker must refuse it.
+    // kolors is NOT in MLX_ROUTED_MODELS, so its edit stays on the Python torch path. The
+    // mlx worker must refuse it. (z_image_edit was ported to MLX — epic 3529 / sc-3923 — so
+    // it is no longer a valid torch-only example; see `z_image_edit_routes_to_mlx`.)
     let job = store
         .create_job(image_edit_job_with(
             json!({
-                "model": "z_image_edit",
+                "model": "kolors",
                 "mode": "edit_image",
                 "sourceAssetId": "asset_1",
                 "prompt": "p"
@@ -2548,6 +2556,35 @@ fn torch_only_image_edit_model_stays_on_torch() {
         decision.is_none(),
         "a torch-only edit model is routing-neutral (no mlx_route_decision)"
     );
+}
+
+#[test]
+fn z_image_edit_routes_to_mlx() {
+    // epic 3529 / sc-3923: z_image_edit (and z_image_turbo edit_image) img2img-edit now runs
+    // on the in-process Rust MLX worker — the engine's `Conditioning::Reference` img2img path.
+    for model in ["z_image_edit", "z_image_turbo"] {
+        let store = store(&format!("mlx-routing-z-image-edit-{model}"));
+        register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+        let job = store
+            .create_job(image_edit_job_with(
+                json!({
+                    "model": model,
+                    "mode": "edit_image",
+                    "sourceAssetId": "asset_1",
+                    "prompt": "make it a watercolor painting"
+                }),
+                "auto",
+            ))
+            .expect("job creates");
+
+        let (claimed, decision) = store
+            .claim_next_job_routed("worker-mlx", false)
+            .expect("mlx claim ok");
+        assert_eq!(claimed.expect("mlx claims it").id, job.id, "{model}");
+        let decision = decision.expect("routing decision present");
+        assert_eq!(decision.decision, "claimed_by_mlx", "{model}");
+        assert_eq!(decision.gpu_id, "mlx", "{model}");
+    }
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -82,6 +82,21 @@ const MLX_MODELS: &[MlxModel] = &[
         supports_negative_prompt: false,
         adapter_label: "mlx_z_image",
     },
+    // Z-Image-Edit (epic 3529) — img2img/edit. No dedicated Edit checkpoint exists yet, so
+    // (like the Python `MODEL_TARGETS` row) it runs the **Turbo weights** through the engine's
+    // img2img path (`Conditioning::Reference` — VAE-encode the source + denoise from
+    // `init_time_step(steps, strength)`), so it shares the `z_image_turbo` engine model. The
+    // `z_image_turbo` `edit_image` mode resolves to the same img2img call (`resolve_zimage_edit_init`).
+    MlxModel {
+        sceneworks_id: "z_image_edit",
+        engine_id: "z_image_turbo",
+        default_repo: "Tongyi-MAI/Z-Image-Turbo",
+        default_steps: 8,
+        supports_guidance: false,
+        default_guidance: 0.0,
+        supports_negative_prompt: false,
+        adapter_label: "mlx_z_image",
+    },
     MlxModel {
         sceneworks_id: "flux_schnell",
         engine_id: "flux1_schnell",
@@ -1314,12 +1329,17 @@ async fn generate_mlx_stream(
         Option<(Image, f32)>,
         Option<PathBuf>,
         Option<f32>,
-    ) = if request.model == "z_image_turbo" {
-        (
-            resolve_zimage_identity_init(request, settings, project_path)?,
-            None,
-            None,
-        )
+    ) = if matches!(request.model.as_str(), "z_image_turbo" | "z_image_edit") {
+        // Z-Image base path: `edit_image` → img2img-edit (sourceAssetId + strength, epic 3529);
+        // otherwise the identity-init reference (referenceAssetId + referenceStrength, sc-3619).
+        // Both feed the engine's single `Reference` conditioning; only the source + strength
+        // keying differs. The strict-pose ControlNet tier diverts earlier (zimage_control_available).
+        let init = if request.mode == "edit_image" {
+            resolve_zimage_edit_init(request, settings, project_path)?
+        } else {
+            resolve_zimage_identity_init(request, settings, project_path)?
+        };
+        (init, None, None)
     } else if is_flux_model(&request.model) && has_reference && request.mode != "edit_image" {
         let reference_id = request
             .reference_asset_id
@@ -2007,6 +2027,47 @@ fn resolve_zimage_identity_init(
         asset_id,
         project_path,
     )?;
+    Ok(Some((image, strength)))
+}
+
+/// Resolve the Z-Image Image-Edit img2img init for `mode == "edit_image"` (epic 3529):
+/// `Some((source, strength))` decoding `sourceAssetId` and pre-fitting it to the output W×H
+/// (crop/pad/outpaint via [`should_fit_edit_source`]/[`fit_engine_image`] — never stretch an
+/// off-aspect source); `None` when not an edit job or no source asset (the caller then falls
+/// back to the identity-init reference path / plain txt2img). `strength` is the torch
+/// `ZImageImg2ImgPipeline` knob (`advanced.strength`, default 0.6) forwarded verbatim to the
+/// engine — its `init_time_step(steps, strength)` matches the diffusers img2img start step.
+/// Both `z_image_edit` and `z_image_turbo` (mode `edit_image`) drive this one path (same
+/// Turbo-weights img2img call in torch).
+#[cfg(target_os = "macos")]
+fn resolve_zimage_edit_init(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<Option<(Image, f32)>> {
+    if request.mode != "edit_image" {
+        return Ok(None);
+    }
+    let Some(asset_id) = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let source = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        asset_id,
+        project_path,
+    )?;
+    let image = if should_fit_edit_source(request) {
+        fit_engine_image(source, request.width, request.height, &request.fit_mode)?
+    } else {
+        source
+    };
+    let strength = advanced_f32(request, "strength", 0.6, 0.05, 1.0);
     Ok(Some((image, strength)))
 }
 

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -53,7 +53,6 @@ Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust
 | Model id | Family | Mac disposition | Porting epic |
 |---|---|---|---|
 | `kolors` | kolors (SDXL UNet + ChatGLM3) | 🔵 Port → drop-on-Mac until then | **epic 3532** |
-| `z_image_edit` | z-image (edit) | 🔵 Port → drop-on-Mac until then | **epic 3529** |
 | `instantid_realvisxl` | sdxl (InstantID) | 🔵 Port → drop-on-Mac until then | epic 3109 |
 | `pulid_flux_dev` | flux (PuLID) | 🔵 Port → drop-on-Mac until then | epic 3069 (engine done; owes SceneWorks routing) |
 | `sensenova_u1_8b`, `sensenova_u1_8b_fast` | sensenova-u1 | 🔵 Port → drop-on-Mac until then | epic 3180 |
@@ -76,7 +75,7 @@ dropped — no silent drops.**
 | Strict-pose ControlNet | `qwen_image` (+ `advanced.poses`) | 🔵 Port-pending | epic 3401 (Qwen ControlNet port) |
 | Reference / edit conditioning | base `qwen_image` (reference/`edit_image`) | 🔵 Port-pending | epic 3401 |
 | Reference (XLabs IP-Adapter) | `flux_schnell`, `flux_dev` | 🟢 Ported (MLX) | sc-3535 (spike) → epic 3621 (sc-3622–3625) |
-| `edit_image` (img2img-edit) | `z_image_turbo` | 🔵 Port-pending | epic 3529 (folds into Z-Image-Edit port) |
+| `edit_image` (img2img-edit) | `z_image_turbo`, `z_image_edit` | 🟢 Ported (MLX) | epic 3529 / sc-3923 (engine `Conditioning::Reference` img2img; Turbo weights) |
 | reference-without-pose | `z_image_turbo` | 🟢 Ported (MLX) | sc-3536 (spike GO) → sc-3619 |
 | Third-party LyCORIS (LoHa / non-peft LoKr) | all families (`networkType=lycoris`) | 🟢 Ported (MLX) | sc-3537 (spike) → epic 3641 (sc-3642/3643/3671 engine + sc-3644 routing) |
 
@@ -142,6 +141,8 @@ Listed so a reviewer doesn't re-file these. All run in the Rust/MLX flow on Mac.
   DiT, T5-only true-CFG; `mlx-gen-chroma`) — epic 3531 / sc-3843.
 - SDXL advanced shapes — reference/IP-Adapter, `edit_image`, masked inpaint, outpaint, and
   tile-detail (`image_detail` on `sdxl`/`realvisxl`) — epic 3041 / sc-3060.
+- Z-Image img2img-edit: `z_image_edit` + `z_image_turbo` `edit_image` mode (Turbo weights via the
+  engine's `Conditioning::Reference` img2img path; `sourceAssetId` + `strength`) — epic 3529 / sc-3923.
 - FLUX.2-klein single-file conversion in-process Rust (`flux2_klein_diffusers`, sc-3136).
 - Video `text_to_video`/`image_to_video` on Wan2.2 + LTX-2.3 (+ synchronized audio), epic 3018.
 - Advanced video — `first_last_frame`, `extend_clip`, `video_bridge`, `replace_person` (→ native

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2215,7 +2215,7 @@
       },
       "macSupport": {
         "features": {
-          "edit": false,
+          "edit": true,
           "lycoris": true,
           "pose": true,
           "reference": true


### PR DESCRIPTION
## Epic 3529 — Port Z-Image-Edit (`z_image_edit`) to MLX

Closes the macOS torch gap for `z_image_edit` (epic 3482 Python-eradication inventory). It also folds in the `z_image_turbo` `edit_image` mode gap — both are the *same* `ZImageImg2ImgPipeline`+Turbo-weights call in torch, so they close together.

### Key finding: this is wiring + validation, not an engine port
The `mlx-gen-z-image` img2img path (`Conditioning::Reference`: VAE-encode init → `init_time_step(steps, strength)` → noise blend → denoise-from-start) was **already in the pinned engine rev `a67e8ed`** — the Character-Studio identity-init flow (sc-3146/3619) drives it in production. So **no mlx-gen pin bump and no engine PR**. `z_image_edit` has no dedicated checkpoint yet, so (like the Python `MODEL_TARGETS` row) it runs Turbo weights via img2img and shares the `z_image_turbo` engine model.

### What changed

**Worker (sc-3923)** — `crates/sceneworks-worker/src/image_jobs.rs`
- `MLX_MODELS`: add `z_image_edit` (engine_id `z_image_turbo`, 8 steps, no guidance/neg).
- New `resolve_zimage_edit_init`: decode `sourceAssetId`, pre-fit to output W×H via the existing `should_fit_edit_source`/`fit_engine_image` (crop/pad/outpaint — never stretch off-aspect), pair with `advanced.strength` (default 0.6, clamp 0.05–1.0).
- `generate_mlx_stream`: the z-image reference block now picks edit-init (`edit_image`) vs identity-init (referenceAssetId) by mode; both feed the engine's single `Reference` conditioning.

**Routing / oracle / UI (sc-3923 + sc-3924)** — `crates/sceneworks-core/src/jobs_store.rs`
- `MLX_ROUTED_MODELS` += `z_image_edit`; `image_request_mlx_eligible` arm `"z_image_turbo" | "z_image_edit"`.
- `z_image_mlx_eligible` now allows `edit_image` **with a `sourceAssetId`** (an edit with nothing to edit stays torch).
- Dropped `z_image_edit` from `torch_only_image_model_epic` and removed the now-dead `classify_image_gap` edit arm (+ orphaned `is_edit` binding). `model_mac_support` auto-flips `edit: true`.

**Docs** — `docs/mac-rust-gaps.md`: moved the `z_image_edit` / `z_image_turbo` edit rows to ported.

**Tests** — `crates/sceneworks-core/tests/jobs_store.rs`: repurposed torch-only edit coverage onto `kolors`, added `z_image_edit_routes_to_mlx` (both ids), and swapped the shared-GPU edit tests off the now-MLX-eligible `z_image_edit` (it would be soft-deferred to the idle mlx worker). In-module: split `z_image_edit_mode_*` into with-source (eligible) / without-source (not).

Windows / Linux / Docker `MODEL_TARGETS` (`image_adapters.py`) untouched — they keep the torch path.

### Validation
- **Engine img2img parity vs the mflux fork** (real `Tongyi-MAI/Z-Image-Turbo` weights, Mac GPU): all 5 gates green. Gate E drives the exact public `generate()` + `Conditioning::Reference` path the worker feeds — **0.000% pixel divergence @ strength 0.6**.
- **Strength sweep**: 0.3 → 0.022%, 0.6 → 0.000%, 0.9 → 0.000% (`init_time_step` maps to start-step 1/2/3).
- **Gates**: `cargo fmt --check` clean, `cargo clippy --all-targets` clean (no `-D` warnings), core 96 integration + 30 unit + worker 194 lib tests pass.
- Regression: identity-init reference path (sc-3619) unchanged and shares the proven engine path.

### Reviewer notes
- Parity oracle is the **mflux fork** (mlx-gen's port source), not diffusers — a diffusers `ZImageImg2ImgPipeline` A/B would measure fork-vs-diffusers scheduler differences, not this wiring.
- Residual (sc-3925): a single in-app click-through Mac edit through the full job queue → worker → asset pipeline. The engine call is Gate E; the surrounding plumbing (sourceAssetId decode via the shared `load_reference_image`, strength default/clamp, routing) is unit/integration-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)