### PR TITLE
perf(core): hoist per-candidate active-GPU checks in claim dispatch (sc-4273)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2549,10 +2549,23 @@ fn should_defer_auto_gpu_claim(
         ",
     )?;
     let candidates = collect_workers(statement.query_map(params![worker.id], row_to_worker)?)?;
+    // Cache the active-GPU-job fact per gpu_id so two idle workers sharing a GPU
+    // don't each re-run the same `active_gpu_job_exists` query (sc-4273).
+    let mut active_by_gpu: std::collections::HashMap<String, bool> =
+        std::collections::HashMap::new();
     for candidate in candidates {
-        if !worker_supports_job(&candidate, job)
-            || active_gpu_job_exists(connection, &candidate.gpu_id)?
-        {
+        if !worker_supports_job(&candidate, job) {
+            continue;
+        }
+        let gpu_busy = match active_by_gpu.get(&candidate.gpu_id) {
+            Some(&busy) => busy,
+            None => {
+                let busy = active_gpu_job_exists(connection, &candidate.gpu_id)?;
+                active_by_gpu.insert(candidate.gpu_id.clone(), busy);
+                busy
+            }
+        };
+        if gpu_busy {
             continue;
         }
         let candidate_score = dispatch_score(job, &candidate);
@@ -2707,14 +2720,13 @@ fn idle_mlx_worker_can_claim(
         ",
     )?;
     let candidates = collect_workers(statement.query_map(params![worker.id], row_to_worker)?)?;
-    for candidate in candidates {
-        if worker_supports_job(&candidate, job)
-            && !active_gpu_job_exists(connection, &candidate.gpu_id)?
-        {
-            return Ok(true);
-        }
-    }
-    Ok(false)
+    // Every candidate here has `gpu_id = 'mlx'`, so the active-GPU-job fact is
+    // identical for all of them — resolve a supporting candidate first, then run
+    // `active_gpu_job_exists` once instead of once per candidate (sc-4273).
+    let Some(candidate) = candidates.iter().find(|c| worker_supports_job(c, job)) else {
+        return Ok(false);
+    };
+    Ok(!active_gpu_job_exists(connection, &candidate.gpu_id)?)
 }
 
 fn active_gpu_job_exists(connection: &Connection, gpu_id: &str) -> JobsStoreResult<bool> {


### PR DESCRIPTION
## sc-4273 — [F-CORE-13] `claim_next_job_routed` runs the full per-worker dispatch sweep inside the global write transaction

Fixes code-review finding F-CORE-13 (P3/Low, efficiency).

### Problem
The claim holds the process `Mutex` and a `BEGIN IMMEDIATE` write transaction while the dispatch predicates loop over idle workers and call `active_gpu_job_exists` **once per candidate**, so claim cost grows with idle-worker count.

### Fix (semantics-preserving hoists — the "× worker count" amplifier)
- **`idle_mlx_worker_can_claim`**: every candidate is filtered to `gpu_id = 'mlx'`, so the active-GPU-job fact is identical for all of them. Resolve a supporting candidate first, then run `active_gpu_job_exists` **once** instead of once per candidate. (Algebraically: `∃ c: supports(c) && !busy('mlx')` ≡ `(∃ c: supports(c)) && !busy('mlx')`.)
- **`should_defer_auto_gpu_claim`**: memoize `active_gpu_job_exists` per `gpu_id` so two idle workers sharing a GPU don't each re-run the same query.

### Scope note (intentional, per success criteria)
The suggested SQL-`where` capability filter on the queued scan is **not** done. That scan is **deliberately uncapped** (documented in-code at `jobs_store.rs`): `choose_claimable_job` must see the *whole* gpu/type-compatible set for its priority pass (an explicit-GPU / loaded-model job jumps ahead of an earlier auto-GPU one), and the in-code comment names this "the scale lever if queues ever grow large enough." Pushing the capability filter into SQL risks that routing correctness on the most safety-critical concurrency path (extensive prior hardening: BEGIN IMMEDIATE, route-decision observability) for a P3/Low with no evidence of queues large enough to matter. The "× worker count" amplifier is addressed; the "× queue depth" lever is left as the documented, deliberate design. Happy to file a follow-up if you want the SQL-filter pursued.

### Tests
- No behavior change: the 103 `jobs_store` routing/dispatch integration tests (cpu/gpu/mlx deferral, health-based auto-GPU comparison, idle-mlx availability, `mlx_required`) all pass and are the regression coverage for the touched predicates.
- `cargo fmt`, `cargo clippy -p sceneworks-core --all-targets` (clean, `-D warnings`), full `cargo test -p sceneworks-core` green (147 lib + 103 jobs_store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)