### PR TITLE
sc-3778: in-app About → Licenses screen (aggregate bundled third-party notices)

### DIFF
--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "Source of truth for the in-app About → Licenses screen (sc-3778). License text lives alongside each entry in this directory; build-sidecar.mjs also stages these files next to the corresponding binaries in the packaged app. The `description` below is shown to end users — keep it user-facing.",
+  "description": "SceneWorks bundles the following third-party components. Their license notices and any written offers are reproduced below.",
+  "components": [
+    {
+      "id": "ffmpeg",
+      "name": "FFmpeg",
+      "version": "7.1",
+      "publisher": "The FFmpeg developers",
+      "license": "GPL-3.0-or-later",
+      "homepage": "https://ffmpeg.org/",
+      "platforms": ["macos"],
+      "usage": "Bundled static binary (macOS arm64), invoked as a separate program for video/audio encode, mux, frame sampling and timeline export.",
+      "documents": [
+        { "label": "Notice & written offer for source", "key": "ffmpeg-notice" },
+        { "label": "GNU General Public License v3", "key": "ffmpeg-gpl" }
+      ]
+    },
+    {
+      "id": "onnxruntime",
+      "name": "ONNX Runtime",
+      "version": "1.26.0",
+      "publisher": "Microsoft Corporation",
+      "license": "MIT",
+      "homepage": "https://onnxruntime.ai/",
+      "platforms": ["macos"],
+      "usage": "Bundled CoreML dynamic library (macOS arm64), loaded at runtime for the in-app DWPose pose detector.",
+      "documents": [
+        { "label": "Notice", "key": "onnxruntime-notice" },
+        { "label": "MIT License", "key": "onnxruntime-license" }
+      ]
+    }
+  ]
+}

--- a/apps/desktop/licenses/onnxruntime/LICENSE
+++ b/apps/desktop/licenses/onnxruntime/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/licenses/onnxruntime/NOTICE.txt
+++ b/apps/desktop/licenses/onnxruntime/NOTICE.txt
@@ -1,0 +1,22 @@
+ONNX Runtime — license notice
+==============================
+
+SceneWorks bundles the ONNX Runtime dynamic library (macOS arm64) and loads it
+at runtime for the in-app DWPose pose detector (sc-3487). See the accompanying
+LICENSE for the full MIT license text.
+
+License
+-------
+ONNX Runtime is licensed under the MIT License, Copyright (c) Microsoft
+Corporation. The MIT license requires that the copyright notice and permission
+notice (LICENSE) be included with the distribution; this notice and the
+accompanying LICENSE satisfy that requirement.
+
+Version & provenance
+--------------------
+- ONNX Runtime version: 1.26.0
+- Target: macOS arm64 (aarch64)
+- Component: the CoreML-enabled `libonnxruntime.<ver>.dylib`
+- Delivery: extracted from the official `onnxruntime` macOS arm64 PyPI wheel
+  (pinned in apps/desktop/scripts/stage-onnxruntime.py).
+- Upstream: https://github.com/microsoft/onnxruntime (https://onnxruntime.ai/).

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -63,6 +63,18 @@ if (triple.includes("apple-darwin")) {
   const py = process.env.PYTHON || "python3";
   run(py, ["apps/desktop/scripts/stage-onnxruntime.py", dylibDest]);
   console.log(`build-sidecar: staged ${dylibDest}`);
+  // onnxruntime is MIT — ship its license text + notice next to the dylib so the
+  // MIT "include the copyright + permission notice" requirement is satisfied at
+  // the distribution level (mirrors the ffmpeg GPLv3 §6 staging below). Source of
+  // truth: apps/desktop/licenses/onnxruntime/ (tracked); also surfaced in the
+  // in-app About → Licenses screen (sc-3778).
+  for (const name of ["LICENSE", "NOTICE.txt"]) {
+    copyFileSync(
+      join(desktopDir, "licenses", "onnxruntime", name),
+      join(ortDir, name),
+    );
+  }
+  console.log(`build-sidecar: staged onnxruntime MIT license + notice`);
 } else {
   writeFileSync(
     join(ortDir, "README.txt"),

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -19,6 +19,7 @@ import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
 import { SettingsScreen } from "./screens/SettingsScreen.jsx";
 import { LogsScreen } from "./screens/LogsScreen.jsx";
+import { LicensesScreen } from "./screens/LicensesScreen.jsx";
 import { SetupWizard } from "./screens/SetupWizard.jsx";
 import { editModelForAsset } from "./presetUtils.js";
 import { sortNewest, sortOldest, sortWorkers } from "./sorters.js";
@@ -189,6 +190,7 @@ const navSections = [
       { id: "Queue", icon: Icon.Queue },
       { id: "Logs", icon: Icon.Logs },
       { id: "Settings", icon: Icon.Sliders },
+      { id: "Licenses", icon: Icon.Info },
     ],
   },
 ];
