### PR TITLE
fix(api): default bind to loopback; warn on open bind without a token (sc-4201)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
-# API bind address and exposed port. In Docker, keep the bind host at 0.0.0.0;
-# use the published port and access token to control host/LAN access.
-# Default is 8010 (8000 commonly collides with ComfyUI on the same machine).
+# API bind address and exposed port. The binary defaults to 127.0.0.1 (loopback)
+# so it is not LAN-reachable until you opt in. In Docker, keep the bind host at
+# 0.0.0.0 (set here) so the published host port can reach the container; pair it
+# with SCENEWORKS_ACCESS_TOKEN below for access control.
+# Default port is 8010 (8000 commonly collides with ComfyUI on the same machine).
 SCENEWORKS_API_HOST=0.0.0.0
 SCENEWORKS_API_PORT=8010
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,16 @@ Event streams use a short-lived one-shot ticket instead of putting the access to
 
 This is for privacy and control over local media, model downloads, and long-running GPU work. It is not a content moderation system.
 
-Inside Docker, `SCENEWORKS_API_HOST=0.0.0.0` is expected so the published host
-port can reach the container. Use `SCENEWORKS_ACCESS_TOKEN` for access control
-and extend `SCENEWORKS_CORS_ORIGINS` with LAN hostnames or IP origins when the
-web app is opened from another machine.
+The API binds to `127.0.0.1` (loopback) by default, so a direct binary run is not
+reachable from the network until you opt in. To expose it (a server install, or
+access from another machine), set `SCENEWORKS_API_HOST=0.0.0.0` **and** set
+`SCENEWORKS_ACCESS_TOKEN` — without a token, every endpoint (project file reads,
+credential writes, job creation, large model uploads) is reachable unauthenticated,
+and the API logs a warning on startup. Inside Docker, `SCENEWORKS_API_HOST=0.0.0.0`
+is set by `docker-compose.yml` so the published host port can reach the container;
+control access with `SCENEWORKS_ACCESS_TOKEN` and the published-port boundary, and
+extend `SCENEWORKS_CORS_ORIGINS` with LAN hostnames or IP origins when the web app is
+opened from another machine.
 
 For offline development or deterministic Rust API tests, set `SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1` to skip live Hugging Face model size lookups. The catalog still returns the same fields with unknown sizes.
 

--- a/apps/rust-api/README.md
+++ b/apps/rust-api/README.md
@@ -5,7 +5,11 @@ service with `docker/rust-api.Dockerfile`.
 
 The API uses these compose contracts:
 
-- `SCENEWORKS_API_HOST` and `SCENEWORKS_API_PORT` control the container bind address.
+- `SCENEWORKS_API_HOST` and `SCENEWORKS_API_PORT` control the bind address. The
+  binary defaults `SCENEWORKS_API_HOST` to `127.0.0.1` (loopback); compose sets it to
+  `0.0.0.0` so the published host port can reach the container. A non-loopback bind
+  with no `SCENEWORKS_ACCESS_TOKEN` serves every endpoint unauthenticated and logs a
+  startup warning.
 - `SCENEWORKS_DATA_DIR=/sceneworks/data` maps to `${SCENEWORKS_DATA_BIND:-./data}`.
 - `SCENEWORKS_CONFIG_DIR=/sceneworks/config` maps writable to `${SCENEWORKS_CONFIG_BIND:-./config}` for user manifests.
 - `SCENEWORKS_JOBS_DB_PATH=/sceneworks/data/cache/jobs.db` stores queue state on the existing data bind mount.

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -127,6 +127,11 @@ const EVENT_BUFFER_SIZE: usize = 100;
 const HEARTBEAT_SSE_DATA: &str = "{}";
 #[cfg(test)]
 const HEARTBEAT_SSE_WIRE: &str = "event: heartbeat\ndata: {}\n\n";
+// sc-4201 (F-API-1): default to loopback so a bare/server run that doesn't set
+// SCENEWORKS_API_HOST isn't exposed to the whole LAN with auth off. Docker and the
+// desktop wrapper set the host explicitly (0.0.0.0 / 127.0.0.1 respectively), so this
+// only changes the out-of-the-box default for a direct binary run.
+const DEFAULT_API_HOST: &str = "127.0.0.1";
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MAX_MODEL_UPLOAD_BYTES: usize = 256 * 1024 * 1024 * 1024;
 const MAX_LORA_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
@@ -180,7 +185,7 @@ impl Settings {
             .unwrap_or_else(|| data_dir.join("cache").join("jobs.db"));
         Self {
             app_version: env_string("SCENEWORKS_APP_VERSION", "0.2.0"),
-            host: env_string("SCENEWORKS_API_HOST", "0.0.0.0"),
+            host: env_string("SCENEWORKS_API_HOST", DEFAULT_API_HOST),
             port: std::env::var("SCENEWORKS_API_PORT")
                 .ok()
                 .and_then(|value| value.parse().ok())
@@ -251,6 +256,13 @@ where
     }
 }
 
