### PR TITLE
sc-3905: wire SenseNova-U1 VQA + Document Studio (interleave) to the Rust MLX worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "image",
  "inventory",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "image",
  "inventory",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "image",
  "inventory",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b9b9aba70953602dacaf182a6c754b9a1bcc26ee#b9b9aba70953602dacaf182a6c754b9a1bcc26ee"
 dependencies = [
  "image",
  "inventory",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -880,6 +880,12 @@ impl JobsStore {
             || should_defer_video_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
             || should_defer_training_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
             || should_defer_caption_to_mlx_worker(&transaction, &queued, &worker, mlx_required)?
+            || should_defer_understanding_to_mlx_worker(
+                &transaction,
+                &queued,
+                &worker,
+                mlx_required,
+            )?
         {
             // A non-mlx worker is yielding this MLX-eligible job to an idle mlx worker.
             let decision = RouteDecision::new(
@@ -1676,6 +1682,7 @@ fn job_is_any_mlx_eligible(job: &JobSnapshot) -> bool {
         || video_job_is_mlx_eligible(job)
         || training_job_is_mlx_eligible(job)
         || caption_job_is_mlx_eligible(job)
+        || understanding_job_is_mlx_eligible(job)
 }
 
 /// Actionable terminal error for an MLX-eligible job stranded on macOS with no live `mlx`
@@ -1781,10 +1788,14 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
             Some("epic 3041"),
         )),
 
+        // SenseNova-U1 VQA + Document-Studio interleave are ported to the Rust MLX worker
+        // (sc-3905, via the concrete `T2iModel` — the `Generator` contract can't express
+        // text / text+image output); eligible jobs early-return `Ok` above. This arm is
+        // reached only for an understanding job on a model with no in-process path.
         JobType::ImageVqa | JobType::ImageInterleave => Err(UnsupportedReason::new(
             model,
-            "image understanding / interleave",
-            "image VQA / interleaved generation is the SenseNova-U1 understanding surface; it lands with the SenseNova port.",
+            "image understanding / interleave on this model",
+            "image VQA / interleaved generation runs on MLX for the SenseNova-U1 model (sensenova_u1_8b[_fast]); other models have no in-process understanding path and stay on the Python torch path.",
             Some("epic 3180"),
         )),
 
@@ -2546,6 +2557,29 @@ fn should_defer_caption_to_mlx_worker(
     idle_mlx_worker_can_claim(connection, job, worker)
 }
 
+/// Understanding sibling of [`should_defer_image_to_mlx_worker`] (sc-3905): a non-mlx GPU worker
+/// defers an `auto` MLX-eligible SenseNova-U1 `image_vqa` / `image_interleave` job to an idle mlx
+/// worker, so the in-process `T2iModel` (`vqa` / `interleave_gen`) claims it. Windows/Linux and
+/// explicit non-auto GPU requests keep the Python torch SenseNova path.
+fn should_defer_understanding_to_mlx_worker(
+    connection: &Connection,
+    job: &JobSnapshot,
+    worker: &WorkerSnapshot,
+    mlx_required: bool,
+) -> JobsStoreResult<bool> {
+    if worker.gpu_id.eq_ignore_ascii_case("mlx") || !understanding_job_is_mlx_eligible(job) {
+        return Ok(false);
+    }
+    // macOS MLX-required (sc-3483): yield unconditionally, same as the image sibling.
+    if mlx_required {
+        return Ok(true);
+    }
+    if job.requested_gpu != "auto" {
+        return Ok(false);
+    }
+    idle_mlx_worker_can_claim(connection, job, worker)
+}
+
 /// Whether an idle `mlx` worker (other than `worker`) exists that supports `job`
 /// and has no active GPU job — the shared tail of the image/video MLX deferral.
 fn idle_mlx_worker_can_claim(
@@ -2728,6 +2762,28 @@ fn image_detail_mlx_eligible(job: &JobSnapshot) -> bool {
 /// Whether the in-process MLX worker can serve this GPU job (image_generate or image_detail).
 fn job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     image_job_is_mlx_eligible(job) || image_detail_mlx_eligible(job)
+}
+
+/// Epic 3180 / sc-3905 routing — does this understanding job (`image_vqa` / `image_interleave`)
+/// belong on the in-process Rust MLX worker on macOS? These two modes are SenseNova-U1's
+/// understanding/interleave surface, served via the concrete `T2iModel` (`vqa` / `interleave_gen`)
+/// because the `Generator` contract emits Images/Video only. SenseNova-U1 is the only model with an
+/// in-process understanding path, so eligibility = a SenseNova-U1 id (the worker handler validates
+/// the per-mode request: VQA needs a source image + question; interleave needs a prompt). Other
+/// models on these job types have no MLX path and stay on the Python torch worker.
+fn understanding_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
+    if !matches!(job.job_type, JobType::ImageVqa | JobType::ImageInterleave) {
+        return false;
+    }
+    // The understanding job types are SenseNova-specific; a missing model defaults to the base id.
+    let model = job
+        .payload
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("sensenova_u1_8b");
+    matches!(model, "sensenova_u1_8b" | "sensenova_u1_8b_fast")
 }
 
 /// SDXL MLX-routing conditions. sc-3026 brought txt2img + LoRA; sc-3060 (epic 3041) adds the
@@ -3182,6 +3238,15 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         // via `ort`/CoreML. `aura-sr` has no Rust path, so the mlx worker refuses it and
         // it stays on the Python torch worker.
         if matches!(job.job_type, JobType::ImageUpscale) && !upscale_job_is_mlx_eligible(job) {
+            return false;
+        }
+        // SenseNova-U1 understanding (sc-3905): the mlx worker serves `image_vqa` /
+        // `image_interleave` only for the SenseNova-U1 ids (the sole in-process understanding
+        // path). A non-SenseNova understanding job is not MLX-eligible, so the mlx worker
+        // refuses it and it stays on the Python torch worker.
+        if matches!(job.job_type, JobType::ImageVqa | JobType::ImageInterleave)
+            && !understanding_job_is_mlx_eligible(job)
+        {
             return false;
         }
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1519,6 +1519,63 @@ fn qwen_edit_image_job_defers_to_mlx_worker() {
 }
 
 #[test]
+fn sensenova_understanding_jobs_defer_to_mlx_worker() {
+    // sc-3905: SenseNova-U1 VQA (`image_vqa`) + Document-Studio interleave (`image_interleave`)
+    // are served in-process via the concrete `T2iModel`. A worker that advertises the
+    // understanding capabilities defers an eligible job to the idle mlx worker, which claims it.
+    let understanding_caps = vec![
+        WorkerCapability::Gpu,
+        WorkerCapability::ImageVqa,
+        WorkerCapability::ImageInterleave,
+    ];
+    let cases = [
+        (
+            "vqa",
+            JobType::ImageVqa,
+            json!({ "model": "sensenova_u1_8b", "sourceAssetId": "asset_1", "question": "what is this?" }),
+        ),
+        (
+            "interleave",
+            JobType::ImageInterleave,
+            json!({ "model": "sensenova_u1_8b_fast", "prompt": "a short illustrated guide" }),
+        ),
+    ];
+    for (label, job_type, payload) in cases {
+        let store = store(&format!("mlx-routing-sensenova-{label}"));
+        register_gpu_worker(&store, "worker-torch", "mps", understanding_caps.clone());
+        register_gpu_worker(&store, "worker-mlx", "mlx", understanding_caps.clone());
+
+        let job = store
+            .create_job(CreateJob {
+                job_type,
+                project_id: Some("project-1".to_owned()),
+                project_name: Some("Project 1".to_owned()),
+                payload: object(payload),
+                requested_gpu: "auto".to_owned(),
+                source_job_id: None,
+                duplicate_of_job_id: None,
+                attempts: 1,
+            })
+            .expect("job creates");
+
+        // The torch worker defers it to the idle mlx worker, which claims it in-process.
+        assert!(
+            store
+                .claim_next_job("worker-torch")
+                .expect("torch claim ok")
+                .is_none(),
+            "{label}: torch worker should defer to the idle mlx worker"
+        );
+        let claimed = store
+            .claim_next_job("worker-mlx")
+            .expect("mlx claim ok")
+            .expect("mlx claims the job");
+        assert_eq!(claimed.id, job.id, "{label}");
+        assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"), "{label}");
+    }
+}
+
+#[test]
 fn qwen_edit_lightning_image_job_defers_to_mlx_worker() {
     let store = store("mlx-routing-qwen-edit-lightning");
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
@@ -1803,9 +1860,9 @@ fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
         // instantid_realvisxl is NO LONGER wholly torch-only (sc-3345: identity + angle set run on
         // MLX); its remaining per-feature gaps are covered by
         // `mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped`.
-        // SenseNova-U1 (sensenova_u1_8b[_fast]) was likewise ported to MLX (epic 3180 / sc-3900):
-        // its image modes are now MLX-routed, so it is no longer a torch-only image model. Its VQA /
-        // interleave understanding surface (a separate job type) is still gap-classified to epic 3180.
+        // SenseNova-U1 (sensenova_u1_8b[_fast]) was likewise ported to MLX (epic 3180 / sc-3900
+        // image modes, sc-3905 VQA + interleave): all of its surface is now MLX-routed, so it is no
+        // longer a torch-only image model (and its understanding job types are MLX-supported too).
         ("lens_turbo", "epic 3164"),
     ];
     for (model, epic) in cases {
@@ -2026,14 +2083,38 @@ fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
         mac_rust_supported(&z_ref).is_ok(),
         "z-image reference-without-pose should be MLX-supported (sc-3619)"
     );
-    // Image understanding folds into the SenseNova port (epic 3180).
-    let vqa = job_of(
+    // Image understanding (VQA) + Document-Studio interleave are now ported to the Rust MLX worker
+    // for the SenseNova-U1 ids (epic 3180 / sc-3905, via the concrete `T2iModel`), so they are
+    // MLX-supported rather than a torch-fallback gap.
+    for (job_type, payload) in [
+        (
+            JobType::ImageVqa,
+            json!({ "model": "sensenova_u1_8b", "sourceAssetId": "asset_1", "question": "what is this?" }),
+        ),
+        (
+            JobType::ImageVqa,
+            json!({ "model": "sensenova_u1_8b_fast", "sourceAssetId": "asset_1", "question": "?" }),
+        ),
+        (
+            JobType::ImageInterleave,
+            json!({ "model": "sensenova_u1_8b", "prompt": "a tutorial" }),
+        ),
+    ] {
+        let job = job_of(&store, job_type, payload);
+        assert!(
+            mac_rust_supported(&job).is_ok(),
+            "SenseNova-U1 understanding/interleave should be MLX-supported (sc-3905)"
+        );
+    }
+    // A non-SenseNova understanding job has no in-process path and stays gap-classified to the
+    // SenseNova epic (the only model that serves these modes).
+    let other_vqa = job_of(
         &store,
         JobType::ImageVqa,
-        json!({ "model": "sensenova_u1_8b" }),
+        json!({ "model": "some_future_vlm" }),
     );
     assert_eq!(
-        mac_rust_supported(&vqa)
+        mac_rust_supported(&other_vqa)
             .unwrap_err()
             .suggested_epic
             .as_deref(),

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,10 +68,13 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 72214e3 (mlx-gen main, merged PR #199, epic 3180): adds the native-MLX SenseNova-U1 family
-# crate `mlx-gen-sensenova` (NEO-Unify — a dense dual-path Qwen3-MoT AR LLM + flow-matching image
-# generator + NEO ViT; sc-3181..sc-3194). Two registered ids: `sensenova_u1_8b` (base, 50 NFE /
-# text-CFG 4 + image-CFG via true_cfg) and `sensenova_u1_8b_fast` (8-step distill-LoRA merged at
+# Rev b9b9aba (mlx-gen main, merged PR #200, epic 3180 / sc-3905): primes the empty `<think></think>`
+# block in `T2iModel::vqa` (matching the reference `chat(think=False)` + the no-think interleave
+# path) so the VQA answer isn't consumed by a chain-of-thought — required for the SceneWorks VQA
+# cutover (sc-3905). On top of rev 72214e3 (merged PR #199, epic 3180): the native-MLX SenseNova-U1
+# family crate `mlx-gen-sensenova` (NEO-Unify — a dense dual-path Qwen3-MoT AR LLM + flow-matching
+# image generator + NEO ViT; sc-3181..sc-3194). Two registered ids: `sensenova_u1_8b` (base, 50 NFE
+# / text-CFG 4 + image-CFG via true_cfg) and `sensenova_u1_8b_fast` (8-step distill-LoRA merged at
 # load, CFG 1). Public `T2iModel::{vqa, interleave_gen}` serve the VQA + Document-Studio paths the
 # `Generator` contract can't express (sc-3905). Q4/Q8 backbone quant (sc-3193). The mlx-rs pin is
 # unchanged (e59ffd88) so MLX core rebuilds nothing.
@@ -102,7 +105,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -110,60 +113,60 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -172,7 +175,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b9b9aba70953602dacaf182a6c754b9a1bcc26ee" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -399,6 +399,15 @@ pub(crate) fn mlx_gpu() -> DiscoveredGpu {
             // Tile-ControlNet detail refine (epic 3041, sc-3060) — the SDXL-family
             // `image_detail` job runs in-process on the engine here too.
             WorkerCapability::ImageDetail,
+            // SenseNova-U1 understanding + Document Studio (epic 3180, sc-3905): visual
+            // question answering (`image_vqa`) and interleaved text-image generation
+            // (`image_interleave`) run in-process via the concrete `T2iModel` (the modes the
+            // `Generator` contract can't express). The API routes these here only for the
+            // SenseNova-U1 ids (`jobs_store::understanding_job_is_mlx_eligible`); off macOS the
+            // capabilities are never advertised, so the Python torch worker serves them on
+            // Windows/Linux.
+            WorkerCapability::ImageVqa,
+            WorkerCapability::ImageInterleave,
             WorkerCapability::VideoGenerate,
             // Clip-conditioning advanced video modes (epic 3040, sc-3522): extend_clip /
             // video_bridge run the LTX IC-LoRA keyframe-append path in-process. The API gates

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -592,13 +592,13 @@ async fn generate_stub_stream(
 }
 
 /// Per-job invariants shared across every image in the generation set.
-struct ImagePlan {
-    request: ImageRequest,
-    genset_id: String,
-    created_at: String,
-    family: String,
-    slug: String,
-    generation_set: Value,
+pub(crate) struct ImagePlan {
+    pub(crate) request: ImageRequest,
+    pub(crate) genset_id: String,
+    pub(crate) created_at: String,
+    pub(crate) family: String,
+    pub(crate) slug: String,
+    pub(crate) generation_set: Value,
     /// Number of images this job produces. Usually `request.count`, but a FLUX.2 angle
     /// set is 11 and a pose set is the pose count (sc-3030) — the generation set's
     /// `count`/`expectedCount` reflect this so the gallery streams against the real
@@ -616,7 +616,7 @@ impl ImagePlan {
     }
 
     /// Build a plan whose generation set reports `image_count` images (see the field).
-    fn with_count(request: &ImageRequest, image_count: u32) -> Self {
+    pub(crate) fn with_count(request: &ImageRequest, image_count: u32) -> Self {
         let genset_id = format!("genset_{}", Uuid::new_v4().simple());
         let created_at = now_rfc3339();
         let family = resolve_family(request);
@@ -646,7 +646,7 @@ impl ImagePlan {
 /// fact the API turns into an indexed asset (every key here is consumed by
 /// `build_image_sidecar_parts`). Shared by the stub and real paths.
 #[allow(clippy::too_many_arguments)]
-fn write_image_asset(
+pub(crate) fn write_image_asset(
     plan: &ImagePlan,
     index: usize,
     seed: i64,
@@ -783,7 +783,7 @@ fn resolve_family(request: &ImageRequest) -> String {
 /// Resolve the seed for image `index`, matching the Python worker's `resolve_seed`:
 /// a base `seed` (offset by index) wins, else an explicit per-image seed, else a
 /// deterministic `sha256("{prompt}:{index}")` so a re-run reproduces.
-fn resolve_seed(request: &ImageRequest, index: usize) -> i64 {
+pub(crate) fn resolve_seed(request: &ImageRequest, index: usize) -> i64 {
     if let Some(base) = request.seed {
         return base.wrapping_add(index as i64);
     }
@@ -796,7 +796,7 @@ fn resolve_seed(request: &ImageRequest, index: usize) -> i64 {
 
 /// Progress payload with the worker's real backend label (the shared
 /// `progress_payload` hardcodes `cpu`; the MLX worker reports `mlx`).
-fn image_progress(
+pub(crate) fn image_progress(
     status: JobStatus,
     stage: ProgressStage,
     progress: f64,
@@ -903,7 +903,7 @@ fn model_repo(request: &ImageRequest, model: &MlxModel) -> String {
 /// HuggingFace cache snapshot for the model repo. `None` when the model is not a known
 /// engine family or its snapshot is absent.
 #[cfg(target_os = "macos")]
-fn resolve_weights_dir(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+pub(crate) fn resolve_weights_dir(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
     if let Some(path) = request
         .advanced
         .get("modelPath")
@@ -1262,7 +1262,7 @@ fn resolve_flux_ip_adapter_dir(settings: &Settings) -> WorkerResult<PathBuf> {
 /// `image_distill_lora_fuse_*` / `image_lora_apply_*` sub-phase events. A `start`
 /// with no matching `complete` means the load failed (the error propagates via `?`).
 #[cfg(target_os = "macos")]
-fn emit_load_event(event: &str, job_id: &str, engine: &str, adapter_count: usize) {
+pub(crate) fn emit_load_event(event: &str, job_id: &str, engine: &str, adapter_count: usize) {
     emit_event(
         event,
         json!({

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -43,6 +43,12 @@ mod media_jobs;
 use media_jobs::*;
 mod image_jobs;
 use image_jobs::*;
+// SenseNova-U1 understanding + interleave jobs (epic 3180, sc-3905 — Path B). VQA + Document
+// Studio (interleave) consume the concrete `T2iModel` directly (the `Generator` contract emits
+// Images/Video only). The handlers are compiled cross-platform (with non-macOS error stubs); the
+// real in-process MLX work is macOS-gated inside the module.
+mod sensenova_jobs;
+use sensenova_jobs::*;
 mod video_jobs;
 use video_jobs::*;
 // Replace-person mask pipeline (epic 3040, sc-3521): cross-platform mask rasterization /
@@ -566,6 +572,18 @@ async fn run_utility_job(
         JobType::ImageDetail => run_image_detail_job(api, settings, &job)
             .await
             .map_err(|error| ("Image detail enhancement failed.", error)),
+        // SenseNova-U1 visual question answering + Document Studio interleave (epic 3180,
+        // sc-3905). These bypass the `Generator` registry and call the concrete `T2iModel`
+        // directly (text / text+images output the `GenerationOutput` contract can't express).
+        // The API routes them here only on Mac (`understanding_job_is_mlx_eligible`); off macOS
+        // the `image_vqa`/`image_interleave` capabilities are never advertised, so these arms
+        // are unreachable there (the Python torch worker serves them on Windows/Linux).
+        JobType::ImageVqa => run_vqa_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Visual question answering failed.", error)),
+        JobType::ImageInterleave => run_interleave_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Interleaved generation failed.", error)),
         // Native MLX video generation, served in-process by the linked mlx-gen engine
         // on the macOS Apple-Silicon GPU worker (epic 3018). sc-3033 ships the runtime
         // + procedural stub; the real Wan (sc-3034) / LTX+audio (sc-3035) models link

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -25,6 +25,8 @@
 //! error loudly (the Python torch worker serves these modes on Windows/Linux).
 
 use super::*;
+// Only the macOS handlers parse an `ImageRequest`; the non-macOS stubs don't.
+#[cfg(target_os = "macos")]
 use sceneworks_core::image_request::ImageRequest;
 
 #[cfg(target_os = "macos")]
@@ -735,7 +737,9 @@ fn interleave_resolution_snap(width: i64, height: i64) -> (i32, i32) {
 
 /// Drop any `<think>…</think>` reasoning so only the answer is returned — removes complete think
 /// blocks and any dangling/unclosed one (reasoning truncated by `max_new_tokens`). Mirrors the
-/// Python `SenseNovaU1Adapter._strip_reasoning`.
+/// Python `SenseNovaU1Adapter._strip_reasoning`. Used by the macOS VQA handler; also unit-tested
+/// cross-platform (it is pure string logic), so it compiles under `test` off macOS too.
+#[cfg(any(target_os = "macos", test))]
 fn strip_reasoning(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
@@ -757,7 +761,8 @@ fn strip_reasoning(text: &str) -> String {
 }
 
 /// `safe_int` over a top-level payload field: parse (int / float / numeric string) else `default`,
-/// then clamp to `[lo, hi]`.
+/// then clamp to `[lo, hi]`. Used by the macOS handlers; also unit-tested cross-platform.
+#[cfg(any(target_os = "macos", test))]
 fn payload_int(payload: &JsonObject, key: &str, default: i64, lo: i64, hi: i64) -> i64 {
     payload
         .get(key)
@@ -786,6 +791,7 @@ fn advanced_float(advanced: &JsonObject, key: &str, default: f32) -> f32 {
         .unwrap_or(default)
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn json_to_i64(value: &Value) -> Option<i64> {
     value
         .as_i64()

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -1,0 +1,1007 @@
+//! SenseNova-U1 understanding + interleave jobs (epic 3180, sc-3905 — Path B).
+//!
+//! These are the two SenseNova-U1 modes the mlx-gen `Generator` contract can't express
+//! (`GenerationOutput` is Images/Video only), so they bypass the registry and call the public
+//! [`T2iModel`](mlx_gen_sensenova::T2iModel) methods directly:
+//!
+//! * **VQA** (`image_vqa`): one source image + a question → a text answer. No asset write.
+//! * **Interleave / Document Studio** (`image_interleave`): a prompt (+ optional source images) →
+//!   ordered text + generated images, persisted as image assets plus an
+//!   [`InterleavedDocument`](sceneworks_core::contracts::InterleavedDocument) `document` asset.
+//!
+//! Path A (sc-3900) routes the image-producing modes through the `Generator` registry and bumped
+//! the `mlx-gen` pin + force-linked `mlx_gen_sensenova`; this module reuses that dependency. The
+//! `Generator` crate has no public `SenseNova` constructor, so the worker assembles a concrete
+//! `T2iModel` here (replicating the engine's private `load_inner`) from the public re-exports.
+//!
+//! Parity: VQA mirrors the Python `SenseNovaU1Adapter.answer_question`; interleave mirrors
+//! `generate_interleaved` / `_write_interleaved_document` byte-for-byte (request fields, the
+//! interleave resolution buckets + think/no-think system protocol, and the response/asset shapes).
+//! The understanding + generation model loads dense (no distill LoRA, no quantization) exactly as
+//! the torch adapter does (`_load_model(distill_lora=None)`), keeping the VQA decode bit-identical.
+//!
+//! Off macOS the in-process engine is unavailable and the `image_vqa` / `image_interleave`
+//! capabilities are never advertised by this worker, so the handlers are unreachable stubs that
+//! error loudly (the Python torch worker serves these modes on Windows/Linux).
+
+use super::*;
+use sceneworks_core::image_request::ImageRequest;
+
+#[cfg(target_os = "macos")]
+use mlx_gen::image::{decoded_to_image, resize_bicubic_u8};
+#[cfg(target_os = "macos")]
+use mlx_gen::tokenizer::TextTokenizer;
+#[cfg(target_os = "macos")]
+use mlx_gen::Image;
+#[cfg(target_os = "macos")]
+use mlx_gen_sensenova::{
+    load_raw, load_tokenizer, smart_resize, NeoChatConfig, Sampler, T2iModel, T2iOptions,
+    INTERLEAVE_RESOLUTIONS, INTERLEAVE_SYSTEM_MESSAGE,
+};
+#[cfg(target_os = "macos")]
+use mlx_rs::ops::divide;
+#[cfg(target_os = "macos")]
+use mlx_rs::Array;
+
+/// The adapter id recorded on the generated assets + the interleaved document (the MLX SenseNova
+/// path, matching the `adapter_label` the sc-3900 image rows use).
+#[cfg(target_os = "macos")]
+const SENSENOVA_ADAPTER: &str = "mlx_sensenova";
+
+// ===========================================================================
+// VQA (image_vqa)
+// ===========================================================================
+
+/// Visual question answering: a text answer about one source image. Mirrors the Python
+/// `SenseNovaU1Adapter.answer_question` — same request fields, same `{answer, question,
+/// sourceAssetId, model, realModelInference}` result, no asset write. The source image resolves
+/// only through the project sidecar/DB (`load_reference_image`), so there is no client-supplied
+/// path escape.
+#[cfg(target_os = "macos")]
+pub(crate) async fn run_vqa_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let request = ImageRequest::from_payload(&job.payload);
+    if request.project_id.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Missing payload.projectId".to_owned(),
+        ));
+    }
+    let model_id = if request.model.trim().is_empty() {
+        "sensenova_u1_8b".to_owned()
+    } else {
+        request.model.clone()
+    };
+    let question = job
+        .payload
+        .get("question")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Visual question answering requires a question.".to_owned())
+        })?
+        .to_owned();
+    let source_asset_id = job
+        .payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "Visual question answering requires a source image asset.".to_owned(),
+            )
+        })?
+        .to_owned();
+
+    // VQA latency ~ output tokens + input vision tokens; both default low and are tunable per
+    // request (top-level payload, mirroring the Python adapter — NOT under `advanced`).
+    let max_new_tokens = payload_int(&job.payload, "maxNewTokens", 256, 16, 2048) as usize;
+    let max_image_pixels = payload_int(
+        &job.payload,
+        "maxImagePixels",
+        768 * 768,
+        256 * 256,
+        2048 * 2048,
+    );
+
+    let weights_dir = resolve_weights_dir(&request, settings)
+        .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
+
+    let project =
+        ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
+    let project_path = PathBuf::from(project.path);
+    let backend = backend_label(&settings.gpu_id).to_owned();
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.08,
+            "Preparing visual question.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    // Decode the source image on the async side (Send `Image` moves into the blocking task).
+    let source = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        &source_asset_id,
+        &project_path,
+    )?;
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.6,
+            "Analyzing image.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    let job_id = job.id.clone();
+    let question_for_vqa = question.clone();
+    let answer = tokio::task::spawn_blocking(move || -> WorkerResult<String> {
+        emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
+        let (model, tokenizer) = load_sensenova_model(&weights_dir)?;
+        emit_load_event(
+            "image_pipeline_load_complete",
+            &job_id,
+            "sensenova_u1_8b",
+            0,
+        );
+        // ImageNet-normalized inside `vqa`; pass [3,H,W] in [0,1], 32-aligned, within the
+        // understanding pixel budget (default 768², `load_image_native` min 256²).
+        let pixel_values = image_to_chw01(&source, 256 * 256, max_image_pixels)?;
+        let answer = model
+            .vqa(
+                &tokenizer,
+                &question_for_vqa,
+                std::slice::from_ref(&pixel_values),
+                max_new_tokens,
+                Sampler::Greedy,
+            )
+            .map_err(|error| {
+                WorkerError::InvalidPayload(format!("SenseNova VQA failed: {error}"))
+            })?;
+        Ok(strip_reasoning(&answer))
+    })
+    .await
+    .map_err(|error| WorkerError::InvalidPayload(format!("VQA task join: {error}")))??;
+
+    let result = json!({
+        "answer": answer,
+        "question": question,
+        "sourceAssetId": source_asset_id,
+        "model": model_id,
+        "realModelInference": true,
+    })
+    .as_object()
+    .cloned()
+    .expect("json! object literal");
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Answer ready.",
+            Some(result),
+            &backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Off macOS the in-process engine is unavailable; `image_vqa` is served by the Python torch
+/// worker (the `mlx` worker — the only one advertising this capability — is macOS-only).
+#[cfg(not(target_os = "macos"))]
+pub(crate) async fn run_vqa_job(
+    _api: &ApiClient,
+    _settings: &Settings,
+    _job: &JobSnapshot,
+) -> WorkerResult<()> {
+    Err(WorkerError::InvalidPayload(
+        "image_vqa runs on the macOS MLX worker or the Python torch worker, not this Rust worker"
+            .to_owned(),
+    ))
+}
+
+// ===========================================================================
+// Interleave / Document Studio (image_interleave)
+// ===========================================================================
+
+/// Interleaved text-image generation: one model rollout yields ordered text + images, persisted as
+/// a `document` asset whose segments reference the generated image assets in order. Mirrors the
+/// Python `generate_interleaved` → `_write_interleaved_document` contract (request fields, resolution
+/// buckets, think/no-think protocol, asset/result shapes). The base understanding+generation model
+/// loads dense (no distill LoRA) — interleave needs the full model, never the distilled gen LoRA.
+#[cfg(target_os = "macos")]
+pub(crate) async fn run_interleave_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let request = ImageRequest::from_payload(&job.payload);
+    if request.project_id.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Missing payload.projectId".to_owned(),
+        ));
+    }
+    let prompt = request.prompt.trim().to_owned();
+    if prompt.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Interleaved generation requires a prompt.".to_owned(),
+        ));
+    }
+    let model_id = if request.model.trim().is_empty() {
+        "sensenova_u1_8b".to_owned()
+    } else {
+        request.model.clone()
+    };
+    let advanced = &request.advanced;
+
+    let max_images = advanced_int(advanced, "maxImages", 6, 1, 10) as usize;
+    // Snap the requested W×H to the nearest interleave bucket by aspect ratio (log-space), mirroring
+    // the Python `interleave_resolution_for`. Defaults 2048×1152 (16:9), clamped 256..4096.
+    let req_width = payload_int(&job.payload, "width", 2048, 256, 4096);
+    let req_height = payload_int(&job.payload, "height", 1152, 256, 4096);
+    let (width, height) = interleave_resolution_snap(req_width, req_height);
+
+    let source_asset_ids: Vec<String> = job
+        .payload
+        .get("sourceAssetIds")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Upstream interleave defaults (examples/interleave/inference.py @238d6cf).
+    let steps = advanced_int(advanced, "numInferenceSteps", 50, 1, 100) as usize;
+    let cfg_scale = advanced_float(advanced, "guidanceScale", 4.0);
+    let img_cfg_scale = advanced_float(advanced, "imageGuidanceScale", 1.0);
+    let timestep_shift = advanced_float(advanced, "timestepShift", 3.0);
+    let max_new_tokens = advanced_int(advanced, "maxNewTokens", 2048, 64, 8192) as usize;
+    // Non-Think by default: the document is the deliverable, so skip the chain-of-thought.
+    let think_mode = advanced
+        .get("thinkMode")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let system_message = advanced
+        .get("systemMessage")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| INTERLEAVE_SYSTEM_MESSAGE.to_owned());
+    let seed = resolve_seed(&request, 0);
+
+    let weights_dir = resolve_weights_dir(&request, settings)
+        .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
+
+    let project =
+        ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
+    let project_path = PathBuf::from(project.path);
+    tokio::fs::create_dir_all(project_path.join("assets").join("documents")).await?;
+    tokio::fs::create_dir_all(project_path.join("assets").join("images")).await?;
+    let backend = backend_label(&settings.gpu_id).to_owned();
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.08,
+            "Preparing interleaved document.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    // Decode the optional source images on the async side (Send moves into the blocking task).
+    let mut input_images = Vec::with_capacity(source_asset_ids.len());
+    for asset_id in &source_asset_ids {
+        input_images.push(load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            asset_id,
+            &project_path,
+        )?);
+    }
+
+    // The engine `interleave_gen` is a single uninterruptible rollout, so check for cancellation
+    // before launching it. `check_cancel` marks the job canceled + returns `Canceled` on a cancel;
+    // a real API error still propagates.
+    match check_cancel(api, &job.id, "Interleaved generation canceled by user.").await {
+        Ok(()) => {}
+        Err(WorkerError::Canceled(_)) => return Ok(()),
+        Err(other) => return Err(other),
+    }
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.45,
+            "Composing interleaved document.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+
+    // The engine's `interleave_gen` is a single synchronous rollout with no per-segment callback,
+    // so (like the Python adapter's single `interleave_gen` call) the document streams as one final
+    // result rather than incrementally. The whole rollout runs on a blocking thread; the decoded
+    // images come back as Send `Image`s for asset writing on the async side.
+    let job_id = job.id.clone();
+    let prompt_for_gen = prompt.clone();
+    let (generated_text, images) =
+        tokio::task::spawn_blocking(move || -> WorkerResult<(String, Vec<Image>)> {
+            emit_load_event("image_pipeline_load_start", &job_id, "sensenova_u1_8b", 0);
+            let (model, tokenizer) = load_sensenova_model(&weights_dir)?;
+            emit_load_event(
+                "image_pipeline_load_complete",
+                &job_id,
+                "sensenova_u1_8b",
+                0,
+            );
+
+            // Source images: [3,H,W] in [0,1], 32-aligned. Bounds mirror the torch
+            // `interleave_gen` (`load_image_native` min 512², max min(2048², 4096²/n)).
+            let n = input_images.len().max(1) as i64;
+            let max_pixels = (2048 * 2048).min((4096 * 4096) / n);
+            let mut input_arrays = Vec::with_capacity(input_images.len());
+            for image in &input_images {
+                input_arrays.push(image_to_chw01(image, 512 * 512, max_pixels)?);
+            }
+
+            let opts = T2iOptions {
+                cfg_scale,
+                img_cfg_scale,
+                num_steps: steps,
+                timestep_shift,
+                seed: seed as u64,
+                think_mode,
+                ..Default::default()
+            };
+            let out = model
+                .interleave_gen(
+                    &tokenizer,
+                    &prompt_for_gen,
+                    &input_arrays,
+                    width,
+                    height,
+                    &opts,
+                    &system_message,
+                    max_new_tokens,
+                    max_images,
+                    None,
+                )
+                .map_err(|error| {
+                    WorkerError::InvalidPayload(format!("SenseNova interleave failed: {error}"))
+                })?;
+            // The generated images are model-space [-1,1] `[1,3,H,W]` arrays — decode each to RGB8
+            // exactly as the `Generator` image path does (`decoded_to_image`).
+            let mut decoded = Vec::with_capacity(out.images.len());
+            for image in &out.images {
+                decoded.push(decoded_to_image(image).map_err(|error| {
+                    WorkerError::InvalidPayload(format!("SenseNova interleave decode: {error}"))
+                })?);
+            }
+            Ok((out.text, decoded))
+        })
+        .await
+        .map_err(|error| WorkerError::InvalidPayload(format!("interleave task join: {error}")))??;
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Saving,
+            ProgressStage::Saving,
+            0.9,
+            "Saving interleaved document.",
+            None,
+            &backend,
+        ),
+    )
+    .await?;
+
+    let result = write_interleaved_document(
+        &request,
+        job,
+        &project_path,
+        &prompt,
+        &model_id,
+        seed,
+        max_images,
+        width,
+        height,
+        steps,
+        cfg_scale,
+        img_cfg_scale,
+        timestep_shift,
+        max_new_tokens,
+        think_mode,
+        &generated_text,
+        images,
+    )?;
+
+    update_job(
+        api,
+        &job.id,
+        image_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Interleaved document ready.",
+            Some(result),
+            &backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Off macOS the in-process engine is unavailable; `image_interleave` is served by the Python torch
+/// worker (the `mlx` worker — the only one advertising this capability — is macOS-only).
+#[cfg(not(target_os = "macos"))]
+pub(crate) async fn run_interleave_job(
+    _api: &ApiClient,
+    _settings: &Settings,
+    _job: &JobSnapshot,
+) -> WorkerResult<()> {
+    Err(WorkerError::InvalidPayload(
+        "image_interleave runs on the macOS MLX worker or the Python torch worker, not this Rust worker"
+            .to_owned(),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Document assembly (macOS): write the generated images as ordinary image assets, split the model
+// text on `<image>` markers into ordered segments, then write the `InterleavedDocument` body + the
+// `document` asset fact. Mirrors the Python `_write_interleaved_document` / `_build_interleaved_segments`.
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn write_interleaved_document(
+    request: &ImageRequest,
+    job: &JobSnapshot,
+    project_path: &Path,
+    prompt: &str,
+    model_id: &str,
+    seed: i64,
+    max_images: usize,
+    width: i32,
+    height: i32,
+    steps: usize,
+    cfg_scale: f32,
+    img_cfg_scale: f32,
+    timestep_shift: f32,
+    max_new_tokens: usize,
+    think_mode: bool,
+    generated_text: &str,
+    images: Vec<Image>,
+) -> WorkerResult<JsonObject> {
+    let resolution = format!("{width}x{height}");
+    // Flat telemetry mirroring the Python `raw_settings` (advanced overlay + resolved knobs).
+    let mut raw_settings = request.advanced.clone();
+    raw_settings.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw_settings.insert("repo".to_owned(), Value::String(model_repo_for(request)));
+    raw_settings.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw_settings.insert("guidanceScale".to_owned(), json!(cfg_scale));
+    raw_settings.insert("imageGuidanceScale".to_owned(), json!(img_cfg_scale));
+    raw_settings.insert("timestepShift".to_owned(), json!(timestep_shift));
+    raw_settings.insert("maxImages".to_owned(), json!(max_images));
+    raw_settings.insert("maxNewTokens".to_owned(), json!(max_new_tokens));
+    raw_settings.insert("thinkMode".to_owned(), Value::Bool(think_mode));
+    raw_settings.insert("resolution".to_owned(), Value::String(resolution.clone()));
+
+    // Generated images persist as ordinary image assets — the worker saves the PNG + reports facts,
+    // and the Rust API builds + indexes their sidecars. The document references them in order.
+    let plan = ImagePlan::with_count(request, images.len() as u32);
+    let mut image_raw_settings = raw_settings.clone();
+    image_raw_settings.insert("interleaved".to_owned(), Value::Bool(true));
+    let mut image_writes: Vec<Value> = Vec::with_capacity(images.len());
+    for (index, image) in images.into_iter().enumerate() {
+        let fact = write_image_asset(
+            &plan,
+            index,
+            seed,
+            image.width,
+            image.height,
+            image.pixels,
+            SENSENOVA_ADAPTER,
+            image_raw_settings.clone(),
+            project_path,
+        )?;
+        image_writes.push(Value::Object(fact));
+    }
+    let image_asset_ids: Vec<String> = image_writes
+        .iter()
+        .filter_map(|write| write.get("assetId").and_then(Value::as_str))
+        .map(str::to_owned)
+        .collect();
+
+    let segments = build_interleaved_segments(generated_text, &image_writes);
+
+    let created_at = crate::now_rfc3339();
+    let document_id = format!("doc_{}", Uuid::new_v4().simple());
+    let media_rel = format!("assets/documents/{document_id}.json");
+    let document_body = json!({
+        "schemaVersion": 1,
+        "id": document_id,
+        "projectId": request.project_id,
+        "jobId": job.id,
+        "model": model_id,
+        "prompt": prompt,
+        "createdAt": created_at,
+        "segments": segments,
+    });
+    let media_path = project_path.join(&media_rel);
+    if let Some(parent) = media_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temp_path = media_path.with_extension("tmp.json");
+    std::fs::write(
+        &temp_path,
+        serde_json::to_vec_pretty(&document_body)
+            .map_err(|error| WorkerError::InvalidPayload(format!("serialize document: {error}")))?,
+    )?;
+    std::fs::rename(&temp_path, &media_path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&temp_path);
+    })?;
+
+    let display_name: String = {
+        let trimmed: String = prompt.chars().take(56).collect();
+        if trimmed.trim().is_empty() {
+            "Interleaved document".to_owned()
+        } else {
+            trimmed
+        }
+    };
+    let asset_id = fresh_asset_id();
+    let document_write = json!({
+        "type": "document",
+        "assetId": asset_id,
+        "mediaPath": media_rel,
+        "mimeType": "application/json",
+        "displayName": display_name,
+        "createdAt": created_at,
+        "mode": "interleave",
+        "model": model_id,
+        "adapter": SENSENOVA_ADAPTER,
+        "prompt": prompt,
+        "negativePrompt": "",
+        "seed": seed,
+        "loras": [],
+        "rawAdapterSettings": raw_settings,
+        "maxImages": max_images,
+        "resolution": resolution,
+        "imageCount": image_asset_ids.len(),
+        "parents": image_asset_ids,
+    });
+
+    let mut asset_writes = image_writes;
+    asset_writes.push(document_write);
+    let expected_count = asset_writes.len();
+
+    Ok(json!({
+        "documentId": document_id,
+        "documentAssetId": asset_id,
+        "imageAssetIds": image_asset_ids,
+        "segments": segments,
+        "model": model_id,
+        "realModelInference": true,
+        "generationSetId": plan.genset_id,
+        "expectedCount": expected_count,
+        "generationSet": plan.generation_set,
+        "assetWrites": asset_writes,
+    })
+    .as_object()
+    .cloned()
+    .expect("json! object literal"))
+}
+
+/// Split the model output on its inline `<image>` markers and slot the generated image assets in
+/// order: text[0], image[0], text[1], image[1], …. Mirrors the Python `_build_interleaved_segments`
+/// (reads each image fact's `assetId` + `mediaPath`).
+#[cfg(target_os = "macos")]
+fn build_interleaved_segments(generated_text: &str, image_writes: &[Value]) -> Vec<Value> {
+    let mut segments = Vec::new();
+    for (index, part) in generated_text.split("<image>").enumerate() {
+        let text = part.trim();
+        if !text.is_empty() {
+            segments.push(json!({ "type": "text", "text": text }));
+        }
+        if let Some(write) = image_writes.get(index) {
+            segments.push(json!({
+                "type": "image",
+                "assetId": write.get("assetId").cloned().unwrap_or(Value::Null),
+                "path": write.get("mediaPath").cloned().unwrap_or(Value::Null),
+            }));
+        }
+    }
+    segments
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Assemble the concrete unified `T2iModel` + tokenizer for a SenseNova-U1 snapshot, replicating the
+/// engine's private `load_inner` from public re-exports. Loads dense bf16 with NO distill LoRA and
+/// NO quantization — the understanding (VQA) + interleave paths use the full base model, exactly as
+/// the torch adapter's `_load_model(distill_lora=None)`, keeping the VQA decode bit-identical.
+#[cfg(target_os = "macos")]
+fn load_sensenova_model(weights_dir: &Path) -> WorkerResult<(T2iModel, TextTokenizer)> {
+    let cfg = NeoChatConfig::from_dir(weights_dir)
+        .map_err(|error| WorkerError::InvalidPayload(format!("SenseNova-U1 config: {error}")))?;
+    let weights = load_raw(weights_dir)
+        .map_err(|error| WorkerError::InvalidPayload(format!("SenseNova-U1 weights: {error}")))?;
+    let model = T2iModel::from_weights(&weights, &cfg).map_err(|error| {
+        WorkerError::InvalidPayload(format!("SenseNova-U1 model build: {error}"))
+    })?;
+    let tokenizer = load_tokenizer(weights_dir)
+        .map_err(|error| WorkerError::InvalidPayload(format!("SenseNova-U1 tokenizer: {error}")))?;
+    Ok((model, tokenizer))
+}
+
+/// Decode an [`Image`] (RGB8 HWC) to a `[3,H,W]` f32 tensor in `[0,1]`, smart-resized to a
+/// 32-aligned bucket within `[min_pixels, max_pixels]`. Replicates the engine's private
+/// `image_to_chw01` (its `preprocess_image` ImageNet-normalizes internally, so this stays in
+/// `[0,1]`). VQA passes the understanding budget; interleave passes the it2i source budget.
+#[cfg(target_os = "macos")]
+fn image_to_chw01(img: &Image, min_pixels: i64, max_pixels: i64) -> WorkerResult<Array> {
+    let (in_w, in_h) = (img.width as i32, img.height as i32);
+    let (out_h, out_w) = smart_resize(in_h, in_w, 32, min_pixels, max_pixels);
+    let hwc = resize_bicubic_u8(
+        &img.pixels,
+        in_h as usize,
+        in_w as usize,
+        out_h as usize,
+        out_w as usize,
+    );
+    let hwc = Array::from_slice(&hwc, &[out_h, out_w, 3]);
+    let chw = hwc
+        .transpose_axes(&[2, 0, 1])
+        .map_err(|error| WorkerError::InvalidPayload(format!("image transpose: {error}")))?;
+    divide(&chw, Array::from_f32(255.0))
+        .map_err(|error| WorkerError::InvalidPayload(format!("image normalize: {error}")))
+}
+
+/// The SenseNova-U1 repo (manifest `repo` else the default), for the document telemetry.
+#[cfg(target_os = "macos")]
+fn model_repo_for(request: &ImageRequest) -> String {
+    request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("sensenova/SenseNova-U1-8B-MoT")
+        .to_owned()
+}
+
+/// Snap a requested W×H to the nearest interleave bucket by aspect ratio in log-space (ties resolve
+/// to the first bucket). Mirrors the Python `snap_to_aspect_bucket` over the same
+/// `INTERLEAVE_RESOLUTIONS` table (priority order).
+#[cfg(target_os = "macos")]
+fn interleave_resolution_snap(width: i64, height: i64) -> (i32, i32) {
+    let target = (width.max(1) as f64 / height.max(1) as f64).ln();
+    let mut best = INTERLEAVE_RESOLUTIONS[0].1;
+    let mut best_distance = f64::INFINITY;
+    for &(_, (bucket_w, bucket_h)) in INTERLEAVE_RESOLUTIONS {
+        let distance = (target - (bucket_w as f64 / bucket_h as f64).ln()).abs();
+        if distance < best_distance {
+            best_distance = distance;
+            best = (bucket_w, bucket_h);
+        }
+    }
+    best
+}
+
+/// Drop any `<think>…</think>` reasoning so only the answer is returned — removes complete think
+/// blocks and any dangling/unclosed one (reasoning truncated by `max_new_tokens`). Mirrors the
+/// Python `SenseNovaU1Adapter._strip_reasoning`.
+fn strip_reasoning(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("<think>") {
+        out.push_str(&rest[..start]);
+        match rest[start..].find("</think>") {
+            // Complete block: drop `<think>…</think>` and continue after it.
+            Some(end) => rest = &rest[start + end + "</think>".len()..],
+            // Dangling/unclosed block (truncated by max_new_tokens): drop everything from
+            // `<think>` on.
+            None => {
+                rest = "";
+                break;
+            }
+        }
+    }
+    out.push_str(rest);
+    out.trim().to_owned()
+}
+
+/// `safe_int` over a top-level payload field: parse (int / float / numeric string) else `default`,
+/// then clamp to `[lo, hi]`.
+fn payload_int(payload: &JsonObject, key: &str, default: i64, lo: i64, hi: i64) -> i64 {
+    payload
+        .get(key)
+        .and_then(json_to_i64)
+        .unwrap_or(default)
+        .clamp(lo, hi)
+}
+
+/// `safe_int` over an `advanced` field (same parse/clamp as [`payload_int`]).
+#[cfg(target_os = "macos")]
+fn advanced_int(advanced: &JsonObject, key: &str, default: i64, lo: i64, hi: i64) -> i64 {
+    payload_int(advanced, key, default, lo, hi)
+}
+
+/// `_advanced_float`: parse an `advanced` field as f32 else `default`.
+#[cfg(target_os = "macos")]
+fn advanced_float(advanced: &JsonObject, key: &str, default: f32) -> f32 {
+    advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(default)
+}
+
+fn json_to_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().map(|float| float as i64))
+        .or_else(|| value.as_str()?.trim().parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_reasoning_removes_think_blocks() {
+        assert_eq!(strip_reasoning("<think>reasoning</think>answer"), "answer");
+        assert_eq!(
+            strip_reasoning("before <think>mid</think> after"),
+            "before  after"
+        );
+        // Dangling/unclosed block (truncated by max_new_tokens) is dropped entirely.
+        assert_eq!(strip_reasoning("answer<think>cut off"), "answer");
+        // No think block: returned trimmed, unchanged.
+        assert_eq!(strip_reasoning("  plain answer  "), "plain answer");
+    }
+
+    #[test]
+    fn payload_int_parses_clamps_and_defaults() {
+        let map = json!({ "a": 500, "b": "1024", "c": 3.0, "d": "bad" })
+            .as_object()
+            .cloned()
+            .unwrap();
+        assert_eq!(payload_int(&map, "a", 256, 16, 2048), 500);
+        assert_eq!(payload_int(&map, "b", 256, 16, 2048), 1024);
+        assert_eq!(
+            payload_int(&map, "c", 256, 16, 2048),
+            16,
+            "3 clamps up to lo"
+        );
+        assert_eq!(
+            payload_int(&map, "d", 256, 16, 2048),
+            256,
+            "unparseable → default"
+        );
+        assert_eq!(payload_int(&map, "missing", 768, 16, 2048), 768);
+        assert_eq!(
+            payload_int(&map, "a", 256, 16, 400),
+            400,
+            "500 clamps to hi"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn interleave_resolution_snaps_to_aspect_bucket() {
+        // Exact 16:9 → its bucket.
+        assert_eq!(interleave_resolution_snap(2048, 1152), (2048, 1152));
+        // Square-ish → 1:1.
+        assert_eq!(interleave_resolution_snap(1000, 1000), (1536, 1536));
+        // Tall portrait → 9:16.
+        assert_eq!(interleave_resolution_snap(1152, 2048), (1152, 2048));
+        // Extreme wide → 3:1.
+        assert_eq!(interleave_resolution_snap(3000, 1000), (2592, 864));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn build_segments_interleaves_text_and_images() {
+        let writes = vec![
+            json!({ "assetId": "asset_a", "mediaPath": "assets/images/g/a.png" }),
+            json!({ "assetId": "asset_b", "mediaPath": "assets/images/g/b.png" }),
+        ];
+        let segments = build_interleaved_segments("intro<image>middle<image>end", &writes);
+        assert_eq!(segments.len(), 5);
+        assert_eq!(segments[0], json!({ "type": "text", "text": "intro" }));
+        assert_eq!(
+            segments[1],
+            json!({ "type": "image", "assetId": "asset_a", "path": "assets/images/g/a.png" })
+        );
+        assert_eq!(segments[2], json!({ "type": "text", "text": "middle" }));
+        assert_eq!(
+            segments[3],
+            json!({ "type": "image", "assetId": "asset_b", "path": "assets/images/g/b.png" })
+        );
+        assert_eq!(segments[4], json!({ "type": "text", "text": "end" }));
+    }
+
+    /// The HF-cache snapshot dir for a cached repo (test helper).
+    #[cfg(target_os = "macos")]
+    fn hf_snapshot(model_dir: &str) -> PathBuf {
+        let home = std::env::var("HOME").expect("HOME set");
+        std::fs::read_dir(
+            PathBuf::from(home).join(format!(".cache/huggingface/hub/{model_dir}/snapshots")),
+        )
+        .expect("HF cache snapshots dir")
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| path.is_dir())
+        .expect("a snapshot dir")
+    }
+
+    /// A synthetic RGB8 gradient (test source image).
+    #[cfg(target_os = "macos")]
+    fn gradient_image(width: u32, height: u32) -> Image {
+        let mut pixels = Vec::with_capacity((width * height * 3) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                pixels.push((x % 256) as u8);
+                pixels.push((y % 256) as u8);
+                pixels.push(((x + y) % 256) as u8);
+            }
+        }
+        Image {
+            width,
+            height,
+            pixels,
+        }
+    }
+
+    /// Real-weights smoke: SenseNova-U1 VQA. Loads the dense base `T2iModel` (~35GB
+    /// `sensenova/SenseNova-U1-8B-MoT`), preprocesses a synthetic image, and asserts the answer
+    /// text is non-empty (post think-strip). Needs the HF cache + a Metal device; run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored sensenova_vqa_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real SenseNova-U1-8B-MoT weights (~35GB) + Metal device"]
+    fn sensenova_vqa_real_weights_answers_non_empty() {
+        let snapshot = hf_snapshot("models--sensenova--SenseNova-U1-8B-MoT");
+        let (model, tokenizer) = load_sensenova_model(&snapshot).expect("load model");
+        let image = gradient_image(512, 512);
+        let pixel_values = image_to_chw01(&image, 256 * 256, 768 * 768).expect("preprocess");
+        let answer = model
+            .vqa(
+                &tokenizer,
+                "What colors appear in this image?",
+                std::slice::from_ref(&pixel_values),
+                64,
+                Sampler::Greedy,
+            )
+            .expect("vqa");
+        let answer = strip_reasoning(&answer);
+        assert!(
+            !answer.is_empty(),
+            "VQA answer should be non-empty: {answer:?}"
+        );
+    }
+
+    /// Real-weights smoke: SenseNova-U1 interleave. Loads the dense base `T2iModel`, runs a short
+    /// think-mode interleave rollout (mirroring the engine's own real-weight test, which reliably
+    /// emits an image), decodes the generated image(s), and asserts ≥1 image + a valid segment set
+    /// with at least one image segment. Small 512² + 8 steps for speed (production buckets are
+    /// 1536²+ / 50 steps). Run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored sensenova_interleave_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real SenseNova-U1-8B-MoT weights (~35GB) + Metal device"]
+    fn sensenova_interleave_real_weights_produces_document() {
+        let snapshot = hf_snapshot("models--sensenova--SenseNova-U1-8B-MoT");
+        let (model, tokenizer) = load_sensenova_model(&snapshot).expect("load model");
+        let opts = T2iOptions {
+            cfg_scale: 4.0,
+            img_cfg_scale: 1.0,
+            num_steps: 8,
+            timestep_shift: 3.0,
+            seed: 42,
+            think_mode: true,
+            ..Default::default()
+        };
+        // Budget mirrors the engine's own passing interleave real-weight test (512 new tokens,
+        // generous max_images) so the think-mode rollout reliably reaches an `<img>`.
+        let out = model
+            .interleave_gen(
+                &tokenizer,
+                "Generate an illustration of a single red circle on a white background, then briefly describe it.",
+                &[],
+                512,
+                512,
+                &opts,
+                INTERLEAVE_SYSTEM_MESSAGE,
+                512,
+                4,
+                None,
+            )
+            .expect("interleave_gen");
+        assert!(!out.images.is_empty(), "expected >= 1 generated image");
+        let mut image_writes = Vec::new();
+        for (index, image) in out.images.iter().enumerate() {
+            let decoded = decoded_to_image(image).expect("decode");
+            assert_eq!(
+                decoded.pixels.len(),
+                (decoded.width * decoded.height * 3) as usize
+            );
+            image_writes.push(json!({
+                "assetId": format!("asset_{index}"),
+                "mediaPath": format!("assets/images/g/{index}.png"),
+            }));
+        }
+        let segments = build_interleaved_segments(&out.text, &image_writes);
+        assert!(
+            segments.iter().any(|s| s["type"] == "image"),
+            "document should contain >= 1 image segment: {segments:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn build_segments_trailing_image_without_marker_is_appended() {
+        // One `<image>` marker but two images generated. Mirrors the Python splitter exactly:
+        // split → ["only one", ""]; index 0 slots image[0] after the text, index 1 (empty text)
+        // still slots image[1] because `index < len(image_writes)`. So the extra image trails.
+        let writes = vec![
+            json!({ "assetId": "asset_a", "mediaPath": "a.png" }),
+            json!({ "assetId": "asset_b", "mediaPath": "b.png" }),
+        ];
+        let segments = build_interleaved_segments("only one<image>", &writes);
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0], json!({ "type": "text", "text": "only one" }));
+        assert_eq!(segments[1]["assetId"], "asset_a");
+        assert_eq!(segments[2]["assetId"], "asset_b");
+    }
+}

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -128,7 +128,7 @@ in-process Rust path. Per Michael's 2026-06-07 decision, all four spikes are **p
 | Image upscaler (standalone) | `image_upscale` | Real-ESRGAN / AuraSR (torch) | ✅ Ported (Real-ESRGAN via Rust `ort`/CoreML, macOS MLX worker; **AuraSR** engine stays on Python) | sc-3489 |
 | Dataset captioning | `training_caption` | JoyCaption MLX provider (Python torch fallback off-MLX) | ✅ Ported (macOS MLX worker) | sc-3556 |
 | Wan/LTX model conversion | `model_convert` (non-`flux2_klein_diffusers` converter) | `mlx_video.convert_*` (Python) | 🔵 Port-pending | sc-3491 (= sc-3224) |
-| Image understanding / interleave | `image_vqa`, `image_interleave` | torch (SenseNova-U1) | 🔵 Port-pending (engine done; worker wiring next) | epic 3180 / **sc-3905** (consumed via `T2iModel::vqa`/`interleave_gen` — the `Generator` registry emits Images/Video only; SenseNova image modes already ported, sc-3900) |
+| Image understanding / interleave | `image_vqa`, `image_interleave` | torch (SenseNova-U1) | ✅ Ported (macOS MLX worker, native `T2iModel`) | epic 3180 / sc-3905 (see §6) |
 
 ## 6. Already ported — NOT gaps (context)
 
@@ -143,7 +143,12 @@ Listed so a reviewer doesn't re-file these. All run in the Rust/MLX flow on Mac.
   (`edit_image` → Reference), and Character Studio (`character_image` → MultiReference, incl. the
   angle set), base + 8-step distill, Q4/Q8 (`mlx-gen-sensenova`, NEO-Unify; dual CFG: text via
   `guidance`, image via `true_cfg`). No ControlNet (strict pose stays torch), no user LoRA. epic
-  3180 / sc-3900. **VQA + Document Studio (interleave) are still pending — see §5 / sc-3905.**
+  3180 / sc-3900.
+- SenseNova-U1 understanding + Document Studio: `image_vqa` (image+question → text) and
+  `image_interleave` (prompt → ordered text + generated images → `InterleavedDocument`) — served
+  in-process via the concrete `T2iModel::{vqa, interleave_gen}` (the `Generator` registry emits
+  Images/Video only). Loads dense (no distill LoRA, no quant) for torch parity; the VQA decode is
+  bit-identical (no-think primed, sc-3905 engine fix). epic 3180 / sc-3905.
 - SDXL advanced shapes — reference/IP-Adapter, `edit_image`, masked inpaint, outpaint, and
   tile-detail (`image_detail` on `sdxl`/`realvisxl`) — epic 3041 / sc-3060.
 - FLUX.2-klein single-file conversion in-process Rust (`flux2_klein_diffusers`, sc-3136).


### PR DESCRIPTION
**Path B** of the SceneWorks SenseNova-U1 cutover (epic 3180), on top of [sc-3900 / #512](https://github.com/michaeltrefry/SceneWorks/pull/512) (Path A image modes). Wires the two modes the mlx-gen `Generator` contract can't express (`GenerationOutput` is Images/Video only) by consuming the concrete `T2iModel` methods directly.

## What lands
- **VQA** (`image_vqa`): image + question → text answer (no asset write).
- **Document Studio interleave** (`image_interleave`): prompt (+ optional source images) → ordered text + generated images, persisted as image assets + an `InterleavedDocument` `document` asset.

New macOS-gated `sensenova_jobs.rs` (non-macOS error stubs) assembles a concrete `T2iModel` worker-side (the crate has no public `SenseNova` ctor — replicates `load_inner`), loads **dense** (no distill LoRA / no quant) for torch parity, replicates the engine's private `image_to_chw01` preprocessing, and mirrors the Python `answer_question` / `generate_interleaved` / `_write_interleaved_document` contracts byte-for-byte (request fields, resolution buckets, think/no-think protocol, response/asset shapes, `<image>`-marker segment split).

## Routing + capability (`jobs_store`)
`understanding_job_is_mlx_eligible` (SenseNova-U1 ids on these job types) → folded into `job_is_any_mlx_eligible`; `should_defer_understanding_to_mlx_worker` (torch worker yields to an idle mlx worker); the `worker_supports_job` mlx gate; a precise `mac_rust_supported` arm; and the `ImageVqa`/`ImageInterleave` capabilities advertised by the mlx worker. **Torch path retained for Windows/Linux** (cross-platform model — epic 3482).

## Engine dependency
Bumps `mlx-gen` `72214e3 → b9b9aba` (merged [mlx-gen#200](https://github.com/michaeltrefry/mlx-gen/pull/200), sc-3937): primes the empty `<think></think>` block in `T2iModel::vqa` so the answer isn't consumed by a chain-of-thought (matching the reference `chat(think=False)`). Without it the stripped VQA answer was empty. **mlx-rs pin unchanged → no MLX rebuild.**

## Verification
- `cargo fmt --all`, full-workspace `clippy -D warnings`, `cargo test` (201 pass), `cargo build` — all green.
- **Real-weight E2E** (`#[ignore]`) on the cached 33GB `SenseNova-U1-8B-MoT` snapshot: VQA returns a non-empty answer; interleave produces ≥1 image + a valid `InterleavedDocument` with image segments.
- Routing units: eligibility, torch→mlx deferral, `mac_rust_supported` ok / non-SenseNova gap.

Closes sc-3905 (depends on sc-3937 / mlx-gen#200, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)