### PR TITLE
refactor(core,worker,api): share HF-cache + JSONC helpers; one manifest upserter (sc-4279)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -25,6 +25,7 @@ use sceneworks_core::contracts::{
     RetryJobRequest, WorkerCapability, WorkerHeartbeatRequest, WorkerRegisterRequest,
     WorkerSnapshot, WorkerStatus,
 };
+use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
 use sceneworks_core::jobs_store::{
     mac_capabilities, mac_rust_supported, model_mac_support, CreateJob, DuplicateJob, JobsStore,
     JobsStoreError, MacCapabilities, ProgressUpdate, RegisterWorker, RetryJob, RouteDecision,
@@ -1534,61 +1535,6 @@ fn slugify_lora_id(value: &str) -> String {
 
 fn now_rfc3339() -> String {
     format_unix_seconds(now_unix_seconds())
-}
-
-fn huggingface_hub_cache_dir(data_dir: &FsPath) -> PathBuf {
-    if let Some(path) = std::env::var("HF_HUB_CACHE")
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        return PathBuf::from(path);
-    }
-    if let Some(path) = std::env::var("HUGGINGFACE_HUB_CACHE")
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        return PathBuf::from(path);
-    }
-    if let Some(path) = std::env::var("HF_HOME")
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        return PathBuf::from(path).join("hub");
-    }
-    data_dir.join("cache").join("huggingface").join("hub")
-}
-
-/// The `<X>` in Hugging Face hub's `models--<X>` cache directory name: every
-/// character outside `[A-Za-z0-9._-]` becomes `--`, then surrounding `-` are
-/// trimmed. `None` when nothing survives. Kept byte-identical to the Python
-/// worker (`hf_cache.safe_repo_dir_name`) and the Rust CPU worker — pinned by
-/// the `repo_slugs.json` cross-language contract (story 1667).
-fn safe_repo_dir_name(repo: &str) -> Option<String> {
-    let safe_repo = repo
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
-                character.to_string()
-            } else {
-                "--".to_owned()
-            }
-        })
-        .collect::<String>()
-        .trim_matches('-')
-        .to_owned();
-    if safe_repo.is_empty() {
-        None
-    } else {
-        Some(safe_repo)
-    }
-}
-
-fn huggingface_repo_cache_path(data_dir: &FsPath, repo: &str) -> Option<PathBuf> {
-    let safe_repo = safe_repo_dir_name(repo)?;
-    Some(huggingface_hub_cache_dir(data_dir).join(format!("models--{safe_repo}")))
 }
 
 fn huggingface_repo_cache_exists(path: &FsPath) -> bool {

--- a/apps/rust-api/src/manifest.rs
+++ b/apps/rust-api/src/manifest.rs
@@ -260,51 +260,7 @@ pub(crate) fn merge_object(base: &mut Value, override_value: Value) {
     }
 }
 
