### PR TITLE
perf(core): cache generation-sets + HashSet dedup in list_assets (sc-4270)

### DIFF
--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -102,10 +103,37 @@ pub(crate) fn derive_origin(mode: &str, asset_type: &str) -> &'static str {
     }
 }
 
+/// Caches generation-set JSON by id within a single batch normalize so each
+/// `generation-sets/<id>.json` is read+parsed at most once instead of once per
+/// asset in the set. `None` records a missing/unreadable set so it isn't probed
+/// again. Sized for a `list_assets` call; single-asset GETs use a throwaway one
+/// (sc-4270 / F-CORE-10).
+#[derive(Default)]
+pub(crate) struct GenerationSetCache {
+    entries: HashMap<String, Option<Value>>,
+}
+
 pub(crate) fn normalize_asset(
     project_id: &str,
     project_path: &Path,
     sidecar_path: &Path,
+) -> ProjectStoreResult<Value> {
+    normalize_asset_cached(
+        project_id,
+        project_path,
+        sidecar_path,
+        &mut GenerationSetCache::default(),
+    )
+}
+
+/// Like [`normalize_asset`] but resolves the embedded `generationSet` through a
+/// caller-owned [`GenerationSetCache`], so a batch listing reads each
+/// generation-set file once rather than once per asset (sc-4270 / F-CORE-10).
+pub(crate) fn normalize_asset_cached(
+    project_id: &str,
+    project_path: &Path,
+    sidecar_path: &Path,
+    generation_sets: &mut GenerationSetCache,
 ) -> ProjectStoreResult<Value> {
     let mut asset = read_json(sidecar_path)?;
     // Guarantee every API response carries an `origin`, even for legacy sidecars
@@ -128,14 +156,18 @@ pub(crate) fn normalize_asset(
         }
     }
     if let Some(generation_set_id) = asset.get("generationSetId").and_then(Value::as_str) {
-        let generation_set_path = project_path
-            .join("generation-sets")
-            .join(format!("{generation_set_id}.json"));
-        if generation_set_path.exists() {
-            if let Ok(generation_set) = read_json(&generation_set_path) {
-                if let Some(object) = asset.as_object_mut() {
-                    object.insert("generationSet".to_owned(), generation_set);
-                }
+        let cached = generation_sets
+            .entries
+            .entry(generation_set_id.to_owned())
+            .or_insert_with(|| {
+                let generation_set_path = project_path
+                    .join("generation-sets")
+                    .join(format!("{generation_set_id}.json"));
+                read_json(&generation_set_path).ok()
+            });
+        if let Some(generation_set) = cached.clone() {
+            if let Some(object) = asset.as_object_mut() {
+                object.insert("generationSet".to_owned(), generation_set);
             }
         }
     }

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use crate::asset_index::{
-    asset_origin, asset_sidecars, normalize_asset, row_to_asset_record, upsert_asset_row,
-    AssetRecord,
+    asset_origin, asset_sidecars, normalize_asset, normalize_asset_cached, row_to_asset_record,
+    upsert_asset_row, AssetRecord, GenerationSetCache,
 };
 use crate::character_store::{
     apply_character_migrations, clear_character_tables, reindex_characters_on_connection,
@@ -763,7 +763,11 @@ impl ProjectStore {
                 row.get::<_, Option<String>>(1)?,
             ))
         })?;
