### PR TITLE
feat(web): Key Point Library UI — capture, collections, angle-set override (sc-4435)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -7,6 +7,7 @@ import { FullscreenPreview } from "./components/assetPanels.jsx";
 import { fallbackModels, terminalStatuses } from "./constants.js";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
 import { PoseLibraryScreen } from "./screens/PoseLibraryScreen.jsx";
+import { KeyPointLibraryScreen } from "./screens/KeyPointLibraryScreen.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { DocumentStudio } from "./screens/DocumentStudio.jsx";
@@ -175,6 +176,7 @@ const navSections = [
       { id: "Library", label: "Assets", icon: Icon.Library },
       { id: "LibraryDataSets", label: "Data Sets", icon: Icon.Train },
       { id: "Poses", label: "Pose Library", icon: Icon.Character },
+      { id: "Keypoints", label: "Key Point Library", icon: Icon.Character },
       { id: "Presets", icon: Icon.Preset },
       { id: "Models", icon: Icon.Model },
     ],
@@ -193,6 +195,10 @@ const viewTitles = {
   Library: { title: "Assets", blurb: "Browse stills and clips across all your projects." },
   LibraryDataSets: { title: "Data Sets", blurb: "Create and caption training datasets." },
   Poses: { title: "Pose Library", blurb: "Manage whole-body pose skeletons and create new ones from photos." },
+  Keypoints: {
+    title: "Key Point Library",
+    blurb: "Capture face-angle framing presets and compose angle-set collections for character turnarounds.",
+  },
   Image: { title: "Image Studio", blurb: "Describe what you want — we'll render variations side by side." },
   Video: { title: "Video Studio", blurb: "Bring stills to life, or render new clips from scratch." },
   Document: { title: "Document Studio", blurb: "Generate interleaved text-image documents — guides, storyboards, tutorials." },
@@ -1802,6 +1808,10 @@ export function App() {
 
         {activeView === "Poses" ? (
           <PoseLibraryScreen />
+        ) : null}
+
+        {activeView === "Keypoints" ? (
+          <KeyPointLibraryScreen />
         ) : null}
 
         {activeView === "Image" ? (

--- a/apps/web/src/components/KeypointCollectionField.jsx
+++ b/apps/web/src/components/KeypointCollectionField.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useKeypointCollections } from "../keypointLibrary.js";
+
+// Per-generation angle-set override for Character Studio's InstantID angle panel (epic 4422,
+// sc-4435/sc-4450). Lets the user pick which Key Point Library collection "Generate angle set"
+// runs, instead of the active default. Value "" = use the active default (no override sent);
+// any other value sets advanced.keypointCollectionId, which the worker resolves at generation
+// time. onChange(id, collection) also hands back the chosen collection so the caller can size
+// the run to its (variable) angle count.
+export function KeypointCollectionField({ value = "", onChange }) {
+  const { collections, loading, error } = useKeypointCollections();
+
+  function handleChange(id) {
+    const collection = collections.find((item) => item.id === id) ?? null;
+    onChange?.(id, collection);
+  }
+
+  const defaultCollection = collections.find((item) => item.isDefault);
+
+  return (
+    <label>
+      Angle set
+      <select onChange={(event) => handleChange(event.target.value)} value={value}>
+        <option value="">
+          {defaultCollection
+            ? `Default (${defaultCollection.name}, ${defaultCollection.orderedPresetIds?.length ?? 0} angles)`
+            : "Default angles"}
+        </option>
+        {collections.map((collection) => (
+          <option key={collection.id} value={collection.id}>
+            {collection.name} ({collection.orderedPresetIds?.length ?? 0} angles)
+            {collection.isDefault ? " — default" : ""}
+          </option>
+        ))}
+      </select>
+      {loading ? <span className="muted"> Loading collections…</span> : null}
+      {error ? <span className="inline-warning"> Collections unavailable.</span> : null}
+    </label>
+  );
+}

--- a/apps/web/src/components/KpsOverlay.jsx
+++ b/apps/web/src/components/KpsOverlay.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+// Renders a face-angle preset: the 5 normalized landmarks (green-dot style) over the preset's
+// source image, or — for built-ins, which have no captured photo — over a neutral canvas
+// (epic 4422, sc-4435). kps are normalized to a SQUARE letterbox `[0,1]`, so the source image
+// is drawn with preserveAspectRatio "xMidYMid meet" (centered letterbox) and the dots overlay
+// in the same square space, keeping image and landmarks aligned for any source aspect ratio.
+//
+// `kps`: array of [x, y] in [0,1] (order [left_eye, right_eye, nose, mouth_left, mouth_right]).
+// `imageUrl`: optional source image URL; absent → neutral canvas (built-in presets).
+// `label`: accessible description for the figure.
+
+const POINT_LABELS = ["left eye", "right eye", "nose", "mouth left", "mouth right"];
+
+export function KpsOverlay({ kps = [], imageUrl, label = "face landmark preset" }) {
+  const points = Array.isArray(kps)
+    ? kps
+        .map((point) => (Array.isArray(point) ? [Number(point[0]), Number(point[1])] : null))
+        .filter((point) => point && Number.isFinite(point[0]) && Number.isFinite(point[1]))
+    : [];
+
+  return (
+    <svg
+      className="kps-overlay"
+      viewBox="0 0 1 1"
+      role="img"
+      aria-label={label}
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {imageUrl ? (
+        <image
+          href={imageUrl}
+          x="0"
+          y="0"
+          width="1"
+          height="1"
+          preserveAspectRatio="xMidYMid meet"
+        />
+      ) : (
+        <rect x="0" y="0" width="1" height="1" className="kps-overlay-canvas" />
+      )}
+      {points.map(([x, y], index) => (
+        <g key={index}>
+          <circle cx={x} cy={y} r="0.03" className="kps-overlay-halo" />
+          <circle cx={x} cy={y} r="0.018" className="kps-overlay-dot">
+            <title>{POINT_LABELS[index] ?? `point ${index + 1}`}</title>
+          </circle>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/apps/web/src/keypointLibrary.js
+++ b/apps/web/src/keypointLibrary.js
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from "react";
+import { API_BASE_URL, apiFetch } from "./api.js";
+import { useAppContext } from "./context/AppContext.js";
+
+// The reserved global project that holds user-created keypoint (face-angle) preset assets
+// (epic 4422, sc-4434). Mirrors crates/sceneworks-core::GLOBAL_KEYPOINTS_PROJECT_ID; hidden
+// from the project switcher and addressed directly by the Key Point Library screen. The
+// face-angle sibling of GLOBAL_POSES_PROJECT_ID.
+export const GLOBAL_KEYPOINTS_PROJECT_ID = "project_global_keypoints";
+
+// The id of the seeded virtual default collection (the built-in 11). Mirrors
+// sceneworks_core::angle_kps::BUILTIN_DEFAULT_COLLECTION_ID.
+export const BUILTIN_DEFAULT_COLLECTION_ID = "builtin_default";
+
+// The Key Point Library is the union of two preset sources, both served by
+// GET /api/v1/keypoints/presets:
+//  - BUILT-IN: the 11 validated angle presets (front, three-quarters, profiles, up/down,
+//    diagonals). `builtin: true`, `sourceImageRef: null` (their framing was tuned, not
+//    captured from a committed photo — render the kps overlay on a neutral canvas).
+//  - USER: type:"keypoint" assets captured from an uploaded photo via SCRFD extraction
+//    (sc-4433). `builtin: false`, `sourceImageRef` points at the retained source image.
+// A preset record: { id, name, angle?, kps:[[x,y]×5], builtin, sourceImageRef, sourceAssetId? }.
+// A collection record: { id, name, orderedPresetIds[], isDefault, builtin? }.
+
+// Build a displayable URL for a user preset's retained source image. `sourceImageRef` is a
+// path relative to the reserved keypoints project (e.g. "assets/keypoints/asset_x.png");
+// mirrors assetMedia.assetUrl's projectId+path fallback. Null/built-in refs → "".
+export function keypointSourceImageUrl(sourceImageRef) {
+  if (!sourceImageRef) {
+    return "";
+  }
+  const normalized = String(sourceImageRef).replaceAll("\\", "/");
+  return `${API_BASE_URL}/api/v1/projects/${GLOBAL_KEYPOINTS_PROJECT_ID}/files/${normalized}`;
+}
+
+export async function loadKeypointPresets(token, options = {}) {
+  const presets = await apiFetch("/api/v1/keypoints/presets", token, options);
+  return Array.isArray(presets) ? presets : [];
+}
+
+export async function loadKeypointCollections(token, options = {}) {
+  const collections = await apiFetch("/api/v1/keypoints/collections", token, options);
+  return Array.isArray(collections) ? collections : [];
+}
+
+// Stage an uploaded photo to the TRANSIENT keypoint-source area (NOT a workspace asset). The
+// worker reads it by path for kps_extract; saving a preset copies it into the library, and a
+// startup sweep reclaims paths that are never saved. Returns { path, displayName }.
+export async function stageKeypointSource(token, file) {
+  const body = new FormData();
+  body.append("file", file);
+  const result = await apiFetch("/api/v1/keypoints/sources", token, { method: "POST", body });
+  const staged = Array.isArray(result?.sources) ? result.sources : [];
+  return staged[0] ?? null;
+}
+
+// Persist a captured preset from an extracted kps + a staged source image.
+export async function saveKeypointPreset(token, spec) {
+  return apiFetch("/api/v1/keypoints", token, { method: "POST", body: JSON.stringify(spec) });
+}
+
+export async function deleteKeypointPreset(token, presetId) {
+  return apiFetch(`/api/v1/projects/${GLOBAL_KEYPOINTS_PROJECT_ID}/assets/${presetId}`, token, {
+    method: "DELETE",
+  });
+}
+
+// Create or update a user angle-set collection: { id?, name, orderedPresetIds[], isDefault? }.
+export async function upsertKeypointCollection(token, spec) {
+  return apiFetch("/api/v1/keypoints/collections", token, {
+    method: "POST",
+    body: JSON.stringify(spec),
+  });
+}
+
+export async function setDefaultKeypointCollection(token, collectionId) {
+  return apiFetch(`/api/v1/keypoints/collections/${encodeURIComponent(collectionId)}/default`, token, {
+    method: "PUT",
+  });
+}
+
+export async function deleteKeypointCollection(token, collectionId) {
+  return apiFetch(`/api/v1/keypoints/collections/${encodeURIComponent(collectionId)}`, token, {
+    method: "DELETE",
+  });
+}
+
+// Load the preset list (built-in 11 + user) once per token. Best-effort: a fetch failure
+// surfaces via `error`; built-ins always come back from the API so the list is rarely empty.
+export function useKeypointPresets() {
+  const { token } = useAppContext();
+  const [state, setState] = useState({ presets: [], loading: true, error: "" });
+  const reload = useCallback(
+    async (signal) => {
+      try {
+        setState((prev) => ({ ...prev, loading: true }));
+        const presets = await loadKeypointPresets(token, signal ? { signal } : {});
+        setState({ presets, loading: false, error: "" });
+      } catch (error) {
+        if (signal?.aborted) return;
+        setState({ presets: [], loading: false, error: String(error?.message ?? error) });
+      }
+    },
+    [token],
+  );
+  useEffect(() => {
+    const controller = new AbortController();
+    reload(controller.signal);
+    return () => controller.abort();
+  }, [reload]);
+  return { ...state, reload };
+}
+
+// Load the collection list (built-in default + user collections). Used by the Collections tab
+// and by the per-generation override picker in Character Studio's angle set.
+export function useKeypointCollections() {
+  const { token } = useAppContext();
+  const [state, setState] = useState({ collections: [], loading: true, error: "" });
+  const reload = useCallback(
+    async (signal) => {
+      try {
+        setState((prev) => ({ ...prev, loading: true }));
+        const collections = await loadKeypointCollections(token, signal ? { signal } : {});
+        setState({ collections, loading: false, error: "" });
+      } catch (error) {
+        if (signal?.aborted) return;
+        setState({ collections: [], loading: false, error: String(error?.message ?? error) });
+      }
+    },
+    [token],
+  );
+  useEffect(() => {
+    const controller = new AbortController();
+    reload(controller.signal);
+    return () => controller.abort();
+  }, [reload]);
+  return { ...state, reload };
+}

--- a/apps/web/src/screens/KeyPointLibraryScreen.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.jsx
@@ -1,0 +1,578 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { apiFetch } from "../api.js";
+import { useAppContext } from "../context/AppContext.js";
+import { terminalStatuses } from "../jobTypes.js";
+import { KpsOverlay } from "../components/KpsOverlay.jsx";
+import {
+  BUILTIN_DEFAULT_COLLECTION_ID,
+  GLOBAL_KEYPOINTS_PROJECT_ID,
+  deleteKeypointCollection,
+  deleteKeypointPreset,
+  keypointSourceImageUrl,
+  saveKeypointPreset,
+  setDefaultKeypointCollection,
+  stageKeypointSource,
+  upsertKeypointCollection,
+  useKeypointCollections,
+  useKeypointPresets,
+} from "../keypointLibrary.js";
+
+// The Key Point Library screen (epic 4422, sc-4435) — the face-angle sibling of the Pose
+// Library. Three tabs:
+//  - "Library": browse every angle preset (built-in 11 + user captures) as its source image
+//    with the 5 kps overlaid; delete user presets (built-ins are protected).
+//  - "Capture": upload a photo → SCRFD extraction (kps_extract job, sc-4433) → preview the
+//    landmarks → name + save as a reusable preset. Extraction failures are explained.
+//  - "Collections": compose ordered angle-set collections from any presets, mark one the
+//    default (what "generate angles" runs, sc-4450), and override per generation in the studio.
+const TABS = [
+  ["library", "Library"],
+  ["capture", "Capture"],
+  ["collections", "Collections"],
+];
+
+function presetSourceUrl(preset) {
+  return preset?.builtin ? "" : keypointSourceImageUrl(preset?.sourceImageRef);
+}
+
+// --- Library tab ------------------------------------------------------------
+
+function PresetCard({ preset, onDelete }) {
+  return (
+    <div className="keypoint-card">
+      <div className="keypoint-card-figure">
+        <KpsOverlay
+          kps={preset.kps}
+          imageUrl={presetSourceUrl(preset)}
+          label={`${preset.name} face landmarks`}
+        />
+      </div>
+      <div className="keypoint-card-meta">
+        <span className="keypoint-card-name" title={preset.name}>
+          {preset.name}
+        </span>
+        <span className={preset.builtin ? "keypoint-badge builtin" : "keypoint-badge custom"}>
+          {preset.builtin ? "Built-in" : "Custom"}
+        </span>
+      </div>
+      {!preset.builtin && onDelete ? (
+        <button className="link-button danger" onClick={() => onDelete(preset)} type="button">
+          Delete
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function KeypointLibraryPanel({ hidden, presets, loading, error, onDelete }) {
+  const builtins = presets.filter((preset) => preset.builtin);
+  const custom = presets.filter((preset) => !preset.builtin);
+  return (
+    <div aria-labelledby="keypoint-tab-library" hidden={hidden} id="keypoint-panel-library" role="tabpanel">
+      {error ? <p className="inline-warning">Key Point Library unavailable: {error}</p> : null}
+      {loading && !presets.length ? (
+        <div className="empty-panel">Loading presets…</div>
+      ) : (
+        <>
+          <div className="keypoint-section">
+            <p className="eyebrow">
+              Built-in angles <span className="muted">({builtins.length})</span>
+            </p>
+            <div className="keypoint-grid">
+              {builtins.map((preset) => (
+                <PresetCard key={preset.id} preset={preset} />
+              ))}
+            </div>
+          </div>
+          <div className="keypoint-section">
+            <p className="eyebrow">
+              Your captures <span className="muted">({custom.length})</span>
+            </p>
+            {custom.length ? (
+              <div className="keypoint-grid">
+                {custom.map((preset) => (
+                  <PresetCard key={preset.id} preset={preset} onDelete={onDelete} />
+                ))}
+              </div>
+            ) : (
+              <div className="empty-panel">
+                No captured presets yet — add one from a photo in the Capture tab.
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// --- Capture tab ------------------------------------------------------------
+
+// Upload one photo → stage it → fire a kps_extract job → watch the live jobs list → preview the
+// detected landmarks → name + save. Mirrors the Pose Library Create tab's staged-source +
+// job-watch shape, but for a single face and the SCRFD detector.
+function KeypointCapturePanel({ hidden, onSaved }) {
+  const { token, requestedGpu, jobs = [] } = useAppContext();
+  const [source, setSource] = useState(null); // { path, displayName, objectUrl }
+  const [phase, setPhase] = useState("idle"); // idle | extracting | review
+  const [jobId, setJobId] = useState(null);
+  const [extraction, setExtraction] = useState(null); // { kps, lowConfidence, sourceWidth, sourceHeight }
+  const [name, setName] = useState("");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const objectUrlRef = useRef(null);
+  const clearSource = useCallback(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+  }, []);
+  useEffect(() => () => clearSource(), [clearSource]);
+
+  const reset = useCallback(() => {
+    clearSource();
+    setSource(null);
+    setExtraction(null);
+    setName("");
+    setPhase("idle");
+    setJobId(null);
+  }, [clearSource]);
+
+  const onPick = useCallback(
+    async (event) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (!file || !file.type?.startsWith("image/")) {
+        return;
+      }
+      setError("");
+      setExtraction(null);
+      clearSource();
+      const objectUrl = URL.createObjectURL(file);
+      objectUrlRef.current = objectUrl;
+      try {
+        const staged = await stageKeypointSource(token, file);
+        if (!staged?.path) {
+          throw new Error("Upload did not return a staged path.");
+        }
+        setSource({ path: staged.path, displayName: staged.displayName ?? file.name, objectUrl });
+        setName(stripExtension(staged.displayName ?? file.name));
+        // Fire the extraction immediately — the value is the landmarks, not the upload.
+        const job = await postExtractJob(token, requestedGpu, staged.path);
+        setJobId(job.id);
+        setPhase("extracting");
+      } catch (err) {
+        clearSource();
+        setSource(null);
+        setError(String(err?.message ?? err));
+      }
+    },
+    [token, requestedGpu, clearSource],
+  );
+
+  // Watch the live (SSE-fed) jobs list for the extraction to finish.
+  useEffect(() => {
+    if (!jobId) return;
+    const job = jobs.find((item) => item.id === jobId);
+    if (!job || !terminalStatuses.has(job.status)) return;
+    setJobId(null);
+    if (job.status !== "completed") {
+      setError(job.error ?? job.message ?? "Face detection failed.");
+      setPhase("idle");
+      return;
+    }
+    const result = job.result ?? {};
+    if (!result.detected || !Array.isArray(result.kps)) {
+      setError(
+        "No usable face was found in that image. Try a clearer, front-facing photo where the face is large in frame.",
+      );
+      setPhase("idle");
+      return;
+    }
+    setExtraction({
+      kps: result.kps,
+      lowConfidence: Boolean(result.lowConfidence),
+      sourceWidth: result.sourceWidth ?? null,
+      sourceHeight: result.sourceHeight ?? null,
+    });
+    setPhase("review");
+  }, [jobId, jobs]);
+
+  const save = useCallback(async () => {
+    if (!source || !extraction || !name.trim()) return;
+    setSaving(true);
+    setError("");
+    try {
+      await saveKeypointPreset(token, {
+        name: name.trim(),
+        kps: extraction.kps,
+        sourceUploadPath: source.path,
+        sourceWidth: extraction.sourceWidth,
+        sourceHeight: extraction.sourceHeight,
+      });
+      reset();
+      onSaved?.();
+    } catch (err) {
+      setError(String(err?.message ?? err));
+    } finally {
+      setSaving(false);
+    }
+  }, [source, extraction, name, token, reset, onSaved]);
+
+  return (
+    <div aria-labelledby="keypoint-tab-capture" hidden={hidden} id="keypoint-panel-capture" role="tabpanel">
+      <div className="keypoint-capture">
+        {error ? <p className="inline-warning">{error}</p> : null}
+        <div className="toolbar">
+          <button onClick={() => fileInputRef.current?.click()} type="button">
+            {source ? "Choose another photo" : "Upload a photo"}
+          </button>
+          <input accept="image/*" hidden onChange={onPick} ref={fileInputRef} type="file" />
+          {phase === "extracting" ? <span className="muted">Detecting face landmarks…</span> : null}
+        </div>
+
+        {phase === "review" && extraction ? (
+          <div className="keypoint-capture-review">
+            <div className="keypoint-card-figure large">
+              <KpsOverlay kps={extraction.kps} imageUrl={source?.objectUrl} label="captured face landmarks" />
+            </div>
+            <div className="keypoint-capture-form">
+              {extraction.lowConfidence ? (
+                <p className="inline-warning">
+                  Low detection confidence — the angle may be extreme or the face small. Check the overlay before
+                  saving.
+                </p>
+              ) : null}
+              <label>
+                Preset name
+                <input onChange={(event) => setName(event.target.value)} value={name} placeholder="e.g. My front" />
+              </label>
+              <div className="toolbar">
+                <button className="primary-action" disabled={!name.trim() || saving} onClick={save} type="button">
+                  {saving ? "Saving…" : "Save preset"}
+                </button>
+                <button onClick={reset} type="button">
+                  Discard
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="empty-panel">
+            Upload a clear, front-facing photo. We detect the face and capture its 5-point framing as a reusable
+            angle preset.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- Collections tab --------------------------------------------------------
+
+function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoading, onChanged }) {
+  const { token } = useAppContext();
+  const [name, setName] = useState("");
+  const [orderedIds, setOrderedIds] = useState([]);
+  const [editingId, setEditingId] = useState(null);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const presetById = useMemo(() => Object.fromEntries(presets.map((preset) => [preset.id, preset])), [presets]);
+
+  const resetBuilder = useCallback(() => {
+    setName("");
+    setOrderedIds([]);
+    setEditingId(null);
+    setError("");
+  }, []);
+
+  const startEdit = useCallback((collection) => {
+    setEditingId(collection.id);
+    setName(collection.name ?? "");
+    setOrderedIds(Array.isArray(collection.orderedPresetIds) ? [...collection.orderedPresetIds] : []);
+    setError("");
+  }, []);
+
+  const togglePreset = useCallback((id) => {
+    setOrderedIds((prev) => (prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]));
+  }, []);
+
+  const move = useCallback((index, delta) => {
+    setOrderedIds((prev) => {
+      const next = [...prev];
+      const target = index + delta;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  }, []);
+
+  const wrap = useCallback(
+    async (action) => {
+      setBusy(true);
+      setError("");
+      try {
+        await action();
+        onChanged?.();
+      } catch (err) {
+        setError(String(err?.message ?? err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [onChanged],
+  );
+
+  const save = useCallback(async () => {
+    if (!name.trim() || !orderedIds.length) return;
+    await wrap(async () => {
+      await upsertKeypointCollection(token, {
+        ...(editingId ? { id: editingId } : {}),
+        name: name.trim(),
+        orderedPresetIds: orderedIds,
+      });
+      resetBuilder();
+    });
+  }, [name, orderedIds, editingId, token, wrap, resetBuilder]);
+
+  return (
+    <div aria-labelledby="keypoint-tab-collections" hidden={hidden} id="keypoint-panel-collections" role="tabpanel">
+      <div className="keypoint-collections">
+        {error ? <p className="inline-warning">{error}</p> : null}
+
+        <div className="keypoint-section">
+          <p className="eyebrow">Collections</p>
+          <p className="muted">
+            The default collection is what “Generate angle set” runs. Built-in defaults work with zero setup.
+          </p>
+          {collectionsLoading && !collections.length ? (
+            <div className="empty-panel">Loading collections…</div>
+          ) : (
+            <ul className="keypoint-collection-list">
+              {collections.map((collection) => (
+                <li className="keypoint-collection-row" key={collection.id}>
+                  <div>
+                    <span className="keypoint-card-name">{collection.name}</span>
+                    <span className="muted"> · {collection.orderedPresetIds?.length ?? 0} angles</span>
+                    {collection.isDefault ? <span className="keypoint-badge builtin">Default</span> : null}
+                  </div>
+                  <div className="toolbar">
+                    {!collection.isDefault ? (
+                      <button
+                        className="link-button"
+                        disabled={busy}
+                        onClick={() => wrap(() => setDefaultKeypointCollection(token, collection.id))}
+                        type="button"
+                      >
+                        Set default
+                      </button>
+                    ) : null}
+                    {collection.id !== BUILTIN_DEFAULT_COLLECTION_ID ? (
+                      <>
+                        <button className="link-button" onClick={() => startEdit(collection)} type="button">
+                          Edit
+                        </button>
+                        <button
+                          className="link-button danger"
+                          disabled={busy}
+                          onClick={() => wrap(() => deleteKeypointCollection(token, collection.id))}
+                          type="button"
+                        >
+                          Delete
+                        </button>
+                      </>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="keypoint-section">
+          <p className="eyebrow">{editingId ? "Edit collection" : "New collection"}</p>
+          <label>
+            Name
+            <input onChange={(event) => setName(event.target.value)} value={name} placeholder="e.g. LoRA coverage" />
+          </label>
+
+          {orderedIds.length ? (
+            <ol className="keypoint-selected-list">
+              {orderedIds.map((id, index) => {
+                const preset = presetById[id];
+                return (
+                  <li className="keypoint-selected-row" key={id}>
+                    <div className="keypoint-card-figure tiny">
+                      <KpsOverlay
+                        kps={preset?.kps ?? []}
+                        imageUrl={presetSourceUrl(preset)}
+                        label={preset?.name ?? id}
+                      />
+                    </div>
+                    <span className="keypoint-card-name">{preset?.name ?? id}</span>
+                    <div className="toolbar">
+                      <button disabled={index === 0} onClick={() => move(index, -1)} type="button" aria-label="Move up">
+                        ↑
+                      </button>
+                      <button
+                        disabled={index === orderedIds.length - 1}
+                        onClick={() => move(index, 1)}
+                        type="button"
+                        aria-label="Move down"
+                      >
+                        ↓
+                      </button>
+                      <button className="link-button danger" onClick={() => togglePreset(id)} type="button">
+                        Remove
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          ) : (
+            <p className="muted">Pick presets below to build an ordered set.</p>
+          )}
+
+          <p className="eyebrow">Add presets</p>
+          <div className="keypoint-grid">
+            {presets.map((preset) => {
+              const selected = orderedIds.includes(preset.id);
+              return (
+                <button
+                  aria-pressed={selected}
+                  className={selected ? "keypoint-pick selected" : "keypoint-pick"}
+                  key={preset.id}
+                  onClick={() => togglePreset(preset.id)}
+                  type="button"
+                >
+                  <div className="keypoint-card-figure">
+                    <KpsOverlay kps={preset.kps} imageUrl={presetSourceUrl(preset)} label={preset.name} />
+                  </div>
+                  <span className="keypoint-card-name">{preset.name}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="toolbar">
+            <button
+              className="primary-action"
+              disabled={!name.trim() || !orderedIds.length || busy}
+              onClick={save}
+              type="button"
+            >
+              {editingId ? "Save changes" : "Create collection"}
+            </button>
+            {editingId || name || orderedIds.length ? (
+              <button onClick={resetBuilder} type="button">
+                Cancel
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Job helpers ------------------------------------------------------------
+
+function stripExtension(filename) {
+  return String(filename || "").replace(/\.[^.]+$/, "");
+}
+
+async function postExtractJob(token, requestedGpu, sourcePath) {
+  return apiFetch("/api/v1/jobs", token, {
+    method: "POST",
+    body: JSON.stringify({
+      type: "kps_extract",
+      // The reserved keypoints project owns the staged upload; the worker reads sourcePath.
+      projectId: GLOBAL_KEYPOINTS_PROJECT_ID,
+      projectName: "Key Point Library",
+      requestedGpu,
+      payload: { projectId: GLOBAL_KEYPOINTS_PROJECT_ID, sourcePath },
+    }),
+  });
+}
+
+// --- Screen -----------------------------------------------------------------
+
+export function KeyPointLibraryScreen() {
+  const [activeTab, setActiveTab] = useState("library");
+  const { token } = useAppContext();
+  const { presets, loading: presetsLoading, error: presetsError, reload: reloadPresets } = useKeypointPresets();
+  const {
+    collections,
+    loading: collectionsLoading,
+    reload: reloadCollections,
+  } = useKeypointCollections();
+
+  const deletePreset = useCallback(
+    async (preset) => {
+      await deleteKeypointPreset(token, preset.id);
+      await reloadPresets();
+      await reloadCollections();
+    },
+    [token, reloadPresets, reloadCollections],
+  );
+
+  return (
+    <section className="main-surface library-surface keypoint-library-surface">
+      <div className="surface-header hero">
+        <div className="section-heading">
+          <p className="eyebrow">Key Point Library</p>
+          <h2>Face angles</h2>
+          <p className="hero-blurb">
+            Capture face-angle framing presets from photos and compose them into angle-set collections. The default
+            collection drives Character Studio’s “Generate angle set”.
+          </p>
+        </div>
+        <div className="segmented-control" role="tablist" aria-label="Key Point Library sections">
+          {TABS.map(([id, label]) => (
+            <button
+              aria-controls={`keypoint-panel-${id}`}
+              aria-selected={activeTab === id}
+              className={activeTab === id ? "active" : ""}
+              id={`keypoint-tab-${id}`}
+              key={id}
+              onClick={() => setActiveTab(id)}
+              role="tab"
+              type="button"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <KeypointLibraryPanel
+        hidden={activeTab !== "library"}
+        presets={presets}
+        loading={presetsLoading}
+        error={presetsError}
+        onDelete={deletePreset}
+      />
+      <KeypointCapturePanel
+        hidden={activeTab !== "capture"}
+        onSaved={() => {
+          setActiveTab("library");
+          reloadPresets();
+        }}
+      />
+      <KeypointCollectionsPanel
+        hidden={activeTab !== "collections"}
+        presets={presets}
+        collections={collections}
+        collectionsLoading={collectionsLoading}
+        onChanged={() => {
+          reloadCollections();
+          reloadPresets();
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
@@ -1,0 +1,233 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Control the mocked API: GETs return the fixture lists; mutations resolve and are recorded.
+const apiCalls = [];
+let presets = [];
+let collections = [];
+
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual, // keep API_BASE_URL etc. for keypointSourceImageUrl
+    apiFetch: vi.fn(async (path, _token, options = {}) => {
+      const method = options.method ?? "GET";
+      apiCalls.push({ path, method, body: options.body });
+      if (method === "GET" && path === "/api/v1/keypoints/presets") return presets;
+      if (method === "GET" && path === "/api/v1/keypoints/collections") return collections;
+      if (method === "POST" && path === "/api/v1/keypoints/sources") {
+        return { sources: [{ path: "/data/cache/keypoint-uploads/upload-x.png", displayName: "face.png" }] };
+      }
+      if (method === "POST" && path === "/api/v1/jobs") return { id: "job_kps_1", status: "queued" };
+      return {};
+    }),
+  };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { KeyPointLibraryScreen } from "./KeyPointLibraryScreen.jsx";
+
+const FRONT_KPS = [
+  [0.4, 0.34],
+  [0.6, 0.34],
+  [0.5, 0.43],
+  [0.43, 0.53],
+  [0.57, 0.53],
+];
+
+function builtinPreset(overrides = {}) {
+  return { id: "builtin_front", name: "Front", angle: "front", kps: FRONT_KPS, builtin: true, sourceImageRef: null, ...overrides };
+}
+function customPreset(overrides = {}) {
+  return {
+    id: "asset_k1",
+    name: "My Side",
+    kps: FRONT_KPS,
+    builtin: false,
+    sourceImageRef: "assets/keypoints/asset_k1.png",
+    sourceAssetId: null,
+    ...overrides,
+  };
+}
+
+async function click(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+async function setInputValue(input, value) {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+    setter.call(input, value);
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  });
+}
+const byText = (text, selector = "button") =>
+  [...document.querySelectorAll(selector)].find((el) => el.textContent.includes(text));
+
+function makeContext(overrides = {}) {
+  return { token: "test-token", requestedGpu: "auto", jobs: [], ...overrides };
+}
+
+describe("KeyPointLibraryScreen", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    apiCalls.length = 0;
+    presets = [];
+    collections = [];
+    window.URL.createObjectURL = () => "blob:test";
+    window.URL.revokeObjectURL = () => {};
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context = makeContext()) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <KeyPointLibraryScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {}); // flush the load effects
+  }
+
+  it("renders each preset's landmarks as a 5-point overlay, with a source image for captures", async () => {
+    presets = [builtinPreset(), customPreset()];
+    await render();
+    // Each preset card carries an SVG overlay with exactly 5 landmark dots.
+    const overlays = container.querySelectorAll(".keypoint-card .kps-overlay");
+    expect(overlays.length).toBeGreaterThanOrEqual(2);
+    const dots = overlays[0].querySelectorAll(".kps-overlay-dot");
+    expect(dots.length).toBe(5);
+    // Built-ins render on a neutral canvas (no source image); captures show their photo.
+    expect(container.textContent).toContain("Front");
+    expect(container.textContent).toContain("My Side");
+    const image = [...container.querySelectorAll("image")].find((el) =>
+      (el.getAttribute("href") ?? "").includes("assets/keypoints/asset_k1.png"),
+    );
+    expect(image).toBeTruthy();
+  });
+
+  it("protects built-ins (no delete) and deletes a user preset against the reserved project", async () => {
+    presets = [builtinPreset(), customPreset()];
+    await render();
+    const deletes = [...container.querySelectorAll("button")].filter((b) => b.textContent.trim() === "Delete");
+    // Only the one custom preset is deletable; the built-in has no delete control.
+    expect(deletes).toHaveLength(1);
+    await click(deletes[0]);
+    expect(
+      apiCalls.some(
+        (c) => c.method === "DELETE" && c.path === "/api/v1/projects/project_global_keypoints/assets/asset_k1",
+      ),
+    ).toBe(true);
+  });
+
+  it("captures a preset: upload → extract → preview → save", async () => {
+    presets = [builtinPreset()];
+    const job = {
+      id: "job_kps_1",
+      type: "kps_extract",
+      status: "completed",
+      result: { detected: true, kps: FRONT_KPS, lowConfidence: false, sourceWidth: 800, sourceHeight: 1000 },
+    };
+    await render(makeContext({ jobs: [job] }));
+    await click(container.querySelector("#keypoint-tab-capture"));
+
+    const fileInput = container.querySelector('#keypoint-panel-capture input[type="file"]');
+    const file = new File(["x"], "face.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+    await act(async () => fileInput.dispatchEvent(new window.Event("change", { bubbles: true })));
+    await act(async () => {}); // flush staging + job post + the job-watch effect
+
+    // Staged to the transient endpoint and a kps_extract job fired.
+    expect(apiCalls.some((c) => c.method === "POST" && c.path === "/api/v1/keypoints/sources")).toBe(true);
+    const jobPost = apiCalls.find((c) => c.method === "POST" && c.path === "/api/v1/jobs");
+    expect(JSON.parse(jobPost.body).type).toBe("kps_extract");
+    expect(JSON.parse(jobPost.body).payload.sourcePath).toBe("/data/cache/keypoint-uploads/upload-x.png");
+
+    // The completed job yields a preview + a name seeded from the filename.
+    const nameInput = container.querySelector('#keypoint-panel-capture input[type="text"], #keypoint-panel-capture input:not([type])');
+    expect(nameInput.value).toBe("face");
+    await setInputValue(nameInput, "Captured front");
+    await click(byText("Save preset"));
+
+    const save = apiCalls.find((c) => c.method === "POST" && c.path === "/api/v1/keypoints");
+    expect(save).toBeTruthy();
+    const body = JSON.parse(save.body);
+    expect(body).toMatchObject({
+      name: "Captured front",
+      sourceUploadPath: "/data/cache/keypoint-uploads/upload-x.png",
+      sourceWidth: 800,
+      sourceHeight: 1000,
+    });
+    expect(body.kps).toEqual(FRONT_KPS);
+  });
+
+  it("explains an extraction failure instead of saving silently", async () => {
+    presets = [builtinPreset()];
+    const job = { id: "job_kps_1", type: "kps_extract", status: "completed", result: { detected: false, reason: "no_face" } };
+    await render(makeContext({ jobs: [job] }));
+    await click(container.querySelector("#keypoint-tab-capture"));
+
+    const fileInput = container.querySelector('#keypoint-panel-capture input[type="file"]');
+    const file = new File(["x"], "face.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+    await act(async () => fileInput.dispatchEvent(new window.Event("change", { bubbles: true })));
+    await act(async () => {});
+
+    expect(container.querySelector("#keypoint-panel-capture").textContent).toContain("No usable face");
+    // No Save control offered and nothing posted to the preset endpoint.
+    expect(byText("Save preset")).toBeFalsy();
+    expect(apiCalls.some((c) => c.method === "POST" && c.path === "/api/v1/keypoints")).toBe(false);
+  });
+
+  it("builds an ordered collection from selected presets", async () => {
+    presets = [builtinPreset(), customPreset()];
+    collections = [
+      { id: "builtin_default", name: "Default angles", orderedPresetIds: ["builtin_front"], isDefault: true, builtin: true },
+    ];
+    await render();
+    await click(container.querySelector("#keypoint-tab-collections"));
+
+    const nameInput = container.querySelector('#keypoint-panel-collections input');
+    await setInputValue(nameInput, "LoRA coverage");
+    // Add both presets from the picker grid (in order).
+    await click(byText("Front", ".keypoint-pick"));
+    await click(byText("My Side", ".keypoint-pick"));
+    await click(byText("Create collection"));
+
+    const post = apiCalls.find((c) => c.method === "POST" && c.path === "/api/v1/keypoints/collections");
+    expect(post).toBeTruthy();
+    expect(JSON.parse(post.body)).toMatchObject({
+      name: "LoRA coverage",
+      orderedPresetIds: ["builtin_front", "asset_k1"],
+    });
+  });
+
+  it("sets a non-default collection as the default", async () => {
+    presets = [builtinPreset()];
+    collections = [
+      { id: "builtin_default", name: "Default angles", orderedPresetIds: ["builtin_front"], isDefault: true, builtin: true },
+      { id: "col_user", name: "My Set", orderedPresetIds: ["builtin_front"], isDefault: false },
+    ];
+    await render();
+    await click(container.querySelector("#keypoint-tab-collections"));
+
+    await click(byText("Set default"));
+    expect(
+      apiCalls.some((c) => c.method === "PUT" && c.path === "/api/v1/keypoints/collections/col_user/default"),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -7,6 +7,7 @@ import { terminalStatuses } from "../jobTypes.js";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
 import { LoraPickerField, useLoraSelection } from "../components/LoraPickerField.jsx";
 import { CharacterAdvancedOptions, useCharacterAdvancedOptions } from "../components/CharacterAdvancedOptions.jsx";
+import { KeypointCollectionField } from "../components/KeypointCollectionField.jsx";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 import { extractFamilies } from "../presetUtils.js";
 
@@ -521,6 +522,19 @@ export function CharacterAngleSet({
   });
   const [referenceAssetId, setReferenceAssetId] = React.useState("");
   const [prompt, setPrompt] = React.useState("");
+  // Key Point Library override (sc-4435/sc-4450): only InstantID consumes the angle
+  // kps collection (it's the landmark-ControlNet family — `identityStructure`); the
+  // prompt-driven tiers iterate the built-in angle prompts and ignore it. `""` = run
+  // the active default collection. `overrideCount` sizes the run to a chosen
+  // collection's variable angle count; null falls back to the backbone's nominal count.
+  const supportsKpsCollections = Boolean(activeAngleModel?.ui?.identityStructure);
+  const [keypointCollectionId, setKeypointCollectionId] = React.useState("");
+  const [overrideCount, setOverrideCount] = React.useState(null);
+  const onPickCollection = React.useCallback((id, collection) => {
+    setKeypointCollectionId(id);
+    setOverrideCount(id ? (collection?.orderedPresetIds?.length ?? null) : null);
+  }, []);
+  const effectiveAngleCount = overrideCount ?? angleCount;
   const [submitting, setSubmitting] = React.useState(false);
   const [status, setStatus] = React.useState("");
   const fileInputRef = React.useRef(null);
@@ -546,6 +560,13 @@ export function CharacterAngleSet({
       setSelectedAngleModelId(availableModels[0]?.id ?? "");
     }
   }, [availableModels, selectedAngleModelId]);
+  // Clear a stale angle-set override when switching to a backbone that can't use it.
+  React.useEffect(() => {
+    if (!supportsKpsCollections) {
+      setKeypointCollectionId("");
+      setOverrideCount(null);
+    }
+  }, [supportsKpsCollections]);
 
   if (!activeAngleModel || !selectedCharacter) {
     return null;
@@ -600,7 +621,10 @@ export function CharacterAngleSet({
         width: 1024,
         height: 1024,
         loras: loraSelection.serializedLoras,
-        advanced: advanced.buildAdvanced({ angleSet: true }),
+        advanced: advanced.buildAdvanced({
+          angleSet: true,
+          ...(supportsKpsCollections && keypointCollectionId ? { keypointCollectionId } : {}),
+        }),
       });
       if (job?.id) {
         rememberLocalGenerationJob?.("image", job);
@@ -657,13 +681,16 @@ export function CharacterAngleSet({
         <p className="inline-warning">No approved reference yet — upload one below or approve a reference above.</p>
       )}
       <LoraPickerField selection={loraSelection} />
+      {supportsKpsCollections ? (
+        <KeypointCollectionField value={keypointCollectionId} onChange={onPickCollection} />
+      ) : null}
       <div className="inline-create">
         <button onClick={() => fileInputRef.current?.click()} type="button">
           Upload reference
         </button>
         <input accept="image/*" hidden onChange={onUpload} ref={fileInputRef} type="file" />
         <button disabled={!referenceAssetId || submitting} onClick={generate} type="button">
-          {submitting ? "Starting…" : `Generate angle set (${angleCount} views)`}
+          {submitting ? "Starting…" : `Generate angle set (${effectiveAngleCount} views)`}
         </button>
       </div>
       <label>
@@ -686,7 +713,7 @@ export function CharacterAngleSet({
               }}
               thumbnailsVariant="image-grid"
               thumbnailAssets={jobImageAssets(job, assets)}
-              expectedThumbnailCount={angleCount}
+              expectedThumbnailCount={effectiveAngleCount}
               onThumbnailClick={(previewed) => onPreview?.(previewed, jobImageAssets(job, assets))}
               onCancel={onCancel}
               onRetry={onRetry}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1843,6 +1843,168 @@ label {
   margin-top: 6px;
 }
 
+/* Key Point Library (epic 4422, sc-4435): preset cards render the 5 face landmarks
+   over the source image (or a neutral canvas for the built-ins). */
+.keypoint-library-surface .keypoint-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 8px 0 18px;
+}
+
+.keypoint-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.keypoint-card,
+.keypoint-pick {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  padding: 6px;
+  background: var(--bg-2);
+  border: 2px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text-muted);
+  text-align: left;
+}
+
+.keypoint-pick {
+  cursor: pointer;
+}
+
+.keypoint-pick.selected {
+  border-color: var(--accent);
+}
+
+.keypoint-card-figure {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: var(--r-sm);
+  overflow: hidden;
+  background: #000;
+}
+
+.keypoint-card-figure.large {
+  max-width: 320px;
+}
+
+.keypoint-card-figure.tiny {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+}
+
+.kps-overlay {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.kps-overlay-canvas {
+  fill: var(--bg-3, #1b1f27);
+}
+
+.kps-overlay-dot {
+  fill: #28d17c;
+}
+
+.kps-overlay-halo {
+  fill: rgba(40, 209, 124, 0.25);
+}
+
+.keypoint-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.keypoint-card-name {
+  font-size: 12px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.keypoint-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.keypoint-badge.builtin {
+  background: rgba(40, 209, 124, 0.15);
+  color: #28d17c;
+}
+
+.keypoint-badge.custom {
+  background: var(--bg-3, #1b1f27);
+  color: var(--text-muted);
+}
+
+.link-button.danger {
+  color: var(--danger, #e5534b);
+}
+
+.keypoint-capture,
+.keypoint-collections {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 8px 0;
+}
+
+.keypoint-capture-review {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.keypoint-capture-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 220px;
+  flex: 1;
+}
+
+.keypoint-collection-list,
+.keypoint-selected-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.keypoint-collection-row,
+.keypoint-selected-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+}
+
+.keypoint-selected-row {
+  justify-content: flex-start;
+}
+
+.keypoint-selected-row .keypoint-card-name {
+  flex: 1;
+}
+
 .reference-strength {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes the last story of epic 4422: the face-angle front-end, consuming the keypoints storage API (sc-4434) and the SCRFD `kps_extract` job (sc-4433).

## What

New **Key Point Library** screen (nav item + route), the face-angle sibling of the Pose Library, with three tabs:

- **Library** — every preset (built-in 11 + user captures) shown as its source image with the 5 kps overlaid (`KpsOverlay` SVG; built-ins render on a neutral canvas since their framing was tuned, not captured from a committed photo). User presets are deletable; built-ins are protected (no delete control).
- **Capture** — upload a photo → fire a `kps_extract` job → preview the detected landmarks over the photo → name + save as a reusable preset. No-face / failed extraction is **explained, never a silent save**; low-confidence detections warn before saving.
- **Collections** — compose ordered angle-set collections from any presets (built-in or custom), reorder, mark one the **default** (what "Generate angle set" runs, sc-4450), and edit/delete user collections.

**Per-generation override** lands in Character Studio's InstantID angle panel: a `KeypointCollectionField` sets `advanced.keypointCollectionId`, and the run sizes to the chosen collection's (variable) angle count. It's gated to the kps-consuming family (`identityStructure` — InstantID), since the prompt-driven angle tiers iterate the built-in angle prompts and ignore kps, matching the worker.

## Scope notes

- **Studio surface:** the override is wired into the InstantID **angle-set** panel (the only generation path that consumes a kps collection, per sc-4450). The Library itself is a top-level nav screen reachable from anywhere, including alongside Image Studio. There's no kps-collection generation path in Image Studio to override, so none was added there.
- **Built-in source images:** built-in presets carry `sourceImageRef: null` (the 11 reference frames aren't committed), so they render the kps overlay on a neutral canvas rather than a photo — consistent with the storage contract from sc-4434.

## Tests

`KeyPointLibraryScreen.test.jsx` (vitest) covers the acceptance bullets: overlay display (5-dot SVG + source image for captures), built-in protection + user-preset delete, the capture happy path (stage → extract → preview → save), the extraction-failure path, collection build (ordered), and set-default.

- **372 web tests pass**; production `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)