-pub(crate) fn strip_jsonc_comments(value: &str) -> String {
-    let mut output = String::with_capacity(value.len());
-    let mut chars = value.chars().peekable();
-    let mut in_string = false;
-    let mut escaped = false;
-    while let Some(character) = chars.next() {
-        if in_string {
-            output.push(character);
-            if escaped {
-                escaped = false;
-            } else if character == '\\' {
-                escaped = true;
-            } else if character == '"' {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if character == '"' {
-            in_string = true;
-            output.push(character);
-            continue;
-        }
-        if character == '/' && chars.peek() == Some(&'/') {
-            chars.next();
-            for next in chars.by_ref() {
-                if next == '\r' || next == '\n' {
-                    output.push(next);
-                    break;
-                }
-            }
-            continue;
-        }
-        if character == '/' && chars.peek() == Some(&'*') {
-            chars.next();
-            let mut previous = '\0';
-            for next in chars.by_ref() {
-                if previous == '*' && next == '/' {
-                    break;
-                }
-                previous = next;
-            }
-            continue;
-        }
-        output.push(character);
-    }
-    output
-}
+// Shared JSONC comment stripper, moved to sceneworks-core (sc-4279 / F-MLXW-15).
+// Re-exported `pub(crate)` so the crate-root `use manifest::*` keeps it available
+// to the rest of the api (and tests) under the same path as before.
+pub(crate) use sceneworks_core::jsonc::strip_jsonc_comments;

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5,11 +5,10 @@ use super::workers::person_readiness_from_workers;
 use super::{
     create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
     inprocess_worker_gpu_id, lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
-    safe_download_dir, safe_repo_dir_name, serialize_job_lora, should_warn_open_bind,
-    strip_jsonc_comments, sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before,
-    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
-    DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE,
-    TEST_MAX_LORA_UPLOAD_BYTES,
+    safe_download_dir, serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
+    sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before, Settings, WorkerCapability,
+    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE,
+    HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -178,9 +177,10 @@ fn model_convert_request_parses_optional_mlx_quant_fields() {
 
 #[test]
 fn repo_slug_functions_match_cross_language_contract() {
-    // story 1667: these repo->dir slug ops are duplicated in the Python
-    // worker and the Rust CPU worker; repo_slugs.json is the shared contract
-    // pinning them byte-for-byte across languages.
+    // story 1667: safe_download_dir is the api-only repo->dir slug op pinned by
+    // the shared repo_slugs.json contract. (safe_repo_dir_name moved to
+    // sceneworks-core in sc-4279 and is contract-tested there, so it is no longer
+    // re-asserted here.)
     let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../tests/fixtures/rust_migration_contracts/repo_slugs.json");
     let contract: Value =
@@ -194,11 +194,6 @@ fn repo_slug_functions_match_cross_language_contract() {
             safe_download_dir(repo),
             case["safeDownloadDir"].as_str().expect("safeDownloadDir"),
             "safe_download_dir drift for {repo:?}"
-        );
-        assert_eq!(
-            safe_repo_dir_name(repo).as_deref(),
-            case["safeRepoDirName"].as_str(),
-            "safe_repo_dir_name drift for {repo:?}"
         );
     }
 }

--- a/crates/sceneworks-core/src/hf_home.rs
+++ b/crates/sceneworks-core/src/hf_home.rs
@@ -11,7 +11,7 @@
 //! per-user cache, deduplicated with every other HF tool. The desktop and Docker
 //! Compose already inject `HF_HOME`, so this only changes the env-less case.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The OS Hugging Face home, `~/.cache/huggingface` (the literal `~/.cache`, not
 /// the platform cache dir — matching huggingface_hub and `Path.home()/.cache/
@@ -54,10 +54,94 @@ pub fn ensure_default_huggingface_home() -> Option<PathBuf> {
     Some(chosen)
 }
 
+/// The Hugging Face hub cache directory: `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE`
+/// if set, else `<HF_HOME>/hub`, else `<data_dir>/cache/huggingface/hub`. Shared
+/// by the rust-api and rust-worker so cache-path resolution can't drift between
+/// them (sc-4279 / F-MLXW-15).
+pub fn huggingface_hub_cache_dir(data_dir: &Path) -> PathBuf {
+    if let Some(path) = std::env::var("HF_HUB_CACHE")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path);
+    }
+    if let Some(path) = std::env::var("HUGGINGFACE_HUB_CACHE")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path);
+    }
+    if let Some(path) = std::env::var("HF_HOME")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path).join("hub");
+    }
+    data_dir.join("cache").join("huggingface").join("hub")
+}
+
+/// The `<X>` in Hugging Face hub's `models--<X>` cache directory name: every
+/// character outside `[A-Za-z0-9._-]` becomes `--`, then surrounding `-` are
+/// trimmed. `None` when nothing survives. Kept byte-identical to the Python
+/// worker (`hf_cache.safe_repo_dir_name`), the rust-api and the rust-worker —
+/// pinned by the `repo_slugs.json` cross-language contract (story 1667).
+pub fn safe_repo_dir_name(repo: &str) -> Option<String> {
+    let safe_repo = repo
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+                character.to_string()
+            } else {
+                "--".to_owned()
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned();
+    if safe_repo.is_empty() {
+        None
+    } else {
+        Some(safe_repo)
+    }
+}
+
+/// The `models--<safe_repo>` cache directory for `repo` under the hub cache.
+/// `None` when the repo slug sanitizes to nothing.
+pub fn huggingface_repo_cache_path(data_dir: &Path, repo: &str) -> Option<PathBuf> {
+    let safe_repo = safe_repo_dir_name(repo)?;
+    Some(huggingface_hub_cache_dir(data_dir).join(format!("models--{safe_repo}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::Path;
+
+    /// sc-4279 / F-MLXW-15: canonical home for the `repo_slugs.json`
+    /// cross-language contract now that `safe_repo_dir_name` lives in core (it was
+    /// duplicated, with a per-crate test, in both the rust-api and the rust-worker).
+    /// The slug must match what the Python worker and HF hub produce for every case.
+    #[test]
+    fn safe_repo_dir_name_matches_repo_slugs_contract() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/rust_migration_contracts/repo_slugs.json");
+        let contract: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&fixture).expect("read repo_slugs.json"))
+                .expect("parse repo_slugs.json");
+        let cases = contract["cases"].as_array().expect("cases array");
+        assert!(!cases.is_empty(), "repo_slugs fixture has no cases");
+        for case in cases {
+            let repo = case["repo"].as_str().expect("repo string");
+            assert_eq!(
+                safe_repo_dir_name(repo).as_deref(),
+                case["safeRepoDirName"].as_str(),
+                "safe_repo_dir_name drift for {repo:?}"
+            );
+        }
+    }
 
     #[test]
     fn defaults_to_os_home_when_no_hf_env_is_set() {

--- a/crates/sceneworks-core/src/jsonc.rs
+++ b/crates/sceneworks-core/src/jsonc.rs
@@ -1,0 +1,80 @@
+//! Minimal JSONC (`.jsonc`) comment stripping for the manifest readers shared by
+//! the rust-api and the rust-worker (sc-4279 / F-MLXW-15). Both crates read the
+//! same `.jsonc` model/LoRA manifests, so the stripper lives here once rather
+//! than byte-identically in each.
+
+/// Strip `//` line and `/* */` block comments from a JSONC string, leaving the
+/// JSON otherwise byte-for-byte (newlines inside line comments are preserved so
+/// downstream error spans keep their line numbers). String literals — including
+/// escaped quotes — are passed through untouched so a `//` inside a string is not
+/// mistaken for a comment.
+pub fn strip_jsonc_comments(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(character) = chars.next() {
+        if in_string {
+            output.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if character == '"' {
+            in_string = true;
+            output.push(character);
+            continue;
+        }
+        if character == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            for next in chars.by_ref() {
+                if next == '\r' || next == '\n' {
+                    output.push(next);
+                    break;
+                }
+            }
+            continue;
+        }
+        if character == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            let mut previous = '\0';
+            for next in chars.by_ref() {
+                if previous == '*' && next == '/' {
+                    break;
+                }
+                previous = next;
+            }
+            continue;
+        }
+        output.push(character);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_jsonc_comments;
+
+    #[test]
+    fn strips_line_and_block_comments_but_preserves_strings() {
+        let input = r#"{
+            // a line comment
+            "url": "https://example.com", /* trailing block */
+            "note": "a // b /* c */ d"
+        }"#;
+        let stripped = strip_jsonc_comments(input);
+        // Comments gone, but the string literal (incl. its // and /* */) survives.
+        assert!(!stripped.contains("a line comment"));
+        assert!(!stripped.contains("trailing block"));
+        assert!(stripped.contains(r#""note": "a // b /* c */ d""#));
+        assert!(stripped.contains(r#""url": "https://example.com""#));
+        // Still valid JSON after stripping.
+        let parsed: serde_json::Value = serde_json::from_str(&stripped).expect("valid json");
+        assert_eq!(parsed["url"], "https://example.com");
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod credentials;
 pub mod hf_home;
 pub mod image_request;
 pub mod jobs_store;
+pub mod jsonc;
 pub mod lora_family;
 pub mod lora_url;
 pub mod project_store;

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -12,6 +12,8 @@ use sceneworks_core::contracts::{
     ProgressRequest, ProgressStage, WorkerCapability, WorkerHeartbeatRequest,
     WorkerRegisterRequest, WorkerSnapshot, WorkerStatus, WorkerUtilizationSnapshot,
 };
+use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
+use sceneworks_core::jsonc::strip_jsonc_comments;
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
     read_safetensors_header, reconcile_detected_family, FamilyMismatch, SafetensorsHeaderError,
@@ -1045,61 +1047,6 @@ pub fn safe_download_dir(value: &str) -> String {
     }
 }
 
-fn huggingface_hub_cache_dir(data_dir: &Path) -> PathBuf {
-    if let Some(path) = std::env::var("HF_HUB_CACHE")
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        return PathBuf::from(path);
-    }
-    if let Some(path) = std::env::var("HUGGINGFACE_HUB_CACHE")
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        return PathBuf::from(path);
-    }
-    if let Some(path) = std::env::var("HF_HOME")
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        return PathBuf::from(path).join("hub");
-    }
-    data_dir.join("cache").join("huggingface").join("hub")
-}
-
-/// The `<X>` in Hugging Face hub's `models--<X>` cache directory name: every
-/// character outside `[A-Za-z0-9._-]` becomes `--`, then surrounding `-` are
-/// trimmed. `None` when nothing survives. Kept byte-identical to the Python
-/// worker (`hf_cache.safe_repo_dir_name`) and the Rust API — pinned by the
-/// `repo_slugs.json` cross-language contract (story 1667).
-fn safe_repo_dir_name(repo: &str) -> Option<String> {
-    let safe_repo = repo
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
-                character.to_string()
-            } else {
-                "--".to_owned()
-            }
-        })
-        .collect::<String>()
-        .trim_matches('-')
-        .to_owned();
-    if safe_repo.is_empty() {
-        None
-    } else {
-        Some(safe_repo)
-    }
-}
-
-fn huggingface_repo_cache_path(data_dir: &Path, repo: &str) -> Option<PathBuf> {
-    let safe_repo = safe_repo_dir_name(repo)?;
-    Some(huggingface_hub_cache_dir(data_dir).join(format!("models--{safe_repo}")))
-}
-
 async fn directory_size(path: &Path) -> u64 {
     let mut total = 0_u64;
     let mut stack = vec![path.to_path_buf()];
@@ -1420,88 +1367,50 @@ async fn read_json_value(path: &Path) -> WorkerResult<Value> {
     Ok(serde_json::from_slice(&tokio::fs::read(path).await?)?)
 }
 
-fn strip_jsonc_comments(value: &str) -> String {
-    let mut output = String::with_capacity(value.len());
-    let mut chars = value.chars().peekable();
-    let mut in_string = false;
-    let mut escaped = false;
-    while let Some(character) = chars.next() {
-        if in_string {
-            output.push(character);
-            if escaped {
-                escaped = false;
-            } else if character == '\\' {
-                escaped = true;
-            } else if character == '"' {
-                in_string = false;
-            }
-            continue;
-        }
-        if character == '"' {
-            in_string = true;
-            output.push(character);
-            continue;
-        }
-        if character == '/' && chars.peek() == Some(&'/') {
-            chars.next();
-            for next in chars.by_ref() {
-                if next == '\r' || next == '\n' {
-                    output.push(next);
-                    break;
-                }
-            }
-            continue;
-        }
-        if character == '/' && chars.peek() == Some(&'*') {
-            chars.next();
-            let mut previous = '\0';
-            for next in chars.by_ref() {
-                if previous == '*' && next == '/' {
-                    break;
-                }
-                previous = next;
-            }
-            continue;
-        }
-        output.push(character);
-    }
-    output
-}
-
-async fn upsert_lora_manifest_entry(
+/// Upsert `entry` (keyed by its `id`) into the `collection_key` array of a JSONC
+/// manifest at `path`, creating the manifest when absent. An existing entry with
+/// the same id is merged (incoming fields win) but keeps its original `createdAt`.
+/// Shared by the LoRA (`"loras"`) and model (`"models"`) manifests, which differed
+/// only by this array key (sc-4279 / F-MLXW-15).
+async fn upsert_manifest_entry(
     path: &Path,
+    collection_key: &str,
     entry: serde_json::Map<String, Value>,
 ) -> WorkerResult<()> {
     let mut manifest = match tokio::fs::read_to_string(path).await {
         Ok(payload) => serde_json::from_str(&strip_jsonc_comments(&payload))?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            json!({ "schemaVersion": 1, "loras": [] })
+            let mut object = serde_json::Map::new();
+            object.insert("schemaVersion".to_owned(), json!(1));
+            object.insert(collection_key.to_owned(), Value::Array(Vec::new()));
+            Value::Object(object)
         }
         Err(error) => return Err(error.into()),
     };
-    let lora_id = entry
-        .get("id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| WorkerError::InvalidPayload("LoRA manifest entry requires id".to_owned()))?;
-    let loras = manifest
+    let entry_id = entry.get("id").and_then(Value::as_str).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!("{collection_key} manifest entry requires id"))
+    })?;
+    let collection = manifest
         .as_object_mut()
