### PR TITLE
docs(worker): correct stale person detect/track routing comment (sc-4280)

### DIFF
--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -491,9 +491,11 @@ pub(crate) fn worker_capabilities_with_utility(
             WorkerCapability::ModelConvert,
             WorkerCapability::LoraImport,
             // Procedural detection/tracking is a preview only. Real, model-backed
-            // PersonDetect/PersonTrack run on the Python GPU worker; advertising the
-            // preview capabilities here keeps the CPU placeholder claimable solely
-            // for explicit `preview: true` jobs (jobs_store::worker_supports_job).
+            // PersonDetect/PersonTrack run on the macOS MLX worker (native
+            // YOLO11/SAM2, epic 3482) or the Python GPU worker on Windows/Linux;
+            // advertising the preview capabilities here keeps the CPU placeholder
+            // claimable solely for explicit `preview: true` jobs
+            // (jobs_store::worker_supports_job).
             WorkerCapability::PersonDetectPreview,
             WorkerCapability::PersonTrackPreview,
         ]);


### PR DESCRIPTION
## sc-4280 — [F-MLXW-17] Stale comment: CPU-worker capability block claims real person detect/track "run on the Python GPU worker"

Fixes code-review finding F-MLXW-17 (P3/Low, readability).

### Problem
The comment in `worker_capabilities_with_utility` (gpu.rs) said real `PersonDetect`/`PersonTrack` "run on the Python GPU worker", but since epic 3482 `mlx_gpu()` advertises real `PersonDetect`/`PersonTrack` served by the native MLX YOLO11/SAM2 pipeline on macOS — only Windows/Linux still use Python. Misleads the next reader about macOS routing, exactly where routing bugs get investigated (epic 3447).

### Fix
Updated the comment to: real PersonDetect/PersonTrack "run on the macOS MLX worker (native YOLO11/SAM2, epic 3482) or the Python GPU worker on Windows/Linux".

Comment-only change; worker builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)