### PR TITLE
fix(worker): guard sidecar media paths against traversal (sc-4278)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -2529,7 +2529,11 @@ pub(crate) fn load_reference_image(
         .ok_or_else(|| {
             WorkerError::InvalidPayload(format!("reference asset {asset_id} has no media path"))
         })?;
-    let path = project_path.join(rel);
+    // The asset's file.path comes from an on-disk sidecar the user can edit, so
+    // route it through safe_project_path (rejects `..`/absolute components) rather
+    // than a bare join — matching the media-jobs reads and keeping a poisoned
+    // sidecar from reading an arbitrary file as the reference (sc-4278 / F-MLXW-14).
+    let path = crate::safe_project_path(project_path, rel)?;
     let decoded = image::open(&path)
         .map_err(|error| {
             WorkerError::InvalidPayload(format!("reference image {}: {error}", path.display()))

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -1557,6 +1557,23 @@ fn path_and_error_helpers_are_bounded_and_defensive() {
         .to_string()
         .contains("Project-relative path is required"));
 
+    // sc-4278 / F-MLXW-14: load_reference_image and resolve_clip_media_path route
+    // sidecar-sourced media paths through safe_project_path, so a traversal or
+    // absolute path (from a poisoned, user-editable sidecar) must be rejected
+    // rather than escaping the project.
+    for unsafe_rel in ["../../etc/passwd", "assets/../../secret.png", "/etc/passwd"] {
+        let error = safe_project_path(temp.path(), unsafe_rel)
+            .expect_err("traversal/absolute path rejects");
+        assert!(
+            error.to_string().contains("Unsafe project-relative path"),
+            "{unsafe_rel} should be rejected as unsafe, got {error}"
+        );
+    }
+    // A normal project-relative media path still resolves under the project root.
+    let safe = safe_project_path(temp.path(), "assets/images/x.png").expect("safe path resolves");
+    assert!(safe.starts_with(temp.path()));
+    assert!(safe.ends_with("assets/images/x.png"));
+
     let noisy = (0..100)
         .map(|index| format!("line {index} caf\u{e9}"))
         .collect::<Vec<_>>()

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2082,7 +2082,10 @@ fn resolve_clip_media_path(
         .ok_or_else(|| {
             WorkerError::InvalidPayload(format!("source clip asset {asset_id} has no media path"))
         })?;
-    let path = project_path.join(rel);
+    // file.path is sidecar-sourced (user-editable on disk), so guard it through
+    // safe_project_path instead of a bare join so a poisoned sidecar can't escape
+    // the project to read an arbitrary file as the source clip (sc-4278 / F-MLXW-14).
+    let path = crate::safe_project_path(project_path, rel)?;
     if !path.exists() {
         return Err(WorkerError::InvalidPayload(format!(
             "source clip file is missing for asset {asset_id}: {}",


### PR DESCRIPTION
## sc-4278 — [F-MLXW-14] Asset media paths joined without traversal guard in `load_reference_image`

Fixes code-review finding F-MLXW-14 (P3/Low, **security**).

### Problem
`load_reference_image` (`image_jobs.rs`) and `resolve_clip_media_path` (`video_jobs.rs`) did `project_path.join(rel)` on an asset's `file.path`. That relative path comes from an **on-disk sidecar the user can edit** (assets are indexed from JSON), so a crafted `..`/absolute `rel` escapes the project and makes the MLX edit/reference reads and source-clip reads load an **arbitrary file** as the reference/clip — whose content then flows into generated outputs. The equivalent reads in `media_jobs.rs` already route the same store-sourced path through `safe_project_path`; these two missed it, breaking the containment the rest of the crate maintains.

### Fix (per the suggested approach)
Route both through `safe_project_path(project_path, rel)?` (rejects `..` and absolute components), matching `media_jobs`.

### Tests
- Strengthened the existing `path_and_error_helpers_are_bounded_and_defensive` test to assert `safe_project_path` rejects `../../etc/passwd`, `assets/../../secret.png`, and `/etc/passwd`, and that a normal relative path still resolves under the project root — the containment property both fixed call sites now rely on.
- `cargo fmt`, `cargo clippy -p sceneworks-worker --all-targets` (clean, `-D warnings`), `cargo test -p sceneworks-worker` green (217 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)