### PR TITLE
feat(worker): kps extraction from image (SCRFD) capability (sc-4433)

### DIFF
--- a/apps/worker/scene_worker/kps_extract_adapters.py
+++ b/apps/worker/scene_worker/kps_extract_adapters.py
@@ -1,0 +1,157 @@
+"""SCRFD 5-point face-landmark extraction for the Key Point Library (epic 4422, sc-4433).
+
+The Windows/Linux InsightFace counterpart of the macOS native-MLX path
+(``crates/sceneworks-worker/src/kps_jobs.rs``). Given one image, detect the largest face
+and return its 5 landmarks (``[left_eye, right_eye, nose, mouth_left, mouth_right]``)
+normalized to a square ``[0,1]`` canvas — directly consumable as an InstantID
+angle/framing preset by the engine pass-in path (``generate_with_kps``, sc-4425). The
+reference supplies *identity*; these kps supply the *pose/framing*.
+
+Detection-only: reuses the antelopev2 SCRFD detector InstantID already provisions
+(``instantid_adapter._ensure_antelopev2``); no ArcFace embedding or SDXL stack. The
+worker advertises ``kps_extract`` only when the InsightFace backend is installed.
+
+Normalization mirrors the engine's centered square letterbox (``kps::letterbox`` /
+``instantid_adapter._letterbox``): a detected pixel ``(px, py)`` in a ``w x h`` image maps
+to ``((1 - w/M)/2 + px/M, (1 - h/M)/2 + py/M)`` with ``M = max(w, h)`` — scale-free, so the
+result round-trips through ``generate_with_kps`` (which draws ``kps_norm * side`` on a
+square canvas after letterboxing the reference the same way). Kept byte-identical in
+spirit to the Rust ``normalize_to_square`` so both platforms produce the same preset.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Callable
+
+ProgressCallback = Callable[[str, str, float, str], None]
+CancelCallback = Callable[[], bool]
+
+# Landmark order, surfaced on the result so a consumer never has to assume it. Matches
+# the Rust ``KPS_ORDER`` and the InstantID ``VIEW_ANGLE_KPS`` ordering.
+KPS_ORDER = ["left_eye", "right_eye", "nose", "mouth_left", "mouth_right"]
+# SCRFD detector input (square), matches the macOS native path + InstantID.
+DET_SIZE = (640, 640)
+# Below this detection score the landmarks are returned but flagged ``lowConfidence`` so
+# the caller can warn the captured angle may be unreliable (matches the Rust threshold).
+LOW_CONF_THRESH = 0.65
+_DETECTOR = {"id": "antelopev2_scrfd", "backend": "insightface"}
+
+
+class KpsExtractError(RuntimeError):
+    """Raised for an unusable extraction request (no resolvable source image)."""
+
+
+def kps_extractor_backend_available() -> bool:
+    """True when InsightFace + onnxruntime + OpenCV are importable (the SCRFD path)."""
+    return all(
+        importlib.util.find_spec(mod) is not None
+        for mod in ("insightface", "onnxruntime", "cv2")
+    )
+
+
+def _normalize_to_square(px: float, py: float, w: int, h: int) -> list[float]:
+    """Map a detected pixel coordinate into square-normalized ``[0,1]`` preset space,
+    applying the engine's centered-letterbox geometry analytically (no image resize)."""
+    m = float(max(w, h))
+    return [(1.0 - w / m) / 2.0 + px / m, (1.0 - h / m) / 2.0 + py / m]
+
+
+def _face_app(settings: Any) -> Any:
+    """Load the antelopev2 FaceAnalysis app (CPU EP), reusing InstantID's provisioning."""
+    from insightface.app import FaceAnalysis
+
+    from .instantid_adapter import _ensure_antelopev2
+
+    root = _ensure_antelopev2()
+    app = FaceAnalysis(
+        name="antelopev2", root=str(root), providers=["CPUExecutionProvider"]
+    )
+    app.prepare(ctx_id=0, det_size=DET_SIZE)
+    return app
+
+
+def _resolve_source_path(settings: Any, job: dict[str, Any], payload: dict[str, Any]) -> str:
+    """Resolve the source image: a staged ``sourcePath`` or a project ``sourceAssetId``
+    (+ ``projectId``). Mirrors the dual contract the Rust handler accepts."""
+    raw = payload.get("sourcePath")
+    if raw and str(raw).strip():
+        return str(raw)
+
+    asset_id = payload.get("sourceAssetId")
+    project_id = payload.get("projectId") or job.get("projectId")
+    if asset_id and str(asset_id).strip() and project_id:
+        from sceneworks_shared import find_project_path, load_asset_with_media
+
+        project_path = find_project_path(
+            Path(getattr(settings, "data_dir", ".")) / "recent-projects.json",
+            str(project_id),
+        )
+        if project_path is not None:
+            _record, media_path = load_asset_with_media(project_path, str(asset_id))
+            if media_path is not None:
+                return str(media_path)
+
+    raise KpsExtractError("kps extraction needs a sourceAssetId or sourcePath")
+
+
+def run_kps_extract(
+    settings: Any,
+    job: dict[str, Any],
+    *,
+    progress: ProgressCallback | None = None,
+    cancel_requested: CancelCallback | None = None,
+) -> dict[str, Any]:
+    """Detect the largest face in one image and return its normalized 5-point kps.
+
+    payload: ``{"projectId"?, "sourceAssetId"?, "sourcePath"?}``
+    result:  ``{"detected", "kps"?, "kpsOrder"?, "bbox"?, "detScore"?, "lowConfidence"?,
+                "sourceWidth", "sourceHeight", "detector"}``
+
+    ``detected: false`` (with ``reason: "no_face"``) is an explicit, well-formed result —
+    the acceptance "clear failure, not silent bad data" — not an exception.
+    """
+    import cv2
+    import numpy as np
+    from PIL import Image as PILImage
+
+    payload = job.get("payload") or {}
+    image_path = _resolve_source_path(settings, job, payload)
+    pil = PILImage.open(image_path).convert("RGB")
+    w, h = pil.width, pil.height
+
+    if progress is not None:
+        progress("running", "running", 0.5, "Detecting face landmarks.")
+
+    app = _face_app(settings)
+    bgr = cv2.cvtColor(np.array(pil), cv2.COLOR_RGB2BGR)
+    faces = app.get(bgr)
+    if not faces:
+        return {
+            "detected": False,
+            "reason": "no_face",
+            "sourceWidth": w,
+            "sourceHeight": h,
+            "detector": dict(_DETECTOR),
+        }
+
+    face = sorted(
+        faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1])
+    )[-1]
+    kps = [_normalize_to_square(float(x), float(y), w, h) for x, y in face.kps[:5]]
+    bbox = _normalize_to_square(
+        float(face.bbox[0]), float(face.bbox[1]), w, h
+    ) + _normalize_to_square(float(face.bbox[2]), float(face.bbox[3]), w, h)
+    score = float(getattr(face, "det_score", 0.0))
+    return {
+        "detected": True,
+        "kps": kps,
+        "kpsOrder": list(KPS_ORDER),
+        "bbox": bbox,
+        "detScore": score,
+        "lowConfidence": score < LOW_CONF_THRESH,
+        "sourceWidth": w,
+        "sourceHeight": h,
+        "detector": dict(_DETECTOR),
+    }

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -46,6 +46,7 @@ from .person_adapters import (
     segmenter_backend_available,
     tracker_backend_available,
 )