-        .ok_or_else(|| WorkerError::InvalidPayload("LoRA manifest must be an object".to_owned()))?
-        .entry("loras")
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!("{collection_key} manifest must be an object"))
+        })?
+        .entry(collection_key.to_owned())
         .or_insert_with(|| Value::Array(Vec::new()));
-    let loras = loras.as_array_mut().ok_or_else(|| {
-        WorkerError::InvalidPayload("LoRA manifest loras must be an array".to_owned())
+    let collection = collection.as_array_mut().ok_or_else(|| {
+        WorkerError::InvalidPayload(format!("{collection_key} manifest array must be an array"))
     })?;
     let mut found = false;
-    for item in loras.iter_mut() {
-        if item.get("id").and_then(Value::as_str) != Some(lora_id) {
+    for item in collection.iter_mut() {
+        if item.get("id").and_then(Value::as_str) != Some(entry_id) {
             continue;
         }
         found = true;
         let created_at = item.get("createdAt").cloned();
         let Some(object) = item.as_object_mut() else {
-            return Err(WorkerError::InvalidPayload(
-                "LoRA manifest entry must be an object".to_owned(),
-            ));
+            return Err(WorkerError::InvalidPayload(format!(
+                "{collection_key} manifest entry must be an object"
+            )));
         };
         for (key, value) in entry.clone() {
             object.insert(key, value);
@@ -1511,54 +1420,7 @@ async fn upsert_lora_manifest_entry(
         }
     }
     if !found {
-        loras.push(Value::Object(entry));
-    }
-    write_json_value(path, &manifest).await
-}
-
-async fn upsert_model_manifest_entry(
-    path: &Path,
-    entry: serde_json::Map<String, Value>,
-) -> WorkerResult<()> {
-    let mut manifest = match tokio::fs::read_to_string(path).await {
-        Ok(payload) => serde_json::from_str(&strip_jsonc_comments(&payload))?,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            json!({ "schemaVersion": 1, "models": [] })
-        }
-        Err(error) => return Err(error.into()),
-    };
-    let model_id = entry.get("id").and_then(Value::as_str).ok_or_else(|| {
-        WorkerError::InvalidPayload("Model manifest entry requires id".to_owned())
-    })?;
-    let models = manifest
-        .as_object_mut()
-        .ok_or_else(|| WorkerError::InvalidPayload("Model manifest must be an object".to_owned()))?
-        .entry("models")
-        .or_insert_with(|| Value::Array(Vec::new()));
-    let models = models.as_array_mut().ok_or_else(|| {
-        WorkerError::InvalidPayload("Model manifest models must be an array".to_owned())
-    })?;
-    let mut found = false;
-    for item in models.iter_mut() {
-        if item.get("id").and_then(Value::as_str) != Some(model_id) {
-            continue;
-        }
-        found = true;
-        let created_at = item.get("createdAt").cloned();
-        let Some(object) = item.as_object_mut() else {
-            return Err(WorkerError::InvalidPayload(
-                "Model manifest entry must be an object".to_owned(),
-            ));
-        };
-        for (key, value) in entry.clone() {
-            object.insert(key, value);
-        }
-        if let Some(created_at) = created_at {
-            object.insert("createdAt".to_owned(), created_at);
-        }
-    }
-    if !found {
-        models.push(Value::Object(entry));
+        collection.push(Value::Object(entry));
     }
     write_json_value(path, &manifest).await
 }

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1063,7 +1063,7 @@ pub(crate) async fn run_lora_import_job(
                 .or_insert(Value::String(family));
         }
         let manifest_path = lora_manifest_target(settings, &job.payload)?;
-        upsert_lora_manifest_entry(&manifest_path, manifest_entry).await?;
+        upsert_manifest_entry(&manifest_path, "loras", manifest_entry).await?;
     }
 
     let mut result = JsonObject::new();
@@ -1368,7 +1368,7 @@ pub(crate) async fn run_model_import_job(
             );
         }
         let manifest_path = model_manifest_target(settings, &job.payload)?;
-        upsert_model_manifest_entry(&manifest_path, manifest_entry).await?;
+        upsert_manifest_entry(&manifest_path, "models", manifest_entry).await?;
     }
 
     let mut result = JsonObject::new();

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -236,9 +236,10 @@ fn huggingface_cache_paths_follow_hub_layout() {
 
 #[test]
 fn repo_slug_functions_match_cross_language_contract() {
-    // story 1667: these repo->dir slug ops are duplicated in the Python
-    // worker and the Rust API; repo_slugs.json is the shared contract that
-    // pins them byte-for-byte across languages.
+    // story 1667: safe_download_dir is the worker-only repo->dir slug op pinned
+    // by the shared repo_slugs.json contract. (safe_repo_dir_name moved to
+    // sceneworks-core in sc-4279 and is contract-tested there, so it is no longer
+    // re-asserted here.)
     let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../tests/fixtures/rust_migration_contracts/repo_slugs.json");
     let contract: serde_json::Value =
@@ -252,11 +253,6 @@ fn repo_slug_functions_match_cross_language_contract() {
             super::safe_download_dir(repo),
             case["safeDownloadDir"].as_str().expect("safeDownloadDir"),
             "safe_download_dir drift for {repo:?}"
-        );
-        assert_eq!(
-            super::safe_repo_dir_name(repo).as_deref(),
-            case["safeRepoDirName"].as_str(),
-            "safe_repo_dir_name drift for {repo:?}"
         );
     }
 }


