### PR TITLE
fix(worker): missing MLX weights fail loudly instead of stubbing on macOS (sc-4176)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -531,6 +531,20 @@ pub(crate) async fn run_image_generate_job(
     #[cfg(not(target_os = "macos"))]
     let handled = false;
 
+    // An MLX-routed model id whose weights/snapshot didn't resolve must fail
+    // loudly with a precise re-download error instead of completing the job
+    // with procedural stub output (sc-4176, epic 3482 "unsupported jobs error
+    // loudly"). `mlx_available` is the last dispatch arm, so reaching here
+    // with a known engine model means exactly that its weights are unusable.
+    // Model ids outside the engine families still stub (test models,
+    // not-yet-ported families, non-macOS lanes).
+    #[cfg(target_os = "macos")]
+    if !handled {
+        if let Some(gap) = mlx_weights_gap(&request, settings) {
+            return Err(WorkerError::InvalidPayload(gap));
+        }
+    }
+
     if !handled {
         generate_stub_stream(
             api,
@@ -897,6 +911,25 @@ enum GenEvent {
 
 /// True when this job can run real in-process inference: the model is a linked,
 /// engine-backed family and its weights resolve locally.
+/// Fail-loud gate for the stub fallback (sc-4176): Some(message) when the
+/// requested model id is a known MLX engine model but its weights snapshot
+/// can't be resolved (partially deleted HF cache, stale refs, missing
+/// modelPath). None when the model isn't engine-backed (the stub is its
+/// intended path) or the weights resolve.
+#[cfg(target_os = "macos")]
+pub(crate) fn mlx_weights_gap(request: &ImageRequest, settings: &Settings) -> Option<String> {
+    let model = mlx_model(&request.model)?;
+    if resolve_weights_dir(request, settings).is_some() {
+        return None;
+    }
+    Some(format!(
+        "{}: MLX weights not found or incomplete (Hugging Face repo {}). \
+         Re-download the model in Model Manager, then retry.",
+        request.model,
+        model_repo(request, model),
+    ))
+}
+
 #[cfg(target_os = "macos")]
 fn mlx_available(request: &ImageRequest, settings: &Settings) -> bool {
     mlx_model(&request.model).is_some() && resolve_weights_dir(request, settings).is_some()

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2085,3 +2085,81 @@ async fn cancel_poll_continues_when_no_cancel_requested() {
     .await;
     assert!(!canceled);
 }
+
+/// sc-4176 — on macOS an MLX-routed model whose weights don't resolve must
+/// fail loudly with a precise re-download error instead of silently completing
+/// with procedural stub output; non-engine model ids keep the stub path.
+#[cfg(target_os = "macos")]
+mod stub_fallback_gate {
+    use super::*;
+    use crate::image_jobs::mlx_weights_gap;
+    use crate::video_jobs::ensure_video_engine_weights;
+    use sceneworks_core::image_request::ImageRequest;
+    use sceneworks_core::video_request::VideoRequest;
+    use serde_json::Map;
+
+    fn settings_with_empty_data_dir() -> (tempfile::TempDir, Settings) {
+        let dir = tempdir().expect("tempdir");
+        let mut settings = test_settings("http://127.0.0.1:1".to_owned(), None);
+        settings.data_dir = dir.path().to_path_buf();
+        (dir, settings)
+    }
+
+    fn object(value: serde_json::Value) -> Map<String, serde_json::Value> {
+        value.as_object().expect("object").clone()
+    }
+
+    #[test]
+    fn image_engine_model_without_weights_is_a_precise_error_not_a_stub() {
+        let (_dir, settings) = settings_with_empty_data_dir();
+        let request = ImageRequest::from_payload(&object(json!({ "model": "z_image_turbo" })));
+        let gap = mlx_weights_gap(&request, &settings).expect("missing weights flagged");
+        assert!(gap.contains("z_image_turbo"), "{gap}");
+        assert!(gap.contains("Re-download"), "{gap}");
+    }
+
+    #[test]
+    fn image_non_engine_model_keeps_the_stub_path() {
+        let (_dir, settings) = settings_with_empty_data_dir();
+        let request = ImageRequest::from_payload(&object(json!({ "model": "base-model" })));
+        assert_eq!(mlx_weights_gap(&request, &settings), None);
+    }
+
+    #[test]
+    fn image_explicit_model_path_resolves_and_passes_the_gate() {
+        let (dir, settings) = settings_with_empty_data_dir();
+        let request = ImageRequest::from_payload(&object(json!({
+            "model": "z_image_turbo",
+            "advanced": { "modelPath": dir.path().to_string_lossy() },
+        })));
+        assert_eq!(mlx_weights_gap(&request, &settings), None);
+    }
+
+    #[test]
+    fn video_engine_model_without_weights_is_a_precise_error_not_a_stub() {
+        let (_dir, settings) = settings_with_empty_data_dir();
+        let request = VideoRequest::from_payload(&object(json!({ "model": "wan_2_2_i2v_14b" })));
+        let error = ensure_video_engine_weights(&request, &settings)
+            .expect_err("missing Wan weights flagged");
+        assert!(
+            error.to_string().contains("no MLX weights found"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn video_svd_without_source_asset_is_an_invalid_payload_error() {
+        let (_dir, settings) = settings_with_empty_data_dir();
+        let request = VideoRequest::from_payload(&object(json!({ "model": "svd" })));
+        let error = ensure_video_engine_weights(&request, &settings)
+            .expect_err("svd without a source image flagged");
+        assert!(error.to_string().contains("source image"), "{error}");
+    }
+
+    #[test]
+    fn video_non_engine_model_keeps_the_stub_path() {
+        let (_dir, settings) = settings_with_empty_data_dir();
+        let request = VideoRequest::from_payload(&object(json!({ "model": "stub-model" })));
+        ensure_video_engine_weights(&request, &settings).expect("non-engine model passes");
+    }
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -251,6 +251,13 @@ pub(crate) async fn run_video_generate_job(
             None,
         )
     } else {
+        // An MLX-routed video model whose snapshot didn't resolve must fail
+        // loudly with the resolver's precise error instead of completing with
+        // procedural stub output (sc-4176, epic 3482 "unsupported jobs error
+        // loudly"). replace_person above already follows this rule; the stub
+        // remains only for ids outside the engine families (test models,
+        // not-yet-ported families).
+        ensure_video_engine_weights(&request, settings)?;
         (
             generate_stub_video(&request, seed),
             STUB_ADAPTER,
@@ -873,6 +880,33 @@ fn wan_engine_id(model: &str) -> Option<&'static str> {
 /// Whether the linked Wan engine can serve this request now: a Wan model id with
 /// resolvable on-disk weights. Off macOS / non-Wan / weights-absent → the stub
 /// (mirrors the image `mlx_available` weights gate).
+/// Fail-loud gate for the stub fallback (sc-4176): when the requested model id
+/// maps to an MLX video engine family (Wan/LTX/SVD) but its weights/snapshot
+/// can't be resolved, surface the resolver's precise re-download error instead
+/// of silently degrading the job to procedural stub output. Non-engine model
+/// ids pass through (the stub is their intended path).
+#[cfg(target_os = "macos")]
+pub(crate) fn ensure_video_engine_weights(
+    request: &VideoRequest,
+    settings: &Settings,
+) -> WorkerResult<()> {
+    if let Some(engine_id) = wan_engine_id(&request.model) {
+        resolve_wan_model_dir(settings, &request.model, engine_id)?;
+    }
+    if ltx_engine_id(&request.model).is_some() {
+        resolve_ltx_model_dir(settings, request)?;
+    }
+    if svd_engine_id(&request.model).is_some() {
+        if request.source_asset_id.is_none() {
+            return Err(WorkerError::InvalidPayload(
+                "SVD image-to-video requires a source image asset.".to_owned(),
+            ));
+        }
+        resolve_svd_model_dir(settings)?;
+    }
+    Ok(())
+}
+
 #[cfg(target_os = "macos")]
 fn wan_available(request: &VideoRequest, settings: &Settings) -> bool {
     match wan_engine_id(&request.model) {


### PR DESCRIPTION
## Summary
- Fixes [sc-4176](https://app.shortcut.com/trefry/story/4176) (code-review finding F-MLXW-2, P1/High): on the macOS MLX worker, an MLX-routed model whose weights snapshot failed `resolve_weights_dir` (partially deleted HF cache, stale `refs/main`) fell through the dispatch chain to `generate_stub_stream`/`generate_stub_video` — the job reported **Completed** with synthetic gradient media, masking the real provisioning failure (contrary to the epic-3482 "unsupported jobs error loudly" principle).
- Image path: new `mlx_weights_gap()` gate before the stub fallback — a known engine model with unresolvable weights fails with a precise `'<model>: MLX weights not found or incomplete (Hugging Face repo <repo>). Re-download the model in Model Manager'` error. Since `mlx_available` is the last dispatch arm, reaching the fallback with a known engine model means exactly that its weights are unusable.
- Video path: new `ensure_video_engine_weights()` guards the stub arm — Wan/LTX/SVD model ids surface their resolver's existing precise error (which names the expected directory/repo); SVD without a source image gets its own clear error. `replace_person` already followed this rule (the review's cited correct example).
- Stub behavior is preserved exactly where intended: non-engine model ids (test models, not-yet-ported families) and non-macOS lanes.

## Testing
- 6 new macOS-gated tests: engine image/video model + empty data dir → precise error (message content asserted); non-engine ids → stub path preserved; explicit `modelPath` → passes the gate; SVD-without-source → distinct payload error.
- `npm run rust:check` — green (211 worker tests, fmt, clippy -D warnings; gates are macOS-cfg'd so the Linux parity lane is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)