### PR TITLE
fix(core): mac_capabilities poseFromPhoto agrees with the Rust oracle (sc-4206)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2778,10 +2778,9 @@ async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
     // Real-ESRGAN upscaling is ported to the Rust worker (sc-3489) → supported, no reason.
     assert_eq!(caps["features"]["imageUpscale"]["supported"], true);
     assert_eq!(caps["features"]["imageUpscale"]["reason"], Value::Null);
-    assert_eq!(
-        caps["features"]["poseFromPhoto"]["reason"]["suggestedEpic"],
-        "sc-3487"
-    );
+    // DWPose pose detection is ported to the Rust worker (sc-3487) → supported (sc-4206).
+    assert_eq!(caps["features"]["poseFromPhoto"]["supported"], true);
+    assert_eq!(caps["features"]["poseFromPhoto"]["reason"], Value::Null);
     assert!(caps["training"]["supportedKernels"]
         .as_array()
         .unwrap()

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2119,6 +2119,11 @@ pub struct MacFeatureSupport {
 }
 
 impl MacFeatureSupport {
+    // Declares a Mac feature gap with the reason + suggested port epic. Currently no
+    // feature is gated (poseFromPhoto was the last, ported in sc-3487/flipped in
+    // sc-4206) — kept as the gating vocabulary for the next torch-only surface that
+    // appears before its Rust port lands, so a gap is declared the same way every time.
+    #[allow(dead_code)]
     fn unsupported(feature: &str, detail: &str, suggested_epic: &str) -> Self {
         Self {
             supported: false,
@@ -2177,12 +2182,16 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         },
     );
     features.insert(
+        // DWPose pose detection is ported to the Rust worker (sc-3487): RTMW whole-body
+        // via `ort`/CoreML on the macOS MLX worker, so the Pose Library "create from
+        // photo" flow runs Python-free. This must agree with the PoseDetect arm of
+        // `mac_rust_supported` — what the UI hides can never drift from what routing
+        // refuses (sc-4206 / F-CORE-2).
         "poseFromPhoto".to_owned(),
-        MacFeatureSupport::unsupported(
-            "DWPose pose detection",
-            "photo→skeleton pose detection runs on Python onnxruntime (DWPose).",
-            "sc-3487",
-        ),
+        MacFeatureSupport {
+            supported: true,
+            reason: None,
+        },
     );
     features.insert(
         // Person detection + tracking are ported to the Rust worker (sc-3488 /

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1858,6 +1858,31 @@ fn mac_rust_supported_accepts_eligible_and_mlx_agnostic_jobs() {
 }
 
 #[test]
+fn mac_capabilities_features_agree_with_the_rust_oracle() {
+    // sc-4206 (F-CORE-2): a feature the Mac UI gates must agree with what
+    // mac_rust_supported refuses for the corresponding job type — "what the UI hides
+    // can never drift from what routing refuses". poseFromPhoto/PoseDetect was the
+    // drift this guards (DWPose is ported to Rust, sc-3487).
+    let store = store("capabilities-oracle-agreement");
+    let features = mac_capabilities("darwin", true).features;
+    for (feature, job_type) in [
+        ("poseFromPhoto", JobType::PoseDetect),
+        ("personDetect", JobType::PersonDetect),
+    ] {
+        let supported = features
+            .get(feature)
+            .unwrap_or_else(|| panic!("{feature} capability is present"))
+            .supported;
+        let job = job_of(&store, job_type, json!({}));
+        assert_eq!(
+            supported,
+            mac_rust_supported(&job).is_ok(),
+            "{feature} capability must agree with its mac_rust_supported job-type arm"
+        );
+    }
+}
+
+#[test]
 fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
     let store = store("oracle-torch-model");
     // Each torch-only model points at its dedicated MLX-porting epic (epic 3482 policy),
@@ -2246,7 +2271,9 @@ fn mac_capabilities_master_switch_and_infra_features() {
     // Real-ESRGAN upscaling is ported (sc-3489) → supported, no reason/epic.
     assert_eq!(epic("imageUpscale"), None);
     assert!(mac.features["imageUpscale"].supported);
-    assert_eq!(epic("poseFromPhoto").as_deref(), Some("sc-3487"));
+    // DWPose pose detection is ported (sc-3487) → supported, no reason/epic (sc-4206).
+    assert_eq!(epic("poseFromPhoto"), None);
+    assert!(mac.features["poseFromPhoto"].supported);
     // Person detect/track is ported (sc-3488 / sc-3633/3634/3709) → supported, no epic.
     assert_eq!(epic("personDetect"), None);
     assert!(mac.features["personDetect"].supported);
@@ -2257,15 +2284,16 @@ fn mac_capabilities_master_switch_and_infra_features() {
     // via each video model's macSupport.features.videoModes instead.
     assert!(!mac.features.contains_key("advancedVideoModes"));
     assert!(mac.features["datasetCaptioning"].supported);
-    // datasetCaptioning + imageUpscale + personDetect are the ported (supported) infra
-    // features; the rest stay gated until their port lands.
+    // datasetCaptioning + imageUpscale + personDetect + poseFromPhoto are the ported
+    // (supported) infra features; the rest stay gated until their port lands.
+    // poseFromPhoto joined the supported set in sc-4206 (DWPose ported, sc-3487).
     assert!(mac
         .features
         .iter()
         .filter(|(key, _)| {
             !matches!(
                 key.as_str(),
-                "datasetCaptioning" | "imageUpscale" | "personDetect"
+                "datasetCaptioning" | "imageUpscale" | "personDetect" | "poseFromPhoto"
             )
         })
         .all(|(_, f)| !f.supported));


### PR DESCRIPTION
## Summary
Fixes **sc-4206 / F-CORE-2** (P2, bad-pattern). `mac_rust_supported` returns `Ok(())` for `JobType::PoseDetect` ("DWPose now ported to the Rust worker, sc-3487"), but `mac_capabilities` still marked **`poseFromPhoto` unsupported** ("runs on Python onnxruntime"). The two surfaces are documented as one source of truth — *"what the UI hides can never drift from what routing refuses"* — and had drifted: once `SCENEWORKS_MLX_REQUIRED` gating is active, the Mac UI would hide the Pose Library "create from photo" flow even though the job runs natively, and the gap doc/Logs would point at a non-existent gap.

## Fix
- **Flip `poseFromPhoto` to `supported: true`** (mirroring `personDetect`/`datasetCaptioning`), with a comment tying it to the `PoseDetect` oracle arm.
- **`mac_capabilities_features_agree_with_the_rust_oracle`**: asserts the `poseFromPhoto`/`personDetect` capabilities match `mac_rust_supported` for `PoseDetect`/`PersonDetect` — a regression guard against future drift (the test the finding asked for).
- Updated the existing capability assertions (core `mac_capabilities_master_switch_and_infra_features` + the rust-api capabilities endpoint test) that encoded the old unsupported state.
- `MacFeatureSupport::unsupported` is now unused (no current gap); kept as the gating vocabulary behind `#[allow(dead_code)]` rather than churn the framework — features flip as ports land.

## Tests
- `cargo fmt --check` + `clippy --all-targets` clean on both crates.
- **102** `sceneworks-core` jobs_store tests + **109** `sceneworks-rust-api` lib tests pass (incl. the new agreement test and the updated capability-endpoint test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)