### PR TITLE
refactor(worker): shared advanced knob accessors, clamp explicit (sc-4281)

### DIFF
--- a/crates/sceneworks-worker/src/advanced.rs
+++ b/crates/sceneworks-worker/src/advanced.rs
@@ -1,0 +1,147 @@
+//! Shared accessors for a job's `advanced` knob map (the per-request `advanced`
+//! JSON object).
+//!
+//! These were previously re-implemented per job module, and had drifted: image
+//! and video both had a private `advanced_f32`, but only the image one clamped —
+//! so a reader moving between the files would wrongly assume identical behavior
+//! and could add an unclamped user knob believing it was range-protected
+//! (sc-4281 / F-MLXW-18). Centralizing them here makes clamping **explicit at the
+//! call site**: `f32`/`u32` read raw, `f32_clamped`/`u32_clamped` clamp to a
+//! `RangeInclusive`. All accept the parsed `advanced` object directly so they are
+//! reusable regardless of the request type that owns it.
+
+use std::ops::RangeInclusive;
+
+use sceneworks_core::contracts::JsonObject;
+use serde_json::Value;
+
+/// Permissive truthiness: a JSON `true`, a non-zero number, a non-empty string,
+/// or a non-empty array all read as `true`; everything else (incl. absent) is
+/// `false`. (Was image's `advanced_flag`.)
+pub(crate) fn flag(advanced: &JsonObject, key: &str) -> bool {
+    match advanced.get(key) {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Number(number)) => number.as_f64().map(|value| value != 0.0).unwrap_or(false),
+        Some(Value::String(value)) => !value.is_empty(),
+        Some(Value::Array(value)) => !value.is_empty(),
+        _ => false,
+    }
+}
+
+/// Strict boolean: only a JSON `true`/`false`, default `false`. (Was video's
+/// `advanced_bool`.) Use [`flag`] for the permissive truthiness reading.
+pub(crate) fn bool(advanced: &JsonObject, key: &str) -> bool {
+    advanced.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+/// Float (JSON number or numeric string), default `default`, **no clamp**.
+pub(crate) fn f32(advanced: &JsonObject, key: &str, default: f32) -> f32 {
+    advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+        .unwrap_or(default)
+}
+
+/// Float, parsed like [`f32`] then clamped to `range`.
+pub(crate) fn f32_clamped(
+    advanced: &JsonObject,
+    key: &str,
+    default: f32,
+    range: RangeInclusive<f32>,
+) -> f32 {
+    f32(advanced, key, default).clamp(*range.start(), *range.end())
+}
+
+/// Signed 32-bit int (JSON int or numeric string), default `default`, **no clamp**.
+pub(crate) fn i32(advanced: &JsonObject, key: &str, default: i32) -> i32 {
+    advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as i32)
+        .unwrap_or(default)
+}
+
+/// Unsigned 32-bit int (JSON uint or numeric string), default `default`, then
+/// clamped to `range`.
+pub(crate) fn u32_clamped(
+    advanced: &JsonObject,
+    key: &str,
+    default: u32,
+    range: RangeInclusive<u32>,
+) -> u32 {
+    advanced
+        .get(key)
+        .and_then(|value| {
+            value
+                .as_u64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as u32)
+        .unwrap_or(default)
+        .clamp(*range.start(), *range.end())
+}
+
+/// Trimmed non-empty string, else `default`.
+pub(crate) fn str(advanced: &JsonObject, key: &str, default: &str) -> String {
+    advanced
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn obj(value: serde_json::Value) -> JsonObject {
+        value.as_object().expect("object").clone()
+    }
+
+    #[test]
+    fn f32_clamped_vs_raw_make_the_clamp_explicit() {
+        let advanced = obj(json!({ "x": 5.0, "s": "2.5" }));
+        // Raw f32 does not clamp; the *_clamped variant does — the call site now
+        // says which it wants (sc-4281).
+        assert_eq!(f32(&advanced, "x", 0.0), 5.0);
+        assert_eq!(f32_clamped(&advanced, "x", 0.0, 0.0..=1.0), 1.0);
+        // Numeric strings parse for both.
+        assert_eq!(f32(&advanced, "s", 0.0), 2.5);
+        // Absent key falls back to default.
+        assert_eq!(f32_clamped(&advanced, "missing", 0.3, 0.0..=1.0), 0.3);
+    }
+
+    #[test]
+    fn flag_is_permissive_bool_is_strict() {
+        let advanced = obj(json!({ "n": 2, "s": "hi", "arr": [1], "b": false }));
+        assert!(flag(&advanced, "n"));
+        assert!(flag(&advanced, "s"));
+        assert!(flag(&advanced, "arr"));
+        assert!(!flag(&advanced, "missing"));
+        // Strict bool only honors a real JSON boolean.
+        assert!(!bool(&advanced, "n"));
+        assert!(!bool(&advanced, "b"));
+        assert!(bool(&obj(json!({ "b": true })), "b"));
+    }
+
+    #[test]
+    fn int_and_string_accessors_parse_and_default() {
+        let advanced = obj(json!({ "i": -4, "u": "7", "name": "  z " }));
+        assert_eq!(i32(&advanced, "i", 0), -4);
+        assert_eq!(u32_clamped(&advanced, "u", 0, 0..=5), 5);
+        assert_eq!(str(&advanced, "name", "d"), "z");
+        assert_eq!(str(&advanced, "missing", "d"), "d");
+    }
+}

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1474,11 +1474,22 @@ async fn generate_mlx_stream(
             &reference_id,
             project_path,
         )?;
-        let scale = advanced_f32(request, "ipAdapterScale", FLUX_IP_SCALE, 0.0, 1.0);
+        let scale = advanced::f32_clamped(
+            &request.advanced,
+            "ipAdapterScale",
+            FLUX_IP_SCALE,
+            0.0..=1.0,
+        );
         let ip_dir = resolve_flux_ip_adapter_dir(settings)?;
         // Real CFG only on dev (schnell is distilled — no CFG).
-        let true_cfg = (request.model == "flux_dev")
-            .then(|| advanced_f32(request, "trueCfgScale", FLUX_IP_TRUE_CFG, 1.0, 10.0));
+        let true_cfg = (request.model == "flux_dev").then(|| {
+            advanced::f32_clamped(
+                &request.advanced,
+                "trueCfgScale",
+                FLUX_IP_TRUE_CFG,
+                1.0..=10.0,
+            )
+        });
         (Some((image, scale)), Some(ip_dir), true_cfg)
     } else {
         (None, None, None)
@@ -2210,7 +2221,7 @@ fn resolve_zimage_edit_init(
     } else {
         source
     };
-    let strength = advanced_f32(request, "strength", 0.6, 0.05, 1.0);
+    let strength = advanced::f32_clamped(&request.advanced, "strength", 0.6, 0.05..=1.0);
     Ok(Some((image, strength)))
 }
 
