### PR TITLE
perf(api): move catalog filesystem walks off the async executor (sc-4202)

### DIFF
--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -124,45 +124,58 @@ pub(crate) async fn lora_catalog(
         load_manifest_entries(state, &manifest_dir.join("builtin.loras.jsonc"), "loras").await?;
     let user =
         load_manifest_entries(state, &manifest_dir.join("user.loras.jsonc"), "loras").await?;
-    let mut loras = Vec::new();
-    for lora in builtin {
-        loras.push(normalize_lora_entry(
-            lora,
-            "builtin",
-            &manifest_dir.join("builtin.loras.jsonc"),
-            &state.settings.data_dir,
-            &state.settings.data_dir,
-        )?);
-    }
-    let user = user
-        .into_iter()
-        .map(|lora| {
-            normalize_lora_entry(
-                lora,
-                "global",
-                &manifest_dir.join("user.loras.jsonc"),
-                &state.settings.data_dir,
-                &state.settings.data_dir,
-            )
+    let data_dir = state.settings.data_dir.clone();
+    let builtin_manifest = manifest_dir.join("builtin.loras.jsonc");
+    let user_manifest = manifest_dir.join("user.loras.jsonc");
+    // sc-4202 (F-API-3): normalize_lora_entry probes the filesystem for installed
+    // artifact paths; run the builtin+user normalize off the async executor.
+    let mut loras = {
+        let data_dir = data_dir.clone();
+        tokio::task::spawn_blocking(move || -> Result<Vec<Value>, ApiError> {
+            let mut loras = Vec::new();
+            for lora in builtin {
+                loras.push(normalize_lora_entry(
+                    lora,
+                    "builtin",
+                    &builtin_manifest,
+                    &data_dir,
+                    &data_dir,
+                )?);
+            }
+            let user = user
+                .into_iter()
+                .map(|lora| {
+                    normalize_lora_entry(lora, "global", &user_manifest, &data_dir, &data_dir)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(merge_entries_by_id(loras, user))
         })
-        .collect::<Result<Vec<_>, _>>()?;
-    loras = merge_entries_by_id(loras, user);
+        .await
+        .map_err(|err| ApiError::internal(format!("LoRA catalog normalize task failed: {err}")))??
+    };
     if let Some(project_id) = project_id {
         let project_path = project_path_for_id(state.clone(), project_id).await?;
         let project_manifest = project_path.join("loras").join("manifest.jsonc");
-        let project_loras = load_manifest_entries(state, &project_manifest, "loras")
-            .await?
-            .into_iter()
-            .map(|lora| {
-                normalize_lora_entry(
-                    lora,
-                    "project",
-                    &project_manifest,
-                    &project_path,
-                    &state.settings.data_dir,
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let entries = load_manifest_entries(state, &project_manifest, "loras").await?;
+        let data_dir = data_dir.clone();
+        let project_loras = tokio::task::spawn_blocking(move || -> Result<Vec<Value>, ApiError> {
+            entries
+                .into_iter()
+                .map(|lora| {
+                    normalize_lora_entry(
+                        lora,
+                        "project",
+                        &project_manifest,
+                        &project_path,
+                        &data_dir,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .await
+        .map_err(|err| {
+            ApiError::internal(format!("LoRA catalog project normalize task failed: {err}"))
+        })??;
         loras = merge_entries_by_id(loras, project_loras);
     }
     for lora in &mut loras {
@@ -648,16 +661,26 @@ pub(crate) async fn validate_job_lora_compatibility(
         .get("model")
         .and_then(Value::as_str)
         .ok_or_else(|| ApiError::bad_request("Model is required for LoRA compatibility"))?;
+    let model_id = model_id.to_owned();
     let models = model_catalog(state).await?;
     let catalog_loras = lora_catalog(state, project_id).await?;
-    let normalized = validate_lora_specs_for_model(
-        &models,
-        &catalog_loras,
-        model_id,
-        &loras,
-        allow_inline_loras,
-        "LoRA",
-    )?;
+    // sc-4202 (F-API-3): validate_lora_specs_for_model reads safetensors headers off
+    // disk (validate_lora_safetensors_header) inline. Run it on the blocking pool so a
+    // slow/network volume can't stall a tokio worker thread on the job-creation path.
+    let normalized = tokio::task::spawn_blocking(move || {
+        validate_lora_specs_for_model(
+            &models,
+            &catalog_loras,
+            &model_id,
+            &loras,
+            allow_inline_loras,
+            "LoRA",
+        )
+    })
+    .await
+    .map_err(|err| {
+        ApiError::internal(format!("LoRA compatibility validation task failed: {err}"))
+    })??;
     job_payload.insert("loras".to_owned(), Value::Array(normalized));
     Ok(())
 }

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -800,211 +800,226 @@ async fn model_catalog_inner(
     }))
     .await;
 
-    for (model, (download_context, download_size_bytes)) in models
-        .iter_mut()
-        .zip(download_contexts.into_iter().zip(download_size_bytes))
-    {
-        let fallback_size_bytes = download_context
-            .as_ref()
-            .and_then(|context| context.fallback_size_bytes);
-        let effective_download_size_bytes = download_size_bytes.or(fallback_size_bytes);
-        let download_size_estimated =
-            download_size_bytes.is_none() && fallback_size_bytes.is_some();
-        let (downloadable, installed_path, installed, cache_incomplete, missing_required_files) =
-            if let Some(download_context) = download_context {
-                let managed_path = state
-                    .settings
-                    .data_dir
-                    .join("models")
-                    .join(safe_download_dir(&download_context.repo));
-                let cache_path =
-                    huggingface_repo_cache_path(&state.settings.data_dir, &download_context.repo);
-                let cache_health = cache_path
+    let data_dir = state.settings.data_dir.clone();
+    // sc-4202 (F-API-3): the per-model install-state probes below hit the filesystem
+    // (huggingface_cache_health snapshot walks, model_is_installed, mlx_catalog_status)
+    // for every model. Assemble the catalog on the blocking pool so these synchronous
+    // walks don't stall a tokio worker thread under load or on a slow/network volume.
+    let models =
+        tokio::task::spawn_blocking(move || -> Result<Vec<Value>, ApiError> {
+            for (model, (download_context, download_size_bytes)) in models
+                .iter_mut()
+                .zip(download_contexts.into_iter().zip(download_size_bytes))
+            {
+                let fallback_size_bytes = download_context
                     .as_ref()
-                    .map(|path| huggingface_cache_health(path, &download_context.files));
-                let cache_installed = cache_health.as_ref().is_some_and(|health| health.installed);
-                let cache_incomplete = cache_health
-                    .as_ref()
-                    .is_some_and(|health| health.incomplete);
-                let missing_required_files = cache_health
-                    .as_ref()
-                    .map(|health| health.missing_files.clone())
-                    .unwrap_or_default();
-                let managed_installed = model_is_installed(&managed_path);
-                let installed_path = if cache_installed || cache_incomplete {
-                    cache_path.clone()
-                } else {
-                    Some(managed_path)
-                };
-                (
-                    true,
-                    installed_path.map(|path| path.display().to_string()),
-                    managed_installed || cache_installed,
+                    .and_then(|context| context.fallback_size_bytes);
+                let effective_download_size_bytes = download_size_bytes.or(fallback_size_bytes);
+                let download_size_estimated =
+                    download_size_bytes.is_none() && fallback_size_bytes.is_some();
+                let (
+                    downloadable,
+                    installed_path,
+                    installed,
                     cache_incomplete,
                     missing_required_files,
-                )
-            } else if let Some(installed_path) =
-                model_manifest_installed_path(model, &state.settings.data_dir)
-            {
-                let installed = model_is_installed(&installed_path);
-                (
-                    false,
-                    Some(installed_path.display().to_string()),
-                    installed,
-                    false,
-                    Vec::new(),
-                )
-            } else {
-                (false, None, false, false, Vec::new())
-            };
-        let object = model
-            .as_object_mut()
-            .ok_or_else(|| ApiError::internal("Model manifest entry must be an object"))?;
-        let model_id = object.get("id").and_then(Value::as_str).unwrap_or_default();
-        let user_managed = user_model_ids.contains(model_id);
-        object.insert(
-            "catalogScope".to_owned(),
-            Value::String(if user_managed { "user" } else { "builtin" }.to_owned()),
-        );
-        object.insert("downloadable".to_owned(), Value::Bool(downloadable));
-        object.insert(
-            "downloadSizeBytes".to_owned(),
-            effective_download_size_bytes
-                .map(|value| json!(value))
-                .unwrap_or(Value::Null),
-        );
-        object.insert(
-            "downloadSizeLabel".to_owned(),
-            effective_download_size_bytes
-                .map(format_bytes)
-                .map(Value::String)
-                .unwrap_or(Value::Null),
-        );
-        object.insert(
-            "downloadSizeEstimated".to_owned(),
-            Value::Bool(download_size_estimated),
-        );
-        object.insert(
-            "installState".to_owned(),
-            Value::String(if installed { "installed" } else { "missing" }.to_owned()),
-        );
-        object.insert(
-            "cacheState".to_owned(),
-            Value::String(
-                if cache_incomplete {
-                    "incomplete"
-                } else if installed {
-                    "complete"
+                ) = if let Some(download_context) = download_context {
+                    let managed_path = data_dir
+                        .join("models")
+                        .join(safe_download_dir(&download_context.repo));
+                    let cache_path = huggingface_repo_cache_path(&data_dir, &download_context.repo);
+                    let cache_health = cache_path
+                        .as_ref()
+                        .map(|path| huggingface_cache_health(path, &download_context.files));
+                    let cache_installed =
+                        cache_health.as_ref().is_some_and(|health| health.installed);
+                    let cache_incomplete = cache_health
+                        .as_ref()
+                        .is_some_and(|health| health.incomplete);
+                    let missing_required_files = cache_health
+                        .as_ref()
+                        .map(|health| health.missing_files.clone())
+                        .unwrap_or_default();
+                    let managed_installed = model_is_installed(&managed_path);
+                    let installed_path = if cache_installed || cache_incomplete {
+                        cache_path.clone()
+                    } else {
+                        Some(managed_path)
+                    };
+                    (
+                        true,
+                        installed_path.map(|path| path.display().to_string()),
+                        managed_installed || cache_installed,
+                        cache_incomplete,
+                        missing_required_files,
+                    )
+                } else if let Some(installed_path) = model_manifest_installed_path(model, &data_dir)
+                {
+                    let installed = model_is_installed(&installed_path);
+                    (
+                        false,
+                        Some(installed_path.display().to_string()),
+                        installed,
+                        false,
+                        Vec::new(),
+                    )
                 } else {
-                    "missing"
+                    (false, None, false, false, Vec::new())
+                };
+                let object = model
+                    .as_object_mut()
+                    .ok_or_else(|| ApiError::internal("Model manifest entry must be an object"))?;
+                let model_id = object.get("id").and_then(Value::as_str).unwrap_or_default();
+                let user_managed = user_model_ids.contains(model_id);
+                object.insert(
+                    "catalogScope".to_owned(),
+                    Value::String(if user_managed { "user" } else { "builtin" }.to_owned()),
+                );
+                object.insert("downloadable".to_owned(), Value::Bool(downloadable));
+                object.insert(
+                    "downloadSizeBytes".to_owned(),
+                    effective_download_size_bytes
+                        .map(|value| json!(value))
+                        .unwrap_or(Value::Null),
+                );
+                object.insert(
+                    "downloadSizeLabel".to_owned(),
+                    effective_download_size_bytes
+                        .map(format_bytes)
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                );
+                object.insert(
+                    "downloadSizeEstimated".to_owned(),
+                    Value::Bool(download_size_estimated),
+                );
+                object.insert(
+                    "installState".to_owned(),
+                    Value::String(if installed { "installed" } else { "missing" }.to_owned()),
+                );
+                object.insert(
+                    "cacheState".to_owned(),
+                    Value::String(
+                        if cache_incomplete {
+                            "incomplete"
+                        } else if installed {
+                            "complete"
+                        } else {
+                            "missing"
+                        }
+                        .to_owned(),
+                    ),
+                );
+                object.insert(
+                    "missingRequiredFiles".to_owned(),
+                    Value::Array(
+                        missing_required_files
+                            .into_iter()
+                            .map(Value::String)
+                            .collect(),
+                    ),
+                );
+                object.insert(
+                    "repairAvailable".to_owned(),
+                    Value::Bool(downloadable && cache_incomplete),
+                );
+                object.insert(
+                    "installedPath".to_owned(),
+                    installed_path.map(Value::String).unwrap_or(Value::Null),
+                );
+                object.insert(
+                    "removable".to_owned(),
+                    Value::Bool(user_managed || installed),
+                );
+                // Gated-model signal (sc-1898): a machine-readable `gated` flag plus the
+                // credential host the download requires, so the Models screen can route the
+                // user to the credential screen before a download will succeed. The host
+                // honors an explicit manifest `credentialHost` and otherwise derives from
+                // the download provider/source URL; `licenseUrl` passes through untouched.
+                let gated = object
+                    .get("gated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                object.insert("gated".to_owned(), Value::Bool(gated));
+                if gated {
+                    let credential_host = object
+                        .get("credentialHost")
+                        .and_then(Value::as_str)
+                        .map(normalize_host)
+                        .filter(|host| !host.is_empty())
+                        .or_else(|| derive_credential_host(object));
+                    object.insert(
+                        "credentialHost".to_owned(),
+                        credential_host.map(Value::String).unwrap_or(Value::Null),
+                    );
                 }
-                .to_owned(),
-            ),
-        );
-        object.insert(
-            "missingRequiredFiles".to_owned(),
-            Value::Array(
-                missing_required_files
-                    .into_iter()
-                    .map(Value::String)
-                    .collect(),
-            ),
-        );
-        object.insert(
-            "repairAvailable".to_owned(),
-            Value::Bool(downloadable && cache_incomplete),
-        );
-        object.insert(
-            "installedPath".to_owned(),
-            installed_path.map(Value::String).unwrap_or(Value::Null),
-        );
-        object.insert(
-            "removable".to_owned(),
-            Value::Bool(user_managed || installed),
-        );
-        // Gated-model signal (sc-1898): a machine-readable `gated` flag plus the
-        // credential host the download requires, so the Models screen can route the
-        // user to the credential screen before a download will succeed. The host
-        // honors an explicit manifest `credentialHost` and otherwise derives from
-        // the download provider/source URL; `licenseUrl` passes through untouched.
-        let gated = object
-            .get("gated")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        object.insert("gated".to_owned(), Value::Bool(gated));
-        if gated {
-            let credential_host = object
-                .get("credentialHost")
-                .and_then(Value::as_str)
-                .map(normalize_host)
-                .filter(|host| !host.is_empty())
-                .or_else(|| derive_credential_host(object));
-            object.insert(
-                "credentialHost".to_owned(),
-                credential_host.map(Value::String).unwrap_or(Value::Null),
-            );
-        }
-        // Mac UI gating (sc-3486): per-model Rust/MLX support so the web client can
-        // hide/disable a torch-only model in the pickers and disable the feature
-        // controls a supported model can't run on MLX. Computed from the same routing
-        // predicates as the `mac_rust_supported` oracle, and platform-independent (a
-        // fact about the Rust flow) — the client only acts on it when the capabilities
-        // endpoint reports `macGatingActive`, so non-Mac pickers are untouched.
-        let mac_support = {
-            let id = object.get("id").and_then(Value::as_str).unwrap_or_default();
-            let model_type = object
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or_default();
-            model_mac_support(id, model_type)
-        };
-        if let Ok(mac_support) = serde_json::to_value(mac_support) {
-            object.insert("macSupport".to_owned(), mac_support);
-        }
-        // macOS Model Manager: MLX availability + conversion status for models that
-        // declare an `mlx` variant. Additive fields the web/Docker build ignores; the
-        // probes are cheap and portable, so a const `cfg!` check gates them rather
-        // than per-OS compilation. minMemoryGb passes through from the raw manifest.
-        let mlx_status = if cfg!(target_os = "macos") {
-            mlx_catalog_status(object, &state.settings.data_dir)
-        } else {
-            None
-        };
-        if let Some(status) = mlx_status {
-            object.insert(
-                "mlxInstallState".to_owned(),
-                Value::String(status.install_state.to_owned()),
-            );
-            object.insert(
-                "mlxConversionState".to_owned(),
-                Value::String(status.conversion_state.to_owned()),
-            );
-            object.insert(
-                "mlxConvertedPath".to_owned(),
-                status
-                    .converted_path
-                    .map(|path| Value::String(path.display().to_string()))
-                    .unwrap_or(Value::Null),
-            );
-        }
-    }
-    models.sort_by(|left, right| {
-        let left_key = (
-            left.get("type").and_then(Value::as_str).unwrap_or_default(),
-            left.get("name").and_then(Value::as_str).unwrap_or_default(),
-        );
-        let right_key = (
-            right
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-            right
-                .get("name")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-        );
-        left_key.cmp(&right_key)
-    });
+                // Mac UI gating (sc-3486): per-model Rust/MLX support so the web client can
+                // hide/disable a torch-only model in the pickers and disable the feature
+                // controls a supported model can't run on MLX. Computed from the same routing
+                // predicates as the `mac_rust_supported` oracle, and platform-independent (a
+                // fact about the Rust flow) — the client only acts on it when the capabilities
+                // endpoint reports `macGatingActive`, so non-Mac pickers are untouched.
+                let mac_support = {
+                    let id = object.get("id").and_then(Value::as_str).unwrap_or_default();
+                    let model_type = object
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    model_mac_support(id, model_type)
+                };
+                if let Ok(mac_support) = serde_json::to_value(mac_support) {
+                    object.insert("macSupport".to_owned(), mac_support);
+                }
+                // macOS Model Manager: MLX availability + conversion status for models that
+                // declare an `mlx` variant. Additive fields the web/Docker build ignores; the
+                // probes are cheap and portable, so a const `cfg!` check gates them rather
+                // than per-OS compilation. minMemoryGb passes through from the raw manifest.
+                let mlx_status = if cfg!(target_os = "macos") {
+                    mlx_catalog_status(object, &data_dir)
+                } else {
+                    None
+                };
+                if let Some(status) = mlx_status {
+                    object.insert(
+                        "mlxInstallState".to_owned(),
+                        Value::String(status.install_state.to_owned()),
+                    );
+                    object.insert(
+                        "mlxConversionState".to_owned(),
+                        Value::String(status.conversion_state.to_owned()),
+                    );
+                    object.insert(
+                        "mlxConvertedPath".to_owned(),
+                        status
+                            .converted_path
+                            .map(|path| Value::String(path.display().to_string()))
+                            .unwrap_or(Value::Null),
+                    );
+                }
+            }
+            models.sort_by(|left, right| {
+                let left_key = (
+                    left.get("type").and_then(Value::as_str).unwrap_or_default(),
+                    left.get("name").and_then(Value::as_str).unwrap_or_default(),
+                );
+                let right_key = (
+                    right
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                    right
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                );
+                left_key.cmp(&right_key)
+            });
+            Ok(models)
+        })
+        .await
+        .map_err(|err| {
+            ApiError::internal(format!("model catalog assembly task failed: {err}"))
+        })??;
     Ok(models)
 }
 

--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -33,15 +33,14 @@ fn preferences_path(state: &AppState) -> PathBuf {
     state.settings.config_dir.join(PREFERENCES_FILENAME)
 }
 
-fn load_preferences(state: &AppState) -> UiPreferences {
-    std::fs::read_to_string(preferences_path(state))
+fn load_preferences(path: &std::path::Path) -> UiPreferences {
+    std::fs::read_to_string(path)
         .ok()
         .and_then(|body| serde_json::from_str(&body).ok())
         .unwrap_or_default()
 }
 
-fn save_preferences(state: &AppState, prefs: &UiPreferences) -> std::io::Result<()> {
-    let path = preferences_path(state);
+fn save_preferences(path: &std::path::Path, prefs: &UiPreferences) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -71,7 +70,12 @@ fn normalize_accent(input: Option<&str>) -> Option<String> {
 pub(crate) async fn get_ui_preferences(
     State(state): State<AppState>,
 ) -> Result<Json<UiPreferences>, ApiError> {
-    Ok(Json(load_preferences(&state)))
+    // sc-4202 (F-API-3): keep the preferences-file read off the async executor.
+    let path = preferences_path(&state);
+    let prefs = tokio::task::spawn_blocking(move || load_preferences(&path))
+        .await
+        .map_err(|err| ApiError::internal(format!("UI preferences load task failed: {err}")))?;
+    Ok(Json(prefs))
 }
 
 /// Merge the supplied preferences in and persist. Only recognized fields/values
@@ -80,15 +84,23 @@ pub(crate) async fn set_ui_preferences(
     State(state): State<AppState>,
     ApiJson(payload): ApiJson<UiPreferences>,
 ) -> Result<Json<UiPreferences>, ApiError> {
-    let mut prefs = load_preferences(&state);
-    if let Some(theme) = normalize_theme(payload.theme.as_deref()) {
-        prefs.theme = Some(theme);
-    }
-    if let Some(accent) = normalize_accent(payload.accent.as_deref()) {
-        prefs.accent = Some(accent);
-    }
-    save_preferences(&state, &prefs)
-        .map_err(|error| ApiError::internal(format!("Failed to save UI preferences: {error}")))?;
+    // sc-4202 (F-API-3): the read-modify-write of the preferences file runs on the
+    // blocking pool so it can't stall a tokio worker thread.
+    let path = preferences_path(&state);
+    let prefs = tokio::task::spawn_blocking(move || -> std::io::Result<UiPreferences> {
+        let mut prefs = load_preferences(&path);
+        if let Some(theme) = normalize_theme(payload.theme.as_deref()) {
+            prefs.theme = Some(theme);
+        }
+        if let Some(accent) = normalize_accent(payload.accent.as_deref()) {
+            prefs.accent = Some(accent);
+        }
+        save_preferences(&path, &prefs)?;
+        Ok(prefs)
+    })
+    .await
+    .map_err(|err| ApiError::internal(format!("UI preferences save task failed: {err}")))?
+    .map_err(|error| ApiError::internal(format!("Failed to save UI preferences: {error}")))?;
     Ok(Json(prefs))
 }
 


### PR DESCRIPTION
## Summary
Fixes **sc-4202 / F-API-3** (P2, bad-pattern). Unlike DB/project access (`store_call`/`project_call` + `spawn_blocking`), the model/LoRA catalog code did `std::fs` metadata probes, **recursive HF snapshot-dir walks** (snapshots can hold thousands of files), and safetensors header reads **inline in async handlers** (`list_models`, `create_image_job` via `validate_job_lora_compatibility`, `list_loras`, `get`/`set_ui_preferences`). That blocks tokio worker threads under load or on slow/network volumes, adding tail latency to unrelated requests (including SSE heartbeats).

## Fix
Wrap the synchronous fs work in `tokio::task::spawn_blocking`, mirroring the existing `store_call` pattern:
- **`model_catalog_inner`**: the per-model install-state assembly loop (`snapshot_files` / `huggingface_cache_health` / `model_is_installed` / `mlx_catalog_status` + the final sort) runs on the blocking pool — only an owned `data_dir` + the per-model inputs cross into the closure (the async HF size-estimate stays before it).
- **`validate_job_lora_compatibility`**: `validate_lora_specs_for_model` (reads safetensors headers) runs on the blocking pool.
- **`lora_catalog`**: the builtin/user and project `normalize_lora_entry` loops (fs install-path probes) run on the blocking pool.
- **preferences**: `get`/`set_ui_preferences` read-modify-write the prefs file on the blocking pool (`load_preferences`/`save_preferences` now take a `&Path`).

## Tests
- No API contract change (the wraps move work to another thread; responses are identical).
- `cargo fmt --check` + `cargo clippy --all-targets` clean; **106** `sceneworks-rust-api` lib tests + the preferences unit tests pass — including `model_and_lora_routes_match_manifest_behavior`, the route-level catalog test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)