### PR TITLE
Fix training base-model path resolution (HF-cache snapshot + converted MLX models)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1,6 +1,6 @@
 use super::auth::requires_token;
 use super::events::{EventHub, EventMessage};
-use super::training::insufficient_disk_space;
+use super::training::{insufficient_disk_space, resolve_base_model_path};
 use super::workers::person_readiness_from_workers;
 use super::{
     create_app, huggingface_repo_cache_path, inject_converted_model_path, inprocess_worker_gpu_id,
@@ -7659,4 +7659,92 @@ mod recipe_presets_parity {
         assert!(preset["id"] != "cinematic", "new id is different");
         assert!(preset["name"] != "My Cinematic", "new name is different");
     }
+}
+
+#[test]
+fn resolve_base_model_path_descends_into_hf_snapshot() {
+    // Trainers read their weight tree (z-image/sdxl: tokenizer/ text_encoder/ unet|transformer/
+    // vae/; ltx: transformer.safetensors / vae_*.safetensors / connector.safetensors) from inside
+    // the HF snapshot dir, not the repo cache root. Resolving to the repo root made every
+    // HF-cache base model fail at trainer load — z-image "tokenizer: No such file or directory",
+    // sdxl "read vocab.json: No such file or directory", ltx "Path must point to a local file".
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = super::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "z_image_turbo")
+        .expect("z_image_turbo target");
+    let repo = target.base_model_repo.clone().expect("repo set");
+
+    // Materialize an HF hub cache: refs/main -> a snapshot holding the tokenizer.
+    let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");
+    let revision = "abc123";
+    let snapshot = repo_root.join("snapshots").join(revision);
+    std::fs::create_dir_all(snapshot.join("tokenizer")).expect("create snapshot tree");
+    std::fs::write(snapshot.join("tokenizer").join("tokenizer.json"), "{}")
+        .expect("write tokenizer.json");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("create refs");
+    std::fs::write(repo_root.join("refs").join("main"), revision).expect("write refs/main");
+
+    let resolved = resolve_base_model_path(&target, &data_dir);
+
+    assert_eq!(
+        resolved,
+        snapshot.display().to_string(),
+        "resolver must descend into the snapshot dir, not stop at the repo root"
+    );
+    assert!(
+        std::path::Path::new(&resolved)
+            .join("tokenizer")
+            .join("tokenizer.json")
+            .is_file(),
+        "the component tree must be reachable from the resolved path"
+    );
+}
+
+#[test]
+fn resolve_base_model_path_prefers_converted_mlx_dir_for_conversion_models() {
+    // `requiresConversion` models (Wan) keep usable weights in <data>/models/mlx/<id>, while the
+    // HF cache holds only the native *source* checkpoint the converter consumes. Resolving Wan
+    // training to the HF source made the trainer fail ("wan umt5 tokenizer: No such file"); it
+    // must read the converted dir, mirroring inference's local_mlx_dir.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = super::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "wan_2_2")
+        .expect("wan_2_2 (TI2V-5B) target");
+    let repo = target.base_model_repo.clone().expect("repo set");
+
+    // Materialize BOTH: the HF source snapshot (native checkpoint) and the converted MLX dir.
+    // The converted dir must win.
+    let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");
+    let snapshot = repo_root.join("snapshots").join("rev0");
+    std::fs::create_dir_all(&snapshot).expect("create snapshot");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("create refs");
+    std::fs::write(repo_root.join("refs").join("main"), "rev0").expect("write refs/main");
+
+    let converted = data_dir.join("models").join("mlx").join("wan_2_2");
+    std::fs::create_dir_all(&converted).expect("create converted dir");
+    std::fs::write(converted.join("config.json"), "{}").expect("write config.json");
+
+    let resolved = resolve_base_model_path(&target, &data_dir);
+
+    assert_eq!(
+        resolved,
+        converted.display().to_string(),
+        "conversion models must resolve to the converted MLX dir, not the HF source snapshot"
+    );
+
+    // Without the converted dir (config.json gates it), it falls back to the HF snapshot.
+    std::fs::remove_file(converted.join("config.json")).expect("remove config.json");
+    assert_eq!(
+        resolve_base_model_path(&target, &data_dir),
+        snapshot.display().to_string(),
+        "with no converted dir, fall back to the HF snapshot"
+    );
 }

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -519,11 +519,22 @@ pub(crate) async fn create_training_job(
     Ok((StatusCode::CREATED, Json(job)))
 }
 
