### PR TITLE
fix(worker): gc.collect before empty_cache in InstantID/PuLID unload (sc-4192)

### DIFF
--- a/apps/worker/scene_worker/instantid_adapter.py
+++ b/apps/worker/scene_worker/instantid_adapter.py
@@ -43,6 +43,7 @@ from .image_adapters import (
     format_batch_running_message,
     huggingface_repo_cache_exists,
     load_reference_image,
+    release_inference_memory,
     require_inference_backend_for_gpu_worker,
     resolve_seed,
     safe_int,
@@ -209,18 +210,11 @@ class InstantIDAdapter:
         self._loaded_model = None
         self._loaded_controlnet_mode = None
         self._loaded_lora_state = LoraPipelineState()
-        self._empty_cache(importlib.import_module("torch"))
+        # release_inference_memory runs gc.collect() BEFORE empty_cache() — required
+        # so the dropped ~7 GB SDXL+ControlNet pipe's nn.Module reference cycles are
+        # actually freed, not left resident until an incidental cyclic GC (sc-4192).
+        release_inference_memory(importlib.import_module("torch"))
         return True
-
-    @staticmethod
-    def _empty_cache(torch: Any) -> None:
-        try:
-            if torch.backends.mps.is_available():
-                torch.mps.empty_cache()
-            elif torch.cuda.is_available():
-                torch.cuda.empty_cache()
-        except Exception:
-            pass
 
     # ---- face analysis -------------------------------------------------
     def _face_analysis(self) -> Any:

--- a/apps/worker/scene_worker/pulid_flux_adapter.py
+++ b/apps/worker/scene_worker/pulid_flux_adapter.py
@@ -43,6 +43,7 @@ from .image_adapters import (
     image_batch_progress,
     format_batch_running_message,
     load_reference_image,
+    release_inference_memory,
     require_inference_backend_for_gpu_worker,
     resolve_seed,
     safe_int,
@@ -140,19 +141,11 @@ class PuLIDFluxAdapter:
         self._pulid = None
         self._loaded_repo = None
         self._loaded_model = None
-        torch = importlib.import_module("torch")
-        self._empty_cache(torch)
+        # gc.collect() BEFORE empty_cache() (release_inference_memory) is required so
+        # the dropped ~37 GB PuLID-FLUX stack's reference cycles are freed immediately
+        # rather than lingering beside the next model until a cyclic GC (sc-4192).
+        release_inference_memory(importlib.import_module("torch"))
         return True
-
-    @staticmethod
-    def _empty_cache(torch: Any) -> None:
-        try:
-            if torch.backends.mps.is_available():
-                torch.mps.empty_cache()
-            elif torch.cuda.is_available():
-                torch.cuda.empty_cache()
-        except Exception:
-            pass
 
     # ---- model load ---------------------------------------------------
     def _load_pipeline(

--- a/tests/test_instantid_adapter.py
+++ b/tests/test_instantid_adapter.py
@@ -391,7 +391,9 @@ def test_unload_resets_lora_state(monkeypatch):
     adapter = InstantIDAdapter()
     adapter._pipe = SimpleNamespace(tag="fakepipe")
     adapter._loaded_lora_state = LoraPipelineState(key="applied", adapter_names=("sw_test",))
-    adapter._empty_cache = lambda *_a, **_k: None  # the cache-empty call itself is a no-op
+    # release_inference_memory runs gc.collect()+empty_cache against the fake torch;
+    # stub it so the test exercises unload()'s state reset, not the real free (sc-4192).
+    monkeypatch.setattr("scene_worker.instantid_adapter.release_inference_memory", lambda *_a, **_k: None)
     assert adapter.unload() is True
     # The merge belongs to the (now-discarded) pipe; the next pipe must start clean.
     assert adapter._loaded_lora_state == LoraPipelineState()

--- a/tests/test_pulid_flux_adapter.py
+++ b/tests/test_pulid_flux_adapter.py
@@ -7,6 +7,7 @@ not here.
 """
 from __future__ import annotations
 
+import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -108,6 +109,27 @@ def test_requires_reference_image(pulid_flux_model):
 
 def test_unload_when_empty_is_false():
     assert PuLIDFluxAdapter().unload() is False
+
+
+def test_unload_routes_through_gc_ordered_release(monkeypatch):
+    # sc-4192: a non-empty unload must free the ~37 GB stack via
+    # release_inference_memory (gc.collect() BEFORE empty_cache()), not a bare
+    # empty_cache() that leaves reference-cycled weights resident.
+    adapter = PuLIDFluxAdapter()
+    adapter._flow_model = SimpleNamespace(tag="fake")
+    fake_torch = object()
+    monkeypatch.setattr(
+        "scene_worker.pulid_flux_adapter.importlib.import_module",
+        lambda name: fake_torch if name == "torch" else importlib.import_module(name),
+    )
+    calls = []
+    monkeypatch.setattr(
+        "scene_worker.pulid_flux_adapter.release_inference_memory",
+        lambda torch: calls.append(torch),
+    )
+    assert adapter.unload() is True
+    assert calls == [fake_torch]
+    assert adapter._flow_model is None
 
 
 def test_builtin_pulid_flux_target_is_wired():


### PR DESCRIPTION
## Summary
Fixes **sc-4192 / F-WORKER-9** (P2, bad-pattern). `InstantIDAdapter.unload` and `PuLIDFluxAdapter.unload` each called only `torch.mps/cuda.empty_cache()` through a private `_empty_cache` helper. The codebase's own documented rule (`image_adapters.release_inference_memory`, and the SenseNova comment) is that **`gc.collect()` must run BEFORE `empty_cache()`** — otherwise the dropped pipeline's `nn.Module` reference cycles keep the multi-GB weights resident until an incidental cyclic GC. That's the exact MPS memory-stacking bug already fixed elsewhere ("base↔fast switches stacked to tens of GB before this fix").

When `evict_other_image_adapters` unloads InstantID (~7 GB SDXL+ControlNet) or PuLID-FLUX (~37 GB stack) before loading another family, the evicted weights could stay resident alongside the new model.

## Fix
Replace both private `_empty_cache` helpers with `release_inference_memory(torch)` from `image_adapters` (the exact suggested fix) — `gc.collect()` then `empty_cache()`, in order.

## Tests
- `test_unload_routes_through_gc_ordered_release` (PuLID): a non-empty unload routes through `release_inference_memory` with the resolved torch and clears state — guards against a revert to bare `empty_cache`.
- `test_unload_resets_lora_state` (InstantID): repatched to stub the shared helper instead of the removed `_empty_cache`.
- Full Python suite: **547 passed** (`pytest tests/ -m "not e2e and not parity"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)