+// sc-4201 (F-API-1): true when the API would serve every endpoint without auth to
+// the network — no access token AND a non-loopback bind address. Pure so the security
+// decision is unit-tested without spinning up a listener.
+fn should_warn_open_bind(access_token: &str, ip: std::net::IpAddr) -> bool {
+    access_token.trim().is_empty() && !ip.is_loopback()
+}
+
 fn json_rejection_response(rejection: JsonRejection) -> Response {
     let detail = match rejection {
         JsonRejection::JsonDataError(error) => error.body_text(),
@@ -284,6 +296,17 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     let settings = Settings::from_env();
     let address: SocketAddr = format!("{}:{}", settings.host, settings.port).parse()?;
+    // sc-4201 (F-API-1): a non-loopback bind with no access token serves every
+    // endpoint — file reads, credential writes, job creation, large uploads — to the
+    // whole network without authentication. The default is now loopback; warn loudly
+    // when an operator opts into a wider bind (e.g. Docker's 0.0.0.0) without a token.
+    if should_warn_open_bind(&settings.access_token, address.ip()) {
+        eprintln!(
+            "WARNING: SceneWorks API is binding to {address} with no SCENEWORKS_ACCESS_TOKEN set — \
+             every endpoint is reachable without authentication from the network. Set \
+             SCENEWORKS_ACCESS_TOKEN, or bind to 127.0.0.1, before exposing this beyond a trusted host."
+        );
+    }
     let run_utility_inprocess = settings.run_utility_inprocess;
     let app = create_app(settings)?;
     let listener = tokio::net::TcpListener::bind(address).await?;

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5,9 +5,10 @@ use super::workers::person_readiness_from_workers;
 use super::{
     create_app, huggingface_repo_cache_path, inject_converted_model_path, inprocess_worker_gpu_id,
     lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status, safe_download_dir,
-    safe_repo_dir_name, serialize_job_lora, strip_jsonc_comments, sweep_stale_lora_uploads_before,
-    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
-    EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    safe_repo_dir_name, serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
+    sweep_stale_lora_uploads_before, Settings, WorkerCapability, WorkerSnapshot, WorkerStatus,
+    API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
+    HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -16,6 +17,28 @@ use std::sync::atomic::Ordering;
 use std::time::{Duration, SystemTime};
 use tokio_stream::StreamExt;
 use tower::ServiceExt;
+
+#[test]
+fn default_api_host_is_loopback() {
+    // sc-4201 (F-API-1): an out-of-the-box bind must not expose the API to the LAN.
+    let ip: std::net::IpAddr = DEFAULT_API_HOST.parse().expect("default host parses");
+    assert!(ip.is_loopback(), "default API host must be loopback");
+}
+
+#[test]
+fn warns_only_on_open_bind_without_token() {
+    use std::net::IpAddr;
+    let v4 = |s: &str| s.parse::<IpAddr>().unwrap();
+    // No token + a wider bind (0.0.0.0 / a concrete LAN IP) → warn.
+    assert!(should_warn_open_bind("", v4("0.0.0.0")));
+    assert!(should_warn_open_bind("   ", v4("0.0.0.0")));
+    assert!(should_warn_open_bind("", v4("192.168.1.5")));
+    assert!(should_warn_open_bind("", "::".parse().unwrap()));
+    // A token, or a loopback bind, is safe → no warning.
+    assert!(!should_warn_open_bind("secret", v4("0.0.0.0")));
+    assert!(!should_warn_open_bind("", v4("127.0.0.1")));
+    assert!(!should_warn_open_bind("", "::1".parse().unwrap()));
+}
 
 #[test]
 fn serialize_job_lora_carries_network_type_to_payload() {


### PR DESCRIPTION
## Summary
Fixes **sc-4201 / F-API-1** (P2, security). `Settings::from_env` defaulted `SCENEWORKS_API_HOST` to `0.0.0.0` while `SCENEWORKS_ACCESS_TOKEN` defaults to empty (and `is_authorized` returns `true` for everyone when the token is blank). A bare/server run that didn't set the env therefore served **every** endpoint — project file reads, credential writes (`PUT /api/v1/credentials`), arbitrary job creation, up-to-256GB model uploads — to any host on the LAN, unauthenticated.

## Fix (both halves of the suggested fix)
- **Default the bind host to `127.0.0.1`** (`DEFAULT_API_HOST`). Docker (`docker-compose.yml` sets `0.0.0.0`) and the desktop wrapper (`setup.rs` sets `127.0.0.1`) already bind explicitly, so this only changes the out-of-the-box default for a **direct binary run** — the exact exposed case.
- **Loud startup warning** (`should_warn_open_bind`) when binding to a non-loopback address with no access token. This covers an explicit `0.0.0.0` opt-in (including Docker's default, where the operator relies on the published-port boundary) **without** hard-refusing — refusing would break the documented Docker deployment.
- Docs updated (README, `apps/rust-api/README.md`, `.env.example`) to explain the loopback default and the host + token opt-in for network exposure.

## Tests
- `default_api_host_is_loopback`: asserts the new default parses to a loopback IP.
- `warns_only_on_open_bind_without_token`: warn matrix — `0.0.0.0` / a LAN IP / `::` with an empty (or whitespace) token → warn; a token set, or a loopback bind (`127.0.0.1` / `::1`) → no warn.
- All **106** `sceneworks-rust-api` lib tests pass; `cargo fmt --check` + `cargo clippy` clean. No API contract change (the parity/snapshot tests bind `127.0.0.1` explicitly and are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)