### PR TITLE
perf(core): generate random_hex ids via getrandom, not per-call SQLite (sc-4209)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,6 +4167,7 @@ name = "sceneworks-core"
 version = "0.2.0"
 dependencies = [
  "directories",
+ "getrandom 0.3.4",
  "mime_guess",
  "parking_lot",
  "rusqlite",

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 directories = "5"
+getrandom = "0.3"
 parking_lot = "0.12"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sceneworks-core/src/store_util.rs
+++ b/crates/sceneworks-core/src/store_util.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 use parking_lot::{ReentrantMutex, ReentrantMutexGuard};
-use rusqlite::Connection;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
@@ -118,13 +117,24 @@ pub(crate) fn optional_f64(value: &Value, key: &str) -> Option<f64> {
     value.get(key).and_then(Value::as_f64)
 }
 
+/// Generate a random lowercase-hex id of `bytes` random bytes (so `2 * bytes`
+/// hex chars). Previously this ran `hex(randomblob(n))` through a fresh
+/// in-memory SQLite connection per call, so saving a timeline with N new items
+/// opened N connections and turned SQLite-init failures into id-generation
+/// failures (sc-4209 / F-CORE-5). Now it pulls from the OS CSPRNG via
+/// `getrandom` and hex-encodes in Rust — no connection, no SQLite failure
+/// surface.
 pub(crate) fn random_hex(bytes: usize) -> ProjectStoreResult<String> {
-    let connection = Connection::open_in_memory()?;
-    Ok(connection.query_row(
-        &format!("select lower(hex(randomblob({bytes})))"),
-        [],
-        |row| row.get(0),
-    )?)
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut buffer = vec![0u8; bytes];
+    getrandom::fill(&mut buffer)
+        .map_err(|error| ProjectStoreError::Io(std::io::Error::other(error.to_string())))?;
+    let mut hex = String::with_capacity(bytes * 2);
+    for byte in buffer {
+        hex.push(HEX_DIGITS[(byte >> 4) as usize] as char);
+        hex.push(HEX_DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    Ok(hex)
 }
 
 pub(crate) fn parse_string_enum<T>(value: &str) -> T
@@ -137,7 +147,35 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{atomic_write, lock_project_files};
+    use super::{atomic_write, lock_project_files, random_hex};
+    use std::collections::HashSet;
+
+    /// sc-4209 / F-CORE-5: `random_hex(n)` returns `2n` lowercase-hex chars,
+    /// generated without a SQLite connection. Covers the length/charset contract
+    /// and that successive ids differ (i.e. it is actually random, not constant).
+    #[test]
+    fn random_hex_produces_lowercase_hex_of_expected_length() {
+        for bytes in [1usize, 4, 16] {
+            let id = random_hex(bytes).expect("id generates");
+            assert_eq!(
+                id.len(),
+                bytes * 2,
+                "{bytes} bytes -> {} hex chars",
+                bytes * 2
+            );
+            assert!(
+                id.chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                "id {id:?} is lowercase hex"
+            );
+        }
+
+        // Distinct across many calls — a constant/low-entropy generator would collide.
+        let ids = (0..1000)
+            .map(|_| random_hex(16).expect("id generates"))
+            .collect::<HashSet<_>>();
+        assert_eq!(ids.len(), 1000, "16-byte ids are unique across 1000 draws");
+    }
 
     #[test]
     fn atomic_write_tolerates_concurrent_writers_to_same_path() {


### PR DESCRIPTION
## sc-4209 — [F-CORE-5] `random_hex` opens a new in-memory SQLite connection per call

Fixes code-review finding F-CORE-5 (P2/Medium, efficiency).

### Problem
`random_hex()` in `store_util.rs` opened a fresh in-memory SQLite connection on **every call** just to run `hex(randomblob(n))`. Every random id — assets, timelines, characters, looks, LoRA links, dataset items, atomic-write temp-file tokens, and *every timeline item lacking an id* in `validate_timeline_item` — paid a connection open. Saving a timeline with N new items spun up N connections (same on dataset/batch import). It also turned SQLite-init errors into id-generation errors.

### Fix
Pull random bytes from the OS CSPRNG via `getrandom::fill` and hex-encode in Rust (lowercase, matching the old `lower(hex(...))`). No connection per call, no SQLite failure surface.

- `getrandom` 0.3 was **already a transitive dependency** (its compiled crate is unchanged in the build); this only adds the direct dependency edge in `Cargo.toml` + `Cargo.lock`. Default backend covers macOS/Windows/Linux with no extra config.
- Removed the now-orphaned `use rusqlite::Connection;` from `store_util.rs`.

### Tests
- New unit test `random_hex_produces_lowercase_hex_of_expected_length`: asserts `random_hex(n)` returns `2n` lowercase-hex chars for several sizes and that 1000 draws are unique (catches a constant/low-entropy regression).
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (140 lib + 103 jobs_store), and `cargo build -p sceneworks-rust-api` succeeds.

### Dependency note
Adds `getrandom = "0.3"` as a direct dependency of `sceneworks-core` (already present transitively; no new crate version introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)