### PR TITLE
refactor(web): centralize studio LoRA selection + extract picker/save panels (sc-4196)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -68,8 +68,6 @@ import {
   applyPresetDefault,
   buildStudioPresetPayload,
   finiteNumberOrUndefined,
-  loraMatchesModel,
-  loraWeight,
   presetNameTaken,
   serializeLora,
   clearPresetDefault,
@@ -78,9 +76,11 @@ import {
   slugifyPresetId,
 } from "../presetUtils.js";
 import {
+  LoraPickerSection,
   onPromptKeyDown,
   PresetGuidanceStrip,
   PresetValidationWarnings,
+  SavePresetPanel,
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
@@ -312,9 +312,6 @@ export function ImageStudio() {
   const [upscaleEnabled, setUpscaleEnabled] = useState(saved.upscaleEnabled ?? false);
   const [upscaleFactor, setUpscaleFactor] = useState(saved.upscaleFactor ?? 2);
   const [upscaleEngine, setUpscaleEngine] = useState(saved.upscaleEngine ?? "real-esrgan");
-  const [selectedLoraIds, setSelectedLoraIds] = useState(saved.selectedLoraIds ?? []);
-  const [loraWeights, setLoraWeights] = useState(saved.loraWeights ?? {});
-  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
   const [submitting, setSubmitting] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);
   // "Save as Preset" sidebar control — snapshots the current config into the
@@ -601,6 +598,20 @@ export function ImageStudio() {
     presetLoraDetails,
     presetValidationResult,
     localJobs,
+    selectedLoraIds,
+    setSelectedLoraIds,
+    loraWeights,
+    setLoraWeights,
+    showIncompatibleLoras,
+    setShowIncompatibleLoras,
+    compatibleLoras,
+    selectedLoras,
+    userSelectedLoraCount,
+    selectedLoraValidationResult,
+    loraEmptyMessage,
+    toggleLora,
+    effectiveLoraWeight,
+    setLoraWeight,
   } = useGenerationStudio({
     mode,
     presets,
@@ -618,6 +629,11 @@ export function ImageStudio() {
     latestAssets,
     trackedLocalJobs,
     initialPresetId: saved.selectedPresetId ?? null,
+    advancedOpen,
+    setAdvancedOpen,
+    initialSelectedLoraIds: saved.selectedLoraIds ?? [],
+    initialLoraWeights: saved.loraWeights ?? {},
+    initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
   });
   useEffect(() => {
     if (launchRequest?.view !== "Image" || !launchRequest.recipe) {
@@ -687,41 +703,6 @@ export function ImageStudio() {
       handleUpscaleEngineChange(upscale.engine);
     }
   }, [launchRequest?.id]);
-  const compatibleLoras = useMemo(() => loras.filter((lora) => {
-    if (lora.presetManaged) {
-      return false;
-    }
-    if (lora.installState === "missing") {
-      return false;
-    }
-    if (showIncompatibleLoras) {
-      return true;
-    }
-    return loraMatchesModel(lora, selectedModel);
-  }), [loras, selectedModel, showIncompatibleLoras]);
-  const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
-  const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
-  const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
-  const selectedLoraValidationResult = useMemo(() => {
-    const incompatible = selectedLoras.filter((lora) => !loraMatchesModel(lora, selectedModel)).map((lora) => lora.name ?? lora.id);
-    return {
-      incompatible,
-      ok: incompatible.length === 0,
-    };
-  }, [selectedLoras, selectedModel]);
-  useEffect(() => {
-    if (selectedLoraValidationResult.incompatible.length && !advancedOpen) {
-      setAdvancedOpen(true);
-    }
-  }, [advancedOpen, selectedLoraValidationResult.incompatible.length]);
-  const hasPendingCompatibleLoras = Boolean(selectedModel) && loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
-  const loraEmptyMessage = !selectedModel
-    ? "No model selected"
-    : hasPendingCompatibleLoras
-      ? "No installed compatible LoRAs. Imports appear after the Queue completes."
-      : showIncompatibleLoras
-        ? "No installed LoRAs in the library."
-        : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
   const [width, height] = resolution.split("x").map((value) => Number(value));
 
   // When restoring a snapshot, the saved count/resolution/negativePrompt already
@@ -812,33 +793,6 @@ export function ImageStudio() {
     guidanceScale: guidanceOverride,
   });
 
-  useEffect(() => {
-    setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
-  }, [compatibleLoraKey]);
-
-  function toggleLora(lora) {
-    setSelectedLoraIds((ids) => {
-      if (ids.includes(lora.id)) {
-        return ids.filter((id) => id !== lora.id);
-      }
-      const selected = ids.map((id) => compatibleLoras.find((item) => item.id === id)).filter(Boolean);
-      const userCount = selected.filter((item) => item.scope !== "builtin").length;
-      if (lora.scope !== "builtin" && userCount >= 2) {
-        return ids;
-      }
-      return [...ids, lora.id];
-    });
-  }
-
-  // Per-LoRA strength: the override map falls back to the LoRA's default weight.
-  // Order of application is intentionally not exposed — the worker combines
-  // adapters additively (set_adapters / dequant-to-bf16 merge), so order has no
-  // effect on output.
-  function effectiveLoraWeight(lora) {
-    const override = loraWeights[lora.id];
-    return Number.isFinite(override) ? override : loraWeight(lora);
-  }
-
   // Snapshot the current working config into a named recipe preset in the
   // workspace library. Captures the literal prompt + every visible knob + the
   // selected LoRAs with their weights; the seed is intentionally left out so the
@@ -904,10 +858,6 @@ export function ImageStudio() {
     } finally {
       setSavingPreset(false);
     }
-  }
-
-  function setLoraWeight(id, value) {
-    setLoraWeights((current) => ({ ...current, [id]: value }));
   }
 
   // Each stacked run carries its already-resolved completed assets + the
@@ -1374,63 +1324,17 @@ export function ImageStudio() {
               </div>
             </div>
 
-            <div className="save-preset">
-              <div className="save-preset-row">
-                <input
-                  aria-label="Preset name"
-                  className="save-preset-name"
-                  disabled={savingPreset}
-                  onChange={(event) => {
-                    setPresetName(event.target.value);
-                    if (presetSaveMessage.text) {
-                      setPresetSaveMessage({ tone: "neutral", text: "" });
-                    }
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      handleSaveAsPreset();
-                    }
-                  }}
-                  placeholder="Name this setup…"
-                  value={presetName}
-                />
-                <button
-                  className="save-preset-btn"
-                  disabled={savingPreset || !presetName.trim()}
-                  onClick={handleSaveAsPreset}
-                  type="button"
-                >
-                  <Icon.Preset size={14} /> {savingPreset ? "Saving…" : "Save as Preset"}
-                </button>
-              </div>
-              <div className="save-preset-scope scope-segment" role="radiogroup" aria-label="Preset scope">
-                <button
-                  aria-checked={presetScope === "project"}
-                  className={presetScope === "project" ? "active" : ""}
-                  disabled={!activeProject}
-                  onClick={() => setPresetScope("project")}
-                  role="radio"
-                  type="button"
-                >
-                  <Icon.Folder size={13} /> This project
-                </button>
-                <button
-                  aria-checked={presetScope === "global"}
-                  className={presetScope === "global" ? "active" : ""}
-                  onClick={() => setPresetScope("global")}
-                  role="radio"
-                  type="button"
-                >
-                  <Icon.Stars size={13} /> All projects
-                </button>
-              </div>
-              {presetSaveMessage.text ? (
-                <p className={presetSaveMessage.tone === "success" ? "inline-success" : "inline-warning"}>
-                  {presetSaveMessage.text}
-                </p>
-              ) : null}
-            </div>
+            <SavePresetPanel
+              presetName={presetName}
+              setPresetName={setPresetName}
+              savingPreset={savingPreset}
+              presetSaveMessage={presetSaveMessage}
+              setPresetSaveMessage={setPresetSaveMessage}
+              onSave={handleSaveAsPreset}
+              presetScope={presetScope}
+              setPresetScope={setPresetScope}
+              activeProject={activeProject}
+            />
 
             <div className="control-grid preset-rail-row">
               <label>
@@ -1570,64 +1474,19 @@ export function ImageStudio() {
                   Negative prompt
                   <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
                 </label>
-                <section className="lora-picker" aria-label="LoRA selection">
-                  <div>
-                    <strong>LoRAs</strong>
-                    <span>{selectedLoras.length ? `${selectedLoras.length} selected` : selectedModel ? "Installed and compatible" : "Choose a model"}</span>
-                  </div>
-                  <label className="checkline">
-                    <input
-                      checked={showIncompatibleLoras}
-                      onChange={(event) => setShowIncompatibleLoras(event.target.checked)}
-                      type="checkbox"
-                    />
-                    Show incompatible
-                  </label>
-                  {compatibleLoras.length ? (
-                    <div className="lora-choice-list">
-                      {compatibleLoras.map((lora) => {
-                        const checked = selectedLoraIds.includes(lora.id);
-                        const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
-                        const weight = effectiveLoraWeight(lora);
-                        return (
-                          <div className="lora-choice-item" key={lora.id}>
-                            <label className={checked ? "lora-choice active" : "lora-choice"}>
-                              <input
-                                checked={checked}
-                                disabled={userLimitReached}
-                                onChange={() => toggleLora(lora)}
-                                type="checkbox"
-                              />
-                              <span>
-                                <strong>{lora.name ?? lora.id}</strong>
-                                <small>
-                                  {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
-                                </small>
-                              </span>
-                            </label>
-                            {checked ? (
-                              <div className="lora-weight-row">
-                                <span>Weight</span>
-                                <input
-                                  aria-label={`${lora.name ?? lora.id} weight`}
-                                  max="2"
-                                  min="0"
-                                  onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
-                                  step="0.05"
-                                  type="range"
-                                  value={weight}
-                                />
-                                <span className="lora-weight-value">{weight.toFixed(2)}</span>
-                              </div>
-                            ) : null}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  ) : (
-                    <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
-                  )}
-                </section>
+                <LoraPickerSection
+                  selectedModel={selectedModel}
+                  selectedLoras={selectedLoras}
+                  selectedLoraIds={selectedLoraIds}
+                  compatibleLoras={compatibleLoras}
+                  userSelectedLoraCount={userSelectedLoraCount}
+                  showIncompatibleLoras={showIncompatibleLoras}
+                  setShowIncompatibleLoras={setShowIncompatibleLoras}
+                  toggleLora={toggleLora}
+                  effectiveLoraWeight={effectiveLoraWeight}
+                  setLoraWeight={setLoraWeight}
+                  loraEmptyMessage={loraEmptyMessage}
+                />
               </div>
             ) : null}
 

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -65,8 +65,6 @@ import {
   clearPresetDefault,
   finiteNumberOrUndefined,
   loraLooksLikeIcLora,
-  loraMatchesModel,
-  loraWeight,
   noPresetId,
   presetNameTaken,
   rememberPresetDefault,
@@ -74,9 +72,11 @@ import {
   slugifyPresetId,
 } from "../presetUtils.js";
 import {
+  LoraPickerSection,
   onPromptKeyDown,
   PresetGuidanceStrip,
   PresetValidationWarnings,
+  SavePresetPanel,
   useGenerationStudio,
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel, findReplacementModel } from "./ReplacePersonPanel.jsx";
@@ -173,9 +173,6 @@ export function VideoStudio() {
   const [precision, setPrecision] = useState(saved.precision ?? "fp8");
   const [quantization, setQuantization] = useState(saved.quantization ?? "auto");
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
-  const [selectedLoraIds, setSelectedLoraIds] = useState(saved.selectedLoraIds ?? []);
-  const [loraWeights, setLoraWeights] = useState(saved.loraWeights ?? {});
-  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(saved.showIncompatibleLoras ?? false);
   const [model, setModel] = useState(saved.model ?? videoModels[0]?.id ?? ltxVideoModelId);
   const [guideOpen, setGuideOpen] = useState(false);
   // Mac UI gating (sc-3486): hide torch-only video models (e.g. SVD) and snap off one if selected.
@@ -268,6 +265,20 @@ export function VideoStudio() {
     presetLoraDetails,
     presetValidationResult,
     localJobs,
+    selectedLoraIds,
+    setSelectedLoraIds,
+    loraWeights,
+    setLoraWeights,
+    showIncompatibleLoras,
+    setShowIncompatibleLoras,
+    compatibleLoras,
+    selectedLoras,
+    userSelectedLoraCount,
+    selectedLoraValidationResult,
+    loraEmptyMessage,
+    toggleLora,
+    effectiveLoraWeight,
+    setLoraWeight,
   } = useGenerationStudio({
     mode,
     presets,
@@ -285,6 +296,11 @@ export function VideoStudio() {
     latestAssets,
     trackedLocalJobs,
     initialPresetId: saved.selectedPresetId ?? null,
+    advancedOpen,
+    setAdvancedOpen,
+    initialSelectedLoraIds: saved.selectedLoraIds ?? [],
+    initialLoraWeights: saved.loraWeights ?? {},
+    initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
   });
   // Sampler / scheduler menus declared by the model. Video Wan torch
   // declares the full menu; sealed paths (LTX native, MLX) drop to
@@ -313,69 +329,6 @@ export function VideoStudio() {
   }, [schedulerOptions, scheduler, selectedModel]);
   const requiresLtxIcLora = selectedModel?.id === ltxVideoModelId && ltxIcLoraRequiredModes.has(mode);
   const hasLtxIcLora = presetLoraDetails.some((lora) => !lora.missing && loraLooksLikeIcLora(lora));
-  const compatibleLoras = useMemo(() => loras.filter((lora) => {
-    if (lora.presetManaged) {
-      return false;
-    }
-    if (lora.installState === "missing") {
-      return false;
-    }
-    if (showIncompatibleLoras) {
-      return true;
-    }
-    return loraMatchesModel(lora, selectedModel);
-  }), [loras, selectedModel, showIncompatibleLoras]);
-  const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
-  const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
-  const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
-  const selectedLoraValidationResult = useMemo(() => {
-    const incompatible = selectedLoras.filter((lora) => !loraMatchesModel(lora, selectedModel)).map((lora) => lora.name ?? lora.id);
-    return {
-      incompatible,
-      ok: incompatible.length === 0,
-    };
-  }, [selectedLoras, selectedModel]);
-  const hasPendingCompatibleLoras = Boolean(selectedModel) && loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
-  const loraEmptyMessage = !selectedModel
-    ? "No model selected"
-    : hasPendingCompatibleLoras
-      ? "No installed compatible LoRAs. Imports appear after the Queue completes."
-      : showIncompatibleLoras
-        ? "No installed LoRAs in the library."
-        : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
-
-  useEffect(() => {
-    setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
-  }, [compatibleLoraKey]);
-
-  useEffect(() => {
-    if (selectedLoraValidationResult.incompatible.length && !advancedOpen) {
-      setAdvancedOpen(true);
-    }
-  }, [advancedOpen, selectedLoraValidationResult.incompatible.length]);
-
-  function toggleLora(lora) {
-    setSelectedLoraIds((ids) => {
-      if (ids.includes(lora.id)) {
-        return ids.filter((id) => id !== lora.id);
-      }
-      const selected = ids.map((id) => compatibleLoras.find((item) => item.id === id)).filter(Boolean);
-      const userCount = selected.filter((item) => item.scope !== "builtin").length;
-      if (lora.scope !== "builtin" && userCount >= 2) {
-        return ids;
-      }
-      return [...ids, lora.id];
-    });
-  }
-
-  // Per-LoRA strength: the override map falls back to the LoRA's default weight.
-  // Order of application is intentionally not exposed — the worker combines
-  // adapters additively (set_adapters / dequant-to-bf16 merge), so order has no
-  // effect on output.
-  function effectiveLoraWeight(lora) {
-    const override = loraWeights[lora.id];
-    return Number.isFinite(override) ? override : loraWeight(lora);
-  }
 
   // Snapshot the current working config into a named recipe preset in the
   // workspace library. Captures the literal prompt + every visible knob + the
@@ -448,10 +401,6 @@ export function VideoStudio() {
     } finally {
       setSavingPreset(false);
     }
-  }
-
-  function setLoraWeight(id, value) {
-    setLoraWeights((current) => ({ ...current, [id]: value }));
   }
 
   useEffect(() => {
@@ -1183,64 +1132,19 @@ export function VideoStudio() {
                 </div>
               </div>
 
-              <div className="save-preset">
-                <div className="save-preset-row">
-                  <input
-                    aria-label="Preset name"
-                    className="save-preset-name"
-                    disabled={savingPreset}
-                    onChange={(event) => {
-                      setPresetName(event.target.value);
-                      if (presetSaveMessage.text) {
-                        setPresetSaveMessage({ tone: "neutral", text: "" });
-                      }
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter") {
-                        event.preventDefault();
-                        handleSaveAsPreset();
-                      }
-                    }}
-                    placeholder="Name this setup…"
-                    value={presetName}
-                  />
-                  <button
-                    className="save-preset-btn"
-                    disabled={savingPreset || !presetName.trim() || !VIDEO_PRESET_MODES.includes(mode)}
-                    onClick={handleSaveAsPreset}
-                    title={VIDEO_PRESET_MODES.includes(mode) ? undefined : "Presets are available in Image→Video, Text→Video, or First/Last mode."}
-                    type="button"
-                  >
-                    <Icon.Preset size={14} /> {savingPreset ? "Saving…" : "Save as Preset"}
-                  </button>
-                </div>
-                <div className="save-preset-scope scope-segment" role="radiogroup" aria-label="Preset scope">
-                  <button
-                    aria-checked={presetScope === "project"}
-                    className={presetScope === "project" ? "active" : ""}
-                    disabled={!activeProject}
-                    onClick={() => setPresetScope("project")}
-                    role="radio"
-                    type="button"
-                  >
-                    <Icon.Folder size={13} /> This project
-                  </button>
-                  <button
-                    aria-checked={presetScope === "global"}
-                    className={presetScope === "global" ? "active" : ""}
-                    onClick={() => setPresetScope("global")}
-                    role="radio"
-                    type="button"
-                  >
-                    <Icon.Stars size={13} /> All projects
-                  </button>
-                </div>
-                {presetSaveMessage.text ? (
-                  <p className={presetSaveMessage.tone === "success" ? "inline-success" : "inline-warning"}>
-                    {presetSaveMessage.text}
-                  </p>
-                ) : null}
-              </div>
+              <SavePresetPanel
+                presetName={presetName}
+                setPresetName={setPresetName}
+                savingPreset={savingPreset}
+                presetSaveMessage={presetSaveMessage}
+                setPresetSaveMessage={setPresetSaveMessage}
+                onSave={handleSaveAsPreset}
+                presetScope={presetScope}
+                setPresetScope={setPresetScope}
+                activeProject={activeProject}
+                saveDisabled={!VIDEO_PRESET_MODES.includes(mode)}
+                saveTitle={VIDEO_PRESET_MODES.includes(mode) ? undefined : "Presets are available in Image→Video, Text→Video, or First/Last mode."}
+              />
 
               <label>
                 Quality
@@ -1523,64 +1427,19 @@ export function VideoStudio() {
                     Negative prompt
                     <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
                   </label>
-                  <section className="lora-picker" aria-label="LoRA selection">
-                    <div>
-                      <strong>LoRAs</strong>
-                      <span>{selectedLoras.length ? `${selectedLoras.length} selected` : selectedModel ? "Installed and compatible" : "Choose a model"}</span>
-                    </div>
-                    <label className="checkline">
-                      <input
-                        checked={showIncompatibleLoras}
-                        onChange={(event) => setShowIncompatibleLoras(event.target.checked)}
-                        type="checkbox"
-                      />
-                      Show incompatible
-                    </label>
-                    {compatibleLoras.length ? (
-                      <div className="lora-choice-list">
-                        {compatibleLoras.map((lora) => {
-                          const checked = selectedLoraIds.includes(lora.id);
-                          const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
-                          const weight = effectiveLoraWeight(lora);
-                          return (
-                            <div className="lora-choice-item" key={lora.id}>
-                              <label className={checked ? "lora-choice active" : "lora-choice"}>
-                                <input
-                                  checked={checked}
-                                  disabled={userLimitReached}
-                                  onChange={() => toggleLora(lora)}
-                                  type="checkbox"
-                                />
-                                <span>
-                                  <strong>{lora.name ?? lora.id}</strong>
-                                  <small>
-                                    {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
-                                  </small>
-                                </span>
-                              </label>
-                              {checked ? (
-                                <div className="lora-weight-row">
-                                  <span>Weight</span>
-                                  <input
-                                    aria-label={`${lora.name ?? lora.id} weight`}
-                                    max="2"
-                                    min="0"
-                                    onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
-                                    step="0.05"
-                                    type="range"
-                                    value={weight}
-                                  />
-                                  <span className="lora-weight-value">{weight.toFixed(2)}</span>
-                                </div>
-                              ) : null}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
-                    )}
-                  </section>
+                  <LoraPickerSection
+                    selectedModel={selectedModel}
+                    selectedLoras={selectedLoras}
+                    selectedLoraIds={selectedLoraIds}
+                    compatibleLoras={compatibleLoras}
+                    userSelectedLoraCount={userSelectedLoraCount}
+                    showIncompatibleLoras={showIncompatibleLoras}
+                    setShowIncompatibleLoras={setShowIncompatibleLoras}
+                    toggleLora={toggleLora}
+                    effectiveLoraWeight={effectiveLoraWeight}
+                    setLoraWeight={setLoraWeight}
+                    loraEmptyMessage={loraEmptyMessage}
+                  />
                   {characterId ? (
                     <div className="guidance-strip">
                       <strong>Character reference</strong>

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
 import { terminalStatuses } from "../jobTypes.js";
 import {
+  loraMatchesModel,
+  loraWeight,
   noPresetId,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
@@ -95,9 +98,21 @@ export function useGenerationStudio({
   latestAssets,
   trackedLocalJobs,
   initialPresetId = null,
+  // sc-4196: LoRA selection state + validation, formerly duplicated in both studios.
+  // Seeded from the persisted studio snapshot; advancedOpen/setAdvancedOpen are the
+  // studio's own advanced-panel toggle (the hook auto-opens it when an incompatible
+  // LoRA is selected so the blocking warning is visible).
+  advancedOpen = false,
+  setAdvancedOpen = () => {},
+  initialSelectedLoraIds = [],
+  initialLoraWeights = {},
+  initialShowIncompatibleLoras = false,
 }) {
   const [selectedPresetId, setSelectedPresetId] = useState(initialPresetId);
   const [resultFallbackTick, setResultFallbackTick] = useState(0);
+  const [selectedLoraIds, setSelectedLoraIds] = useState(initialSelectedLoraIds);
+  const [loraWeights, setLoraWeights] = useState(initialLoraWeights);
+  const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(initialShowIncompatibleLoras);
 
   // Snap the model back into range when the catalog changes out from under it.
   useEffect(() => {
@@ -189,6 +204,77 @@ export function useGenerationStudio({
     [assets, latestAssets, trackedLocalJobs, resultFallbackTick],
   );
 
+  // ---- LoRA selection (sc-4196: shared by Image + Video studios) ----
+  const compatibleLoras = useMemo(() => loras.filter((lora) => {
+    if (lora.presetManaged) {
+      return false;
+    }
+    if (lora.installState === "missing") {
+      return false;
+    }
+    if (showIncompatibleLoras) {
+      return true;
+    }
+    return loraMatchesModel(lora, selectedModel);
+  }), [loras, selectedModel, showIncompatibleLoras]);
+  const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
+  const selectedLoras = selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean);
+  const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
+  const selectedLoraValidationResult = useMemo(() => {
+    const incompatible = selectedLoras.filter((lora) => !loraMatchesModel(lora, selectedModel)).map((lora) => lora.name ?? lora.id);
+    return {
+      incompatible,
+      ok: incompatible.length === 0,
+    };
+  }, [selectedLoras, selectedModel]);
+  const hasPendingCompatibleLoras = Boolean(selectedModel) && loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
+  const loraEmptyMessage = !selectedModel
+    ? "No model selected"
+    : hasPendingCompatibleLoras
+      ? "No installed compatible LoRAs. Imports appear after the Queue completes."
+      : showIncompatibleLoras
+        ? "No installed LoRAs in the library."
+        : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
+
+  // Drop selections that fall out of the compatible set (model/filter change).
+  useEffect(() => {
+    setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
+  }, [compatibleLoraKey]);
+  // Auto-open the advanced panel when an incompatible LoRA is selected so the
+  // generate-blocking warning is visible.
+  useEffect(() => {
+    if (selectedLoraValidationResult.incompatible.length && !advancedOpen) {
+      setAdvancedOpen(true);
+    }
+  }, [advancedOpen, selectedLoraValidationResult.incompatible.length]);
+
+  function toggleLora(lora) {
+    setSelectedLoraIds((ids) => {
+      if (ids.includes(lora.id)) {
+        return ids.filter((id) => id !== lora.id);
+      }
+      const selected = ids.map((id) => compatibleLoras.find((item) => item.id === id)).filter(Boolean);
+      const userCount = selected.filter((item) => item.scope !== "builtin").length;
+      if (lora.scope !== "builtin" && userCount >= 2) {
+        return ids;
+      }
+      return [...ids, lora.id];
+    });
+  }
+
+  // Per-LoRA strength: the override map falls back to the LoRA's default weight.
+  // Order of application is intentionally not exposed — the worker combines
+  // adapters additively (set_adapters / dequant-to-bf16 merge), so order has no
+  // effect on output.
+  function effectiveLoraWeight(lora) {
+    const override = loraWeights[lora.id];
+    return Number.isFinite(override) ? override : loraWeight(lora);
+  }
+
+  function setLoraWeight(id, value) {
+    setLoraWeights((current) => ({ ...current, [id]: value }));
+  }
+
   return {
     availablePresets,
     selectedPreset,
@@ -198,7 +284,180 @@ export function useGenerationStudio({
     presetLoraDetails,
     presetValidationResult,
     localJobs,
+    // LoRA selection bundle (sc-4196).
+    selectedLoraIds,
+    setSelectedLoraIds,
+    loraWeights,
+    setLoraWeights,
+    showIncompatibleLoras,
+    setShowIncompatibleLoras,
+    compatibleLoras,
+    selectedLoras,
+    userSelectedLoraCount,
+    selectedLoraValidationResult,
+    loraEmptyMessage,
+    toggleLora,
+    effectiveLoraWeight,
+    setLoraWeight,
   };
+}
+
+// The LoRA picker shared by both studios (sc-4196): the compatible-LoRA checklist
+// with per-LoRA weight sliders, the "Show incompatible" toggle, and the empty state.
+// All state lives in useGenerationStudio; this is a pure presentation of its bundle.
+export function LoraPickerSection({
+  selectedModel,
+  selectedLoras,
+  selectedLoraIds,
+  compatibleLoras,
+  userSelectedLoraCount,
+  showIncompatibleLoras,
+  setShowIncompatibleLoras,
+  toggleLora,
+  effectiveLoraWeight,
+  setLoraWeight,
+  loraEmptyMessage,
+}) {
+  return (
+    <section className="lora-picker" aria-label="LoRA selection">
+      <div>
+        <strong>LoRAs</strong>
+        <span>{selectedLoras.length ? `${selectedLoras.length} selected` : selectedModel ? "Installed and compatible" : "Choose a model"}</span>
+      </div>
+      <label className="checkline">
+        <input
+          checked={showIncompatibleLoras}
+          onChange={(event) => setShowIncompatibleLoras(event.target.checked)}
+          type="checkbox"
+        />
+        Show incompatible
+      </label>
+      {compatibleLoras.length ? (
+        <div className="lora-choice-list">
+          {compatibleLoras.map((lora) => {
+            const checked = selectedLoraIds.includes(lora.id);
+            const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= 2;
+            const weight = effectiveLoraWeight(lora);
+            return (
+              <div className="lora-choice-item" key={lora.id}>
+                <label className={checked ? "lora-choice active" : "lora-choice"}>
+                  <input
+                    checked={checked}
+                    disabled={userLimitReached}
+                    onChange={() => toggleLora(lora)}
+                    type="checkbox"
+                  />
+                  <span>
+                    <strong>{lora.name ?? lora.id}</strong>
+                    <small>
+                      {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
+                    </small>
+                  </span>
+                </label>
+                {checked ? (
+                  <div className="lora-weight-row">
+                    <span>Weight</span>
+                    <input
+                      aria-label={`${lora.name ?? lora.id} weight`}
+                      max="2"
+                      min="0"
+                      onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
+                      step="0.05"
+                      type="range"
+                      value={weight}
+                    />
+                    <span className="lora-weight-value">{weight.toFixed(2)}</span>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
+      )}
+    </section>
+  );
+}
+
+// The "Save as Preset" panel shared by both studios (sc-4196): name field, save
+// button, project/global scope segment, and the inline save message. The actual
+// save handler differs per studio (different payloads), so it's passed as onSave.
+export function SavePresetPanel({
+  presetName,
+  setPresetName,
+  savingPreset,
+  presetSaveMessage,
+  setPresetSaveMessage,
+  onSave,
+  presetScope,
+  setPresetScope,
+  activeProject,
+  // Video studio gates saving to a subset of modes; pass an extra disable + a
+  // tooltip explaining why. Image studio omits both (always saveable).
+  saveDisabled = false,
+  saveTitle = undefined,
+}) {
+  return (
+    <div className="save-preset">
+      <div className="save-preset-row">
+        <input
+          aria-label="Preset name"
+          className="save-preset-name"
+          disabled={savingPreset}
+          onChange={(event) => {
+            setPresetName(event.target.value);
+            if (presetSaveMessage.text) {
+              setPresetSaveMessage({ tone: "neutral", text: "" });
+            }
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              onSave();
+            }
+          }}
+          placeholder="Name this setup…"
+          value={presetName}
+        />
+        <button
+          className="save-preset-btn"
+          disabled={savingPreset || !presetName.trim() || saveDisabled}
+          onClick={onSave}
+          title={saveTitle}
+          type="button"
+        >
+          <Icon.Preset size={14} /> {savingPreset ? "Saving…" : "Save as Preset"}
+        </button>
+      </div>
+      <div className="save-preset-scope scope-segment" role="radiogroup" aria-label="Preset scope">
+        <button
+          aria-checked={presetScope === "project"}
+          className={presetScope === "project" ? "active" : ""}
+          disabled={!activeProject}
+          onClick={() => setPresetScope("project")}
+          role="radio"
+          type="button"
+        >
+          <Icon.Folder size={13} /> This project
+        </button>
+        <button
+          aria-checked={presetScope === "global"}
+          className={presetScope === "global" ? "active" : ""}
+          onClick={() => setPresetScope("global")}
+          role="radio"
+          type="button"
+        >
+          <Icon.Stars size={13} /> All projects
+        </button>
+      </div>
+      {presetSaveMessage.text ? (
+        <p className={presetSaveMessage.tone === "success" ? "inline-success" : "inline-warning"}>
+          {presetSaveMessage.text}
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 // The "what this preset adds" strip shown under the preset picker in both studios.


### PR DESCRIPTION
## Summary
Fixes **sc-4196 / F-WEB-7** (P2, redundant). ImageStudio and VideoStudio duplicated the entire LoRA selection machinery — `compatibleLoras`/`compatibleLoraKey`/`selectedLoras`/`selectedLoraValidationResult`/`loraEmptyMessage`, the prune-on-model-change and auto-open-advanced effects, and `toggleLora`/`effectiveLoraWeight`/`setLoraWeight` (the 2-user-LoRA cap rule lived in **three** places) — plus near-identical LoRA-picker and Save-as-Preset JSX. ~300 duplicated lines that had already been patched in tandem several times.

## Fix
- **Move the LoRA selection state + validation into `useGenerationStudio`** (which both studios already call): `selectedLoraIds`/`loraWeights`/`showIncompatibleLoras` (seeded from the persisted snapshot via new `initial*` args), the derived `compatibleLoras`/`selectedLoras`/`selectedLoraValidationResult`/`loraEmptyMessage`, the two effects, and `toggleLora`/`effectiveLoraWeight`/`setLoraWeight`. The hook returns the bundle under the **same names** the studios used, so the persistence/launch/generate code is untouched. `advancedOpen`/`setAdvancedOpen` are passed in for the auto-open-on-incompatible effect.
- **Extract `<LoraPickerSection>` and `<SavePresetPanel>`** into `generationStudio.jsx`, next to the existing `PresetGuidanceStrip`/`PresetValidationWarnings`. `handleSaveAsPreset` stays per-studio (different payloads); VideoStudio's mode-gated save-disable + tooltip ride along as optional `saveDisabled`/`saveTitle` props (ImageStudio omits both, preserving its always-saveable behavior).

## Tests
- Full web suite: **377 passed**. `ImageStudio.test.jsx` (6), `VideoStudio.test.jsx` (3), and `main.test.jsx` (170) drive the LoRA picker (toggle, weights, 2-user cap) and preset save through the new shared code — direct regression coverage.
- `vite build` clean. Studios shrink ~380 duplicated lines for +259 shared (net −23, with the dedup concentrated into one place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)