### PR DESCRIPTION
## sc-4279 — [F-MLXW-15] Cross-crate duplicate helpers re-implemented in worker and rust-api

Fixes code-review finding F-MLXW-15 (P3/Low, redundant).

### Problem
Byte-identical contract-critical helpers lived in **both** the rust-worker and the rust-api (each with its own `repo_slugs.json` contract test) instead of in `sceneworks-core`, which both crates already depend on. A change merged to one crate only would drift cache-path resolution and only fail late. The worker also had two near-identical manifest upserters differing only by the array key.

### Fix
- **Moved to `sceneworks-core`:** `huggingface_hub_cache_dir`, `safe_repo_dir_name`, `huggingface_repo_cache_path` → `core::hf_home`; `strip_jsonc_comments` → new `core::jsonc`. Both crates import them; the duplicated definitions are deleted.
- **Contract test consolidated:** the `repo_slugs.json` cross-language pin for `safe_repo_dir_name` now lives once in `core::hf_home`. The worker/api keep their contract tests for the crate-local `safe_download_dir` only (they no longer re-assert the moved slug). The api keeps `strip_jsonc_comments` reachable via a `pub(crate) use` re-export through `use manifest::*`.
- **Manifest upserter parameterized:** `upsert_lora_manifest_entry` + `upsert_model_manifest_entry` → one `upsert_manifest_entry(path, collection_key, entry)`; the two call sites pass `"loras"` / `"models"`.

Pure dedup, no behavior change.

### Tests
- New core tests: `hf_home::safe_repo_dir_name_matches_repo_slugs_contract` (canonical contract pin) and `jsonc::strips_line_and_block_comments_but_preserves_strings`.
- Existing suites all green through the moved/re-exported helpers: **core** (140 lib + 103 jobs_store + …), **worker** 217, **rust-api** 109 (incl. `repo_slug_functions_match_cross_language_contract`, manifest merge/malformed tests via the re-exported `strip_jsonc_comments`).
- `cargo fmt`, `cargo clippy --all-targets -D warnings` clean across all three crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)