### PR TITLE
Classify worker runtime errors separately

### DIFF
--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -135,9 +135,7 @@ pub(crate) async fn run_training_caption_job(
             JOY_CAPTION_MODEL,
             &LoadSpec::new(WeightsSource::Dir(weights_dir)),
         )
-        .map_err(|error| {
-            WorkerError::InvalidPayload(format!("JoyCaption MLX load failed: {error}"))
-        })?;
+        .map_err(|error| WorkerError::Engine(format!("JoyCaption MLX load failed: {error}")))?;
         emit_event(
             "caption_pipeline_load_complete",
             json!({
@@ -172,9 +170,7 @@ pub(crate) async fn run_training_caption_job(
             let output = captioner
                 .caption(&request, &mut on_progress)
                 .map_err(|error| {
-                    WorkerError::InvalidPayload(format!(
-                        "JoyCaption MLX generation failed: {error}"
-                    ))
+                    WorkerError::Engine(format!("JoyCaption MLX generation failed: {error}"))
                 })?;
             let text = mlx_gen::caption::joycaption::apply_trigger_words(
                 &output.text,
@@ -252,9 +248,9 @@ pub(crate) async fn run_training_caption_job(
         }
     }
 
-    blocking.await.map_err(|error| {
-        WorkerError::InvalidPayload(format!("caption task panicked: {error}"))
-    })??;
+    blocking
+        .await
+        .map_err(|error| task_join_error("caption task join", error))??;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -13,9 +13,7 @@ pub(crate) async fn fetch_bytes(http_client: &reqwest::Client, url: &str) -> Wor
         .send()
         .await?
         .error_for_status()
-        .map_err(|error| {
-            WorkerError::InvalidPayload(format!("weight download failed ({url}): {error}"))
-        })?
+        .map_err(|error| WorkerError::Engine(format!("weight download failed ({url}): {error}")))?
         .bytes()
         .await?
         .to_vec())

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1261,7 +1261,7 @@ fn mlx_load_with_ip(
         spec = spec.with_ip_adapter(WeightsSource::Dir(dir));
     }
     mlx_gen::load(engine_id, &spec)
-        .map_err(|error| WorkerError::InvalidPayload(format!("{engine_id} load failed: {error}")))
+        .map_err(|error| WorkerError::Engine(format!("{engine_id} load failed: {error}")))
 }
 
 /// XLabs FLUX IP-Adapter repos (epic 3621). The torch `flux_dev` path already declares +
@@ -1397,15 +1397,15 @@ fn mlx_generate_one(
     };
     let output = generator
         .generate(&request, on_progress)
-        .map_err(|error| WorkerError::InvalidPayload(format!("generation failed: {error}")))?;
+        .map_err(|error| WorkerError::Engine(format!("generation failed: {error}")))?;
     match output {
         GenerationOutput::Images(mut images) => {
-            let image = images.pop().ok_or_else(|| {
-                WorkerError::InvalidPayload("generator produced no image".to_owned())
-            })?;
+            let image = images
+                .pop()
+                .ok_or_else(|| WorkerError::Engine("generator produced no image".to_owned()))?;
             Ok((image.width, image.height, image.pixels))
         }
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "generator returned non-image output".to_owned(),
         )),
     }
@@ -1780,7 +1780,7 @@ async fn consume_gen_events(
 
     let task_result = blocking
         .await
-        .map_err(|error| WorkerError::InvalidPayload(format!("generation task join: {error}")))?;
+        .map_err(|error| task_join_error("generation task join", error))?;
     if canceled {
         // check_cancel already posted the Canceled update; treat the (likely) generate
         // error as the clean cancel.
@@ -1920,9 +1920,8 @@ fn zimage_control_load(
     if !adapters.is_empty() {
         spec = spec.with_adapters(adapters);
     }
-    mlx_gen::load(ZIMAGE_CONTROL_ENGINE_ID, &spec).map_err(|error| {
-        WorkerError::InvalidPayload(format!("Z-Image control load failed: {error}"))
-    })
+    mlx_gen::load(ZIMAGE_CONTROL_ENGINE_ID, &spec)
+        .map_err(|error| WorkerError::Engine(format!("Z-Image control load failed: {error}")))
 }
 
 /// Generate one strict-pose image: the `control` skeleton drives the Fun-Controlnet-Union
@@ -1969,17 +1968,17 @@ fn zimage_control_generate_one(
         cancel: cancel.clone(),
         ..Default::default()
     };
-    let output = generator.generate(&request, on_progress).map_err(|error| {
-        WorkerError::InvalidPayload(format!("control generation failed: {error}"))
-    })?;
+    let output = generator
+        .generate(&request, on_progress)
+        .map_err(|error| WorkerError::Engine(format!("control generation failed: {error}")))?;
     match output {
         GenerationOutput::Images(mut images) => {
             let image = images.pop().ok_or_else(|| {
-                WorkerError::InvalidPayload("control generator produced no image".to_owned())
+                WorkerError::Engine("control generator produced no image".to_owned())
             })?;
             Ok((image.width, image.height, image.pixels))
         }
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "control generator returned non-image output".to_owned(),
         )),
     }