+from .kps_extract_adapters import kps_extractor_backend_available, run_kps_extract
 from .pose_adapters import pose_detector_backend_available, run_pose_detect
 from .prompt_refine import PromptRefineError, PromptRefiner
 from .settings import WorkerSettings
@@ -74,6 +75,12 @@ PERSON_JOB_TYPES = ("person_detect", "person_track")
 # is installed; routed via requested_gpu (not in NON_GPU_JOB_TYPES). Keep in sync with
 # crates/sceneworks-core/src/contracts.rs::JobType / WorkerCapability.
 POSE_JOB_TYPES = ("pose_detect",)
+# SCRFD 5-point face-landmark extraction for the Key Point Library (epic 4422, sc-4433).
+# InsightFace (antelopev2 SCRFD) like the InstantID face stack — advertised by the Python
+# worker only when the backend is installed; routed via requested_gpu (not in
+# NON_GPU_JOB_TYPES). The macOS Rust worker serves it natively (native-MLX SCRFD). Keep in
+# sync with crates/sceneworks-core/src/contracts.rs::JobType / WorkerCapability.
+KPS_EXTRACT_JOB_TYPES = ("kps_extract",)
 # Keep GPU-required job types in sync with
 # crates/sceneworks-core/src/jobs_store.rs::job_requires_gpu and
 # apps/web/src/screens/QueueScreen.jsx::gpuRequiredJobTypes.