@@ -2313,19 +2324,6 @@ fn augment_prompt_for_pose(base: &str) -> String {
     }
 }
 
-/// Python's `bool(advanced.get(key))` for the JSON types the UI sends: bool as-is,
-/// non-zero number, non-empty string/array → true; absent/null/false → false.
-#[cfg(target_os = "macos")]
-fn advanced_flag(request: &ImageRequest, key: &str) -> bool {
-    match request.advanced.get(key) {
-        Some(Value::Bool(value)) => *value,
-        Some(Value::Number(number)) => number.as_f64().map(|value| value != 0.0).unwrap_or(false),
-        Some(Value::String(value)) => !value.is_empty(),
-        Some(Value::Array(value)) => !value.is_empty(),
-        _ => false,
-    }
-}
-
 /// How a FLUX.2 edit job batches its iterations.
 #[cfg(target_os = "macos")]
 enum Flux2Grouping {
@@ -2350,7 +2348,7 @@ fn flux2_grouping(request: &ImageRequest) -> Flux2Grouping {
     if poses > 0 {
         return Flux2Grouping::Poses(poses);
     }
-    if advanced_flag(request, "angleSet") {
+    if advanced::flag(&request.advanced, "angleSet") {
         return Flux2Grouping::Angles;
     }
     Flux2Grouping::Plain
@@ -4128,22 +4126,6 @@ fn load_mask_asset_image(
     load_reference_image(&settings.data_dir, project_id, mask_asset_id, project_path)
 }
 
-/// Float field on `advanced` (number or numeric string), clamped to `[lo, hi]`.
-#[cfg(target_os = "macos")]
-fn advanced_f32(request: &ImageRequest, key: &str, default: f32, lo: f32, hi: f32) -> f32 {
-    request
-        .advanced
-        .get(key)
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(default)
-        .clamp(lo, hi)
-}
-
 /// Composite `source` contained (long edge fits) + centered on a black `width`×`height`
 /// canvas, using the **engine's** `contain_box` so the padded source lines up pixel-for-pixel
 /// with [`mlx_gen::image::outpaint_border_mask`] (both derive the same kept rect).
@@ -4320,7 +4302,12 @@ async fn generate_sdxl_advanced_stream(
                     "SDXL IP-Adapter weights not found (download {SDXL_IP_ADAPTER_REPO})."
                 ))
             })?;