-/// Absolute path to the target's base model weights on the worker host. Prefers
-/// the Hugging Face hub cache for the target's repo, falling back to the local
-/// models directory. The path need not exist yet — model installation is a
-/// separate job; the dry-run plan only records where the kernel will read from.
+/// Absolute path to the target's base model weights on the worker host. Prefers a
+/// locally-converted MLX model dir (`requiresConversion` models like Wan), then the
+/// Hugging Face hub snapshot for the target's repo, falling back to the local models
+/// directory. The path need not exist yet — model installation is a separate job; the
+/// dry-run plan only records where the kernel will read from.
 pub(crate) fn resolve_base_model_path(target: &TrainingTarget, data_dir: &FsPath) -> String {
+    // Locally-converted MLX model: `requiresConversion` models (Wan TI2V-5B / A14B) keep
+    // their usable weights in the app-managed `<data>/models/mlx/<id>` tree, NOT the HF cache
+    // — which holds only the native *source* checkpoint the converter consumes. Inference reads
+    // the converted dir via `video_jobs::local_mlx_dir` (gated on `config.json`); training must
+    // read the same tree, so prefer it whenever it is populated. The converted dir is keyed by
+    // the manifest model id, which equals `target.base_model` for every conversion target.
+    let converted = data_dir.join("models").join("mlx").join(&target.base_model);
+    if converted.join("config.json").is_file() {
+        return converted.display().to_string();
+    }
     if let Some(repo) = target
         .base_model_repo
         .as_deref()
@@ -531,6 +542,15 @@ pub(crate) fn resolve_base_model_path(target: &TrainingTarget, data_dir: &FsPath
         .filter(|repo| !repo.is_empty())
     {
         if let Some(cache_path) = huggingface_repo_cache_path(data_dir, repo) {
+            // The diffusers component tree (tokenizer/ text_encoder/ transformer/ vae/) the
+            // trainer and pipeline read lives inside the resolved snapshot dir
+            // (snapshots/<rev>/), not at the repo cache root — which holds only blobs/ refs/
+            // snapshots/. Descend into the main snapshot so callers get a usable component
+            // root, exactly as inference does. Fall back to the cache root when no snapshot is
+            // materialized yet (the path need not exist at dry-run time).
+            if let Some(snapshot) = huggingface_snapshot_dirs(&cache_path).into_iter().next() {
+                return snapshot.display().to_string();
+            }
             return cache_path.display().to_string();
         }
     }


### PR DESCRIPTION
## Summary

Training's `resolve_base_model_path` handed trainers the wrong directory in two ways, both surfacing as missing-file errors at `mlx_gen::load_trainer`. Inference resolves these correctly; training never mirrored it.

### 1. HF-cache snapshot descent — [sc-4564](https://app.shortcut.com/trefry/story/4564)
It returned the HF repo **cache root** (`models--.../`, which holds only `blobs/ refs/ snapshots/`) instead of the snapshot dir one level down where the component tree lives. Every HF-cache base model failed at load:
- z-image-turbo → `tokenizer: No such file or directory`
- sdxl → `sdxl tokenizer: read vocab.json: No such file or directory`
- ltx_2_3 → `safetensors I/O failed: Path must point to a local file`

Now descends into the main snapshot (`huggingface_snapshot_dirs(..).next()`, main-first), falling back to the cache root for the not-yet-materialized dry-run case.

### 2. Converted-MLX models — [sc-4571](https://app.shortcut.com/trefry/story/4571)
`requiresConversion` models (Wan) keep usable weights in `<data>/models/mlx/<id>`; the HF cache holds only the **native source** checkpoint the converter consumes. Training pointed the trainer at the source, so `wan2_2_ti2v_5b` failed `wan umt5 tokenizer: No such file`. Now prefers the converted dir (gated on `config.json`), mirroring inference's `video_jobs::local_mlx_dir`. The converted dir is keyed by the manifest model id, which equals `target.base_model` for every conversion target.

The install-health check (`training_base_model_installed`) correctly operates on the repo cache root and is unchanged.

## Tests
- `resolve_base_model_path_descends_into_hf_snapshot`
- `resolve_base_model_path_prefers_converted_mlx_dir_for_conversion_models`
- Full `-p sceneworks-rust-api` training suite green; `fmt`/`clippy` clean.

## Out of scope / follow-ups
- **Wan data-state** (done on dev machine, not code): the canonical `models/mlx/wan_2_2` held a stale 14B config and the real 5B weights sat under a hand-named `wan_2_2_ti2v_5b`. Both deleted; native checkpoint is cached for reconvert. ⚠️ After reconvert, verify the canonical dir gets a `ti2v`/2.2 config — there's a chance the convert job itself mis-emits (see sc-4571).
- **Kolors training** ([sc-4568](https://app.shortcut.com/trefry/story/4568)) is a separate gap (no Rust trainer exists → falls back to MPS); not addressed here.
- Training does not mirror inference's Wan env overrides (`SCENEWORKS_MLX_WAN5B_DIR` etc.) — minor parity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)