### PR TITLE
fix(core): terminal jobs immutable to progress reports + owner-checked writes (sc-4172)

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -278,6 +278,7 @@ pub(crate) async fn update_job_progress(
                 peak_gpu_memory_pct,
                 peak_gpu_load_pct,
                 backend: payload.backend,
+                worker_id: payload.worker_id,
             },
         )
     })

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2145,6 +2145,20 @@ impl From<JobsStoreError> for ApiError {
                 status: StatusCode::BAD_REQUEST,
                 detail: format!("Job retry limit reached after {max_attempts} attempts."),
             },
+            // 409 tells the worker its report lost a race with cancel/sweep/
+            // reclaim: abandon the job instead of retrying (sc-4172).
+            JobsStoreError::TerminalJobImmutable { job_id, status } => Self {
+                status: StatusCode::CONFLICT,
+                detail: format!(
+                    "Job {job_id} is already {status}; terminal jobs cannot be updated."
+                ),
+            },
+            JobsStoreError::NotJobOwner { job_id } => Self {
+                status: StatusCode::CONFLICT,
+                detail: format!(
+                    "Progress rejected: the reporting worker no longer owns job {job_id}."
+                ),
+            },
             other => Self::internal(other.to_string()),
         }
     }

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -146,6 +146,9 @@ class ApiClient:
         if settings.access_token:
             headers["X-SceneWorks-Token"] = settings.access_token
         self.client = httpx.Client(base_url=settings.api_url, headers=headers, timeout=20)
+        # Stamped onto every progress report so the server can reject writes
+        # from a worker that no longer owns the job (sc-4172).
+        self.worker_id = settings.worker_id
 
     def post(self, path: str, payload: dict) -> dict:
         response = self.client.post(path, json=payload)
@@ -359,6 +362,13 @@ def heartbeat_with_loaded_models(
 
 
 def update_job(api: ApiClient, job_id: str, payload: dict[str, Any]) -> dict:
+    # Identify the reporting worker; the server 409s if this worker no longer
+    # owns the job (swept stale / canceled / reclaimed), which raises
+    # httpx.HTTPStatusError here and aborts the local handling — i.e. the
+    # worker abandons the job instead of resurrecting it (sc-4172).
+    worker_id = getattr(api, "worker_id", None)
+    if worker_id:
+        payload.setdefault("workerId", worker_id)
     job = api.post(f"/api/v1/jobs/{job_id}/progress", payload)
     emit({"event": "job_progress", "jobId": job_id, "status": job["status"], "stage": job["stage"]})
     return job

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -626,6 +626,12 @@ pub struct ProgressRequest {
     /// arch pill should reflect which one ran. First non-null value sticks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend: Option<String>,
+    /// Id of the worker reporting this progress. When present, the server
+    /// rejects the report with 409 unless the job's `worker_id` still matches —
+    /// so a zombie worker whose job was swept to `interrupted` or reclaimed
+    /// can't resurrect it (sc-4172). Omitted = legacy trusted caller.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_id: Option<String>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -86,7 +86,22 @@ pub enum JobsStoreError {
     InvalidStatus(String),
     InvalidNumber(String),
     InvalidRequestedGpu(String),
-    RetryLimit { max_attempts: u32 },
+    RetryLimit {
+        max_attempts: u32,
+    },
+    /// A progress report tried to change a job that already reached a terminal
+    /// status. Terminal jobs are immutable; only an idempotent re-report of the
+    /// same terminal status succeeds (sc-4172).
+    TerminalJobImmutable {
+        job_id: String,
+        status: String,
+    },
+    /// A progress report came from a worker that no longer owns the job — the
+    /// job was swept/canceled (worker_id cleared) or reclaimed. The worker
+    /// should abandon the job (sc-4172).
+    NotJobOwner {
+        job_id: String,
+    },
 }
 
 impl std::fmt::Display for JobsStoreError {
@@ -103,6 +118,18 @@ impl std::fmt::Display for JobsStoreError {
                 write!(
                     formatter,
                     "Job retry limit reached after {max_attempts} attempts."
+                )
+            }
+            Self::TerminalJobImmutable { job_id, status } => {
+                write!(
+                    formatter,
+                    "Job {job_id} is already {status}; terminal jobs cannot be updated."
+                )
+            }
+            Self::NotJobOwner { job_id } => {
+                write!(
+                    formatter,
+                    "Progress rejected: the reporting worker no longer owns job {job_id}."
                 )
             }
         }
@@ -199,6 +226,12 @@ pub struct ProgressUpdate {
     /// progress updates can't accidentally clear it. Drives the
     /// WorkerProgressCard arch pill.
     pub backend: Option<String>,
+    /// Id of the worker reporting this progress. When set, the store rejects
+    /// the update unless the job's `worker_id` still matches — a zombie worker
+    /// whose job was swept to `interrupted` (worker_id cleared) or reclaimed by
+    /// another worker can no longer resurrect or corrupt it (sc-4172). `None`
+    /// keeps legacy trusted-caller behavior.
+    pub worker_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -955,6 +988,30 @@ impl JobsStore {
         let _guard = self.lock.lock();
         let mut connection = self.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        // Guard against zombie-worker writes (sc-4172): a worker that went
+        // silent long enough for the stale sweep to mark its job `interrupted`
+        // (or whose job the user canceled) must not resurrect it with a late
+        // progress report — that's exactly the failure mode the heartbeat
+        // machinery exists to handle.
+        let current = self.get_job_on_connection(&transaction, job_id)?;
+        if is_terminal_status(current.status.as_str()) {
+            // Idempotent re-report of the same terminal status (e.g. a retried
+            // "canceled" POST) succeeds without touching the row.
+            if current.status == update.status {
+                return Ok(current);
+            }
+            return Err(JobsStoreError::TerminalJobImmutable {
+                job_id: job_id.to_owned(),
+                status: current.status.as_str().to_owned(),
+            });
+        }
+        if let Some(reporter) = update.worker_id.as_deref() {
+            if current.worker_id.as_deref() != Some(reporter) {
+                return Err(JobsStoreError::NotJobOwner {
+                    job_id: job_id.to_owned(),
+                });
+            }
+        }
         let now = utc_now();
         let completed_at = is_terminal_status(update.status.as_str()).then_some(now.clone());
         let canceled_at = (update.status == JobStatus::Canceled).then_some(now.clone());

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -87,6 +87,7 @@ fn job_lifecycle_create_claim_complete() {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
+                worker_id: None,
             },
         )
         .expect("progress updates");
@@ -123,6 +124,7 @@ fn progress_keeps_running_max_for_peak_gpu_meters() {
             peak_gpu_memory_pct: memory,
             peak_gpu_load_pct: load,
             backend: None,
+            worker_id: None,
         }
     }
 
@@ -216,6 +218,7 @@ fn progress_leaves_peaks_null_when_no_samples_arrive() {
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
         backend: None,
+        worker_id: None,
     };
     for _ in 0..3 {
         store
@@ -660,6 +663,7 @@ fn training_progress_stages_persist_under_running_and_reject_unknown_status() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
+                    worker_id: None,
                 },
             )
             .expect("running status with a training stage is accepted");
