### PR TITLE
fix(worker): restart after CUDA OOM in upscale/detail jobs (sc-4187)

### DIFF
--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1189,10 +1189,9 @@ def run_upscale_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None
         job,
         kind_label="Image upscale",
         setup=setup,
-        # On OOM, release the activation pool instead of restarting the child:
-        # the lazily-loaded upscale engine is the only resident and dropping the
-        # pool reclaims it without losing the worker's other cached state.
-        oom_restart=False,
+        # Release the activation pool, then restart like every other GPU
+        # handler — a poisoned CUDA context can't reliably reclaim VRAM in
+        # place (sc-4187; the no-restart behavior here was drift, not policy).
         on_oom=release_image_worker_memory,
     )
 
@@ -1227,8 +1226,7 @@ def run_detail_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
         job,
         kind_label="Detail enhancement",
         setup=setup,
-        # Same OOM policy as run_upscale_job: release the pool, keep the child.
-        oom_restart=False,
+        # Same OOM policy as run_upscale_job (sc-4187): release, then restart.
         on_oom=release_image_worker_memory,
     )
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -6884,6 +6884,57 @@ def test_video_job_failure_runs_cleanup_to_free_gpu(monkeypatch):
     assert events["status"] == "failed"
 
 
+def test_upscale_and_detail_jobs_restart_after_cuda_oom(monkeypatch):
+    # sc-4187: upscale/detail set needs_oom_restart but never restarted — the
+    # worker kept running with a poisoned CUDA context. They now release the
+    # activation pool and restart like every other GPU handler.
+    from scene_worker.runtime import run_detail_job, run_upscale_job
+
+    class Api:
+        def __init__(self):
+            self.status = None
+
+        def post(self, path, payload):
+            if path.endswith("/heartbeat"):
+                return {}
+            if path.endswith("/progress"):
+                self.status = payload.get("status")
+                return {"status": payload["status"], "stage": payload.get("stage")}
+            raise AssertionError(path)
+
+        def get(self, _path):
+            return {"cancelRequested": False}
+
+    for handler, runner_target in (
+        (run_upscale_job, "scene_worker.runtime.run_image_upscale"),
+        (run_detail_job, "scene_worker.runtime.run_image_detail"),
+    ):
+        released = {"count": 0}
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("CUDA error: out of memory")
+
+        monkeypatch.setattr(runner_target, boom)
+        monkeypatch.setattr("scene_worker.runtime.find_project_path", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            "scene_worker.runtime.release_image_worker_memory",
+            lambda: released.__setitem__("count", released["count"] + 1),
+        )
+        monkeypatch.setattr(
+            "scene_worker.runtime.run_blocking_job_step",
+            lambda *_args, **_kwargs: _args[4](lambda: False),
+        )
+        api = Api()
+        with pytest.raises(SystemExit):
+            handler(
+                api,
+                SimpleNamespace(worker_id="worker-1", gpu_id="0", data_dir=Path(".")),
+                {"id": "job-oom", "payload": {"projectId": "project-1"}},
+            )
+        assert api.status == "failed"
+        assert released["count"] == 1, handler.__name__
+
+
 def test_video_job_nonoom_failure_does_not_restart(monkeypatch):
     events = {"cleanup": 0, "status": None}
 


### PR DESCRIPTION
## Summary
- Fixes [sc-4187](https://app.shortcut.com/trefry/story/4187) (code-review finding F-WORKER-3, P2/Medium): `run_upscale_job` and `run_detail_job` computed `needs_oom_restart` but only released the activation pool — they never called `restart_worker_after_oom` like every other GPU handler, so after a CUDA OOM the worker kept serving jobs on a poisoned CUDA context (unrecoverable allocator errors until manual restart). The variable name shows the restart was intended; this was drift, which the sc-4185 scaffold preserved as an explicit knob.
- Fix: drop `oom_restart=False` from both handlers. They now release the pool (`on_oom`), mark the job failed, and exit so the supervisor restarts the child with a fresh context — identical semantics to `run_image_job` / `run_video_job` / training.

## Testing
- New regression test runs both handlers with a CUDA-OOM-raising runner: asserts the job is reported failed, the pool released exactly once, and the process exits for the supervisor restart (`SystemExit`), mirroring the existing video OOM test.
- Full light Python suite on pinned CI deps: 521 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)