### PR TITLE
[codex] Reset Image Studio advanced defaults on model change

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -110,6 +110,11 @@ const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x128
 // segmented control actually exposes. Edit lives in its own workflow; text and
 // character share the text_to_image workflow.
 const IMAGE_MODES = ["text_to_image", "edit_image", "character_image"];
+
+function preferredOption(defaultValue, options) {
+  return options.includes(defaultValue) ? defaultValue : options[0] ?? "default";
+}
+
 const UPSCALE_ENGINES = [
   { id: "real-esrgan", label: "Real-ESRGAN", factors: [2, 4] },
   { id: "aura-sr", label: "AuraSR", factors: [4] },
@@ -290,7 +295,7 @@ export function ImageStudio() {
   const [selectedPoseIds, setSelectedPoseIds] = useState([]);
   // Configurable sampler / scheduler (epic 1753). Restored from per-workspace
   // settings; reset to the selected model's manifest defaults whenever the
-  // model changes and the saved value is no longer offered by limits.
+  // model changes.
   const [sampler, setSampler] = useState(saved.sampler ?? "default");
   const [scheduler, setScheduler] = useState(saved.scheduler ?? "default");
   const [schedulerShift, setSchedulerShift] = useState(saved.schedulerShift ?? 3.0);
@@ -540,6 +545,23 @@ export function ImageStudio() {
   const schedulerOptions = useMemo(() => schedulerOptionsFromModel(selectedModel), [selectedModel]);
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
+  const advancedDefaultsModel = useRef(model);
+  const skipAdvancedDefaultsReset = useRef(false);
+  useEffect(() => {
+    if (advancedDefaultsModel.current === model) {
+      return;
+    }
+    advancedDefaultsModel.current = model;
+    if (skipAdvancedDefaultsReset.current) {
+      skipAdvancedDefaultsReset.current = false;
+      return;
+    }
+    setSampler(preferredOption(samplerDefaultFromModel(selectedModel), samplerOptions));
+    setScheduler(preferredOption(schedulerDefaultFromModel(selectedModel), schedulerOptions));
+    setSchedulerShift(schedulerShiftDefaultFromModel(selectedModel));
+    setStepsOverride("");
+    setGuidanceOverride("");
+  }, [model, samplerOptions, schedulerOptions, selectedModel]);
   // Snap the sampler / scheduler back to the model's declared default when the
   // current value is no longer in the menu (e.g. user switched to a sealed
   // model whose only option is "default"). Mirrors the resolution-snap effect.
@@ -547,19 +569,13 @@ export function ImageStudio() {
     if (samplerOptions.includes(sampler)) {
       return;
     }
-    const preferred = samplerOptions.includes(samplerDefaultFromModel(selectedModel))
-      ? samplerDefaultFromModel(selectedModel)
-      : samplerOptions[0];
-    setSampler(preferred);
+    setSampler(preferredOption(samplerDefaultFromModel(selectedModel), samplerOptions));
   }, [samplerOptions, sampler, selectedModel]);
   useEffect(() => {
     if (schedulerOptions.includes(scheduler)) {
       return;
     }
-    const preferred = schedulerOptions.includes(schedulerDefaultFromModel(selectedModel))
-      ? schedulerDefaultFromModel(selectedModel)
-      : schedulerOptions[0];
-    setScheduler(preferred);
+    setScheduler(preferredOption(schedulerDefaultFromModel(selectedModel), schedulerOptions));
   }, [schedulerOptions, scheduler, selectedModel]);
   // Keep the selected resolution valid for the current model's buckets. Switching
   // to a model whose options exclude the current value snaps to its default (or
@@ -624,6 +640,9 @@ export function ImageStudio() {
     setSelectedPresetId(noPresetId);
     setMode(nextMode);
     if (recipe.model) {
+      if (recipe.model !== advancedDefaultsModel.current) {
+        skipAdvancedDefaultsReset.current = true;
+      }
       setModel(recipe.model);
     }
     setPrompt(String(recipe.prompt ?? ""));

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -71,6 +71,12 @@ function setInput(element, value) {
   element.dispatchEvent(new window.Event("input", { bubbles: true }));
 }
 
+function setSelect(element, value) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set;
+  setter.call(element, value);
+  element.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
 function setFileInput(element, files) {
   Object.defineProperty(element, "files", {
     configurable: true,
@@ -82,6 +88,12 @@ function setFileInput(element, files) {
 const saveButton = (container) =>
   [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
 const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
+const field = (container, labelText) => {
+  const label = [...container.querySelectorAll("label")].find((node) =>
+    node.textContent.trim().startsWith(labelText),
+  );
+  return label?.querySelector("input, select");
+};
 
 describe("ImageStudio Save as Preset", () => {
   let container;
@@ -156,6 +168,115 @@ describe("ImageStudio Save as Preset", () => {
 
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");
+  });
+});
+
+describe("ImageStudio advanced model defaults", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("resets advanced overrides to the newly selected model defaults", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({
+        createImageJob,
+        imageModels: [
+          {
+            ...Z_IMAGE,
+            defaults: {
+              resolution: "1024x1024",
+              sampler: "euler",
+              scheduler: "shift",
+              schedulerShift: 1.5,
+              steps: 12,
+              guidanceScale: 2.5,
+            },
+            limits: {
+              resolutions: ["1024x1024", "1536x1024"],
+              samplers: ["default", "euler", "unipc"],
+              schedulers: ["default", "shift", "karras"],
+            },
+          },
+          {
+            id: "qwen_image",
+            name: "Qwen Image",
+            type: "image",
+            family: "qwen-image",
+            capabilities: ["text_to_image"],
+            defaults: {
+              resolution: "1024x1024",
+              sampler: "unipc",
+              scheduler: "shift",
+              schedulerShift: 4.2,
+              steps: 28,
+              guidanceScale: 6.5,
+            },
+            limits: {
+              resolutions: ["1024x1024", "1536x1024"],
+              samplers: ["default", "euler", "unipc"],
+              schedulers: ["default", "shift", "karras"],
+            },
+            loraCompatibility: {},
+            ui: {},
+          },
+        ],
+      }),
+    );
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Advanced"));
+    await act(async () => setSelect(field(container, "Sampler"), "euler"));
+    await act(async () => setSelect(field(container, "Scheduler"), "shift"));
+    await act(async () => setInput(field(container, "Schedule shift"), "7.7"));
+    await act(async () => setInput(field(container, "Steps"), "44"));
+    await act(async () => setInput(field(container, "Guidance"), "11"));
+
+    await act(async () => setSelect(field(container, "Model"), "qwen_image"));
+    await act(async () => {});
+
+    expect(field(container, "Sampler").value).toBe("unipc");
+    expect(field(container, "Scheduler").value).toBe("shift");
+    expect(field(container, "Schedule shift").value).toBe("4.2");
+    expect(field(container, "Steps").value).toBe("");
+    expect(field(container, "Steps").placeholder).toBe("28");
+    expect(field(container, "Guidance").value).toBe("");
+    expect(field(container, "Guidance").placeholder).toBe("6.5");
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Generate"));
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.model).toBe("qwen_image");
+    expect(payload.advanced).toMatchObject({
+      resolution: "1024x1024",
+      sampler: "unipc",
+      scheduler: "shift",
+      schedulerShift: 4.2,
+    });
+    expect(payload.advanced).not.toHaveProperty("steps");
+    expect(payload.advanced).not.toHaveProperty("guidanceScale");
   });
 });
 


### PR DESCRIPTION
## Summary
- Reset Image Studio advanced sampler/scheduler controls when the selected model changes.
- Clear explicit steps/guidance overrides on model switch so the new model defaults drive generation.
- Preserve recipe replay hydration so saved recipe settings still restore intentionally.

## Root Cause
Image Studio only snapped sampler and scheduler when the existing value was unsupported by the new model. If the old value was still valid, it stayed selected even when the new model declared a different default; steps and guidance overrides also carried across models.

## Validation
- npm --prefix apps/web test -- ImageStudio.test.jsx
- npm --prefix apps/web run build
