### PR TITLE
fix(worker,web): kps capture decodes by content + shared asset dialog (sc-4435)

### DIFF
--- a/apps/web/src/screens/KeyPointLibraryScreen.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.jsx
@@ -3,6 +3,8 @@ import { apiFetch } from "../api.js";
 import { useAppContext } from "../context/AppContext.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { KpsOverlay } from "../components/KpsOverlay.jsx";
+import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
+import { assetUrl } from "../components/assetMedia.jsx";
 import {
   BUILTIN_DEFAULT_COLLECTION_ID,
   GLOBAL_KEYPOINTS_PROJECT_ID,
@@ -108,19 +110,22 @@ function KeypointLibraryPanel({ hidden, presets, loading, error, onDelete }) {
 
 // --- Capture tab ------------------------------------------------------------
 
-// Upload one photo → stage it → fire a kps_extract job → watch the live jobs list → preview the
-// detected landmarks → name + save. Mirrors the Pose Library Create tab's staged-source +
-// job-watch shape, but for a single face and the SCRFD detector.
+// Pick a source — a workspace asset, a character image, or a file upload (the shared
+// single-select DatasetAddDialog, same as the Image Editor) → stage it → fire a kps_extract
+// job → watch the live jobs list → preview the detected landmarks → name + save. Every source
+// is staged to the transient keypoint-uploads area so the extraction + save path is uniform
+// (asset picks are re-fetched and staged the same as an upload), and the saved preset retains
+// its own copy of the source image.
 function KeypointCapturePanel({ hidden, onSaved }) {
-  const { token, requestedGpu, jobs = [] } = useAppContext();
-  const [source, setSource] = useState(null); // { path, displayName, objectUrl }
+  const { token, requestedGpu, jobs = [], assets = [], characters = [] } = useAppContext();
+  const [source, setSource] = useState(null); // { path, displayName, previewUrl, sourceAssetId? }
   const [phase, setPhase] = useState("idle"); // idle | extracting | review
   const [jobId, setJobId] = useState(null);
   const [extraction, setExtraction] = useState(null); // { kps, lowConfidence, sourceWidth, sourceHeight }
   const [name, setName] = useState("");
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
-  const fileInputRef = useRef(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const objectUrlRef = useRef(null);
   const clearSource = useCallback(() => {
@@ -140,26 +145,20 @@ function KeypointCapturePanel({ hidden, onSaved }) {
     setJobId(null);
   }, [clearSource]);
 
-  const onPick = useCallback(
-    async (event) => {
-      const file = event.target.files?.[0];
-      event.target.value = "";
-      if (!file || !file.type?.startsWith("image/")) {
-        return;
-      }
+  // Stage a source, seed the name, and fire the extraction. `previewUrl` backs the overlay
+  // preview; `sourceAssetId` records provenance when the source was an existing asset.
+  const beginExtraction = useCallback(
+    async ({ file, displayName, previewUrl, sourceAssetId }) => {
       setError("");
       setExtraction(null);
-      clearSource();
-      const objectUrl = URL.createObjectURL(file);
-      objectUrlRef.current = objectUrl;
       try {
         const staged = await stageKeypointSource(token, file);
         if (!staged?.path) {
           throw new Error("Upload did not return a staged path.");
         }
-        setSource({ path: staged.path, displayName: staged.displayName ?? file.name, objectUrl });
-        setName(stripExtension(staged.displayName ?? file.name));
-        // Fire the extraction immediately — the value is the landmarks, not the upload.
+        const label = displayName ?? staged.displayName ?? file.name ?? "image";
+        setSource({ path: staged.path, displayName: label, previewUrl, sourceAssetId });
+        setName(stripExtension(label));
         const job = await postExtractJob(token, requestedGpu, staged.path);
         setJobId(job.id);
         setPhase("extracting");
@@ -170,6 +169,54 @@ function KeypointCapturePanel({ hidden, onSaved }) {
       }
     },
     [token, requestedGpu, clearSource],
+  );
+
+  // File upload (DatasetAddDialog onImport): stage the File directly; preview from an objectUrl.
+  const onImport = useCallback(
+    async (files) => {
+      const file = files?.[0];
+      setPickerOpen(false);
+      if (!file || !file.type?.startsWith("image/")) {
+        return;
+      }
+      clearSource();
+      const objectUrl = URL.createObjectURL(file);
+      objectUrlRef.current = objectUrl;
+      await beginExtraction({ file, displayName: file.name, previewUrl: objectUrl });
+    },
+    [beginExtraction, clearSource],
+  );
+
+  // Asset / character pick (DatasetAddDialog onAdd): re-fetch the asset's bytes and stage them
+  // like an upload, so extraction + save are identical to the file path. Preview from its URL.
+  const onAddAsset = useCallback(
+    async (ids) => {
+      const asset = assets.find((item) => item.id === ids?.[0]);
+      setPickerOpen(false);
+      if (!asset) {
+        return;
+      }
+      clearSource();
+      setError("");
+      const url = assetUrl(asset);
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Could not load the selected image (${response.status}).`);
+        }
+        const blob = await response.blob();
+        const file = new File([blob], asset.displayName ?? "image", { type: blob.type || "image/png" });
+        await beginExtraction({
+          file,
+          displayName: asset.displayName ?? asset.id,
+          previewUrl: url,
+          sourceAssetId: asset.id,
+        });
+      } catch (err) {
+        setError(String(err?.message ?? err));
+      }
+    },
+    [assets, beginExtraction, clearSource],
   );
 
   // Watch the live (SSE-fed) jobs list for the extraction to finish.
@@ -211,6 +258,7 @@ function KeypointCapturePanel({ hidden, onSaved }) {
         sourceUploadPath: source.path,
         sourceWidth: extraction.sourceWidth,
         sourceHeight: extraction.sourceHeight,
+        ...(source.sourceAssetId ? { sourceAssetId: source.sourceAssetId } : {}),
       });
       reset();
       onSaved?.();
@@ -226,17 +274,16 @@ function KeypointCapturePanel({ hidden, onSaved }) {
       <div className="keypoint-capture">
         {error ? <p className="inline-warning">{error}</p> : null}
         <div className="toolbar">
-          <button onClick={() => fileInputRef.current?.click()} type="button">
-            {source ? "Choose another photo" : "Upload a photo"}
+          <button onClick={() => setPickerOpen(true)} type="button">
+            {source ? "Choose another image" : "Choose image"}
           </button>
-          <input accept="image/*" hidden onChange={onPick} ref={fileInputRef} type="file" />
           {phase === "extracting" ? <span className="muted">Detecting face landmarks…</span> : null}
         </div>
 
         {phase === "review" && extraction ? (
           <div className="keypoint-capture-review">
             <div className="keypoint-card-figure large">
-              <KpsOverlay kps={extraction.kps} imageUrl={source?.objectUrl} label="captured face landmarks" />
+              <KpsOverlay kps={extraction.kps} imageUrl={source?.previewUrl} label="captured face landmarks" />
             </div>
             <div className="keypoint-capture-form">
               {extraction.lowConfidence ? (
@@ -261,11 +308,27 @@ function KeypointCapturePanel({ hidden, onSaved }) {
           </div>
         ) : (
           <div className="empty-panel">
-            Upload a clear, front-facing photo. We detect the face and capture its 5-point framing as a reusable
-            angle preset.
+            Choose a clear, front-facing image — from your assets, a character, or a file upload. We detect the face
+            and capture its 5-point framing as a reusable angle preset.
           </div>
         )}
       </div>
+
+      {pickerOpen ? (
+        <DatasetAddDialog
+          assets={assets}
+          characters={characters}
+          confirmLabel="Use image"
+          eyebrow="Capture"
+          fileAccept="image/*"
+          fileHint="Drag an image here, or"
+          multiple={false}
+          onAdd={onAddAsset}
+          onClose={() => setPickerOpen(false)}
+          onImport={onImport}
+          title="Choose a face image"
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
@@ -144,6 +144,7 @@ describe("KeyPointLibraryScreen", () => {
     };
     await render(makeContext({ jobs: [job] }));
     await click(container.querySelector("#keypoint-tab-capture"));
+    await click(byText("Choose image")); // open the shared asset dialog (File tab default)
 
     const fileInput = container.querySelector('#keypoint-panel-capture input[type="file"]');
     const file = new File(["x"], "face.png", { type: "image/png" });
@@ -175,11 +176,55 @@ describe("KeyPointLibraryScreen", () => {
     expect(body.kps).toEqual(FRONT_KPS);
   });
 
+  it("captures from an existing asset via the shared dialog, recording provenance", async () => {
+    presets = [builtinPreset()];
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(["img-bytes"], { type: "image/png" }),
+    }));
+    const asset = {
+      id: "asset_img_1",
+      type: "image",
+      displayName: "Studio Photo",
+      origin: "upload",
+      status: { trashed: false },
+      file: { path: "assets/images/p.png", mimeType: "image/png" },
+      url: "/api/v1/projects/project_1/files/assets/images/p.png",
+    };
+    const job = {
+      id: "job_kps_1",
+      type: "kps_extract",
+      status: "completed",
+      result: { detected: true, kps: FRONT_KPS, lowConfidence: false, sourceWidth: 640, sourceHeight: 640 },
+    };
+    await render(makeContext({ jobs: [job], assets: [asset] }));
+    await click(container.querySelector("#keypoint-tab-capture"));
+    await click(byText("Choose image"));
+    await click(byText("Asset Library")); // dialog tab
+    await click(byText("Studio Photo")); // candidate card
+    await click(byText("Use image")); // single-select commit
+    await act(async () => {}); // flush fetch -> stage -> job post -> job-watch
+
+    // The asset's bytes were re-staged like an upload, then a kps_extract job fired.
+    expect(global.fetch).toHaveBeenCalled();
+    expect(apiCalls.some((c) => c.method === "POST" && c.path === "/api/v1/keypoints/sources")).toBe(true);
+    expect(apiCalls.some((c) => c.method === "POST" && c.path === "/api/v1/jobs")).toBe(true);
+
+    const nameInput = container.querySelector('#keypoint-panel-capture input[type="text"], #keypoint-panel-capture input:not([type])');
+    await setInputValue(nameInput, "From asset");
+    await click(byText("Save preset"));
+
+    const save = apiCalls.find((c) => c.method === "POST" && c.path === "/api/v1/keypoints");
+    expect(JSON.parse(save.body)).toMatchObject({ name: "From asset", sourceAssetId: "asset_img_1" });
+  });
+
   it("explains an extraction failure instead of saving silently", async () => {
     presets = [builtinPreset()];
     const job = { id: "job_kps_1", type: "kps_extract", status: "completed", result: { detected: false, reason: "no_face" } };
     await render(makeContext({ jobs: [job] }));
     await click(container.querySelector("#keypoint-tab-capture"));
+    await click(byText("Choose image"));
 
     const fileInput = container.querySelector('#keypoint-panel-capture input[type="file"]');
     const file = new File(["x"], "face.png", { type: "image/png" });

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1483,20 +1483,26 @@ impl ProjectStore {
         let created_at = utc_now();
         let dir = project_path.join("assets").join("keypoints");
         fs::create_dir_all(&dir)?;
-        let ext = canonical_source
-            .extension()
-            .and_then(|value| value.to_str())
-            .map(str::to_ascii_lowercase)
-            .filter(|value| matches!(value.as_str(), "png" | "jpg" | "jpeg" | "webp"))
-            .unwrap_or_else(|| "png".to_owned());
+        // Determine the format from the file CONTENT, not the staged path's extension: uploads
+        // arrive as `upload-<uuid>.tmp` (the generic temp writer keeps no extension), so keying
+        // off the extension would mislabel every capture as PNG. Fall back to the extension, then
+        // PNG, when the magic bytes aren't recognized.
+        let (ext, mime) = sniff_image_format(&canonical_source)
+            .or_else(|| {
+                canonical_source
+                    .extension()
+                    .and_then(|value| value.to_str())
+                    .and_then(|value| match value.to_ascii_lowercase().as_str() {
+                        "jpg" | "jpeg" => Some(("jpg", "image/jpeg")),
+                        "webp" => Some(("webp", "image/webp")),
+                        "png" => Some(("png", "image/png")),
+                        _ => None,
+                    })
+            })
+            .unwrap_or(("png", "image/png"));
         let media_path = dir.join(format!("{asset_id}.{ext}"));
         fs::copy(&canonical_source, &media_path)?;
         let media_rel = relative_string(&project_path, &media_path)?;
-        let mime = match ext.as_str() {
-            "jpg" | "jpeg" => "image/jpeg",
-            "webp" => "image/webp",
-            _ => "image/png",
-        };
 
         let source_asset_id = spec
             .get("sourceAssetId")
@@ -3109,6 +3115,26 @@ fn build_document_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Va
 }
 
 /// Parse + validate the 5-point normalized kps from a spec into a JSON `[[x,y]×5]` array.
+/// Sniff a still-image format from its magic bytes → `(extension, mime)`, or `None` when the
+/// header isn't a format the library retains. Used to label a captured keypoint source correctly
+/// regardless of the staged temp file's (extension-less) name.
+fn sniff_image_format(path: &Path) -> Option<(&'static str, &'static str)> {
+    let mut header = [0u8; 12];
+    let mut file = fs::File::open(path).ok()?;
+    let read = std::io::Read::read(&mut file, &mut header).ok()?;
+    let header = &header[..read];
+    if header.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        return Some(("jpg", "image/jpeg"));
+    }
+    if header.starts_with(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]) {
+        return Some(("png", "image/png"));
+    }
+    if header.len() >= 12 && &header[0..4] == b"RIFF" && &header[8..12] == b"WEBP" {
+        return Some(("webp", "image/webp"));
+    }
+    None
+}
+
 fn parse_normalized_kps(value: Option<&Value>) -> ProjectStoreResult<Vec<Value>> {
     let points = value.and_then(Value::as_array).ok_or_else(|| {
         ProjectStoreError::BadRequest("keypoint spec missing kps array".to_owned())
@@ -3546,8 +3572,8 @@ fn move_or_copy_file(source: &Path, destination: &Path) -> ProjectStoreResult<()
 mod tests {
     use super::{
         apply_project_migrations, build_generated_asset_sidecar, guess_mime_from_filename,
-        is_safe_relative_path, normalize_asset_tags, AssetScope, CharacterCreateInput,
-        CharacterLookInput, ProjectStore, ProjectStoreError, UploadAsset,
+        is_safe_relative_path, normalize_asset_tags, sniff_image_format, AssetScope,
+        CharacterCreateInput, CharacterLookInput, ProjectStore, ProjectStoreError, UploadAsset,
         GLOBAL_KEYPOINTS_PROJECT_ID, GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS,
         PROJECT_SCHEMA_VERSION,
     };
@@ -4304,6 +4330,52 @@ mod tests {
         assert_eq!(user["name"], "My Front");
         assert_eq!(user["builtin"], false);
         assert!(user["sourceImageRef"].as_str().is_some());
+    }
+
+    #[test]
+    fn create_keypoint_asset_labels_extensionless_upload_by_content() {
+        // Regression: uploads stage as `upload-<uuid>.tmp` (no real extension). The saved
+        // library asset must take its extension + mime from the file CONTENT, not the `.tmp`
+        // name, or a JPEG capture gets mislabeled image/png.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let data_dir = temp_dir.path().join("data");
+        let store = ProjectStore::new(&data_dir, "test-version");
+        let dir = data_dir.join("cache").join("keypoint-uploads");
+        std::fs::create_dir_all(&dir).expect("uploads dir");
+        let upload = dir.join("upload-deadbeef.tmp");
+        // Minimal JPEG SOI + APP0 marker bytes — enough for the magic-byte sniff.
+        std::fs::write(&upload, [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]).expect("staged jpeg");
+
+        let asset = store
+            .create_keypoint_asset(&json!({
+                "name": "From Photo",
+                "kps": front_kps(),
+                "sourceUploadPath": upload.to_string_lossy(),
+            }))
+            .expect("preset persists");
+        let media_rel = asset["file"]["path"].as_str().expect("media path");
+        assert!(
+            media_rel.ends_with(".jpg"),
+            "expected .jpg, got {media_rel}"
+        );
+        assert_eq!(asset["file"]["mimeType"], "image/jpeg");
+    }
+
+    #[test]
+    fn sniff_image_format_reads_magic_bytes() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let png = temp_dir.path().join("a.bin");
+        std::fs::write(&png, b"\x89PNG\r\n\x1a\n....").unwrap();
+        assert_eq!(sniff_image_format(&png), Some(("png", "image/png")));
+        let jpg = temp_dir.path().join("b.bin");
+        std::fs::write(&jpg, [0xFF, 0xD8, 0xFF, 0xE0]).unwrap();
+        assert_eq!(sniff_image_format(&jpg), Some(("jpg", "image/jpeg")));
+        let webp = temp_dir.path().join("c.bin");
+        std::fs::write(&webp, b"RIFF\x00\x00\x00\x00WEBPVP8 ").unwrap();
+        assert_eq!(sniff_image_format(&webp), Some(("webp", "image/webp")));
+        let other = temp_dir.path().join("d.bin");
+        std::fs::write(&other, b"not an image").unwrap();
+        assert_eq!(sniff_image_format(&other), None);
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -190,7 +190,14 @@ fn load_source_image(settings: &Settings, job: &JobSnapshot) -> WorkerResult<Ima
         .map(str::trim)
         .filter(|p| !p.is_empty())
     {
-        let decoded = image::open(path)
+        // Decode by CONTENT, not file extension: staged uploads land as `upload-<uuid>.tmp`
+        // (the API's generic temp-file writer keeps no extension), so `image::open` — which
+        // picks the codec from the extension — would reject a perfectly valid JPEG/PNG. Read
+        // the bytes and let `load_from_memory` sniff the format from the magic bytes.
+        let bytes = std::fs::read(path).map_err(|error| {
+            WorkerError::InvalidPayload(format!("kps extraction source {path}: {error}"))
+        })?;
+        let decoded = image::load_from_memory(&bytes)
             .map_err(|error| {
                 WorkerError::InvalidPayload(format!("kps extraction source {path}: {error}"))
             })?


### PR DESCRIPTION
Two issues found testing the Key Point Library capture flow (sc-4435, just merged in #540).

## 1. Uploading a JPEG failed with a `.tmp` extension error
> kps extract: ... `upload-….tmp`: The file extension `."tmp"` was not recognized as an image format

The API stages uploads as `upload-<uuid>.tmp` (the generic temp-file writer keeps no extension), and the kps worker's `image::open` picks the codec from the **extension** — so a valid JPEG was rejected.

**Fix:** the worker now reads the bytes and decodes by **content** (`image::load_from_memory`), robust to any staged name. And `create_keypoint_asset` sniffs the format from the magic bytes (new `sniff_image_format`) so the saved library asset gets the correct extension + mime instead of being mislabeled `image/png`.

## 2. Support the general asset dialog
Capture previously only had a raw file input. It now uses the shared single-select `DatasetAddDialog` — the same picker as the **Image Editor** — so you can choose from **workspace assets**, a **character's images**, or a **file upload**. Asset picks are re-fetched and staged like an upload so extraction + save stay a single uniform path, and the saved preset records `sourceAssetId` provenance.

## Tests
- Core: `create_keypoint_asset_labels_extensionless_upload_by_content` (a `.tmp` file with JPEG bytes → saved `.jpg` / `image/jpeg`) + `sniff_image_format_reads_magic_bytes`.
- Web: capture tests updated for the dialog flow + a new **asset-source capture** case (pick from the library → fetch + stage → save with `sourceAssetId`).
- `npm run rust:check` green (fmt/clippy/test/build); **373 web tests pass**; `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)