### PR TITLE
fix(core): validate asset/character ids before path use (sc-4211)

### DIFF
--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Map, Value};
 use crate::asset_index::{asset_sidecars, normalize_asset, row_to_asset_record, upsert_asset_row};
 use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
-    atomic_write, optional_bool, optional_f64, optional_str, random_hex, read_json,
+    atomic_write, is_safe_id, optional_bool, optional_f64, optional_str, random_hex, read_json,
     relative_string, write_json,
 };
 use crate::time::utc_now;
@@ -765,7 +765,7 @@ pub fn reindex_characters_on_connection(
 
 pub fn write_character_sidecar(project_path: &Path, character: &Value) -> ProjectStoreResult<()> {
     let character_id = required_str(character, "id")?.to_owned();
-    write_character_json(&character_file(project_path, &character_id), character)
+    write_character_json(&character_file(project_path, &character_id)?, character)
 }
 
 fn ensure_character_index(project_path: &Path) -> ProjectStoreResult<()> {
@@ -833,7 +833,7 @@ fn index_character_on_connection(
     project_path: &Path,
     character: &Value,
 ) -> ProjectStoreResult<()> {
-    let sidecar_path = character_file(project_path, required_str(character, "id")?);
+    let sidecar_path = character_file(project_path, required_str(character, "id")?)?;
     index_character_sidecar_on_connection(connection, project_path, &sidecar_path, character)
 }
 
@@ -1005,14 +1005,23 @@ fn character_sidecars(project_path: &Path) -> ProjectStoreResult<Vec<PathBuf>> {
     Ok(sidecars)
 }
 
-fn character_file(project_path: &Path, character_id: &str) -> PathBuf {
-    project_path
+/// Resolve the on-disk sidecar path for a character id. The id is charset-checked
+/// before it is joined into the path so a crafted sidecar (e.g. from an imported
+/// project) carrying `"id": "../../x"` can't make reindex/get/purge read, write,
+/// or delete files outside the `characters/` directory (sc-4211 / F-CORE-7).
+fn character_file(project_path: &Path, character_id: &str) -> ProjectStoreResult<PathBuf> {
+    if !is_safe_id(character_id) {
+        return Err(ProjectStoreError::BadRequest(
+            "Invalid character id".to_owned(),
+        ));
+    }
+    Ok(project_path
         .join("characters")
-        .join(format!("{character_id}.sceneworks.character.json"))
+        .join(format!("{character_id}.sceneworks.character.json")))
 }
 
 fn find_character_file(project_path: &Path, character_id: &str) -> ProjectStoreResult<PathBuf> {
-    let path = character_file(project_path, character_id);
+    let path = character_file(project_path, character_id)?;
     if path.exists() {
         return Ok(path);
     }
@@ -1215,6 +1224,11 @@ fn copy_lora_into_project(
     character_id: &str,
     source_path: Option<&str>,
 ) -> ProjectStoreResult<(Option<String>, bool)> {
+    if !is_safe_id(character_id) {
+        return Err(ProjectStoreError::BadRequest(
+            "Invalid character id".to_owned(),
+        ));
+    }
     let Some(source_path) = source_path.filter(|value| !value.trim().is_empty()) else {
         return Ok((None, false));
     };

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1257,6 +1257,11 @@ impl ProjectStore {
         let asset_id = fact.get("assetId").and_then(Value::as_str).ok_or_else(|| {
             ProjectStoreError::BadRequest("generated asset fact missing assetId".to_owned())
         })?;
+        // The asset id comes from the worker's result fact and is joined into the
+        // recipe path below, so charset-check it before path use (sc-4211 / F-CORE-7).
+        if !is_safe_id(asset_id) {
+            return Err(ProjectStoreError::BadRequest("Invalid asset id".to_owned()));
+        }
         let asset = build_generated_asset_sidecar(project_id, job_id, generation_set_id, fact);
         let media_path = project_path.join(media_rel);
         let sidecar_path = media_path.with_extension("sceneworks.json");
@@ -2132,6 +2137,14 @@ impl ProjectStore {
         project_path: &Path,
         asset_id: &str,
     ) -> ProjectStoreResult<PathBuf> {
+        // Charset-check before any path use. This is the chokepoint every
+        // asset-mutating method (get/update/delete/purge) hits first, so a
+        // crafted-sidecar id like `../../x` is rejected before `delete_asset`/
+        // `purge_asset` join it into a `trash/<asset_id>` dir or `remove_dir_all`
+        // it (sc-4211 / F-CORE-7).
+        if !is_safe_id(asset_id) {
+            return Err(ProjectStoreError::BadRequest("Invalid asset id".to_owned()));
+        }
         find_asset_sidecar_path(project_path, asset_id)?
             .ok_or_else(|| ProjectStoreError::NotFound("Asset not found".to_owned()))
     }
@@ -4271,6 +4284,38 @@ mod tests {
             .create_pose_asset(&spec)
             .expect_err("traversal rejected");
         assert!(matches!(err, ProjectStoreError::BadRequest(_)));
+    }
+
+    /// sc-4211 / F-CORE-7: asset ids are joined into `trash/<id>` and recipe
+    /// paths, so the asset-sidecar chokepoint must reject a traversal id before
+    /// any path use. Without it, `delete_asset`/`purge_asset` could create or
+    /// `remove_dir_all` directories outside the project's trash folder.
+    #[test]
+    fn asset_methods_reject_path_traversal_ids() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Assets").expect("project creates");
+
+        // A real sidecar outside the project that traversal would try to reach.
+        let outside = temp_dir.path().join("outside");
+        std::fs::create_dir_all(&outside).expect("outside dir");
+        std::fs::write(outside.join("victim.txt"), b"do not touch").expect("victim writes");
+
+        let evil = "../../../outside/victim";
+        assert!(matches!(
+            store.get_asset(&project.id, evil),
+            Err(ProjectStoreError::BadRequest(_))
+        ));
+        assert!(matches!(
+            store.delete_asset(&project.id, evil),
+            Err(ProjectStoreError::BadRequest(_))
+        ));
+        assert!(matches!(
+            store.purge_asset(&project.id, evil),
+            Err(ProjectStoreError::BadRequest(_))
+        ));
+        // The traversal target is untouched.
+        assert!(outside.join("victim.txt").exists());
     }
 
     // ---- Key Point Library (sc-4434) ---------------------------------------------------

--- a/crates/sceneworks-core/tests/character_store.rs
+++ b/crates/sceneworks-core/tests/character_store.rs
@@ -44,6 +44,31 @@ fn character_sidecar_writer_byte_matches_fixture() {
     assert_eq!(actual, expected);
 }
 
+/// sc-4211 / F-CORE-7: a character id is joined into
+/// `characters/<id>.sceneworks.character.json`, so a crafted character carrying a
+/// traversal id must be rejected before any path use rather than letting the
+/// sidecar write escape the project's `characters/` directory.
+#[test]
+fn character_sidecar_writer_rejects_path_traversal_id() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let outside = temp_dir.path().join("outside.sceneworks.character.json");
+    let character = json!({
+        "schemaVersion": 1,
+        "id": "../../outside",
+        "projectId": "project_fixture",
+        "name": "Evil",
+        "type": "person",
+    });
+
+    let err =
+        write_character_sidecar(temp_dir.path(), &character).expect_err("traversal id is rejected");
+    assert!(
+        format!("{err:?}").contains("Invalid character id"),
+        "got {err:?}"
+    );
+    assert!(!outside.exists(), "no file written outside characters/");
+}
+
 #[test]
 fn character_sidecar_writer_preserves_string_newlines_as_json_escapes() {
     let temp_dir = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
## sc-4211 — [F-CORE-7] Asset/character ids joined into filesystem paths without `is_safe_id`

Fixes code-review finding F-CORE-7 (P2/Medium, **security**).

### Problem
Person-track ids (`is_safe_track_id`) and dataset ids (`is_safe_id`) are charset-validated before path use, but **asset ids and character ids were not**:
- `delete_asset`/`purge_asset` build `trash/<asset_id>` and `remove_dir_all` it;
- `persist_generated_asset` joins the worker-fact `assetId` into a recipe path;
- `character_file` builds `characters/<character_id>.sceneworks.character.json` (read/written/removed by get/update/purge);
- `copy_lora_into_project` builds `loras/characters/<character_id>`.

Generated ids never contain separators, but `reindex_project_path` ingests **any sidecar found on disk**, so a crafted sidecar (e.g. from a shared/imported project) with `"id": "../../something"` makes delete/purge/index operations create, remove, or `remove_dir_all` paths **outside** the project's trash/characters folders.

### Fix
Apply `is_safe_id` at the path chokepoints, matching the track/dataset pattern:
- **project_store**: `find_asset_sidecar` (the first step every asset get/update/delete/purge hits, so the `trash/<asset_id>` join + `remove_dir_all` are never reached with an unsafe id) and `persist_generated_asset` (worker-fact `assetId`).
- **character_store**: `character_file` now returns `Result` and rejects unsafe ids — covering `find_character_file` and the reindex/index sidecar code paths that take an id from a (possibly sidecar-derived) value — plus `copy_lora_into_project` validates before building `loras/characters/<id>`.

`is_safe_id` accepts the `alnum + _ + -` charset that all generated ids (`asset_<hex>`, `character_<hex>`) already use, so no legitimate id is rejected (verified: full suite green).

### Tests
- `project_store::tests::asset_methods_reject_path_traversal_ids`: `get_asset`/`delete_asset`/`purge_asset` with `../../../outside/victim` → `BadRequest`, and the outside file is untouched.
- `character_sidecar_writer_rejects_path_traversal_id`: a character with `"id": "../../outside"` → `Invalid character id`, no file written outside `characters/`.
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (143 lib + 103 jobs_store + 7 character_store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)