### PR TITLE
refactor(worker): one ensure_cached_file for download-on-first-use (sc-4283)

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -1,5 +1,48 @@
 use super::*;
 
+/// GET `url` into memory via the shared HTTP client, with a clear error on a
+/// non-success status. The common fetch behind the worker's download-on-first-use
+/// weight fetchers (sc-4283 / F-MLXW-22) — one place to later add streaming /
+/// size-limits / integrity verification (F-MLXW-21) instead of the former four
+/// hand-rolled copies.
+#[cfg(target_os = "macos")]
+pub(crate) async fn fetch_bytes(http_client: &reqwest::Client, url: &str) -> WorkerResult<Vec<u8>> {
+    Ok(http_client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("weight download failed ({url}): {error}"))
+        })?
+        .bytes()
+        .await?
+        .to_vec())
+}
+
+/// Download `url` to `target` on first use: return it if already present, else GET
+/// into a sibling `.download.tmp` then atomically rename into place, so a partial
+/// download is never mistaken for a complete file. Creates `target`'s parent dir.
+/// Replaces the four bespoke GET→tmp→rename copies (sc-4283 / F-MLXW-22).
+#[cfg(target_os = "macos")]
+pub(crate) async fn ensure_cached_file(
+    http_client: &reqwest::Client,
+    url: &str,
+    target: &Path,
+) -> WorkerResult<PathBuf> {
+    if target.exists() {
+        return Ok(target.to_path_buf());
+    }
+    if let Some(parent) = target.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let bytes = fetch_bytes(http_client, url).await?;
+    let tmp = target.with_extension("download.tmp");
+    tokio::fs::write(&tmp, &bytes).await?;
+    tokio::fs::rename(&tmp, target).await?;
+    Ok(target.to_path_buf())
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct SnapshotFile {
     pub(crate) path: String,
@@ -860,4 +903,37 @@ pub fn download_progress_payload(
         None,
         eta_seconds,
     )
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod ensure_cached_file_tests {
+    use super::ensure_cached_file;
+
+    /// sc-4283 / F-MLXW-22: when the target already exists, `ensure_cached_file`
+    /// returns it without any network access (the cache-hit short-circuit shared
+    /// by all the download-on-first-use weight fetchers). A bogus URL proves no
+    /// request is made.
+    #[tokio::test]
+    async fn returns_existing_target_without_downloading() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("weights").join("model.safetensors");
+        tokio::fs::create_dir_all(target.parent().unwrap())
+            .await
+            .expect("parent dir");
+        tokio::fs::write(&target, b"already here")
+            .await
+            .expect("seed target");
+
+        let client = reqwest::Client::new();
+        let resolved =
+            ensure_cached_file(&client, "http://invalid.invalid/should-not-fetch", &target)
+                .await
+                .expect("cache hit returns without downloading");
+        assert_eq!(resolved, target);
+        // Content untouched (no overwrite).
+        assert_eq!(
+            tokio::fs::read(&target).await.expect("read"),
+            b"already here"
+        );
+    }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -4840,27 +4840,7 @@ async fn ensure_instantid_file(
     name: &str,
     url: &str,
 ) -> WorkerResult<PathBuf> {
-    let target = dir.join(name);
-    if target.exists() {
-        return Ok(target);
-    }
-    tokio::fs::create_dir_all(dir).await?;
-    let bytes = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|error| {
-            WorkerError::InvalidPayload(format!(
-                "InstantID weight download failed ({url}): {error}"
-            ))
-        })?
-        .bytes()
-        .await?;
-    let tmp = target.with_extension("download.tmp");
-    tokio::fs::write(&tmp, &bytes).await?;
-    tokio::fs::rename(&tmp, &target).await?;
-    Ok(target)
+    ensure_cached_file(client, url, &dir.join(name)).await
 }
 
 /// Resolve only the SCRFD detector weights (`scrfd_10g.safetensors`) from the same converted

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -34,6 +34,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+use crate::downloads::ensure_cached_file;
 use image::RgbImage;
 use serde_json::{json, Value};
 
@@ -764,20 +765,12 @@ pub(crate) async fn ensure_detector_weights(
     if let Some(path) = resolve_detector_weights(settings) {
         return Ok(path);
     }
-    let cache = settings.data_dir.join("cache").join("person-detect");
-    tokio::fs::create_dir_all(&cache).await?;
-    let target = cache.join(DET_FILE);
-    let bytes = http_client
-        .get(DET_URL)
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?;
-    let tmp = target.with_extension("safetensors.tmp");
-    tokio::fs::write(&tmp, &bytes).await?;
-    tokio::fs::rename(&tmp, &target).await?;
-    Ok(target)
+    let target = settings
+        .data_dir
+        .join("cache")
+        .join("person-detect")
+        .join(DET_FILE);
+    ensure_cached_file(http_client, DET_URL, &target).await
 }
 
 #[cfg(test)]

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -21,6 +21,7 @@
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
+use crate::downloads::ensure_cached_file;
 use mlx_gen::weights::Weights;
 use mlx_gen_sam2::{Sam2ModelSize, Sam2VideoPredictor};
 
@@ -79,20 +80,12 @@ pub(crate) async fn ensure_segmenter_weights(
     if let Some(path) = resolve_segmenter_weights(settings) {
         return Ok(path);
     }
-    let cache = settings.data_dir.join("cache").join("person-segment");
-    tokio::fs::create_dir_all(&cache).await?;
-    let target = cache.join(SEG_FILE);
-    let bytes = http_client
-        .get(SEG_URL)
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?;
-    let tmp = target.with_extension("safetensors.tmp");
-    tokio::fs::write(&tmp, &bytes).await?;
-    tokio::fs::rename(&tmp, &target).await?;
-    Ok(target)
+    let target = settings
+        .data_dir
+        .join("cache")
+        .join("person-segment")
+        .join(SEG_FILE);
+    ensure_cached_file(http_client, SEG_URL, &target).await
 }
 
 /// Scale a normalized `(x, y, width, height)` box to a pixel-space `[x1, y1, x2, y2]`

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -24,6 +24,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+use crate::downloads::fetch_bytes;
 use image::RgbImage;
 use ort::execution_providers::CoreMLExecutionProvider;
 use ort::session::Session;
@@ -577,13 +578,7 @@ async fn ensure_one(
         }
     }
     tokio::fs::create_dir_all(cache).await?;
