### PR TITLE
fix(web): add queueSummary to queueCounts memo deps (sc-4193)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -734,7 +734,7 @@ export function App() {
       },
       { active: 0 },
     );
-  }, [jobs]);
+  }, [jobs, queueSummary]);
   const filteredJobs = useMemo(() => {
     if (projectFilter === "all") {
       return jobs;

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -589,6 +589,34 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Queue");
   });
 
+  // sc-4193 regression (F-WEB-3): the queueCounts memo reads queueSummary, so a
+  // queue.updated SSE event (which changes queueSummary but NOT jobs) must refresh
+  // the topbar "Queue N" chip. Before the fix the memo's deps were [jobs] only, so
+  // queue-only updates served stale counts until the next jobs mutation.
+  it("updates the Queue chip on a queue.updated event with no jobs change", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    const queueChip = () => [...container.querySelectorAll(".queue-chip")][0];
+    expect(queueChip()?.textContent).toContain("Queue 0");
+
+    // Pure queue.updated: two active jobs, and no job.updated to mutate `jobs`.
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["queue.updated"]({
+        data: JSON.stringify({
+          counts: { active: 2, queued: 2 },
+          activeJobs: [{ id: "job-a" }, { id: "job-b" }],
+        }),
+      });
+    });
+    await settle();
+
+    expect(queueChip()?.textContent).toContain("Queue 2");
+  });
+
   // sc-4168 regression: App must provide `token` through AppContext. Screens that
   // call apiFetch directly (Logs, Image Editor, Pose Library, useUserPoseLoader)
   // read it from context; before the fix they got `undefined` and never sent the


### PR DESCRIPTION
## Summary
Fixes **sc-4193 / F-WEB-3** (P2, bad-pattern). The `queueCounts` `useMemo` in `App.jsx` branches on `queueSummary?.counts` but its dependency array was `[jobs]`. SSE `queue.updated` events update `queueSummary` without necessarily changing `jobs`, so the memo served stale counts until the next `jobs` mutation. The topbar "Queue N" chip and the Queue nav pulse could show stale active counts after queue-only updates — intermittent and confusing because job events usually accompany queue events.

## Fix
Add `queueSummary` to the dependency array (`[jobs, queueSummary]`). `terminalStatuses` is a stable module constant, so no other dep is needed.

## Tests
- New regression test in `main.test.jsx`: mounts `App`, fires a `queue.updated` SSE event (two `activeJobs`, **no** `job.updated`), asserts the `.queue-chip` updates from "Queue 0" to "Queue 2".
- Verified it **fails on the old `[jobs]`-only deps** (`expected 'Queue 0' to contain 'Queue 2'`) and passes with the fix.
- Full web suite: **374 passed**; `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)