### PR TITLE
fix(worker): heartbeat during cold model load for gen jobs (sc-4276)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1620,11 +1620,24 @@ async fn consume_gen_events(
             );
         }
     };
-    while let Some(event) = rx.recv().await {
-        if canceled {
-            continue; // drain remaining events so the blocking sender never blocks.
-        }
-        match event {
+    // Heartbeat + cancel-poll on a fixed interval, not only when the blocking
+    // thread emits an event. The cold model-load phase (multi-GB load + quantize)
+    // emits nothing, so without an interval arm the worker reports no Busy
+    // heartbeat and honors no cancel until the first denoise step — long enough
+    // for the API's staleness check to think it died (sc-4276 / F-MLXW-12;
+    // mirrors the caption-job select!-with-interval).
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            maybe_event = rx.recv() => {
+                let Some(event) = maybe_event else {
+                    break;
+                };
+                if canceled {
+                    continue; // drain remaining events so the blocking sender never blocks.
+                }
+                match event {
             GenEvent::Step {
                 index,
                 current,
@@ -1710,6 +1723,18 @@ async fn consume_gen_events(
                 )
                 .await?;
                 heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+            }
+                }
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                if !canceled && last_cancel_check.elapsed() >= Duration::from_secs(2) {
+                    last_cancel_check = Instant::now();
+                    if cancel_requested(api, &job.id, "Image generation canceled by user.").await {
+                        cancel.cancel();
+                        canceled = true;
+                    }
+                }
             }
         }
     }

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1582,10 +1582,21 @@ async fn generate_video(
 
     let mut canceled = false;
     let mut last_cancel = Instant::now();
-    while let Some(progress) = rx.recv().await {
-        if canceled {
-            continue; // drain so the blocking sender never blocks.
-        }
+    // Interval arm so the cold model-load phase (mlx_gen::load emits no progress)
+    // still heartbeats and polls cancel, instead of looking dead to the API's
+    // staleness check until the first denoise step (sc-4276 / F-MLXW-12; mirrors
+    // the caption-job select!-with-interval).
+    let mut interval = tokio::time::interval(crate::progress_report_interval(settings));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            maybe_progress = rx.recv() => {
+                let Some(progress) = maybe_progress else {
+                    break;
+                };
+                if canceled {
+                    continue; // drain so the blocking sender never blocks.
+                }
         if last_cancel.elapsed() >= Duration::from_secs(2) {
             last_cancel = Instant::now();
             if cancel_requested(api, &job.id, CANCEL_MESSAGE).await {
@@ -1615,6 +1626,18 @@ async fn generate_video(
             ),
         )
         .await?;
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                if !canceled && last_cancel.elapsed() >= Duration::from_secs(2) {
+                    last_cancel = Instant::now();
+                    if cancel_requested(api, &job.id, CANCEL_MESSAGE).await {
+                        cancel.cancel();
+                        canceled = true;
+                    }
+                }
+            }
+        }
     }
 
     let result = blocking


### PR DESCRIPTION
## sc-4276 — [F-MLXW-12] No worker heartbeat during the (minutes-long) model-load phase of generation jobs

Fixes code-review finding F-MLXW-12 (P3/Low, bad-pattern).

### Problem
The image/video event consumers (`consume_gen_events` in `image_jobs.rs`, `generate_video` in `video_jobs.rs`) only heartbeat + poll-cancel when the blocking generation thread emits an event — and `mlx_gen::load` emits none. So during a long cold load (multi-GB load + quantize):
- no `WorkerStatus::Busy` heartbeat fires, so the API's worker-staleness check can think the busy worker died, and
- a cancel pressed during load isn't honored until the first denoise step.

The caption path already got this right with an `interval.tick()` arm in its `tokio::select!`.

### Fix
Adopt the caption-job `tokio::select!`-with-interval pattern in both consumers:
- the `rx.recv()` arm keeps the existing per-event progress reporting + 2s cancel poll, and
- a new `interval.tick()` arm (`progress_report_interval` = the heartbeat cadence, `heartbeat_seconds.clamp(5,15)`) heartbeats and polls cancel on a fixed tick — **including before the first event**, i.e. throughout the cold load. `MissedTickBehavior::Delay` so it doesn't burst after busy stretches.

### Tests
- 216 worker tests pass — the event-handling refactor is behavior-preserving (the existing image/video job tests drive these consumers with simulated event streams).
- The interval arm is the same idiom already shipping and tested in `caption_jobs.rs`. The cold-load timing itself isn't unit-testable without a faked clock + long load; the behavior-preservation of the refactor is what's covered.
- `cargo fmt`, `cargo clippy -p sceneworks-worker --all-targets` (clean, `-D warnings`), `cargo test -p sceneworks-worker` green (216 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)