### PR TITLE
fix(worker): reset supervisor restart backoff after a healthy run (sc-4282)

### DIFF
--- a/crates/sceneworks-worker/src/supervisor.rs
+++ b/crates/sceneworks-worker/src/supervisor.rs
@@ -10,6 +10,21 @@ pub(crate) struct SupervisedChild {
     pub(crate) spec: WorkerSpec,
     pub(crate) process: Child,
     pub(crate) restart_attempt: u32,
+    /// When the current process was (re)spawned, so a child that ran healthily
+    /// for a while resets its restart backoff instead of ratcheting it up forever
+    /// (sc-4282 / F-MLXW-20).
+    pub(crate) spawned_at: Instant,
+}
+
+/// A child that stayed alive at least this long before exiting is treated as
+/// having had a healthy run, so its restart-backoff counter resets rather than
+/// saturating upward across rare, widely-spaced crashes (sc-4282 / F-MLXW-20).
+const HEALTHY_UPTIME_RESET: Duration = Duration::from_secs(300);
+
+/// Whether a child's `uptime` (time since its last spawn) was long enough to
+/// count as a healthy run and reset the restart backoff.
+fn backoff_resets_after_healthy_uptime(uptime: Duration) -> bool {
+    uptime >= HEALTHY_UPTIME_RESET
 }
 
 pub(crate) async fn supervise_auto_workers(settings: Settings) -> WorkerResult<()> {
@@ -38,6 +53,7 @@ pub(crate) async fn supervise_children(
                 spec,
                 process,
                 restart_attempt: 0,
+                spawned_at: Instant::now(),
             },
         );
     }
@@ -75,6 +91,12 @@ where
     let mut exited = Vec::new();
     for (worker_id, child) in children.iter_mut() {
         if let Some(status) = child.process.try_wait()? {
+            // A child that ran healthily for a while before exiting starts its
+            // backoff fresh, so rare widely-spaced crashes don't ratchet the delay
+            // up to the cap forever (sc-4282 / F-MLXW-20).
+            if backoff_resets_after_healthy_uptime(child.spawned_at.elapsed()) {
+                child.restart_attempt = 0;
+            }
             // Advance the attempt once here so the logged ETA and the actual
             // backoff below both read the same stored value.
             child.restart_attempt = child.restart_attempt.saturating_add(1);
@@ -105,6 +127,7 @@ where
         }
         let process = spawner(settings, &child.spec)?;
         child.process = process;
+        child.spawned_at = Instant::now();
         children.insert(child.spec.worker_id.clone(), child);
     }
     Ok(())
@@ -221,5 +244,25 @@ pub(crate) fn utility_worker_id(base_worker_id: &str, index: usize) -> String {
         cpu_id
     } else {
         format!("{cpu_id}-{index}")
+    }
+}
+
+#[cfg(test)]
+mod backoff_tests {
+    use super::{backoff_resets_after_healthy_uptime, HEALTHY_UPTIME_RESET};
+    use std::time::Duration;
+
+    /// sc-4282 / F-MLXW-20: the backoff resets only once a child has been up for
+    /// at least the healthy-uptime threshold.
+    #[test]
+    fn backoff_resets_only_after_the_healthy_uptime_threshold() {
+        assert!(!backoff_resets_after_healthy_uptime(Duration::from_secs(0)));
+        assert!(!backoff_resets_after_healthy_uptime(
+            HEALTHY_UPTIME_RESET - Duration::from_secs(1)
+        ));
+        assert!(backoff_resets_after_healthy_uptime(HEALTHY_UPTIME_RESET));
+        assert!(backoff_resets_after_healthy_uptime(
+            HEALTHY_UPTIME_RESET + Duration::from_secs(60)
+        ));
     }
 }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -543,6 +543,7 @@ async fn supervisor_restarts_exited_children_with_backoff_state() {
             spec,
             process: exited,
             restart_attempt: 0,
+            spawned_at: std::time::Instant::now(),
         },
     )]);
     let mut spawns = 0_u32;
@@ -564,6 +565,56 @@ async fn supervisor_restarts_exited_children_with_backoff_state() {
         .try_wait()
         .expect("child status checks")
         .is_none());
+    let _ = child.process.start_kill();
+    let _ = child.process.wait().await;
+}
+
+/// sc-4282 / F-MLXW-20: a child that ran healthily past the reset threshold
+/// before exiting starts its restart backoff fresh, rather than carrying a
+/// counter that has saturated upward over many widely-spaced crashes.
+#[tokio::test]
+async fn supervisor_resets_backoff_after_a_healthy_run() {
+    let settings = test_settings("http://127.0.0.1".to_owned(), None);
+    let spec = WorkerSpec {
+        worker_id: "worker-gpu-auto-0".to_owned(),
+        gpu_id: "0".to_owned(),
+    };
+    let mut exited = spawn_exit_child();
+    for _ in 0..20 {
+        if exited.try_wait().expect("child status checks").is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // The counter has ratcheted up over time, but this run stayed alive well past
+    // the healthy-uptime threshold (spawned > 6 minutes ago).
+    let mut children = HashMap::from([(
+        spec.worker_id.clone(),
+        SupervisedChild {
+            spec,
+            process: exited,
+            restart_attempt: 7,
+            spawned_at: std::time::Instant::now()
+                .checked_sub(Duration::from_secs(360))
+                .expect("monotonic clock backdates 6 minutes"),
+        },
+    )]);
+
+    restart_exited_children_with_spawner(&settings, &mut children, |_settings, _spec| {
+        Ok(spawn_sleep_child())
+    })
+    .await
+    .expect("child restarts");
+
+    let child = children
+        .get_mut("worker-gpu-auto-0")
+        .expect("restarted child is tracked");
+    // Reset to 0 on the healthy run, then advanced once for this restart.
+    assert_eq!(
+        child.restart_attempt, 1,
+        "a healthy run resets the backoff counter"
+    );
     let _ = child.process.start_kill();
     let _ = child.process.wait().await;
 }


### PR DESCRIPTION
## sc-4282 — [F-MLXW-20] Supervisor restart backoff counter never resets after a healthy run

Fixes code-review finding F-MLXW-20 (P3/Low, bad-pattern).

### Problem
`restart_attempt` was incremented on every child exit and never reset when a restarted child subsequently ran healthily. `retry_delay` caps the delay at 30s, but the counter saturates upward forever — so a worker that crashes once a day eventually always waits the max backoff even after weeks of clean uptime between failures (and a real annoyance if the cap is ever raised).

### Fix (per the suggested approach)
Track each child's spawn time (new `SupervisedChild.spawned_at: Instant`) and reset `restart_attempt` to 0 when an exiting child had been up at least the healthy-uptime threshold (`HEALTHY_UPTIME_RESET` = 5 min). So rare, widely-spaced crashes restart with minimal backoff, while a genuine crash-loop (quick exits) still ratchets up to the cap. The timestamp is set on initial spawn and refreshed on each respawn.

### Tests
- `supervisor::backoff_tests::backoff_resets_only_after_the_healthy_uptime_threshold` — pure threshold logic (0 / just-under / at / over).
- `supervisor_resets_backoff_after_a_healthy_run` — a child with `restart_attempt: 7` and a >6-min-old `spawned_at` resets to `1` on restart.
- The existing `supervisor_restarts_exited_children_with_backoff_state` (fresh spawn) still keeps its counter (no spurious reset).
- `cargo fmt`, `cargo clippy -p sceneworks-worker --all-targets` (clean, `-D warnings`), `cargo test -p sceneworks-worker` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)