### PR TITLE
fix(api): clean up upload temp files on error paths + sweep cache/uploads (sc-4204)

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -75,41 +75,54 @@ pub(crate) async fn import_asset(
     let mut file: Option<(String, Option<String>, PathBuf)> = None;
     let mut source_asset_id: Option<String> = None;
     let mut provenance: Option<serde_json::Value> = None;
-    while let Some(field) = multipart
-        .next_field()
-        .await
-        .map_err(|error| ApiError::bad_request(error.to_string()))?
-    {
-        match field.name() {
-            Some("file") => {
-                let filename = field.file_name().unwrap_or("upload").to_owned();
-                let content_type = field.content_type().map(str::to_owned);
-                let temp_path = write_upload_field_to_temp_file(&state, field).await?;
-                file = Some((filename, content_type, temp_path));
-            }
-            Some("sourceAssetId") => {
-                let value = field
-                    .text()
-                    .await
-                    .map_err(|error| ApiError::bad_request(error.to_string()))?;
-                let value = value.trim();
-                if !value.is_empty() {
-                    source_asset_id = Some(value.to_owned());
+    // sc-4204 (F-API-6): the `file` field can be staged to a temp file before a later
+    // field errors (e.g. invalid `provenance` JSON, or a truncated multipart stream).
+    // Collect inside a fallible block so a staged temp file is removed before we bail.
+    let collect_result = async {
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            match field.name() {
+                Some("file") => {
+                    let filename = field.file_name().unwrap_or("upload").to_owned();
+                    let content_type = field.content_type().map(str::to_owned);
+                    let temp_path = write_upload_field_to_temp_file(&state, field).await?;
+                    file = Some((filename, content_type, temp_path));
                 }
-            }
-            Some("provenance") => {
-                let value = field
-                    .text()
-                    .await
-                    .map_err(|error| ApiError::bad_request(error.to_string()))?;
-                if !value.trim().is_empty() {
-                    provenance = Some(serde_json::from_str(&value).map_err(|error| {
-                        ApiError::bad_request(format!("Invalid provenance JSON: {error}"))
-                    })?);
+                Some("sourceAssetId") => {
+                    let value = field
+                        .text()
+                        .await
+                        .map_err(|error| ApiError::bad_request(error.to_string()))?;
+                    let value = value.trim();
+                    if !value.is_empty() {
+                        source_asset_id = Some(value.to_owned());
+                    }
                 }
+                Some("provenance") => {
+                    let value = field
+                        .text()
+                        .await
+                        .map_err(|error| ApiError::bad_request(error.to_string()))?;
+                    if !value.trim().is_empty() {
+                        provenance = Some(serde_json::from_str(&value).map_err(|error| {
+                            ApiError::bad_request(format!("Invalid provenance JSON: {error}"))
+                        })?);
+                    }
+                }
+                _ => {}
             }
-            _ => {}
         }
+        Ok::<(), ApiError>(())
+    }
+    .await;
+    if let Err(error) = collect_result {
+        if let Some((_, _, temp_path)) = file.as_ref() {
+            let _ = tokio::fs::remove_file(temp_path).await;
+        }
+        return Err(error);
     }
 
     let (filename, content_type, temp_path) =
@@ -141,6 +154,47 @@ pub(crate) async fn write_upload_field_to_temp_file(
     write_upload_field_to_dir(state, field, "uploads").await
 }
 
+/// Remove stale asset-import temp uploads (`<data_dir>/cache/uploads/upload-*`) at
+/// startup — the backstop for aborted or errored imports whose error path didn't
+/// clean up (sc-4204). Mirrors `sweep_stale_pose_uploads` / `sweep_stale_lora_uploads`.
+pub(crate) fn sweep_stale_asset_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
+    sweep_stale_asset_uploads_before(
+        data_dir,
+        SystemTime::now() - Duration::from_secs(STALE_LORA_UPLOAD_SECONDS),
+    )
+}
+
+pub(crate) fn sweep_stale_asset_uploads_before(
+    data_dir: &FsPath,
+    cutoff: SystemTime,
+) -> std::io::Result<usize> {
+    let upload_root = data_dir.join("cache").join("uploads");
+    let entries = match std::fs::read_dir(upload_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    let mut removed = 0usize;
+    for entry in entries {
+        let entry = entry?;
+        let filename = entry.file_name();
+        if !filename.to_string_lossy().starts_with("upload-") {
+            continue;
+        }
+        let modified = entry.metadata()?.modified().unwrap_or(UNIX_EPOCH);
+        if modified <= cutoff {
+            let path = entry.path();
+            let _ = if entry.file_type()?.is_dir() {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
 /// Stream a multipart field to a unique temp file under `<data_dir>/cache/<subdir>`,
 /// enforcing the upload size cap. Callers own the returned path (move it into place
 /// or delete it). `subdir` lets transient flows isolate their staging area (e.g.
@@ -158,24 +212,34 @@ pub(crate) async fn write_upload_field_to_dir(
     let mut file = tokio::fs::File::create(&temp_path)
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
+    // sc-4204 (F-API-6): clean up the temp file on EVERY error path (chunk read,
+    // write, flush, or size cap), not just the size cap — an aborted or malformed
+    // multi-gigabyte upload otherwise leaks as an orphaned upload-*.tmp. Mirrors
+    // write_lora_upload_field_to_staged_file.
     let mut uploaded_bytes = 0usize;
-    while let Some(chunk) = field
-        .chunk()
-        .await
-        .map_err(|error| ApiError::bad_request(error.to_string()))?
-    {
-        uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
-        if uploaded_bytes > MAX_UPLOAD_BYTES {
-            let _ = tokio::fs::remove_file(&temp_path).await;
-            return Err(ApiError::payload_too_large("Uploaded file is too large"));
-        }
-        file.write_all(&chunk)
+    let write_result = async {
+        while let Some(chunk) = field
+            .chunk()
             .await
-            .map_err(|error| ApiError::internal(error.to_string()))?;
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            uploaded_bytes = uploaded_bytes.saturating_add(chunk.len());
+            if uploaded_bytes > MAX_UPLOAD_BYTES {
+                return Err(ApiError::payload_too_large("Uploaded file is too large"));
+            }
+            file.write_all(&chunk)
+                .await
+                .map_err(|error| ApiError::internal(error.to_string()))?;
+        }
+        file.flush()
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))
     }
-    file.flush()
-        .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
+    .await;
+    if let Err(error) = write_result {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(error);
+    }
     Ok(temp_path)
 }
 

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -517,6 +517,8 @@ pub(crate) fn create_app_with_state(
     let _ = sweep_stale_lora_uploads(&settings.data_dir);
     let _ = sweep_stale_pose_uploads(&settings.data_dir);
     let _ = sweep_stale_keypoint_uploads(&settings.data_dir);
+    // sc-4204 (F-API-6): asset-import temp files (cache/uploads) had no startup sweep.
+    let _ = sweep_stale_asset_uploads(&settings.data_dir);
     let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
     jobs_store.initialize()?;
     let interrupted_jobs_on_startup = jobs_store.mark_interrupted_on_startup()?.len();

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -6,9 +6,10 @@ use super::{
     create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
     inprocess_worker_gpu_id, lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
     safe_download_dir, safe_repo_dir_name, serialize_job_lora, should_warn_open_bind,
-    strip_jsonc_comments, sweep_stale_lora_uploads_before, Settings, WorkerCapability,
-    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE,
-    HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    strip_jsonc_comments, sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before,
+    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
+    DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE,
+    TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -563,6 +564,87 @@ fn stale_lora_upload_sweep_removes_only_upload_dirs_before_cutoff() {
     assert!(!expired.exists());
     assert!(!fresh.exists());
     assert!(unrelated.exists());
+}
+
+#[test]
+fn stale_asset_upload_sweep_removes_only_upload_tmp_before_cutoff() {
+    // sc-4204 (F-API-6): cache/uploads now has a startup-sweep backstop.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let upload_root = temp_dir.path().join("data/cache/uploads");
+    std::fs::create_dir_all(&upload_root).expect("upload root creates");
+    let expired = upload_root.join("upload-expired.tmp");
+    let fresh = upload_root.join("upload-fresh.tmp");
+    let unrelated = upload_root.join("keep-me.txt");
+    std::fs::write(&expired, b"x").expect("expired writes");
+    std::fs::write(&fresh, b"y").expect("fresh writes");
+    std::fs::write(&unrelated, b"z").expect("unrelated writes");
+
+    let removed = sweep_stale_asset_uploads_before(
+        &temp_dir.path().join("data"),
+        SystemTime::now() + Duration::from_secs(1),
+    )
+    .expect("asset uploads sweep");
+
+    assert_eq!(removed, 2);
+    assert!(!expired.exists());
+    assert!(!fresh.exists());
+    assert!(unrelated.exists(), "non upload-* files are left alone");
+}
+
+#[tokio::test]
+async fn import_asset_removes_staged_temp_file_when_a_later_field_errors() {
+    // sc-4204 (F-API-6): the `file` field is staged to cache/uploads before a later
+    // field is parsed; an invalid `provenance` JSON must not leave an orphan tmp.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    let boundary = "SCENEWORKS_IMPORT_BOUNDARY";
+    let mut body = Vec::new();
+    // `file` first so it is staged, then an invalid `provenance` that errors.
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"file\"; filename=\"x.png\"\r\n",
+    );
+    body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+    body.extend_from_slice(b"\x89PNG\r\n\x1a\n payload bytes");
+    body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(b"Content-Disposition: form-data; name=\"provenance\"\r\n\r\n");
+    body.extend_from_slice(b"{not valid json");
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+    let (status, _, response) = request_raw(
+        app,
+        "POST",
+        "/api/v1/projects/project-1/assets",
+        body,
+        &[(
+            "content-type",
+            &format!("multipart/form-data; boundary={boundary}"),
+        )],
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let value: Value = serde_json::from_slice(&response).expect("json body parses");
+    assert!(value["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("Invalid provenance JSON")));
+
+    // No orphaned temp file should remain under cache/uploads.
+    let upload_root = data_dir.join("cache").join("uploads");
+    let leaked: Vec<_> = std::fs::read_dir(&upload_root)
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with("upload-"))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        leaked.is_empty(),
+        "staged upload temp file leaked on error: {leaked:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Fixes **sc-4204 / F-API-6** (P2, bad-pattern). The asset/pose/keypoint upload helper `write_upload_field_to_dir` only removed its temp file on the **size-cap** branch — a chunk-read, write, or flush error returned without cleanup, leaking an orphaned `upload-*.tmp` (cap is 2GB each). `import_asset` also leaked the staged `file` temp when a *later* field errored (e.g. invalid `provenance` JSON, or a truncated multipart). And unlike `lora-uploads`/`pose-uploads`/`keypoint-uploads`, **`cache/uploads` had no stale-sweep backstop**.

## Fix
- **`write_upload_field_to_dir`**: wrap the write loop in a fallible block and remove the temp file on **any** error — mirroring `write_lora_upload_field_to_staged_file`.
- **`import_asset`**: collect the multipart fields in a fallible block and remove the staged `file` temp before bailing on a later field error.
- **`sweep_stale_asset_uploads`** (cache/uploads, 24h cutoff, with a `_before(cutoff)` variant for testing) added and wired into the startup sweeps next to the lora/pose/keypoint ones.

## Tests
- `import_asset_removes_staged_temp_file_when_a_later_field_errors`: file staged, invalid `provenance` → 400, and **no orphan** `upload-*` remains under `cache/uploads`.
- `stale_asset_upload_sweep_removes_only_upload_tmp_before_cutoff`: `upload-*.tmp` removed before cutoff, non-`upload-*` files left alone.
- **109** `sceneworks-rust-api` lib tests pass; `cargo fmt --check` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)