### PR TITLE
Pin source URL downloads to validated DNS

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::net::SocketAddr;
 
 /// GET `url` into memory via the shared HTTP client, with a clear error on a
 /// non-success status. The common fetch behind the worker's download-on-first-use
@@ -500,14 +501,10 @@ pub(crate) async fn download_source_url(
     let url =
         parse_lora_source_url_with_private(source_url, context.settings.allow_private_lora_urls)
             .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
-    validate_lora_url_dns(context.settings, &url).await?;
     let file_name = lora_source_url_file_name(source_url)
         .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
     tokio::fs::create_dir_all(target_dir).await?;
     let target_path = target_dir.join(file_name);
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()?;
 
     // Attach a stored credential matching the source host. Bearer tokens ride an
     // Authorization header (dropped on cross-host redirects below); query tokens
@@ -526,6 +523,7 @@ pub(crate) async fn download_source_url(
         _ => None,
     };
 
+    let client = source_url_client_for_request(context.settings, &request_url).await?;
     let total_bytes = lora_source_content_length(&client, &request_url, bearer).await?;
     if total_bytes.is_some_and(|total| total > max_bytes) {
         return Err(WorkerError::InvalidPayload(format!(
@@ -539,7 +537,6 @@ pub(crate) async fn download_source_url(
     }
     let range_header = (existing_bytes > 0).then(|| format!("bytes={existing_bytes}-"));
     let mut response = send_source_url_with_redirects(
-        &client,
         context.settings,
         &request_url,
         bearer,
@@ -647,13 +644,13 @@ pub(crate) fn credential_for_host<'a>(
 
 /// GET `initial_url`, manually following up to `MAX_SOURCE_URL_REDIRECTS` hops
 /// (the download client uses `Policy::none()` so we control each hop). Every
-/// redirect target is re-validated for SSRF (scheme + host/DNS) before being
-/// fetched, and the bearer `Authorization` header is dropped on any cross-host
-/// hop so a token never leaks to a CDN. Returns the final non-redirect response
-/// without `error_for_status`, so the caller can still inspect
+/// redirect target is re-validated for SSRF (scheme + host/DNS), then fetched
+/// with a client pinned to the validated socket addresses. The bearer
+/// `Authorization` header is dropped on any cross-host hop so a token never
+/// leaks to a CDN. Returns the final non-redirect response without
+/// `error_for_status`, so the caller can still inspect
 /// `RANGE_NOT_SATISFIABLE`.
 async fn send_source_url_with_redirects(
-    client: &reqwest::Client,
     settings: &Settings,
     initial_url: &str,
     bearer: Option<&str>,
@@ -665,6 +662,7 @@ async fn send_source_url_with_redirects(
         .and_then(|url| url.host_str().map(str::to_ascii_lowercase));
     let mut bearer = bearer.map(str::to_owned);
     for _ in 0..=MAX_SOURCE_URL_REDIRECTS {
+        let client = source_url_client_for_request(settings, &current_url).await?;
         let mut request = client.get(&current_url);
         if let Some(token) = &bearer {
             request = request.bearer_auth(token);
@@ -695,8 +693,6 @@ async fn send_source_url_with_redirects(
                 "sourceUrl redirect must use http or https".to_owned(),
             ));
         }
-        // Re-run SSRF validation against the redirect target before following it.
-        validate_lora_url_dns(settings, &next).await?;
         let next_host = next.host_str().map(str::to_ascii_lowercase);
         if next_host != current_host {
             // Cross-host redirect: never carry the bearer token to a new origin.
@@ -708,6 +704,34 @@ async fn send_source_url_with_redirects(
     Err(WorkerError::InvalidPayload(
         "sourceUrl exceeded the redirect limit".to_owned(),
     ))
+}
+
+async fn source_url_client_for_request(
+    settings: &Settings,
+    request_url: &str,
+) -> WorkerResult<reqwest::Client> {
+    let url = reqwest::Url::parse(request_url)
+        .map_err(|_| WorkerError::InvalidPayload("sourceUrl was invalid".to_owned()))?;
+    source_url_client_for_url(settings, &url).await
+}
+
+async fn source_url_client_for_url(
+    settings: &Settings,
+    url: &reqwest::Url,
+) -> WorkerResult<reqwest::Client> {
+    let validated_addrs = validate_lora_url_dns(settings, url).await?;
+    build_source_url_client(url, validated_addrs.as_deref())
+}
+
+pub(crate) fn build_source_url_client(
+    url: &reqwest::Url,
+    validated_addrs: Option<&[SocketAddr]>,
+) -> WorkerResult<reqwest::Client> {
+    let mut builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::none());
+    if let (Some(host), Some(addrs)) = (url.host_str(), validated_addrs) {
+        builder = builder.resolve_to_addrs(host, addrs);
+    }
+    Ok(builder.build()?)
 }
 
 pub(crate) async fn lora_source_content_length(
@@ -750,33 +774,33 @@ pub(crate) fn content_range_total(value: &str) -> Option<u64> {
 pub(crate) async fn validate_lora_url_dns(
     settings: &Settings,
     url: &reqwest::Url,
-) -> WorkerResult<()> {
+) -> WorkerResult<Option<Vec<SocketAddr>>> {
     if settings.allow_private_lora_urls {
-        return Ok(());
+        return Ok(None);
     }
     let Some(host) = url.host_str() else {
         return Err(WorkerError::InvalidPayload(
             "LoRA sourceUrl host is not allowed".to_owned(),
         ));
     };
+    let port = url.port_or_known_default().unwrap_or(443);
     if let Ok(address) = host.parse::<IpAddr>() {
         validate_public_ip(address)
             .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
-        return Ok(());
+        return Ok(Some(vec![SocketAddr::new(address, port)]));
     }
-    let port = url.port_or_known_default().unwrap_or(443);
-    let mut resolved_any = false;
+    let mut addrs = Vec::new();
     for address in tokio::net::lookup_host((host, port)).await? {
-        resolved_any = true;
         validate_public_ip(address.ip())
             .map_err(|error| WorkerError::InvalidPayload(error.message().to_owned()))?;
+        addrs.push(address);
     }
-    if resolved_any {
-        Ok(())
-    } else {
+    if addrs.is_empty() {
         Err(WorkerError::InvalidPayload(
             "LoRA sourceUrl host did not resolve".to_owned(),
         ))
+    } else {
+        Ok(Some(addrs))
     }
 }
 

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::Stdio as StdStdio;
 use std::time::Duration;
@@ -15,9 +16,9 @@ use tempfile::tempdir;
 
 use super::api_client::ApiClient;
 use super::downloads::{
-    credential_for_host, download_lora_source_url, download_progress_payload,
-    download_snapshot_into_cache, DownloadContext, DownloadProgress, HuggingFaceSnapshot,
-    SnapshotFile,
+    build_source_url_client, credential_for_host, download_lora_source_url,
+    download_progress_payload, download_snapshot_into_cache, DownloadContext, DownloadProgress,
+    HuggingFaceSnapshot, SnapshotFile,
 };
 #[cfg(target_os = "macos")]
 use super::gpu::mlx_gpu;
@@ -1385,6 +1386,49 @@ async fn source_url_follows_redirect_and_strips_auth_across_hosts() {
             .unwrap(),
         b"civitai-lora"
     );
+}
+
+#[tokio::test]
+async fn source_url_client_pins_dns_to_validated_address() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    let state = BinaryStubState {
+        bytes: b"weights!!".to_vec(),
+        status: AxumStatusCode::OK,
+        cancel_requested: false,
+    };
+    let app = Router::new()
+        .route("/file/style.safetensors", get(binary_stub))
+        .with_state(state);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+
+    let url = reqwest::Url::parse(&format!(
+        "http://rebind.test:{}/file/style.safetensors",
+        address.port()
+    ))
+    .expect("test URL parses");
+    let validated = [SocketAddr::new(
+        "127.0.0.1".parse().unwrap(),
+        address.port(),
+    )];
+    let client = build_source_url_client(&url, Some(&validated)).expect("client builds");
+
+    let bytes = client
+        .get(url)
+        .send()
+        .await
+        .expect("request uses pinned address")
+        .error_for_status()
+        .expect("stub response is successful")
+        .bytes()
+        .await
+        .expect("response body reads");
+
+    assert_eq!(bytes.as_ref(), b"weights!!");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- build source-url download clients pinned to the DNS addresses validated by the SSRF guard
- apply the pinned client to the preflight HEAD request and to every manually followed redirect hop
- add regression coverage proving a host name is resolved through the validated socket address

## Validation
- 
- 
running 4 tests
test tests::source_url_client_pins_dns_to_validated_address ... ok
test tests::source_url_rejects_redirect_to_non_http_scheme ... ok
test tests::source_url_rejects_excessive_redirects ... ok
test tests::source_url_follows_redirect_and_strips_auth_across_hosts ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 265 filtered out; finished in 0.02s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
- 
running 269 tests
test gpu::mlx_utilization_tests::live_mlx_utilization_probe_reports_system_memory ... ignored
test gpu::mlx_utilization_tests::free_is_clamped_when_used_exceeds_total ... ok
test gpu::mlx_utilization_tests::builds_snapshot_with_total_used_and_load ... ok
test gpu::mlx_utilization_tests::returns_none_when_nothing_is_available ... ok
test gpu::mlx_utilization_tests::load_only_snapshot_leaves_memory_unset ... ok
test gpu::mlx_utilization_tests::vm_stat_used_is_none_without_required_counters ... ok
test image_jobs::tests::chroma_base_real_weights_generates_one_image ... ignored, needs real Chroma1-Base weights + Metal device
test image_jobs::tests::chroma_flash_real_weights_generates_one_image ... ignored, needs real Chroma1-Flash weights + Metal device
test image_jobs::tests::chroma_hd_real_weights_generates_one_image ... ignored, needs real Chroma1-HD weights + Metal device
test advanced::tests::flag_is_permissive_bool_is_strict ... ok
test image_jobs::tests::contain_box_centers_the_contained_rect ... ok
test image_jobs::tests::character_angle_set_is_eleven_ordered_angles ... ok
test gpu::mlx_utilization_tests::vm_stat_page_size_parsed_from_header ... ok
test advanced::tests::int_and_string_accessors_parse_and_default ... ok
test image_jobs::tests::flux2_edit_real_weights_generates_one_image ... ignored, needs real FLUX.2-klein-9b weights + Metal device
test image_jobs::tests::distinct_seeds_produce_distinct_pixels ... ok
test image_jobs::tests::detail_feather_ramps_over_overlap ... ok
test image_jobs::tests::engine_dim_rounds_up_to_mult8_and_clamps ... ok
test image_jobs::tests::flux2_klein_9b_kv_real_weights_generates_one_image ... ignored, needs real FLUX.2-klein-9b-kv weights + Metal device
test image_jobs::tests::flux2_klein_9b_real_weights_generates_one_image ... ignored, needs real FLUX.2-klein-9b weights + Metal device
test image_jobs::tests::flux2_klein_9b_true_v2_real_weights_generates_one_image ... ignored, needs a converted true_v2 dir + Metal device
test image_jobs::tests::flux2_pose_tier_real_weights_generates_one_image ... ignored, needs real FLUX.2-klein-9b weights + Metal device
test image_jobs::tests::flux_dev_real_weights_generates_one_image ... ignored, needs real FLUX.1-dev weights + Metal device
test advanced::tests::f32_clamped_vs_raw_make_the_clamp_explicit ... ok
test image_jobs::tests::flux_ip_reference_worker_e2e ... ignored, real-Mac E2E: loads FLUX.1-dev + XLabs IP-Adapter + CLIP-ViT-L from the HF cache
test image_jobs::tests::flux_schnell_real_weights_generates_one_image ... ignored, needs real FLUX.1-schnell weights + Metal device
test image_jobs::tests::instantid_angle_kps_real_weights_fills_frame_and_holds_identity ... ignored, needs real InstantID weights + Metal device
test image_jobs::tests::augment_prompt_for_angle_appends_clause_and_strips_punctuation ... ok
test image_jobs::tests::backend_label_defaults_empty_to_cpu ... ok
test image_jobs::tests::augment_prompt_for_pose_appends_cue ... ok
test image_jobs::tests::flux2_edit_engine_id_maps_variants ... ok
test image_jobs::tests::qwen_control_real_weights_generates_one_pose ... ignored, needs real Qwen-Image + InstantX ControlNet weights + Metal device
test image_jobs::tests::build_edit_conditioning_single_vs_multi ... ok
test image_jobs::tests::qwen_edit_engine_id_maps_variants ... ok
test image_jobs::tests::qwen_edit_lightning_real_weights_generates_one_image ... ignored, needs real Qwen-Image-Edit-2511 + lightx2v distill LoRA weights + Metal device
test gpu::mlx_utilization_tests::ioreg_parser_extracts_load_and_skips_string_values ... ok
test image_jobs::tests::qwen_edit_real_weights_generates_one_image ... ignored, needs real Qwen-Image-Edit-2511 weights + Metal device
test image_jobs::tests::qwen_edit_lightning_model_row_is_cfg_off_4step_distill ... ok
test image_jobs::tests::qwen_edit_model_table_rows ... ok
test image_jobs::tests::mlx_model_table_maps_known_families ... ok
test caption_jobs::tests::caption_job_options_preserve_training_surface ... ok
test caption_jobs::tests::caption_items_require_ids_and_paths ... ok
test gpu::mlx_utilization_tests::vm_stat_used_is_app_plus_wired_plus_compressed ... ok
test gpu::mlx_utilization_tests::vm_stat_counts_parsed_and_header_skipped ... ok
test image_jobs::tests::qwen_real_weights_generates_one_image ... ignored, needs real Qwen-Image weights + Metal device
test image_jobs::tests::realvisxl_real_weights_generates_one_image ... ignored, needs real RealVisXL weights + Metal device
test image_jobs::tests::adapter_id_reports_per_family_mlx_label ... ok
test image_jobs::tests::pose_entries_filters_to_objects ... ok
test image_jobs::tests::quant_mapping_defaults_to_q8_and_maps_bits ... ok
test image_jobs::tests::flux2_grouping_poses_over_angles_over_plain ... ok
test image_jobs::tests::qwen_edit_reference_ids_prefers_reference_then_source ... ok
test image_jobs::tests::flux2_edit_reference_ids_prefers_reference_then_source ... ok
test image_jobs::tests::resolve_control_scale_defaults_and_clamps ... ok
test image_jobs::tests::sc3031_ab_dump_pose ... ignored, sc-3031 A/B dump harness (pose): drive via SC3031_PAYLOAD + SC3031_OUT
test image_jobs::tests::sc3031_ab_dump_txt2img ... ignored, sc-3031 A/B dump harness: drive via SC3031_PAYLOAD + SC3031_OUT
test image_jobs::tests::sc3031_dump_skeleton ... ignored, sc-3031 skeleton-render dump: drive via SC3031_PAYLOAD + SC3031_OUT
test image_jobs::tests::sdxl_real_weights_generates_one_image ... ignored, needs real SDXL weights + Metal device
test image_jobs::tests::resolve_guidance_none_for_distilled_set_for_dev ... ok
test image_jobs::tests::resolve_qwen_edit_guidance_reads_true_cfg_scale_not_guidance_scale ... ok
test image_jobs::tests::qwen_control_raw_settings_records_control_recipe ... ok
test image_jobs::tests::resolve_negative_prompt_only_for_true_cfg_families ... ok
test image_jobs::tests::parse_poses_extracts_keypoints_hands_face ... ok
test image_jobs::tests::sdxl_sub_mode_classifies_advanced_shapes ... ok
test image_jobs::tests::sensenova_it2i_real_weights_generates_one_image ... ignored, needs real SenseNova-U1-8B-MoT weights (~35GB) + Metal device
test image_jobs::tests::zimage_control_real_weights_generates_one_pose ... ignored, needs real Z-Image + Fun-Controlnet-Union weights + Metal device
test image_jobs::tests::sensenova_dual_cfg_and_shift_resolve_per_mode ... ok
test image_jobs::tests::zimage_real_weights_generates_one_image ... ignored, needs real Z-Image weights + Metal device
test image_jobs::tests::steps_default_is_family_default_and_clamps ... ok
test image_jobs::tests::resolve_seed_matches_python_precedence ... ok
test kps_jobs::tests::kps_extract_real_weights_extracts_frontal_landmarks ... ignored, needs real SCRFD weights + Metal device
test image_jobs::tests::should_fit_edit_source_only_for_off_aspect_edit_image ... ok
test kps_jobs::tests::normalize_landscape_centers_vertically ... ok
test kps_jobs::tests::normalize_portrait_centers_horizontally ... ok
test kps_jobs::tests::normalize_square_image_is_plain_fraction ... ok
test image_jobs::tests::zimage_identity_strength_gate_and_clamp ... ok
test media_jobs::person_track_e2e_tests::person_track_e2e_detect_track_segment_writes_masks_and_active_state ... ignored, real Mac E2E: set SCENEWORKS_PERSON_E2E_VIDEO to a person clip; downloads YOLO11 + SAM2 weights; Apple Silicon only
test media_jobs::frame_seek_tests::frame_seek_never_goes_negative_on_tiny_clips ... ok
test model_jobs::tests::flux2_true_v2_rust_convert_real_weights ... ignored
test model_jobs::tests::ltx_eros_rust_convert_real_weights ... ignored
test model_jobs::tests::wan_ti2v_5b_rust_convert_real_weights ... ignored
test openpose_skeleton::tests::body_stickwidth_scales_and_floors ... ok
test openpose_skeleton::tests::normalize_keypoints_is_always_18 ... ok
test openpose_skeleton::tests::hsv_to_rgb_spans_the_wheel ... ok
test openpose_skeleton::tests::normalize_points_pads_truncates_and_drops_low_confidence ... ok
test openpose_skeleton::tests::square_fit_letterboxes_non_square ... ok
test person_jobs::tests::decode_keeps_person_anchors_above_conf_and_builds_xyxy ... ok
test person_jobs::tests::decode_clamps_boxes_to_the_frame ... ok
test person_jobs::tests::letterbox_centers_pad_on_the_short_axis ... ok
test openpose_skeleton::tests::normalize_hands_accepts_pair_and_flat ... ok
test person_jobs::tests::yolo11_downloads_and_detects_from_huggingface ... ignored, network: downloads the fused weights from HuggingFace
test person_jobs::tests::un_letterbox_inverts_the_forward_mapping ... ok
test image_jobs::tests::streaming_result_carries_facts_for_api_persistence ... ok
test person_jobs::tests::yolo11_matches_ultralytics_reference_on_photo ... ignored, requires staged yolo11m_fused_mlx.safetensors + people.jpg fixtures in the app cache
test person_jobs::tests::yolo11_mlx_forward_matches_reference_oracle ... ignored, requires staged yolo11m_fused_mlx.safetensors + refs.safetensors in the app cache
test person_jobs::tests::yolo11_mlx_per_block_isolation ... ignored, requires staged yolo11m_fused_mlx.safetensors + refs_ext.safetensors in the app cache
test openpose_skeleton::tests::draw_wholebody_empty_pose_is_all_black ... ok
test media_jobs::frame_seek_tests::frame_seek_clamps_only_the_final_inclusive_end_sample ... ok
test image_jobs::tests::sensenova_edit_available_needs_a_reference ... ok
test person_replace::tests::box_mask_missing_or_empty_is_black ... ok
test person_replace::tests::box_mask_clips_to_image_bounds ... ok
test person_jobs::tests::detections_to_json_normalizes_orders_and_drops_degenerate ... ok
test person_jobs::tests::nms_drops_high_overlap_keeps_disjoint ... ok
test person_replace::tests::person_track_masks_errors_without_frames_or_selection ... ok
test person_replace::tests::python_round_is_half_to_even ... ok
test kps_jobs::tests::detected_result_carries_normalized_kps_and_order ... ok
test kps_jobs::tests::no_face_result_is_explicit ... ok
test person_replace::tests::resample_indices_matches_python_formula ... ok
test openpose_skeleton::tests::draw_bodypose_fills_thin_limbs ... ok
test person_segment::tests::box_norm_scales_and_clamps_to_the_frame ... ok
test person_replace::tests::corrections_override_box_and_clear_mask ... ok
test person_replace::tests::rejected_frame_borrows_nearest_accepted_box ... ok
test person_segment::tests::mask_box_coverage_measures_foreground_inside_box ... ok
test person_segment::tests::mask_state_rollup_matches_python_segment_track ... ok
test image_jobs::tests::mlx_engine_registry_links_image_families ... ok
test person_track::tests::choose_target_matches_overlapping_id ... ok
test person_track::tests::iou_matches_known_values ... ok
test person_track::tests::assemble_marks_detected_and_lost_frames ... ok
test person_track::tests::sample_cadence_clamps_and_spans_ends ... ok
test person_replace::tests::box_mask_pads_three_percent_and_fills_inclusive ... ok
test person_track::tests::tracker_drops_track_after_max_age ... ok
test person_track::tests::frames_serialize_to_sidecar_shape ... ok
test person_track::tests::tracker_separates_two_people ... ok
test person_track::tests::xyxy_normalizes_and_orders_corners ... ok
test person_track::tests::tracker_keeps_one_id_for_a_moving_person ... ok
test person_replace::tests::load_track_masks_degrades_to_box_when_no_stored_mask ... ok
test pose_jobs::tests::bbox_and_mean_conf_respect_threshold ... ok
test pose_jobs::tests::pose_decode_argmax_and_rescale ... ok
test pose_jobs::tests::facing_classifies_head_keypoints ... ok
test pose_jobs::tests::pose_decode_negative_value_marks_missing ... ok
test pose_jobs::tests::squareify_pads_short_axis_centered ... ok
test pose_jobs::tests::thresholded_drops_low_conf_points ... ok
test person_replace::tests::person_track_masks_falls_back_to_selected_detection ... ok
test pose_jobs::tests::wholebody_to_openpose_maps_indices_and_computes_neck ... ok
test pose_jobs::tests::yolox_decode_embedded_nms_branch ... ok
test sensenova_jobs::tests::sensenova_interleave_real_weights_produces_document ... ignored, needs real SenseNova-U1-8B-MoT weights (~35GB) + Metal device
test sensenova_jobs::tests::sensenova_vqa_real_weights_answers_non_empty ... ignored, needs real SenseNova-U1-8B-MoT weights (~35GB) + Metal device
test sensenova_jobs::tests::payload_int_parses_clamps_and_defaults ... ok
test sensenova_jobs::tests::strip_reasoning_removes_think_blocks ... ok
test sensenova_jobs::tests::interleave_resolution_snaps_to_aspect_bucket ... ok
test supervisor::backoff_tests::backoff_resets_only_after_the_healthy_uptime_threshold ... ok
test sensenova_jobs::tests::build_segments_interleaves_text_and_images ... ok
test sensenova_jobs::tests::build_segments_trailing_image_without_marker_is_appended ... ok
test person_segment::tests::poisoned_model_cache_lock_recovers_and_resets ... ok
test tests::credential_for_host_matches_case_insensitively ... ok
test tests::download_snapshot_into_cache_matches_real_huggingface_layout ... ignored, network: downloads a tiny public repo from huggingface.co
test tests::download_progress_payload_matches_python_shape ... ok
test tests::downloaded_model_windows_untrusted_mount_detection_is_inconclusive ... ok
test tests::auto_worker_ids_and_child_environment_match_python_supervisor ... ok
test tests::download_family_check_proceeds_when_no_weights_to_detect ... ok
test tests::ffmpeg_helper_shapes_match_python_timeline_exporter ... ok
test openpose_skeleton::tests::draw_wholebody_paints_a_skeleton_on_black ... ok
test tests::hf_cli_download_inputs_reject_option_injection ... ok
test tests::hf_cli_download_inputs_accept_catalog_values ... ok
test tests::hf_cli_download_inputs_reject_traversal_and_absolute_patterns ... ok
test tests::hf_cli_environment_forces_python_utf8_output ... ok
test person_replace::tests::load_track_masks_uses_stored_segmentation_when_present ... ok
test tests::hf_cli_windows_encoding_failures_are_detected ... ok
test tests::image_edit_job_dispatches_to_image_generate_handler ... ok
test tests::huggingface_cache_paths_follow_hub_layout ... ok
test tests::cancel_poll_tolerates_transient_get_errors ... ok
test downloads::ensure_cached_file_tests::returns_existing_target_without_downloading ... ok
test tests::cancel_poll_continues_when_no_cancel_requested ... ok
test tests::cancel_poll_retries_when_cancel_ack_post_fails ... ok
test tests::cancel_poll_cancels_on_confirmed_user_cancel ... ok
test tests::missing_crossfade_duration_defaults_to_python_mux_duration ... ok
test tests::mlx_gpu_advertises_generation_capabilities_only ... ok
test tests::now_matches_python_second_precision ... ok
test tests::huggingface_snapshot_resolve_accepts_tree_and_sibling_shapes_with_auth ... ok
test tests::nvidia_smi_parsing_and_visible_device_filtering_match_python_worker ... ok
test tests::parse_credentials_env_normalizes_and_skips_blanks ... ok
test tests::model_destinations_are_constrained_to_data_models ... ok
test tests::parse_credentials_env_tolerates_invalid_json ... ok
test tests::pattern_filtering_and_download_dir_match_python_behavior ... ok
test tests::person_detection_jitter_uses_python_sha256_bytes ... ok
test tests::plan_segments_carries_item_transitions ... ok
test tests::path_and_error_helpers_are_bounded_and_defensive ... ok
test tests::plan_segments_inserts_gaps_and_totals_duration ... ok
test tests::plan_segments_rejects_nonpositive_item_span ... ok
test tests::rust_cpu_capabilities_do_not_claim_gpu_generation_jobs ... ok
test tests::repo_slug_functions_match_cross_language_contract ... ok
test tests::finalize_converted_dir_promotes_atomically_and_replaces_stale ... ok
test tests::source_url_client_pins_dns_to_validated_address ... ok
test tests::lora_url_import_skips_existing_matching_file ... ok
test tests::lora_url_import_rejects_failed_and_oversized_downloads ... ok
test tests::stub_fallback_gate::image_engine_model_without_weights_is_a_precise_error_not_a_stub ... ok
test tests::download_family_check_proceeds_when_detection_matches_catalog ... ok
test tests::download_family_check_flags_confident_mismatch ... ok
test tests::stub_fallback_gate::image_non_engine_model_keeps_the_stub_path ... ok
test tests::stub_fallback_gate::image_explicit_model_path_resolves_and_passes_the_gate ... ok
test tests::stub_fallback_gate::video_non_engine_model_keeps_the_stub_path ... ok
test tests::stub_fallback_gate::video_engine_model_without_weights_is_a_precise_error_not_a_stub ... ok
test tests::stub_fallback_gate::video_svd_without_source_asset_is_an_invalid_payload_error ... ok
test image_jobs::tests::fit_rgb_crop_pad_stretch_produce_exact_dims_and_geometry ... ok
test tests::download_snapshot_rejects_truncated_file ... ok
test tests::source_url_rejects_redirect_to_non_http_scheme ... ok
test tests::utility_worker_specs_scale_to_requested_count ... ok
test tests::worker_credentials_env_overrides_file_per_host ... ok
test tests::lora_url_import_downloads_to_named_file ... ok
test tests::lora_url_import_honors_midstream_cancel ... ok
test training_jobs::tests::map_training_config_defaults_when_advanced_is_empty ... ok
test training_jobs::tests::dry_run_summary_carries_plan_facts ... ok
test tests::paired_moe_upload_writes_high_low_convention_files ... ok
test training_jobs::tests::validate_rejects_empty_dataset ... ok
test training_jobs::tests::map_training_config_reads_advanced_and_passes_optimizer_verbatim ... ok
test training_jobs::tests::validate_rejects_missing_image ... ok
test training_jobs::tests::engine_trainer_id_maps_mlx_native_families_and_rejects_the_rest ... ok
test tests::lora_file_and_directory_import_preserve_copy_semantics ... ok
test upscale_jobs::tests::crop_to_chw_subregion ... ok
test training_jobs::tests::validate_accepts_present_images ... ok
test upscale_jobs::tests::crop_to_chw_layout_and_normalization ... ok
test upscale_jobs::tests::onnx_filename_per_factor ... ok
test upscale_jobs::tests::manifest_onnx_resource_extracts_repo_file ... ok
test training_jobs::tests::validate_rejects_unknown_plan_version ... ok
test upscale_jobs::tests::tile_slices_single_when_image_fits ... ok
test upscale_jobs::tests::tile_slices_grid_row_major_clamped ... ok
test upscale_jobs::tests::tile_slices_zero_tile_is_single ... ok
test video_jobs::tests::advanced_numeric_helpers_parse_flf_keyframe_knobs ... ok
test video_jobs::tests::extend_anchor_frames_defaults_and_clamps ... ok
test video_jobs::tests::extend_vace_conditioning_pins_tail_and_generates_rest ... ok
test video_jobs::tests::bridge_vace_conditioning_keeps_both_ends_generates_gap ... ok
test video_jobs::tests::asset_fact_and_streaming_result_shape ... ok
test video_jobs::tests::asset_fact_embeds_replacement_status_when_present ... ok
test video_jobs::tests::family_prefers_manifest_then_infers_from_model ... ok
test video_jobs::tests::ltx_real_weights_with_audio ... ignored, loads the real LTX-2.3 weights + Gemma TE; needs a snapshot complete for the current engine
test video_jobs::tests::ltx_advanced_flags_map_to_video_gen_input ... ok
test video_jobs::tests::ic_lora_detection_matches_torch_markers ... ok
test video_jobs::tests::replacement_mode_maps_the_three_granularities ... ok
test video_jobs::tests::ltx_engine_id_maps_base_and_eros ... ok
test video_jobs::tests::keyframe_conditioning_requires_both_frame_assets ... ok
test video_jobs::tests::plan_builds_nested_media_path ... ok
test video_jobs::tests::replacement_status_reads_track_and_counts ... ok
test video_jobs::tests::resolve_seed_prefers_explicit_then_hashes_prompt ... ok
test video_jobs::tests::svd_engine_id_maps_only_svd ... ok
test video_jobs::tests::svd_knobs_resolve_advanced_over_manifest_over_default ... ok
test video_jobs::tests::svd_real_weights_image_to_video ... ignored, loads the real SVD-XT weights; run manually on a Mac with the checkpoint cached
test tests::uploaded_lora_source_cleanup_removes_staged_file_and_parent ... ok
test video_jobs::tests::vace_conditioning_builds_control_clip_plus_references ... ok
test video_jobs::tests::video_clip_conditioning_bridge_maps_left_zero_right_tail ... ok
test video_jobs::tests::video_clip_conditioning_bridge_requires_right_clip ... ok
test video_jobs::tests::video_clip_conditioning_extend_maps_single_clip_at_zero ... ok
test video_jobs::tests::wan_5b_real_weights ... ignored, loads the real Wan2.2 TI2V-5B weights; run manually on a Mac with them present
test video_jobs::tests::wan_boundary_conditioning_bridge_pins_both_boundaries ... ok
test video_jobs::tests::wan_boundary_conditioning_bridge_requires_right_frame ... ok
test video_jobs::tests::video_clip_conditioning_requires_ic_lora ... ok
test tests::writes_model_install_marker_with_expected_keys ... ok
test tests::source_url_rejects_excessive_redirects ... ok
test video_jobs::tests::wan_boundary_conditioning_extend_pins_last_frame_at_zero ... ok
test video_jobs::tests::wan_engine_id_maps_the_three_models ... ok
test video_jobs::tests::wan_flf_rejected_on_non_ti2v_engine ... ok
test video_jobs::tests::wan_quant_maps_mlx_quantize ... ok
test video_jobs::tests::wan_sampling_only_overrides_t2v_14b ... ok
test video_jobs::tests::wan_vace_extend_bridge_real_weights ... ignored, loads the real Wan-VACE snapshot; run manually on a Mac with it assembled
test video_jobs::tests::wan_vace_real_weights ... ignored, loads the real Wan-VACE snapshot; run manually on a Mac with it assembled
test tests::uploaded_lora_file_import_prefers_move_over_copy ... ok
test video_jobs::tests::silent_audio_does_not_divide_by_zero ... ok
test video_jobs::tests::wav_header_is_canonical_and_peak_normalized ... ok
test tests::download_snapshot_resumes_existing_partial_blob ... ok
test tests::download_snapshot_writes_hugging_face_cache_layout ... ok
test tests::download_snapshot_fresh_retry_discards_partial_blob ... ok
test video_jobs::tests::wan_vace_adapters_are_single_dense ... ok
test video_jobs::tests::wan_moe_sibling_pairs_high_and_low ... ok
test video_jobs::tests::encode_stub_to_mp4_with_audio_and_poster ... ok
test tests::ffmpeg_runner_surfaces_bounded_stderr_from_failing_process ... ok
test tests::source_url_follows_redirect_and_strips_auth_across_hosts ... ok
test image_jobs::tests::render_and_save_writes_png_and_contract_fact ... ok
test video_jobs::tests::stub_frames_differ_across_time ... ok
{"event":"worker_exited","exitCode":0,"gpuId":"0","reportedAt":"2026-06-11T13:54:33Z","restartInSeconds":1,"workerId":"worker-gpu-auto-0"}
{"event":"worker_exited","exitCode":0,"gpuId":"0","reportedAt":"2026-06-11T13:54:33Z","restartInSeconds":1,"workerId":"worker-gpu-auto-0"}
test video_jobs::tests::stub_video_frames_have_correct_size_and_audio_split ... ok
test tests::supervisor_restarts_exited_children_with_backoff_state ... ok
test tests::supervisor_resets_backoff_after_a_healthy_run ... ok

test result: ok. 227 passed; 0 failed; 42 ignored; 0 measured; 0 filtered out; finished in 1.06s


running 1 test
test nax_16bit_sdpa_is_correct ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.37s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 

Shortcut: sc-4213