@@ -2618,15 +2617,15 @@ fn flux2_edit_generate_one(
     };
     let output = generator
         .generate(&request, on_progress)
-        .map_err(|error| WorkerError::InvalidPayload(format!("edit generation failed: {error}")))?;
+        .map_err(|error| WorkerError::Engine(format!("edit generation failed: {error}")))?;
     match output {
         GenerationOutput::Images(mut images) => {
             let image = images.pop().ok_or_else(|| {
-                WorkerError::InvalidPayload("edit generator produced no image".to_owned())
+                WorkerError::Engine("edit generator produced no image".to_owned())
             })?;
             Ok((image.width, image.height, image.pixels))
         }
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "edit generator returned non-image output".to_owned(),
         )),
     }
@@ -2932,7 +2931,7 @@ fn qwen_control_load(
         spec = spec.with_adapters(adapters);
     }
     mlx_gen::load(QWEN_CONTROL_ENGINE_ID, &spec).map_err(|error| {
-        WorkerError::InvalidPayload(format!("Qwen strict-pose control load failed: {error}"))
+        WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
     })
 }
 
@@ -2972,18 +2971,16 @@ fn qwen_control_generate_one(
         ..Default::default()
     };
     let output = generator.generate(&request, on_progress).map_err(|error| {
-        WorkerError::InvalidPayload(format!("Qwen strict-pose generation failed: {error}"))
+        WorkerError::Engine(format!("Qwen strict-pose generation failed: {error}"))
     })?;
     match output {
         GenerationOutput::Images(mut images) => {
             let image = images.pop().ok_or_else(|| {
-                WorkerError::InvalidPayload(
-                    "Qwen strict-pose generator produced no image".to_owned(),
-                )
+                WorkerError::Engine("Qwen strict-pose generator produced no image".to_owned())
             })?;
             Ok((image.width, image.height, image.pixels))
         }
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "Qwen strict-pose generator returned non-image output".to_owned(),
         )),
     }
@@ -3441,15 +3438,15 @@ fn qwen_edit_generate_one(
     };
     let output = generator
         .generate(&request, on_progress)
-        .map_err(|error| WorkerError::InvalidPayload(format!("edit generation failed: {error}")))?;
+        .map_err(|error| WorkerError::Engine(format!("edit generation failed: {error}")))?;
     match output {
         GenerationOutput::Images(mut images) => {
             let image = images.pop().ok_or_else(|| {
-                WorkerError::InvalidPayload("edit generator produced no image".to_owned())
+                WorkerError::Engine("edit generator produced no image".to_owned())
             })?;
             Ok((image.width, image.height, image.pixels))
         }
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "edit generator returned non-image output".to_owned(),
         )),
     }
@@ -3862,16 +3859,16 @@ fn sensenova_edit_generate_one(
         ..Default::default()
     };
     let output = generator.generate(&request, on_progress).map_err(|error| {
-        WorkerError::InvalidPayload(format!("SenseNova edit generation failed: {error}"))
+        WorkerError::Engine(format!("SenseNova edit generation failed: {error}"))
     })?;
     match output {
         GenerationOutput::Images(mut images) => {
             let image = images.pop().ok_or_else(|| {
-                WorkerError::InvalidPayload("SenseNova edit produced no image".to_owned())
+                WorkerError::Engine("SenseNova edit produced no image".to_owned())
             })?;
             Ok((image.width, image.height, image.pixels))
         }
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "SenseNova edit returned non-image output".to_owned(),
         )),
     }
@@ -4200,7 +4197,7 @@ fn sdxl_advanced_load(
         spec = spec.with_adapters(adapters);
     }
     mlx_gen::load("sdxl", &spec)