@@ -127,6 +134,7 @@ ALL_JOB_TYPES = (
     SUPPORTED_JOB_TYPES
     + PERSON_JOB_TYPES
     + POSE_JOB_TYPES
+    + KPS_EXTRACT_JOB_TYPES
     + TRAINING_JOB_TYPES
     + CAPTION_JOB_TYPES
     + VQA_JOB_TYPES
@@ -199,6 +207,11 @@ def worker_capabilities(gpu: dict) -> list[str]:
         # can't run it.
         if pose_detector_backend_available():
             capabilities.add("pose_detect")
+        # SCRFD 5-point landmark extraction (Key Point Library) — InsightFace, advertised
+        # only when installed so the queue never routes a kps_extract job to a worker that
+        # can't run it (sc-4433).
+        if kps_extractor_backend_available():
+            capabilities.add("kps_extract")
     return sorted(capabilities)
 
 
@@ -1160,6 +1173,40 @@ def run_pose_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     )
 
 
+def run_kps_extract_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+    """Run a kps_extract job: SCRFD 5-point face landmarks from one image (Key Point
+    Library, sc-4433).
+
+    InsightFace-backed (antelopev2 SCRFD), so no torch model is loaded — the worker
+    advertises kps_extract only when the backend is installed (worker_capabilities).
+    Returns the largest face's normalized landmarks, or an explicit ``detected: false``
+    result when no face is found. The macOS Rust worker serves this natively (native-MLX
+    SCRFD); this is the Windows/Linux path.
+    """
+
+    def setup(progress):
+        progress("preparing", "preparing", 0.06, "Preparing face detector.")
+        return JobStep(
+            runner=lambda cancel: run_kps_extract(
+                settings,
+                job,
+                progress=progress,
+                cancel_requested=cancel,
+            ),
+            completion="Face landmarks extracted.",
+        )
+
+    run_job_scaffold(
+        api,
+        settings,
+        job,
+        kind_label="Keypoint extraction",
+        setup=setup,
+        # onnxruntime path: no torch CUDA context worth recycling on OOM.
+        oom_restart=False,
+    )
+
+
 def run_upscale_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
     """Run an image_upscale job: Real-ESRGAN / AuraSR on one existing asset.
 
@@ -1483,6 +1530,8 @@ def run_worker_loop(settings: WorkerSettings) -> None:
                 run_person_job(api, settings, job)
             elif job["type"] in POSE_JOB_TYPES:
                 run_pose_job(api, settings, job)
+            elif job["type"] in KPS_EXTRACT_JOB_TYPES:
+                run_kps_extract_job(api, settings, job)
             elif job["type"] in TRAINING_JOB_TYPES:
                 run_lora_train_job(api, settings, job)
             elif job["type"] in CAPTION_JOB_TYPES:

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -203,6 +203,13 @@ string_enum! {
         // Pose Library (epic 2282). onnxruntime-backed like person_detect; advertised
         // by the Python worker, routed via requested_gpu (not in NON_GPU_JOB_TYPES).
         PoseDetect => "pose_detect",
+        // SCRFD 5-point face-landmark extraction from one image (Key Point Library,
+        // epic 4422 / sc-4433): photo -> normalized [left_eye, right_eye, nose,
+        // mouth_left, mouth_right] in square-canvas [0,1], consumable as an InstantID
+        // angle/framing preset (pass-in kps via generate_with_kps). Native-MLX SCRFD on
+        // the Rust worker (zero-Python, epic 3482); InsightFace on the Python worker.
+        // GPU-routed like pose_detect (not in NON_GPU_JOB_TYPES).
+        KpsExtract => "kps_extract",
         // Standalone upscale of an existing image asset (Image Editor, epic 2427).
         // Torch-backed (Real-ESRGAN / AuraSR), GPU-required like generation; reuses
         // the upscale engines that previously only ran as a generation post-step.
@@ -294,6 +301,12 @@ string_enum! {
         // (runtime.py, gated on pose_detector_backend_available); the Rust utility
         // worker never emits it. See jobs_store::worker_supports_job.
         PoseDetect => "pose_detect",
+        // SCRFD 5-point face-landmark extraction (Key Point Library, epic 4422 /
+        // sc-4433). Advertised by the macOS Rust/MLX worker (native SCRFD, zero-Python)
+        // and by the Python worker when the InsightFace backend is installed
+        // (runtime.py, gated on kps_extractor_backend_available). See
+        // jobs_store::worker_supports_job.
+        KpsExtract => "kps_extract",
         // Procedural detection/tracking previews served by the Rust utility worker.
         // Real, model-backed PersonDetect/PersonTrack jobs are served by the Python
         // GPU worker (YOLO/ByteTrack/SAM2); these preview capabilities keep the CPU

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1894,6 +1894,12 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // "create from photo" flow + InstantID pose conditioning run Python-free.
         JobType::PoseDetect => Ok(()),
 
+        // SCRFD 5-point landmark extraction is native-MLX on the Rust worker (sc-4433,
+        // epic 4422): the same SCRFD detector the InstantID face stack already runs
+        // in-process, so the Key Point Library "extract kps from this image" flow is
+        // Python-free on Mac.
+        JobType::KpsExtract => Ok(()),
+
         // Real-ESRGAN image upscaling is now ported to the Rust worker (sc-3489):
         // RRDBNet x2/x4 via `ort`/CoreML on the macOS MLX worker, so the Image Editor
         // upscale tool runs Python-free. `aura-sr` (a separate GAN upscaler, no clean

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1968,6 +1968,9 @@ fn mac_rust_supported_names_infra_job_types() {
     // DWPose pose detection is ported to the Rust worker (sc-3487) → supported.
     let pose = job_of(&store, JobType::PoseDetect, json!({}));
     assert!(mac_rust_supported(&pose).is_ok());
+    // SCRFD kps extraction is native-MLX on the Rust worker (sc-4433) → supported.
+    let kps = job_of(&store, JobType::KpsExtract, json!({}));
+    assert!(mac_rust_supported(&kps).is_ok());
     // Real-ESRGAN upscaling is ported to the Rust worker (sc-3489): the default engine
     // (real-esrgan) is supported; the AuraSR engine stays a tracked Mac gap.
     let upscale = job_of(&store, JobType::ImageUpscale, json!({}));

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -435,6 +435,12 @@ pub(crate) fn mlx_gpu() -> DiscoveredGpu {
             // Python-free Mac. The detector auto-provisions its onnx weights on first
             // use (download-on-first-use parity with rtmlib).
             WorkerCapability::PoseDetect,
+            // SCRFD 5-point face-landmark extraction (epic 4422, sc-4433): native-MLX
+            // SCRFD in-process (`kps_jobs::run_kps_extract_job`, the InstantID face-stack
+            // detector) for the Key Point Library "extract kps from this image" flow,
+            // Python-free on Mac. Reuses the InstantID `scrfd_10g` bundle (cached on
+            // first InstantID/extraction use).
+            WorkerCapability::KpsExtract,
             // Real-ESRGAN image upscaling (epic 3482, sc-3489): RRDBNet x2/x4 via
             // onnxruntime/CoreML, served in-process by `upscale_jobs::run_image_upscale_job`.
             // Replaces the Python torch Real-ESRGAN path so the Image Editor upscale tool

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -4941,6 +4941,27 @@ async fn ensure_instantid_file(
     Ok(target)
 }
 
+/// Resolve only the SCRFD detector weights (`scrfd_10g.safetensors`) from the same converted
+/// bundle InstantID uses — for the standalone kps-extraction capability (sc-4433), which needs
+/// face detection but neither ArcFace nor the SDXL/IdentityNet stack. Shares the env override
+/// (`SCENEWORKS_INSTANTID_WEIGHTS`) + app cache + download-on-first-use with
+/// [`ensure_instantid_weights`], so a prior InstantID run leaves it already cached.
+#[cfg(target_os = "macos")]
+pub(crate) async fn ensure_scrfd_weights(settings: &Settings) -> WorkerResult<PathBuf> {
+    let client = reqwest::Client::new();
+    let bundle_dir = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| settings.data_dir.join("cache").join("instantid-mlx"));
+    let base = format!("https://huggingface.co/{INSTANTID_MLX_REPO}/resolve/main");
+    ensure_instantid_file(
+        &client,
+        &bundle_dir,
+        INSTANTID_SCRFD_FILE,
+        &format!("{base}/{INSTANTID_SCRFD_FILE}"),
+    )
+    .await
+}
+
 /// Resolve all InstantID weight inputs, downloading the small converted bundle + the stock
 /// IdentityNet on first use. Returns `(identitynet_dir, ip_adapter, scrfd, arcface)` — all
 /// `Send` paths; the `!Send` MLX load happens on the blocking thread. Resolution order favours

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -1,0 +1,405 @@
+//! SCRFD 5-point face-landmark extraction on the Rust worker (epic 4422, sc-4433).
+//!
+//! The reusable "extract kps from this image" capability behind the Key Point Library:
+//! given one photo, detect the largest face and return its 5 landmarks
+//! (`[left_eye, right_eye, nose, mouth_left, mouth_right]`) normalized to a square
+//! `[0,1]` canvas — directly consumable as an InstantID angle/framing preset by the
+//! engine pass-in path (`generate_with_kps`, sc-4425). The reference supplies *identity*;
+//! these kps supply the *pose/framing*, so a user can capture the framing of any photo and
+//! reuse it on any character.
+//!
+//! Native-MLX SCRFD in-process (the same `scrfd_10g` detector the InstantID face stack
+//! already runs), so the capability is Python-free on Mac (epic 3482); the Python worker
+//! keeps the InsightFace path for Windows/Linux. macOS-only here.
+//!
+//! Normalization mirrors the engine's centered square letterbox (`kps::letterbox`): a
+//! detected pixel `(px, py)` in a `w×h` image maps to the square-normalized point
+//! `((1 − w/M)/2 + px/M, (1 − h/M)/2 + py/M)` with `M = max(w, h)` — the side cancels, so
+//! the result is scale-free and round-trips through `generate_with_kps` (which draws
+//! `kps_norm · side` on a square canvas after letterboxing the reference the same way).
+
+use std::path::{Path, PathBuf};
+
+use mlx_gen::weights::Weights;
+use mlx_gen::Image;
+use mlx_gen_face::{detector_blob, Scrfd};
+use serde_json::{json, Value};
+
+use crate::image_jobs::{ensure_scrfd_weights, load_reference_image};
+use crate::{
+    heartbeat, progress_payload, update_job, ApiClient, Settings, WorkerError, WorkerResult,
+};
+use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
+use sceneworks_core::project_store::ProjectStore;
+
+/// SCRFD detection confidence floor (InsightFace / `FaceAnalysis` default).
+const DET_THRESH: f32 = 0.5;
+/// Non-max-suppression IoU threshold (InsightFace / `FaceAnalysis` default).
+const NMS_THRESH: f32 = 0.4;
+/// Below this detection score the landmarks are returned but flagged `lowConfidence`, so the
+/// caller can warn that the captured angle may be unreliable (extreme profile / poor framing).
+const LOW_CONF_THRESH: f32 = 0.65;
+/// The landmark order, surfaced on the result so a consumer never has to assume it.
+const KPS_ORDER: [&str; 5] = ["left_eye", "right_eye", "nose", "mouth_left", "mouth_right"];
+const DETECTOR_ID: &str = "scrfd_10g";
+
+/// Map a detected pixel coordinate into the square-normalized `[0,1]` preset space, applying
+/// the engine's centered-letterbox geometry analytically (no image resize needed). Pure +
+/// unit-tested. `M = max(w, h)`; for a square image this is just `px/w, py/h`.
+fn normalize_to_square(px: f32, py: f32, w: u32, h: u32) -> [f32; 2] {
+    let m = w.max(h) as f32;
+    [
+        (1.0 - w as f32 / m) / 2.0 + px / m,
+        (1.0 - h as f32 / m) / 2.0 + py / m,
+    ]
+}
+
+/// The outcome of a single-image extraction. `detected = false` is an explicit, well-formed
+/// result (the acceptance "clear failure, not silent bad data"), not a job error.
+struct KpsExtraction {
+    detected: bool,
+    /// Normalized 5-point landmarks (square `[0,1]`), largest face. `None` when no face.
+    kps: Option<[[f32; 2]; 5]>,
+    /// Normalized `[x1, y1, x2, y2]` face box (square `[0,1]`). `None` when no face.
+    bbox: Option<[f32; 4]>,
+    det_score: f32,
+    low_confidence: bool,
+    source_width: u32,
+    source_height: u32,
+}
+
+impl KpsExtraction {
+    fn none(source_width: u32, source_height: u32) -> Self {
+        Self {
+            detected: false,
+            kps: None,
+            bbox: None,
+            det_score: 0.0,
+            low_confidence: false,
+            source_width,
+            source_height,
+        }
+    }
+
+    fn into_result(self) -> JsonObject {
+        let mut result = JsonObject::new();
+        result.insert("detected".to_owned(), Value::Bool(self.detected));
+        result.insert("sourceWidth".to_owned(), json!(self.source_width));
+        result.insert("sourceHeight".to_owned(), json!(self.source_height));
+        result.insert(
+            "detector".to_owned(),
+            json!({ "id": DETECTOR_ID, "backend": "mlx" }),
+        );
+        match self.kps {
+            Some(kps) => {
+                result.insert(
+                    "kps".to_owned(),
+                    json!(kps.iter().map(|p| json!([p[0], p[1]])).collect::<Vec<_>>()),
+                );
+                result.insert(
+                    "kpsOrder".to_owned(),
+                    json!(KPS_ORDER.iter().collect::<Vec<_>>()),
+                );
+                if let Some(bbox) = self.bbox {
+                    result.insert("bbox".to_owned(), json!(bbox));
+                }
+                result.insert("detScore".to_owned(), json!(self.det_score));
+                result.insert("lowConfidence".to_owned(), Value::Bool(self.low_confidence));
+            }
+            None => {
+                result.insert("reason".to_owned(), json!("no_face"));
+            }
+        }
+        result
+    }
+}
+
+/// Load SCRFD + detect the largest face's landmarks in `image`, normalized to the square
+/// preset space. Runs the `!Send` MLX work; call inside `spawn_blocking`.
+fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtraction> {
+    let weights = Weights::from_file(scrfd_path).map_err(|error| {
+        WorkerError::InvalidPayload(format!("SCRFD weights {scrfd_path:?}: {error}"))
+    })?;
+    let scrfd = Scrfd::from_weights(&weights)
+        .map_err(|error| WorkerError::InvalidPayload(format!("SCRFD load: {error}")))?;
+    let (blob, det_scale) =
+        detector_blob(&image.pixels, image.height as usize, image.width as usize);
+    let dets = scrfd
+        .detect(&blob, det_scale, DET_THRESH, NMS_THRESH)
+        .map_err(|error| WorkerError::InvalidPayload(format!("SCRFD detect: {error}")))?;
+
+    let (w, h) = (image.width, image.height);
+    let largest = dets.into_iter().max_by(|a, b| {
+        let area = |d: &mlx_gen_face::Detection| {
+            (d.bbox[2] - d.bbox[0]).max(0.0) * (d.bbox[3] - d.bbox[1]).max(0.0)
+        };
+        area(a).total_cmp(&area(b))
+    });
+    let Some(det) = largest else {
+        return Ok(KpsExtraction::none(w, h));
+    };
+
+    let mut kps = [[0.0f32; 2]; 5];
+    for (i, point) in det.kps.iter().enumerate() {
+        kps[i] = normalize_to_square(point[0], point[1], w, h);
+    }
+    let tl = normalize_to_square(det.bbox[0], det.bbox[1], w, h);
+    let br = normalize_to_square(det.bbox[2], det.bbox[3], w, h);
+    Ok(KpsExtraction {
+        detected: true,
+        kps: Some(kps),
+        bbox: Some([tl[0], tl[1], br[0], br[1]]),
+        det_score: det.score,
+        low_confidence: det.score < LOW_CONF_THRESH,
+        source_width: w,
+        source_height: h,
+    })
+}
+
+/// Resolve the source image from the payload: a project `sourceAssetId` (+ `projectId`) or a
+/// staged `sourcePath`. Mirrors the dual source contract pose detection accepts.
+fn load_source_image(settings: &Settings, job: &JobSnapshot) -> WorkerResult<Image> {
+    let payload = &job.payload;
+    let project_id = payload
+        .get("projectId")
+        .and_then(Value::as_str)
+        .or(job.project_id.as_deref());
+
+    if let Some(asset_id) = payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        let project_id = project_id.ok_or_else(|| {
+            WorkerError::InvalidPayload("kps extraction sourceAssetId needs a projectId".to_owned())
+        })?;
+        let store = ProjectStore::new(settings.data_dir.clone(), "worker");
+        let project_path = store
+            .get_project(project_id)
+            .map(|p| PathBuf::from(p.path))
+            .map_err(|error| {
+                WorkerError::InvalidPayload(format!("kps extraction project {project_id}: {error}"))
+            })?;
+        return load_reference_image(&settings.data_dir, project_id, asset_id, &project_path);
+    }
+
+    if let Some(path) = payload
+        .get("sourcePath")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+    {
+        let decoded = image::open(path)
+            .map_err(|error| {
+                WorkerError::InvalidPayload(format!("kps extraction source {path}: {error}"))
+            })?
+            .to_rgb8();
+        return Ok(Image {
+            width: decoded.width(),
+            height: decoded.height(),
+            pixels: decoded.into_raw(),
+        });
+    }
+
+    Err(WorkerError::InvalidPayload(
+        "kps extraction needs a sourceAssetId or sourcePath".to_owned(),
+    ))
+}
+
+/// Run a `kps_extract` job: SCRFD landmark extraction from one image → normalized 5-point
+/// preset (or an explicit `detected: false` result on no face).
+#[cfg(target_os = "macos")]
+pub(crate) async fn run_kps_extract_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.1,
+            "Preparing face detector.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+
+    let image = load_source_image(settings, job)?;
+    let scrfd_path = ensure_scrfd_weights(settings).await?;
+
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Running,
+            ProgressStage::Running,
+            0.5,
+            "Detecting face landmarks.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+
+    let extraction = tokio::task::spawn_blocking(move || detect_largest_kps(&scrfd_path, &image))
+        .await
+        .map_err(|e| WorkerError::InvalidPayload(format!("kps extraction task: {e}")))??;
+
+    let message = if extraction.detected {
+        "Face landmarks extracted."
+    } else {
+        "No face detected in the image."
+    };
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            message,
+            None,
+            Some(extraction.into_result()),
+            None,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_square_image_is_plain_fraction() {
+        // A square image: side cancels, normalized = px/side, py/side.
+        assert_eq!(normalize_to_square(512.0, 256.0, 1024, 1024), [0.5, 0.25]);
+        assert_eq!(normalize_to_square(0.0, 0.0, 800, 800), [0.0, 0.0]);
+    }
+
+    #[test]
+    fn normalize_landscape_centers_vertically() {
+        // 1000x500 landscape (M=1000): x is px/1000; y is letterboxed into the centered band
+        // [0.25, 0.75], so the vertical midpoint (py=250) maps to 0.5.
+        let [x, y] = normalize_to_square(500.0, 250.0, 1000, 500);
+        assert!((x - 0.5).abs() < 1e-6, "x={x}");
+        assert!((y - 0.5).abs() < 1e-6, "y={y}");
+        // Top edge of the source sits at 0.25 in the square (the top pad band).
+        assert!((normalize_to_square(0.0, 0.0, 1000, 500)[1] - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn normalize_portrait_centers_horizontally() {
+        // 500x1000 portrait (M=1000): y is py/1000; x is centered into [0.25, 0.75].
+        let [x, y] = normalize_to_square(250.0, 500.0, 500, 1000);
+        assert!((x - 0.5).abs() < 1e-6, "x={x}");
+        assert!((y - 0.5).abs() < 1e-6, "y={y}");
+        assert!((normalize_to_square(0.0, 0.0, 500, 1000)[0] - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn no_face_result_is_explicit() {
+        let result = KpsExtraction::none(640, 480).into_result();
+        assert_eq!(result.get("detected"), Some(&Value::Bool(false)));
+        assert_eq!(
+            result.get("reason").and_then(Value::as_str),
+            Some("no_face")
+        );
+        assert!(result.get("kps").is_none());
+    }
+
+    #[test]
+    fn detected_result_carries_normalized_kps_and_order() {
+        let extraction = KpsExtraction {
+            detected: true,
+            kps: Some([
+                [0.4, 0.34],
+                [0.6, 0.34],
+                [0.5, 0.43],
+                [0.43, 0.53],
+                [0.57, 0.53],
+            ]),
+            bbox: Some([0.3, 0.2, 0.7, 0.6]),
+            det_score: 0.92,
+            low_confidence: false,
+            source_width: 1024,
+            source_height: 1024,
+        };
+        let result = extraction.into_result();
+        assert_eq!(result.get("detected"), Some(&Value::Bool(true)));
+        let kps = result.get("kps").and_then(Value::as_array).unwrap();
+        assert_eq!(kps.len(), 5);
+        let order = result.get("kpsOrder").and_then(Value::as_array).unwrap();
+        assert_eq!(order[2].as_str(), Some("nose"));
+        assert_eq!(result.get("lowConfidence"), Some(&Value::Bool(false)));
+    }
+
+    /// Real-weights smoke (sc-4433): run the actual native-MLX SCRFD path on a real face photo
+    /// and assert the extracted landmarks are well-formed and in valid frontal geometry —
+    /// eyes above nose above mouth, left-eye left of right-eye, all normalized into `[0,1]`.
+    /// This exercises `detect_largest_kps` end to end (Weights load → blob → detect → largest
+    /// → normalize). Needs the `scrfd_10g.safetensors` bundle (`SCENEWORKS_INSTANTID_WEIGHTS`
+    /// overrides) + a face image (`SCENEWORKS_TEST_FACE` overrides) + a Metal device. On demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored kps_extract_real_weights --nocapture`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real SCRFD weights + Metal device"]
+    fn kps_extract_real_weights_extracts_frontal_landmarks() {
+        let home = std::env::var("HOME").expect("HOME");
+        let scrfd_path = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                PathBuf::from(&home)
+                    .join("Library/Application Support/SceneWorks/data/cache/instantid-mlx")
+            })
+            .join("scrfd_10g.safetensors");
+        assert!(scrfd_path.exists(), "missing SCRFD weights: {scrfd_path:?}");
+        let face_path = std::env::var("SCENEWORKS_TEST_FACE").unwrap_or_else(|_| {
+            "/Users/michael/Library/Application Support/SceneWorks/data/projects/ab.sceneworks/assets/images/genset_e6b07eb5b5374627af1bf47083bac305/2026-06-10_qwen_image_edit_2511_lightning_22-year-old-woman-with-fair-complexion-a-p_0001.png".to_owned()
+        });
+        let decoded = image::open(&face_path)
+            .unwrap_or_else(|e| panic!("face {face_path}: {e}"))
+            .to_rgb8();
+        let image = Image {
+            width: decoded.width(),
+            height: decoded.height(),
+            pixels: decoded.into_raw(),
+        };
+
+        let extraction = detect_largest_kps(&scrfd_path, &image).expect("detect");
+        assert!(extraction.detected, "expected a face in the test image");
+        let kps = extraction.kps.expect("kps on a detected face");
+        let order = KPS_ORDER;
+        for (i, p) in kps.iter().enumerate() {
+            assert!(
+                (0.0..=1.0).contains(&p[0]) && (0.0..=1.0).contains(&p[1]),
+                "{} out of [0,1]: {p:?}",
+                order[i]
+            );
+        }
+        let [le, re, nose, ml, mr] = kps;
+        assert!(le[0] < re[0], "left eye should be left of right eye");
+        assert!(ml[0] < mr[0], "left mouth should be left of right mouth");
+        let eye_y = (le[1] + re[1]) / 2.0;
+        let mouth_y = (ml[1] + mr[1]) / 2.0;
+        assert!(eye_y < nose[1], "eyes above nose ({eye_y} !< {})", nose[1]);
+        assert!(
+            nose[1] < mouth_y,
+            "nose above mouth ({}, {mouth_y})",
+            nose[1]
+        );
+        println!(
+            "  extracted (score {:.3}, low_conf {}): le={le:?} re={re:?} nose={nose:?} ml={ml:?} mr={mr:?}",
+            extraction.det_score, extraction.low_confidence
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -72,6 +72,12 @@ mod openpose_skeleton;
 // rtmlib path stays the Windows/Linux backend.
 #[cfg(target_os = "macos")]
 mod pose_jobs;
+// SCRFD 5-point face-landmark extraction (epic 4422, sc-4433): native-MLX SCRFD
+// in-process (the InstantID face-stack detector) for the Key Point Library
+// "extract kps from this image" capability. macOS-only; the Python InsightFace
+// path stays the Windows/Linux backend.
+#[cfg(target_os = "macos")]
+mod kps_jobs;
 // Real-ESRGAN image upscaling (epic 3482, sc-3489): RRDBNet x2/x4 via `ort`/CoreML,
 // reusing the same bundled onnxruntime sc-3487 ships. macOS-only; the Python torch
 // Real-ESRGAN / AuraSR path stays the Windows/Linux backend.
@@ -91,6 +97,8 @@ mod person_track;
 #[cfg(target_os = "macos")]
 mod person_segment;
 use downloads::*;
+#[cfg(target_os = "macos")]
+use kps_jobs::*;
 #[cfg(target_os = "macos")]
 use pose_jobs::*;
 #[cfg(target_os = "macos")]
@@ -654,6 +662,14 @@ async fn run_utility_job(
         JobType::PoseDetect => run_pose_detect_job(api, settings, http_client, &job)
             .await
             .map_err(|error| ("Pose detection failed.", error)),
+        // SCRFD 5-point landmark extraction (epic 4422, sc-4433): native-MLX SCRFD
+        // in-process for the Key Point Library. macOS-only; off macOS `KpsExtract` is
+        // never advertised by the Rust worker (the Python InsightFace path handles it),
+        // so this falls to the `_` arm there.
+        #[cfg(target_os = "macos")]
+        JobType::KpsExtract => run_kps_extract_job(api, settings, &job)
+            .await
+            .map_err(|error| ("Keypoint extraction failed.", error)),
         // Real-ESRGAN image upscaling (epic 3482, sc-3489): RRDBNet x2/x4 via
         // onnxruntime/CoreML, served in-process by `upscale_jobs::run_image_upscale_job`.
         // Replaces the Python torch Real-ESRGAN path so the Image Editor upscale tool

--- a/tests/test_kps_extract_adapters.py
+++ b/tests/test_kps_extract_adapters.py
@@ -1,0 +1,98 @@
+"""Unit tests for the InsightFace kps-extraction adapter (sc-4433).
+
+Cover the pure square-normalization (kept in parity with the Rust
+``kps_jobs::normalize_to_square``), the backend-availability gate, and the
+``run_kps_extract`` orchestration with a fake detector so coverage needs neither
+the antelopev2 onnx weights nor a GPU.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from scene_worker import kps_extract_adapters as ka
+
+
+def test_normalize_square_image_is_plain_fraction():
+    # Square image: side cancels, normalized = px/side, py/side (Rust parity).
+    assert ka._normalize_to_square(512.0, 256.0, 1024, 1024) == pytest.approx([0.5, 0.25])
+    assert ka._normalize_to_square(0.0, 0.0, 800, 800) == pytest.approx([0.0, 0.0])
+
+
+def test_normalize_landscape_centers_vertically():
+    # 1000x500 landscape (M=1000): x = px/1000; y letterboxed into the centered band.
+    x, y = ka._normalize_to_square(500.0, 250.0, 1000, 500)
+    assert x == pytest.approx(0.5)
+    assert y == pytest.approx(0.5)
+    # Top edge of the source sits at 0.25 (the top pad band).
+    assert ka._normalize_to_square(0.0, 0.0, 1000, 500)[1] == pytest.approx(0.25)
+
+
+def test_normalize_portrait_centers_horizontally():
+    # 500x1000 portrait (M=1000): y = py/1000; x centered into [0.25, 0.75].
+    x, y = ka._normalize_to_square(250.0, 500.0, 500, 1000)
+    assert x == pytest.approx(0.5)
+    assert y == pytest.approx(0.5)
+    assert ka._normalize_to_square(0.0, 0.0, 500, 1000)[0] == pytest.approx(0.25)
+
+
+def test_backend_available_reflects_optional_deps(monkeypatch):
+    monkeypatch.setattr(ka.importlib.util, "find_spec", lambda _name: object())
+    assert ka.kps_extractor_backend_available() is True
+    monkeypatch.setattr(
+        ka.importlib.util,
+        "find_spec",
+        lambda name: None if name == "insightface" else object(),
+    )
+    assert ka.kps_extractor_backend_available() is False
+
+
+def _square_png(tmp_path, side: int = 400):
+    Image = pytest.importorskip("PIL.Image")
+    path = tmp_path / "face.png"
+    Image.new("RGB", (side, side), (128, 128, 128)).save(path)
+    return str(path)
+
+
+def test_run_kps_extract_normalizes_largest_face(tmp_path, monkeypatch):
+    pytest.importorskip("cv2")
+    pytest.importorskip("numpy")
+    path = _square_png(tmp_path, 400)
+
+    # A fake SCRFD face: bbox + 5 kps in pixels on a 400x400 square → normalized = px/400.
+    face = SimpleNamespace(
+        bbox=[100.0, 100.0, 300.0, 300.0],
+        kps=[[150, 160], [250, 160], [200, 210], [160, 260], [240, 260]],
+        det_score=0.91,
+    )
+    monkeypatch.setattr(ka, "_face_app", lambda _s: SimpleNamespace(get=lambda _bgr: [face]))
+    monkeypatch.setattr(ka, "_resolve_source_path", lambda _s, _j, _p: path)
+
+    result = ka.run_kps_extract(None, {"payload": {"sourcePath": path}})
+    assert result["detected"] is True
+    assert result["kpsOrder"][2] == "nose"
+    assert result["kps"][0] == pytest.approx([0.375, 0.4])  # 150/400, 160/400
+    assert result["kps"][2] == pytest.approx([0.5, 0.525])  # nose 200/400, 210/400
+    assert result["bbox"] == pytest.approx([0.25, 0.25, 0.75, 0.75])
+    assert result["lowConfidence"] is False
+    assert result["detector"]["backend"] == "insightface"
+
+
+def test_run_kps_extract_no_face_is_explicit(tmp_path, monkeypatch):
+    pytest.importorskip("cv2")
+    pytest.importorskip("numpy")
+    path = _square_png(tmp_path, 320)
+    monkeypatch.setattr(ka, "_face_app", lambda _s: SimpleNamespace(get=lambda _bgr: []))
+    monkeypatch.setattr(ka, "_resolve_source_path", lambda _s, _j, _p: path)
+
+    result = ka.run_kps_extract(None, {"payload": {"sourcePath": path}})
+    assert result["detected"] is False
+    assert result["reason"] == "no_face"
+    assert "kps" not in result
+
+
+def test_resolve_source_requires_a_source():
+    with pytest.raises(ka.KpsExtractError):
+        ka._resolve_source_path(None, {}, {})

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -258,6 +258,10 @@ def test_gpu_worker_advertises_generation_capabilities(monkeypatch):
 
 def test_gpu_worker_without_cuda_torch_does_not_claim_generation_jobs(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: False)
