### PR TITLE
fix(worker): recover poisoned model-cache locks instead of panicking (sc-4277)

### DIFF
--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -707,7 +707,15 @@ pub(crate) fn detect_people_blocking(
     let (width, height) = (img.width(), img.height());
 
     let cell = DETECTOR.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().expect("person detector mutex poisoned");
+    // Recover from a poisoned lock instead of panicking every subsequent job: if a
+    // prior detection panicked mid-run holding this lock, take the inner guard and
+    // drop the possibly-corrupt cached model so the block below reloads a fresh one
+    // (sc-4277 / F-MLXW-13).
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
     if guard.is_none() {
         *guard = Some(Yolo::load(&weights_path)?);
     }

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -200,7 +200,15 @@ pub(crate) fn propagate_track_blocking(
     let frame_refs: Vec<&[u8]> = rgb.iter().map(|f| f.as_slice()).collect();
 
     let cell = PREDICTOR.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().expect("person predictor mutex poisoned");
+    // Recover from a poisoned lock rather than panicking every subsequent job: a
+    // prior propagation that panicked mid-run leaves the lock poisoned, so take the
+    // inner guard and drop the possibly-corrupt cached predictor to force a clean
+    // reload below (sc-4277 / F-MLXW-13).
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
     if guard.is_none() {
         let weights = Weights::from_file(&weights_path)
             .map_err(|e| WorkerError::InvalidPayload(format!("sam2 weights load: {e}")))?;
@@ -265,6 +273,38 @@ pub(crate) fn propagate_track_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// sc-4277 / F-MLXW-13: the model-cache locks recover from poison instead of
+    /// `.expect()`-panicking. A prior job panicking while holding the lock must
+    /// leave a recoverable lock whose cached model is reset (None) so the next job
+    /// reloads cleanly rather than panicking forever. This pins the recovery idiom
+    /// used at the three call sites.
+    #[test]
+    fn poisoned_model_cache_lock_recovers_and_resets() {
+        let cache: Mutex<Option<i32>> = Mutex::new(Some(7));
+        // Poison the lock: panic in another thread while holding it.
+        let poisoner = &cache;
+        std::thread::scope(|scope| {
+            let handle = scope.spawn(|| {
+                let _guard = poisoner.lock().unwrap();
+                panic!("simulated mid-job panic while holding the model lock");
+            });
+            assert!(handle.join().is_err(), "the poisoning thread panicked");
+        });
+        assert!(cache.lock().is_err(), "precondition: lock is now poisoned");
+
+        // The recovery idiom used at the call sites: take the inner guard and reset
+        // the cached model so the reload path runs.
+        let mut guard = cache.lock().unwrap_or_else(|poisoned| {
+            let mut guard = poisoned.into_inner();
+            *guard = None;
+            guard
+        });
+        assert_eq!(*guard, None, "cached model is dropped on poison recovery");
+        *guard = Some(42); // reload
+        assert_eq!(*guard, Some(42));
+    }
 
     #[test]
     fn box_norm_scales_and_clamps_to_the_frame() {

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -205,7 +205,15 @@ impl Upscaler {
 fn upscale_blocking(onnx_path: PathBuf, factor: u8, img: RgbImage) -> WorkerResult<RgbImage> {
     use std::collections::hash_map::Entry;
     let cell = UPSCALERS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut guard = cell.lock().expect("upscaler mutex poisoned");
+    // Recover from a poisoned lock rather than panicking every subsequent job: if a
+    // prior upscale panicked mid-run holding this lock, take the inner guard and
+    // clear the possibly-corrupt cached sessions so the match below reloads a fresh
+    // one for this factor (sc-4277 / F-MLXW-13).
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        guard.clear();
+        guard
+    });
     let upscaler = match guard.entry(factor) {
         Entry::Occupied(e) => e.into_mut(),
         Entry::Vacant(e) => e.insert(Upscaler::load(&onnx_path)?),


### PR DESCRIPTION
## sc-4277 — [F-MLXW-13] Poisoned-mutex `expect` on the process-wide model caches turns one panic into permanent worker failure

Fixes code-review finding F-MLXW-13 (P3/Low, bad-pattern).

### Problem
The process-wide model caches — `DETECTOR` (person_jobs), `PREDICTOR` (person_segment), `UPSCALERS` (upscale_jobs) — locked with `cell.lock().expect("… mutex poisoned")`. These hold the lock while running real MLX/ort code on payload-derived inputs, so if any job panics mid-run the lock is **poisoned**, and every subsequent job panics on the poisoned lock instead of reloading. One bad frame permanently disables person-detect/segment/upscale for the worker process — and the single-process desktop launch has no supervisor to restart it.

### Fix (per the suggested approach)
Replace each `.expect()` with `lock().unwrap_or_else(|p| p.into_inner())` and **reset the cache on poison** so the existing reload path runs a fresh model:
- `*guard = None` for the two `Mutex<Option<_>>` caches (detector, predictor),
- `guard.clear()` for the `Mutex<HashMap<u8, Upscaler>>` upscaler cache.

A poisoned lock now recovers and reloads instead of bricking the capability.

### Tests
- New `poisoned_model_cache_lock_recovers_and_resets` unit test: deliberately poisons a lock (panic in a scoped thread while holding it), then verifies the recovery idiom takes the inner guard, resets the cached model to `None`, and reloads.
- 216 existing worker tests still pass.
- `cargo fmt`, `cargo clippy -p sceneworks-worker --all-targets` (clean, `-D warnings`), `cargo test -p sceneworks-worker` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)