### PR TITLE
fix(docker): run api/worker/rust-worker as the host user, not root (sc-4285)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,14 @@ SCENEWORKS_CONFIG_DIR=config
 SCENEWORKS_DATA_BIND=./data
 SCENEWORKS_CONFIG_BIND=./config
 
+# UID:GID the api/worker/rust-worker containers run as, so they are NOT root and
+# files they write into the bind-mounted data/config/HF-cache dirs stay owned by
+# you (sc-4285). Defaults to 1000:1000 (the typical first Linux user). If your
+# host UID differs and you hit permission errors on ./data, set these to your own
+# id — `export SCENEWORKS_UID=$(id -u) SCENEWORKS_GID=$(id -g)` (or put them here).
+SCENEWORKS_UID=1000
+SCENEWORKS_GID=1000
+
 # Host path bind-mounted as the Hugging Face cache. Defaults to the user's
 # standard HF cache (%USERPROFILE%\.cache\huggingface on Windows, $HOME/.cache/
 # huggingface on Linux/macOS) so models are shared with other HF tools instead

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 services:
   api:
+    # Run as the invoking host user (not root) so bind-mounted files stay
+    # host-owned and a compromised payload can't act as root over the mounts
+    # (sc-4285 / F-INFRA-10). Defaults to 1000:1000; override via SCENEWORKS_UID /
+    # SCENEWORKS_GID (the rust-api Docker smoke + dev docs set these).
+    user: "${SCENEWORKS_UID:-1000}:${SCENEWORKS_GID:-1000}"
     restart: unless-stopped
     build:
       context: .
@@ -33,6 +38,8 @@ services:
       start_period: 10s
 
   worker:
+    # Run as the invoking host user, not root (sc-4285 / F-INFRA-10).
+    user: "${SCENEWORKS_UID:-1000}:${SCENEWORKS_GID:-1000}"
     build:
       context: .
       dockerfile: docker/worker.Dockerfile
@@ -87,6 +94,8 @@ services:
               capabilities: [gpu]
 
   rust-worker:
+    # Run as the invoking host user, not root (sc-4285 / F-INFRA-10).
+    user: "${SCENEWORKS_UID:-1000}:${SCENEWORKS_GID:-1000}"
     build:
       context: .
       dockerfile: docker/rust.Dockerfile

--- a/scripts/check-docker-api-runtime.mjs
+++ b/scripts/check-docker-api-runtime.mjs
@@ -20,6 +20,15 @@ const env = {
   SCENEWORKS_CONFIG_BIND: path.resolve("config"),
   SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE:
     process.env.SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE || "1",
+  // Run the container as this (host) user so the api isn't root and the files it
+  // seeds into the bind-mounted data dir stay owned by the runner (sc-4285 /
+  // F-INFRA-10), matching the compose `user:` default.
+  ...(typeof process.getuid === "function"
+    ? {
+        SCENEWORKS_UID: String(process.getuid()),
+        SCENEWORKS_GID: String(process.getgid()),
+      }
+    : {}),
 };
 
 function runDocker(args) {


### PR DESCRIPTION
## sc-4285 — [F-INFRA-10] Containers all run as root

Fixes code-review finding F-INFRA-10 (P3/Low, **security**).

### Problem
No service declared a `USER`, so all containers ran as **root** with writable bind mounts into the host repo (`./data`, `./config`, the user's HF cache). That leaks root-owned files into the host checkout (the rust-api Docker smoke already carried a root-container cleanup hack documenting exactly this), and a compromised model/pickle payload in the worker runs as container root over the mounted HF cache.

### Fix (the reviewer's suggested compose-`user:` route)
Add `user: "${SCENEWORKS_UID:-1000}:${SCENEWORKS_GID:-1000}"` to the **api**, **worker**, and **rust-worker** compose services so they run as the invoking host user. Since compose `user:` overrides the image, no Dockerfile change is needed. Files those services write into the bind mounts now stay host-user-owned, and the services no longer run as root.
- The rust-api Docker smoke (`check-docker-api-runtime.mjs`) now exports the runner's uid/gid, so the **parity lane validates the non-root container end-to-end** (build → boot → health → clean teardown).
- `SCENEWORKS_UID`/`SCENEWORKS_GID` documented in `.env.example` (default `1000:1000`; override to your `id -u`/`id -g` if your host UID differs).

### Scope
The **web** Vite dev-server service is handled separately in **sc-4757**: its `node_modules` anonymous volume is image-built (root-owned) and Vite must write its cache there, so it needs a Dockerfile `USER` rework rather than just a compose flag — and it runs no untrusted payloads.

### Validation
- `docker compose config` resolves `user: "<uid>:<gid>"` for api/worker/rust-worker.
- `node scripts/check-scaffold.mjs` + `node scripts/check-compose-config.mjs` pass.
- The parity lane's `check:docker:rust-api` smoke runs the api **non-root** (as the runner uid) and verifies health + clean teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)