-        let mut seen_asset_ids = Vec::new();
+        // HashSet dedup (was an O(n²) Vec linear scan) and a per-call
+        // generation-set cache so a set's JSON is read once, not once per asset
+        // in it (sc-4270 / F-CORE-10).
+        let mut seen_asset_ids = std::collections::HashSet::new();
+        let mut generation_sets = GenerationSetCache::default();
         let mut assets = Vec::new();
         for row in rows {
             let (sidecar_rel, file_rel) = row?;
@@ -782,7 +786,12 @@ impl ProjectStore {
                 if !sidecar_path.exists() {
                     continue;
                 }
-                let Ok(asset) = normalize_asset(project_id, &project_path, &sidecar_path) else {
+                let Ok(asset) = normalize_asset_cached(
+                    project_id,
+                    &project_path,
+                    &sidecar_path,
+                    &mut generation_sets,
+                ) else {
                     continue;
                 };
                 let asset_id = asset
@@ -790,10 +799,9 @@ impl ProjectStore {
                     .and_then(Value::as_str)
                     .unwrap_or_default()
                     .to_owned();
-                if seen_asset_ids.iter().any(|seen| seen == &asset_id) {
+                if !seen_asset_ids.insert(asset_id) {
                     break;
                 }
-                seen_asset_ids.push(asset_id);
                 assets.push(asset);
                 break;
             }
@@ -3932,6 +3940,77 @@ mod tests {
             json!(1024)
         );
         assert_eq!(written["recipe"]["rawAdapterSettings"]["steps"], json!(8));
+    }
+
+    /// sc-4270 / F-CORE-10: list_assets resolves the embedded `generationSet`
+    /// through a per-call cache (read once per set, not once per asset). Two
+    /// assets sharing a set must each still carry the full, correct set — proving
+    /// the cache doesn't drop or corrupt the shared value, and that dedup keeps
+    /// both distinct assets.
+    #[test]
+    fn list_assets_embeds_shared_generation_set_for_each_asset() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Gallery").expect("project creates");
+
+        let generation_set = json!({
+            "id": "genset_shared",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "city",
+            "count": 2,
+            "createdAt": "2026-05-25T00:00:00Z",
+        });
+        let make_fact = |asset_id: &str, name: &str| {
+            json!({
+                "assetId": asset_id,
+                "mediaPath": format!("assets/images/genset_shared/{asset_id}.png"),
+                "mimeType": "image/png",
+                "displayName": name,
+                "createdAt": "2026-05-25T00:00:00Z",
+                "mode": "text_to_image",
+                "model": "z_image_turbo",
+                "adapter": "z_image_diffusers",
+                "prompt": "city",
+            })
+        };
+
+        store
+            .write_generation_set(
+                &project.id,
+                "job-1",
+                &generation_set,
+                Some(&make_fact("asset_one", "city #1")),
+            )
+            .expect("generation set writes");
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "genset_shared",
+                &make_fact("asset_one", "city #1"),
+            )
+            .expect("asset one persists");
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "genset_shared",
+                &make_fact("asset_two", "city #2"),
+            )
+            .expect("asset two persists");
+
+        let assets = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .expect("list");
+        assert_eq!(assets.len(), 2, "both distinct assets are listed (deduped)");
+        for asset in &assets {
+            assert_eq!(
+                asset["generationSet"]["id"],
+                json!("genset_shared"),
+                "each asset embeds the shared generation set"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## sc-4270 — [F-CORE-10] Asset listing does per-row filesystem I/O (N+1 in a hot path)

Fixes code-review finding F-CORE-10 (P3/Low, efficiency).

### Problem
`list_assets` (the Asset Library / studio gallery listing) compounded file I/O:
- `normalize_asset` re-read **and re-parsed** each asset's generation-set JSON (`generation-sets/<id>.json`) once per asset, so a studio batch that emits N assets into one generation set read that set's file N times.
- the dedup used an **O(n²)** `Vec` linear scan (`seen_asset_ids.iter().any`).

### Fix
- Add a per-call `GenerationSetCache` so each generation-set file is read at most once. New `normalize_asset_cached` carries the cache; `normalize_asset` delegates with a throwaway cache, so the 7 single-asset callers are unchanged.
- Switch the dedup from a `Vec` linear scan to a `HashSet` (the reviewer's explicit fallback).
- Drop the now-redundant pre-read `.exists()` probe in the cached path (the read already fails closed).

### Scope note (intentional, per success criteria)
The listing still reads **one sidecar per asset**, because it returns the full normalized asset and **sidecars are this codebase's source of truth** — the DB `assets` table is a derived index (and `list_characters` does the identical thing). Serving the full listing shape purely from indexed columns would require duplicating every sidecar into a DB JSON blob, a drift hazard this codebase deliberately avoids (cf. F-CORE-3/F-CORE-7). So the remaining per-asset sidecar read is intrinsic to the current contract and is **not** changed here; the compounding gen-set re-reads and the O(n²) dedup — the actual amplifiers — are removed.

### Tests
- New `list_assets_embeds_shared_generation_set_for_each_asset`: two assets sharing a set each embed the full set (cache correctness) and both list (dedup).
- Existing `list_assets` scope/filter/dedup tests + generation-set embedding test all pass (they exercise the refactored path).
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (146 lib + 103 jobs_store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)