### PR TITLE
sc-4387: DWPose backend spike — native-MLX vs ort+CoreML findings

### DIFF
--- a/docs/sc-4387/spike-findings.md
+++ b/docs/sc-4387/spike-findings.md
@@ -1,0 +1,136 @@
+# sc-4387 — DWPose backend: native-MLX port vs keep `ort`+CoreML (R2)
+
+**Recommendation: do NOT port DWPose to MLX in isolation.** On the evidence, DWPose
+is the *success* case for the CoreML EP — not a failure case like YOLO11 (hung) or
+SAM2 (fragmented). Keep `ort`+CoreML for DWPose now; treat an MLX port as a deliberate
+*consistency* play to be decided **jointly with the Real-ESRGAN upscaler (sc-3489)**,
+since porting DWPose alone removes zero dependencies and buys no functional win.
+
+Confidence: MODERATE (~65%). The functional/data case for keeping is strong; the case
+*for* porting is purely strategic (single-backend coherence + retiring the CoreML-EP /
+bundled-dylib maintenance tax) and only pays off if the upscaler moves too. The
+port-vs-keep call is Michael's — this spike supplies the evidence, not the verdict.
+
+Date: 2026-06-11 · Hardware: Apple M-series (arm64), macOS 25.5 · onnxruntime 1.26.0 ·
+models: production pins `yolox_m_8xb8-300e_humanart` + `rtmw-dw-x-l_simcc-cocktail14`.
+
+---
+
+## 1. "Does CoreML even belong here?" — YES (measured)
+
+CoreML-EP node partitioning on the two production exports (verbose `GetCapability` +
+`VerifyEachNodeIsAssignedToAnEp`, onnxruntime 1.26):
+
+| export       | CoreML partitions | CPU-only nodes | why the CPU nodes |
+|--------------|-------------------|----------------|-------------------|
+| rtmw-dw-x-l  | **2**             | 48             | GAU head: `MatMul`/`ReduceSum`/`Sqrt`/`Div` (ScaleNorm) + SimCC projections + `DepthToSpace` |
+| yolox_m      | 8                 | 36             | embedded-NMS tail (`NonMaxSuppression`/`TopK`/`Where`) + rank>5 reshape tensors from the FPN `Resize` |
+
+This is the **opposite** of the SAM2 Hiera result (50–437 partitions, sc-3635). The
+heavy rtmw conv backbone runs as **2 clean CoreML islands**; only the light GAU+SimCC
+head (48 small nodes) falls back to CPU. yolox fragments more (8), but its conv
+backbone is still on CoreML and the fragmentation is the NMS tail we wouldn't port
+anyway. **CoreML is genuinely well-suited to these CNNs.**
+
+## 2. Latency (this machine, steady-state, n=20)
+
+| net          | onnxruntime CPU | CoreML | CoreML speedup |
+|--------------|-----------------|--------|----------------|
+| rtmw-dw-x-l  | 37.5 ms         | **15.6 ms** | 2.4× |
+| yolox_m      | 70.8 ms         | ~17–25 ms (sc-3487)¹ | ~3–4× |
+
+End-to-end per image (det+pose) ≈ **35–55 ms on CoreML**, confirming sc-3487. CoreML
+warmup here was ~32 ms (compiled model already cached this session; first-ever compile
+is still the ~4.4 s sc-3487 reported).
+
+¹ The random-noise latency harness can't time yolox CoreML: with no real person in the
+frame the embedded NMS emits 0 boxes → a zero-element dynamic tensor the CoreML EP
+rejects (`coreml_execution_provider.cc:198`). Benign artifact of synthetic input; also
+a live demonstration that the NMS tail is CoreML-hostile. yolox CoreML latency is taken
+from sc-3487 (real images).
+
+## 3. Native-MLX feasibility — HIGH (~90%)
+
+Op inventory from the real ONNX graphs:
+
+- **yolox_m** (25.3M params, 415 nodes): `Conv 107, Mul 102, Sigmoid 100` (CSPDarknet +
+  SiLU), `MaxPool 3` (SPPF), `Resize 2` (FPN), `Concat 20`. This is **op-for-op the
+  YOLO11 set already implemented** in `person_jobs.rs`. The embedded-NMS tail wouldn't
+  be ported — like YOLO11, convert the raw weights and do greedy NMS in pure Rust
+  (already written). Essentially a solved problem.
+- **rtmw-dw-x-l** (57.3M params, 464 nodes): CSPNeXt SiLU backbone (`Conv 122,
+  Sigmoid 116, MaxPool 3, Resize 2`) + `GlobalAveragePool 4`/`HardSigmoid 4`/`Relu 4`
+  (4 SE channel-attention blocks) + `ReduceSum 3`/`Sqrt 3`/`Div 4` (GAU ScaleNorm) +
+  `DepthToSpace 1` (head pixel-shuffle) + **`MatMul 8`** (GAU attention + 2 SimCC
+  projections). SimCC argmax decode is **already in pure Rust** (`pose_jobs.rs:218`).
+
+There are **no exotic ops**. The only genuinely net-new module is the GAU attention
+block (assemblable from existing mlx-gen attention); SE-attention, ScaleNorm and
+DepthToSpace are a few lines each.
+
+**Depthwise convs use native fused grouped conv — NOT the slow shift-trick.** mlx-rs
+`ops::conv2d` takes a `groups` arg and depthwise works at the worker's exact pin
+(`1db3cd0`): the SAM2 memory encoder runs `groups=channels` 7×7 depthwise convs with a
+passing channel-isolation test (`mlx-gen-sam2/src/memory.rs`). CSPNeXt's
+depthwise-separable backbone maps cleanly onto that. (YOLO11's 9-tap shift-trick was a
+choice — it used the groups=1 `mlx_gen::nn` wrapper — not a limitation.)
+
+## 4. Parity risk (reduced-precision Metal matmul) — LOW, cheap to handle
+
+Per the known MLX-Metal matmul reduced-precision issue (~1e-3, affects matmuls not
+convs), the at-risk ops are the **8 MatMuls** — and the parity-critical ones are just
+the 2 final SimCC projections feeding the bin argmax (split 2.0 → 0.5 px/bin). A
+targeted `matmul_device(cpu)` detour on those 8 holds the sc-3487 sub-pixel bar without
+touching the conv bulk that dominates latency. This does **not** materially fight the
+latency case.
+
+## 5. Effort + MLX latency outlook
+
+- **Effort ≈ 2–2.5× the YOLO11 port**: two nets (yolox ≈0.8× YOLO11; rtmw ≈1.3–1.5×) +
+  conv+BN-fuse weight conversion for both + HF hosting (SceneWorks org, cf.
+  `yolo11m-person-detect-mlx`) + per-block parity oracles. Consistent with the story's
+  "SimCC head is heavier than YOLO11's decode."
+- **MLX latency estimate (NOT measured): ~20–45 ms rtmw** = ~1.3–3× CoreML's 15.6 ms.
+  MLX runs the Metal GPU; CoreML gets the ANE + a compiled fused graph. With native
+  grouped conv the catastrophic-slow case is ruled out, but MLX is **very unlikely to
+  beat CoreML** — best case it matches. So MLX latency offers **no functional win**, only
+  a possible small regression. A full MLX forward (= most of the implementation) was
+  *not* built for this spike because it cannot flip the recommendation; the exact number
+  should be confirmed during the implementation story if porting is greenlit.
+
+## 6. The decision the data actually supports
+
+1. **Dropping DWPose's `ort` does not remove `ort`/CoreML/the bundled
+   `libonnxruntime.dylib`** — the Real-ESRGAN upscaler (`upscale_jobs.rs`, sc-3489) uses
+   the same stack and the same dylib. Porting DWPose alone removes call sites, **zero
+   crates**. The dependency-surface payoff is conditional on sc-3489.
+2. **Epic 3482's bar is zero-*Python*, and `ort` is Rust** — DWPose on `ort`+CoreML
+   already satisfies the north star. "Consistency" here means MLX-vs-CoreML backend
+   uniformity, an architecture preference, not a Python-eradication requirement.
+3. **Precedent (sc-3635 SAM2): keep `ort` when it works.** SAM2 stayed on `ort` (CPU-EP)
+   rather than forcing an MLX port the data didn't justify — and SAM2's CoreML was a net
+   *negative*. DWPose's CoreML is a net *positive* (2 partitions, 2.4× CPU), so the case
+   to keep is even stronger than SAM2's.
+4. **YOLO11 went MLX because CoreML was impossible** (hang), not because MLX was
+   preferred. That precedent does not transfer to DWPose, where CoreML works well.
+
+### Ranked options
+1. **(Preferred, ~65%) Keep `ort`+CoreML for DWPose.** Proven, fast, zero-Python,
+   matches the SAM2 precedent. Revisit MLX only as a joint decision with sc-3489.
+2. **(If single-backend consistency is the priority) Port DWPose + upscaler together**
+   as one "retire `ort`+CoreML from the Mac worker" epic — the only framing where the
+   dependency/consistency payoff is real, accepting ~2–2.5× YOLO11 effort and a possible
+   small latency regression as the price.
+3. **(Argue against) Port DWPose alone for "consistency"** — worst of both: full effort,
+   no dependency removal, possible regression, against the SAM2 precedent.
+
+R3 (placement) follows R2: if it stays `ort`, it stays worker-local; if it's ported, it
+becomes an `mlx-gen-dwpose` utility crate (sam2/face pattern).
+
+## Reproduce
+
+```
+~/.dwpose-spike/venv/bin/python scripts/spikes/sc4387_dwpose_diag.py
+# op histogram + CoreML partition counts + CPU/CoreML latency (rtmw on random input;
+# yolox CoreML needs a real image — see §2 note).
+```

