### PR TITLE
fix(core): block IPv4-mapped IPv6 in SSRF guard (sc-4210)

### DIFF
--- a/crates/sceneworks-core/src/lora_url.rs
+++ b/crates/sceneworks-core/src/lora_url.rs
@@ -99,7 +99,19 @@ pub fn validate_lora_url_host(url: &Url) -> Result<(), LoraUrlError> {
 pub fn validate_public_ip(address: IpAddr) -> Result<(), LoraUrlError> {
     let blocked = match address {
         IpAddr::V4(address) => blocked_ipv4(address),
-        IpAddr::V6(address) => blocked_ipv6(address),
+        IpAddr::V6(address) => {
+            // An IPv4-mapped (`::ffff:a.b.c.d`) or IPv4-compatible (`::a.b.c.d`)
+            // IPv6 address reaches the very same IPv4 endpoint, so re-run the v4
+            // blocklist on the embedded address before the v6 checks. Without
+            // this, `http://[::ffff:127.0.0.1]/x.safetensors` (or a DNS AAAA of
+            // `::ffff:10.0.0.1`) slips past both the URL-time host check and the
+            // connect-time re-validation (sc-4210 / F-CORE-6 SSRF bypass).
+            address
+                .to_ipv4_mapped()
+                .or_else(|| address.to_ipv4())
+                .is_some_and(blocked_ipv4)
+                || blocked_ipv6(address)
+        }
     };
     if blocked {
         Err(LoraUrlError::BlockedHost)
@@ -130,7 +142,50 @@ fn blocked_ipv6(address: Ipv6Addr) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{lora_source_url_file_name, parse_lora_source_url, LoraUrlError};
+    use super::{
+        lora_source_url_file_name, parse_lora_source_url, validate_public_ip, LoraUrlError,
+    };
+    use std::net::{IpAddr, Ipv6Addr};
+
+    fn v6(literal: &str) -> IpAddr {
+        IpAddr::V6(literal.parse::<Ipv6Addr>().expect("valid IPv6 literal"))
+    }
+
+    /// sc-4210 / F-CORE-6: an IPv4-mapped/compatible IPv6 address reaches the
+    /// embedded IPv4 endpoint, so the SSRF guard must unmap and re-run the v4
+    /// blocklist. Before the fix these slipped past `validate_public_ip` and the
+    /// connect-time re-validation, letting a crafted URL reach loopback/RFC1918.
+    #[test]
+    fn validate_public_ip_blocks_ipv4_mapped_private_targets() {
+        // IPv4-mapped (`::ffff:a.b.c.d`) loopback / RFC1918 / link-local.
+        for blocked in ["::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:169.254.0.1"] {
+            assert_eq!(
+                validate_public_ip(v6(blocked)),
+                Err(LoraUrlError::BlockedHost),
+                "{blocked} must be blocked"
+            );
+        }
+        // IPv4-compatible (`::a.b.c.d`) loopback.
+        assert_eq!(
+            validate_public_ip(v6("::127.0.0.1")),
+            Err(LoraUrlError::BlockedHost)
+        );
+
+        // A mapped *public* IPv4 and a genuine public IPv6 must still pass — the
+        // fix blocks the bypass, not all v4-mapped traffic.
+        assert!(validate_public_ip(v6("::ffff:1.1.1.1")).is_ok());
+        assert!(validate_public_ip(v6("2606:4700:4700::1111")).is_ok());
+    }
+
+    /// End-to-end: the bracketed IPv4-mapped literal is rejected by URL parsing,
+    /// mirroring the existing literal-`127.0.0.1` case.
+    #[test]
+    fn parse_lora_source_url_blocks_ipv4_mapped_loopback_host() {
+        assert_eq!(
+            parse_lora_source_url("http://[::ffff:127.0.0.1]/style.safetensors").unwrap_err(),
+            LoraUrlError::BlockedHost
+        );
+    }
 
     #[test]
     fn lora_source_urls_validate_scheme_host_and_filename() {


### PR DESCRIPTION
## sc-4210 — [F-CORE-6] `validate_public_ip` misses IPv4-mapped IPv6 addresses (SSRF guard bypass)

Fixes code-review finding F-CORE-6 (P2/Medium, **security**).

### Problem
`validate_public_ip` (`lora_url.rs`) ran the IPv6 blocklist (loopback/unspecified/ULA/link-local/doc/multicast) but never unmapped IPv4-mapped (`::ffff:a.b.c.d`) or IPv4-compatible (`::a.b.c.d`) addresses. Those reach the **same IPv4 endpoint**, so:
- `http://[::ffff:127.0.0.1]/x.safetensors`, or
- a DNS `AAAA` record resolving to `::ffff:10.0.0.1`

passed both the URL-time host check (`validate_lora_url_host`) and the worker's connect-time re-validation (`sceneworks-worker/src/downloads.rs`), which calls this same function on resolved addresses. That's an SSRF blocklist bypass letting a crafted LoRA source URL reach loopback/RFC1918 services from the worker (e.g. the local API itself).

### Fix
In the IPv6 arm, unmap any embedded IPv4 via `to_ipv4_mapped()` (falling back to `to_ipv4()` for the compat form) and re-run the **IPv4** blocklist before the IPv6 checks. Single-point fix — both the URL-time and connect-time call sites use this function. Genuinely-public mapped addresses (`::ffff:1.1.1.1`) and real public IPv6 (`2606:4700:4700::1111`) still pass, so the fix blocks the bypass without over-blocking.

### Tests
- `validate_public_ip_blocks_ipv4_mapped_private_targets`: mapped loopback/RFC1918/link-local and compat loopback → `BlockedHost`; mapped-public and real-public → `Ok`.
- `parse_lora_source_url_blocks_ipv4_mapped_loopback_host`: end-to-end bracketed `[::ffff:127.0.0.1]` literal → `BlockedHost`.
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (142 lib + 103 jobs_store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)