### PR TITLE
Stream first-use worker weight downloads

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -1,45 +1,96 @@
 use super::*;
 use std::net::SocketAddr;
 
-/// GET `url` into memory via the shared HTTP client, with a clear error on a
-/// non-success status. The common fetch behind the worker's download-on-first-use
-/// weight fetchers (sc-4283 / F-MLXW-22) — one place to later add streaming /
-/// size-limits / integrity verification (F-MLXW-21) instead of the former four
-/// hand-rolled copies.
-#[cfg(target_os = "macos")]
-pub(crate) async fn fetch_bytes(http_client: &reqwest::Client, url: &str) -> WorkerResult<Vec<u8>> {
-    Ok(http_client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|error| WorkerError::Engine(format!("weight download failed ({url}): {error}")))?
-        .bytes()
-        .await?
-        .to_vec())
-}
-
-/// Download `url` to `target` on first use: return it if already present, else GET
-/// into a sibling `.download.tmp` then atomically rename into place, so a partial
-/// download is never mistaken for a complete file. Creates `target`'s parent dir.
-/// Replaces the four bespoke GET→tmp→rename copies (sc-4283 / F-MLXW-22).
+/// Download `url` to `target` on first use. Existing complete files are reused;
+/// partial files resume with HTTP Range when the caller can provide `expected_size`.
+/// The transfer shares model-download progress/cancel plumbing instead of buffering
+/// the response body in memory.
 #[cfg(target_os = "macos")]
 pub(crate) async fn ensure_cached_file(
-    http_client: &reqwest::Client,
+    context: &DownloadContext<'_>,
     url: &str,
     target: &Path,
+    label: &str,
+    expected_size: Option<u64>,
 ) -> WorkerResult<PathBuf> {
-    if target.exists() {
+    let expected_size = match expected_size {
+        Some(size) => Some(size),
+        None => remote_content_length(context.client, url).await?,
+    };
+    if let Ok(metadata) = tokio::fs::metadata(target).await {
+        if expected_size
+            .map(|expected| metadata.len() == expected)
+            .unwrap_or(true)
+        {
+            return Ok(target.to_path_buf());
+        }
+    }
+    if expected_size.is_none() && target.exists() {
         return Ok(target.to_path_buf());
     }
     if let Some(parent) = target.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-    let bytes = fetch_bytes(http_client, url).await?;
-    let tmp = target.with_extension("download.tmp");
-    tokio::fs::write(&tmp, &bytes).await?;
-    tokio::fs::rename(&tmp, target).await?;
+    let started_bytes = existing_download_bytes(target, expected_size).await?;
+    let mut progress = DownloadProgress::new(
+        label,
+        started_bytes,
+        expected_size,
+        progress_report_interval(context.settings),
+    );
+    download_file(context, url, target, expected_size, label, &mut progress).await?;
     Ok(target.to_path_buf())
+}
+
+#[cfg(target_os = "macos")]
+async fn remote_content_length(client: &reqwest::Client, url: &str) -> WorkerResult<Option<u64>> {
+    let response = match client.head(url).send().await {
+        Ok(response) => response,
+        Err(_) => return Ok(None),
+    };
+    if response.status().is_success() {
+        Ok(response.content_length().filter(|value| *value > 0))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Resolve a single Hugging Face file and stream it into an app cache target with
+/// size-aware resume/progress. This is for first-use runtime weights that are not
+/// installed through the full model-download flow.
+#[cfg(target_os = "macos")]
+pub(crate) async fn ensure_hf_cached_file(
+    context: &DownloadContext<'_>,
+    repo: &str,
+    revision: &str,
+    file: &str,
+    target: &Path,
+) -> WorkerResult<PathBuf> {
+    let snapshot = HuggingFaceSnapshot::resolve(
+        context.client,
+        context.settings,
+        repo,
+        revision,
+        &[file.to_owned()],
+    )
+    .await?;
+    let Some(snapshot_file) = snapshot
+        .files
+        .into_iter()
+        .find(|candidate| candidate.path == file)
+    else {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Hugging Face file {file} not found in {repo}."
+        )));
+    };
+    ensure_cached_file(
+        context,
+        &snapshot_file.download_url,
+        target,
+        &snapshot_file.path,
+        snapshot_file.size,
+    )
+    .await
 }
 
 #[derive(Debug, Clone)]
