### PR TITLE
Confine worker payload-supplied paths

### DIFF
--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -69,7 +69,7 @@ pub(crate) async fn run_training_caption_job(
         ));
     }
 
-    let items = caption_items(&job.payload)?;
+    let items = caption_items(settings, &job.payload)?;
     if items.is_empty() {
         return Err(WorkerError::InvalidPayload(
             "Training caption job has no items to caption.".to_owned(),
@@ -369,7 +369,17 @@ fn caption_result(
 }
 
 #[cfg(target_os = "macos")]
-fn caption_items(payload: &JsonObject) -> WorkerResult<Vec<CaptionItem>> {
+fn caption_items(settings: &Settings, payload: &JsonObject) -> WorkerResult<Vec<CaptionItem>> {
+    let dataset_root = payload
+        .get("datasetRoot")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "Caption payload.datasetRoot must be an app-managed dataset path.".to_owned(),
+            )
+        })?;
     let items = payload
         .get("items")
         .and_then(Value::as_array)
@@ -414,9 +424,15 @@ fn caption_items(payload: &JsonObject) -> WorkerResult<Vec<CaptionItem>> {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
+            let image_path = resolve_dataset_item_path(
+                settings,
+                dataset_root,
+                image_path,
+                &format!("Caption item {item_id} imagePath"),
+            )?;
             Ok(CaptionItem {
                 item_id,
-                image_path: PathBuf::from(image_path),
+                image_path,
                 trigger_words,
             })
         })
@@ -481,22 +497,7 @@ fn resolve_caption_weights_dir(
     settings: &Settings,
     model_name_or_path: &str,
 ) -> WorkerResult<PathBuf> {
-    let direct = PathBuf::from(model_name_or_path);
-    if direct.is_dir() {
-        return Ok(direct);
-    }
-    if direct.exists() {
-        return Err(WorkerError::InvalidPayload(format!(
-            "JoyCaption model path must be a snapshot directory, not a file: {}",
-            direct.display()
-        )));
-    }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, model_name_or_path) {
-        return Ok(snapshot);
-    }
-    Err(WorkerError::InvalidPayload(format!(
-        "JoyCaption model snapshot is not cached for {model_name_or_path}. Download/cache the model first or pass a local snapshot directory."
-    )))
+    resolve_app_managed_model_dir(settings, model_name_or_path, "JoyCaption model path")
 }
 
 #[cfg(target_os = "macos")]