@@ -683,6 +687,7 @@ fn training_progress_stages_persist_under_running_and_reject_unknown_status() {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
+                worker_id: None,
             },
         )
         .expect_err("an unknown status is rejected");
@@ -720,6 +725,7 @@ fn training_progress_merges_latest_sample_batches_into_history() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
+                    worker_id: None,
                 },
             )
             .expect("sample progress updates");
@@ -1223,6 +1229,7 @@ fn invalid_progress_numbers_are_rejected() {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
+                worker_id: None,
             },
         ),
         Err(JobsStoreError::InvalidNumber(field)) if field == "progress"
@@ -1454,6 +1461,7 @@ fn complete_job(store: &JobsStore, job_id: &str) {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
+                worker_id: None,
             },
         )
         .expect("job completes");
@@ -3380,6 +3388,7 @@ fn qwen_txt2img_and_strict_pose_route_to_mlx() {
                 peak_gpu_memory_pct: None,
                 peak_gpu_load_pct: None,
                 backend: None,
+                worker_id: None,
             },
         )
         .expect("txt2img job completes");
@@ -3450,6 +3459,7 @@ fn flux2_klein_variants_route_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
+                    worker_id: None,
                 },
             )
             .expect("complete job");
@@ -3527,6 +3537,7 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
+                    worker_id: None,
                 },
             )
             .expect("complete job");
@@ -3570,6 +3581,7 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
+                    worker_id: None,
                 },
             )
             .expect("complete job");
@@ -3648,6 +3660,7 @@ fn image_detail_routes_to_mlx_worker() {
                     peak_gpu_memory_pct: None,
                     peak_gpu_load_pct: None,
                     backend: None,
+                    worker_id: None,
                 },
             )
             .expect("complete detail job");
