### PR TITLE
refactor(web): replace global error string with a per-kind notices store (sc-4198)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -84,12 +84,14 @@ function isInterleaveJob(job) {
   return job.type === "image_interleave";
 }
 
-function isLoraImportNotice(message) {
-  return String(message ?? "").startsWith("lora import: ");
-}
-
-function isLoraTrainingNotice(message) {
-  return String(message ?? "").startsWith("lora training: ");
+// sc-4198: notice kind for a job-failure banner. LoRA import/train failures get
+// their own kind so the matching job's later completion dismisses exactly that
+// banner (replacing the old "lora import:"/"lora training:" startsWith protocol);
+// everything else is a general error.
+function noticeKindForJob(job) {
+  if (job?.type === "lora_import") return "lora-import";
+  if (job?.type === "lora_train") return "lora-train";
+  return "general";
 }
 
 function jobFreshnessMs(job) {
@@ -486,7 +488,25 @@ export function App() {
     setPreviewAsset(null);
   };
   const [studioLaunch, setStudioLaunch] = useState(null);
-  const [error, setError] = useState("");
+  // sc-4198: a small notices store replaces the single `error` string that used to
+  // double as a message bus — the fragile "lora import:"/"lora training:" startsWith
+  // protocol. Each notice has a stable `kind`; pushing a kind replaces only that kind
+  // and dismissing clears only that kind, so an unrelated success (or a background SSE
+  // refresh) no longer wipes an unread, still-relevant notice of a different kind.
+  const [notices, setNotices] = useState([]);
+  const pushNotice = useCallback((kind, message) => {
+    const text = String(message ?? "");
+    setNotices((current) => {
+      const others = current.filter((notice) => notice.kind !== kind);
+      return text ? [...others, { kind, message: text }] : others;
+    });
+  }, []);
+  const dismissNoticeKind = useCallback((kind) => {
+    setNotices((current) => current.filter((notice) => notice.kind !== kind));
+  }, []);
+  // Back-compat: the existing setError(msg)/setError("") call sites map onto the
+  // "general" notice kind — a truthy message replaces it, "" dismisses only it.
+  const setError = useCallback((message) => pushNotice("general", message), [pushNotice]);
   const [theme, setTheme] = useState(readStoredTheme);
   // Apply a theme and persist it through the API. localStorage gives an instant
   // initial paint, but on the desktop shell the UI runs at the API's per-launch
@@ -971,19 +991,19 @@ export function App() {
         refreshData();
       }
       if (job.status === "completed" && job.type === "lora_import") {
-        setError((current) => (isLoraImportNotice(current) ? "" : current));
+        dismissNoticeKind("lora-import");
         refreshDataWithLoraOverlay(job.projectId ?? activeProjectRef.current?.id);
       }
       if (job.status === "completed" && job.type === "lora_train" && job.payload?.dryRun === false) {
         if (job.result?.loraRegistered === false) {
-          setError(`lora training: ${job.result?.loraRegistrationError ?? "Completed training but could not register the LoRA."}`);
+          pushNotice("lora-train", `lora training: ${job.result?.loraRegistrationError ?? "Completed training but could not register the LoRA."}`);
         } else {
-          setError((current) => (isLoraTrainingNotice(current) ? "" : current));
+          dismissNoticeKind("lora-train");
           refreshDataWithLoraOverlay(job.projectId ?? activeProjectRef.current?.id);
         }
       }
       if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
-        setError(failedJobNotice(job));
+        pushNotice(noticeKindForJob(job), failedJobNotice(job));
       }
     }
 