-            let scale = advanced_f32(request, "ipAdapterScale", SDXL_IP_SCALE, 0.0, 1.0);
+            let scale = advanced::f32_clamped(
+                &request.advanced,
+                "ipAdapterScale",
+                SDXL_IP_SCALE,
+                0.0..=1.0,
+            );
             (
                 vec![Conditioning::Reference {
                     image: reference,
@@ -4351,16 +4338,15 @@ async fn generate_sdxl_advanced_stream(
             // stretch — torch parity with `load_source_image` + `fit_image`.
             let source = fit_engine_image(source, width, height, &request.fit_mode)?;
             let is_inpaint = matches!(sub_mode, SdxlSubMode::Inpaint);
-            let strength = advanced_f32(
-                request,
+            let strength = advanced::f32_clamped(
+                &request.advanced,
                 "strength",
                 if is_inpaint {
                     SDXL_INPAINT_STRENGTH
                 } else {
                     SDXL_EDIT_STRENGTH
                 },
-                0.0,
-                1.0,
+                0.0..=1.0,
             );
             let mut conditioning = vec![Conditioning::Reference {
                 image: source,
@@ -4419,7 +4405,12 @@ async fn generate_sdxl_advanced_stream(
                     WorkerError::InvalidPayload(format!("outpaint mask union failed: {error}"))
                 })?;
             }
-            let strength = advanced_f32(request, "strength", SDXL_INPAINT_STRENGTH, 0.0, 1.0);
+            let strength = advanced::f32_clamped(
+                &request.advanced,
+                "strength",
+                SDXL_INPAINT_STRENGTH,
+                0.0..=1.0,
+            );
             (
                 vec![
                     Conditioning::Reference {
@@ -4601,7 +4592,7 @@ enum InstantIdMode {
 /// The 11-view Character-Studio angle set flag.
 #[cfg(target_os = "macos")]
 fn instantid_angle_set(request: &ImageRequest) -> bool {
-    advanced_flag(request, "angleSet")
+    advanced::flag(&request.advanced, "angleSet")
 }
 
 /// Classify the InstantID iteration mode (pose set > angle set > plain identity).
@@ -4707,7 +4698,7 @@ fn active_angle_collection(
     Vec<sceneworks_core::project_store::ResolvedAnglePreset>,
 ) {
     let store = ProjectStore::new(settings.data_dir.clone(), "worker");
-    let override_id = advanced_str(request, "keypointCollectionId", "");
+    let override_id = advanced::str(&request.advanced, "keypointCollectionId", "");
     let override_id = override_id.trim();
     let override_id = (!override_id.is_empty()).then_some(override_id);
     store
@@ -4768,7 +4759,12 @@ fn instantid_guidance(request: &ImageRequest) -> f32 {
         })
         .map(|value| value as f32)
         .unwrap_or(INSTANTID_DEFAULT_GUIDANCE);
-    advanced_f32(request, "guidanceScale", manifest_default, 0.0, 30.0)
+    advanced::f32_clamped(
+        &request.advanced,
+        "guidanceScale",
+        manifest_default,
+        0.0..=30.0,
+    )
 }
 
 /// Resolve InstantID quantization. **fp16 (dense) is the default** — the validated identity
@@ -5031,13 +5027,17 @@ async fn generate_instantid_stream(
     let steps = instantid_steps(request);
     let guidance = instantid_guidance(request);
     let (quant_bits, recipe_bits) = instantid_quant(request);
-    let ip_scale = advanced_f32(request, "ipAdapterScale", INSTANTID_IP_SCALE, 0.0, 1.0);
-    let controlnet_scale = advanced_f32(
-        request,
+    let ip_scale = advanced::f32_clamped(
+        &request.advanced,
+        "ipAdapterScale",
+        INSTANTID_IP_SCALE,
+        0.0..=1.0,
+    );
+    let controlnet_scale = advanced::f32_clamped(
+        &request.advanced,
         "controlnetConditioningScale",
         INSTANTID_CONTROLNET_SCALE,
-        0.0,
-        2.0,
+        0.0..=2.0,
     );
     let repo = request
         .model_manifest_entry
@@ -5053,8 +5053,13 @@ async fn generate_instantid_stream(
     // The active Key Point Library collection drives the angle set (sc-4450): per-generation
     // override > user default > built-in 11. Resolved once (and only for angle jobs).
     let angle_collection = angle_set.then(|| active_angle_collection(request, settings));
-    let openpose_scale = advanced_f32(request, "openPoseScale", INSTANTID_OPENPOSE_SCALE, 0.0, 2.0);
-    let face_restore = advanced_flag(request, "faceRestore");
+    let openpose_scale = advanced::f32_clamped(
+        &request.advanced,
+        "openPoseScale",
+        INSTANTID_OPENPOSE_SCALE,
+        0.0..=2.0,
+    );
+    let face_restore = advanced::flag(&request.advanced, "faceRestore");
     // Load the xinsir OpenPose ControlNet only for pose mode (it is the MultiControlNet second
     // branch; identity/angle modes don't need it).
     let openpose = if pose_set {
@@ -5359,45 +5364,17 @@ struct DetailParams {
     seed: i64,
 }
 
-/// Unsigned int field on `advanced` (number or numeric string), clamped to `[lo, hi]`.
-#[cfg(target_os = "macos")]
-fn advanced_u32(request: &ImageRequest, key: &str, default: u32, lo: u32, hi: u32) -> u32 {
-    request
-        .advanced
-        .get(key)
-        .and_then(|value| {
-            value
-                .as_u64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as u32)
-        .unwrap_or(default)
-        .clamp(lo, hi)
-}
-
-#[cfg(target_os = "macos")]
-fn advanced_str(request: &ImageRequest, key: &str, default: &str) -> String {
-    request
-        .advanced
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(default)
-        .to_owned()
-}
-
 #[cfg(target_os = "macos")]
 fn resolve_detail_params(request: &ImageRequest) -> DetailParams {
     DetailParams {
-        strength: advanced_f32(request, "strength", 0.55, 0.2, 1.0),
-        cn_scale: advanced_f32(request, "cnScale", 0.7, 0.1, 1.5),
-        steps: advanced_u32(request, "steps", 24, 1, 60),
-        guidance: advanced_f32(request, "guidanceScale", 5.0, 1.0, 15.0),
-        tile: advanced_u32(request, "tile", 1024, 512, 1536),
-        overlap: advanced_u32(request, "overlap", 128, 0, 512),
-        prompt: advanced_str(request, "prompt", DETAIL_DEFAULT_PROMPT),
-        negative: advanced_str(request, "negativePrompt", DETAIL_DEFAULT_NEGATIVE),
+        strength: advanced::f32_clamped(&request.advanced, "strength", 0.55, 0.2..=1.0),
+        cn_scale: advanced::f32_clamped(&request.advanced, "cnScale", 0.7, 0.1..=1.5),
+        steps: advanced::u32_clamped(&request.advanced, "steps", 24, 1..=60),
+        guidance: advanced::f32_clamped(&request.advanced, "guidanceScale", 5.0, 1.0..=15.0),
+        tile: advanced::u32_clamped(&request.advanced, "tile", 1024, 512..=1536),
+        overlap: advanced::u32_clamped(&request.advanced, "overlap", 128, 0..=512),
+        prompt: advanced::str(&request.advanced, "prompt", DETAIL_DEFAULT_PROMPT),
+        negative: advanced::str(&request.advanced, "negativePrompt", DETAIL_DEFAULT_NEGATIVE),
         // Python defaults the detail seed to 7 when the payload omits one.
         seed: request.seed.unwrap_or(7),
     }
@@ -5736,7 +5713,11 @@ pub(crate) async fn run_image_detail_job(
         .or_else(|| huggingface_snapshot_dir(&settings.data_dir, engine_model.default_repo));
     let weights_dir = weights_dir
         .ok_or_else(|| WorkerError::InvalidPayload("SDXL detail weights not found".to_owned()))?;
-    let control_repo = advanced_str(&request, "tileControlNetRepo", TILE_CONTROLNET_REPO);
+    let control_repo = advanced::str(
+        &request.advanced,
+        "tileControlNetRepo",
+        TILE_CONTROLNET_REPO,
+    );
     let control_dir =
         huggingface_snapshot_dir(&settings.data_dir, &control_repo).ok_or_else(|| {
             WorkerError::InvalidPayload(format!(

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -33,6 +33,11 @@ use tokio::process::{Child, Command};
 use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
 
+// Shared `advanced` knob accessors (sc-4281). Every caller (image/video MLX job
+// paths) is macOS-gated, so the module is too — otherwise its accessors would be
+// uncalled (dead_code) on the Linux/Windows builds.
+#[cfg(target_os = "macos")]
+mod advanced;
 mod api_client;
 use api_client::*;
 mod gpu;

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1230,7 +1230,7 @@ fn build_wan_boundary_conditioning(
     let mut conditioning = vec![Conditioning::Keyframe {
         image: left_frame,
         frame_idx: 0,
-        strength: advanced_f32(request, "videoConditioningStrength", 1.0),
+        strength: advanced::f32(&request.advanced, "videoConditioningStrength", 1.0),
     }];
     if request.mode == "video_bridge" {
         let right = right_frame.ok_or_else(|| {
@@ -1242,7 +1242,11 @@ fn build_wan_boundary_conditioning(
         conditioning.push(Conditioning::Keyframe {
             image: right,
             frame_idx: -1,
-            strength: advanced_f32(request, "bridgeRightVideoConditioningStrength", 1.0),
+            strength: advanced::f32(
+                &request.advanced,
+                "bridgeRightVideoConditioningStrength",
+                1.0,
+            ),
         });
     }
     Ok(conditioning)
@@ -1853,46 +1857,6 @@ fn resolve_ltx_conditioning(
 }
 
 /// Read an `advanced` boolean flag (JSON bool), default `false` (Python `bool(.get(k))`).
-#[cfg(target_os = "macos")]
-fn advanced_bool(request: &VideoRequest, key: &str) -> bool {
-    request
-        .advanced
-        .get(key)
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-}
-
-/// Read an `advanced` float (JSON number or numeric string), default `fallback` — mirrors the
-/// Python `_advanced_float`.
-#[cfg(target_os = "macos")]
-fn advanced_f32(request: &VideoRequest, key: &str, fallback: f32) -> f32 {
-    request
-        .advanced
-        .get(key)
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(fallback)
-}
-
-/// Read an `advanced` integer (JSON int or numeric string), default `fallback`.
-#[cfg(target_os = "macos")]
-fn advanced_i32(request: &VideoRequest, key: &str, fallback: i32) -> i32 {
-    request
-        .advanced
-        .get(key)
-        .and_then(|value| {
-            value
-                .as_i64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as i32)
-        .unwrap_or(fallback)
-}
-
 /// First/last-frame conditioning (sc-3055 cutover): two [`Conditioning::Keyframe`]s — the source
 /// image pinned at latent frame 0 and the last-frame image at latent frame `-1` (the engine's
 /// Python-style negative-from-end index, so the worker needs no latent-frame math; the engine
@@ -1932,13 +1896,13 @@ fn resolve_keyframe_conditioning(
     Ok(vec![
         Conditioning::Keyframe {
             image: first,
-            frame_idx: advanced_i32(request, "imageFrameIndex", 0),
-            strength: advanced_f32(request, "imageConditioningStrength", 1.0),
+            frame_idx: advanced::i32(&request.advanced, "imageFrameIndex", 0),
+            strength: advanced::f32(&request.advanced, "imageConditioningStrength", 1.0),
         },
         Conditioning::Keyframe {
             image: last,
             frame_idx: -1,
-            strength: advanced_f32(request, "lastFrameConditioningStrength", 1.0),
+            strength: advanced::f32(&request.advanced, "lastFrameConditioningStrength", 1.0),
         },
     ])
 }
@@ -2041,7 +2005,7 @@ fn build_video_clip_conditioning(
     let mut conditioning = vec![Conditioning::VideoClip {
         frames: left_frames,
         frame_idx: 0,
-        strength: advanced_f32(request, "videoConditioningStrength", 1.0),
+        strength: advanced::f32(&request.advanced, "videoConditioningStrength", 1.0),
     }];
     if request.mode == "video_bridge" {
         let right = right_frames.ok_or_else(|| {
@@ -2053,7 +2017,11 @@ fn build_video_clip_conditioning(
         conditioning.push(Conditioning::VideoClip {
             frames: right,
             frame_idx: -1,
-            strength: advanced_f32(request, "bridgeRightVideoConditioningStrength", 1.0),
+            strength: advanced::f32(
+                &request.advanced,
+                "bridgeRightVideoConditioningStrength",
+                1.0,
+            ),
         });
     }
     Ok(conditioning)
@@ -2284,7 +2252,7 @@ async fn generate_ltx(
     engine_id: &'static str,
     backend: &str,
 ) -> WorkerResult<DecodedVideo> {
-    let video_mode = advanced_bool(request, "noAudio").then(|| "no_audio".to_owned());
+    let video_mode = advanced::bool(&request.advanced, "noAudio").then(|| "no_audio".to_owned());
     let enhance_max_tokens = request
         .advanced
         .get("enhanceMaxTokens")
@@ -2321,8 +2289,8 @@ async fn generate_ltx(
         seed: resolve_video_seed(request) as u64,
         control_scale: None,
         video_mode,
-        enhance_prompt: advanced_bool(request, "enhancePrompt"),
-        use_uncensored_enhancer: advanced_bool(request, "useUncensoredEnhancer"),
+        enhance_prompt: advanced::bool(&request.advanced, "enhancePrompt"),
+        use_uncensored_enhancer: advanced::bool(&request.advanced, "useUncensoredEnhancer"),
         enhance_max_tokens,
         enhance_temperature,
         ..VideoGenInput::default()
@@ -3005,7 +2973,7 @@ async fn generate_wan_vace(
     let reference_count = references.len();
     let frame_total = frames.len();
 
-    let masking_strength = advanced_f32(request, "maskingStrength", 1.0);
+    let masking_strength = advanced::f32(&request.advanced, "maskingStrength", 1.0);
     let conditioning = build_vace_conditioning(
         frames,
         masks,
@@ -3045,7 +3013,7 @@ async fn generate_wan_vace(
         steps,
         guidance,
         seed: resolve_video_seed(request) as u64,
-        control_scale: Some(advanced_f32(request, "conditioningScale", 1.0)),
+        control_scale: Some(advanced::f32(&request.advanced, "conditioningScale", 1.0)),
         ..VideoGenInput::default()
     };
     let decoded = generate_video(api, settings, job, backend, input).await?;
@@ -3415,7 +3383,7 @@ async fn generate_wan_vace_extend_bridge(
         steps,
         guidance,
         seed: resolve_video_seed(request) as u64,
-        control_scale: Some(advanced_f32(request, "conditioningScale", 1.0)),
+        control_scale: Some(advanced::f32(&request.advanced, "conditioningScale", 1.0)),
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, input).await
@@ -4328,9 +4296,9 @@ mod tests {
             "projectId": "p", "model": "ltx_2_3", "prompt": "a fox",
             "advanced": { "noAudio": true, "enhancePrompt": true }
         }));
-        assert!(advanced_bool(&req, "noAudio"));
-        assert!(advanced_bool(&req, "enhancePrompt"));
-        assert!(!advanced_bool(&req, "useUncensoredEnhancer"));
+        assert!(advanced::bool(&req.advanced, "noAudio"));
+        assert!(advanced::bool(&req.advanced, "enhancePrompt"));
+        assert!(!advanced::bool(&req.advanced, "useUncensoredEnhancer"));
         // LTX adapters: a plain user LoRA is uniform (no per-pass schedule, no moe tag).
         let none = resolve_ltx_adapters(&req).unwrap();
         assert!(none.is_empty());
@@ -4350,20 +4318,26 @@ mod tests {
                 "imageFrameIndex": 2
             }
         }));
-        assert_eq!(advanced_f32(&req, "imageConditioningStrength", 1.0), 0.8);
         assert_eq!(
-            advanced_f32(&req, "lastFrameConditioningStrength", 1.0),
+            advanced::f32(&req.advanced, "imageConditioningStrength", 1.0),
+            0.8
+        );
+        assert_eq!(
+            advanced::f32(&req.advanced, "lastFrameConditioningStrength", 1.0),
             0.65
         );
-        assert_eq!(advanced_i32(&req, "imageFrameIndex", 0), 2);
+        assert_eq!(advanced::i32(&req.advanced, "imageFrameIndex", 0), 2);
         // Absent keys → the fully-pinned defaults (strength 1.0, first index 0).
         let bare = request(json!({ "projectId": "p", "model": "ltx_2_3", "prompt": "a fox" }));
-        assert_eq!(advanced_f32(&bare, "imageConditioningStrength", 1.0), 1.0);
         assert_eq!(
-            advanced_f32(&bare, "lastFrameConditioningStrength", 1.0),
+            advanced::f32(&bare.advanced, "imageConditioningStrength", 1.0),
             1.0
         );
-        assert_eq!(advanced_i32(&bare, "imageFrameIndex", 0), 0);
+        assert_eq!(
+            advanced::f32(&bare.advanced, "lastFrameConditioningStrength", 1.0),
+            1.0
+        );
+        assert_eq!(advanced::i32(&bare.advanced, "imageFrameIndex", 0), 0);
     }
 
     /// `resolve_keyframe_conditioning` fails clearly when an FLF source/last-frame asset id is


### PR DESCRIPTION
## sc-4281 — [F-MLXW-18] Same-named `advanced_f32` helpers with different signatures/semantics across modules

Fixes code-review finding F-MLXW-18 (P3/Low, readability).

### Problem
`image_jobs` and `video_jobs` each had a private `advanced_f32`, but **only the image one clamped** — same name, different behavior across files. A reader moving between them assumes identical behavior and could add an unclamped user knob believing it was range-protected (e.g. `videoConditioningStrength` is *not* clamped while `ipAdapterScale` is). `advanced_flag`/`advanced_bool` and `advanced_u32`/`advanced_i32` showed the same near-duplication.

### Fix
New shared `advanced` module operating on the parsed `advanced` JSON object, with **clamping explicit at the call site**:
- `f32` (raw) vs `f32_clamped(.., RangeInclusive)`, `u32_clamped(.., RangeInclusive)`
- `flag` (permissive truthiness — was image's `advanced_flag`), `bool` (strict JSON bool — was video's `advanced_bool`), `i32`, `str`

Every `image_jobs` + `video_jobs` call site is migrated to it and the per-file helpers deleted. The module is `#[cfg(target_os = "macos")]` to match its callers (the MLX job paths were all already macOS-gated), so the Linux/Windows worker builds are unaffected.

Pure dedup, no behavior change.

### Scope note
`sensenova_jobs` and `training_jobs` keep their own module-local `advanced_*` helpers — they have distinct names and don't participate in the image↔video same-name hazard the finding cites (its Location names image_jobs + video_jobs, and the suggested fix says "both job files"). Adopting this shared module there is a clean possible fast-follow.

### Tests
- New `advanced` unit tests pin the raw-vs-clamped distinction, permissive-`flag` vs strict-`bool`, and int/string parsing+defaults.
- The migrated `advanced_numeric_helpers_parse_flf_keyframe_knobs` video test + all 220 worker tests pass.
- `cargo fmt`, `cargo clippy -p sceneworks-worker --all-targets` (clean, `-D warnings`), `cargo test -p sceneworks-worker` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)