### PR TITLE
fix(ci): run the whole Python suite via markers instead of a hardcoded file list (sc-4180)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,9 +40,12 @@ jobs:
       - name: Install contract test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==9.0.2 httpx==0.28.1 "pillow>=12.0.0,<13" "numpy>=2.0,<3"
+          python -m pip install pytest==9.0.2 httpx==0.28.1 "pillow>=12.0.0,<13" "numpy>=2.0,<3" "opencv-python-headless>=4.10,<5"
       - name: Run worker test suite
-        run: python -m pytest -q tests/test_worker_runtime.py tests/test_worker_gpu.py tests/test_person_adapters.py
+        # Marker expression instead of a hardcoded file list so new test files
+        # are picked up automatically; e2e/parity-marked tests run in their own
+        # later steps against the built Rust API (sc-4180).
+        run: python -m pytest -q tests/ -m "not e2e and not parity" --strict-markers
       - name: Run scaffold and compose checks
         run: |
           npm run check

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -28,6 +28,12 @@ from scene_worker.runtime import (
 )
 from scene_worker.settings import WorkerSettings
 
+# Every test here drives the compiled Rust API binary (the `rust_api` fixture
+# spawns `cargo run -p sceneworks-rust-api`), so the whole module is e2e: it
+# must run in the CI step that follows the Rust build, not in the lightweight
+# worker-suite step (sc-4180).
+pytestmark = pytest.mark.e2e
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -184,7 +190,6 @@ def test_python_worker_protocol_round_trips_against_rust_api_binary(rust_api):
     assert completed["cancelRequested"] is True
 
 
-@pytest.mark.e2e
 def test_python_worker_completes_procedural_image_job_against_rust_api_binary(
     rust_api, tmp_path, monkeypatch
 ):
@@ -295,7 +300,6 @@ class _RecordingImageAdapter:
         )
 
 
-@pytest.mark.e2e
 def test_character_image_angle_and_pose_sets_carry_loras_through_worker(rust_api, tmp_path, monkeypatch):
     """sc-2226: a character_image angle set AND pose set, each carrying a `loras` array,
     submitted through the Rust API binary and run by the in-process worker, deliver those


### PR DESCRIPTION
## Summary
- Fixes [sc-4180](https://app.shortcut.com/trefry/story/4180) (code-review finding F-INFRA-2, P1/High): the parity lane ran a hardcoded three-file subset, so `test_instantid_adapter.py`, `test_pulid_flux_adapter.py`, `test_pose_adapters.py`, `test_lycoris_lokr.py`, and `test_sampler_registry.py` (~1,600 lines) provided zero CI signal.
- The story's suggested fix: `python -m pytest -q tests/ -m "not e2e and not parity" --strict-markers` — new test files are now picked up automatically; the e2e/parity-marked tests keep running in their existing later steps against the built Rust API.
- One dependency addition the file list had been masking: three of the dark tests exercise the real `cv2` skeleton-drawing path (`draw_bodypose` — where the sc-3219 limb-rendering bug lived), so `opencv-python-headless` joins the lane deps.

## Testing
- Verified locally on the exact pinned CI deps (Python venv with pytest 9.0.2 / httpx 0.28.1 / pillow / numpy / opencv-headless): **521 passed, 10 skipped, 14 deselected** (the 14 = e2e+parity markers, still covered by their own steps).
- The green parity check on this PR is the live validation of the new selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)