@@ -1834,7 +1854,9 @@ export function App() {
           </button>
         </header>
 
-        {error ? <p className="notice error">{error}</p> : null}
+        {notices.map((notice) => (
+          <p className="notice error" key={notice.kind}>{notice.message}</p>
+        ))}
 
         {access.authRequired && !window.localStorage.getItem("sceneworks-token") ? (
           <section className="auth-band">

--- a/apps/web/src/main.test.jsx
+++ b/apps/web/src/main.test.jsx
@@ -4551,6 +4551,80 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("lora import: LoRA manifestPath must target");
   });
 
+  // sc-4198 regression: notices are kept per-kind, so a LoRA-import banner and a
+  // LoRA-train banner coexist, and clearing one (here, the LoRA import's later
+  // completion) leaves the unrelated, still-relevant notice untouched — unlike the
+  // old single `error` string where any clear wiped everything.
+  it("keeps an unrelated notice when a LoRA import notice clears", async () => {
+    global.fetch.mockImplementation((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    // A LoRA import fails (kind "lora-import") and a LoRA training run completes but
+    // fails to register (kind "lora-train") — both banners show at once.
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "lora-import-job-1",
+          type: "lora_import",
+          status: "failed",
+          createdAt: "2026-05-18T00:00:00Z",
+          error: "manifest write failed",
+          payload: { loraId: "detail_lora", family: "z-image" },
+        }),
+      });
+    });
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "lora-train-job-1",
+          type: "lora_train",
+          status: "completed",
+          createdAt: "2026-05-18T00:00:01Z",
+          payload: { dryRun: false },
+          result: { loraRegistered: false, loraRegistrationError: "registry locked" },
+        }),
+      });
+    });
+    await settle();
+    expect(container.textContent).toContain("lora import: manifest write failed");
+    expect(container.textContent).toContain("lora training: registry locked");
+
+    // A later LoRA import completes — only the lora-import banner clears; the
+    // unrelated lora-train notice must survive.
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "lora-import-job-2",
+          type: "lora_import",
+          status: "completed",
+          createdAt: "2026-05-18T00:00:02Z",
+          payload: { loraId: "detail_lora", family: "z-image" },
+        }),
+      });
+    });
+    await settle();
+
+    expect(container.textContent).not.toContain("lora import: manifest write failed");
+    expect(container.textContent).toContain("lora training: registry locked");
+  });
+
   it("rejects oversized LoRA uploads before posting from the Models page", async () => {
     let importCalls = 0;
     global.fetch.mockImplementation((url, options = {}) => {


### PR DESCRIPTION
## Summary
Fixes **sc-4198 / F-WEB-13** (P2, bad-pattern). The single `error` string doubled as a message bus — fetch failures, job-failure notices, and `lora import:`/`lora training:` notices that other code detected via `String.startsWith` (`isLoraImportNotice`/`isLoraTrainingNotice`). Because nearly every successful action calls `setError("")`, a background refresh (e.g. SSE-triggered `refreshAssets`) could wipe an unrelated, still-relevant notice the user hadn't read, and the prefix-sniffing contract broke silently if a notice string was renamed.

## Fix
Replace it with a small **notices store**: `notices = [{ kind, message }]`, with `pushNotice(kind, message)` (replaces same-kind) and `dismissNoticeKind(kind)`.
- The LoRA import/train banners now carry **explicit kinds** (`lora-import`/`lora-train`) derived from the job type via `noticeKindForJob`, instead of the `startsWith` prefix protocol; a job's completion dismisses exactly its kind. `isLoraImportNotice`/`isLoraTrainingNotice` removed.
- The banner renders **every** notice (each kind independent).
- `setError` is kept as a thin back-compat shim over the `general` kind (truthy message replaces it; `""` dismisses only it), so the **~150 existing `setError` call sites are unchanged** — yet clearing one kind no longer wipes another.

## Tests
- New regression in `main.test.jsx`: a `lora-import` banner and a `lora-train` banner coexist, and the import's later **completion clears only the import banner** — the train notice survives (the old single string wiped everything). The existing 3 lora-banner tests (show + clear-on-completion) still pass against the new kind-based flow.
- Full web suite **378 passed**; `eslint src` 0 errors; `vite build` clean.

## Scope note (honest)
This eliminates the fragile prefix protocol and the **cross-kind** clobbering the finding called out. Making a *general* error survive an **unrelated general success** needs per-action notice ids threaded through the ~150 `setError` call sites — a larger follow-on that the notices store now makes possible (the store already supports it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)