### PR TITLE
fix(ci): re-point the dead macOS MLX worker lane at main (sc-4177)

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -23,9 +23,12 @@ name: macOS MLX worker
 # all external contributors' workflows" enabled in the repo Actions settings as
 # defense in depth.
 
+# Epic-3018 stories merged to main via PR #456 and `rust-mlx-integration` was
+# deleted; epic work now branches off and PRs into main (sc-4177 re-pointed the
+# lane after it sat dead on the deleted branch).
 on:
   push:
-    branches: [rust-mlx-integration]
+    branches: [main]
     paths: &mlx_paths
       - "crates/**"
       - "apps/rust-worker/**"
@@ -34,7 +37,7 @@ on:
       - ".cargo/config.toml"
       - ".github/workflows/macos-mlx.yml"
   pull_request:
-    branches: [rust-mlx-integration]
+    branches: [main]
     paths: *mlx_paths
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Fixes [sc-4177](https://app.shortcut.com/trefry/story/4177) (code-review finding F-INFRA-1, P1/High): `.github/workflows/macos-mlx.yml` only triggered on `rust-mlx-integration`, a branch merged and deleted via [#456](https://github.com/michaeltrefry/SceneWorks/pull/456) — so the MLX-linked `sceneworks-worker` build, its tests, the NAX 16-bit SDPA guard, and worker clippy haven't run in CI since, on the production Mac inference path.
- Exactly the story's suggested fix: both `branches:` filters → `[main]`. Path filters, the `workflow_dispatch` escape hatch, the concurrency group, and the same-repo `if:` guard for the self-hosted runner are unchanged.
- Verified the `nax-macos` self-hosted runner is registered and online before re-pointing, so PRs touching `crates/**` won't queue forever.

## Testing
- This PR itself touches the workflow file (in its own paths filter) and targets main, so the lane runs live on this PR — the green `nax-worker` check below is the end-to-end validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)