### PR TITLE
fix(worker): require weights_only on upscaler .pth load, no unsafe fallback (sc-4230)

### DIFF
--- a/apps/worker/scene_worker/upscalers.py
+++ b/apps/worker/scene_worker/upscalers.py
@@ -191,10 +191,19 @@ def _load_state_dict(torch: Any, weights_path: Path) -> dict[str, Any]:
         safetensors_torch = importlib.import_module("safetensors.torch")
         checkpoint = safetensors_torch.load_file(str(weights_path), device="cpu")
     else:
+        # weights_only=True refuses to execute pickle while loading these .pth
+        # weights, which come from third-party HF repos or a user-supplied
+        # advanced.upscaleModelPath/env path — an unrestricted torch.load there is
+        # arbitrary-code-execution. torch >= 2.8 (our pin) always supports the flag,
+        # so never silently fall back to an unsafe load on an ancient torch: fail
+        # loudly instead (sc-4230 / F-WORKER-6).
         try:
             checkpoint = torch.load(str(weights_path), map_location="cpu", weights_only=True)
-        except TypeError:
-            checkpoint = torch.load(str(weights_path), map_location="cpu")
+        except TypeError as error:
+            raise RuntimeError(
+                "Installed torch is too old to load upscaler weights safely "
+                "(torch.load lacks weights_only); upgrade to torch >= 2.8."
+            ) from error
 
     state = checkpoint
     if isinstance(checkpoint, dict):

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -68,6 +68,7 @@ from scene_worker.upscalers import (
     RealESRGANUpscaler,
     TileSlice,
     UpscaleJob,
+    _load_state_dict,
     create_upscaler_engine,
     tile_slices,
 )
@@ -10413,3 +10414,31 @@ def test_qwen_image_adapter_pose_loop_renders_skeleton_and_passes_multi_image(mo
     for entry in captured:
         assert entry["pose_skeleton"] is not None
         assert POSE_SKELETON_PROMPT in (entry["prompt_override"] or "")
+
+
+def test_load_state_dict_requires_weights_only(tmp_path):
+    """sc-4230 / F-WORKER-6: .pth upscaler weights load with weights_only=True
+    (no pickle execution), and there is NO silent fallback to an unrestricted
+    torch.load — an ancient torch without the flag fails loudly instead."""
+    weights = tmp_path / "model.pth"
+    weights.write_bytes(b"not really a checkpoint")
+
+    class _SafeTorch:
+        def load(self, path, map_location=None, weights_only=False):
+            assert weights_only is True, "must load with weights_only=True"
+            return {"module.body.weight": 1, "other": 2}
+
+    state = _load_state_dict(_SafeTorch(), weights)
+    # `module.` prefix stripped; the safe load result is returned.
+    assert state == {"body.weight": 1, "other": 2}
+
+    class _AncientTorch:
+        """torch.load that predates weights_only — it must NOT be retried unsafely."""
+
+        def load(self, path, map_location=None, **kwargs):
+            if "weights_only" in kwargs:
+                raise TypeError("load() got an unexpected keyword argument 'weights_only'")
+            raise AssertionError("must not fall back to an unrestricted torch.load")
+
+    with pytest.raises(RuntimeError, match="weights_only"):
+        _load_state_dict(_AncientTorch(), weights)


### PR DESCRIPTION
## sc-4230 — [F-WORKER-6] `torch.load` fallback without `weights_only` for downloaded .pth upscaler weights

Fixes code-review finding F-WORKER-6 (P3/Low, **security**).

### Problem
`upscalers._load_state_dict` did `torch.load(..., weights_only=True)` and, on `TypeError`, fell back to an **unrestricted** `torch.load`, which executes arbitrary pickle. The `.pth` weights come from third-party HF repos (`nateraw/real-esrgan`) or a user-supplied `advanced.upscaleModelPath`/env path — so that fallback is an arbitrary-code-execution surface. With the pinned `torch >= 2.8` the flag always exists, so the unsafe branch is dead code — but the `try/except` silently re-enabled pickle execution on any ancient torch and hid that fact.

### Fix (per the suggested approach)
Drop the unsafe fallback: keep `weights_only=True`, and if torch is too old to support it, raise a clear `RuntimeError` ("upgrade to torch >= 2.8") instead of loading unsafely.

### Tests
- New `test_load_state_dict_requires_weights_only`: the safe path returns the (`module.`-stripped) state dict and asserts `weights_only=True` is passed; a torch whose `load` lacks `weights_only` raises `RuntimeError` **without ever retrying unsafely** (the fake torch fails the assertion if a fallback call is made).
- `python -m pytest tests/test_worker_runtime.py` green (418 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)