### PR TITLE
perf(api): only republish the queue on a job status transition (sc-4203)

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -264,8 +264,11 @@ pub(crate) async fn update_job_progress(
     if let Some(result_obj) = result.as_mut() {
         persist_reported_assets(&state, &job_id, result_obj).await?;
     }
-    let job = store_call(state.clone(), move |store, _timeout| {
-        store.update_job_progress(
+    let (job, status_changed) = store_call(state.clone(), move |store, _timeout| {
+        // Read the prior status in the same blocking round-trip so we can tell a
+        // pure progress tick (status unchanged) from a real queue transition.
+        let previous_status = store.get_job(&job_id).map(|job| job.status).ok();
+        let job = store.update_job_progress(
             &job_id,
             ProgressUpdate {
                 status: payload.status,
@@ -280,11 +283,21 @@ pub(crate) async fn update_job_progress(
                 backend: payload.backend,
                 worker_id: payload.worker_id,
             },
-        )
+        )?;
+        let status_changed = previous_status.as_ref() != Some(&job.status);
+        Ok::<(JobSnapshot, bool), JobsStoreError>((job, status_changed))
     })
     .await?;
     publish(&state, "job.updated", &job);
-    publish_queue(&state).await?;
+    // sc-4203 (F-API-5): workers POST progress per inference step. The queue summary
+    // is a full SQLite aggregation plus a stale-worker sweep, serialized and
+    // broadcast to every SSE subscriber — but the queue composition only changes when
+    // a job's status transitions (queued/running/terminal), not on a percentage tick.
+    // Skip the refresh on pure ticks; the stale sweep still runs on worker heartbeats
+    // and on every status transition.
+    if status_changed {
+        publish_queue(&state).await?;
+    }
     Ok(Json(job))
 }
 

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -500,6 +500,15 @@ async fn shutdown_signal() {
 }
 
 pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
+    Ok(create_app_with_state(settings)?.0)
+}
+
+// Like create_app but also returns a clone of the AppState (the same Arc-shared
+// stores + event hub the router uses), so tests can subscribe to the event hub and
+// assert on what the handlers publish (sc-4203).
+pub(crate) fn create_app_with_state(
+    settings: Settings,
+) -> Result<(Router, AppState), JobsStoreError> {
     let _ = std::fs::create_dir_all(&settings.data_dir);
     let _ = std::fs::create_dir_all(&settings.config_dir);
     if let Some(jobs_db_parent) = settings.jobs_db_path.parent() {
@@ -538,8 +547,9 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         interrupted_jobs_on_startup,
     };
     let cors = cors_layer(&state.settings);
+    let returned_state = state.clone();
 
-    Ok(Router::new()
+    let router = Router::new()
         .route("/api/v1/health", get(health))
         .route("/api/v1/access", get(access))
         .route("/api/v1/auth/verify", post(verify_access))
@@ -784,7 +794,8 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
         .with_state(state.clone())
         .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
         .layer(middleware::from_fn_with_state(state, access_control))
-        .layer(cors))
+        .layer(cors);
+    Ok((router, returned_state))
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3,12 +3,12 @@ use super::events::{EventHub, EventMessage};
 use super::training::{insufficient_disk_space, resolve_base_model_path};
 use super::workers::person_readiness_from_workers;
 use super::{
-    create_app, huggingface_repo_cache_path, inject_converted_model_path, inprocess_worker_gpu_id,
-    lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status, safe_download_dir,
-    safe_repo_dir_name, serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
-    sweep_stale_lora_uploads_before, Settings, WorkerCapability, WorkerSnapshot, WorkerStatus,
-    API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
-    HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
+    inprocess_worker_gpu_id, lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
+    safe_download_dir, safe_repo_dir_name, serialize_job_lora, should_warn_open_bind,
+    strip_jsonc_comments, sweep_stale_lora_uploads_before, Settings, WorkerCapability,
+    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE,
+    HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -633,6 +633,107 @@ async fn worker_can_register_claim_and_complete_job_through_http() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(queue["counts"]["completed"], 1);
     assert_eq!(queue["workers"][0]["status"], "idle");
+}
+
+#[tokio::test]
+async fn progress_ticks_only_republish_queue_on_status_change() {
+    // sc-4203 (F-API-5): a pure progress tick (status unchanged) must not trigger the
+    // full queue-summary recompute + queue.updated broadcast; a status transition must.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let (app, state) = create_app_with_state(test_settings(&temp_dir)).expect("app creates");
+
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/register",
+        json!({
+            "workerId": "worker-1",
+            "gpuId": "gpu-0",
+            "gpuName": "GPU 0",
+            "capabilities": ["image_generate"],
+            "loadedModels": []
+        }),
+    )
+    .await;
+    let (_, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "image_generate",
+            "projectId": "project-1",
+            "projectName": "Project 1",
+            "payload": { "prompt": "mist" },
+            "requestedGpu": "auto"
+        }),
+    )
+    .await;
+    let job_id = created["id"].as_str().expect("job id is string").to_owned();
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/claim",
+        json!({ "workerId": "worker-1" }),
+    )
+    .await;
+    // Move the job into `running` (a transition from `preparing`).
+    request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/progress"),
+        json!({ "status": "running", "stage": "running", "progress": 0.2, "message": "step" }),
+    )
+    .await;
+
+    // Subscribe AFTER the transition so we only observe the next ticks' events.
+    let mut events = state.events.subscribe();
+
+    // A pure progress tick (running -> running): job.updated, but NOT queue.updated.
+    request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/progress"),
+        json!({ "status": "running", "stage": "running", "progress": 0.6, "message": "step" }),
+    )
+    .await;
+    let tick_events = drain_event_names(&mut events).await;
+    assert!(
+        tick_events.iter().any(|name| name == "job.updated"),
+        "a progress tick still emits job.updated: {tick_events:?}"
+    );
+    assert!(
+        !tick_events.iter().any(|name| name == "queue.updated"),
+        "a pure progress tick must not republish the queue: {tick_events:?}"
+    );
+
+    // A status transition (running -> completed) republishes the queue.
+    request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/progress"),
+        json!({ "status": "completed", "stage": "completed", "progress": 1, "message": "done" }),
+    )
+    .await;
+    let done_events = drain_event_names(&mut events).await;
+    assert!(
+        done_events.iter().any(|name| name == "queue.updated"),
+        "a status transition must republish the queue: {done_events:?}"
+    );
+}
+
+// Collect the event names currently buffered for a subscriber, stopping after a brief
+// quiet period (handlers publish synchronously before the request future resolves, so
+// everything is already buffered by the time we drain).
+async fn drain_event_names(
+    events: &mut tokio_stream::wrappers::ReceiverStream<EventMessage>,
+) -> Vec<String> {
+    let mut names = Vec::new();
+    while let Ok(Some(message)) =
+        tokio::time::timeout(Duration::from_millis(150), events.next()).await
+    {
+        names.push(message.event);
+    }
+    names
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Fixes **sc-4203 / F-API-5** (P2, efficiency). Workers POST progress per inference step. `update_job_progress` **unconditionally** called `publish_queue`, which runs the stale-worker sweep + a full `queue_summary` SQLite aggregation, serializes it, and broadcasts `queue.updated` to every SSE subscriber — even for pure percentage ticks where the queue composition didn't change. That's redundant SQLite work and SSE chatter scaling with **step-count × concurrent jobs**, contributing to the `jobs.db` contention sc-3448 had to mitigate.

## Fix
Read the prior status in the **same `store_call` round-trip** and only call `publish_queue` when the job's status actually transitions (queued/running/terminal). On a pure tick the queue summary is invariant, so it's skipped. The stale-worker sweep still runs on worker heartbeats and on every transition, so nothing that depends on it regresses.

No core jobs-store API change (the store method has ~25 test callers; a return-type change would churn them all), and no extra round-trip — the prior-status read piggybacks on the existing blocking task.

## Tests
- Adds `create_app_with_state` (returns a clone of the Arc-shared `AppState`) so a test can subscribe to the event hub.
- New `progress_ticks_only_republish_queue_on_status_change`: a `running -> running` tick emits `job.updated` but **not** `queue.updated`; a `running -> completed` transition **does** emit `queue.updated`.
- **107** `sceneworks-rust-api` lib tests pass; `cargo fmt --check` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)