+    # kps_extract is torch-independent (InsightFace SCRFD), so it is advertised whenever
+    # that backend is installed — force it off here so this torch-gating assertion stays
+    # deterministic whether or not insightface is present in the env (sc-4433).
+    monkeypatch.setattr("scene_worker.runtime.kps_extractor_backend_available", lambda: False)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu", "nvidia"]})
 
     # lora_train dry-run validation needs no inference backend, so it is
@@ -282,6 +286,10 @@ def test_cpu_worker_does_not_advertise_lora_train():
 
 def test_python_worker_only_advertises_inference_job_capabilities(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    # Detection backends (pose/kps) are advertised only when their optional deps are
+    # installed; force kps off so this torch-inference list stays deterministic whether
+    # or not insightface/cv2 happen to be present in the test env (sc-4433).
+    monkeypatch.setattr("scene_worker.runtime.kps_extractor_backend_available", lambda: False)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
     job_capabilities = [capability for capability in capabilities if capability != "gpu"]
 
@@ -708,6 +716,20 @@ def test_gpu_worker_omits_pose_detect_without_backend(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.pose_detector_backend_available", lambda: False)
     capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
     assert "pose_detect" not in capabilities
+
+
+def test_gpu_worker_advertises_kps_extract_when_backend_installed(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.kps_extractor_backend_available", lambda: True)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    assert "kps_extract" in capabilities
+
+
+def test_gpu_worker_omits_kps_extract_without_backend(monkeypatch):
+    monkeypatch.setattr("scene_worker.runtime.torch_inference_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.kps_extractor_backend_available", lambda: False)
+    capabilities = worker_capabilities({"id": "gpu-0", "name": "GPU 0", "capabilities": ["placeholder", "gpu"]})
+    assert "kps_extract" not in capabilities
 
 
 def test_cpu_worker_never_advertises_pose_detect(monkeypatch):
@@ -4982,6 +5004,7 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.tracker_backend_available", lambda: True)
     monkeypatch.setattr("scene_worker.runtime.segmenter_backend_available", lambda: True)
     monkeypatch.setattr("scene_worker.runtime.pose_detector_backend_available", lambda: True)
+    monkeypatch.setattr("scene_worker.runtime.kps_extractor_backend_available", lambda: True)
     monkeypatch.setattr(
         "scene_worker.runtime.discover_gpu",
         lambda _gpu_id: {"id": "0", "name": "GPU 0", "capabilities": ["gpu"]},
@@ -5000,6 +5023,8 @@ def test_worker_check_reports_inference_sidecar_capabilities(monkeypatch):
         "person_detect",
         "person_track",
         "pose_detect",
+        # sc-4433: SCRFD 5-point landmark extraction (Key Point Library).
+        "kps_extract",
         "lora_train",
         "training_caption",
         # sc-1635: VQA + interleave are advertised and dispatched, so the check


### PR DESCRIPTION
The reusable "extract kps from this image" capability behind the Key Point Library (epic 4422). Given one photo, detect the largest face and return its 5 landmarks (eyes/nose/mouth-corners) normalized to a square `[0,1]` canvas — directly consumable as an InstantID angle/framing preset via the engine pass-in path (`generate_with_kps`, sc-4425). The reference supplies *identity*; these kps supply the *pose/framing*, so a user can capture any photo's framing and reuse it on any character.

## What's in scope (sc-4433 = backend capability)
New job type `kps_extract` / capability `KpsExtract`, served on **both platforms**:
- **Mac** — native-MLX SCRFD in-process (`kps_jobs.rs`), the same `scrfd_10g` detector the InstantID face stack already runs → zero-Python (epic 3482). Reuses the cached InstantID bundle via a new `ensure_scrfd_weights`.
- **Win/Linux** — InsightFace antelopev2 SCRFD (`kps_extract_adapters.py`), advertised only when the backend is installed.

Storage (sc-4434) and the Library UI (sc-4435) are **separate stories** — this PR is the backend capability only.

## Design
- **Normalization** applies the engine's centered square-letterbox geometry analytically (`M = max(w,h)`; `nx = (1−w/M)/2 + px/M`) — scale-free, so extracted kps round-trip through `generate_with_kps` (which draws `kps_norm·side` on a square canvas after letterboxing the reference the same way). Kept identical across Rust + Python.
- **No face / undetectable** → an explicit `{"detected": false, "reason": "no_face"}` result (the acceptance "clear failure, not silent bad data"), not a job error. Low detection score is returned but flagged `lowConfidence`.
- Result: `{detected, kps[5], kpsOrder, bbox, detScore, lowConfidence, sourceWidth, sourceHeight, detector}`. Input: `sourceAssetId`(+`projectId`) or a staged `sourcePath`.

## Wiring (full job-type addition)
core `JobType`+`WorkerCapability` · `mac_rust_supported` arm · Rust dispatch + `gpu.rs` MLX capability · Python `runtime.py` (job-type group, `ALL_JOB_TYPES`, capability gate, dispatch, wrapper). API is transparent (generic create-job). `jobTypes.js` left as-is to match the existing `pose_detect`/`person_detect` treatment (detection jobs aren't in that set).

## Validation
- **Rust real-weight smoke** (`#[ignore]`): extracts well-formed frontal landmarks from a real photo; on the genset front image the kps land **within ~0.02 of the built-in "front" preset** — round-trip confirmed. `le=[0.416,0.348] re=[0.581,0.345] nose=[0.501,0.425] ml=[0.439,0.515] mr=[0.567,0.513]` vs front preset `[(0.403,0.342),(0.594,0.339),(0.501,0.432),(0.430,0.535),(0.577,0.533)]`.
- **Rust unit tests** (5): normalization geometry (square/landscape/portrait) + result shaping. Plus core `mac_rust_supported` coverage. fmt / clippy `-D warnings` / `rust:check` green; worker 216 + core 101 tests pass.
- **Python** (ran on a real InsightFace venv): 7 adapter tests + worker-runtime capability/`run_check` tests, **all green** (414 runtime + 7 adapter). Made three exact-set assertions deterministic, since `kps_extract` is torch-independent and advertised whenever insightface is present — a latent fragility this surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)