### PR TITLE
fix(web): ReferenceError in fullscreen-preview Edit — modelLoraFamilies used without import (sc-4162)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -19,6 +19,7 @@ import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { SettingsScreen } from "./screens/SettingsScreen.jsx";
 import { LogsScreen } from "./screens/LogsScreen.jsx";
 import { SetupWizard } from "./screens/SetupWizard.jsx";
+import { editModelForAsset } from "./presetUtils.js";
 import { sortNewest, sortOldest, sortWorkers } from "./sorters.js";
 import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
@@ -1332,35 +1333,6 @@ export function App() {
     setActiveView("Image");
   }
 
-  // Resolve an edit-capable model whose family matches the image's generating model.
-  // Prefers the exact generating model when it can edit, then any same-family
-  // edit-capable model; returns null so Image Studio keeps its default edit model
-  // when nothing matches.
-  function editModelForAsset(asset) {
-    const sourceModelId = asset?.recipe?.model;
-    if (!sourceModelId) {
-      return null;
-    }
-    const canEdit = (item) => {
-      const caps = item?.capabilities ?? [];
-      return caps.includes("edit_image") || caps.includes("image_edit");
-    };
-    const sourceModel = imageModels.find((item) => item.id === sourceModelId);
-    if (sourceModel && canEdit(sourceModel)) {
-      return sourceModel.id;
-    }
-    const families = modelLoraFamilies(sourceModel ?? { family: sourceModelId });
-    if (families.length) {
-      const sibling = imageModels.find(
-        (item) => canEdit(item) && modelLoraFamilies(item).some((family) => families.includes(family)),
-      );
-      if (sibling) {
-        return sibling.id;
-      }
-    }
-    return null;
-  }
-
   // "Edit" from the fullscreen preview: open Image Studio in edit mode with this
   // image as the source, preselecting the family-matched edit model when possible.
   function sendAssetToImageEdit(asset) {
@@ -1373,7 +1345,7 @@ export function App() {
       view: "Image",
       assetId: asset.id,
       mode: "edit_image",
-      model: editModelForAsset(asset),
+      model: editModelForAsset(asset, imageModels),
     });
     setActiveView("Image");
   }

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -110,6 +110,36 @@ export function loraMatchesModel(lora, model) {
   return !modelFamilies.length || !families.length || families.some((family) => modelFamilies.includes(family));
 }
 
+// Resolve an edit-capable model whose family matches the asset's generating model.
+// Prefers the exact generating model when it can edit, then any same-family
+// edit-capable model; returns null so Image Studio keeps its default edit model
+// when nothing matches.
+export function editModelForAsset(asset, imageModels) {
+  const sourceModelId = asset?.recipe?.model;
+  if (!sourceModelId) {
+    return null;
+  }
+  const models = Array.isArray(imageModels) ? imageModels : [];
+  const canEdit = (item) => {
+    const caps = item?.capabilities ?? [];
+    return caps.includes("edit_image") || caps.includes("image_edit");
+  };
+  const sourceModel = models.find((item) => item.id === sourceModelId);
+  if (sourceModel && canEdit(sourceModel)) {
+    return sourceModel.id;
+  }
+  const families = modelLoraFamilies(sourceModel ?? { family: sourceModelId });
+  if (families.length) {
+    const sibling = models.find(
+      (item) => canEdit(item) && modelLoraFamilies(item).some((family) => families.includes(family)),
+    );
+    if (sibling) {
+      return sibling.id;
+    }
+  }
+  return null;
+}
+
 export function loraLooksLikeIcLora(lora) {
   if (lora?.icLora === true || lora?.isIcLora === true) {
     return true;

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -4,6 +4,7 @@ import {
   buildStudioPresetPayload,
   cleanPresetDefaults,
   clearPresetDefault,
+  editModelForAsset,
   finiteNumberOrUndefined,
   presetMatchesModel,
   presetNameTaken,
@@ -201,5 +202,36 @@ describe("applyPresetDefault + clearPresetDefault round-trip", () => {
     box.setter(2); // user manually edits after the preset applied
     clearPresetDefault(box.setter, snapshots, "count");
     expect(box.get()).toBe(2);
+  });
+});
+
+// sc-4162 regression: editModelForAsset previously lived in App.jsx and called
+// modelLoraFamilies without importing it — a ReferenceError on the family-sibling
+// path (any asset whose generating model can't edit).
+describe("editModelForAsset", () => {
+  const t2iOnly = { id: "z_image_turbo", family: "z-image", capabilities: ["text_to_image"] };
+  const editSibling = { id: "z_image_edit", family: "z-image", capabilities: ["edit_image"] };
+  const editSelf = { id: "qwen_image_edit", family: "qwen-image", capabilities: ["image_edit"] };
+  const models = [t2iOnly, editSibling, editSelf];
+
+  it("prefers the generating model when it is edit-capable", () => {
+    expect(editModelForAsset({ recipe: { model: "qwen_image_edit" } }, models)).toBe("qwen_image_edit");
+  });
+
+  it("falls back to a same-family edit-capable sibling when the source model cannot edit", () => {
+    expect(editModelForAsset({ recipe: { model: "z_image_turbo" } }, models)).toBe("z_image_edit");
+  });
+
+  it("matches a family sibling when the generating model is not in the catalog", () => {
+    expect(editModelForAsset({ recipe: { model: "z-image" } }, models)).toBe("z_image_edit");
+  });
+
+  it("returns null when no family-matched edit model exists", () => {
+    expect(editModelForAsset({ recipe: { model: "z_image_turbo" } }, [t2iOnly, editSelf])).toBe(null);
+  });
+
+  it("returns null for assets without a recipe model", () => {
+    expect(editModelForAsset({ recipe: {} }, models)).toBe(null);
+    expect(editModelForAsset(null, models)).toBe(null);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes [sc-4162](https://app.shortcut.com/trefry/story/4162) (code-review finding F-WEB-1, P1/High): `editModelForAsset` in App.jsx called `modelLoraFamilies(...)` but App.jsx never imported it, so the fullscreen-preview **Edit** action threw `ReferenceError: modelLoraFamilies is not defined` for any asset whose generating model is not itself edit-capable — the click silently did nothing.
- Fix: extract `editModelForAsset(asset, imageModels)` into `presetUtils.js` (where `modelLoraFamilies` is defined) and import it in App.jsx, making the dependency explicit and the logic unit-testable.
- Adds regression tests covering the previously-broken family-sibling fallback path plus the edit-capable-source, missing-catalog-model, no-match, and no-recipe cases.

## Testing
- `npm --prefix apps/web run test` — 364/364 pass (5 new)
- `npm --prefix apps/web run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)