@@ -528,6 +529,28 @@ fn caption_step_progress(index: usize, current: u32, total: u32, item_count: usi
 mod tests {
     use super::*;
 
+    fn test_settings(data_dir: &Path) -> Settings {
+        Settings {
+            api_url: "http://127.0.0.1".to_owned(),
+            access_token: None,
+            data_dir: data_dir.to_path_buf(),
+            config_dir: data_dir.join("config"),
+            worker_id: "test-worker".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            is_child_worker: false,
+            poll_seconds: 1,
+            heartbeat_seconds: 1,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: DEFAULT_HUGGINGFACE_BASE_URL.to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            max_lora_url_bytes: DEFAULT_MAX_LORA_URL_BYTES,
+            max_model_url_bytes: DEFAULT_MAX_MODEL_URL_BYTES,
+            allow_private_lora_urls: false,
+            utility_workers: 1,
+        }
+    }
+
     #[test]
     fn caption_job_options_preserve_training_surface() {
         let options = caption_job_options(&serde_json::Map::from_iter([(
@@ -557,17 +580,52 @@ mod tests {
 
     #[test]
     fn caption_items_require_ids_and_paths() {
-        let payload = serde_json::Map::from_iter([(
-            "items".to_owned(),
-            json!([{
-                "itemId": "item_1",
-                "imagePath": "/tmp/image.png",
-                "triggerWords": ["miraStyle", ""]
-            }]),
-        )]);
-        let items = caption_items(&payload).expect("items parse");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let dataset_root = dir.path().join("datasets").join("ds-1");
+        let image_path = dataset_root.join("image.png");
+        let payload = serde_json::Map::from_iter([
+            (
+                "datasetRoot".to_owned(),
+                json!(dataset_root.display().to_string()),
+            ),
+            (
+                "items".to_owned(),
+                json!([{
+                    "itemId": "item_1",
+                    "imagePath": image_path.display().to_string(),
+                    "triggerWords": ["miraStyle", ""]
+                }]),
+            ),
+        ]);
+        let items = caption_items(&settings, &payload).expect("items parse");
         assert_eq!(items[0].item_id, "item_1");
-        assert_eq!(items[0].image_path, PathBuf::from("/tmp/image.png"));
+        assert_eq!(items[0].image_path, image_path);
         assert_eq!(items[0].trigger_words, vec!["miraStyle"]);
+    }
+
+    #[test]
+    fn caption_items_reject_paths_outside_dataset_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let dataset_root = dir.path().join("datasets").join("ds-1");
+        let payload = serde_json::Map::from_iter([
+            (
+                "datasetRoot".to_owned(),
+                json!(dataset_root.display().to_string()),
+            ),
+            (
+                "items".to_owned(),
+                json!([{
+                    "itemId": "item_1",
+                    "imagePath": dir.path().join("other.png").display().to_string()
+                }]),
+            ),
+        ]);
+        let error = caption_items(&settings, &payload).expect_err("unsafe image path rejected");
+        assert!(
+            error.to_string().contains("Caption item item_1 imagePath"),
+            "{error}"
+        );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -919,8 +919,10 @@ enum GenEvent {
 #[cfg(target_os = "macos")]
 pub(crate) fn mlx_weights_gap(request: &ImageRequest, settings: &Settings) -> Option<String> {
     let model = mlx_model(&request.model)?;
-    if resolve_weights_dir(request, settings).is_some() {
-        return None;
+    match resolve_weights_dir(request, settings) {
+        Ok(Some(_)) => return None,
+        Err(error) => return Some(error.to_string()),
+        Ok(None) => {}
     }
     Some(format!(
         "{}: MLX weights not found or incomplete (Hugging Face repo {}). \
@@ -932,7 +934,8 @@ pub(crate) fn mlx_weights_gap(request: &ImageRequest, settings: &Settings) -> Op
 
 #[cfg(target_os = "macos")]
 fn mlx_available(request: &ImageRequest, settings: &Settings) -> bool {
-    mlx_model(&request.model).is_some() && resolve_weights_dir(request, settings).is_some()
+    mlx_model(&request.model).is_some()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
 /// The HuggingFace repo for the model: the manifest entry's `repo` wins, else the
@@ -953,7 +956,10 @@ fn model_repo(request: &ImageRequest, model: &MlxModel) -> String {
 /// HuggingFace cache snapshot for the model repo. `None` when the model is not a known
 /// engine family or its snapshot is absent.
 #[cfg(target_os = "macos")]
-pub(crate) fn resolve_weights_dir(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+pub(crate) fn resolve_weights_dir(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
     if let Some(path) = request
         .advanced
         .get("modelPath")
@@ -961,14 +967,17 @@ pub(crate) fn resolve_weights_dir(request: &ImageRequest, settings: &Settings) -
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
+        .map(str::to_owned)
     {
-        if path.is_dir() {
-            return Some(path);
-        }
+        return resolve_app_managed_model_dir(settings, &path, "Image modelPath").map(Some);
     }
-    let model = mlx_model(&request.model)?;
-    huggingface_snapshot_dir(&settings.data_dir, &model_repo(request, model))
+    let Some(model) = mlx_model(&request.model) else {
+        return Ok(None);
+    };
+    Ok(huggingface_snapshot_dir(
+        &settings.data_dir,
+        &model_repo(request, model),
+    ))
 }
 
 #[cfg(target_os = "macos")]
@@ -1413,7 +1422,7 @@ async fn generate_mlx_stream(
     let request = &plan.request;
     let model = mlx_model(&request.model)
         .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
-    let weights_dir = resolve_weights_dir(request, settings)
+    let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("model weights not found".to_owned()))?;
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, model);
@@ -1797,7 +1806,7 @@ fn pose_entries(request: &ImageRequest) -> Vec<&Value> {
 fn zimage_control_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.model == "z_image_turbo"
         && !pose_entries(request).is_empty()
-        && resolve_weights_dir(request, settings).is_some()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
 /// Resolve the Fun-Controlnet-Union checkpoint (`advanced.controlWeights.{repo,filename}`
@@ -2005,7 +2014,7 @@ async fn generate_zimage_control_stream(
     // skeleton changes). None → the pose-only tier (the validated sc-2257 default).
     let identity_init = resolve_zimage_identity_init(request, settings, project_path)?;
 
-    let weights_dir = resolve_weights_dir(request, settings)
+    let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("Z-Image weights not found".to_owned()))?;
     let control_weights = resolve_control_weights(request, settings).ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
@@ -2502,7 +2511,7 @@ fn flux2_edit_reference_ids(request: &ImageRequest) -> Vec<String> {
 fn flux2_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
     flux2_edit_engine_id(&request.model).is_some()
         && !flux2_edit_reference_ids(request).is_empty()
-        && resolve_weights_dir(request, settings).is_some()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
 /// Resolve a reference/source asset id to an in-memory RGB8 image (the engine VAE-
@@ -2649,7 +2658,7 @@ async fn generate_flux2_edit_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
     let engine_id = flux2_edit_engine_id(&request.model)
         .ok_or_else(|| WorkerError::InvalidPayload("not a FLUX.2 edit model".to_owned()))?;
-    let weights_dir = resolve_weights_dir(request, settings)
+    let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("FLUX.2 weights not found".to_owned()))?;
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, model);
@@ -2879,7 +2888,7 @@ fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.model == "qwen_image"
         && request.mode != "edit_image"
         && !pose_entries(request).is_empty()
-        && resolve_weights_dir(request, settings).is_some()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
 #[cfg(target_os = "macos")]
@@ -3005,7 +3014,7 @@ async fn generate_qwen_control_stream(
     let request = &plan.request;
     let qwen = mlx_model("qwen_image")
         .ok_or_else(|| WorkerError::InvalidPayload("Qwen model row missing".to_owned()))?;
-    let weights_dir = resolve_weights_dir(request, settings)
+    let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("Qwen-Image weights not found".to_owned()))?;
     let control_weights = resolve_qwen_control_weights(request, settings).ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
@@ -3294,7 +3303,7 @@ fn qwen_edit_reference_ids(request: &ImageRequest) -> Vec<String> {
 fn qwen_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
     qwen_edit_engine_id(&request.model).is_some()
         && !qwen_edit_reference_ids(request).is_empty()
-        && resolve_weights_dir(request, settings).is_some()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
 /// The number of images this image_generate job produces, accounting for grouped edit
@@ -3448,7 +3457,7 @@ async fn generate_qwen_edit_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
     let engine_id = qwen_edit_engine_id(&request.model)
         .ok_or_else(|| WorkerError::InvalidPayload("not a Qwen edit model".to_owned()))?;
-    let weights_dir = resolve_weights_dir(request, settings).ok_or_else(|| {
+    let weights_dir = resolve_weights_dir(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload("Qwen-Image-Edit weights not found".to_owned())
     })?;
     let (quant, quant_bits) = resolve_quant(request);
@@ -3707,7 +3716,7 @@ async fn generate_qwen_edit_stream(
 fn sensenova_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
     is_sensenova_model(&request.model)
         && !qwen_edit_reference_ids(request).is_empty()
-        && resolve_weights_dir(request, settings).is_some()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
 /// Snap a dimension to SenseNova's 32-pixel cell (the engine rejects off-cell sizes), clamped to
@@ -3868,7 +3877,7 @@ async fn generate_sensenova_edit_stream(
     let model = mlx_model(&request.model)
         .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
     let engine_id = model.engine_id;
-    let weights_dir = resolve_weights_dir(request, settings)
+    let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, model);
@@ -4098,7 +4107,7 @@ fn sdxl_sub_mode(request: &ImageRequest) -> Option<SdxlSubMode> {
 fn sdxl_advanced_available(request: &ImageRequest, settings: &Settings) -> bool {
     sdxl_engine_model(&request.model).is_some()
         && sdxl_sub_mode(request).is_some()
-        && resolve_weights_dir(request, settings).is_some()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
 /// Resolve the IP-Adapter snapshot directory (`advanced.ipAdapterRepo` override, else the
@@ -4262,7 +4271,7 @@ async fn generate_sdxl_advanced_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("not an SDXL engine model".to_owned()))?;
     let sub_mode = sdxl_sub_mode(request)
         .ok_or_else(|| WorkerError::InvalidPayload("not an SDXL advanced job".to_owned()))?;
-    let weights_dir = resolve_weights_dir(request, settings)
+    let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("SDXL weights not found".to_owned()))?;
     let (quant, quant_bits) = resolve_quant(request);
     let steps = resolve_steps(request, model);
@@ -4639,7 +4648,10 @@ fn pose_to_body_points(keypoints: &[crate::openpose_skeleton::Keypoint]) -> Vec<
 /// RealVisXL_V5.0). The big base is staged by the normal model-download flow; `None` here
 /// means it is not present, so the job is not MLX-runnable (falls through to torch).
 #[cfg(target_os = "macos")]
-fn resolve_instantid_sdxl_base(request: &ImageRequest, settings: &Settings) -> Option<PathBuf> {
+fn resolve_instantid_sdxl_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
     if let Some(path) = request
         .advanced
         .get("modelPath")
@@ -4647,11 +4659,10 @@ fn resolve_instantid_sdxl_base(request: &ImageRequest, settings: &Settings) -> O
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
+        .map(str::to_owned)
     {
-        if path.is_dir() {
-            return Some(path);
-        }
+        return resolve_app_managed_model_dir(settings, &path, "InstantID SDXL modelPath")
+            .map(Some);
     }
     let repo = request
         .model_manifest_entry
@@ -4660,7 +4671,7 @@ fn resolve_instantid_sdxl_base(request: &ImageRequest, settings: &Settings) -> O
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(INSTANTID_SDXL_REPO);
-    huggingface_snapshot_dir(&settings.data_dir, repo)
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
 }
 
 /// True when this is a native-MLX-eligible InstantID job: the production model in
@@ -4672,7 +4683,7 @@ fn instantid_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.model == INSTANTID_MODEL
         && request.mode == "character_image"
         && non_empty(&request.reference_asset_id)
-        && resolve_instantid_sdxl_base(request, settings).is_some()
+        && matches!(resolve_instantid_sdxl_base(request, settings), Ok(Some(_)))
 }
 
 /// The number of images an InstantID job produces: `n` for a pose set, the active angle
@@ -4983,7 +4994,7 @@ async fn generate_instantid_stream(
     asset_writes: &mut Vec<Value>,
 ) -> WorkerResult<()> {
     let request = &plan.request;
-    let sdxl_base = resolve_instantid_sdxl_base(request, settings).ok_or_else(|| {
+    let sdxl_base = resolve_instantid_sdxl_base(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload("InstantID base (RealVisXL) not found".to_owned())
     })?;
     let reference_id = request
@@ -5689,7 +5700,7 @@ pub(crate) async fn run_image_detail_job(
     let params = resolve_detail_params(&request);
     let (quant, _) = resolve_quant(&request);
     // Reuse the model's manifest/modelPath/cache resolution; engine_model gives the default repo.
-    let weights_dir = resolve_weights_dir(&request, settings)
+    let weights_dir = resolve_weights_dir(&request, settings)?
         .or_else(|| huggingface_snapshot_dir(&settings.data_dir, engine_model.default_repo));
     let weights_dir = weights_dir
         .ok_or_else(|| WorkerError::InvalidPayload("SDXL detail weights not found".to_owned()))?;
@@ -6892,7 +6903,9 @@ mod tests {
         let guidance = resolve_guidance(&req, model);
         let negative = resolve_negative_prompt(&req, model);
         let (quant, _bits) = resolve_quant(&req);
-        let weights = resolve_weights_dir(&req, &settings).expect("weights in HF cache");
+        let weights = resolve_weights_dir(&req, &settings)
+            .expect("weights resolve")
+            .expect("weights in HF cache");
         let adapters = resolve_adapters(&req).expect("adapters");
         let seed = resolve_seed(&req, 0);
         let generator = mlx_load(model.engine_id, weights, quant, adapters).expect("load");
@@ -6941,7 +6954,9 @@ mod tests {
         let req = request(payload);
         let settings = Settings::from_env();
 
-        let weights = resolve_weights_dir(&req, &settings).expect("z-image weights in HF cache");
+        let weights = resolve_weights_dir(&req, &settings)
+            .expect("z-image weights resolve")
+            .expect("z-image weights in HF cache");
         let control_weights =
             resolve_control_weights(&req, &settings).expect("Fun-Controlnet-Union weights");
         let (quant, _bits) = resolve_quant(&req);

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1194,6 +1194,123 @@ fn normalize_absolute_path(path: &Path) -> WorkerResult<PathBuf> {
     Ok(output)
 }
 
+fn normalized_data_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    normalize_absolute_path(&settings.data_dir)
+}
+
+fn ensure_path_under(path: PathBuf, roots: &[PathBuf], label: &str) -> WorkerResult<PathBuf> {
+    if roots.iter().any(|root| path.starts_with(root)) {
+        return Ok(path);
+    }
+    let allowed = roots
+        .iter()
+        .map(|root| root.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(WorkerError::InvalidPayload(format!(
+        "{label} must be inside an app-managed directory ({allowed})."
+    )))
+}
+
+fn normalize_app_managed_path(
+    settings: &Settings,
+    raw_path: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    let raw_path = raw_path.trim();
+    if raw_path.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
+    }
+    let data_dir = normalized_data_dir(settings)?;
+    let path = normalize_absolute_path(Path::new(raw_path))?;
+    ensure_path_under(path, &[data_dir], label)
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn looks_like_huggingface_repo(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() || value.contains('\\') || Path::new(value).is_absolute() {
+        return false;
+    }
+    let mut parts = value.split('/');
+    let Some(owner) = parts.next() else {
+        return false;
+    };
+    let Some(repo) = parts.next() else {
+        return false;
+    };
+    !owner.is_empty()
+        && !repo.is_empty()
+        && parts.next().is_none()
+        && ![owner, repo]
+            .iter()
+            .any(|part| *part == "." || *part == "..")
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn resolve_app_managed_model_dir(
+    settings: &Settings,
+    model_name_or_path: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    let model_name_or_path = model_name_or_path.trim();
+    if model_name_or_path.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
+    }
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, model_name_or_path) {
+        return Ok(snapshot);
+    }
+    if looks_like_huggingface_repo(model_name_or_path) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{label} snapshot is not cached for {model_name_or_path}."
+        )));
+    }
+    let path = normalize_app_managed_path(settings, model_name_or_path, label)?;
+    if path.is_dir() {
+        return Ok(path);
+    }
+    if path.exists() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{label} must be a snapshot directory, not a file: {}",
+            path.display()
+        )));
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{label} is not installed at {}.",
+        path.display()
+    )))
+}
+
+fn resolve_training_output_dir(
+    settings: &Settings,
+    output_dir: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    let path = normalize_app_managed_path(settings, output_dir, label)?;
+    let data_dir = normalized_data_dir(settings)?;
+    let allowed_roots = [data_dir.join("loras"), data_dir.join("models")];
+    ensure_path_under(path, &allowed_roots, label)
+}
+
+fn resolve_dataset_item_path(
+    settings: &Settings,
+    dataset_root: &str,
+    image_path: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    let root = normalize_app_managed_path(settings, dataset_root, "Dataset root")?;
+    let raw_image = Path::new(image_path.trim());
+    if image_path.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
+    }
+    let path = if raw_image.is_absolute() {
+        normalize_absolute_path(raw_image)?
+    } else {
+        normalize_absolute_path(&root.join(raw_image))?
+    };
+    ensure_path_under(path, &[root], label)
+}
+
 fn project_path_for_payload(
     settings: &Settings,
     payload: &JsonObject,

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -110,7 +110,7 @@ pub(crate) async fn run_vqa_job(
         2048 * 2048,
     );
 
-    let weights_dir = resolve_weights_dir(&request, settings)
+    let weights_dir = resolve_weights_dir(&request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
 
     let project =
@@ -302,7 +302,7 @@ pub(crate) async fn run_interleave_job(
         .unwrap_or_else(|| INTERLEAVE_SYSTEM_MESSAGE.to_owned());
     let seed = resolve_seed(&request, 0);
 
-    let weights_dir = resolve_weights_dir(&request, settings)
+    let weights_dir = resolve_weights_dir(&request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
 
     let project =

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -2304,6 +2304,19 @@ mod stub_fallback_gate {
     }
 
     #[test]
+    fn image_explicit_model_path_outside_data_dir_is_rejected() {
+        let (_dir, settings) = settings_with_empty_data_dir();
+        let outside = tempdir().expect("outside tempdir");
+        let request = ImageRequest::from_payload(&object(json!({
+            "model": "z_image_turbo",
+            "advanced": { "modelPath": outside.path().to_string_lossy() },
+        })));
+        let gap = mlx_weights_gap(&request, &settings).expect("unsafe modelPath rejected");
+        assert!(gap.contains("Image modelPath"), "{gap}");
+        assert!(gap.contains("app-managed"), "{gap}");
+    }
+
+    #[test]
     fn video_engine_model_without_weights_is_a_precise_error_not_a_stub() {
         let (_dir, settings) = settings_with_empty_data_dir();
         let request = VideoRequest::from_payload(&object(json!({ "model": "wan_2_2_i2v_14b" })));

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -73,7 +73,7 @@ fn parse_plan(payload: &JsonObject) -> WorkerResult<TrainingPlan> {
 /// Validate a resolved plan the way the Python `validate_training_plan` does:
 /// reject an unknown plan version, an empty dataset, or missing dataset images.
 /// Shared by the dry-run validator and the real run so both reject the same inputs.
-fn validate_training_plan(plan: &TrainingPlan) -> WorkerResult<()> {
+fn validate_training_plan(settings: &Settings, plan: &TrainingPlan) -> WorkerResult<()> {
     if plan.plan_version != TRAINING_PLAN_VERSION {
         return Err(WorkerError::InvalidPayload(format!(
             "Unsupported training plan version {}; this worker understands version {}.",
@@ -85,18 +85,29 @@ fn validate_training_plan(plan: &TrainingPlan) -> WorkerResult<()> {
             "Training plan dataset has no items to train on.".to_owned(),
         ));
     }
-    let missing: Vec<&str> = plan
-        .dataset
-        .items
-        .iter()
-        .filter(|item| !Path::new(&item.image_path).exists())
-        .map(|item| item.image_path.as_str())
-        .collect();
+    normalize_app_managed_path(
+        settings,
+        &plan.target.base_model_path,
+        "Training baseModelPath",
+    )?;
+    resolve_training_output_dir(settings, &plan.output.output_dir, "Training outputDir")?;
+    let mut missing = Vec::new();
+    for item in &plan.dataset.items {
+        let image_path = resolve_dataset_item_path(
+            settings,
+            &plan.dataset.root_path,
+            &item.image_path,
+            "Training dataset imagePath",
+        )?;
+        if !image_path.exists() {
+            missing.push(image_path.display().to_string());
+        }
+    }
     if !missing.is_empty() {
         let preview = missing
             .iter()
             .take(3)
-            .copied()
+            .map(String::as_str)
             .collect::<Vec<_>>()
             .join(", ");
         return Err(WorkerError::InvalidPayload(format!(
@@ -132,7 +143,7 @@ async fn run_training_dry_run(
         ),
     )
     .await?;
-    validate_training_plan(plan)?;
+    validate_training_plan(settings, plan)?;
     let item_count = plan.dataset.items.len();
     update_job(
         api,
@@ -155,7 +166,7 @@ async fn run_training_dry_run(
             ProgressStage::Completed,
             1.0,
             &format!("Dry run validated {item_count} dataset item(s); training plan is ready."),
-            Some(dry_run_summary(plan)),
+            Some(dry_run_summary(settings, plan)),
             backend,
         ),
     )
@@ -165,8 +176,13 @@ async fn run_training_dry_run(
 
 /// The dry-run completion summary (keys mirror the Python `dry_run_training_summary`
 /// so the Training Studio reads an identical shape regardless of which worker runs it).
-fn dry_run_summary(plan: &TrainingPlan) -> JsonObject {
-    let base_model_installed = Path::new(&plan.target.base_model_path).exists();
+fn dry_run_summary(settings: &Settings, plan: &TrainingPlan) -> JsonObject {
+    let base_model_installed = normalize_app_managed_path(
+        settings,
+        &plan.target.base_model_path,
+        "Training baseModelPath",
+    )
+    .is_ok_and(|path| path.exists());
     let mut summary = JsonObject::new();
     summary.insert("mode".to_owned(), json!("dry_run"));
     summary.insert("validated".to_owned(), json!(true));
@@ -377,7 +393,7 @@ async fn run_training_execution(
     )
     .await?;
 
-    validate_training_plan(plan)?;
+    validate_training_plan(settings, plan)?;
 
     let engine_id = engine_trainer_id(plan).ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
@@ -386,26 +402,32 @@ async fn run_training_execution(
         ))
     })?;
 
-    let weights_dir = PathBuf::from(&plan.target.base_model_path);
-    if !weights_dir.is_dir() {
-        return Err(WorkerError::InvalidPayload(format!(
-            "Base model weights are not installed at {}.",
-            weights_dir.display()
-        )));
-    }
+    let weights_dir = resolve_app_managed_model_dir(
+        settings,
+        &plan.target.base_model_path,
+        "Training baseModelPath",
+    )?;
 
-    let output_dir = PathBuf::from(&plan.output.output_dir);
+    let output_dir =
+        resolve_training_output_dir(settings, &plan.output.output_dir, "Training outputDir")?;
     tokio::fs::create_dir_all(&output_dir).await?;
 
     let items: Vec<TrainingItem> = plan
         .dataset
         .items
         .iter()
-        .map(|item| TrainingItem {
-            image_path: PathBuf::from(&item.image_path),
-            caption: item.caption.clone(),
+        .map(|item| {
+            Ok(TrainingItem {
+                image_path: resolve_dataset_item_path(
+                    settings,
+                    &plan.dataset.root_path,
+                    &item.image_path,
+                    "Training dataset imagePath",
+                )?,
+                caption: item.caption.clone(),
+            })
         })
-        .collect();
+        .collect::<WorkerResult<Vec<_>>>()?;
     let config = map_training_config(&plan.config);
     let total_steps = config.steps;
     let file_name = plan.output.file_name.clone();
@@ -673,15 +695,39 @@ async fn run_training_execution(
 mod tests {
     use super::*;
 
+    fn test_settings(data_dir: &Path) -> Settings {
+        Settings {
+            api_url: "http://127.0.0.1".to_owned(),
+            access_token: None,
+            data_dir: data_dir.to_path_buf(),
+            config_dir: data_dir.join("config"),
+            worker_id: "test-worker".to_owned(),
+            gpu_id: "gpu-0".to_owned(),
+            is_child_worker: false,
+            poll_seconds: 1,
+            heartbeat_seconds: 1,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: DEFAULT_HUGGINGFACE_BASE_URL.to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            max_lora_url_bytes: DEFAULT_MAX_LORA_URL_BYTES,
+            max_model_url_bytes: DEFAULT_MAX_MODEL_URL_BYTES,
+            allow_private_lora_urls: false,
+            utility_workers: 1,
+        }
+    }
+
     /// A complete resolved plan as the API serializes it, parameterized by the
     /// fields the worker glue reads. `baseModelPath` is a path that does not exist,
     /// so `baseModelInstalled` is false unless a test overrides it.
     fn plan_json(
+        data_dir: &Path,
         kernel: &str,
         base_model: &str,
         network_type: &str,
         image_paths: &[&str],
     ) -> Value {
+        let dataset_root = data_dir.join("datasets").join("ds-1");
         let items: Vec<Value> = image_paths
             .iter()
             .map(|path| json!({ "imagePath": path, "caption": "a photo of mychar" }))
@@ -697,12 +743,12 @@ mod tests {
                 "modality": "image",
                 "outputKind": "lora",
                 "baseModel": base_model,
-                "baseModelPath": "/tmp/sceneworks-test-base-does-not-exist"
+                "baseModelPath": data_dir.join("models").join("base-missing").display().to_string()
             },
             "dataset": {
                 "datasetId": "ds-1",
                 "datasetVersion": 1,
-                "rootPath": "/tmp/ds",
+                "rootPath": dataset_root.display().to_string(),
                 "items": items
             },
             "config": {
@@ -730,7 +776,7 @@ mod tests {
             },
             "output": {
                 "loraId": "lora-1",
-                "outputDir": "/tmp/out",
+                "outputDir": data_dir.join("loras").join("lora-1").display().to_string(),
                 "fileName": "lora.safetensors",
                 "format": "safetensors",
                 "triggerWords": ["mychar"]
@@ -754,9 +800,19 @@ mod tests {
 
     #[test]
     fn validate_rejects_unknown_plan_version() {
-        let mut value = plan_json("z_image_lora", "z_image_turbo", "lora", &["/tmp/x.png"]);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let image = dir.path().join("datasets").join("ds-1").join("x.png");
+        let mut value = plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        );
         value["planVersion"] = json!(999);
-        let error = validate_training_plan(&parse(value)).expect_err("version mismatch rejected");
+        let error = validate_training_plan(&settings, &parse(value))
+            .expect_err("version mismatch rejected");
         assert!(error
             .to_string()
             .contains("Unsupported training plan version"));
@@ -764,40 +820,123 @@ mod tests {
 
     #[test]
     fn validate_rejects_empty_dataset() {
-        let plan = parse(plan_json("z_image_lora", "z_image_turbo", "lora", &[]));
-        let error = validate_training_plan(&plan).expect_err("empty dataset rejected");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let plan = parse(plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[],
+        ));
+        let error = validate_training_plan(&settings, &plan).expect_err("empty dataset rejected");
         assert!(error.to_string().contains("no items"));
     }
 
     #[test]
     fn validate_rejects_missing_image() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let image = dir.path().join("datasets").join("ds-1").join("missing.png");
         let plan = parse(plan_json(
+            dir.path(),
             "z_image_lora",
             "z_image_turbo",
             "lora",
-            &["/tmp/sceneworks-missing-7f3a9c.png"],
+            &[&image.display().to_string()],
         ));
-        let error = validate_training_plan(&plan).expect_err("missing image rejected");
+        let error = validate_training_plan(&settings, &plan).expect_err("missing image rejected");
         assert!(error.to_string().contains("missing on the worker"));
     }
 
     #[test]
     fn validate_accepts_present_images() {
-        let file = tempfile::NamedTempFile::new().expect("temp file");
-        let path = file.path().to_string_lossy().into_owned();
-        let plan = parse(plan_json("z_image_lora", "z_image_turbo", "lora", &[&path]));
-        assert!(validate_training_plan(&plan).is_ok());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let dataset_root = dir.path().join("datasets").join("ds-1");
+        std::fs::create_dir_all(&dataset_root).expect("dataset root");
+        let image = dataset_root.join("image.png");
+        std::fs::write(&image, b"png").expect("image");
+        let plan = parse(plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        ));
+        assert!(validate_training_plan(&settings, &plan).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_image_outside_dataset_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let image = dir.path().join("other").join("image.png");
+        let plan = parse(plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        ));
+        let error = validate_training_plan(&settings, &plan).expect_err("outside image rejected");
+        assert!(error.to_string().contains("Training dataset imagePath"));
+    }
+
+    #[test]
+    fn validate_rejects_base_model_outside_data_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let image = dir.path().join("datasets").join("ds-1").join("image.png");
+        let mut value = plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        );
+        value["target"]["baseModelPath"] = json!("/tmp/sceneworks-outside-base");
+        let error = validate_training_plan(&settings, &parse(value))
+            .expect_err("outside base model rejected");
+        assert!(error.to_string().contains("Training baseModelPath"));
+    }
+
+    #[test]
+    fn validate_rejects_output_dir_outside_app_lora_or_model_roots() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let image = dir.path().join("datasets").join("ds-1").join("image.png");
+        let mut value = plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        );
+        value["output"]["outputDir"] =
+            json!(dir.path().join("tmp").join("lora-1").display().to_string());
+        let error = validate_training_plan(&settings, &parse(value))
+            .expect_err("outside output dir rejected");
+        assert!(error.to_string().contains("Training outputDir"));
     }
 
     #[test]
     fn dry_run_summary_carries_plan_facts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let image_a = dir.path().join("datasets").join("ds-1").join("a.png");
+        let image_b = dir.path().join("datasets").join("ds-1").join("b.png");
         let plan = parse(plan_json(
+            dir.path(),
             "sdxl_lora",
             "sdxl",
             "lora",
-            &["/tmp/a.png", "/tmp/b.png"],
+            &[
+                &image_a.display().to_string(),
+                &image_b.display().to_string(),
+            ],
         ));
-        let summary = dry_run_summary(&plan);
+        let summary = dry_run_summary(&settings, &plan);
         assert_eq!(summary.get("mode").unwrap(), "dry_run");
         assert_eq!(summary.get("kernel").unwrap(), "sdxl_lora");
         assert_eq!(summary.get("datasetItemCount").unwrap(), 2);
@@ -823,8 +962,16 @@ mod tests {
             // Unknown A14B base model variant.
             ("wan_moe_lora", "wan_2_2_mystery", None),
         ];
+        let dir = tempfile::tempdir().expect("tempdir");
+        let image = dir.path().join("datasets").join("ds-1").join("x.png");
         for (kernel, base_model, expected) in cases {
-            let plan = parse(plan_json(kernel, base_model, "lora", &["/tmp/x.png"]));
+            let plan = parse(plan_json(
+                dir.path(),
+                kernel,
+                base_model,
+                "lora",
+                &[&image.display().to_string()],
+            ));
             assert_eq!(
                 engine_trainer_id(&plan),
                 *expected,
@@ -836,11 +983,14 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn map_training_config_reads_advanced_and_passes_optimizer_verbatim() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let image = dir.path().join("datasets").join("ds-1").join("x.png");
         let plan = parse(plan_json(
+            dir.path(),
             "z_image_lora",
             "z_image_turbo",
             "lokr",
-            &["/tmp/x.png"],
+            &[&image.display().to_string()],
         ));
         let cfg = map_training_config(&plan.config);
         assert_eq!(cfg.rank, 16);
@@ -867,7 +1017,15 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn map_training_config_defaults_when_advanced_is_empty() {
-        let mut value = plan_json("sdxl_lora", "sdxl", "lora", &["/tmp/x.png"]);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let image = dir.path().join("datasets").join("ds-1").join("x.png");
+        let mut value = plan_json(
+            dir.path(),
+            "sdxl_lora",
+            "sdxl",
+            "lora",
+            &[&image.display().to_string()],
+        );
         value["config"]["advanced"] = json!({});
         let plan = parse(value);
         let cfg = map_training_config(&plan.config);


### PR DESCRIPTION
## Summary
- confine payload-supplied caption dataset image paths to the supplied app-managed dataset root
- require explicit image/SenseNova/InstantID model paths and JoyCaption model paths to resolve through the app data/HF cache boundary
- constrain LoRA training base paths, dataset item paths, and output dirs before dry-run or execution touches them

## Validation
- cargo fmt --check
- cargo test -p sceneworks-worker validate_rejects -- --nocapture
- cargo test -p sceneworks-worker caption_items -- --nocapture
- cargo test -p sceneworks-worker image_explicit_model_path -- --nocapture
- cargo test -p sceneworks-worker validate_accepts_present_images -- --nocapture
- cargo test -p sceneworks-worker dry_run_summary_carries_plan_facts -- --nocapture
- cargo test -p sceneworks-worker -- --nocapture
- cargo clippy -p sceneworks-worker --all-targets -- -D warnings

Shortcut: sc-4214