@@ -3846,6 +3859,7 @@ fn concurrent_claims_never_lock_and_stay_exactly_once() {
                                 peak_gpu_memory_pct: None,
                                 peak_gpu_load_pct: None,
                                 backend: None,
+                                worker_id: None,
                             },
                         ) {
                             errors.lock().unwrap().push(error.to_string());
@@ -3870,4 +3884,148 @@ fn concurrent_claims_never_lock_and_stay_exactly_once() {
     let unique: HashSet<&String> = claimed.iter().collect();
     assert_eq!(claimed.len(), JOBS, "every job claimed (count)");
     assert_eq!(unique.len(), JOBS, "no job claimed twice");
+}
+
+/// sc-4172 — a zombie worker's late progress report must not resurrect a job
+/// the stale sweep marked `interrupted`; terminal statuses are immutable except
+/// for an idempotent re-report of the same terminal status.
+#[test]
+fn progress_cannot_resurrect_terminal_jobs() {
+    fn report(status: JobStatus, stage: ProgressStage, worker_id: Option<&str>) -> ProgressUpdate {
+        ProgressUpdate {
+            status,
+            stage,
+            progress: 0.9,
+            message: "late report".to_owned(),
+            error: None,
+            result: None,
+            eta_seconds: None,
+            peak_gpu_memory_pct: None,
+            peak_gpu_load_pct: None,
+            backend: None,
+            worker_id: worker_id.map(str::to_owned),
+        }
+    }
+
+    let store = store("terminal-immutable");
+    register_image_worker(&store);
+    let created = store
+        .create_job(image_job(Map::new()))
+        .expect("job creates");
+    store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+
+    // Age the worker out and sweep its job to interrupted (worker_id cleared).
+    let connection = Connection::open(store.db_path()).expect("db opens");
+    connection
+        .execute(
+            "update workers set last_seen_at = '2000-01-01T00:00:00Z' where id = ?1",
+            params!["worker-1"],
+        )
+        .expect("worker timestamp updates");
+    store
+        .mark_stale_workers_interrupted(1)
+        .expect("sweep succeeds");
+
+    // The zombie's "running" report must be rejected, not resurrect the job.
+    let error = store
+        .update_job_progress(
+            &created.id,
+            report(JobStatus::Running, ProgressStage::Running, Some("worker-1")),
+        )
+        .expect_err("terminal job rejects an active-status report");
+    assert!(matches!(
+        error,
+        JobsStoreError::TerminalJobImmutable { ref status, .. } if status == "interrupted"
+    ));
+
+    // Its late "completed" report must not flip the terminal status either.
+    let error = store
+        .update_job_progress(
+            &created.id,
+            report(
+                JobStatus::Completed,
+                ProgressStage::Completed,
+                Some("worker-1"),
+            ),
+        )
+        .expect_err("terminal job rejects a different terminal status");
+    assert!(matches!(error, JobsStoreError::TerminalJobImmutable { .. }));
+
+    // An idempotent re-report of the same terminal status is a no-op success
+    // (e.g. a worker retrying its own "canceled" POST).
+    let job = store
+        .update_job_progress(
+            &created.id,
+            report(
+                JobStatus::Interrupted,
+                ProgressStage::Interrupted,
+                Some("worker-1"),
+            ),
+        )
+        .expect("same-terminal re-report succeeds");
+    assert_eq!(job.status, JobStatus::Interrupted);
+    assert_eq!(
+        job.message, "Job was interrupted after its worker stopped sending heartbeats.",
+        "no-op re-report must not rewrite the row"
+    );
+
+    let job = store.get_job(&created.id).expect("job loads");
+    assert_eq!(job.status, JobStatus::Interrupted);
+    assert_eq!(job.worker_id, None);
+}
+
+/// sc-4172 — a progress report that names a worker other than the job's owner
+/// is rejected; the owner's reports (and legacy reports with no worker id)
+/// still land.
+#[test]
+fn progress_from_non_owner_worker_is_rejected() {
+    fn running(worker_id: Option<&str>) -> ProgressUpdate {
+        ProgressUpdate {
+            status: JobStatus::Running,
+            stage: ProgressStage::Running,
+            progress: 0.5,
+            message: "running".to_owned(),
+            error: None,
+            result: None,
+            eta_seconds: None,
+            peak_gpu_memory_pct: None,
+            peak_gpu_load_pct: None,
+            backend: None,
+            worker_id: worker_id.map(str::to_owned),
+        }
+    }
+
+    let store = store("non-owner-progress");
+    register_image_worker(&store);
+    let created = store
+        .create_job(image_job(Map::new()))
+        .expect("job creates");
+    store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+
+    let error = store
+        .update_job_progress(&created.id, running(Some("worker-2")))
+        .expect_err("non-owner report is rejected");
+    assert!(matches!(error, JobsStoreError::NotJobOwner { .. }));
+    let job = store.get_job(&created.id).expect("job loads");
+    assert_eq!(
+        job.status,
+        JobStatus::Preparing,
+        "rejected write must not land"
+    );
+
+    let job = store
+        .update_job_progress(&created.id, running(Some("worker-1")))
+        .expect("owner report lands");
+    assert_eq!(job.status, JobStatus::Running);
+
+    let job = store
+        .update_job_progress(&created.id, running(None))
+        .expect("legacy report without a worker id still lands");
+    assert_eq!(job.status, JobStatus::Running);
 }

--- a/crates/sceneworks-worker/src/api_client.rs
+++ b/crates/sceneworks-worker/src/api_client.rs
@@ -5,6 +5,9 @@ pub(crate) struct ApiClient {
     client: reqwest::Client,
     api_url: String,
     access_token: Option<String>,
+    /// This worker's id, stamped onto every progress report so the server can
+    /// reject writes from a worker that no longer owns the job (sc-4172).
+    pub(crate) worker_id: String,
 }
 
 impl ApiClient {
@@ -13,6 +16,7 @@ impl ApiClient {
             client: reqwest::Client::new(),
             api_url: settings.api_url.trim_end_matches('/').to_owned(),
             access_token: settings.access_token.clone(),
+            worker_id: settings.worker_id.clone(),
         }
     }
 

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -332,6 +332,8 @@ fn caption_progress(
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
         backend: Some(backend.to_owned()),
+        // Stamped by update_job before posting (sc-4172).
+        worker_id: None,
         extra: BTreeMap::new(),
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -830,6 +830,8 @@ fn image_progress(
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
         backend: Some(backend.to_owned()),
+        // Stamped by update_job before posting (sc-4172).
+        worker_id: None,
         extra: BTreeMap::new(),
     }
 }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -810,8 +810,13 @@ async fn check_cancel(api: &ApiClient, job_id: &str, message: &str) -> WorkerRes
 async fn update_job(
     api: &ApiClient,
     job_id: &str,
-    payload: ProgressRequest,
+    mut payload: ProgressRequest,
 ) -> WorkerResult<JobSnapshot> {
+    // Stamp the reporting worker so the server can reject the write if this
+    // worker no longer owns the job (swept stale / canceled / reclaimed). The
+    // resulting 409 propagates as WorkerError::Api and aborts the local job
+    // handling — i.e. the worker abandons the job (sc-4172).
+    payload.worker_id = Some(api.worker_id.clone());
     api.post_json(&format!("/api/v1/jobs/{job_id}/progress"), &payload)
         .await
 }
@@ -1110,6 +1115,8 @@ fn progress_payload(
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
         backend: Some("cpu".to_owned()),
+        // Stamped by update_job before posting (sc-4172).
+        worker_id: None,
         extra: BTreeMap::new(),
     }
 }

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -221,6 +221,8 @@ fn training_progress(
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
         backend: Some(backend.to_owned()),
+        // Stamped by update_job before posting (sc-4172).
+        worker_id: None,
         extra: BTreeMap::new(),
     }
 }

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -824,6 +824,8 @@ fn video_progress(
         peak_gpu_memory_pct: None,
         peak_gpu_load_pct: None,
         backend: Some(backend.to_owned()),
+        // Stamped by update_job before posting (sc-4172).
+        worker_id: None,
         extra: BTreeMap::new(),
     }
 }


