### PR TITLE
perf(web): memoize App context value + useCallback data-hook actions (sc-4194)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -467,7 +467,8 @@ export function App() {
   // `scopeAssets` is the exact list the calling gallery rendered (folded or not);
   // we snapshot its ids so navigation tracks the live asset state but never
   // wanders outside that collection. Passing no scope clears it (global nav).
-  const openPreview = (asset, scopeAssets) => {
+  // sc-4194: useCallback so the context-exposed setPreviewAsset identity is stable.
+  const openPreview = useCallback((asset, scopeAssets) => {
     if (!asset) {
       setPreviewScopeIds(null);
       setPreviewAsset(null);
@@ -479,7 +480,7 @@ export function App() {
         : null,
     );
     setPreviewAsset(asset);
-  };
+  }, []);
   const closePreview = () => {
     setPreviewScopeIds(null);
     setPreviewAsset(null);
@@ -529,6 +530,39 @@ export function App() {
     if (guard && !guard()) return; // guard returned false → user cancelled the leave
     setActiveView(viewId);
   }, []);
+
+  // sc-4194: defined here (above the data hooks) because useTimelines takes it as a
+  // dependency; a stable identity keeps the timeline hook's queue action stable too.
+  const createVideoJob = useCallback(
+    async (payload, options = {}) => {
+      const { navigateToQueue = false } = options;
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const job = await apiFetch("/api/v1/video/jobs", token, {
+          method: "POST",
+          body: JSON.stringify({
+            ...payload,
+            projectId: activeProject.id,
+            projectName: activeProject.name,
+            requestedGpu,
+          }),
+        });
+        if (navigateToQueue) {
+          setActiveView("Queue");
+        }
+        setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, requestedGpu],
+  );
 
   const {
     characters,
@@ -1145,135 +1179,150 @@ export function App() {
     }
   }
 
-  async function createPlaceholderJob(event) {
-    event.preventDefault();
-    try {
-      await apiFetch("/api/v1/jobs", token, {
-        method: "POST",
-        body: JSON.stringify({
-          type: "placeholder",
-          projectId: activeProject?.id ?? null,
-          projectName: activeProject?.name ?? null,
-          requestedGpu,
-          payload: {
-            prompt: jobPrompt,
-            createdFrom: activeView,
-          },
-        }),
-      });
-      setActiveView("Queue");
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
+  const createPlaceholderJob = useCallback(
+    async (event) => {
+      event.preventDefault();
+      try {
+        await apiFetch("/api/v1/jobs", token, {
+          method: "POST",
+          body: JSON.stringify({
+            type: "placeholder",
+            projectId: activeProject?.id ?? null,
+            projectName: activeProject?.name ?? null,
+            requestedGpu,
+            payload: {
+              prompt: jobPrompt,
+              createdFrom: activeView,
+            },
+          }),
+        });
+        setActiveView("Queue");
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token, activeProject, requestedGpu, jobPrompt, activeView],
+  );
 
-  async function createImageJob(payload) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch("/api/v1/image/jobs", token, {
-        method: "POST",
-        body: JSON.stringify({
-          ...payload,
-          projectId: activeProject.id,
-          projectName: activeProject.name,
-          requestedGpu,
-        }),
-      });
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const createImageJob = useCallback(
+    async (payload) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const job = await apiFetch("/api/v1/image/jobs", token, {
+          method: "POST",
+          body: JSON.stringify({
+            ...payload,
+            projectId: activeProject.id,
+            projectName: activeProject.name,
+            requestedGpu,
+          }),
+        });
+        setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, requestedGpu],
+  );
 
   // Refine a prompt via the prompt_refine worker job: POST creates the job, then
   // poll until it reaches a terminal state and return the rewritten prompt. Project-
   // independent (no activeProject gate); throws on failure so the studio can surface
   // the message inline without clobbering the original prompt.
-  async function refinePrompt({ prompt, modelId, workflow, guide }) {
-    const created = await apiFetch("/api/v1/prompts/refine", token, {
-      method: "POST",
-      body: JSON.stringify({ prompt, modelId, workflow, guide }),
-    });
-    const jobId = created?.id;
-    if (!jobId) {
-      throw new Error("Could not start prompt refinement.");
-    }
-    const deadline = Date.now() + 120000;
-    while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const job = await apiFetch(`/api/v1/jobs/${jobId}`, token);
-      if (job.status === "completed") {
-        const refined = job.result?.refinedPrompt;
-        if (!refined) {
-          throw new Error("Refinement returned an empty prompt.");
+  const refinePrompt = useCallback(
+    async ({ prompt, modelId, workflow, guide }) => {
+      const created = await apiFetch("/api/v1/prompts/refine", token, {
+        method: "POST",
+        body: JSON.stringify({ prompt, modelId, workflow, guide }),
+      });
+      const jobId = created?.id;
+      if (!jobId) {
+        throw new Error("Could not start prompt refinement.");
+      }
+      const deadline = Date.now() + 120000;
+      while (Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        const job = await apiFetch(`/api/v1/jobs/${jobId}`, token);
+        if (job.status === "completed") {
+          const refined = job.result?.refinedPrompt;
+          if (!refined) {
+            throw new Error("Refinement returned an empty prompt.");
+          }
+          return refined;
         }
-        return refined;
+        if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
+          throw new Error(job.message || job.error || "Prompt refinement failed.");
+        }
       }
-      if (job.status === "failed" || job.status === "canceled" || job.status === "interrupted") {
-        throw new Error(job.message || job.error || "Prompt refinement failed.");
+      throw new Error("Prompt refinement timed out. Is the refinement runtime running?");
+    },
+    [token],
+  );
+
+  const createVqaJob = useCallback(
+    async (asset, question, maxNewTokens) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
       }
-    }
-    throw new Error("Prompt refinement timed out. Is the refinement runtime running?");
-  }
+      try {
+        const job = await apiFetch("/api/v1/image/vqa/jobs", token, {
+          method: "POST",
+          body: JSON.stringify({
+            projectId: activeProject.id,
+            projectName: activeProject.name,
+            sourceAssetId: asset.id,
+            question,
+            maxNewTokens,
+            requestedGpu,
+          }),
+        });
+        setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, requestedGpu],
+  );
 
-  async function createVqaJob(asset, question, maxNewTokens) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch("/api/v1/image/vqa/jobs", token, {
-        method: "POST",
-        body: JSON.stringify({
-          projectId: activeProject.id,
-          projectName: activeProject.name,
-          sourceAssetId: asset.id,
-          question,
-          maxNewTokens,
-          requestedGpu,
-        }),
-      });
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const createInterleaveJob = useCallback(
+    async (payload) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const job = await apiFetch("/api/v1/image/interleave/jobs", token, {
+          method: "POST",
+          body: JSON.stringify({
+            ...payload,
+            projectId: activeProject.id,
+            projectName: activeProject.name,
+            requestedGpu,
+          }),
+        });
+        setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, requestedGpu],
+  );
 
-  async function createInterleaveJob(payload) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch("/api/v1/image/interleave/jobs", token, {
-        method: "POST",
-        body: JSON.stringify({
-          ...payload,
-          projectId: activeProject.id,
-          projectName: activeProject.name,
-          requestedGpu,
-        }),
-      });
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  function rememberLocalGenerationJob(kind, job) {
+  const rememberLocalGenerationJob = useCallback((kind, job) => {
     if (!job?.id) {
       return;
     }
@@ -1283,7 +1332,7 @@ export function App() {
       // runs stack in the studio instead of the latest run evicting the previous one.
       [kind]: [job.id, ...current[kind].filter((id) => id !== job.id)].slice(0, localJobStackLimit),
     }));
-  }
+  }, []);
 
   function hasVisibleLocalFailure(job) {
     const active = activeViewRef.current;
@@ -1300,35 +1349,7 @@ export function App() {
     return active === "Models" && job.type === "model_download";
   }
 
-  async function createVideoJob(payload, options = {}) {
-    const { navigateToQueue = false } = options;
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch("/api/v1/video/jobs", token, {
-        method: "POST",
-        body: JSON.stringify({
-          ...payload,
-          projectId: activeProject.id,
-          projectName: activeProject.name,
-          requestedGpu,
-        }),
-      });
-      if (navigateToQueue) {
-        setActiveView("Queue");
-      }
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  function sendAssetToImage(asset, mode = null) {
+  const sendAssetToImage = useCallback((asset, mode = null) => {
     if (!asset) {
       return;
     }
@@ -1337,7 +1358,7 @@ export function App() {
       setStudioLaunch({ id: crypto.randomUUID(), view: "Image", assetId: asset.id, mode });
     }
     setActiveView("Image");
-  }
+  }, []);
 
   // "Edit" from the fullscreen preview: open Image Studio in edit mode with this
   // image as the source, preselecting the family-matched edit model when possible.
@@ -1377,7 +1398,7 @@ export function App() {
     setActiveView("Image");
   }
 
-  function sendAssetToVideo(asset, mode = null) {
+  const sendAssetToVideo = useCallback((asset, mode = null) => {
     if (!asset) {
       return;
     }
@@ -1386,9 +1407,9 @@ export function App() {
       setStudioLaunch({ id: crypto.randomUUID(), view: "Video", assetId: asset.id, mode });
     }
     setActiveView("Video");
-  }
+  }, []);
 
-  function sendCharacterToImage(character, lookId = null, referenceAssetId = null) {
+  const sendCharacterToImage = useCallback((character, lookId = null, referenceAssetId = null) => {
     if (!character) {
       return;
     }
@@ -1401,124 +1422,142 @@ export function App() {
       mode: "character_image",
     });
     setActiveView("Image");
-  }
+  }, []);
 
-  function sendCharacterToVideo(character, lookId = null) {
+  const sendCharacterToVideo = useCallback((character, lookId = null) => {
     if (!character) {
       return;
     }
     setStudioLaunch({ id: crypto.randomUUID(), view: "Video", characterId: character.id, lookId, mode: "text_to_video" });
     setActiveView("Video");
-  }
+  }, []);
 
   // sc-2022: open a specific dataset in the Dataset editor (Character Studio's
   // "Open" action on an associated dataset). The editor consumes studioLaunch.
-  function openDatasetInLibrary(datasetId) {
+  const openDatasetInLibrary = useCallback((datasetId) => {
     if (!datasetId) {
       return;
     }
     setStudioLaunch({ id: crypto.randomUUID(), view: "LibraryDataSets", datasetId });
     setActiveView("LibraryDataSets");
-  }
+  }, []);
 
-  async function updateAssetStatus(asset, changes) {
-    try {
-      const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/status`, token, {
-        method: "PATCH",
-        body: JSON.stringify(changes),
-      });
-      setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
-
-  async function updateAssetTags(asset, tags) {
-    try {
-      const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/tags`, token, {
-        method: "PATCH",
-        body: JSON.stringify({ tags }),
-      });
-      setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
-
-  async function deleteAsset(asset) {
-    try {
-      await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}`, token, { method: "DELETE" });
-      setAssets((items) =>
-        items.map((item) =>
-          item.id === asset.id ? { ...item, status: { ...item.status, trashed: true } } : item,
-        ),
-      );
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
-
-  async function purgeAsset(asset) {
-    try {
-      await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge`, token, { method: "DELETE" });
-      setAssets((items) => items.filter((item) => item.id !== asset.id));
-      setSelectedAssetId((current) => (current === asset.id ? null : current));
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
-
-  async function importAsset(file, options = {}) {
-    if (!activeProject || !file) {
-      const error = new Error("Create or open a project first.");
-      if (options.throwOnError) {
-        throw error;
+  const updateAssetStatus = useCallback(
+    async (asset, changes) => {
+      try {
+        const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/status`, token, {
+          method: "PATCH",
+          body: JSON.stringify(changes),
+        });
+        setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        setError("");
+      } catch (err) {
+        setError(err.message);
       }
-      setError(error.message);
-      return;
-    }
-    const body = new FormData();
-    body.append("file", file);
-    // Optional lineage for derived imports (Image Editor Save, sc-2434): link the
-    // new asset to the source it was opened from + record the edit-chain provenance.
-    if (options.sourceAssetId) body.append("sourceAssetId", options.sourceAssetId);
-    if (options.provenance) body.append("provenance", JSON.stringify(options.provenance));
-    try {
-      const imported = await apiFetch(`/api/v1/projects/${activeProject.id}/assets`, token, {
-        method: "POST",
-        body,
-      });
-      setAssets((items) => [imported, ...items.filter((item) => item.id !== imported.id)]);
-      setSelectedAssetId(imported.id);
-      setError("");
-      return imported;
-    } catch (err) {
-      if (options.throwOnError) {
-        throw err;
-      }
-      setError(err.message);
-      return null;
-    }
-  }
+    },
+    [token],
+  );
 
-  async function jobAction(job, action, options = {}) {
-    try {
-      const path = action === "duplicate" ? `/api/v1/jobs/${job.id}/duplicate` : `/api/v1/jobs/${job.id}/${action}`;
-      const body =
-        action === "duplicate"
-          ? { payloadChanges: { duplicatedAt: new Date().toISOString() } }
-          : (options.body ?? {});
-      const updatedJob = await apiFetch(path, token, { method: "POST", body: JSON.stringify(body) });
-      setJobs((items) => [updatedJob, ...items.filter((item) => item.id !== updatedJob.id)].sort(sortNewest));
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
+  const updateAssetTags = useCallback(
+    async (asset, tags) => {
+      try {
+        const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/tags`, token, {
+          method: "PATCH",
+          body: JSON.stringify({ tags }),
+        });
+        setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token],
+  );
+
+  const deleteAsset = useCallback(
+    async (asset) => {
+      try {
+        await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}`, token, { method: "DELETE" });
+        setAssets((items) =>
+          items.map((item) =>
+            item.id === asset.id ? { ...item, status: { ...item.status, trashed: true } } : item,
+          ),
+        );
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token],
+  );
+
+  const purgeAsset = useCallback(
+    async (asset) => {
+      try {
+        await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge`, token, { method: "DELETE" });
+        setAssets((items) => items.filter((item) => item.id !== asset.id));
+        setSelectedAssetId((current) => (current === asset.id ? null : current));
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token],
+  );
+
+  const importAsset = useCallback(
+    async (file, options = {}) => {
+      if (!activeProject || !file) {
+        const error = new Error("Create or open a project first.");
+        if (options.throwOnError) {
+          throw error;
+        }
+        setError(error.message);
+        return;
+      }
+      const body = new FormData();
+      body.append("file", file);
+      // Optional lineage for derived imports (Image Editor Save, sc-2434): link the
+      // new asset to the source it was opened from + record the edit-chain provenance.
+      if (options.sourceAssetId) body.append("sourceAssetId", options.sourceAssetId);
+      if (options.provenance) body.append("provenance", JSON.stringify(options.provenance));
+      try {
+        const imported = await apiFetch(`/api/v1/projects/${activeProject.id}/assets`, token, {
+          method: "POST",
+          body,
+        });
+        setAssets((items) => [imported, ...items.filter((item) => item.id !== imported.id)]);
+        setSelectedAssetId(imported.id);
+        setError("");
+        return imported;
+      } catch (err) {
+        if (options.throwOnError) {
+          throw err;
+        }
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject],
+  );
+
+  const jobAction = useCallback(
+    async (job, action, options = {}) => {
+      try {
+        const path = action === "duplicate" ? `/api/v1/jobs/${job.id}/duplicate` : `/api/v1/jobs/${job.id}/${action}`;
+        const body =
+          action === "duplicate"
+            ? { payloadChanges: { duplicatedAt: new Date().toISOString() } }
+            : (options.body ?? {});
+        const updatedJob = await apiFetch(path, token, { method: "POST", body: JSON.stringify(body) });
+        setJobs((items) => [updatedJob, ...items.filter((item) => item.id !== updatedJob.id)].sort(sortNewest));
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token],
+  );
 
   const titleInfo = viewTitles[activeView] ?? { title: activeView, blurb: "" };
   // Activity dots only — counts live in the topbar so nav button textContent stays clean.
@@ -1538,7 +1577,13 @@ export function App() {
   // sc-1651 Phase B: shared primitives screens read via useAppContext() instead of
   // drilled props. Screens build any screen-specific wrappers from these (e.g. a
   // send-to-studio action with a mode). Grown one screen at a time as screens convert.
-  const appContextValue = {
+  // sc-4194: memoized so the provider value only changes identity when one of its
+  // entries actually changes, instead of being a fresh ~120-key literal on every App
+  // render (SSE job/worker/queue ticks re-render App continuously). The actions above
+  // and the data-hook actions are useCallback-stable, so this holds across renders
+  // that don't change data. NOTE: this dependency array must mirror the object below —
+  // every value referenced here is a dependency.
+  const appContextValue = useMemo(() => ({
     activeProject,
     mediaAssets,
     setPreviewAsset: openPreview,
@@ -1663,7 +1708,31 @@ export function App() {
     sendCharacterToImage,
     sendCharacterToVideo,
     openDatasetInLibrary,
-  };
+  }), [
+    activeProject, mediaAssets, openPreview, sendAssetToImage, sendAssetToVideo,
+    activeTimeline, timelines, selectedTimelineId, setSelectedTimelineId, setActiveTimeline,
+    createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
+    assets, selectedAsset, setSelectedAssetId, deleteAsset, purgeAsset, importAsset,
+    updateAssetStatus, updateAssetTags, latestImageAssets,
+    jobs, jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob, filteredJobs,
+    jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects, visibleWorkers, workersById,
+    createVideoJob, createImageJob, refinePrompt, latestVideoAssets, recentImageAssets,
+    recentVideoAssets, videoLocalJobs, imageLocalJobs, documentLocalJobs, studioLaunch,
+    rememberLocalGenerationJob, personTracks, personReadiness, createPersonDetectionJob,
+    createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,
+    loras, deleteLora, deleteModel, createModelDownloadJob, createModelConvertJob,
+    createLoraImportJob, createModelImportJob, gpuOptions, requestedGpu, setRequestedGpu,
+    presets, createPreset, updatePreset, deletePreset, duplicatePreset, token, authenticated,
+    trainingDatasets, trainingDatasetsProjectId, trainingDatasetsError, loadingTrainingDatasets,
+    refreshTrainingDatasets, loadTrainingDataset, createTrainingDataset, uploadTrainingDatasetItem,
+    updateTrainingDataset, batchRenameTrainingDataset, writeTrainingDatasetCaptionSidecars,
+    createTrainingDatasetCaptionJob, createTrainingJob, trainingPresets, trainingPresetsError,
+    trainingTargets, trainingTargetsError, setActiveView, registerLeaveGuard, characters,
+    createCharacter, updateCharacter, archiveCharacter, addCharacterReference, updateCharacterReference,
+    removeCharacterReference, createCharacterLook, updateCharacterLook, deleteCharacterLook,
+    attachCharacterLora, updateCharacterLora, detachCharacterLora, createCharacterTestJob,
+    sendCharacterToImage, sendCharacterToVideo, openDatasetInLibrary,
+  ]);
 
   return (
     <AppContext.Provider value={appContextValue}>

--- a/apps/web/src/hooks/hookStability.test.jsx
+++ b/apps/web/src/hooks/hookStability.test.jsx
@@ -1,0 +1,112 @@
+// sc-4194 regression: the data hooks must return useCallback-stable action
+// identities across re-renders that don't change their inputs. Before the fix every
+// action was an inline function recreated each render, so appContextValue (which
+// spreads them) changed identity on every SSE-driven App re-render and defeated
+// memoization across the whole consumer tree. If a hook action is ever reverted to a
+// plain inline function, its identity will change on the forced re-render below and
+// this test fails.
+import React, { useEffect, useRef, useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { usePresets } from "./usePresets.js";
+import { usePersonTracks } from "./usePersonTracks.js";
+import { useCharacters } from "./useCharacters.js";
+
+const ACTION_KEYS = {
+  usePresets: ["refreshPresets", "createPreset", "updatePreset", "duplicatePreset", "deletePreset"],
+  usePersonTracks: ["refreshPersonTracks", "createPersonDetectionJob", "createPersonTrackJob", "saveTrackCorrections"],
+  useCharacters: [
+    "refreshCharacters", "createCharacter", "updateCharacter", "archiveCharacter",
+    "addCharacterReference", "createCharacterLook", "attachCharacterLora", "createCharacterTestJob",
+  ],
+};
+
+async function settle() {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+describe("data hook action identity stability (sc-4194)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  // Renders `useHook` with fixed props, forces one re-render via an internal counter,
+  // and reports the action identities captured on render #1 and render #2.
+  function probe(useHook, actionKeys) {
+    const captures = [];
+    let bump = () => {};
+
+    // Stable across renders so the only thing changing on the forced re-render is the
+    // counter — mirrors how App feeds these hooks identity-stable token/project/setters
+    // while jobs churn. If the actions still change identity, it's the hook's fault.
+    const stableProps = {
+      token: "tok",
+      activeProject: { id: "p1", name: "P1" },
+      setError: () => {},
+      requestedGpu: "auto",
+      setActiveView: () => {},
+    };
+
+    function Harness() {
+      const [, setN] = useState(0);
+      bump = () => setN((n) => n + 1);
+      const api = useHook(stableProps);
+      const snapshot = {};
+      actionKeys.forEach((key) => {
+        snapshot[key] = api[key];
+      });
+      const ref = useRef(null);
+      // Record one snapshot per commit.
+      useEffect(() => {
+        ref.current = snapshot;
+        captures.push(snapshot);
+      });
+      return null;
+    }
+
+    return { Harness, captures, bumpRef: () => bump() };
+  }
+
+  it.each(Object.entries(ACTION_KEYS).map(([name]) => name))(
+    "%s returns stable action identities across an unrelated re-render",
+    async (hookName) => {
+      const hooks = { usePresets, usePersonTracks, useCharacters };
+      const { Harness, captures, bumpRef } = probe(hooks[hookName], ACTION_KEYS[hookName]);
+
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<Harness />);
+      });
+      await settle();
+
+      await act(async () => {
+        bumpRef();
+      });
+      await settle();
+
+      expect(captures.length).toBeGreaterThanOrEqual(2);
+      const first = captures[0];
+      const last = captures[captures.length - 1];
+      for (const key of ACTION_KEYS[hookName]) {
+        expect(typeof last[key]).toBe("function");
+        expect(last[key]).toBe(first[key]); // identity preserved across re-render
+      }
+    },
+  );
+});

--- a/apps/web/src/hooks/useCharacters.js
+++ b/apps/web/src/hooks/useCharacters.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 
 // Owns the project's character roster plus every character CRUD/reference/look/LoRA
@@ -6,174 +6,210 @@ import { apiFetch, isAbortError } from "../api.js";
 // unchanged — shared concerns (token, active project, error/navigation) are passed in
 // so the hook stays a thin data layer. Character test jobs surface live via the SSE
 // job stream (the create endpoint publishes job.updated), so no post-create refetch.
+//
+// sc-4194: every returned action is wrapped in useCallback so its identity is stable
+// across App's SSE-driven re-renders, which lets appContextValue memoize instead of
+// rebuilding (and changing identity) on every job.updated tick.
 export function useCharacters({ token, activeProject, setError, requestedGpu, setActiveView }) {
   const [characters, setCharacters] = useState([]);
 
-  async function refreshCharacters(projectId = activeProject?.id, { signal } = {}) {
-    if (!projectId) {
-      return;
-    }
-    try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/characters`, token, { signal });
-      setCharacters(items);
-      setError("");
-    } catch (err) {
-      if (isAbortError(err)) return;
-      setError(err.message);
-    }
-  }
+  const refreshCharacters = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      if (!projectId) {
+        return;
+      }
+      try {
+        const items = await apiFetch(`/api/v1/projects/${projectId}/characters`, token, { signal });
+        setCharacters(items);
+        setError("");
+      } catch (err) {
+        if (isAbortError(err)) return;
+        setError(err.message);
+      }
+    },
+    [token, activeProject, setError],
+  );
 
-  async function withCharacterApi(callback) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const result = await callback(activeProject.id);
-      setError("");
-      return result;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const withCharacterApi = useCallback(
+    async (callback) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const result = await callback(activeProject.id);
+        setError("");
+        return result;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [activeProject, setError],
+  );
 
-  async function createCharacter(payload) {
-    return withCharacterApi(async (projectId) => {
-      const created = await apiFetch(`/api/v1/projects/${projectId}/characters`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      setCharacters((items) => [created, ...items.filter((item) => item.id !== created.id)]);
-      return created;
-    });
-  }
+  const createCharacter = useCallback(
+    async (payload) =>
+      withCharacterApi(async (projectId) => {
+        const created = await apiFetch(`/api/v1/projects/${projectId}/characters`, token, {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        setCharacters((items) => [created, ...items.filter((item) => item.id !== created.id)]);
+        return created;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function updateCharacter(characterId, changes) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}`, token, {
-        method: "PATCH",
-        body: JSON.stringify(changes),
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const updateCharacter = useCallback(
+    async (characterId, changes) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}`, token, {
+          method: "PATCH",
+          body: JSON.stringify(changes),
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function archiveCharacter(characterId) {
-    return withCharacterApi(async (projectId) => {
-      await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/archive`, token, { method: "POST" });
-      setCharacters((items) => items.filter((item) => item.id !== characterId));
-      return { id: characterId, status: "archived" };
-    });
-  }
+  const archiveCharacter = useCallback(
+    async (characterId) =>
+      withCharacterApi(async (projectId) => {
+        await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/archive`, token, { method: "POST" });
+        setCharacters((items) => items.filter((item) => item.id !== characterId));
+        return { id: characterId, status: "archived" };
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function addCharacterReference(characterId, payload) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/references`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const addCharacterReference = useCallback(
+    async (characterId, payload) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/references`, token, {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function updateCharacterReference(characterId, assetId, changes) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/references/${assetId}`, token, {
-        method: "PATCH",
-        body: JSON.stringify(changes),
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const updateCharacterReference = useCallback(
+    async (characterId, assetId, changes) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/references/${assetId}`, token, {
+          method: "PATCH",
+          body: JSON.stringify(changes),
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function removeCharacterReference(characterId, assetId) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/references/${assetId}`, token, {
-        method: "DELETE",
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const removeCharacterReference = useCallback(
+    async (characterId, assetId) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/references/${assetId}`, token, {
+          method: "DELETE",
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function createCharacterLook(characterId, payload) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/looks`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const createCharacterLook = useCallback(
+    async (characterId, payload) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/looks`, token, {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function updateCharacterLook(characterId, lookId, changes) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/looks/${lookId}`, token, {
-        method: "PATCH",
-        body: JSON.stringify(changes),
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const updateCharacterLook = useCallback(
+    async (characterId, lookId, changes) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/looks/${lookId}`, token, {
+          method: "PATCH",
+          body: JSON.stringify(changes),
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function deleteCharacterLook(characterId, lookId) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/looks/${lookId}`, token, {
-        method: "DELETE",
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const deleteCharacterLook = useCallback(
+    async (characterId, lookId) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/looks/${lookId}`, token, {
+          method: "DELETE",
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function attachCharacterLora(characterId, payload) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/loras`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const attachCharacterLora = useCallback(
+    async (characterId, payload) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/loras`, token, {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function updateCharacterLora(characterId, linkId, changes) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/loras/${linkId}`, token, {
-        method: "PATCH",
-        body: JSON.stringify(changes),
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const updateCharacterLora = useCallback(
+    async (characterId, linkId, changes) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/loras/${linkId}`, token, {
+          method: "PATCH",
+          body: JSON.stringify(changes),
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function detachCharacterLora(characterId, linkId) {
-    return withCharacterApi(async (projectId) => {
-      const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/loras/${linkId}`, token, {
-        method: "DELETE",
-      });
-      setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
-      return updated;
-    });
-  }
+  const detachCharacterLora = useCallback(
+    async (characterId, linkId) =>
+      withCharacterApi(async (projectId) => {
+        const updated = await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/loras/${linkId}`, token, {
+          method: "DELETE",
+        });
+        setCharacters((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        return updated;
+      }),
+    [withCharacterApi, token],
+  );
 
-  async function createCharacterTestJob(characterId, payload) {
-    return withCharacterApi(async (projectId) => {
-      await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/test-jobs`, token, {
-        method: "POST",
-        body: JSON.stringify({ ...payload, requestedGpu }),
-      });
-      setActiveView("Queue");
-      return { id: characterId, status: "queued" };
-    });
-  }
+  const createCharacterTestJob = useCallback(
+    async (characterId, payload) =>
+      withCharacterApi(async (projectId) => {
+        await apiFetch(`/api/v1/projects/${projectId}/characters/${characterId}/test-jobs`, token, {
+          method: "POST",
+          body: JSON.stringify({ ...payload, requestedGpu }),
+        });
+        setActiveView("Queue");
+        return { id: characterId, status: "queued" };
+      }),
+    [withCharacterApi, token, requestedGpu, setActiveView],
+  );
 
   return {
     characters,

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { sortNewest } from "../sorters.js";
 
@@ -28,31 +28,40 @@ export function useModelsAndLoras({
   const [models, setModels] = useState([]);
   const [loras, setLoras] = useState([]);
 
-  async function refreshLoras(projectId = activeProject?.id, { signal } = {}) {
-    try {
-      const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-      const items = await apiFetch(`/api/v1/loras${query}`, token, { signal });
-      setLoras(items);
+  // sc-4194: actions wrapped in useCallback so their identity is stable across App's
+  // SSE-driven re-renders, letting appContextValue memoize.
+  const refreshLoras = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      try {
+        const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+        const items = await apiFetch(`/api/v1/loras${query}`, token, { signal });
+        setLoras(items);
+        setError("");
+      } catch (err) {
+        if (isAbortError(err)) return;
+        setError(err.message);
+      }
+    },
+    [token, activeProject, setError],
+  );
+
+  const deleteModel = useCallback(
+    async (model) => {
+      const result = await apiFetch(`/api/v1/models/${encodeURIComponent(model.id)}`, token, {
+        method: "DELETE",
+      });
+      if (result.removedManifestEntry) {
+        setModels((items) => items.filter((item) => item.id !== model.id));
+      }
       setError("");
-    } catch (err) {
-      if (isAbortError(err)) return;
-      setError(err.message);
-    }
-  }
+      await refreshData();
+      return result;
+    },
+    [token, setError, refreshData],
+  );
 
-  async function deleteModel(model) {
-    const result = await apiFetch(`/api/v1/models/${encodeURIComponent(model.id)}`, token, {
-      method: "DELETE",
-    });
-    if (result.removedManifestEntry) {
-      setModels((items) => items.filter((item) => item.id !== model.id));
-    }
-    setError("");
-    await refreshData();
-    return result;
-  }
-
-  async function deleteLora(lora) {
+  const deleteLora = useCallback(
+    async (lora) => {
     const params = new URLSearchParams();
     if (lora.scope) {
       params.set("scope", lora.scope);
@@ -70,9 +79,12 @@ export function useModelsAndLoras({
     setError("");
     await refreshDataWithLoraOverlay(activeProject?.id);
     return result;
-  }
+    },
+    [token, activeProject, setError, refreshDataWithLoraOverlay],
+  );
 
-  async function createModelImportJob(payload, options = {}) {
+  const createModelImportJob = useCallback(
+    async (payload, options = {}) => {
     const { file, ...metadata } = payload;
     if (file?.size > maxModelUploadBytes) {
       throw new Error(`Uploaded model file exceeds the ${uploadLimitLabel(maxModelUploadBytes)} limit`);
@@ -99,9 +111,12 @@ export function useModelsAndLoras({
     }
     setError("");
     return job;
-  }
+    },
+    [token, setJobs, setActiveView, setError],
+  );
 
-  async function createLoraImportJob(payload, options = {}) {
+  const createLoraImportJob = useCallback(
+    async (payload, options = {}) => {
     if (payload.scope === "project" && !activeProject) {
       throw new Error("Create or open a project first.");
     }
@@ -147,37 +162,45 @@ export function useModelsAndLoras({
     }
     setError("");
     return job;
-  }
+    },
+    [token, activeProject, setJobs, setActiveView, setError],
+  );
 
-  async function createModelDownloadJob(model) {
-    try {
-      const job = await apiFetch(`/api/v1/models/${model.id}/download`, token, {
-        method: "POST",
-        body: JSON.stringify({ requestedGpu: "auto" }),
-      });
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const createModelDownloadJob = useCallback(
+    async (model) => {
+      try {
+        const job = await apiFetch(`/api/v1/models/${model.id}/download`, token, {
+          method: "POST",
+          body: JSON.stringify({ requestedGpu: "auto" }),
+        });
+        setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, setJobs, setError],
+  );
 
-  async function createModelConvertJob(model) {
-    try {
-      const job = await apiFetch(`/api/v1/models/${model.id}/convert`, token, {
-        method: "POST",
-        body: JSON.stringify({ requestedGpu: "auto" }),
-      });
-      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const createModelConvertJob = useCallback(
+    async (model) => {
+      try {
+        const job = await apiFetch(`/api/v1/models/${model.id}/convert`, token, {
+          method: "POST",
+          body: JSON.stringify({ requestedGpu: "auto" }),
+        });
+        setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, setJobs, setError],
+  );
 
   return {
     models,

--- a/apps/web/src/hooks/usePersonTracks.js
+++ b/apps/web/src/hooks/usePersonTracks.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 
 // Owns the project's person-track state plus detection/track job creation and manual
@@ -9,86 +9,100 @@ import { apiFetch, isAbortError } from "../api.js";
 export function usePersonTracks({ token, activeProject, setError, requestedGpu, setActiveView }) {
   const [personTracks, setPersonTracks] = useState([]);
 
-  async function refreshPersonTracks(projectId = activeProject?.id, { signal } = {}) {
-    if (!projectId) {
-      return;
-    }
-    try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token, { signal });
-      setPersonTracks(items);
-      setError("");
-    } catch (err) {
-      if (isAbortError(err)) return;
-      setError(err.message);
-    }
-  }
-
-  async function createPersonDetectionJob(payload, options = {}) {
-    const { navigateToQueue = false } = options;
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/detections`, token, {
-        method: "POST",
-        body: JSON.stringify({ ...payload, requestedGpu }),
-      });
-      if (navigateToQueue) {
-        setActiveView("Queue");
+  // sc-4194: every action is wrapped in useCallback so its identity is stable
+  // across the SSE-driven re-renders of App, letting appContextValue memoize.
+  const refreshPersonTracks = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      if (!projectId) {
+        return;
       }
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
-
-  async function createPersonTrackJob(payload, options = {}) {
-    const { navigateToQueue = false } = options;
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/jobs`, token, {
-        method: "POST",
-        body: JSON.stringify({ ...payload, requestedGpu }),
-      });
-      if (navigateToQueue) {
-        setActiveView("Queue");
+      try {
+        const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token, { signal });
+        setPersonTracks(items);
+        setError("");
+      } catch (err) {
+        if (isAbortError(err)) return;
+        setError(err.message);
       }
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+    },
+    [token, activeProject, setError],
+  );
 
-  async function saveTrackCorrections(trackId, corrections) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const track = await apiFetch(
-        `/api/v1/projects/${activeProject.id}/person-tracks/${trackId}/corrections`,
-        token,
-        {
+  const createPersonDetectionJob = useCallback(
+    async (payload, options = {}) => {
+      const { navigateToQueue = false } = options;
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/detections`, token, {
           method: "POST",
-          body: JSON.stringify({ corrections }),
-        },
-      );
-      setPersonTracks((items) => items.map((item) => (item.id === track.id ? track : item)));
-      setError("");
-      return track;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+          body: JSON.stringify({ ...payload, requestedGpu }),
+        });
+        if (navigateToQueue) {
+          setActiveView("Queue");
+        }
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError, requestedGpu, setActiveView],
+  );
+
+  const createPersonTrackJob = useCallback(
+    async (payload, options = {}) => {
+      const { navigateToQueue = false } = options;
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const job = await apiFetch(`/api/v1/projects/${activeProject.id}/person-tracks/jobs`, token, {
+          method: "POST",
+          body: JSON.stringify({ ...payload, requestedGpu }),
+        });
+        if (navigateToQueue) {
+          setActiveView("Queue");
+        }
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError, requestedGpu, setActiveView],
+  );
+
+  const saveTrackCorrections = useCallback(
+    async (trackId, corrections) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const track = await apiFetch(
+          `/api/v1/projects/${activeProject.id}/person-tracks/${trackId}/corrections`,
+          token,
+          {
+            method: "POST",
+            body: JSON.stringify({ corrections }),
+          },
+        );
+        setPersonTracks((items) => items.map((item) => (item.id === track.id ? track : item)));
+        setError("");
+        return track;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError],
+  );
 
   return {
     personTracks,

--- a/apps/web/src/hooks/usePresets.js
+++ b/apps/web/src/hooks/usePresets.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 
 // Owns the recipe-preset list plus its scoped refresh/create/update/duplicate/delete
@@ -9,69 +9,89 @@ import { apiFetch, isAbortError } from "../api.js";
 export function usePresets({ token, activeProject, setError }) {
   const [presets, setPresets] = useState([]);
 
-  async function refreshPresets(projectId = activeProject?.id, { signal } = {}) {
-    try {
-      const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-      const items = await apiFetch(`/api/v1/recipe-presets${query}`, token, { signal });
-      setPresets(items);
-      setError("");
-      return items;
-    } catch (err) {
-      if (isAbortError(err)) return [];
-      setError(err.message);
-      return [];
-    }
-  }
+  // sc-4194: actions wrapped in useCallback so their identity is stable across
+  // App's SSE-driven re-renders, enabling appContextValue to memoize.
+  const refreshPresets = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      try {
+        const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+        const items = await apiFetch(`/api/v1/recipe-presets${query}`, token, { signal });
+        setPresets(items);
+        setError("");
+        return items;
+      } catch (err) {
+        if (isAbortError(err)) return [];
+        setError(err.message);
+        return [];
+      }
+    },
+    [token, activeProject, setError],
+  );
 
-  function presetQuery(scope = null) {
-    const params = new URLSearchParams();
-    if (scope) {
-      params.set("scope", scope);
-    }
-    if (scope === "project" && activeProject?.id) {
-      params.set("projectId", activeProject.id);
-    }
-    const value = params.toString();
-    return value ? `?${value}` : "";
-  }
+  const presetQuery = useCallback(
+    (scope = null) => {
+      const params = new URLSearchParams();
+      if (scope) {
+        params.set("scope", scope);
+      }
+      if (scope === "project" && activeProject?.id) {
+        params.set("projectId", activeProject.id);
+      }
+      const value = params.toString();
+      return value ? `?${value}` : "";
+    },
+    [activeProject],
+  );
 
-  async function createPreset(payload) {
-    if (payload.scope === "project" && !activeProject) {
-      throw new Error("Create or open a project first.");
-    }
-    const created = await apiFetch(`/api/v1/recipe-presets${presetQuery(payload.scope)}`, token, {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    await refreshPresets(activeProject?.id);
-    return created;
-  }
+  const createPreset = useCallback(
+    async (payload) => {
+      if (payload.scope === "project" && !activeProject) {
+        throw new Error("Create or open a project first.");
+      }
+      const created = await apiFetch(`/api/v1/recipe-presets${presetQuery(payload.scope)}`, token, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      await refreshPresets(activeProject?.id);
+      return created;
+    },
+    [token, activeProject, presetQuery, refreshPresets],
+  );
 
-  async function updatePreset(presetId, payload, scope = payload.scope) {
-    const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
-      method: "PATCH",
-      body: JSON.stringify(payload),
-    });
-    await refreshPresets(activeProject?.id);
-    return updated;
-  }
+  const updatePreset = useCallback(
+    async (presetId, payload, scope = payload.scope) => {
+      const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+      });
+      await refreshPresets(activeProject?.id);
+      return updated;
+    },
+    [token, activeProject, presetQuery, refreshPresets],
+  );
 
-  async function duplicatePreset(presetId, scope = null) {
-    const duplicated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}/duplicate${presetQuery(scope)}`, token, {
-      method: "POST",
-      body: JSON.stringify({}),
-    });
-    await refreshPresets(activeProject?.id);
-    return duplicated;
-  }
+  const duplicatePreset = useCallback(
+    async (presetId, scope = null) => {
+      const duplicated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}/duplicate${presetQuery(scope)}`, token, {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+      await refreshPresets(activeProject?.id);
+      return duplicated;
+    },
+    [token, activeProject, presetQuery, refreshPresets],
+  );
 
-  async function deletePreset(presetId, scope = null) {
-    const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
-      method: "DELETE",
-    });
-    await refreshPresets(activeProject?.id);
-    return archived;
-  }
+  const deletePreset = useCallback(
+    async (presetId, scope = null) => {
+      const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
+        method: "DELETE",
+      });
+      await refreshPresets(activeProject?.id);
+      return archived;
+    },
+    [token, activeProject, presetQuery, refreshPresets],
+  );
 
   return {
     presets,

--- a/apps/web/src/hooks/useTimelines.js
+++ b/apps/web/src/hooks/useTimelines.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { ensureItemVersionFields } from "../timeline.js";
 
@@ -39,27 +39,36 @@ export function useTimelines({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeProject?.id, selectedTimelineId, timelinesProjectId]);
 
-  async function refreshTimelines(projectId = activeProject?.id, { signal } = {}) {
-    if (!projectId) {
-      return;
-    }
-    try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token, { signal });
-      if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
+  // sc-4194: the context-exposed actions (and refreshTimelines, on which they depend)
+  // are wrapped in useCallback so their identity is stable across App's SSE-driven
+  // re-renders, letting appContextValue memoize. The internal helpers below
+  // (loadTimeline, applyTimelineGenerationResult, enqueueTimelineGenerationApply) are
+  // not part of the context value, so they stay plain function declarations — keeping
+  // loadTimeline hoisted for the load-on-selection effect above.
+  const refreshTimelines = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      if (!projectId) {
         return;
       }
-      setTimelines(items);
-      setTimelinesProjectId(projectId);
-      setSelectedTimelineId((current) => (items.some((item) => item.id === current) ? current : items[0]?.id ?? null));
-      if (!items.length) {
-        setActiveTimeline(null);
+      try {
+        const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token, { signal });
+        if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
+          return;
+        }
+        setTimelines(items);
+        setTimelinesProjectId(projectId);
+        setSelectedTimelineId((current) => (items.some((item) => item.id === current) ? current : items[0]?.id ?? null));
+        if (!items.length) {
+          setActiveTimeline(null);
+        }
+        setError("");
+      } catch (err) {
+        if (isAbortError(err)) return;
+        setError(err.message);
       }
-      setError("");
-    } catch (err) {
-      if (isAbortError(err)) return;
-      setError(err.message);
-    }
-  }
+    },
+    [token, activeProject, activeProjectRef, setError],
+  );
 
   async function loadTimeline(projectId, timelineId) {
     try {
@@ -74,87 +83,100 @@ export function useTimelines({
     }
   }
 
-  async function createTimeline(payload) {
-    if (!activeProject) {
-      setError("Create or open a project first.");
-      return null;
-    }
-    try {
-      const created = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      setTimelines((items) => [created, ...items.filter((item) => item.id !== created.id)]);
-      setTimelinesProjectId(activeProject.id);
-      setSelectedTimelineId(created.id);
-      setActiveTimeline(created);
-      setError("");
-      return created;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const createTimeline = useCallback(
+    async (payload) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const created = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines`, token, {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        setTimelines((items) => [created, ...items.filter((item) => item.id !== created.id)]);
+        setTimelinesProjectId(activeProject.id);
+        setSelectedTimelineId(created.id);
+        setActiveTimeline(created);
+        setError("");
+        return created;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError],
+  );
 
-  async function saveTimeline(timeline) {
-    if (!activeProject || !timeline) {
-      return null;
-    }
-    try {
-      const saved = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}`, token, {
-        method: "PUT",
-        body: JSON.stringify({ timeline }),
-      });
-      setActiveTimeline(saved);
-      refreshTimelines(activeProject.id);
-      setError("");
-      return saved;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const saveTimeline = useCallback(
+    async (timeline) => {
+      if (!activeProject || !timeline) {
+        return null;
+      }
+      try {
+        const saved = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}`, token, {
+          method: "PUT",
+          body: JSON.stringify({ timeline }),
+        });
+        setActiveTimeline(saved);
+        refreshTimelines(activeProject.id);
+        setError("");
+        return saved;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError, refreshTimelines],
+  );
 
-  async function exportTimeline(timeline, options) {
-    if (!activeProject || !timeline) {
-      return;
-    }
-    const saved = await saveTimeline(timeline);
-    if (!saved) {
-      return;
-    }
-    try {
-      await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${saved.id}/exports`, token, {
-        method: "POST",
-        body: JSON.stringify({ ...options, requestedGpu }),
-      });
-      setActiveView("Queue");
-      setError("");
-    } catch (err) {
-      setError(err.message);
-    }
-  }
+  const exportTimeline = useCallback(
+    async (timeline, options) => {
+      if (!activeProject || !timeline) {
+        return;
+      }
+      const saved = await saveTimeline(timeline);
+      if (!saved) {
+        return;
+      }
+      try {
+        await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${saved.id}/exports`, token, {
+          method: "POST",
+          body: JSON.stringify({ ...options, requestedGpu }),
+        });
+        setActiveView("Queue");
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token, activeProject, setError, requestedGpu, setActiveView, saveTimeline],
+  );
 
-  async function extractTimelineFrame({ timeline, item, playheadSeconds, intendedUse }) {
-    if (!activeProject || !timeline || !item) {
-      return null;
-    }
-    try {
-      const job = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}/items/${item.id}/frames`, token, {
-        method: "POST",
-        body: JSON.stringify({ playheadSeconds, intendedUse, requestedGpu }),
-      });
-      setError("");
-      return job;
-    } catch (err) {
-      setError(err.message);
-      return null;
-    }
-  }
+  const extractTimelineFrame = useCallback(
+    async ({ timeline, item, playheadSeconds, intendedUse }) => {
+      if (!activeProject || !timeline || !item) {
+        return null;
+      }
+      try {
+        const job = await apiFetch(`/api/v1/projects/${activeProject.id}/timelines/${timeline.id}/items/${item.id}/frames`, token, {
+          method: "POST",
+          body: JSON.stringify({ playheadSeconds, intendedUse, requestedGpu }),
+        });
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError, requestedGpu],
+  );
 
-  async function queueTimelineVideoJob(payload) {
-    return createVideoJob(payload, { navigateToQueue: false });
-  }
+  const queueTimelineVideoJob = useCallback(
+    async (payload) => createVideoJob(payload, { navigateToQueue: false }),
+    [createVideoJob],
+  );
 
   function applyTimelineGenerationResult(timeline, job) {
     const payload = job.payload ?? {};

--- a/apps/web/src/hooks/useTraining.js
+++ b/apps/web/src/hooks/useTraining.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { sortNewest } from "../sorters.js";
 
@@ -7,144 +7,174 @@ import { sortNewest } from "../sorters.js";
 // preset catalogs stay in App (bulk-loaded by refreshData) — only the project-scoped
 // dataset workflow lives here. Shared concerns (token, activeProject, error, jobs) are
 // passed in; caption/training jobs push onto the shared jobs list via setJobs.
+//
+// sc-4194: actions are wrapped in useCallback so their identity is stable across App's
+// SSE-driven re-renders, letting appContextValue memoize.
 export function useTraining({ token, activeProject, setError, setJobs }) {
   const [trainingDatasets, setTrainingDatasets] = useState([]);
   const [trainingDatasetsProjectId, setTrainingDatasetsProjectId] = useState(null);
   const [loadingTrainingDatasets, setLoadingTrainingDatasets] = useState(false);
   const [trainingDatasetsError, setTrainingDatasetsError] = useState("");
 
-  async function refreshTrainingDatasets(projectId = activeProject?.id, { signal } = {}) {
-    if (!projectId) {
-      setTrainingDatasets([]);
-      setTrainingDatasetsProjectId(null);
-      setTrainingDatasetsError("");
-      return [];
-    }
-    setLoadingTrainingDatasets(true);
-    try {
-      const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, { signal });
-      setTrainingDatasets(items);
-      setTrainingDatasetsProjectId(projectId);
-      setTrainingDatasetsError("");
-      return items;
-    } catch (err) {
-      if (isAbortError(err)) return [];
-      setTrainingDatasets([]);
-      setTrainingDatasetsProjectId(projectId);
-      setTrainingDatasetsError(err.message);
-      return [];
-    } finally {
-      // A superseded load must not clear the loading flag the new load just set.
-      if (!signal?.aborted) {
-        setLoadingTrainingDatasets(false);
+  const refreshTrainingDatasets = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      if (!projectId) {
+        setTrainingDatasets([]);
+        setTrainingDatasetsProjectId(null);
+        setTrainingDatasetsError("");
+        return [];
       }
-    }
-  }
+      setLoadingTrainingDatasets(true);
+      try {
+        const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, { signal });
+        setTrainingDatasets(items);
+        setTrainingDatasetsProjectId(projectId);
+        setTrainingDatasetsError("");
+        return items;
+      } catch (err) {
+        if (isAbortError(err)) return [];
+        setTrainingDatasets([]);
+        setTrainingDatasetsProjectId(projectId);
+        setTrainingDatasetsError(err.message);
+        return [];
+      } finally {
+        // A superseded load must not clear the loading flag the new load just set.
+        if (!signal?.aborted) {
+          setLoadingTrainingDatasets(false);
+        }
+      }
+    },
+    [token, activeProject],
+  );
 
-  async function loadTrainingDataset(datasetId, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      return null;
-    }
-    return apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token);
-  }
+  const loadTrainingDataset = useCallback(
+    async (datasetId, projectId = activeProject?.id) => {
+      if (!projectId || !datasetId) {
+        return null;
+      }
+      return apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token);
+    },
+    [token, activeProject],
+  );
 
-  async function createTrainingDataset(payload, projectId = activeProject?.id) {
-    if (!projectId) {
-      throw new Error("Create or open a project first.");
-    }
-    const created = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    await refreshTrainingDatasets(projectId);
-    return created;
-  }
-
-  async function uploadTrainingDatasetItem(file, projectId = activeProject?.id) {
-    if (!projectId) {
-      throw new Error("Create or open a project first.");
-    }
-    const form = new FormData();
-    form.append("file", file);
-    return apiFetch(`/api/v1/projects/${projectId}/training/uploads`, token, {
-      method: "POST",
-      body: form,
-    });
-  }
-
-  async function updateTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const updated = await apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token, {
-      method: "PATCH",
-      body: JSON.stringify(payload),
-    });
-    await refreshTrainingDatasets(projectId);
-    return updated;
-  }
-
-  async function batchRenameTrainingDataset(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const updated = await apiFetch(
-      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/batch-rename`,
-      token,
-      {
+  const createTrainingDataset = useCallback(
+    async (payload, projectId = activeProject?.id) => {
+      if (!projectId) {
+        throw new Error("Create or open a project first.");
+      }
+      const created = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, {
         method: "POST",
         body: JSON.stringify(payload),
-      },
-    );
-    await refreshTrainingDatasets(projectId);
-    return updated;
-  }
+      });
+      await refreshTrainingDatasets(projectId);
+      return created;
+    },
+    [token, activeProject, refreshTrainingDatasets],
+  );
 
-  async function writeTrainingDatasetCaptionSidecars(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const result = await apiFetch(
-      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-sidecars`,
-      token,
-      {
+  const uploadTrainingDatasetItem = useCallback(
+    async (file, projectId = activeProject?.id) => {
+      if (!projectId) {
+        throw new Error("Create or open a project first.");
+      }
+      const form = new FormData();
+      form.append("file", file);
+      return apiFetch(`/api/v1/projects/${projectId}/training/uploads`, token, {
         method: "POST",
-        body: JSON.stringify(payload),
-      },
-    );
-    await refreshTrainingDatasets(projectId);
-    return result;
-  }
+        body: form,
+      });
+    },
+    [token, activeProject],
+  );
 
-  async function createTrainingDatasetCaptionJob(datasetId, payload, projectId = activeProject?.id) {
-    if (!projectId || !datasetId) {
-      throw new Error("Select a training dataset first.");
-    }
-    const job = await apiFetch(
-      `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-jobs`,
-      token,
-      {
+  const updateTrainingDataset = useCallback(
+    async (datasetId, payload, projectId = activeProject?.id) => {
+      if (!projectId || !datasetId) {
+        throw new Error("Select a training dataset first.");
+      }
+      const updated = await apiFetch(`/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}`, token, {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+      });
+      await refreshTrainingDatasets(projectId);
+      return updated;
+    },
+    [token, activeProject, refreshTrainingDatasets],
+  );
+
+  const batchRenameTrainingDataset = useCallback(
+    async (datasetId, payload, projectId = activeProject?.id) => {
+      if (!projectId || !datasetId) {
+        throw new Error("Select a training dataset first.");
+      }
+      const updated = await apiFetch(
+        `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/batch-rename`,
+        token,
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+      );
+      await refreshTrainingDatasets(projectId);
+      return updated;
+    },
+    [token, activeProject, refreshTrainingDatasets],
+  );
+
+  const writeTrainingDatasetCaptionSidecars = useCallback(
+    async (datasetId, payload, projectId = activeProject?.id) => {
+      if (!projectId || !datasetId) {
+        throw new Error("Select a training dataset first.");
+      }
+      const result = await apiFetch(
+        `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-sidecars`,
+        token,
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+      );
+      await refreshTrainingDatasets(projectId);
+      return result;
+    },
+    [token, activeProject, refreshTrainingDatasets],
+  );
+
+  const createTrainingDatasetCaptionJob = useCallback(
+    async (datasetId, payload, projectId = activeProject?.id) => {
+      if (!projectId || !datasetId) {
+        throw new Error("Select a training dataset first.");
+      }
+      const job = await apiFetch(
+        `/api/v1/projects/${projectId}/training/datasets/${encodeURIComponent(datasetId)}/caption-jobs`,
+        token,
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+      );
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+      setError("");
+      return job;
+    },
+    [token, activeProject, setJobs, setError],
+  );
+
+  const createTrainingJob = useCallback(
+    async (request, projectId = activeProject?.id) => {
+      if (!projectId) {
+        throw new Error("Select a workspace before creating a training job.");
+      }
+      const job = await apiFetch(`/api/v1/projects/${projectId}/training/jobs`, token, {
         method: "POST",
-        body: JSON.stringify(payload),
-      },
-    );
-    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-    setError("");
-    return job;
-  }
-
-  async function createTrainingJob(request, projectId = activeProject?.id) {
-    if (!projectId) {
-      throw new Error("Select a workspace before creating a training job.");
-    }
-    const job = await apiFetch(`/api/v1/projects/${projectId}/training/jobs`, token, {
-      method: "POST",
-      body: JSON.stringify(request),
-    });
-    setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
-    setError("");
-    return job;
-  }
+        body: JSON.stringify(request),
+      });
+      setJobs((items) => [job, ...items.filter((item) => item.id !== job.id)].sort(sortNewest));
+      setError("");
+      return job;
+    },
+    [token, activeProject, setJobs, setError],
+  );
 
   return {
     trainingDatasets,


### PR DESCRIPTION
## Summary
Fixes **sc-4194 / F-WEB-4** (P2, efficiency). `appContextValue` was a ~120-key object literal recreated on every App render, and every action in the data hooks (`useCharacters`, `usePresets`, `useTraining`, `useModelsAndLoras`, `usePersonTracks`, `useTimelines`) plus the App-local handlers were recreated each render. SSE `job.updated`/`worker.updated`/`queue.updated` events re-render App continuously during generation, so context identity changed on every event and defeated any `React.memo`/`useMemo` bailout in the whole consumer tree.

## Fix (the finding's primary suggested fix)
- **`useCallback` every data-hook action** — deps = `token`/`activeProject`/`requestedGpu`/stable setters/sibling actions — so identities are stable across re-renders that don't change inputs.
- **`useCallback` the App-local context handlers** (`openPreview`, `createImageJob`, `createVideoJob`, `createVqaJob`, `createInterleaveJob`, `createPlaceholderJob`, `refinePrompt`, `rememberLocalGenerationJob`, `sendAssetTo*`/`sendCharacterTo*`, `openDatasetInLibrary`, `update/delete/purge/importAsset`, `jobAction`). `createVideoJob` is hoisted above the data hooks because `useTimelines` takes it as a dependency.
- **Wrap `appContextValue` in `useMemo`** with a complete dependency array (kept adjacent to the object with a note that it must mirror it).

### Scope note / honest tradeoff
This **stabilizes the provider** so the value only changes identity when its contents actually change — the prerequisite the finding's impact explicitly calls out ("it makes future memoization impossible without first fixing the provider"). The value still legitimately changes when `jobs`/`workers`/`queue` change (it carries that data), so the remaining generation-tick re-render of *pure-action* consumers is the downstream consumer-memoization / context-split work, not part of this finding's fix.

## Tests
- New `src/hooks/hookStability.test.jsx`: asserts action identities survive an unrelated re-render for `usePresets`/`usePersonTracks`/`useCharacters` (parametrized). Verified the assertion fires on identity drift.
- Full web suite: **377 passed** (incl. the 170-test App-mount/SSE/studio/asset/character/training suite — strong evidence behavior is unchanged); `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)