### PR TITLE
refactor(core): hoist a single ensure_column into store_util (sc-4271)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -15,7 +15,7 @@ use crate::contracts::{
     ContractNumber, JobSnapshot, JobStatus, JobType, ProgressStage, QueueSummary, WorkerCapability,
     WorkerSnapshot, WorkerStatus, WorkerUtilizationSnapshot,
 };
-use crate::store_util::parse_string_enum;
+use crate::store_util::{ensure_column, parse_string_enum};
 use crate::time::{format_unix_seconds, now_unix_seconds, utc_now};
 
 pub const ACTIVE_STATUSES: &[&str] = &[
@@ -1717,25 +1717,6 @@ fn remove_sqlite_sidecars(db_path: &Path) {
         ));
         let _ = fs::remove_file(sidecar);
     }
-}
-
-fn ensure_column(
-    connection: &Connection,
-    table: &str,
-    column: &str,
-    definition: &str,
-) -> JobsStoreResult<()> {
-    let mut statement = connection.prepare(&format!("pragma table_info({table})"))?;
-    let columns = statement
-        .query_map([], |row| row.get::<_, String>("name"))?
-        .collect::<Result<Vec<_>, _>>()?;
-    if !columns.iter().any(|existing| existing == column) {
-        connection.execute(
-            &format!("alter table {table} add column {column} {definition}"),
-            [],
-        )?;
-    }
-    Ok(())
 }
 
 fn is_active_status(status: &str) -> bool {

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -22,8 +22,8 @@ pub use crate::character_store::{
 };
 use crate::slug::slugify;
 use crate::store_util::{
-    is_safe_id, is_safe_relative_path, lock_project_files, optional_f64, optional_str,
-    optional_u64, random_hex, read_json, relative_string, write_json,
+    ensure_column, is_safe_id, is_safe_relative_path, lock_project_files, optional_f64,
+    optional_str, optional_u64, random_hex, read_json, relative_string, write_json,
 };
 use crate::time::utc_now;
 use crate::training::TrainingDataset;
@@ -2880,25 +2880,6 @@ fn write_project_file(
 fn connect_project_db(project_path: &Path) -> ProjectStoreResult<Connection> {
     fs::create_dir_all(project_path)?;
     Ok(Connection::open(project_path.join("project.db"))?)
-}
-
-fn ensure_column(
-    connection: &Connection,
-    table: &str,
-    column: &str,
-    definition: &str,
-) -> ProjectStoreResult<()> {
-    let mut statement = connection.prepare(&format!("pragma table_info({table})"))?;
-    let columns = statement
-        .query_map([], |row| row.get::<_, String>(1))?
-        .collect::<Result<Vec<_>, _>>()?;
-    if !columns.iter().any(|existing| existing == column) {
-        connection.execute(
-            &format!("alter table {table} add column {column} {definition}"),
-            [],
-        )?;
-    }
-    Ok(())
 }
 
 /// Assemble the on-disk asset sidecar from the worker-reported flat facts. Rust

--- a/crates/sceneworks-core/src/store_util.rs
+++ b/crates/sceneworks-core/src/store_util.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 use parking_lot::{ReentrantMutex, ReentrantMutexGuard};
+use rusqlite::Connection;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -154,11 +155,70 @@ where
         .expect("string enum deserialization is infallible")
 }
 
+/// Idempotent additive migration: add `column` (`column definition`) to `table`
+/// if `pragma table_info` doesn't already list it.
+///
+/// Hoisted from three near-identical per-store copies that had drifted on how
+/// they read the PRAGMA column name — one used the positional index `1`, the
+/// others the `"name"` accessor. This standardizes on the by-name accessor
+/// (sc-4271 / F-CORE-11). Returns the raw `rusqlite::Error` so each store's `?`
+/// maps it into its own error type.
+pub(crate) fn ensure_column(
+    connection: &Connection,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> rusqlite::Result<()> {
+    let mut statement = connection.prepare(&format!("pragma table_info({table})"))?;
+    let exists = statement
+        .query_map([], |row| row.get::<_, String>("name"))?
+        .collect::<Result<Vec<_>, _>>()?
+        .iter()
+        .any(|existing| existing == column);
+    if !exists {
+        connection.execute(
+            &format!("alter table {table} add column {column} {definition}"),
+            [],
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{atomic_write, lock_project_files, parse_string_enum, random_hex};
+    use super::{atomic_write, ensure_column, lock_project_files, parse_string_enum, random_hex};
     use crate::contracts::JobStatus;
+    use rusqlite::Connection;
     use std::collections::HashSet;
+
+    /// sc-4271 / F-CORE-11: the hoisted `ensure_column` adds a missing column and
+    /// is a no-op when it already exists (the three per-store copies it replaced
+    /// disagreed on the PRAGMA accessor; this is the single by-name version).
+    #[test]
+    fn ensure_column_adds_missing_column_and_is_idempotent() {
+        let connection = Connection::open_in_memory().expect("in-memory db");
+        connection
+            .execute("create table widgets (id text primary key)", [])
+            .expect("seed table");
+
+        let has_color = |conn: &Connection| {
+            let mut statement = conn.prepare("pragma table_info(widgets)").expect("pragma");
+            let columns: Vec<String> = statement
+                .query_map([], |row| row.get::<_, String>("name"))
+                .expect("columns")
+                .filter_map(Result::ok)
+                .collect();
+            columns.iter().any(|name| name == "color")
+        };
+        assert!(!has_color(&connection), "precondition: no color column");
+
+        ensure_column(&connection, "widgets", "color", "text").expect("adds column");
+        assert!(has_color(&connection), "column added");
+
+        // Second call is a no-op (would error if it re-ran the ALTER).
+        ensure_column(&connection, "widgets", "color", "text").expect("idempotent");
+        assert!(has_color(&connection));
+    }
 
     /// sc-4269 / F-CORE-9: the `StringEnum` bound makes `parse_string_enum`
     /// infallible — a value never written by the app (or a hand-edited DB row)

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 
 use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
-    atomic_write, is_safe_id, is_safe_relative_path, parse_string_enum, random_hex, read_json,
-    relative_string, write_json,
+    atomic_write, ensure_column, is_safe_id, is_safe_relative_path, parse_string_enum, random_hex,
+    read_json, relative_string, write_json,
 };
 use crate::time::utc_now;
 use crate::training::{
@@ -1075,16 +1075,8 @@ fn ensure_training_dataset_column(
     column: &str,
     definition: &str,
 ) -> ProjectStoreResult<()> {
-    let mut statement = connection.prepare("pragma table_info(training_datasets)")?;
-    let columns = statement
-        .query_map([], |row| row.get::<_, String>("name"))?
-        .collect::<Result<Vec<_>, _>>()?;
-    if !columns.iter().any(|existing| existing == column) {
-        connection.execute(
-            &format!("alter table training_datasets add column {column} {definition}"),
-            [],
-        )?;
-    }
+    // Thin fixed-table wrapper over the shared store_util helper (sc-4271).
+    ensure_column(connection, "training_datasets", column, definition)?;
     Ok(())
 }
 


### PR DESCRIPTION
## sc-4271 — [F-CORE-11] `ensure_column` reads PRAGMA column name by index in one store, by name in another

Fixes code-review finding F-CORE-11 (P3/Low, redundant).

### Problem
Three near-identical private `ensure_column` helpers existed across `jobs_store`, `project_store`, and `training_store` (the last as `ensure_training_dataset_column`). They had **drifted** on how they read the column name from `pragma table_info`: `project_store` used the positional index `1`, while `jobs_store` and `training_store` used the `"name"` accessor. Same logic, three copies, one subtly different.

### Fix
Hoist a single `ensure_column(conn, table, column, def)` into `store_util`, standardized on the **by-name** accessor and returning `rusqlite::Result<()>` so each store's `?` maps it into its own error type (`JobsStoreError` / `ProjectStoreError`).
- `jobs_store` and `project_store` drop their local copies and call the shared helper.
- `training_store::ensure_training_dataset_column` becomes a thin fixed-table wrapper over it.
- The positional→by-name change is behavior-identical: `pragma table_info` column index 1 *is* `name`.

### Tests
- New `ensure_column_adds_missing_column_and_is_idempotent` unit test (adds a missing column; no-op on re-call).
- All existing migration tests (e.g. `migrations_backfill_training_dataset_character_id_on_old_db`) still pass — they exercise the shared helper.
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (147 lib + 103 jobs_store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)