### PR TITLE
fix(web): provide pairing token through AppContext (sc-4168)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1613,6 +1613,10 @@ export function App() {
     updatePreset,
     deletePreset,
     duplicatePreset,
+    // Auth (sc-4168): pairing token for screens that call apiFetch directly
+    // (Image Editor, Logs, Pose Library, useUserPoseLoader). Empty string when
+    // the deployment doesn't require auth.
+    token,
     // Training (sc-1651 Phase B batch 7)
     authenticated,
     trainingDatasets,

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -589,6 +589,38 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Queue");
   });
 
+  // sc-4168 regression: App must provide `token` through AppContext. Screens that
+  // call apiFetch directly (Logs, Image Editor, Pose Library, useUserPoseLoader)
+  // read it from context; before the fix they got `undefined` and never sent the
+  // X-SceneWorks-Token header, breaking every pairing-token deployment.
+  it("provides the pairing token through context so screens send X-SceneWorks-Token", async () => {
+    window.localStorage.setItem("sceneworks-token", "pair-tok-123");
+    const logsTokens = [];
+    const baseFetch = global.fetch.getMockImplementation();
+    global.fetch = vi.fn((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/api/v1/logs")) {
+        logsTokens.push(new Headers(options.headers).get("X-SceneWorks-Token"));
+        return Promise.resolve(response([]));
+      }
+      return baseFetch(url, options);
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Logs").click();
+    });
+    await settle();
+
+    expect(logsTokens.length).toBeGreaterThan(0);
+    expect(logsTokens.every((value) => value === "pair-tok-123")).toBe(true);
+  });
+
   it("gates the studios behind workspace creation when no projects exist", async () => {
     const requests = [];
     global.fetch.mockImplementation((url, options = {}) => {


### PR DESCRIPTION
## Summary
- Fixes [sc-4168](https://app.shortcut.com/trefry/story/4168) (code-review finding F-WEB-2, P1/High): four modules (Image Editor, Logs screen, Pose Library screen, `useUserPoseLoader`) destructure `token` from `useAppContext()`, but App never included it in `appContextValue` — they all called `apiFetch(path, undefined, …)`, so the `X-SceneWorks-Token` header was never sent. Desktop hides this (`authRequired=false`), but every pairing-token deployment (Docker/server) hit auth failures on those screens.
- Fix: add `token` to `appContextValue`.
- Regression test renders the full `App` with a stored pairing token, opens the Logs screen, and asserts the `/api/v1/logs` request carries `X-SceneWorks-Token`. Verified the test fails without the one-line fix.

## Testing
- `npm --prefix apps/web run test` — 365/365 pass (1 new)
- `npm --prefix apps/web run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)