### PR TITLE
fix(worker): clear_loras deletes only non-LyCORIS adapter names (sc-4181)

### DIFF
--- a/apps/worker/scene_worker/lora_adapters.py
+++ b/apps/worker/scene_worker/lora_adapters.py
@@ -642,7 +642,10 @@ def clear_loras(pipe: Any, adapter_names: tuple[str, ...], *, adapter_id: str) -
     # unload_lora_weights (LoRA-only) leaves behind and would leak into the next
     # job (epic 2193). Fall back to unload for pipelines without delete_adapters.
     if hasattr(pipe, "delete_adapters"):
-        pipe.delete_adapters(list(adapter_names))
+        # Only the non-LyCORIS leftovers: the restored LyCORIS names were never
+        # peft adapters, and delete_adapters raises on unknown names — which
+        # would fail the next job on a mixed-adapter cached pipeline (sc-4181).
+        pipe.delete_adapters(remaining)
         return
     if hasattr(pipe, "unload_lora_weights"):
         pipe.unload_lora_weights()

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1634,6 +1634,21 @@ def test_clear_loras_prefers_delete_adapters_so_lokr_is_removed():
     assert pipe.unloaded == 0
 
 
+def test_clear_loras_mixed_lycoris_and_peft_deletes_only_peft_names(monkeypatch):
+    # sc-4181: on a cached pipeline holding a LyCORIS net AND a peft adapter,
+    # clear_loras must pass only the non-LyCORIS leftovers to delete_adapters —
+    # the full list includes the just-restored LyCORIS name, which diffusers'
+    # delete_adapters rejects, failing the next job.
+    monkeypatch.setattr(
+        "scene_worker.lora_adapters._restore_lycoris_nets",
+        lambda module, names: {"lyc_style"},
+    )
+    pipe = FakeTargetedLoraPipe()
+    clear_loras(pipe, ("lyc_style", "char"), adapter_id="sdxl_test")
+    assert pipe.deleted == [["char"]]
+    assert pipe.unloaded == 0
+
+
 def test_set_adapter_weights_on_module_applies_and_guards():
     module = FakeDenoiserModule()
     spec = LoraSpec(id="c", path="p", weight=0.5, adapter_name="c")


### PR DESCRIPTION
## Summary
- Fixes [sc-4181](https://app.shortcut.com/trefry/story/4181) (code-review finding F-WORKER-1, P2/Medium): `clear_loras` computed `remaining` (the non-LyCORIS leftovers) but then called `pipe.delete_adapters(list(adapter_names))` with the full original list — including names just reversed via `_restore_lycoris_nets`. diffusers' `delete_adapters` raises on unknown adapter names, so clearing a mixed LyCORIS+peft cached pipeline failed the next job — exactly the cross-job corruption the epic-2193 machinery exists to prevent.
- One-line fix per the story: pass `remaining`, matching the sibling logic in `apply_loras_to_pipeline` (`non_lycoris_removed`).

## Testing
- New regression test: mixed LyCORIS+peft clear → `delete_adapters` receives only the peft name. Existing all-LyCORIS and all-peft clear tests still green.
- Full light Python suite on pinned CI deps: 520 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)