### PR TITLE
test(worker): real-Mac Kolors validation smokes (T2I + LoRA training step)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -6553,6 +6553,30 @@ mod tests {
         );
     }
 
+    /// Real-weights smoke (sc-3875 + sc-4764): load + generate one Kolors T2I image through the
+    /// worker's own `kolors` engine path. Exercises the ChatGLM3-6B encoder + SDXL-family U-Net +
+    /// SDXL VAE load AND, critically, proves the snapshot's overlaid `tokenizer/tokenizer.json`
+    /// (sc-4764) lets `KolorsTokenizer::from_dir` construct — the engine errors here without it.
+    /// Needs the HF cache (`Kwai-Kolors/Kolors-diffusers`, with the tokenizer overlay) + a Metal
+    /// device; run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored kolors_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real Kolors weights (+ tokenizer.json overlay) + Metal device"]
+    fn kolors_real_weights_generates_one_image() {
+        let snapshot = hf_snapshot("models--Kwai-Kolors--Kolors-diffusers");
+        assert!(
+            snapshot.join("tokenizer").join("tokenizer.json").exists(),
+            "kolors snapshot is missing the overlaid tokenizer.json (sc-4764)"
+        );
+        smoke_generate_one(
+            "kolors",
+            snapshot,
+            Some(5.0),
+            Some("blurry, low quality".to_owned()),
+        );
+    }
+
     /// L2-normalized cosine similarity between two ArcFace embeddings (test helper).
     #[cfg(target_os = "macos")]
     fn cosine(a: &[f32], b: &[f32]) -> f32 {

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -1046,4 +1046,104 @@ mod tests {
         assert_eq!(cfg.timestep_type, "sigmoid");
         assert_eq!(cfg.loss_type, "mse");
     }
+
+    /// Real-weights smoke (sc-4732 + sc-4764): load the Kolors trainer from the installed
+    /// `Kwai-Kolors/Kolors-diffusers` snapshot and run two LoRA micro-steps on a one-image dataset.
+    /// Proves the worker links `mlx-gen-kolors` (the `load_trainer("kolors", …)` registration), the
+    /// snapshot's overlaid `tokenizer/tokenizer.json` (sc-4764) lets the trainer construct, and a
+    /// real step runs (finite loss) + writes an adapter on the Mac GPU. The trainer loads the base
+    /// at **f32** (engine choice for clean autograd), so this is memory-heavy. Run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored kolors_real_weights_trains --nocapture`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real Kolors weights (+ tokenizer.json overlay) + Metal device; f32 base is heavy"]
+    fn kolors_real_weights_trains_a_lora_step() {
+        let home = std::path::PathBuf::from(std::env::var_os("HOME").expect("HOME set"));
+        let snapshot = std::fs::read_dir(
+            home.join(".cache/huggingface/hub/models--Kwai-Kolors--Kolors-diffusers/snapshots"),
+        )
+        .expect("kolors snapshots dir")
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| path.is_dir())
+        .expect("a kolors snapshot dir");
+        assert!(
+            snapshot.join("tokenizer").join("tokenizer.json").exists(),
+            "kolors snapshot is missing the overlaid tokenizer.json (sc-4764)"
+        );
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let image_path = tmp.path().join("swatch.png");
+        image::RgbImage::from_fn(512, 512, |x, y| {
+            image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
+        })
+        .save(&image_path)
+        .expect("write test image");
+        let output_dir = tmp.path().join("out");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        let config = TrainingConfig {
+            rank: 4,
+            alpha: 4.0,
+            learning_rate: 1e-4,
+            steps: 2,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 512,
+            save_every: 0,
+            seed: 42,
+            optimizer: "adamw".to_owned(),
+            weight_decay: 0.0,
+            lr_scheduler: LrSchedule::parse("constant"),
+            lr_warmup_steps: 0,
+            network_type: NetworkType::parse("lora"),
+            decompose_factor: -1,
+            lora_target_modules: Vec::new(),
+            timestep_type: "sigmoid".to_owned(),
+            timestep_bias: "balanced".to_owned(),
+            loss_type: "mse".to_owned(),
+            trigger_word: None,
+        };
+        let request = TrainingRequest {
+            items: vec![TrainingItem {
+                image_path,
+                caption: "a colorful test swatch".to_owned(),
+            }],
+            config,
+            output_dir: output_dir.clone(),
+            file_name: "kolors_smoke.safetensors".to_owned(),
+            trigger_words: Vec::new(),
+            cancel: CancelFlag::new(),
+        };
+
+        let mut trainer =
+            mlx_gen::load_trainer("kolors", &LoadSpec::new(WeightsSource::Dir(snapshot)))
+                .expect("kolors trainer loads (tokenizer.json present)");
+        trainer
+            .validate(&request)
+            .expect("trainer accepts the plan");
+        let mut last_loss = f32::NAN;
+        let output = trainer
+            .train(&request, &mut |progress| {
+                if let TrainingProgress::Training { loss, .. } = progress {
+                    last_loss = loss;
+                }
+            })
+            .expect("training runs a step");
+
+        eprintln!(
+            "[kolors-train-smoke] steps={} final_loss={} last_step_loss={} adapter={}",
+            output.steps,
+            output.final_loss,
+            last_loss,
+            output.adapter_path.display()
+        );
+        assert!(output.steps >= 1, "expected at least one micro-step");
+        assert!(output.final_loss.is_finite(), "final loss must be finite");
+        assert!(last_loss.is_finite(), "a training-step loss was observed");
+        assert!(
+            output_dir.join("kolors_smoke.safetensors").exists(),
+            "trained adapter was written"
+        );
+    }
 }


### PR DESCRIPTION
Supplementary regression coverage + the real-Mac validation record for the Kolors cutover ([#589](https://github.com/michaeltrefry/SceneWorks/pull/589): sc-3875 / sc-4732 / sc-4764).

Two on-demand `#[ignore]` real-weight smokes (mirroring the sdxl/chroma/sensenova ones), each asserting the snapshot's overlaid `tokenizer/tokenizer.json` (sc-4764) is present — the engine errors without it, so these guard the overlay:

- **`kolors_real_weights_generates_one_image`** — loads the `kolors` engine model + generates one 512² T2I image (non-flat + denoise-step progress). Validates sc-3875 + sc-4764.
- **`kolors_real_weights_trains_a_lora_step`** — loads the `KolorsTrainer` + runs 2 LoRA micro-steps on a 1-image dataset (finite loss + written adapter). Validates sc-4732 + sc-4764.

**Verified on Apple-Silicon (this PR's evidence):**
- T2I: non-flat image, real denoise steps.
- Training: `steps=2, final_loss=0.0495, adapter written` (≈ the engine sc-4568 e2e ~0.05).

Skipped in CI (need the 17 GB Kolors weights, not in CI); run locally with `cargo test -p sceneworks-worker --lib -- --ignored kolors_real_weights`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)