### PR TITLE
fix(worker): transient API errors no longer abort generations as user cancels (sc-4174)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1600,10 +1600,7 @@ async fn consume_gen_events(
                 mark_started(index);
                 if last_cancel_check.elapsed() >= Duration::from_secs(2) {
                     last_cancel_check = Instant::now();
-                    if check_cancel(api, &job.id, "Image generation canceled by user.")
-                        .await
-                        .is_err()
-                    {
+                    if cancel_requested(api, &job.id, "Image generation canceled by user.").await {
                         cancel.cancel();
                         canceled = true;
                         continue;
@@ -5635,10 +5632,7 @@ pub(crate) async fn run_image_detail_job(
     while let Some((done, total)) = rx.recv().await {
         if last_cancel_check.elapsed() >= Duration::from_secs(2) {
             last_cancel_check = Instant::now();
-            if check_cancel(api, &job.id, "Detail enhancement canceled by user.")
-                .await
-                .is_err()
-            {
+            if cancel_requested(api, &job.id, "Detail enhancement canceled by user.").await {
                 cancel.cancel();
             }
         }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -813,6 +813,9 @@ async fn check_cancel(api: &ApiClient, job_id: &str, message: &str) -> WorkerRes
 /// the GET, or a failed Canceled-status POST — is tolerated and retried on the
 /// next poll instead of being misread as a user cancel that aborts a
 /// multi-minute run and strands the job in Running (sc-4174).
+// In-band polling call sites are inside macOS-gated generation paths; the
+// helper itself stays unit-tested on every platform.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn cancel_requested(api: &ApiClient, job_id: &str, message: &str) -> bool {
     match check_cancel(api, job_id, message).await {
         Ok(()) => false,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -807,6 +807,23 @@ async fn check_cancel(api: &ApiClient, job_id: &str, message: &str) -> WorkerRes
     Ok(())
 }
 
+/// In-band cancel poll for long-running generation/training loops. Returns
+/// true only when the user actually requested cancellation (check_cancel's
+/// `WorkerError::Canceled`). Any other failure — a transient HTTP/API hiccup on
+/// the GET, or a failed Canceled-status POST — is tolerated and retried on the
+/// next poll instead of being misread as a user cancel that aborts a
+/// multi-minute run and strands the job in Running (sc-4174).
+async fn cancel_requested(api: &ApiClient, job_id: &str, message: &str) -> bool {
+    match check_cancel(api, job_id, message).await {
+        Ok(()) => false,
+        Err(WorkerError::Canceled(_)) => true,
+        Err(error) => {
+            eprintln!("cancel_poll_failed jobId={job_id}: {error}; retrying on the next poll");
+            false
+        }
+    }
+}
+
 async fn update_job(
     api: &ApiClient,
     job_id: &str,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -38,9 +38,9 @@ use super::supervisor::{
     utility_worker_specs, SupervisedChild, WorkerSpec,
 };
 use super::{
-    allow_pattern_matches, bounded_tail, cleanup_uploaded_import_source, copy_lora_source,
-    fresh_asset_id, import_lora_source_file_as, import_lora_source_path, now_rfc3339,
-    parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
+    allow_pattern_matches, bounded_tail, cancel_requested, cleanup_uploaded_import_source,
+    copy_lora_source, fresh_asset_id, import_lora_source_file_as, import_lora_source_path,
+    now_rfc3339, parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
     safe_download_dir, safe_project_path, value_f64, wan_moe_pair_filenames,
     write_model_install_marker, CredentialScheme, JsonObject, SafetensorsHeaderError, Settings,
     WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
@@ -1980,4 +1980,108 @@ fn spawn_sleep_child() -> tokio::process::Child {
         .stderr(StdStdio::null())
         .spawn()
         .expect("test child starts")
+}
+
+/// sc-4174 — the in-band cancel poll for long generations must only cancel on
+/// a confirmed user cancel. A transient API failure (on the GET, or on the
+/// Canceled-status POST inside check_cancel) is tolerated and retried on the
+/// next poll instead of aborting a multi-minute run.
+#[derive(Clone)]
+struct CancelPollStubState {
+    get_status: AxumStatusCode,
+    cancel_requested: bool,
+    post_status: AxumStatusCode,
+}
+
+async fn spawn_cancel_poll_stub(state: CancelPollStubState) -> String {
+    async fn job_route(
+        State(state): State<CancelPollStubState>,
+        axum::extract::Path(job_id): axum::extract::Path<String>,
+    ) -> Response {
+        if state.get_status != AxumStatusCode::OK {
+            return (state.get_status, "stub GET failure").into_response();
+        }
+        Json(job_snapshot_json(&job_id, state.cancel_requested)).into_response()
+    }
+    async fn progress_route(
+        State(state): State<CancelPollStubState>,
+        axum::extract::Path(job_id): axum::extract::Path<String>,
+    ) -> Response {
+        if state.post_status != AxumStatusCode::OK {
+            return (state.post_status, "stub POST failure").into_response();
+        }
+        Json(job_snapshot_json(&job_id, state.cancel_requested)).into_response()
+    }
+    let app = Router::new()
+        .route("/api/v1/jobs/:job_id", get(job_route))
+        .route("/api/v1/jobs/:job_id/progress", post(progress_route))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+    format!("http://{address}")
+}
+
+async fn cancel_poll_with(state: CancelPollStubState) -> bool {
+    let base_url = spawn_cancel_poll_stub(state).await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url;
+    let api = ApiClient::new(&settings);
+    cancel_requested(&api, "job-1", "canceled by user").await
+}
+
+#[tokio::test]
+async fn cancel_poll_tolerates_transient_get_errors() {
+    let canceled = cancel_poll_with(CancelPollStubState {
+        get_status: AxumStatusCode::INTERNAL_SERVER_ERROR,
+        cancel_requested: false,
+        post_status: AxumStatusCode::OK,
+    })
+    .await;
+    assert!(
+        !canceled,
+        "a transient GET failure must not read as a user cancel"
+    );
+}
+
+#[tokio::test]
+async fn cancel_poll_cancels_on_confirmed_user_cancel() {
+    let canceled = cancel_poll_with(CancelPollStubState {
+        get_status: AxumStatusCode::OK,
+        cancel_requested: true,
+        post_status: AxumStatusCode::OK,
+    })
+    .await;
+    assert!(canceled, "a confirmed cancel request must cancel the run");
+}
+
+#[tokio::test]
+async fn cancel_poll_retries_when_cancel_ack_post_fails() {
+    // cancel_requested=true but the Canceled-status POST fails: don't treat it
+    // as canceled yet — the next 2s poll retries the acknowledgement.
+    let canceled = cancel_poll_with(CancelPollStubState {
+        get_status: AxumStatusCode::OK,
+        cancel_requested: true,
+        post_status: AxumStatusCode::INTERNAL_SERVER_ERROR,
+    })
+    .await;
+    assert!(
+        !canceled,
+        "a failed cancel acknowledgement must be retried, not assumed"
+    );
+}
+
+#[tokio::test]
+async fn cancel_poll_continues_when_no_cancel_requested() {
+    let canceled = cancel_poll_with(CancelPollStubState {
+        get_status: AxumStatusCode::OK,
+        cancel_requested: false,
+        post_status: AxumStatusCode::OK,
+    })
+    .await;
+    assert!(!canceled);
 }

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -493,10 +493,7 @@ async fn consume_training_events(
                     && last_cancel_check.elapsed() >= Duration::from_secs(2)
                 {
                     last_cancel_check = Instant::now();
-                    if check_cancel(api, &job.id, "LoRA training canceled by user.")
-                        .await
-                        .is_err()
-                    {
+                    if cancel_requested(api, &job.id, "LoRA training canceled by user.").await {
                         cancel.cancel();
                         canceled = true;
                         continue;

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1554,7 +1554,7 @@ async fn generate_video(
         }
         if last_cancel.elapsed() >= Duration::from_secs(2) {
             last_cancel = Instant::now();
-            if check_cancel(api, &job.id, CANCEL_MESSAGE).await.is_err() {
+            if cancel_requested(api, &job.id, CANCEL_MESSAGE).await {
                 cancel.cancel();
                 canceled = true;
                 continue;


### PR DESCRIPTION
## Summary
- Fixes [sc-4174](https://app.shortcut.com/trefry/story/4174) (code-review finding F-MLXW-1, P1/High): the four in-band cancel-poll sites (`consume_gen_events`, `run_image_detail_job`, `generate_video`, `consume_training_events`) did `if check_cancel(..).is_err() { cancel.cancel() }` — so **any** transient API error mid-denoise canceled a multi-minute generation/training run, and since the Canceled-status POST had also failed, the job was never marked canceled and sat in `Running`.
- Fix: new `cancel_requested` helper in the worker that matches the error variant (the pattern `caption_jobs.rs` already used correctly): `WorkerError::Canceled` → cancel the run; any other error → log + tolerate, retried on the next 2-second poll. A failed cancel *acknowledgement* is likewise retried on the next poll rather than aborting locally and stranding the job. All four sites switched to the helper.
- Sites that propagate `check_cancel` errors as real job failures (media/model/download paths) are unchanged — that's the story's accepted alternative behavior.

## Testing
- 4 new tests against an axum stub API: transient GET failure tolerated; confirmed cancel cancels; failed cancel-ack POST retried (not assumed canceled); no-cancel continues.
- `npm run rust:check` (fmt, clippy -D warnings, all crate tests incl. 238 worker tests, build) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)