### PR TITLE
fix(worker): InstantID MLX black images + inert cancellation (sc-4381, sc-4382)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "image",
  "inventory",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "image",
  "inventory",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "image",
  "inventory",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=37388297f7d82277f58507f537c7a9d77e69bd6c#37388297f7d82277f58507f537c7a9d77e69bd6c"
 dependencies = [
  "image",
  "inventory",
@@ -2964,7 +2964,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "image",
  "inventory",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "image",
  "inventory",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "image",
  "inventory",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=72214e309c6b08290885e8cebb32b86781cc5803#72214e309c6b08290885e8cebb32b86781cc5803"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=36787606669570e8282573d604059bf8305480ff#36787606669570e8282573d604059bf8305480ff"
 dependencies = [
  "image",
  "inventory",
@@ -2964,7 +2964,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,8 +68,8 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 3678760 (mlx-gen branch claude/sc-4380-instantid-cancel = main 4896833 + PR #236, PIN AHEAD
-# OF MERGE — flip to the main merge SHA once #236 lands): InstantID cancellation + step progress
+# Rev 3738829 (mlx-gen main, merged PR #236; also includes #237 SenseNova steps validation,
+# sc-3957): InstantID cancellation + step progress
 # (sc-4380: `InstantIdRequest.cancel` + `on_progress` on every `generate*`/`restore_face`, consumed
 # by generate_instantid_stream, sc-4382). Via main it also picks up the P0 black-image fix
 # sc-3948/92cdf43 (CLIP tokenizer 77-token cap — a >77-token prompt previously gathered
@@ -116,7 +116,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -124,60 +124,60 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -186,7 +186,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "367876
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "37388297f7d82277f58507f537c7a9d77e69bd6c" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,7 +68,17 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# Rev 72214e3 (mlx-gen main, merged PR #199, epic 3180): adds the native-MLX SenseNova-U1 family
+# Rev 3678760 (mlx-gen branch claude/sc-4380-instantid-cancel = main 4896833 + PR #236, PIN AHEAD
+# OF MERGE — flip to the main merge SHA once #236 lands): InstantID cancellation + step progress
+# (sc-4380: `InstantIdRequest.cancel` + `on_progress` on every `generate*`/`restore_face`, consumed
+# by generate_instantid_stream, sc-4382). Via main it also picks up the P0 black-image fix
+# sc-3948/92cdf43 (CLIP tokenizer 77-token cap — a >77-token prompt previously gathered
+# out-of-bounds position rows -> NaN conditioning -> all-black images on every SDXL-tokenizer
+# consumer: sdxl family, InstantID, Kolors; sc-4381), the Chroma cancel fix (sc-3953 #234),
+# Chroma CFG (sc-3950 #233), Z-Image steps validation (sc-3941 #231), Qwen attention split
+# (sc-4004 #230), and the workspace-deps refactor (sc-3976 #212). The mlx-rs pin is unchanged
+# (e59ffd88) so MLX core rebuilds nothing.
+# On top of rev 72214e3 (mlx-gen main, merged PR #199, epic 3180): adds the native-MLX SenseNova-U1 family
 # crate `mlx-gen-sensenova` (NEO-Unify — a dense dual-path Qwen3-MoT AR LLM + flow-matching image
 # generator + NEO ViT; sc-3181..sc-3194). Two registered ids: `sensenova_u1_8b` (base, 50 NFE /
 # text-CFG 4 + image-CFG via true_cfg) and `sensenova_u1_8b_fast` (8-step distill-LoRA merged at
@@ -102,7 +112,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -110,60 +120,60 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -172,7 +182,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "72214e309c6b08290885e8cebb32b86781cc5803" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "36787606669570e8282573d604059bf8305480ff" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -458,6 +458,9 @@ fn caption_job_options(payload: &JsonObject) -> CaptionJobOptions {
                 .and_then(Value::as_u64)
                 .and_then(|value| u32::try_from(value).ok())
                 .unwrap_or(256),
+            // sc-3963 engine knob: `None` keeps the per-call fresh seed (captions vary across
+            // runs, the pre-bump behavior); an explicit `options.seed` reproduces a caption.
+            seed: options.get("seed").and_then(Value::as_u64),
         },
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -4876,9 +4876,10 @@ async fn ensure_instantid_openpose(settings: &Settings) -> WorkerResult<WeightsS
 /// model is `!Send`). Three modes (torch parity): single identity (`generate`), the 11-view angle
 /// set (`generate_angle`), and the pose-library set (`generate_pose`, MultiControlNet IdentityNet
 /// with xinsir OpenPose — sc-3117). `advanced.faceRestore` adds the ADetailer-style re-render pass
-/// (`restore_face`, sc-3380) on each output. The engine `generate*` expose neither a step-progress
-/// callback nor a `CancelFlag`, so streaming is per-image (no `Step`/`Decoding` events) and
-/// cancellation is honoured between images. Reuses [`consume_gen_events`] for the asset writes.
+/// (`restore_face`, sc-3380) on each output. The engine `generate*` take the per-job `CancelFlag`
+/// (via `InstantIdRequest.cancel`) and a `Progress` callback (sc-4380/sc-4382), so streaming is
+/// per-step (`Step`/`Decoding` events) and cancellation is honoured mid-denoise — same contract
+/// as the registry families. Reuses [`consume_gen_events`] for the asset writes.
 #[cfg(target_os = "macos")]
 async fn generate_instantid_stream(
     api: &ApiClient,
@@ -5074,6 +5075,20 @@ async fn generate_instantid_stream(
                 if cancel.is_cancelled() {
                     break;
                 }
+                // Per-step progress → GenEvent::Step, so `consume_gen_events` streams step
+                // updates, fires `image_inference_start`, and polls the cancel API (sc-4382 —
+                // without Step events an InstantID job could never be cancelled).
+                let mut on_progress = |progress: Progress| {
+                    let event = match progress {
+                        Progress::Step { current, total } => GenEvent::Step {
+                            index,
+                            current,
+                            total,
+                        },
+                        Progress::Decoding => GenEvent::Decoding { index },
+                    };
+                    let _ = tx.blocking_send(event);
+                };
                 // Angle + pose sets use a square canvas (the engine forces `req.height =
                 // req.width` for the canonical landmark/skeleton — the sc-2009 kps-aspect rule);
                 // single identity keeps the requested W×H (the engine letterboxes the reference).
@@ -5088,17 +5103,28 @@ async fn generate_instantid_stream(
                     controlnet_scale,
                     openpose_scale,
                     seed: seed as u64,
+                    cancel: cancel.clone(),
                 };
-                let mut out = match &action {
-                    InstantIdAction::Identity => model.generate(&req, &reference),
-                    InstantIdAction::Angle(angle) => model.generate_angle(&req, &reference, angle),
-                    InstantIdAction::Pose(keypoints) => {
-                        model.generate_pose(&req, &reference, keypoints)
+                let result = match &action {
+                    InstantIdAction::Identity => model.generate(&req, &reference, &mut on_progress),
+                    InstantIdAction::Angle(angle) => {
+                        model.generate_angle(&req, &reference, angle, &mut on_progress)
                     }
-                }
-                .map_err(|error| {
-                    WorkerError::InvalidPayload(format!("InstantID generation failed: {error}"))
-                })?;
+                    InstantIdAction::Pose(keypoints) => {
+                        model.generate_pose(&req, &reference, keypoints, &mut on_progress)
+                    }
+                };
+                let mut out = match result {
+                    Ok(out) => out,
+                    // A cancel tripped mid-denoise surfaces as the engine's cancelled error —
+                    // stop cleanly (consume_gen_events posts the Canceled update).
+                    Err(_) if cancel.is_cancelled() => break,
+                    Err(error) => {
+                        return Err(WorkerError::InvalidPayload(format!(
+                            "InstantID generation failed: {error}"
+                        )))
+                    }
+                };
                 // Optional ADetailer-style face-restore re-render (sc-3380), imposing the
                 // reference identity on the cropped face with the gender-neutral restore prompt.
                 if let Some(embedding) = &restore_embedding {
@@ -5113,14 +5139,18 @@ async fn generate_instantid_stream(
                         controlnet_scale,
                         openpose_scale,
                         seed: seed as u64,
+                        cancel: cancel.clone(),
                     };
-                    out = model
-                        .restore_face(&restore_req, &out, embedding)
-                        .map_err(|error| {
-                            WorkerError::InvalidPayload(format!(
+                    out = match model.restore_face(&restore_req, &out, embedding, &mut on_progress)
+                    {
+                        Ok(out) => out,
+                        Err(_) if cancel.is_cancelled() => break,
+                        Err(error) => {
+                            return Err(WorkerError::InvalidPayload(format!(
                                 "InstantID face-restore failed: {error}"
-                            ))
-                        })?;
+                            )))
+                        }
+                    };
                 }
                 if tx
                     .blocking_send(GenEvent::Image {


### PR DESCRIPTION
## Summary
Fixes both InstantID-on-MLX defects reported 2026-06-10 (black images; cancel ignored). Torch/MPS unaffected.

### 1. Black images (sc-4381)
The engine CLIP BPE tokenizer at pin `72214e3` applied **no 77-token cap**, and the text encoder gathers positions `0..n` from the `[77, D]` position-embedding table. **MLX gathers are not bounds-checked**, so the production character prompt + angle augment (89 BPE tokens) silently gathered garbage rows → 100% NaN conditioning → all-black PNGs (job_d0ac23cd; the only `mlx_instantid` asset ever written was all-zero). diffusers truncates at 77, which is why MPS was fine. Affects every SDXL-tokenizer consumer on the MLX path (sdxl family t2i, InstantID, Kolors) — all fixed by the pin bump (upstream fix: mlx-gen sc-3948 / `92cdf43`, merged to engine main this morning).

Reproduced deterministically in a standalone engine harness with the exact job inputs (RealVisXL base, app-downloaded `SceneWorks/instantid-mlx` weights, real reference image, seed 521593107): black pre-fix, healthy with the fix — including the full 30-step production render.

### 2. Inert cancellation (sc-4382)
`InstantId::generate*` hardcoded a no-op CancelFlag + progress callback, so InstantID emitted no `GenEvent::Step` — and `consume_gen_events` polls the cancel API **only** in its Step handler, so a cancel was never observed (job_d0ac23cd rendered all 11 angle-set images after the user cancelled; `image_inference_start` telemetry never fired). Engine fix: [mlx-gen#236](https://github.com/michaeltrefry/mlx-gen/pull/236) (sc-4380) adds `InstantIdRequest.cancel` + `on_progress` to every generate path.

## Changes
- **Pin bump** `72214e3` → `3678760` = mlx-gen main `4896833` + PR #236. **Pinned ahead of merge** — once you merge mlx-gen#236, flip to the main merge SHA. mlx-rs unchanged (e59ffd88, no MLX core rebuild). ⚠️ Conflicts with the pin bump in #518 (b9b9aba, which predates the black-image fix) — whichever lands second rebases; the final pin must be ≥ `92cdf43`.
- **generate_instantid_stream**: per-job CancelFlag through `InstantIdRequest` (generate + face-restore), engine `Progress` → `GenEvent::Step/Decoding` (step streaming, inference-start events, the 2s cancel poll — same contract as registry families), engine cancelled-error → clean stop.
- **caption_jobs**: upstream `CaptionSampling` gained `seed: Option<u64>` (sc-3963); pass `options.seed` through (`None` = unchanged per-call fresh seed).

## Testing
- `npm run rust:check` green (fmt, clippy -D warnings, core+worker+api tests, build).
- Engine real-weight e2e on this Mac: production-config render healthy at 30 steps (deterministic across repeats); `instantid_honors_cancellation` passes (pre-cancel aborts before tensor work; mid-denoise cancel stops at the next step); identity e2e unchanged (ArcFace-cosine 0.8136 @6 steps).
- Not run: a live in-app cancel of an InstantID job (needs the desktop app rebuilt on this pin) — the wiring matches the generic MLX families whose cancel path is exercised in production.

Stories: sc-4381, sc-4382 (worker) · sc-4380 (engine, PR mlx-gen#236)

🤖 Generated with [Claude Code](https://claude.com/claude-code)