-    let bytes = http_client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?;
+    let bytes = fetch_bytes(http_client, url).await?;
     // The openmmlab bundle is a .zip containing a single .onnx; extract it.
     let target_clone = target.clone();
     let file_owned = file.to_owned();


### PR DESCRIPTION
## sc-4283 — [F-MLXW-22] Four bespoke download-on-first-use implementations alongside the full-featured downloader

Fixes code-review finding F-MLXW-22 (P3/Low, redundant).

### Problem
Four copies of "GET → bytes → tmp → rename" existed — `person_jobs::ensure_detector_weights`, `person_segment::ensure_segmenter_weights`, `pose_jobs::ensure_one`, `image_jobs::ensure_instantid_file` — each independently re-documenting the same `.tmp`+rename trick. Fixing download robustness (e.g. F-MLXW-21 integrity verification) meant touching four sites, and new weight bundles kept cloning the weakest variant.

### Fix (per the suggested approach)
Two shared helpers in `downloads.rs`:
- `fetch_bytes(client, url)` — the common GET with a clear error (one place to later add streaming / size-limits / integrity), used by all four.
- `ensure_cached_file(client, url, target)` — cache-hit short-circuit + GET into a sibling `.download.tmp` + atomic rename + parent-dir create.

`person_jobs` / `person_segment` / `image_jobs` now call `ensure_cached_file`; `pose_jobs` uses `fetch_bytes` then keeps its unique ZIP→`.onnx` extract (its finalize genuinely differs). The helpers are `#[cfg(target_os = "macos")]` to match their callers (all macOS-gated), so the Linux/Windows worker builds are unaffected. Pure dedup, no behavior change.

### Tests
- New network-free `ensure_cached_file` test: an existing target is returned without any request (the cache-hit short-circuit).
- 222 worker tests pass.
- `cargo fmt`, `cargo clippy -p sceneworks-worker --all-targets` (clean, `-D warnings`), `cargo test -p sceneworks-worker` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)