### PR TITLE
feat(worker): angle generation iterates the active keypoint collection (sc-4450)

### DIFF
--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -71,6 +71,17 @@ pub const GLOBAL_KEYPOINTS_PROJECT_NAME: &str = "Key Point Library";
 /// The user angle-set collections store, relative to the global keypoints project.
 const KEYPOINT_COLLECTIONS_FILE: &str = "keypoint-collections.json";
 
+/// One resolved angle preset for generation (sc-4450): the kps to draw + a display name + (for
+/// built-ins) the canonical angle name that drives prompt augmentation. User presets have
+/// `angle: None` (no canonical prompt clause). Produced by [`ProjectStore::resolve_angle_collection`].
+#[derive(Debug, Clone)]
+pub struct ResolvedAnglePreset {
+    pub preset_id: String,
+    pub name: String,
+    pub angle: Option<String>,
+    pub kps: [(f32, f32); 5],
+}
+
 pub type ProjectStoreResult<T> = Result<T, ProjectStoreError>;
 
 #[derive(Debug)]
@@ -1732,6 +1743,79 @@ impl ProjectStore {
         write_user_collections(&project_path, &collections)
     }
 
+    /// Resolve the active angle-set collection to its ordered presets (kps + name + optional
+    /// canonical angle) for generation (sc-4450). Selection: an explicit `collection_id` override
+    /// → the user's default → the built-in default (the 11). Referenced presets that no longer
+    /// resolve (e.g. a custom preset deleted after being added) are skipped; if nothing resolves,
+    /// falls back to the built-in 11. Returns `(collection_id_used, presets)`.
+    pub fn resolve_angle_collection(
+        &self,
+        collection_id: Option<&str>,
+    ) -> ProjectStoreResult<(String, Vec<ResolvedAnglePreset>)> {
+        let collections = self.list_keypoint_collections()?;
+        let target = match collection_id {
+            Some(id) => collections
+                .iter()
+                .find(|collection| collection.get("id").and_then(Value::as_str) == Some(id)),
+            None => collections.iter().find(|collection| {
+                collection.get("isDefault").and_then(Value::as_bool) == Some(true)
+            }),
+        };
+        let used_id = target
+            .and_then(|collection| collection.get("id").and_then(Value::as_str))
+            .unwrap_or(crate::angle_kps::BUILTIN_DEFAULT_COLLECTION_ID)
+            .to_owned();
+        let ordered: Vec<String> = target
+            .and_then(|collection| collection.get("orderedPresetIds"))
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let user_presets = self.list_user_keypoint_presets()?;
+        let mut resolved = Vec::with_capacity(ordered.len());
+        for id in &ordered {
+            if let Some(angle) = id.strip_prefix("builtin_") {
+                if let Some(kps) = crate::angle_kps::angle_kps(angle) {
+                    resolved.push(ResolvedAnglePreset {
+                        preset_id: id.clone(),
+                        name: crate::angle_kps::builtin_angle_display_name(angle),
+                        angle: Some(angle.to_owned()),
+                        kps,
+                    });
+                }
+            } else if let Some(record) = user_presets
+                .iter()
+                .find(|preset| preset.get("id").and_then(Value::as_str) == Some(id.as_str()))
+            {
+                if let Some(kps) = parse_kps_tuple(record.get("kps")) {
+                    resolved.push(ResolvedAnglePreset {
+                        preset_id: id.clone(),
+                        name: record
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or(id)
+                            .to_owned(),
+                        angle: None,
+                        kps,
+                    });
+                }
+            }
+        }
+        if resolved.is_empty() {
+            return Ok((
+                crate::angle_kps::BUILTIN_DEFAULT_COLLECTION_ID.to_owned(),
+                builtin_resolved_presets(),
+            ));
+        }
+        Ok((used_id, resolved))
+    }
+
     /// Write the generation-set JSON for a job from the worker-reported facts.
     /// Idempotent — overwrites the same `<id>.json` on re-applied updates.
     pub fn write_generation_set(
@@ -3059,6 +3143,34 @@ fn parse_normalized_kps(value: Option<&Value>) -> ProjectStoreResult<Vec<Value>>
     Ok(out)
 }
 