--- a/scripts/spikes/sc4387_dwpose_diag.py
+++ b/scripts/spikes/sc4387_dwpose_diag.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""sc-4387 — DWPose backend spike diagnostics (does CoreML belong? + op inventory + latency).
+
+Runs three things against the two production ONNX exports (yolox_m detector +
+rtmw-dw-x-l SimCC pose net) on this Apple Silicon machine:
+
+  1. Op-type histogram + param/initializer counts per graph  -> grounds the
+     native-MLX feasibility/effort call (which ops mlx_gen::nn covers vs bespoke
+     mlx_rs::ops; how many MatMul/Gemm are reduced-precision-risk on Metal).
+  2. CoreML EP partition diagnostic (SAM2-style): how many nodes CoreML accepts
+     and into how many partitions it splits the graph -> answers "does CoreML
+     even belong here?" (fragmentation = net negative, cf. sc-3635 SAM2).
+  3. CoreML vs CPU steady-state latency on correctly-shaped random inputs ->
+     confirms / refreshes sc-3487's CoreML 3-5x-over-CPU finding on this box.
+
+Usage:
+  ~/.dwpose-spike/venv/bin/python scripts/spikes/sc4387_dwpose_diag.py
+"""
+
+from __future__ import annotations
+
+import collections
+import io
+import os
+import re
+import sys
+import time
+from contextlib import redirect_stderr
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+CKPT = Path.home() / ".cache/rtmlib/hub/checkpoints"
+DET = CKPT / "yolox_m_8xb8-300e_humanart-c2c7a14a.onnx"
+POSE = CKPT / "rtmw-dw-x-l_simcc-cocktail14_270e-384x288_20231122.onnx"
+
+
+def human(n: int) -> str:
+    for unit in ("", "K", "M", "B"):
+        if abs(n) < 1000:
+            return f"{n:.1f}{unit}"
+        n /= 1000.0
+    return f"{n:.1f}T"
+
+
+def inventory(path: Path) -> None:
+    m = onnx.load(str(path))
+    g = m.graph
+    ops = collections.Counter(n.op_type for n in g.node)
+    # initializer param count
+    params = 0
+    for init in g.initializer:
+        size = 1
+        for d in init.dims:
+            size *= d
+        params += size
+    print(f"\n=== {path.name} ===")
+    print(f"  nodes: {len(g.node)}   params: {human(params)}")
+    print("  inputs:")
+    for i in g.input:
+        shp = [d.dim_value if (d.dim_value or 0) > 0 else d.dim_param for d in i.type.tensor_type.shape.dim]
+        print(f"    {i.name}: {shp}")
+    print("  outputs:")
+    for o in g.output:
+        shp = [d.dim_value if (d.dim_value or 0) > 0 else d.dim_param for d in o.type.tensor_type.shape.dim]
+        print(f"    {o.name}: {shp}")
+    print("  op histogram:")
+    for op, c in ops.most_common():
+        print(f"    {op:24s} {c}")
+
+
+def partitions(path: Path) -> None:
+    """Create a CoreML-EP session with VERBOSE logging and surface the partition
+    summary onnxruntime prints from GetCapability.
+
+    onnxruntime's C++ log goes to the process stderr (fd 2). We redirect fd 2 to a
+    temp FILE (not a pipe — a pipe's 64KB buffer fills during verbose partition
+    logging and deadlocks session creation), then read it back."""
+    import tempfile
+
+    so = ort.SessionOptions()
+    so.log_severity_level = 0  # VERBOSE -> partition summary goes to stderr
+    print(f"\n=== CoreML partitioning: {path.name} ===")
+    captured = ""
+    with tempfile.NamedTemporaryFile("w+", suffix=".log") as tf:
+        old = os.dup(2)
+        os.dup2(tf.fileno(), 2)
+        try:
+            sess = ort.InferenceSession(
+                str(path),
+                sess_options=so,
+                providers=[("CoreMLExecutionProvider", {})],
+            )
+            sys.stderr.flush()
+            os.fsync(tf.fileno())
+        except Exception as e:  # noqa: BLE001
+            os.dup2(old, 2)
+            os.close(old)
+            print(f"  CoreML session failed: {e}")
+            return
+        finally:
+            os.dup2(old, 2)
+            try:
+                os.close(old)
+            except OSError:
+                pass
+        tf.seek(0)
+        captured = tf.read()
+    print(f"  providers in use: {sess.get_providers()}")
+    # Pull the lines that report node/partition placement.
+    hits = 0
+    for line in captured.splitlines():
+        if re.search(r"partition|placed on|number of nodes|CoreML", line, re.I):
+            print("   ", line.split("]", 1)[-1].strip()[:200])
+            hits += 1
+    if hits == 0:
+        print(f"  (no placement lines matched; captured {len(captured)} bytes of log)")
+
+
+def latency(path: Path, shape: tuple, tag: str, runs: int = 20) -> None:
+    print(f"\n=== latency: {path.name} ===")
+    for ep_name, ep in (("CPU", "CPUExecutionProvider"), ("CoreML", "CoreMLExecutionProvider")):
+        try:
+            sess = ort.InferenceSession(str(path), providers=[ep])
+        except Exception as e:  # noqa: BLE001
+            print(f"  {ep_name}: session failed: {e}")
+            continue
+        # use the graph's real input name (don't assume "input")
+        feeds = {inp.name: np.random.rand(*shape).astype(np.float32) for inp in sess.get_inputs()}
+        try:
+            # warmup (CoreML compiles the graph on first run)
+            t0 = time.perf_counter()
+            sess.run(None, feeds)
+            warm = (time.perf_counter() - t0) * 1e3
+            times = []
+            for _ in range(runs):
+                t0 = time.perf_counter()
+                sess.run(None, feeds)
+                times.append((time.perf_counter() - t0) * 1e3)
+        except Exception as e:  # noqa: BLE001
+            # yolox's embedded NMS yields 0 boxes on random noise -> CoreML rejects the
+            # zero-element dynamic tensor. Real images have people; benign for latency.
+            print(f"  {ep_name:7s} run failed on random input ({str(e).splitlines()[0][:80]})")
+            continue
+        times.sort()
+        med = times[len(times) // 2]
+        print(f"  {ep_name:7s} warmup {warm:7.1f}ms  median {med:7.1f}ms  min {times[0]:7.1f}ms  (n={runs})")
+
+
+def main() -> None:
+    print(f"onnxruntime {ort.__version__}   providers {ort.get_available_providers()}")
+    for p in (DET, POSE):
+        if not p.exists():
+            print(f"MISSING: {p}", file=sys.stderr)
+            sys.exit(1)
+    inventory(DET)
+    inventory(POSE)
+    partitions(DET)
+    partitions(POSE)
+    # yolox_m input is dynamic-batch (1,3,640,640); rtmw is (1,3,384,288)
+    latency(DET, (1, 3, 640, 640), "det")
+    latency(POSE, (1, 3, 384, 288), "pose")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Spike R2 for epic [4778 — Retire ort+CoreML from the Mac worker](https://app.shortcut.com/trefry/epic/4778). Docs + diagnostic script only — **no code or behavior change**.

## What's here
- `docs/sc-4387/spike-findings.md` — the backend recommendation with measured data.
- `scripts/spikes/sc4387_dwpose_diag.py` — reproducible diagnostic (op inventory + CoreML partition counts + CPU/CoreML latency).

## Findings (Apple Silicon, onnxruntime 1.26, production pins)
- **CoreML partitioning:** rtmw-dw-x-l = **2 partitions**, yolox_m = 8 — nowhere near SAM2's 50–437. CoreML is genuinely suited to these CNNs.
- **Latency:** rtmw CoreML **15.6 ms** vs CPU 37.5 ms (2.4×), confirming sc-3487's ~35–55 ms/img.
- **MLX feasibility ~90%:** no exotic ops; native fused grouped/depthwise `conv2d` works at the current pin (SAM2 uses it). Effort ≈ 2–2.5× the YOLO11 port; MLX latency at best matches CoreML.

## Decision
Spike recommended *keep* on functional grounds (CoreML is the success case here). Michael's call: **port** both DWPose + the upscaler to retire `ort`+CoreML entirely (backend uniformity / all-MLX north star). Implementation tracked in epic 4778 (sc-4782 DWPose, sc-4781 upscaler, sc-4783 strip+validate) — currently set aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)