-        .map_err(|error| WorkerError::InvalidPayload(format!("sdxl advanced load failed: {error}")))
+        .map_err(|error| WorkerError::Engine(format!("sdxl advanced load failed: {error}")))
 }
 
 /// Generate one SDXL image conditioned on `conditioning` (Reference[/Mask]). SDXL is true-CFG
@@ -4235,16 +4232,16 @@ fn sdxl_advanced_generate_one(
         ..Default::default()
     };
     let output = generator.generate(&request, on_progress).map_err(|error| {
-        WorkerError::InvalidPayload(format!("sdxl advanced generation failed: {error}"))
+        WorkerError::Engine(format!("sdxl advanced generation failed: {error}"))
     })?;
     match output {
         GenerationOutput::Images(mut images) => {
-            let image = images.pop().ok_or_else(|| {
-                WorkerError::InvalidPayload("sdxl advanced produced no image".to_owned())
-            })?;
+            let image = images
+                .pop()
+                .ok_or_else(|| WorkerError::Engine("sdxl advanced produced no image".to_owned()))?;
             Ok((image.width, image.height, image.pixels))
         }
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "sdxl advanced returned non-image output".to_owned(),
         )),
     }
@@ -4430,7 +4427,7 @@ async fn generate_sdxl_advanced_stream(
                     load_mask_asset_image(settings, &request.project_id, mask_id, project_path)?;
                 let user_mask = fit_engine_image(user_mask, width, height, "pad")?;
                 mask = mlx_gen::image::union_masks(&mask, &user_mask).map_err(|error| {
-                    WorkerError::InvalidPayload(format!("outpaint mask union failed: {error}"))
+                    WorkerError::Engine(format!("outpaint mask union failed: {error}"))
                 })?;
             }
             let strength = advanced::f32_clamped(
@@ -5172,36 +5169,33 @@ async fn generate_instantid_stream(
                 identitynet: controlnet,
                 ip_adapter,
             };
-            let model = InstantId::load(&paths).map_err(|error| {
-                WorkerError::InvalidPayload(format!("InstantID load failed: {error}"))
-            })?;
+            let model = InstantId::load(&paths)
+                .map_err(|error| WorkerError::Engine(format!("InstantID load failed: {error}")))?;
             // Attach OpenPose (pose mode) BEFORE quantize so it quantizes with the stack; quantize
             // before with_face (the engine's documented order).
             let model = match &openpose {
                 Some(source) => model.with_openpose(source).map_err(|error| {
-                    WorkerError::InvalidPayload(format!("InstantID OpenPose load failed: {error}"))
+                    WorkerError::Engine(format!("InstantID OpenPose load failed: {error}"))
                 })?,
                 None => model,
             };
             let model = match quant_bits {
                 Some(bits) => model.quantize(bits).map_err(|error| {
-                    WorkerError::InvalidPayload(format!("InstantID quantize failed: {error}"))
+                    WorkerError::Engine(format!("InstantID quantize failed: {error}"))
                 })?,
                 None => model,
             };
             let scrfd = Weights::from_file(&scrfd_path).map_err(|error| {
-                WorkerError::InvalidPayload(format!(
-                    "InstantID SCRFD weights {scrfd_path:?}: {error}"
-                ))
+                WorkerError::Engine(format!("InstantID SCRFD weights {scrfd_path:?}: {error}"))
             })?;
             let arcface = Weights::from_file(&arcface_path).map_err(|error| {
-                WorkerError::InvalidPayload(format!(
+                WorkerError::Engine(format!(
                     "InstantID ArcFace weights {arcface_path:?}: {error}"
                 ))
             })?;
-            let model = model.with_face(&scrfd, &arcface).map_err(|error| {
-                WorkerError::InvalidPayload(format!("InstantID face stack: {error}"))
-            })?;
+            let model = model
+                .with_face(&scrfd, &arcface)
+                .map_err(|error| WorkerError::Engine(format!("InstantID face stack: {error}")))?;
             // Face-restore needs the reference identity embedding (imposed on the re-rendered
             // crop). Detect it once on the raw reference.
             let restore_embedding = if face_restore {
@@ -5273,9 +5267,9 @@ async fn generate_instantid_stream(
                     // stop cleanly (consume_gen_events posts the Canceled update).
                     Err(_) if cancel.is_cancelled() => break,
                     Err(error) => {
-                        return Err(WorkerError::InvalidPayload(format!(
+                        return Err(WorkerError::Engine(format!(
                             "InstantID generation failed: {error}"
-                        )))
+                        )));
                     }
                 };
                 // Optional ADetailer-style face-restore re-render (sc-3380), imposing the
@@ -5437,7 +5431,7 @@ fn detail_load(
         spec = spec.with_quant(quant);
     }
     mlx_gen::load("sdxl", &spec)
-        .map_err(|error| WorkerError::InvalidPayload(format!("sdxl detail load failed: {error}")))
+        .map_err(|error| WorkerError::Engine(format!("sdxl detail load failed: {error}")))
 }
 
 /// Refine one tile (already sized to engine-valid `eng_w`×`eng_h`): img2img on the tile
@@ -5479,13 +5473,13 @@ fn detail_refine_tile(
     };
     let output = generator
         .generate(&request, &mut noop)
-        .map_err(|error| WorkerError::InvalidPayload(format!("detail tile failed: {error}")))?;
+        .map_err(|error| WorkerError::Engine(format!("detail tile failed: {error}")))?;
     match output {
         GenerationOutput::Images(mut images) => Ok(images
             .pop()
-            .ok_or_else(|| WorkerError::InvalidPayload("detail tile produced no image".to_owned()))?
+            .ok_or_else(|| WorkerError::Engine("detail tile produced no image".to_owned()))?
             .pixels),
-        _ => Err(WorkerError::InvalidPayload(
+        _ => Err(WorkerError::Engine(
             "detail tile returned non-image output".to_owned(),
         )),
     }
@@ -5814,7 +5808,7 @@ pub(crate) async fn run_image_detail_job(
 
     let (refined, tiles) = blocking
         .await
-        .map_err(|error| WorkerError::InvalidPayload(format!("detail task join: {error}")))??;
+        .map_err(|error| task_join_error("detail task join", error))??;
     let (out_w, out_h) = (refined.width(), refined.height());
     let media_path = project_path.join(&media_rel);
     let temp_path = media_path.with_extension("tmp.png");

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -27,7 +27,8 @@ use serde_json::{json, Value};
 
 use crate::image_jobs::{ensure_scrfd_weights, load_reference_image};
 use crate::{
-    heartbeat, progress_payload, update_job, ApiClient, Settings, WorkerError, WorkerResult,
+    heartbeat, progress_payload, task_join_error, update_job, ApiClient, Settings, WorkerError,
+    WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -117,16 +118,15 @@ impl KpsExtraction {
 /// Load SCRFD + detect the largest face's landmarks in `image`, normalized to the square
 /// preset space. Runs the `!Send` MLX work; call inside `spawn_blocking`.
 fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtraction> {
-    let weights = Weights::from_file(scrfd_path).map_err(|error| {
-        WorkerError::InvalidPayload(format!("SCRFD weights {scrfd_path:?}: {error}"))
-    })?;
+    let weights = Weights::from_file(scrfd_path)
+        .map_err(|error| WorkerError::Engine(format!("SCRFD weights {scrfd_path:?}: {error}")))?;
     let scrfd = Scrfd::from_weights(&weights)
-        .map_err(|error| WorkerError::InvalidPayload(format!("SCRFD load: {error}")))?;
+        .map_err(|error| WorkerError::Engine(format!("SCRFD load: {error}")))?;
     let (blob, det_scale) =
         detector_blob(&image.pixels, image.height as usize, image.width as usize);
     let dets = scrfd
         .detect(&blob, det_scale, DET_THRESH, NMS_THRESH)
-        .map_err(|error| WorkerError::InvalidPayload(format!("SCRFD detect: {error}")))?;
+        .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))?;
 
     let (w, h) = (image.width, image.height);
     let largest = dets.into_iter().max_by(|a, b| {
@@ -258,7 +258,7 @@ pub(crate) async fn run_kps_extract_job(
 
     let extraction = tokio::task::spawn_blocking(move || detect_largest_kps(&scrfd_path, &image))
         .await
-        .map_err(|e| WorkerError::InvalidPayload(format!("kps extraction task: {e}")))??;
+        .map_err(|error| task_join_error("kps extraction task", error))??;
 
     let message = if extraction.detected {
         "Face landmarks extracted."

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -299,6 +299,7 @@ pub enum WorkerError {
     ProjectStore(ProjectStoreError),
     Api { status: StatusCode, detail: String },
     InvalidPayload(String),
+    Engine(String),
     Canceled(String),
 }
 
@@ -311,6 +312,7 @@ impl fmt::Display for WorkerError {
             Self::ProjectStore(error) => write!(formatter, "{error}"),
             Self::Api { status, detail } => write!(formatter, "API {status}: {detail}"),
             Self::InvalidPayload(detail) => formatter.write_str(detail),
+            Self::Engine(detail) => formatter.write_str(detail),
             Self::Canceled(detail) => formatter.write_str(detail),
         }
     }
@@ -340,6 +342,10 @@ impl From<ProjectStoreError> for WorkerError {
     fn from(value: ProjectStoreError) -> Self {
         Self::ProjectStore(value)
     }
+}
+
+fn task_join_error(label: &str, error: tokio::task::JoinError) -> WorkerError {
+    WorkerError::Io(std::io::Error::other(format!("{label}: {error}")))
 }
 
 pub type WorkerResult<T> = Result<T, WorkerError>;

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -578,7 +578,7 @@ async fn run_yolo11_person_detect(
         crate::person_jobs::detect_people_blocking(weights, frame_path, conf)
     })
     .await
-    .map_err(|error| WorkerError::InvalidPayload(format!("person detect task: {error}")))??;
+    .map_err(|error| task_join_error("person detect task", error))??;
     let boxes =
         crate::person_jobs::detections_to_json(&result.detections, result.width, result.height);
     Ok((boxes, result.device))
@@ -689,9 +689,7 @@ async fn assemble_real_person_track(
             crate::person_jobs::detect_people_blocking(weights_for_frame, frame_for_task, conf)
         })
         .await
-        .map_err(|error| {
-            WorkerError::InvalidPayload(format!("person track detect task: {error}"))
-        })??;
+        .map_err(|error| task_join_error("person track detect task", error))??;
         device = result.device;
         let boxes = result
             .detections
@@ -2121,7 +2119,7 @@ pub(crate) async fn run_ffmpeg(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| {
-            WorkerError::InvalidPayload(format!(
+            WorkerError::Engine(format!(
                 "Failed to start FFmpeg. Ensure ffmpeg is installed and on PATH: {error}"
             ))
         })?;
@@ -2155,18 +2153,20 @@ pub(crate) async fn run_ffmpeg(
         child.wait().await?
     };
 
-    let stderr = stderr_task.await.unwrap_or_default();
+    let stderr = stderr_task
+        .await
+        .map_err(|error| task_join_error("ffmpeg stderr reader task", error))?;
     if status.success() {
         return Ok(());
     }
     let stderr = String::from_utf8_lossy(&stderr);
     let bounded = bounded_tail(&stderr, 10, 2000);
     if bounded.trim().is_empty() {
-        Err(WorkerError::InvalidPayload(
+        Err(WorkerError::Engine(
             "FFmpeg command failed without stderr output.".to_owned(),
         ))
     } else {
-        Err(WorkerError::InvalidPayload(bounded))
+        Err(WorkerError::Engine(bounded))
     }
 }
 

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -710,15 +710,13 @@ pub(crate) async fn run_model_convert_job(
         Ok(Ok(())) => {}
         Ok(Err(detail)) => {
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-            return Err(WorkerError::InvalidPayload(format!(
+            return Err(WorkerError::Engine(format!(
                 "MLX conversion failed. {detail}"
             )));
         }
         Err(join_error) => {
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-            return Err(WorkerError::InvalidPayload(format!(
-                "MLX conversion task panicked: {join_error}"
-            )));
+            return Err(task_join_error("MLX conversion task", join_error));
         }
     }
 
@@ -848,7 +846,7 @@ pub(crate) async fn download_model_with_hf_cli(
     }
 
     let mut child = command.spawn().map_err(|error| {
-        WorkerError::InvalidPayload(format!(
+        WorkerError::Engine(format!(
             "Failed to start Hugging Face CLI. Falling back to direct downloads is only possible when the CLI is absent, not when it fails to launch: {error}"
         ))
     })?;
@@ -874,7 +872,9 @@ pub(crate) async fn download_model_with_hf_cli(
             }
         }
     };
-    let stderr = stderr_task.await.unwrap_or_default();
+    let stderr = stderr_task
+        .await
+        .map_err(|error| task_join_error("Hugging Face CLI stderr reader task", error))?;
     let repo_cache_path =
         huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
             WorkerError::InvalidPayload(format!(
@@ -901,7 +901,7 @@ pub(crate) async fn download_model_with_hf_cli(
         } else {
             format!("Hugging Face CLI download failed:\n{detail}")
         };
-        return Err(WorkerError::InvalidPayload(message));
+        return Err(WorkerError::Engine(message));
     }
 
     let cache_path = huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_cache_path);

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -348,7 +348,7 @@ struct Yolo {
 impl Yolo {
     fn load(path: &Path) -> WorkerResult<Self> {
         let weights = Weights::from_file(path)
-            .map_err(|e| WorkerError::InvalidPayload(format!("yolo11m weights load: {e}")))?;
+            .map_err(|e| WorkerError::Engine(format!("yolo11m weights load: {e}")))?;
         let (ax, ay, st) = Self::build_anchors();
         Ok(Self {
             weights,

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -204,10 +204,9 @@ pub(crate) fn propagate_track_blocking(
     });
     if guard.is_none() {
         let weights = Weights::from_file(&weights_path)
-            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 weights load: {e}")))?;
-        let predictor =
-            Sam2VideoPredictor::from_weights_for_size(&weights, Sam2ModelSize::Large)
-                .map_err(|e| WorkerError::InvalidPayload(format!("sam2 predictor build: {e}")))?;
+            .map_err(|e| WorkerError::Engine(format!("sam2 weights load: {e}")))?;
+        let predictor = Sam2VideoPredictor::from_weights_for_size(&weights, Sam2ModelSize::Large)
+            .map_err(|e| WorkerError::Engine(format!("sam2 predictor build: {e}")))?;
         *guard = Some(predictor);
     }
     let predictor = guard.as_ref().expect("predictor loaded");
@@ -215,7 +214,7 @@ pub(crate) fn propagate_track_blocking(
     let run = |seeds: &[(usize, BoxNorm)]| -> WorkerResult<Vec<Vec<u8>>> {
         let mut state = predictor
             .init_state_from_frames(&frame_refs, height, width)
-            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 init_state: {e}")))?;
+            .map_err(|e| WorkerError::Engine(format!("sam2 init_state: {e}")))?;
         for &(idx, box_norm) in seeds {
             predictor
                 .add_new_box(
@@ -223,17 +222,17 @@ pub(crate) fn propagate_track_blocking(
                     idx as i32,
                     box_norm_to_pixels(box_norm, width, height),
                 )
-                .map_err(|e| WorkerError::InvalidPayload(format!("sam2 add_box: {e}")))?;
+                .map_err(|e| WorkerError::Engine(format!("sam2 add_box: {e}")))?;
         }
         let masks = predictor
             .propagate(&mut state)
-            .map_err(|e| WorkerError::InvalidPayload(format!("sam2 propagate: {e}")))?;
+            .map_err(|e| WorkerError::Engine(format!("sam2 propagate: {e}")))?;
         // `propagate` yields the prompt frame onward in order; build a dense per-clip-frame vec.
         let mut out = vec![Vec::new(); clip_frame_paths.len()];
         for (frame_idx, low) in &masks {
             let mask = predictor
                 .mask_to_video_res(&state, low)
-                .map_err(|e| WorkerError::InvalidPayload(format!("sam2 mask resize: {e}")))?;
+                .map_err(|e| WorkerError::Engine(format!("sam2 mask resize: {e}")))?;
             out[*frame_idx as usize] = mask.as_slice::<u8>().to_vec();
         }
         Ok(out)

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -33,8 +33,8 @@ use serde_json::{json, Value};
 
 use crate::openpose_skeleton::{body_stickwidth, draw_wholebody, Keypoint};
 use crate::{
-    heartbeat, optional_payload_string, progress_payload, update_job, ApiClient, Settings,
-    WorkerError, WorkerResult,
+    heartbeat, optional_payload_string, progress_payload, task_join_error, update_job, ApiClient,
+    Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -395,7 +395,7 @@ fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
 }
 
 fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
-    WorkerError::InvalidPayload(format!("onnxruntime: {e}"))
+    WorkerError::Engine(format!("onnxruntime: {e}"))
 }
 
 /// Run a single CHW float input; returns each f32 output as (shape, data), skipping
@@ -584,7 +584,7 @@ async fn ensure_one(
     let file_owned = file.to_owned();
     tokio::task::spawn_blocking(move || extract_onnx(&bytes, &file_owned, &target_clone))
         .await
-        .map_err(|e| WorkerError::InvalidPayload(format!("weight extract task: {e}")))??;
+        .map_err(|error| task_join_error("weight extract task", error))??;
     Ok(target)
 }
 
@@ -802,7 +802,7 @@ pub(crate) async fn run_pose_detect_job(
     let (raw, device) =
         tokio::task::spawn_blocking(move || detect_batch(det_path, pose_path, image_paths))
             .await
-            .map_err(|e| WorkerError::InvalidPayload(format!("pose detection task: {e}")))??;
+            .map_err(|error| task_join_error("pose detection task", error))??;
 
     let out_dir = settings
         .data_dir

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -177,13 +177,11 @@ pub(crate) async fn run_vqa_job(
                 max_new_tokens,
                 Sampler::Greedy,
             )
-            .map_err(|error| {
-                WorkerError::InvalidPayload(format!("SenseNova VQA failed: {error}"))
-            })?;
+            .map_err(|error| WorkerError::Engine(format!("SenseNova VQA failed: {error}")))?;
         Ok(strip_reasoning(&answer))
     })
     .await
-    .map_err(|error| WorkerError::InvalidPayload(format!("VQA task join: {error}")))??;
+    .map_err(|error| task_join_error("VQA task join", error))??;
 
     let result = json!({
         "answer": answer,
@@ -411,7 +409,7 @@ pub(crate) async fn run_interleave_job(
                     None,
                 )
                 .map_err(|error| {
-                    WorkerError::InvalidPayload(format!("SenseNova interleave failed: {error}"))
+                    WorkerError::Engine(format!("SenseNova interleave failed: {error}"))
                 })?;
             // The generated images are model-space [-1,1] `[1,3,H,W]` arrays — decode each to RGB8
             // exactly as the `Generator` image path does (`decoded_to_image`).
@@ -424,7 +422,7 @@ pub(crate) async fn run_interleave_job(
             Ok((out.text, decoded))
         })
         .await
-        .map_err(|error| WorkerError::InvalidPayload(format!("interleave task join: {error}")))??;
+        .map_err(|error| task_join_error("interleave task join", error))??;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -1974,12 +1974,12 @@ async fn ffmpeg_runner_surfaces_bounded_stderr_from_failing_process() {
         .expect_err("non-zero process returns an error");
 
     match error {
-        WorkerError::InvalidPayload(message) => {
+        WorkerError::Engine(message) => {
             assert!(message.contains("ffmpeg-line-30"));
             assert!(!message.contains("ffmpeg-line-1"));
             assert!(message.len() <= 2000);
         }
-        other => panic!("expected InvalidPayload, got {other:?}"),
+        other => panic!("expected Engine, got {other:?}"),
     }
 }
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -451,7 +451,7 @@ async fn run_training_execution(
             let mut trainer =
                 mlx_gen::load_trainer(engine_id, &LoadSpec::new(WeightsSource::Dir(weights_dir)))
                     .map_err(|error| {
-                    WorkerError::InvalidPayload(format!("{engine_id} trainer load failed: {error}"))
+                    WorkerError::Engine(format!("{engine_id} trainer load failed: {error}"))
                 })?;
             let request = TrainingRequest {
                 items,
@@ -469,9 +469,9 @@ async fn run_training_execution(
             let mut on_progress = |progress: TrainingProgress| {
                 let _ = tx.blocking_send(TrainEvent::Progress(progress));
             };
-            let output = trainer.train(&request, &mut on_progress).map_err(|error| {
-                WorkerError::InvalidPayload(format!("training failed: {error}"))
-            })?;
+            let output = trainer
+                .train(&request, &mut on_progress)
+                .map_err(|error| WorkerError::Engine(format!("training failed: {error}")))?;
             let _ = tx.blocking_send(TrainEvent::Done(output));
             Ok(())
         })
@@ -562,7 +562,7 @@ async fn consume_training_events(
 
     let task_result = blocking
         .await
-        .map_err(|error| WorkerError::InvalidPayload(format!("training task join: {error}")))?;
+        .map_err(|error| task_join_error("training task join", error))?;
     if canceled {
         // check_cancel already posted the Canceled update; treat the engine's
         // early return as the clean cancel.

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -34,8 +34,8 @@ use ort::value::Tensor;
 use serde_json::{json, Value};
 
 use crate::{
-    fresh_asset_id, heartbeat, now_rfc3339, progress_payload, update_job, ApiClient, Settings,
-    WorkerError, WorkerResult,
+    fresh_asset_id, heartbeat, now_rfc3339, progress_payload, task_join_error, update_job,
+    ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -129,7 +129,7 @@ struct Upscaler {
 static UPSCALERS: OnceLock<Mutex<HashMap<u8, Upscaler>>> = OnceLock::new();
 
 fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
-    WorkerError::InvalidPayload(format!("onnxruntime: {e}"))
+    WorkerError::Engine(format!("onnxruntime: {e}"))
 }
 
 fn build_session(path: &Path, coreml: bool) -> WorkerResult<Session> {
@@ -447,7 +447,7 @@ pub(crate) async fn run_image_upscale_job(
     let upscaled =
         tokio::task::spawn_blocking(move || upscale_blocking(onnx_path, factor, source_image))
             .await
-            .map_err(|e| WorkerError::InvalidPayload(format!("upscale task: {e}")))??;
+            .map_err(|error| task_join_error("upscale task", error))??;
     let (out_w, out_h) = (upscaled.width(), upscaled.height());
 
     // write exactly one child asset with lineage back to the source (mirrors

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1510,7 +1510,7 @@ fn run_video_generation(
         adapters: input.adapters,
     };
     let generator = mlx_gen::load(input.engine_id, &spec)
-        .map_err(|error| WorkerError::InvalidPayload(format!("video load failed: {error}")))?;
+        .map_err(|error| WorkerError::Engine(format!("video load failed: {error}")))?;
     let req = GenerationRequest {
         prompt: input.prompt,
         negative_prompt: input.negative_prompt,
@@ -1535,9 +1535,9 @@ fn run_video_generation(
         cancel: cancel.clone(),
         ..Default::default()
     };
-    let output = generator.generate(&req, on_progress).map_err(|error| {
-        WorkerError::InvalidPayload(format!("video generation failed: {error}"))
-    })?;
+    let output = generator
+        .generate(&req, on_progress)
+        .map_err(|error| WorkerError::Engine(format!("video generation failed: {error}")))?;
     match output {
         GenerationOutput::Video { frames, fps, audio } => Ok(DecodedVideo {
             frames: frames
@@ -1555,7 +1555,7 @@ fn run_video_generation(
                 channels: track.channels,
             }),
         }),
-        GenerationOutput::Images(_) => Err(WorkerError::InvalidPayload(
+        GenerationOutput::Images(_) => Err(WorkerError::Engine(
             "video model returned images, expected video frames".to_owned(),
         )),
     }
@@ -1646,7 +1646,7 @@ async fn generate_video(
 
     let result = blocking
         .await
-        .map_err(|error| WorkerError::InvalidPayload(format!("video task join: {error}")))?;
+        .map_err(|error| task_join_error("video task join", error))?;
     if canceled {
         return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
     }
@@ -2777,7 +2777,7 @@ async fn select_extracted_frames(work_dir: PathBuf, count: usize) -> WorkerResul
             .collect()
     })
     .await
-    .map_err(|error| WorkerError::InvalidPayload(format!("frame decode task: {error}")))?
+    .map_err(|error| task_join_error("frame decode task", error))?
 }
 
 /// The approved character reference images (≤4) for the replacement (Python
@@ -3166,7 +3166,7 @@ async fn select_anchor_frames(
         selected.iter().map(|path| decode_png_image(path)).collect()
     })
     .await
-    .map_err(|error| WorkerError::InvalidPayload(format!("frame decode task: {error}")))?
+    .map_err(|error| task_join_error("frame decode task", error))?
 }
 
 /// Decode one RGB PNG into an engine [`Image`] (shared by the resample + anchor frame selectors).


### PR DESCRIPTION
## Summary
- add `WorkerError::Engine` for model/runtime/external process failures distinct from payload validation
- convert MLX/ONNX/SAM/SCRFD/SenseNova/training/video generation failures and blocking task joins to `Engine`/`Io`
- keep malicious input and request-shape validation on `InvalidPayload`; update ffmpeg stderr regression to assert `Engine`

## Validation
- `cargo fmt --check`
- `cargo test -p sceneworks-worker ffmpeg_runner_surfaces_bounded_stderr_from_failing_process -- --nocapture`
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`
- `cargo test -p sceneworks-worker -- --nocapture` (236 passed, 42 ignored; expected poison-lock panic text from recovery test)

Shortcut: sc-4218