### PR TITLE
fix(core): compute queue_summary counts/active jobs over full table (sc-4208)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -79,6 +79,22 @@ fn active_statuses_sql() -> &'static str {
             .join(", ")
     })
 }
+
+/// The terminal statuses as a quoted SQL list for `status not in (...)` filters,
+/// derived once from [`TERMINAL_STATUSES`] — same anti-drift rationale as
+/// [`active_statuses_sql`]. Used to select the non-terminal (still in-flight,
+/// including `queued`) jobs for the queue summary. Values are crate constants,
+/// never user input, so direct interpolation is safe.
+fn terminal_statuses_sql() -> &'static str {
+    static SQL: OnceLock<String> = OnceLock::new();
+    SQL.get_or_init(|| {
+        TERMINAL_STATUSES
+            .iter()
+            .map(|status| format!("'{status}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    })
+}
 const DISPATCH_MEMORY_NOT_WORSE_TOLERANCE_MB: f64 = 512.0;
 const DISPATCH_MEMORY_RELIEF_THRESHOLD_MB: f64 = 1024.0;
 const DISPATCH_LOW_MEMORY_THRESHOLD_MB: f64 = 2048.0;
@@ -1124,21 +1140,46 @@ impl JobsStore {
     }
 
     pub fn queue_summary(&self) -> JobsStoreResult<QueueSummary> {
-        let jobs = self.list_jobs(None, None, 500)?;
+        // list_workers takes the store lock itself, so resolve it before we take
+        // the lock below to avoid a nested (potential self-deadlock) acquisition.
         let workers = self.list_workers()?;
+        let _guard = self.lock.lock();
+        let connection = self.connect()?;
+
+        // Per-status counts over the WHOLE table — never a capped/newest-N sample.
+        // Filtering an already-capped list silently undercounts once a project
+        // exceeds the cap (sc-4208 / F-CORE-4). Seed every known status at 0 so
+        // the map shape is stable for callers regardless of what rows exist.
         let mut counts = JOB_STATUSES
             .iter()
-            .map(|status| (parse_string_enum::<JobStatus>(status), 0))
+            .map(|status| (parse_string_enum::<JobStatus>(status), 0u32))
             .collect::<std::collections::BTreeMap<_, _>>();
-        for job in &jobs {
-            *counts.entry(job.status.clone()).or_insert(0) += 1;
+        let mut statement =
+            connection.prepare("select status, count(*) from jobs group by status")?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            let (status, count) = row?;
+            // Writes are constrained to JOB_STATUSES so the seeded entry exists;
+            // or_insert keeps an unexpected value counted rather than dropped.
+            *counts
+                .entry(parse_string_enum::<JobStatus>(&status))
+                .or_insert(0) += u32::try_from(count).unwrap_or(u32::MAX);
         }
+
+        // Active (non-terminal, includes `queued`) jobs come from a dedicated
+        // uncapped query so an old still-queued/running job can't fall out of the
+        // newest-N window and become invisible to the operator.
+        let mut statement = connection.prepare(&format!(
+            "select * from jobs where status not in ({terminal}) order by created_at desc",
+            terminal = terminal_statuses_sql()
+        ))?;
+        let active_jobs = collect_jobs(statement.query_map([], row_to_job)?)?;
+
         Ok(QueueSummary {
             counts,
-            active_jobs: jobs
-                .into_iter()
-                .filter(|job| !is_terminal_status(job.status.as_str()))
-                .collect(),
+            active_jobs,
             workers,
             max_job_attempts: MAX_JOB_ATTEMPTS,
             extra: Default::default(),

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1687,6 +1687,54 @@ fn backdate_job_created_at(store: &JobsStore, job_id: &str) {
         .expect("job created_at backdates");
 }
 
+/// sc-4208 / F-CORE-4: `queue_summary` must derive per-status counts and the
+/// active-jobs list from the WHOLE table, not from a newest-500 cap. Before the
+/// fix, once a project exceeded 500 jobs the counts silently undercounted and an
+/// old still-queued job could fall out of the newest-500 window and vanish from
+/// `active_jobs` entirely.
+#[test]
+fn queue_summary_counts_and_active_jobs_ignore_500_row_cap() {
+    let store = store("queue-summary-cap");
+
+    // One old queued job, backdated so it is the OLDEST row by created_at —
+    // exactly the row a newest-500 window would evict first.
+    let old_queued = store
+        .create_job(image_job(object(json!({ "prompt": "oldest queued" }))))
+        .expect("old job creates");
+    backdate_job_created_at(&store, &old_queued.id);
+
+    // 501 newer jobs so the table exceeds the 500-row cap; mark them completed
+    // via raw SQL so the newest-500 window is entirely terminal.
+    for i in 0..501 {
+        store
+            .create_job(image_job(object(
+                json!({ "prompt": format!("completed {i}") }),
+            )))
+            .expect("job creates");
+    }
+    let connection = Connection::open(store.db_path()).expect("db opens");
+    let updated = connection
+        .execute(
+            "update jobs set status = 'completed' where id != ?1",
+            params![old_queued.id],
+        )
+        .expect("bulk completes newer jobs");
+    assert_eq!(updated, 501, "exactly the newer jobs are completed");
+
+    let summary = store.queue_summary().expect("summary computes");
+
+    // Counts come from `group by` over all 502 rows, not a 500-row sample.
+    assert_eq!(
+        summary.counts.get(&JobStatus::Completed).copied(),
+        Some(501)
+    );
+    assert_eq!(summary.counts.get(&JobStatus::Queued).copied(), Some(1));
+
+    // The old queued job survives in active_jobs despite 501 newer terminal rows.
+    assert_eq!(summary.active_jobs.len(), 1);
+    assert_eq!(summary.active_jobs[0].id, old_queued.id);
+}
+
 #[test]
 fn mlx_required_defers_eligible_job_even_with_no_idle_mlx_worker() {
     let store = store("mlx-required-defer");


### PR DESCRIPTION
## sc-4208 — [F-CORE-4] `queue_summary` computes status counts from a 500-row cap

Fixes code-review finding F-CORE-4 (P2/Medium, bug).

### Problem
`queue_summary()` called `self.list_jobs(None, None, 500)` and derived both the per-status `counts` map and `active_jobs` from those **newest-500** rows (by `created_at`). Once a project accumulates >500 jobs (a few weeks of normal generation):
- per-status `counts` silently **undercount**, and
- because the cap keeps the newest, an **old still-queued/running job drops out of `active_jobs`** entirely — invisible to the operator.

### Fix
Per the suggested approach:
- **counts**: `select status, count(*) from jobs group by status` over the whole table, seeded from `JOB_STATUSES` so the map shape stays stable.
- **active_jobs**: a dedicated uncapped `select * from jobs where status not in (<terminal>) order by created_at desc` (still includes `queued`), via a new `terminal_statuses_sql()` `OnceLock` helper mirroring `active_statuses_sql()`/`non_gpu_job_types_sql()`.
- `list_workers()` is resolved before taking the store lock (it locks internally) to avoid a nested acquisition.

The `QueueSummary` contract is unchanged; HTTP callers (`/api/v1/queue`) pass it through verbatim — the result is just complete instead of truncated.

### Tests
- New regression test `queue_summary_counts_and_active_jobs_ignore_500_row_cap`: inserts 502 jobs (one backdated `queued` + 501 `completed`) and asserts `counts[completed] == 501`, `counts[queued] == 1`, and the old queued job survives in `active_jobs` — all of which fail under the old capped implementation.
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (103 jobs_store integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)