### PR TITLE
refactor(core): share asset sidecar resolver + index helper (sc-4272)

### DIFF
--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use rusqlite::{params, Connection, Row};
+use rusqlite::{params, Connection, OptionalExtension, Row};
 use serde_json::Value;
 
 use crate::project_store::{ProjectStoreError, ProjectStoreResult};
@@ -25,6 +25,68 @@ pub(crate) const ASSET_FOLDERS: &[&str] = &[
 pub(crate) struct AssetRecord {
     pub(crate) file_path: Option<String>,
     pub(crate) sidecar_path: Option<String>,
+}
+
+/// Resolve an asset id to its on-disk sidecar path: prefer the indexed
+/// `assets` row's recorded sidecar/file paths, falling back to a scan of all
+/// sidecars matching by `id`. Shared by `project_store` and `character_store`,
+/// which previously kept byte-identical copies that could drift (sc-4272 /
+/// F-CORE-12). Takes a ready `Connection` so each store keeps its own DB-prep
+/// (ensure-ready vs migrate) in its thin wrapper.
+pub(crate) fn find_asset_sidecar_path_on_connection(
+    connection: &Connection,
+    project_path: &Path,
+    asset_id: &str,
+) -> ProjectStoreResult<Option<PathBuf>> {
+    if let Some(record) = connection
+        .query_row(
+            "select file_path, sidecar_path from assets where id = ?1",
+            params![asset_id],
+            row_to_asset_record,
+        )
+        .optional()?
+    {
+        let mut candidates = Vec::new();
+        if let Some(sidecar_path) = record.sidecar_path {
+            candidates.push(project_path.join(sidecar_path));
+        }
+        if let Some(file_path) = record.file_path {
+            candidates.push(
+                project_path
+                    .join(file_path)
+                    .with_extension("sceneworks.json"),
+            );
+        }
+        for candidate in candidates {
+            if candidate.exists() {
+                return Ok(Some(candidate));
+            }
+        }
+    }
+    for sidecar_path in asset_sidecars(project_path)? {
+        let Ok(asset) = read_json(&sidecar_path) else {
+            continue;
+        };
+        if asset.get("id").and_then(Value::as_str) == Some(asset_id) {
+            return Ok(Some(sidecar_path));
+        }
+    }
+    Ok(None)
+}
+
+/// Upsert an asset's index row, deriving the stored relative sidecar path from
+/// its absolute path. Shared by both stores (sc-4272 / F-CORE-12).
+pub(crate) fn index_asset_on_connection(
+    connection: &Connection,
+    project_path: &Path,
+    asset: &Value,
+    sidecar_path: Option<&Path>,
+) -> ProjectStoreResult<()> {
+    let sidecar_rel = match sidecar_path {
+        Some(path) => Some(relative_string(project_path, path)?),
+        None => None,
+    };
+    upsert_asset_row(connection, asset, sidecar_rel.as_deref())
 }
 
 pub(crate) fn row_to_asset_record(row: &Row<'_>) -> rusqlite::Result<AssetRecord> {

--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -6,7 +6,9 @@ use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
-use crate::asset_index::{asset_sidecars, normalize_asset, row_to_asset_record, upsert_asset_row};
+use crate::asset_index::{
+    find_asset_sidecar_path_on_connection, index_asset_on_connection, normalize_asset,
+};
 use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
     atomic_write, is_safe_id, optional_bool, optional_f64, optional_str, random_hex, read_json,
@@ -1155,6 +1157,7 @@ fn update_asset_character_link(
     index_asset_on_connection(connection, project_path, &asset, Some(&sidecar_path))
 }
 
+/// Thin DB-prep wrapper over the shared resolver in `asset_index` (sc-4272).
 fn find_asset_sidecar_path(
     project_path: &Path,
     asset_id: &str,
@@ -1162,60 +1165,6 @@ fn find_asset_sidecar_path(
     let connection = connect_project_db(project_path)?;
     apply_project_migrations(&connection)?;
     find_asset_sidecar_path_on_connection(&connection, project_path, asset_id)
-}
-
-fn find_asset_sidecar_path_on_connection(
-    connection: &Connection,
-    project_path: &Path,
-    asset_id: &str,
-) -> ProjectStoreResult<Option<PathBuf>> {
-    if let Some(record) = connection
-        .query_row(
-            "select file_path, sidecar_path from assets where id = ?1",
-            params![asset_id],
-            row_to_asset_record,
-        )
-        .optional()?
-    {
-        let mut candidates = Vec::new();
-        if let Some(sidecar_path) = record.sidecar_path {
-            candidates.push(project_path.join(sidecar_path));
-        }
-        if let Some(file_path) = record.file_path {
-            candidates.push(
-                project_path
-                    .join(file_path)
-                    .with_extension("sceneworks.json"),
-            );
-        }
-        for candidate in candidates {
-            if candidate.exists() {
-                return Ok(Some(candidate));
-            }
-        }
-    }
-    for sidecar_path in asset_sidecars(project_path)? {
-        let Ok(asset) = read_json(&sidecar_path) else {
-            continue;
-        };
-        if asset.get("id").and_then(Value::as_str) == Some(asset_id) {
-            return Ok(Some(sidecar_path));
-        }
-    }
-    Ok(None)
-}
-
-fn index_asset_on_connection(
-    connection: &Connection,
-    project_path: &Path,
-    asset: &Value,
-    sidecar_path: Option<&Path>,
-) -> ProjectStoreResult<()> {
-    let sidecar_rel = match sidecar_path {
-        Some(path) => Some(relative_string(project_path, path)?),
-        None => None,
-    };
-    upsert_asset_row(connection, asset, sidecar_rel.as_deref())
 }
 
 fn copy_lora_into_project(

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use crate::asset_index::{
-    asset_origin, asset_sidecars, normalize_asset, normalize_asset_cached, row_to_asset_record,
-    upsert_asset_row, AssetRecord, GenerationSetCache,
+    asset_origin, asset_sidecars, find_asset_sidecar_path_on_connection, index_asset_on_connection,
+    normalize_asset, normalize_asset_cached, GenerationSetCache,
 };
 use crate::character_store::{
     apply_character_migrations, clear_character_tables, reindex_characters_on_connection,
@@ -2268,8 +2268,7 @@ fn reindex_project_path(project_path: &Path) -> ProjectStoreResult<ReindexCounts
         if asset.get("id").is_none() || asset.pointer("/file/path").is_none() {
             continue;
         }
-        let sidecar_rel = relative_string(project_path, &sidecar_path)?;
-        index_asset_on_connection(&transaction, &asset, Some(&sidecar_rel))?;
+        index_asset_on_connection(&transaction, project_path, &asset, Some(&sidecar_path))?;
         counts.assets += 1;
     }
 
@@ -3262,70 +3261,24 @@ fn index_asset(
             )?)
             .with_extension("sceneworks.json"),
     };
-    let sidecar_rel = relative_string(project_path, &sidecar_path)?;
     let mut connection = connect_project_db(project_path)?;
     let transaction = connection.transaction()?;
     apply_project_migrations(&transaction)?;
-    index_asset_on_connection(&transaction, asset, Some(&sidecar_rel))?;
+    index_asset_on_connection(&transaction, project_path, asset, Some(&sidecar_path))?;
     transaction.commit()?;
     Ok(())
 }
 
-fn index_asset_on_connection(
-    connection: &Connection,
-    asset: &Value,
-    sidecar_rel: Option<&str>,
-) -> ProjectStoreResult<()> {
-    upsert_asset_row(connection, asset, sidecar_rel)
-}
-
-fn find_asset_record(
-    project_path: &Path,
-    asset_id: &str,
-) -> ProjectStoreResult<Option<AssetRecord>> {
-    ensure_project_db_ready(project_path)?;
-    let connection = connect_project_db(project_path)?;
-    connection
-        .query_row(
-            "select file_path, sidecar_path from assets where id = ?1",
-            params![asset_id],
-            row_to_asset_record,
-        )
-        .optional()
-        .map_err(Into::into)
-}
-
+/// Thin DB-prep wrapper over the shared resolver in `asset_index` (sc-4272).
+/// `ensure_project_db_ready` backfills derived columns after a schema bump
+/// before the lookup, unlike the character-store wrapper's lighter migrate.
 fn find_asset_sidecar_path(
     project_path: &Path,
     asset_id: &str,
 ) -> ProjectStoreResult<Option<PathBuf>> {
-    if let Some(record) = find_asset_record(project_path, asset_id)? {
-        let mut candidates = Vec::new();
-        if let Some(sidecar_path) = record.sidecar_path {
-            candidates.push(project_path.join(sidecar_path));
-        }
-        if let Some(file_path) = record.file_path {
-            candidates.push(
-                project_path
-                    .join(file_path)
-                    .with_extension("sceneworks.json"),
-            );
-        }
-        for candidate in candidates {
-            if candidate.exists() {
-                return Ok(Some(candidate));
-            }
-        }
-    }
-    for sidecar_path in asset_sidecars(project_path)? {
-        let Ok(asset) = read_json(&sidecar_path) else {
-            continue;
-        };
-        if asset.get("id").and_then(Value::as_str) == Some(asset_id) {
-            return Ok(Some(sidecar_path));
-        }
-    }
-    Ok(None)
+    ensure_project_db_ready(project_path)?;
+    let connection = connect_project_db(project_path)?;
+    find_asset_sidecar_path_on_connection(&connection, project_path, asset_id)
 }
 
 fn purge_asset_record(project_path: &Path, asset_id: &str) -> ProjectStoreResult<()> {


### PR DESCRIPTION
## sc-4272 — [F-CORE-12] `find_asset_sidecar_path` duplicated between project_store and character_store

Fixes code-review finding F-CORE-12 (P3/Low, redundant).

### Problem
`project_store` and `character_store` each kept a byte-identical `find_asset_sidecar_path` (DB-row lookup → disk-scan fallback), plus a sibling `index_asset_on_connection`. They had already begun to drift — one prepped the DB via `ensure_project_db_ready`, the other via `apply_project_migrations` — exactly the divergence-under-edits hazard the finding calls out.

### Fix
Hoist both into `asset_index` and call them from both stores:
- `find_asset_sidecar_path_on_connection(conn, project_path, asset_id)` — the shared resolver. It takes a **ready connection**, so each store keeps its own DB-prep in a thin wrapper (the prep genuinely differs: project backfills derived columns via `ensure_project_db_ready`; character does the lighter migrate). The difference is now explicit in two 3-line wrappers instead of buried in duplicated bodies.
- `index_asset_on_connection(conn, project_path, asset, Option<&Path>)` — derives the relative sidecar path then upserts. Both stores now pass the absolute path; project_store's now-redundant `find_asset_record` is removed.

Pure dedup, no behavior change.

### Tests
- Existing coverage exercises both shared functions through **both** stores and passes: project asset import/get/delete/reindex tests (project wrapper + `index_asset_on_connection`) and `references_sync_asset_metadata_and_character_reference_table` (character wrapper + resolver + index).
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (147 lib + 103 jobs_store + 7 character_store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)