@@ -929,7 +980,11 @@ pub fn download_progress_payload(
 
 #[cfg(all(test, target_os = "macos"))]
 mod ensure_cached_file_tests {
-    use super::ensure_cached_file;
+    use super::{ensure_cached_file, DownloadContext};
+    use crate::{
+        ApiClient, Settings, DEFAULT_HUGGINGFACE_BASE_URL, DEFAULT_MAX_LORA_URL_BYTES,
+        DEFAULT_MAX_MODEL_URL_BYTES,
+    };
 
     /// sc-4283 / F-MLXW-22: when the target already exists, `ensure_cached_file`
     /// returns it without any network access (the cache-hit short-circuit shared
@@ -947,10 +1002,43 @@ mod ensure_cached_file_tests {
             .expect("seed target");
 
         let client = reqwest::Client::new();
-        let resolved =
-            ensure_cached_file(&client, "http://invalid.invalid/should-not-fetch", &target)
-                .await
-                .expect("cache hit returns without downloading");
+        let settings = Settings {
+            api_url: "http://127.0.0.1:1".to_owned(),
+            access_token: None,
+            data_dir: dir.path().join("data"),
+            config_dir: dir.path().join("config"),
+            worker_id: "test-worker".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            is_child_worker: false,
+            poll_seconds: 1,
+            heartbeat_seconds: 5,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: DEFAULT_HUGGINGFACE_BASE_URL.to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            max_lora_url_bytes: DEFAULT_MAX_LORA_URL_BYTES,
+            max_model_url_bytes: DEFAULT_MAX_MODEL_URL_BYTES,
+            allow_private_lora_urls: false,
+            utility_workers: 1,
+        };
+        let api = ApiClient::new(&settings);
+        let context = DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        };
+        let resolved = ensure_cached_file(
+            &context,
+            "http://invalid.invalid/should-not-fetch",
+            &target,
+            "test weights",
+            Some(12),
+        )
+        .await
+        .expect("cache hit returns without downloading");
         assert_eq!(resolved, target);
         // Content untouched (no overwrite).
         assert_eq!(

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -4862,12 +4862,12 @@ fn instantid_raw_settings(
 /// for a complete one — same shape as `person_segment::ensure_segmenter_weights`).
 #[cfg(target_os = "macos")]
 async fn ensure_instantid_file(
-    client: &reqwest::Client,
+    context: &DownloadContext<'_>,
+    repo: &str,
     dir: &Path,
     name: &str,
-    url: &str,
 ) -> WorkerResult<PathBuf> {
-    ensure_cached_file(client, url, &dir.join(name)).await
+    ensure_hf_cached_file(context, repo, "main", name, &dir.join(name)).await
 }
 
 /// Resolve only the SCRFD detector weights (`scrfd_10g.safetensors`) from the same converted
@@ -4876,17 +4876,28 @@ async fn ensure_instantid_file(
 /// (`SCENEWORKS_INSTANTID_WEIGHTS`) + app cache + download-on-first-use with
 /// [`ensure_instantid_weights`], so a prior InstantID run leaves it already cached.
 #[cfg(target_os = "macos")]
-pub(crate) async fn ensure_scrfd_weights(settings: &Settings) -> WorkerResult<PathBuf> {
+pub(crate) async fn ensure_scrfd_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<PathBuf> {
     let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "KPS extraction canceled while fetching SCRFD weights.",
+        fresh_download: false,
+    };
     let bundle_dir = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
         .map(PathBuf::from)
         .unwrap_or_else(|_| settings.data_dir.join("cache").join("instantid-mlx"));
-    let base = format!("https://huggingface.co/{INSTANTID_MLX_REPO}/resolve/main");
     ensure_instantid_file(
-        &client,
+        &context,
+        INSTANTID_MLX_REPO,
         &bundle_dir,
         INSTANTID_SCRFD_FILE,
-        &format!("{base}/{INSTANTID_SCRFD_FILE}"),
     )
     .await
 }
@@ -4897,35 +4908,44 @@ pub(crate) async fn ensure_scrfd_weights(settings: &Settings) -> WorkerResult<Pa
 /// an env override / the HF cache before any network fetch.
 #[cfg(target_os = "macos")]
 async fn ensure_instantid_weights(
+    api: &ApiClient,
     settings: &Settings,
+    job: &JobSnapshot,
 ) -> WorkerResult<(WeightsSource, PathBuf, PathBuf, PathBuf)> {
     let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "InstantID generation canceled while fetching weights.",
+        fresh_download: false,
+    };
 
     // Converted bundle (ip-adapter + face stack): an env-pinned dir (pre-staged for local
     // validation) wins, else the app cache (download missing files from SceneWorks/instantid-mlx).
     let bundle_dir = std::env::var("SCENEWORKS_INSTANTID_WEIGHTS")
         .map(PathBuf::from)
         .unwrap_or_else(|_| settings.data_dir.join("cache").join("instantid-mlx"));
-    let base = format!("https://huggingface.co/{INSTANTID_MLX_REPO}/resolve/main");
     let ip_adapter = ensure_instantid_file(
-        &client,
+        &context,
+        INSTANTID_MLX_REPO,
         &bundle_dir,
         INSTANTID_IP_ADAPTER_FILE,
-        &format!("{base}/{INSTANTID_IP_ADAPTER_FILE}"),
     )
     .await?;
     let scrfd = ensure_instantid_file(
-        &client,
+        &context,
+        INSTANTID_MLX_REPO,
         &bundle_dir,
         INSTANTID_SCRFD_FILE,
-        &format!("{base}/{INSTANTID_SCRFD_FILE}"),
     )
     .await?;
     let arcface = ensure_instantid_file(
-        &client,
+        &context,
+        INSTANTID_MLX_REPO,
         &bundle_dir,
         INSTANTID_ARCFACE_FILE,
-        &format!("{base}/{INSTANTID_ARCFACE_FILE}"),
     )
     .await?;
 
@@ -4948,10 +4968,16 @@ async fn ensure_instantid_weights(
         }
     }
     let controlnet_dir = settings.data_dir.join("cache").join("instantid-controlnet");
-    let cn_base =
-        format!("https://huggingface.co/{INSTANTID_CONTROLNET_REPO}/resolve/main/ControlNetModel");
     for file in INSTANTID_CONTROLNET_FILES {
-        ensure_instantid_file(&client, &controlnet_dir, file, &format!("{cn_base}/{file}")).await?;
+        let source = format!("ControlNetModel/{file}");
+        ensure_hf_cached_file(
+            &context,
+            INSTANTID_CONTROLNET_REPO,
+            "main",
+            &source,
+            &controlnet_dir.join(file),
+        )
+        .await?;
     }
     Ok((
         WeightsSource::Dir(controlnet_dir),
@@ -4965,7 +4991,11 @@ async fn ensure_instantid_weights(
 /// (`SCENEWORKS_INSTANTID_OPENPOSE`) → HF cache snapshot → download the two files on first use. A
 /// stock diffusers SDXL ControlNet (loads via `with_openpose`/`load_controlnet`, no conversion).
 #[cfg(target_os = "macos")]
-async fn ensure_instantid_openpose(settings: &Settings) -> WorkerResult<WeightsSource> {
+async fn ensure_instantid_openpose(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<WeightsSource> {
     if let Ok(dir) = std::env::var("SCENEWORKS_INSTANTID_OPENPOSE") {
         let dir = PathBuf::from(dir);
         if dir.is_dir() {
@@ -4981,10 +5011,17 @@ async fn ensure_instantid_openpose(settings: &Settings) -> WorkerResult<WeightsS
         }
     }
     let client = reqwest::Client::new();
+    let context = DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "InstantID generation canceled while fetching OpenPose weights.",
+        fresh_download: false,
+    };
     let dir = settings.data_dir.join("cache").join("instantid-openpose");
-    let base = format!("https://huggingface.co/{INSTANTID_OPENPOSE_REPO}/resolve/main");
     for file in INSTANTID_CONTROLNET_FILES {
-        ensure_instantid_file(&client, &dir, file, &format!("{base}/{file}")).await?;
+        ensure_instantid_file(&context, INSTANTID_OPENPOSE_REPO, &dir, file).await?;
     }
     Ok(WeightsSource::Dir(dir))
 }
@@ -5029,7 +5066,7 @@ async fn generate_instantid_stream(
     )?;
 
     let (controlnet, ip_adapter, scrfd_path, arcface_path) =
-        ensure_instantid_weights(settings).await?;
+        ensure_instantid_weights(api, settings, job).await?;
 
     let steps = instantid_steps(request);
     let guidance = instantid_guidance(request);
@@ -5070,7 +5107,7 @@ async fn generate_instantid_stream(
     // Load the xinsir OpenPose ControlNet only for pose mode (it is the MultiControlNet second
     // branch; identity/angle modes don't need it).
     let openpose = if pose_set {
-        Some(ensure_instantid_openpose(settings).await?)
+        Some(ensure_instantid_openpose(api, settings, job).await?)
     } else {
         None
     };

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -239,7 +239,7 @@ pub(crate) async fn run_kps_extract_job(
     .await?;
 
     let image = load_source_image(settings, job)?;
-    let scrfd_path = ensure_scrfd_weights(settings).await?;
+    let scrfd_path = ensure_scrfd_weights(api, settings, job).await?;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -439,9 +439,15 @@ pub(crate) async fn run_person_detect(
                 Value::Null,
             )
         } else {
-            let (boxes, device) =
-                run_yolo11_person_detect(settings, http_client, media_path.clone(), confidence)
-                    .await?;
+            let (boxes, device) = run_yolo11_person_detect(
+                api,
+                settings,
+                http_client,
+                job,
+                media_path.clone(),
+                confidence,
+            )
+            .await?;
             (
                 boxes,
                 "yolo11m".to_owned(),
@@ -567,12 +573,22 @@ pub(crate) async fn run_person_detect(
 /// (epic 3482, sc-3633); the Python Ultralytics path serves Windows/Linux.
 #[cfg(target_os = "macos")]
 async fn run_yolo11_person_detect(
+    api: &ApiClient,
     settings: &Settings,
     http_client: &reqwest::Client,
+    job: &JobSnapshot,
     frame_path: PathBuf,
     confidence: f64,
 ) -> WorkerResult<(Vec<Value>, &'static str)> {
-    let weights = crate::person_jobs::ensure_detector_weights(settings, http_client).await?;
+    let download_context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Person detection canceled while fetching detector weights.",
+        fresh_download: false,
+    };
+    let weights = crate::person_jobs::ensure_detector_weights(settings, &download_context).await?;
     let conf = confidence as f32;
     let result = tokio::task::spawn_blocking(move || {
         crate::person_jobs::detect_people_blocking(weights, frame_path, conf)
@@ -586,8 +602,10 @@ async fn run_yolo11_person_detect(
 
 #[cfg(not(target_os = "macos"))]
 async fn run_yolo11_person_detect(
+    _api: &ApiClient,
     _settings: &Settings,
     _http_client: &reqwest::Client,
+    _job: &JobSnapshot,
     _frame_path: PathBuf,
     _confidence: f64,
 ) -> WorkerResult<(Vec<Value>, &'static str)> {
@@ -650,7 +668,15 @@ async fn assemble_real_person_track(
     use crate::person_track as pt;
 
     let selected_box = pt::NormalizedBox::from_json(detection.get("box").unwrap_or(&Value::Null));
-    let weights = crate::person_jobs::ensure_detector_weights(settings, http_client).await?;
+    let download_context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Person tracking canceled while fetching detector weights.",
+        fresh_download: false,
+    };
+    let weights = crate::person_jobs::ensure_detector_weights(settings, &download_context).await?;
     let conf = confidence as f32;
     let timestamps = pt::sample_timestamps(duration);
 
@@ -739,7 +765,7 @@ async fn assemble_real_person_track(
         &mut frames_json,
         segment_enabled,
     )
-    .await;
+    .await?;
     let _ = tokio::fs::remove_dir_all(&work_dir).await;
 
     Ok(RealPersonTrack {
@@ -785,37 +811,46 @@ async fn segment_assembly_frames(
     frame_paths: &[PathBuf],
     frames_json: &mut [Value],
     segment_enabled: bool,
-) -> &'static str {
+) -> WorkerResult<&'static str> {
     let detected_total = frames.iter().filter(|frame| frame.detected).count();
     if detected_total == 0 || !segment_enabled {
-        return "missing";
+        return Ok("missing");
     }
 
     // Resolve/download the SAM2 weights once; any failure degrades to box masks.
-    let weights = match crate::person_segment::ensure_segmenter_weights(settings, http_client).await
-    {
-        Ok(path) => path,
-        Err(_) => return "degraded",
+    let download_context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Person segmentation canceled while fetching SAM2 weights.",
+        fresh_download: false,
     };
+    let weights =
+        match crate::person_segment::ensure_segmenter_weights(settings, &download_context).await {
+            Ok(path) => path,
+            Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
+            Err(_) => return Ok("degraded"),
+        };
     let masks_dir = project_path
         .join("person-tracks")
         .join(track_id)
         .join("masks");
     if tokio::fs::create_dir_all(&masks_dir).await.is_err() {
-        return "degraded";
+        return Ok("degraded");
     }
 
     // The track spans first..=last detected frame. Propagate across that contiguous clip; frames
     // outside it (before the person appears / after they leave) are left mask-less as before.
     let Some(first) = frames.iter().position(|f| f.detected) else {
-        return "missing";
+        return Ok("missing");
     };
     let last = frames.iter().rposition(|f| f.detected).unwrap_or(first);
 
     // Clip frame paths + per-frame ByteTrack box anchors (None on the gap frames the predictor
     // fills from memory). The shared sample index ties frame `i` ↔ `frame_paths[i]` ↔ mask `i + 1`.
     if frame_paths.len() <= last {
-        return "degraded";
+        return Ok("degraded");
     }
     let mut clip_paths = Vec::with_capacity(last - first + 1);
     let mut anchors = Vec::with_capacity(last - first + 1);
@@ -829,16 +864,12 @@ async fn segment_assembly_frames(
         )));
     }
 
-    if check_cancel(
+    check_cancel(
         api,
         &job.id,
         "Person tracking canceled during segmentation.",
     )
-    .await
-    .is_err()
-    {
-        return "degraded";
-    }
+    .await?;
 
     let weights_for_task = weights.clone();
     let masks = match tokio::task::spawn_blocking(move || {
@@ -849,7 +880,7 @@ async fn segment_assembly_frames(
         Ok(Ok(masks)) => masks,
         // Propagation failure degrades to box masks (handled by the replacement loader); a track
         // that already located the person is never failed by the mask pass.
-        _ => return "degraded",
+        _ => return Ok("degraded"),
     };
 
     // Write every clip frame's non-empty mask (detected + gap) and set its sidecar `mask`. All the
@@ -874,7 +905,7 @@ async fn segment_assembly_frames(
             .await
         {
             Ok(written) => written,
-            Err(_) => return "degraded",
+            Err(_) => return Ok("degraded"),
         };
 
     let mut generated = 0usize;
@@ -891,7 +922,10 @@ async fn segment_assembly_frames(
         }
     }
 
-    crate::person_segment::rollup_mask_state(generated, detected_total)
+    Ok(crate::person_segment::rollup_mask_state(
+        generated,
+        detected_total,
+    ))
 }
 
 /// Encode each `(assembly_idx, rel, out_path, pixels)` mask as an `L` (8-bit grayscale) PNG,
@@ -2280,12 +2314,23 @@ mod person_track_e2e_tests {
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         rt.block_on(async {
             let http = reqwest::Client::new();
+            let api = ApiClient::new(&settings);
+            let job_id = "person-track-e2e";
+            let download_context = DownloadContext {
+                api: &api,
+                client: &http,
+                settings: &settings,
+                job_id,
+                cancel_message: "person track e2e canceled while fetching weights",
+                fresh_download: false,
+            };
 
             // 1. Provision the real detector weights (download-on-first-use), then sample +
             //    detect each frame exactly as `assemble_real_person_track` does.
-            let det_weights = crate::person_jobs::ensure_detector_weights(&settings, &http)
-                .await
-                .expect("yolo11 weights provisioned");
+            let det_weights =
+                crate::person_jobs::ensure_detector_weights(&settings, &download_context)
+                    .await
+                    .expect("yolo11 weights provisioned");
             let mut per_frame: Vec<(f64, Vec<(crate::person_track::NormalizedBox, f64)>)> =
                 Vec::with_capacity(timestamps.len());
             let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
@@ -2394,9 +2439,10 @@ mod person_track_e2e_tests {
             // 3. Provision the real SAM2 weights and propagate the person's mask across the
             //    detected span with the video predictor (sc-3715), writing masks under
             //    `person-tracks/{track_id}/masks/` (the production layout).
-            let seg_weights = crate::person_segment::ensure_segmenter_weights(&settings, &http)
-                .await
-                .expect("sam2 weights provisioned");
+            let seg_weights =
+                crate::person_segment::ensure_segmenter_weights(&settings, &download_context)
+                    .await
+                    .expect("sam2 weights provisioned");
 
             let first = assembly
                 .frames

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -34,7 +34,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use crate::downloads::ensure_cached_file;
+use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use image::RgbImage;
 use serde_json::{json, Value};
 
@@ -62,12 +62,8 @@ const PAD_VALUE: f32 = 114.0;
 const NMS_IOU: f32 = 0.7;
 /// The fused MLX-layout detector weights in the app cache / model dir.
 const DET_FILE: &str = "yolo11m_fused_mlx.safetensors";
-/// HuggingFace download URL for the fused weights (download-on-first-use, slice 4 /
-/// sc-3636). Public repo, so no credentials are needed — same shape as the DWPose
-/// openmmlab bundles (`pose_jobs`).
-const DET_URL: &str =
-    "https://huggingface.co/SceneWorks/yolo11m-person-detect-mlx/resolve/main/yolo11m_fused_mlx.safetensors";
-
+/// Hugging Face repo for the fused MLX detector weights.
+const DET_REPO: &str = "SceneWorks/yolo11m-person-detect-mlx";
 // ---------------------------------------------------------------------------
 // pure detector math (unit-tested without weights)
 // ---------------------------------------------------------------------------
@@ -756,11 +752,10 @@ pub(crate) fn resolve_detector_weights(settings: &Settings) -> Option<PathBuf> {
 }
 
 /// Resolve the fused MLX detector weights, downloading them from HuggingFace on first
-/// use (into the app cache). Mirrors `pose_jobs::ensure_one` — atomic `.tmp` + rename so
-/// a partial download is never mistaken for a complete one.
+/// use (into the app cache) with streaming progress/cancel and size-aware resume.
 pub(crate) async fn ensure_detector_weights(
     settings: &Settings,
-    http_client: &reqwest::Client,
+    context: &DownloadContext<'_>,
 ) -> WorkerResult<PathBuf> {
     if let Some(path) = resolve_detector_weights(settings) {
         return Ok(path);
@@ -770,7 +765,7 @@ pub(crate) async fn ensure_detector_weights(
         .join("cache")
         .join("person-detect")
         .join(DET_FILE);
-    ensure_cached_file(http_client, DET_URL, &target).await
+    ensure_hf_cached_file(context, DET_REPO, "main", DET_FILE, &target).await
 }
 
 #[cfg(test)]

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -8,6 +8,7 @@ use super::*;
 use mlx_gen::weights::Weights;
 use mlx_rs::Array;
 use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
 
 #[test]
 fn letterbox_centers_pad_on_the_short_axis() {
@@ -506,9 +507,9 @@ fn yolo11_matches_ultralytics_reference_on_photo() {
     }
 }
 
-/// Provisioning parity: download the fused weights from the public HuggingFace URL
-/// (`DET_URL`) into a throwaway dir, then prove a fresh download loads and detects the 4
-/// reference people. Validates the URL + that the hosted artifact is the right weights.
+/// Provisioning parity: stream the fused weights from the public HuggingFace URL
+/// into a throwaway dir, then prove a fresh download loads and detects the 4 reference
+/// people. Validates the URL + that the hosted artifact is the right weights.
 /// Ignored by default (network); run with the people.jpg fixture staged:
 ///   cargo test -p sceneworks-worker person_jobs -- --ignored --nocapture
 #[test]
@@ -526,17 +527,19 @@ fn yolo11_downloads_and_detects_from_huggingface() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
         let client = reqwest::Client::new();
-        let bytes = client
-            .get(DET_URL)
+        let url = format!("https://huggingface.co/{DET_REPO}/resolve/main/{DET_FILE}");
+        let mut response = client
+            .get(url)
             .send()
             .await
             .expect("GET weights")
             .error_for_status()
-            .expect("200 OK")
-            .bytes()
-            .await
-            .expect("body");
-        tokio::fs::write(&target, &bytes).await.unwrap();
+            .expect("200 OK");
+        let mut output = tokio::fs::File::create(&target).await.unwrap();
+        while let Some(chunk) = response.chunk().await.expect("stream chunk") {
+            output.write_all(&chunk).await.unwrap();
+        }
+        output.flush().await.unwrap();
     });
     eprintln!(
         "downloaded {} bytes → {}",

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -21,7 +21,7 @@
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
-use crate::downloads::ensure_cached_file;
+use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use mlx_gen::weights::Weights;
 use mlx_gen_sam2::{Sam2ModelSize, Sam2VideoPredictor};
 
@@ -30,12 +30,10 @@ use crate::{Settings, WorkerError, WorkerResult};
 /// The production SAM2 size (matches the spike + the `SceneWorks/sam2-mlx` upload).
 const SEG_FILE: &str = "sam2.1_hiera_large.safetensors";
 
-/// Download-on-first-use source: the converted MLX SAM2 weights owned by SceneWorks
+/// Download-on-first-use repo: the converted MLX SAM2 weights owned by SceneWorks
 /// (sc-3707, uploaded from the official Meta `.pt` via `tools/convert_sam2_to_mlx.py`;
-/// bit-identical to the avbiswas reference). Public repo, so no credentials are needed —
-/// same shape as the YOLO11 detector weights (`person_jobs::DET_URL`).
-const SEG_URL: &str =
-    "https://huggingface.co/SceneWorks/sam2-mlx/resolve/main/sam2.1_hiera_large.safetensors";
+/// bit-identical to the avbiswas reference).
+const SEG_REPO: &str = "SceneWorks/sam2-mlx";
 
 /// The SAM2 video predictor is loaded once and cached process-wide (weights load is the
 /// expensive part; the per-clip tracking state is built fresh each call). Holds `None` until
@@ -71,11 +69,10 @@ pub(crate) fn resolve_segmenter_weights(settings: &Settings) -> Option<PathBuf> 
 }
 
 /// Resolve the SAM2 weights, downloading them from HuggingFace on first use (into the
-/// app cache). Mirrors `person_jobs::ensure_detector_weights` — atomic `.tmp` + rename
-/// so a partial download is never mistaken for a complete one.
+/// app cache) with streaming progress/cancel and size-aware resume.
 pub(crate) async fn ensure_segmenter_weights(
     settings: &Settings,
-    http_client: &reqwest::Client,
+    context: &DownloadContext<'_>,
 ) -> WorkerResult<PathBuf> {
     if let Some(path) = resolve_segmenter_weights(settings) {
         return Ok(path);
@@ -85,7 +82,7 @@ pub(crate) async fn ensure_segmenter_weights(
         .join("cache")
         .join("person-segment")
         .join(SEG_FILE);
-    ensure_cached_file(http_client, SEG_URL, &target).await
+    ensure_hf_cached_file(context, SEG_REPO, "main", SEG_FILE, &target).await
 }
 
 /// Scale a normalized `(x, y, width, height)` box to a pixel-space `[x1, y1, x2, y2]`

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -24,7 +24,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use crate::downloads::fetch_bytes;
+use crate::downloads::{ensure_cached_file, DownloadContext};
 use image::RgbImage;
 use ort::execution_providers::CoreMLExecutionProvider;
 use ort::session::Session;
@@ -528,16 +528,26 @@ fn detect_batch(
 /// `<data_dir>/cache/dwpose/`, then rtmlib's own cache (dev machines), else download
 /// + unzip the openmmlab bundle into the app cache.
 async fn ensure_weights(
+    api: &ApiClient,
     settings: &Settings,
     http_client: &reqwest::Client,
+    job: &JobSnapshot,
 ) -> WorkerResult<(PathBuf, PathBuf)> {
     let cache = settings.data_dir.join("cache").join("dwpose");
+    let download_context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Pose detection canceled while fetching DWPose weights.",
+        fresh_download: false,
+    };
     let det = ensure_one(
         "SCENEWORKS_DWPOSE_DET",
         DET_FILE,
         DET_URL,
         &cache,
-        http_client,
+        &download_context,
     )
     .await?;
     let pose = ensure_one(
@@ -545,7 +555,7 @@ async fn ensure_weights(
         POSE_FILE,
         POSE_URL,
         &cache,
-        http_client,
+        &download_context,
     )
     .await?;
     Ok((det, pose))
@@ -556,7 +566,7 @@ async fn ensure_one(
     file: &str,
     url: &str,
     cache: &Path,
-    http_client: &reqwest::Client,
+    context: &DownloadContext<'_>,
 ) -> WorkerResult<PathBuf> {
     if let Ok(pinned) = std::env::var(env_key) {
         let path = PathBuf::from(pinned);
@@ -578,18 +588,26 @@ async fn ensure_one(
         }
     }
     tokio::fs::create_dir_all(cache).await?;
-    let bytes = fetch_bytes(http_client, url).await?;
+    let zip_path = target.with_extension("zip");
+    ensure_cached_file(
+        context,
+        url,
+        &zip_path,
+        &format!("DWPose {file} bundle"),
+        None,
+    )
+    .await?;
     // The openmmlab bundle is a .zip containing a single .onnx; extract it.
     let target_clone = target.clone();
     let file_owned = file.to_owned();
-    tokio::task::spawn_blocking(move || extract_onnx(&bytes, &file_owned, &target_clone))
+    tokio::task::spawn_blocking(move || extract_onnx(&zip_path, &file_owned, &target_clone))
         .await
         .map_err(|error| task_join_error("weight extract task", error))??;
     Ok(target)
 }
 
-fn extract_onnx(zip_bytes: &[u8], file: &str, target: &Path) -> WorkerResult<()> {
-    let reader = std::io::Cursor::new(zip_bytes);
+fn extract_onnx(zip_path: &Path, file: &str, target: &Path) -> WorkerResult<()> {
+    let reader = std::fs::File::open(zip_path)?;
     let mut archive = zip::ZipArchive::new(reader)
         .map_err(|e| WorkerError::InvalidPayload(format!("dwpose zip: {e}")))?;
     for i in 0..archive.len() {
@@ -782,7 +800,7 @@ pub(crate) async fn run_pose_detect_job(
         ),
     )
     .await?;
-    let (det_path, pose_path) = ensure_weights(settings, http_client).await?;
+    let (det_path, pose_path) = ensure_weights(api, settings, http_client, job).await?;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use image::RgbImage;
 use ort::execution_providers::CoreMLExecutionProvider;
 use ort::session::Session;
@@ -230,8 +231,10 @@ fn upscale_blocking(onnx_path: PathBuf, factor: u8, img: RgbImage) -> WorkerResu
 /// app cache `<data_dir>/cache/upscale/`, then a manifest `onnx` resource if the job
 /// carried one, else download from the default HF repo.
 async fn ensure_onnx(
+    api: &ApiClient,
     settings: &Settings,
     http_client: &reqwest::Client,
+    job: &JobSnapshot,
     factor: u8,
     manifest_entry: &Value,
 ) -> WorkerResult<PathBuf> {
@@ -256,25 +259,26 @@ async fn ensure_onnx(
     // manifest resource: resources.imageUpscalers.real-esrgan.x{factor}.onnx -> {repo,file}
     let (repo, file) = manifest_onnx_resource(manifest_entry, factor)
         .unwrap_or_else(|| (ONNX_REPO.to_owned(), onnx_file(factor)));
-    let url = format!("https://huggingface.co/{repo}/resolve/main/{file}");
 
     tokio::fs::create_dir_all(&cache).await?;
-    let bytes = http_client
-        .get(&url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| {
-            WorkerError::InvalidPayload(format!(
-                "Real-ESRGAN ONNX download failed ({url}): {e}. Set SCENEWORKS_REALESRGAN_X{factor}_ONNX to a local export, or populate the {ONNX_REPO} HF repo."
-            ))
-        })?
-        .bytes()
-        .await?;
-    let tmp = target.with_extension("onnx.tmp");
-    tokio::fs::write(&tmp, &bytes).await?;
-    tokio::fs::rename(&tmp, &target).await?;
-    Ok(target)
+    let context = DownloadContext {
+        api,
+        client: http_client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "Image upscale canceled while fetching Real-ESRGAN weights.",
+        fresh_download: false,
+    };
+    ensure_hf_cached_file(&context, &repo, "main", &file, &target)
+        .await
+        .map_err(|error| match error {
+            WorkerError::InvalidPayload(detail) => WorkerError::InvalidPayload(format!(
+                "Real-ESRGAN ONNX download failed ({repo}/{file}): {detail}. Set SCENEWORKS_REALESRGAN_X{factor}_ONNX to a local export, or populate the {ONNX_REPO} HF repo."
+            )),
+            other => WorkerError::Engine(format!(
+                "Real-ESRGAN ONNX download failed ({repo}/{file}): {other}. Set SCENEWORKS_REALESRGAN_X{factor}_ONNX to a local export, or populate the {ONNX_REPO} HF repo."
+            )),
+        })
 }
 
 /// Pull a `{repo,file}` ONNX resource out of a job's `modelManifestEntry` if present:
@@ -428,7 +432,7 @@ pub(crate) async fn run_image_upscale_job(
         ),
     )
     .await?;
-    let onnx_path = ensure_onnx(settings, http_client, factor, &manifest_entry).await?;
+    let onnx_path = ensure_onnx(api, settings, http_client, job, factor, &manifest_entry).await?;
 
     update_job(
         api,


### PR DESCRIPTION
## Summary
- replace first-use worker weight fetches that buffered whole responses with shared streaming download plumbing
- route InstantID/SCRFD, YOLO person detect, SAM2 segmentation, DWPose zips, and Real-ESRGAN ONNX provisioning through progress/cancel-aware cache fills
- use Hugging Face metadata for size-aware resume on runtime weight files and preserve cache-hit fast paths

## Validation
- cargo fmt --check
- cargo check -p sceneworks-worker --all-targets
- cargo test -p sceneworks-worker ensure_cached_file_tests -- --nocapture
- cargo test -p sceneworks-worker -- --nocapture
- cargo clippy -p sceneworks-worker --all-targets -- -D warnings

Shortcut: sc-4215