+/// Parse a stored/served kps record (`[[x,y]×5]`) into a fixed `[(f32,f32);5]`, or `None` if it
+/// isn't exactly 5 numeric pairs. Used to resolve a collection's presets for generation (sc-4450).
+fn parse_kps_tuple(value: Option<&Value>) -> Option<[(f32, f32); 5]> {
+    let points = value.and_then(Value::as_array)?;
+    if points.len() != 5 {
+        return None;
+    }
+    let mut out = [(0.0f32, 0.0f32); 5];
+    for (slot, point) in out.iter_mut().zip(points) {
+        let pair = point.as_array().filter(|values| values.len() == 2)?;
+        *slot = (pair[0].as_f64()? as f32, pair[1].as_f64()? as f32);
+    }
+    Some(out)
+}
+
+/// The built-in 11 as resolved angle presets (the generation fallback / default set, sc-4450).
+fn builtin_resolved_presets() -> Vec<ResolvedAnglePreset> {
+    crate::angle_kps::BUILTIN_ANGLE_KPS
+        .iter()
+        .map(|(angle, kps)| ResolvedAnglePreset {
+            preset_id: crate::angle_kps::builtin_preset_id(angle),
+            name: crate::angle_kps::builtin_angle_display_name(angle),
+            angle: Some((*angle).to_owned()),
+            kps: *kps,
+        })
+        .collect()
+}
+
 /// Map a stored `type:"keypoint"` asset → a Key Point Library preset record.
 fn keypoint_asset_to_preset(asset: &Value) -> Value {
     json!({
@@ -4286,6 +4398,56 @@ mod tests {
             .delete_keypoint_collection(&collection_id)
             .expect("delete user collection");
         assert_eq!(store.list_keypoint_collections().expect("list").len(), 1);
+    }
+
+    #[test]
+    fn resolve_angle_collection_default_override_and_custom_preset() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let data_dir = temp_dir.path().join("data");
+        let store = ProjectStore::new(&data_dir, "test-version");
+
+        // No user collection → the built-in 11 in order.
+        let (id, presets) = store.resolve_angle_collection(None).expect("resolve");
+        assert_eq!(id, crate::angle_kps::BUILTIN_DEFAULT_COLLECTION_ID);
+        assert_eq!(presets.len(), 11);
+        assert_eq!(presets[0].preset_id, "builtin_front");
+        assert_eq!(presets[0].angle.as_deref(), Some("front"));
+
+        // A user preset (real source image) + a collection mixing it with a built-in.
+        let upload = stage_kps_upload(&data_dir, "upload-mix.png");
+        let preset = store
+            .create_keypoint_asset(&json!({
+                "name": "My Angle", "kps": front_kps(), "sourceUploadPath": upload
+            }))
+            .expect("preset");
+        let preset_id = preset["id"].as_str().unwrap().to_owned();
+        let collection = store
+            .upsert_keypoint_collection(&json!({
+                "name": "Mix",
+                "orderedPresetIds": [preset_id, "builtin_left_profile"],
+                "isDefault": true,
+            }))
+            .expect("collection");
+        let collection_id = collection["id"].as_str().unwrap().to_owned();
+
+        // Default now resolves to the user's collection (2 presets, in order).
+        let (id, presets) = store.resolve_angle_collection(None).expect("resolve");
+        assert_eq!(id, collection_id);
+        assert_eq!(presets.len(), 2);
+        assert_eq!(presets[0].name, "My Angle");
+        assert!(
+            presets[0].angle.is_none(),
+            "custom preset has no canonical angle"
+        );
+        assert_eq!(presets[1].preset_id, "builtin_left_profile");
+        assert_eq!(presets[1].angle.as_deref(), Some("left_profile"));
+
+        // Explicit override to the built-in default beats the user default.
+        let (id, presets) = store
+            .resolve_angle_collection(Some(crate::angle_kps::BUILTIN_DEFAULT_COLLECTION_ID))
+            .expect("resolve override");
+        assert_eq!(id, crate::angle_kps::BUILTIN_DEFAULT_COLLECTION_ID);
+        assert_eq!(presets.len(), 11);
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -2209,16 +2209,6 @@ const ZIMAGE_ADAPTER_LABEL: &str = "mlx_z_image";
 #[cfg(target_os = "macos")]
 const CHARACTER_ANGLE_SET_ORDER: [&str; 11] = sceneworks_core::angle_kps::BUILTIN_ANGLE_SET_ORDER;
 
-/// The default kps preset for a canonical angle name, or the `front` preset if an unknown name
-/// slips through (callers iterate [`CHARACTER_ANGLE_SET_ORDER`], so the fallback is unreachable
-/// in practice — it just keeps the lookup total). Reads the canonical
-/// [`sceneworks_core::angle_kps`] table (sc-4424 presets, now the library built-ins — sc-4434).
-#[cfg(target_os = "macos")]
-fn instantid_angle_kps(angle: &str) -> [(f32, f32); 5] {
-    sceneworks_core::angle_kps::angle_kps(angle)
-        .unwrap_or(sceneworks_core::angle_kps::BUILTIN_ANGLE_KPS[0].1)
-}
-
 /// The per-angle continuation clause appended to the user's prompt (parity with
 /// `character_studio_angles.ANGLE_PROMPT_AUGMENTS`). Unknown angle → empty.
 #[cfg(target_os = "macos")]
@@ -3288,7 +3278,7 @@ fn qwen_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
 #[cfg(target_os = "macos")]
 fn grouped_image_count(request: &ImageRequest, settings: &Settings) -> u32 {
     if instantid_available(request, settings) {
-        instantid_image_count(request)
+        instantid_image_count(request, settings)
     } else if qwen_edit_available(request, settings) {
         match flux2_grouping(request) {
             Flux2Grouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
@@ -4665,15 +4655,56 @@ fn instantid_available(request: &ImageRequest, settings: &Settings) -> bool {
         && resolve_instantid_sdxl_base(request, settings).is_some()
 }
 
-/// The number of images an InstantID job produces: `n` for a pose set, 11 for an angle set, else
-/// `request.count`.
+/// The number of images an InstantID job produces: `n` for a pose set, the active angle
+/// collection's length for an angle set (sc-4450 — variable N, not fixed 11), else `request.count`.
 #[cfg(target_os = "macos")]
-fn instantid_image_count(request: &ImageRequest) -> u32 {
+fn instantid_image_count(request: &ImageRequest, settings: &Settings) -> u32 {
     match instantid_mode(request) {
         InstantIdMode::PoseSet(count) => count as u32,
-        InstantIdMode::AngleSet => CHARACTER_ANGLE_SET_ORDER.len() as u32,
+        InstantIdMode::AngleSet => active_angle_collection(request, settings).1.len() as u32,
         InstantIdMode::Identity => request.count,
     }
+}
+
+/// Resolve the active angle-set collection for this job (sc-4450): the per-generation override
+/// (`advanced.keypointCollectionId`) → the user default → the built-in 11. Built-in fallback on
+/// any store error so angle generation never hard-fails on a Key Point Library hiccup.
+#[cfg(target_os = "macos")]
+fn active_angle_collection(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> (
+    String,
+    Vec<sceneworks_core::project_store::ResolvedAnglePreset>,
+) {
+    let store = ProjectStore::new(settings.data_dir.clone(), "worker");
+    let override_id = advanced_str(request, "keypointCollectionId", "");
+    let override_id = override_id.trim();
+    let override_id = (!override_id.is_empty()).then_some(override_id);
+    store
+        .resolve_angle_collection(override_id)
+        .unwrap_or_else(|_| {
+            (
+                sceneworks_core::angle_kps::BUILTIN_DEFAULT_COLLECTION_ID.to_owned(),
+                builtin_angle_presets(),
+            )
+        })
+}
+
+/// The built-in 11 as resolved angle presets (the worker-side fallback when the store is
+/// unreachable, sc-4450).
+#[cfg(target_os = "macos")]
+fn builtin_angle_presets() -> Vec<sceneworks_core::project_store::ResolvedAnglePreset> {
+    use sceneworks_core::{angle_kps, project_store::ResolvedAnglePreset};
+    angle_kps::BUILTIN_ANGLE_KPS
+        .iter()
+        .map(|(angle, kps)| ResolvedAnglePreset {
+            preset_id: angle_kps::builtin_preset_id(angle),
+            name: angle_kps::builtin_angle_display_name(angle),
+            angle: Some((*angle).to_owned()),
+            kps: *kps,
+        })
+        .collect()
 }
 
 /// Resolve InstantID denoise steps: `advanced.steps` (clamped 1..=80) → manifest `steps` →
@@ -4990,6 +5021,9 @@ async fn generate_instantid_stream(
     let mode = instantid_mode(request);
     let angle_set = matches!(mode, InstantIdMode::AngleSet);
     let pose_set = matches!(mode, InstantIdMode::PoseSet(_));
+    // The active Key Point Library collection drives the angle set (sc-4450): per-generation
+    // override > user default > built-in 11. Resolved once (and only for angle jobs).
+    let angle_collection = angle_set.then(|| active_angle_collection(request, settings));
     let openpose_scale = advanced_f32(request, "openPoseScale", INSTANTID_OPENPOSE_SCALE, 0.0, 2.0);
     let face_restore = advanced_flag(request, "faceRestore");
     // Load the xinsir OpenPose ControlNet only for pose mode (it is the MultiControlNet second
@@ -5017,6 +5051,18 @@ async fn generate_instantid_stream(
     if face_restore {
         raw_settings.insert("faceRestore".to_owned(), Value::Bool(true));
     }
+    // Record which collection + ordered presets produced the set, so each asset (by index) maps
+    // back to the preset that rendered it (sc-4450).
+    if let Some((collection_id, presets)) = &angle_collection {
+        raw_settings.insert("keypointCollectionId".to_owned(), json!(collection_id));
+        raw_settings.insert(
+            "anglePresetIds".to_owned(),
+            json!(presets
+                .iter()
+                .map(|preset| preset.preset_id.clone())
+                .collect::<Vec<_>>()),
+        );
+    }
 
     // Per-image work items: (seed, prompt, action). Pose + angle sets share one seed (only the
     // pose changes across the set — noise-derived attributes stay constant); single identity is
@@ -5038,14 +5084,21 @@ async fn generate_instantid_stream(
         }
         InstantIdMode::AngleSet => {
             let set_seed = resolve_seed(request, 0);
-            CHARACTER_ANGLE_SET_ORDER
-                .iter()
-                .map(|&angle| {
-                    (
-                        set_seed,
-                        augment_prompt_for_angle(&request.prompt, angle),
-                        InstantIdAction::Angle(instantid_angle_kps(angle)),
-                    )
+            // One image per preset in the active collection's order (sc-4450). Built-in presets
+            // carry their canonical angle so the prompt still gets the per-angle clause; custom
+            // presets render to their kps with the base prompt.
+            let presets = angle_collection
+                .as_ref()
+                .map(|(_, presets)| presets.clone())
+                .unwrap_or_else(builtin_angle_presets);
+            presets
+                .into_iter()
+                .map(|preset| {
+                    let prompt = match &preset.angle {
+                        Some(angle) => augment_prompt_for_angle(&request.prompt, angle),
+                        None => request.prompt.clone(),
+                    };
+                    (set_seed, prompt, InstantIdAction::Angle(preset.kps))
                 })
                 .collect()
         }
@@ -6580,7 +6633,7 @@ mod tests {
         let mut failures: Vec<String> = Vec::new();
         println!("\n  view                 kps-dist   area%   id-cos   verdict");
         for &angle in CHARACTER_ANGLE_SET_ORDER.iter() {
-            let kps = instantid_angle_kps(angle);
+            let kps = sceneworks_core::angle_kps::angle_kps(angle).expect("built-in angle kps");
             let req = InstantIdRequest {
                 prompt: augment_prompt_for_angle("a portrait photo of a woman", angle),
                 negative: "blurry, low quality, deformed".to_owned(),


### PR DESCRIPTION
InstantID angle-set generation now runs the user's **active Key Point Library collection** instead of the hardcoded 11-view order. This closes the data→generation loop: a custom default collection (sc-4434) now actually changes what "angles" produces.

## Resolution
`ProjectStore::resolve_angle_collection` (core): per-generation override (`advanced.keypointCollectionId`) → user default → built-in 11. Returns the ordered presets (`kps` + `name` + optional canonical `angle`). Presets that no longer resolve (e.g. a custom preset deleted after being added to a collection) are skipped; an empty result falls back to the built-in 11. Built-in presets keep their canonical angle so the per-angle prompt clause still applies; custom presets render to their kps with the base prompt.

## Worker
- `generate_instantid_stream` builds one work item per resolved preset — **variable N**, not fixed 11. `instantid_image_count` (and the grouped count the gallery streams against) resolve the active collection's length, so progress/asset-count match.
- Records `keypointCollectionId` + ordered `anglePresetIds` in the job's `rawAdapterSettings` → each asset (by index) maps back to the preset that rendered it.
- Removed the now-dead `instantid_angle_kps` worker wrapper (the angle path reads resolved presets; the real-weight test reads core `angle_kps` directly).

## Scope
**InstantID only.** The FLUX2/Qwen angle paths are prompt-only and can't consume arbitrary kps, so they keep the built-in 11 prompts — a kps collection is meaningless to a prompt-only backbone. The "likeness score per asset" half stays with **sc-4486** (epic 4406 isn't built yet). No API/web change needed: the override rides freeform `advanced`, and the default-collection path needs no override at all — sc-4435 (UI) wires the override + set-default controls.

## Tests
Core `resolve_angle_collection` (default → user-default → explicit override beats user default, custom-preset-mixed-with-built-in, built-in fallback). fmt / clippy `-D warnings` / `rust:check` green; **core 136 + worker 216** pass. The thin worker wrapper (override extraction + settings threading) is compile-checked; the resolution logic lives in core where it's unit-tested. A full worker-level `instantid_image_count` test would need a brittle 20-field `Settings` literal, so I leaned on the core coverage instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)