### PR DESCRIPTION
## Summary
- Fixes [sc-4172](https://app.shortcut.com/trefry/story/4172) (code-review finding F-CORE-1, P1/High): the progress UPDATE was keyed only by job id — no terminal-status guard, no owner check. A zombie worker whose job was swept to `interrupted` (or canceled by the user) resurrected it to `running`/`completed` with its next report, corrupting queue state, the SSE stream, and the worker idle bookkeeping.
- Store (`update_job_progress`): loads the row inside the same `BEGIN IMMEDIATE` transaction and
  - rejects any report against a terminal job (`TerminalJobImmutable`), **except** an idempotent re-report of the same terminal status, which returns the row unchanged (retried "canceled" POSTs stay safe);
  - rejects reports whose `worker_id` doesn't match the job's owner (`NotJobOwner`) — covers both sweep-cleared (`worker_id = NULL`) and reclaimed jobs.
- Contract: `ProgressRequest` gains optional `workerId` (omitted = legacy trusted caller, so the parity contract flow is byte-identical).
- API: both rejections map to **409 Conflict** with distinct details — the worker's signal to abandon the job rather than retry.
- Workers: both stamp their id at the single progress chokepoint — Rust `update_job` (via `ApiClient.worker_id`) and Python `runtime.update_job` (`getattr` so test fakes don't need it). A 409 propagates as an error and aborts local job handling, i.e. the worker abandons the job.

## Testing
- New store tests: zombie report against a swept job rejected (running **and** late-completed variants), same-terminal re-report is a no-op success, non-owner rejected without landing the write, owner and legacy (no workerId) reports still land.
- `npm run rust:check` (fmt, clippy -D warnings, all crate tests, build) — green; core jobs_store suite 100/100.
- Python CI subset (`test_worker_runtime`/`test_worker_gpu`/`test_person_adapters`) — 432 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)