### PR TITLE
perf(worker): keep PromptRefiner resident across prompt_refine jobs (sc-4191)

### DIFF
--- a/apps/worker/scene_worker/prompt_refine.py
+++ b/apps/worker/scene_worker/prompt_refine.py
@@ -13,6 +13,7 @@ import re
 from typing import Any, Optional
 
 from .image_adapters import (
+    release_inference_memory,
     require_inference_backend_for_gpu_worker,
     select_torch_device,
     select_torch_dtype,
@@ -80,7 +81,16 @@ def clean_output(text: str) -> str:
 class PromptRefiner:
     """Loads a small instruction LLM in-process and rewrites prompts. Mirrors
     `JoyCaptioner`: lazy `load()`, shared MPS-aware device/dtype helpers, and a
-    `model.generate` call."""
+    `model.generate` call.
+
+    Held as a long-lived resident adapter in the worker loop's adapter dict
+    (sc-4191): ``load()`` is idempotent so repeat ``prompt_refine`` jobs reuse the
+    already-resident 3B LLM instead of paying a fresh multi-GB
+    ``from_pretrained`` per job, and ``unload()`` lets ``evict_other_image_adapters``
+    free it before another family loads."""
+
+    #: Stable adapter id used as the resident-dict key and evict keep-id.
+    id = "prompt_refiner"
 
     def __init__(self, *, model_name_or_path: str, gpu_id: str, max_new_tokens: int = 512) -> None:
         self.model_name_or_path = model_name_or_path or DEFAULT_REFINE_MODEL
@@ -91,11 +101,40 @@ class PromptRefiner:
         self.torch = None
         self.device = None
         self.torch_dtype = None
+        # Tracks which checkpoint is currently resident so load() can skip a
+        # redundant reload and detect a within-job model switch.
+        self._loaded_model_name: Optional[str] = None
 
     def loaded_models(self) -> list[str]:
         return [self.model_name_or_path] if self.model is not None else []
 
+    def unload(self) -> bool:
+        """Drop the resident model/tokenizer and return cached accelerator blocks
+        to the OS. Returns True if anything was freed (so ``evict_other_image_adapters``
+        can report it). gc.collect() must precede empty_cache() or the dropped
+        ``nn.Module`` reference cycles keep the multi-GB weights resident."""
+        if self.model is None and self.tokenizer is None:
+            return False
+        torch = self.torch
+        self.model = None
+        self.tokenizer = None
+        self.torch = None
+        self.device = None
+        self.torch_dtype = None
+        self._loaded_model_name = None
+        if torch is not None:
+            release_inference_memory(torch)
+        return True
+
     def load(self) -> None:
+        # Resident reuse: the requested checkpoint is already loaded → no-op.
+        if self.model is not None and self._loaded_model_name == self.model_name_or_path:
+            return
+        # A different refine model was requested: free the resident one first so
+        # we never hold two multi-GB LLMs at once (mirrors a within-family switch).
+        if self.model is not None:
+            self.unload()
+
         try:
             import torch
             from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -116,6 +155,7 @@ class PromptRefiner:
             )
             self.model.to(self.device)
             self.model.eval()
+            self._loaded_model_name = self.model_name_or_path
         except PromptRefineError:
             raise
         except Exception as exc:

--- a/apps/worker/scene_worker/runtime.py
+++ b/apps/worker/scene_worker/runtime.py
@@ -1404,15 +1404,17 @@ def run_training_caption_worker_job(api: ApiClient, settings: WorkerSettings, jo
     )
 
 
-def run_prompt_refine_job(api: ApiClient, settings: WorkerSettings, job: dict) -> None:
+def run_prompt_refine_job(api: ApiClient, settings: WorkerSettings, job: dict, image_adapters: dict) -> None:
     job_id = job["id"]
     payload = job.get("payload") or {}
     prompt = (payload.get("prompt") or "").strip()
-    refiner = PromptRefiner(
-        model_name_or_path=payload.get("model") or getattr(settings, "prompt_refine_model", "") or "",
-        gpu_id=getattr(settings, "gpu_id", "auto"),
-        max_new_tokens=getattr(settings, "prompt_refine_max_new_tokens", 512),
-    )
+    # Reuse the long-lived resident refiner (sc-4191) instead of reloading the 3B
+    # LLM per job. Only override the checkpoint when the job names a specific one;
+    # otherwise keep whatever is resident (the configured/default model).
+    refiner = image_adapters["prompt_refiner"]
+    requested_model = (payload.get("model") or getattr(settings, "prompt_refine_model", "") or "").strip()
+    if requested_model:
+        refiner.model_name_or_path = requested_model
     try:
         heartbeat_with_loaded_models(api, settings, "busy", job_id, refiner.loaded_models)
         update_job(
@@ -1420,6 +1422,9 @@ def run_prompt_refine_job(api: ApiClient, settings: WorkerSettings, job: dict) -
             job_id,
             {"status": "loading_model", "stage": "loading_model", "progress": 0.1, "message": "Loading refinement model."},
         )
+        # Free any other resident family before loading so we never hold an image
+        # pipeline and the refine LLM at once; load() is a no-op if already resident.
+        evict_other_image_adapters(image_adapters, getattr(refiner, "id", "prompt_refiner"))
         refiner.load()
         update_job(
             api,
@@ -1478,6 +1483,13 @@ def run_worker_loop(settings: WorkerSettings) -> None:
         "chroma_diffusers": ChromaDiffusersAdapter(),
         "instantid_sdxl": InstantIDAdapter(),
         "pulid_flux": PuLIDFluxAdapter(),
+        # Resident prompt-refine LLM (sc-4191): one instance, kept loaded across
+        # prompt_refine jobs and evicted by evict_other_image_adapters like the rest.
+        "prompt_refiner": PromptRefiner(
+            model_name_or_path=getattr(settings, "prompt_refine_model", "") or "",
+            gpu_id=getattr(settings, "gpu_id", "auto"),
+            max_new_tokens=getattr(settings, "prompt_refine_max_new_tokens", 512),
+        ),
     }
     max_registration_attempts = 20
 
@@ -1537,7 +1549,7 @@ def run_worker_loop(settings: WorkerSettings) -> None:
             elif job["type"] in CAPTION_JOB_TYPES:
                 run_training_caption_worker_job(api, settings, job)
             elif job["type"] in PROMPT_REFINE_JOB_TYPES:
-                run_prompt_refine_job(api, settings, job)
+                run_prompt_refine_job(api, settings, job, image_adapters)
             else:
                 update_job(
                     api,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -9794,6 +9794,7 @@ def _refine_settings(**overrides):
 class _FakeRefiner:
     """Stands in for PromptRefiner in handler tests — no torch/transformers."""
 
+    id = "prompt_refiner"
     instances = []
 
     def __init__(self, *, model_name_or_path, gpu_id, max_new_tokens):
@@ -9801,16 +9802,29 @@ class _FakeRefiner:
         self.gpu_id = gpu_id
         self.max_new_tokens = max_new_tokens
         self.loaded = False
+        self.load_calls = 0
         _FakeRefiner.instances.append(self)
 
     def loaded_models(self):
         return [self.model_name_or_path] if self.loaded and self.model_name_or_path else []
 
     def load(self):
+        self.load_calls += 1
         self.loaded = True
+
+    def unload(self):
+        freed = self.loaded
+        self.loaded = False
+        return freed
 
     def refine(self, prompt, *, guide, workflow):
         return f"Refined ({workflow}): {prompt}"
+
+
+def _refine_adapters(**overrides):
+    """A worker-loop-style adapter dict holding a single resident _FakeRefiner."""
+    refiner = _FakeRefiner(model_name_or_path=overrides.get("model_name_or_path", ""), gpu_id="cpu", max_new_tokens=512)
+    return {"prompt_refiner": refiner}
 
 
 def test_build_system_prompt_uses_workflow_medium_and_embeds_guide():
@@ -9834,6 +9848,47 @@ def test_prompt_refiner_load_unavailable_without_backend():
     # surfaces a clear PromptRefineUnavailable rather than an opaque ImportError.
     with pytest.raises(PromptRefineUnavailable):
         PromptRefiner(model_name_or_path="some/model", gpu_id="cpu").load()
+
+
+def test_prompt_refiner_load_is_idempotent_when_already_resident(monkeypatch):
+    # sc-4191: a second load() for the same checkpoint must not re-import torch /
+    # re-run from_pretrained — it returns immediately while the model is resident.
+    refiner = PromptRefiner(model_name_or_path="some/model", gpu_id="cpu")
+    refiner.model = object()  # pretend the checkpoint is resident
+    refiner._loaded_model_name = "some/model"
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("load() must not reload while the same model is resident")
+
+    monkeypatch.setattr("scene_worker.prompt_refine.require_inference_backend_for_gpu_worker", _boom)
+    refiner.load()  # no exception → early-returned without touching the backend
+
+
+def test_prompt_refiner_unload_frees_and_is_safe_when_empty():
+    # sc-4191: unload() drops the resident model and reports it; a no-op when
+    # nothing is loaded so evict_other_image_adapters can call it unconditionally.
+    refiner = PromptRefiner(model_name_or_path="some/model", gpu_id="cpu")
+    assert refiner.unload() is False  # nothing loaded yet
+
+    released = {}
+
+    refiner.model = object()
+    refiner.tokenizer = object()
+    refiner.torch = object()
+    refiner._loaded_model_name = "some/model"
+    import scene_worker.prompt_refine as pr
+
+    orig = pr.release_inference_memory
+    pr.release_inference_memory = lambda torch: released.setdefault("called", True)
+    try:
+        assert refiner.unload() is True
+    finally:
+        pr.release_inference_memory = orig
+
+    assert released.get("called") is True
+    assert refiner.model is None
+    assert refiner.tokenizer is None
+    assert refiner.loaded_models() == []
 
 
 def test_prompt_refiner_refine_applies_chat_template_and_cleans():
@@ -9888,20 +9943,42 @@ def test_prompt_refiner_refine_applies_chat_template_and_cleans():
 
 def test_run_prompt_refine_job_writes_refined_result(monkeypatch):
     monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
-    monkeypatch.setattr("scene_worker.runtime.PromptRefiner", _FakeRefiner)
     _FakeRefiner.instances = []
+    adapters = _refine_adapters()
     api = _DryRunApi()
     job = {"id": "job-refine-1", "type": "prompt_refine", "payload": {"prompt": "dog in park", "workflow": "image"}}
 
-    run_prompt_refine_job(api, _refine_settings(), job)
+    run_prompt_refine_job(api, _refine_settings(), job, adapters)
 
     terminal = api.progress[-1]
     assert terminal["status"] == "completed"
     assert terminal["result"]["refinedPrompt"] == "Refined (image): dog in park"
     assert terminal["result"]["originalPrompt"] == "dog in park"
     # Loaded the model before refining; emitted a loading_model stage.
-    assert _FakeRefiner.instances[0].loaded is True
+    assert adapters["prompt_refiner"].loaded is True
     assert any(entry["stage"] == "loading_model" for entry in api.progress)
+
+
+def test_run_prompt_refine_job_reuses_resident_refiner(monkeypatch):
+    """sc-4191: repeat prompt_refine jobs must reuse the one resident refiner and
+    its already-loaded model, never construct a new instance or reload per job."""
+    monkeypatch.setattr("scene_worker.runtime.emit", lambda payload: None)
+    _FakeRefiner.instances = []
+    adapters = _refine_adapters()
+    refiner = adapters["prompt_refiner"]
+    api = _DryRunApi()
+
+    for n in range(3):
+        job = {"id": f"job-refine-reuse-{n}", "type": "prompt_refine", "payload": {"prompt": "dog", "workflow": "image"}}
+        run_prompt_refine_job(api, _refine_settings(), job, adapters)
+
+    # Exactly one refiner ever constructed across three jobs.
+    assert len(_FakeRefiner.instances) == 1
+    assert _FakeRefiner.instances[0] is refiner
+    # load() is called each job but stays cheap (idempotent in the real adapter);
+    # the fake just records it. The instance is reused, not rebuilt.
+    assert refiner.load_calls == 3
+    assert refiner.loaded is True
 
 
 def test_run_prompt_refine_job_reports_failure(monkeypatch):
@@ -9911,11 +9988,11 @@ def test_run_prompt_refine_job_reports_failure(monkeypatch):
         def refine(self, prompt, *, guide, workflow):
             raise PromptRefineUnavailable("Could not load the prompt-refinement model.")
 
-    monkeypatch.setattr("scene_worker.runtime.PromptRefiner", _BoomRefiner)
     api = _DryRunApi()
+    adapters = {"prompt_refiner": _BoomRefiner(model_name_or_path="", gpu_id="cpu", max_new_tokens=512)}
     job = {"id": "job-refine-2", "type": "prompt_refine", "payload": {"prompt": "dog", "workflow": "image"}}
 
-    run_prompt_refine_job(api, _refine_settings(), job)
+    run_prompt_refine_job(api, _refine_settings(), job, adapters)
 
     terminal = api.progress[-1]
     assert terminal["status"] == "failed"


### PR DESCRIPTION
## Summary
Fixes **sc-4191 / F-WORKER-8** (P2, efficiency). `run_prompt_refine_job` constructed a fresh `PromptRefiner` and called `load()` — a full `AutoModelForCausalLM.from_pretrained` + `.to(device)` of the ~3B Llama-3.2-3B model — on **every** `prompt_refine` job, caching nothing across jobs (unlike the image adapters' resident-pipe pattern) and never explicitly releasing it. Interactive prompt-refine latency was dominated by reload time.

## Fix
Hold one `PromptRefiner` in the worker loop's `image_adapters` dict (key `prompt_refiner`) and route it through `evict_other_image_adapters` like every other family — the fix suggested in the finding.

- `PromptRefiner` gains:
  - a stable `id = "prompt_refiner"`,
  - an **idempotent `load()`**: no-op when the requested checkpoint is already resident; on a model switch it evicts the old one first so two multi-GB LLMs are never held at once,
  - an `unload()` that drops the model/tokenizer and runs `release_inference_memory` (`gc.collect()` **before** `empty_cache()`, per the documented MPS rule) and reports whether anything was freed.
- `run_prompt_refine_job` now reuses the resident instance, overrides the checkpoint only when the job names one, and evicts other families before loading.

## Tests
- `test_run_prompt_refine_job_reuses_resident_refiner`: 3 jobs → exactly one refiner instance, reused (not rebuilt).
- `test_prompt_refiner_load_is_idempotent_when_already_resident`: second `load()` for the same checkpoint short-circuits without touching the backend.
- `test_prompt_refiner_unload_frees_and_is_safe_when_empty`: frees + reports, and is a safe no-op when nothing is loaded (so eviction can call it unconditionally).
- Updated the two existing handler tests for the new resident-dict signature.
- Full Python suite: **546 passed** (`pytest tests/ -m "not e2e and not parity"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)