### PR TITLE
fix(rust-api): scope LoRA upload-cap test override to thread-local

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -138,9 +138,14 @@ const MAX_MODEL_UPLOAD_BYTES: usize = 256 * 1024 * 1024 * 1024;
 const MAX_LORA_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
 const MAX_MODEL_MULTIPART_BODY_BYTES: usize = MAX_MODEL_UPLOAD_BYTES + 16 * 1024 * 1024;
 const STALE_LORA_UPLOAD_SECONDS: u64 = 24 * 60 * 60;
+// Thread-local (not a process-global atomic) so a test overriding the cap to
+// exercise the size limit can't leak that value into other LoRA-upload tests
+// running concurrently on sibling threads. `#[tokio::test]` uses a current-thread
+// runtime, so the upload handler runs on the same thread that sets the override.
 #[cfg(test)]
-static TEST_MAX_LORA_UPLOAD_BYTES: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+thread_local! {
+    static TEST_MAX_LORA_UPLOAD_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 #[cfg(test)]
 static TEST_MAX_MODEL_UPLOAD_BYTES: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -635,7 +635,7 @@ pub(crate) async fn cleanup_staged_lora_upload(path: &FsPath) {
 pub(crate) fn max_lora_upload_bytes() -> usize {
     #[cfg(test)]
     {
-        let limit = TEST_MAX_LORA_UPLOAD_BYTES.load(std::sync::atomic::Ordering::SeqCst);
+        let limit = TEST_MAX_LORA_UPLOAD_BYTES.with(std::cell::Cell::get);
         if limit > 0 {
             return limit;
         }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -13,7 +13,6 @@ use super::{
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use serde_json::{json, Value};
-use std::sync::atomic::Ordering;
 use std::time::{Duration, SystemTime};
 use tokio_stream::StreamExt;
 use tower::ServiceExt;
@@ -3871,7 +3870,7 @@ async fn model_and_lora_routes_match_manifest_behavior() {
         Some("detail.safetensors")
     );
 
-    TEST_MAX_LORA_UPLOAD_BYTES.store(4, Ordering::SeqCst);
+    TEST_MAX_LORA_UPLOAD_BYTES.with(|cap| cap.set(4));
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
     let (bad_status, bad_error) = request_multipart_lora_upload(
         app,
@@ -3880,7 +3879,7 @@ async fn model_and_lora_routes_match_manifest_behavior() {
         b"12345",
     )
     .await;
-    TEST_MAX_LORA_UPLOAD_BYTES.store(0, Ordering::SeqCst);
+    TEST_MAX_LORA_UPLOAD_BYTES.with(|cap| cap.set(0));
     assert_eq!(bad_status, StatusCode::PAYLOAD_TOO_LARGE);
     assert_eq!(
         bad_error["detail"],


### PR DESCRIPTION
## Problem

`apps/rust-api/src/tests.rs` had a flaky parallel-test race. `max_lora_upload_bytes()` ([loras.rs:635](apps/rust-api/src/loras.rs:635)) read a process-global `TEST_MAX_LORA_UPLOAD_BYTES` `AtomicUsize`. The size-cap rejection test (`rejects_oversized_lora_uploads...`) stored a 4-byte cap, fired one upload expecting a 413, then reset to 0.

Because cargo runs lib tests in **parallel threads of one process**, any other LoRA-upload test (e.g. `paired_moe_lora_upload_writes_convention_files_and_records_base_model`) that POSTed an upload during the transient 4-byte window got a `413 Payload Too Large` instead of `201 Created` — an intermittent CI failure (observed on #558's parity lane; passed on rerun).

## Fix

Convert the override from a process-global atomic to a `thread_local!` `Cell<usize>`. `#[tokio::test]` uses a current-thread runtime, so the upload handler runs on the **same OS thread** that set the override — the value stays visible to the handler but can no longer leak to sibling tests' threads. Least-invasive correct fix: no new deps, no serialization, no slowdown.

The model-upload counterpart (`TEST_MAX_MODEL_UPLOAD_BYTES`) is read but never *set* by any test, so it has no active race and is left untouched.

## Verification

- `cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings` clean; `cargo fmt` clean.
- `cargo test -p sceneworks-rust-api --lib lora` × 8 runs: 16 passed every time.
- `cargo test -p sceneworks-rust-api --lib` (full, max concurrency) × 3: 109 passed every time.

Pre-existing test-infra bug surfaced during sc-4206; not part of that story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)