@@ -213,6 +215,10 @@ const viewTitles = {
   Queue: { title: "Queue", blurb: "All running and recent jobs across workers." },
   Logs: { title: "Logs", blurb: "This session's activity — routing decisions, worker phases and errors." },
   Settings: { title: "Settings", blurb: "Paths, service tokens, and detected GPU." },
+  Licenses: {
+    title: "Licenses",
+    blurb: "Third-party components bundled with SceneWorks and their license notices.",
+  },
 };
 
 function readStoredTheme() {
@@ -1948,6 +1954,7 @@ export function App() {
         ) : null}
         {activeView === "Settings" ? <SettingsScreen /> : null}
         {activeView === "Logs" ? <LogsScreen /> : null}
+        {activeView === "Licenses" ? <LicensesScreen /> : null}
           </>
         )}
       </section>

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -39,6 +39,7 @@ export const Icon = {
   Bell: (p) => <I {...p} d="M6 16V11a6 6 0 0112 0v5l2 2H4zM10 20a2 2 0 004 0" />,
   Folder: (p) => <I {...p} d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />,
   Book: (p) => <I {...p} d="M5 4h11a2 2 0 012 2v14H7a2 2 0 00-2 2zM5 4v16M9 8h6M9 12h5" />,
+  Info: (p) => <I {...p} d="M12 3a9 9 0 100 18 9 9 0 000-18zM12 8h.01M11 12h1v5h1" />,
   ChevDown: (p) => <I {...p} d="M6 9l6 6 6-6" />,
   Sliders: (p) => <I {...p} d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h14M18 18h2M14 4v4M6 10v4M16 16v4" />,
   Play: (p) => <I {...p} fill d="M7 4l13 8-13 8z" />,

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -1,0 +1,34 @@
+// Bundled third-party license corpus for the About → Licenses screen (sc-3778).
+//
+// Single source of truth is apps/desktop/licenses/ — the same tracked files that
+// build-sidecar.mjs stages next to the bundled binaries (ffmpeg GPLv3 §6 text,
+// onnxruntime MIT notice). We import that corpus directly (manifest metadata as
+// JSON, license text as ?raw) rather than keeping a second copy here, so the
+// in-app notices can never drift from what actually ships. The embedded desktop
+// UI is the same web build, so this works on every platform with no Tauri command
+// or API round-trip.
+import manifest from "../../../desktop/licenses/manifest.json";
+import ffmpegNotice from "../../../desktop/licenses/ffmpeg/NOTICE.txt?raw";
+import ffmpegGpl from "../../../desktop/licenses/ffmpeg/COPYING.GPLv3?raw";
+import onnxruntimeNotice from "../../../desktop/licenses/onnxruntime/NOTICE.txt?raw";
+import onnxruntimeLicense from "../../../desktop/licenses/onnxruntime/LICENSE?raw";
+
+// Maps a manifest document `key` to its imported text. New components: add the
+// files under apps/desktop/licenses/<id>/, list them in manifest.json, and wire
+// their keys here.
+const DOCUMENT_TEXT = {
+  "ffmpeg-notice": ffmpegNotice,
+  "ffmpeg-gpl": ffmpegGpl,
+  "onnxruntime-notice": onnxruntimeNotice,
+  "onnxruntime-license": onnxruntimeLicense,
+};
+
+// Resolve each component's document keys to its actual text once, at module load.
+export const bundledLicenses = (manifest.components ?? []).map((component) => ({
+  ...component,
+  documents: (component.documents ?? [])
+    .map((doc) => ({ label: doc.label, text: DOCUMENT_TEXT[doc.key] }))
+    .filter((doc) => typeof doc.text === "string"),
+}));
+
+export const licensesIntro = manifest.description ?? "";

--- a/apps/web/src/screens/LicensesScreen.jsx
+++ b/apps/web/src/screens/LicensesScreen.jsx
@@ -1,0 +1,119 @@
+import React, { useMemo, useState } from "react";
+
+import { bundledLicenses, licensesIntro } from "../data/bundledLicenses.js";
+
+// About → Licenses (sc-3778). Aggregates the third-party components SceneWorks
+// redistributes in the desktop bundle (ffmpeg GPLv3, onnxruntime MIT, …) and
+// exposes their full license text plus any written offers, so the notices are
+// reachable from inside the app. The corpus is imported from the tracked
+// apps/desktop/licenses/ source of truth (see data/bundledLicenses.js), so this
+// screen renders identically on desktop, web and Docker with no backend call.
+export function LicensesScreen() {
+  const components = bundledLicenses;
+  const [selectedId, setSelectedId] = useState(components[0]?.id ?? null);
+  const [docIndex, setDocIndex] = useState(0);
+
+  const selected = useMemo(
+    () => components.find((component) => component.id === selectedId) ?? components[0] ?? null,
+    [components, selectedId],
+  );
+
+  const selectComponent = (id) => {
+    setSelectedId(id);
+    setDocIndex(0);
+  };
+
+  if (!selected) {
+    return (
+      <section className="main-surface licenses-screen">
+        <p className="licenses-empty">No bundled third-party components are recorded.</p>
+      </section>
+    );
+  }
+
+  const activeDoc = selected.documents[docIndex] ?? selected.documents[0];
+
+  return (
+    <section className="main-surface licenses-screen">
+      {licensesIntro ? <p className="licenses-intro">{licensesIntro}</p> : null}
+
+      <div className="licenses-layout">
+        <nav className="licenses-list" aria-label="Bundled components">
+          {components.map((component) => (
+            <button
+              key={component.id}
+              type="button"
+              className={component.id === selected.id ? "licenses-item active" : "licenses-item"}
+              aria-current={component.id === selected.id}
+              onClick={() => selectComponent(component.id)}
+            >
+              <span className="licenses-item-name">{component.name}</span>
+              <span className="licenses-item-meta">
+                {component.license}
+                {component.version ? ` · v${component.version}` : ""}
+              </span>
+            </button>
+          ))}
+        </nav>
+
+        <div className="licenses-detail">
+          <header className="licenses-detail-head">
+            <h3>{selected.name}</h3>
+            <dl className="licenses-facts">
+              {selected.publisher ? (
+                <>
+                  <dt>Publisher</dt>
+                  <dd>{selected.publisher}</dd>
+                </>
+              ) : null}
+              <dt>License</dt>
+              <dd>{selected.license}</dd>
+              {selected.version ? (
+                <>
+                  <dt>Version</dt>
+                  <dd>{selected.version}</dd>
+                </>
+              ) : null}
+              {selected.homepage ? (
+                <>
+                  <dt>Homepage</dt>
+                  <dd>
+                    <a href={selected.homepage} target="_blank" rel="noreferrer">
+                      {selected.homepage}
+                    </a>
+                  </dd>
+                </>
+              ) : null}
+            </dl>
+            {selected.usage ? <p className="licenses-usage">{selected.usage}</p> : null}
+          </header>
+
+          {selected.documents.length > 1 ? (
+            <div className="segmented-control" role="group" aria-label="License documents">
+              {selected.documents.map((doc, index) => (
+                <button
+                  key={doc.label}
+                  type="button"
+                  className={index === docIndex ? "active" : ""}
+                  onClick={() => setDocIndex(index)}
+                >
+                  {doc.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+
+          {activeDoc ? (
+            <pre className="licenses-text" aria-label={`${selected.name} — ${activeDoc.label}`}>
+              {activeDoc.text}
+            </pre>
+          ) : (
+            <p className="licenses-empty">No license text on file for this component.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default LicensesScreen;

--- a/apps/web/src/screens/LicensesScreen.test.jsx
+++ b/apps/web/src/screens/LicensesScreen.test.jsx
@@ -1,0 +1,68 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { LicensesScreen } from "./LicensesScreen.jsx";
+import { bundledLicenses } from "../data/bundledLicenses.js";
+
+// The corpus is imported from apps/desktop/licenses/ at build time, so these tests
+// assert against the real bundled notices rather than a mock.
+describe("LicensesScreen", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(<LicensesScreen />);
+    });
+  }
+
+  it("lists every bundled component", async () => {
+    await render();
+    const items = container.querySelectorAll(".licenses-item");
+    expect(items.length).toBe(bundledLicenses.length);
+    expect(container.textContent).toContain("FFmpeg");
+    expect(container.textContent).toContain("ONNX Runtime");
+  });
+
+  it("shows the first component's license text by default", async () => {
+    await render();
+    // ffmpeg is first: its written-offer notice mentions GPLv3 §6.
+    expect(container.querySelector(".licenses-text").textContent).toContain(
+      "Written offer for corresponding source",
+    );
+  });
+
+  it("switches the displayed component on selection", async () => {
+    await render();
+    const onnx = [...container.querySelectorAll(".licenses-item")].find((b) =>
+      b.textContent.includes("ONNX Runtime"),
+    );
+    await act(async () => onnx.click());
+    expect(container.textContent).toContain("Microsoft Corporation");
+    expect(container.querySelector(".licenses-text").textContent).toContain("MIT License");
+  });
+
+  it("switches between a component's license documents", async () => {
+    await render();
+    // ffmpeg has two docs (notice + GPL text); pick the GPL tab.
+    const gplTab = [...container.querySelectorAll(".segmented-control button")].find((b) =>
+      b.textContent.includes("General Public License"),
+    );
+    await act(async () => gplTab.click());
+    expect(container.querySelector(".licenses-text").textContent).toContain(
+      "GNU GENERAL PUBLIC LICENSE",
+    );
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8050,3 +8050,112 @@ label {
   overflow-x: auto;
   white-space: pre;
 }
+
+/* About → Licenses (sc-3778): aggregated third-party notices. Master list of
+   bundled components on the left, selected component's facts + full license text
+   on the right. */
+.licenses-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+.licenses-intro {
+  margin: 0;
+  color: var(--text-faint);
+  font-size: 13px;
+  max-width: 70ch;
+}
+.licenses-layout {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) 1fr;
+  gap: 16px;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.licenses-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  overflow-y: auto;
+}
+.licenses-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  cursor: pointer;
+}
+.licenses-item:hover {
+  background: var(--surface-2);
+}
+.licenses-item.active {
+  border-color: var(--accent);
+  background: color-mix(in oklch, var(--accent) 10%, transparent);
+}
+.licenses-item-name {
+  font-weight: 600;
+}
+.licenses-item-meta {
+  font-size: 11.5px;
+  color: var(--text-faint);
+}
+.licenses-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+.licenses-detail-head h3 {
+  margin: 0 0 8px;
+}
+.licenses-facts {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 12px;
+  margin: 0;
+  font-size: 13px;
+}
+.licenses-facts dt {
+  color: var(--text-faint);
+}
+.licenses-facts dd {
+  margin: 0;
+  word-break: break-word;
+}
+.licenses-usage {
+  margin: 8px 0 0;
+  color: var(--text-faint);
+  font-size: 13px;
+  max-width: 70ch;
+}
+.licenses-text {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: 0;
+  padding: 12px 14px;
+  overflow: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.licenses-empty {
+  padding: 24px;
+  color: var(--text-faint);
+  text-align: center;
+}
+@media (max-width: 720px) {
+  .licenses-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,4 +1,13 @@
-import { defineConfig } from "vite";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig, searchForWorkspaceRoot } from "vite";
+
+// The About → Licenses screen (sc-3778) imports the bundled-license corpus
+// directly from apps/desktop/licenses/ (single source of truth, no second copy).
+// That dir is outside the web project root, so the dev server / vitest module
+// loader would deny it unless it's on server.fs.allow. (The production embedded
+// build resolves these via rollup and isn't gated by this.)
+const licensesDir = fileURLToPath(new URL("../desktop/licenses", import.meta.url));
 
 export default defineConfig({
   // react-konva pulls its own react-reconciler; without deduping, Vite's dep
@@ -14,6 +23,11 @@ export default defineConfig({
   server: {
     headers: {
       "Cache-Control": "no-store",
+    },
+    fs: {
+      // Keep the default workspace-root allowance and add the desktop license
+      // corpus the Licenses screen imports from.
+      allow: [searchForWorkspaceRoot(process.cwd()), licensesDir],
     },
   },
   build: {


### PR DESCRIPTION
## What

Adds a reachable **System → Licenses** screen that aggregates the third-party components SceneWorks redistributes in the desktop bundle and exposes their full license text + written offers. Closes the optional-UX follow-up [sc-3778](https://app.shortcut.com/trefry/story/3778) (GPLv3 compliance itself was already satisfied by sc-3767 / #498 — this is the nicer-UX layer).

Components covered today (the genuinely bundled native binaries):
- **FFmpeg** — GPLv3 §6 notice + written source offer, sourced from the existing `apps/desktop/licenses/ffmpeg/` files staged by sc-3767.
- **ONNX Runtime** — MIT. This also **closes a latent MIT-notice gap**: `build-sidecar.mjs` now stages the onnxruntime `LICENSE`/`NOTICE.txt` next to the CoreML dylib it bundles (sc-3487), mirroring the ffmpeg §6 staging.

## How

- `apps/desktop/licenses/` stays the **single source of truth** (`manifest.json` + per-component text). New: `manifest.json`, `onnxruntime/LICENSE`, `onnxruntime/NOTICE.txt`.
- The web screen imports that corpus directly via Vite `?raw`, so it renders identically on desktop, web and Docker with **no Tauri command or API round-trip**. `vite.config.js` `server.fs.allow` is widened to the licenses dir for the dev server / vitest only (the production embedded build resolves it via rollup, which isn't fs-gated).
- New `System → Licenses` nav entry (Info icon), master-list + detail layout with document tabs.

## Verification
- 4 new vitest cases for the screen + **full web suite (400) green**, eslint clean (0 errors), production `vite build` OK.
- Live render in the browser preview (light + dark), component selection and document-tab switching, **no console errors**.

## Notes / follow-up
- The obsolete `blocks sc-3492` story relation still needs a **manual removal** in Shortcut (no remove-relation API).
- Reachability matches the existing System screens (Logs/Settings) — gated behind having a workspace. Filed a follow-up for broader **dependency-tree (cargo/npm) + model/vendor** license aggregation, which is a larger, tooling-driven effort beyond the two bundled binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)