### PR TITLE
feat(desktop): MLX-only cutover on macOS + bump mlx-gen to 8b2746e (sc-3492)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2565,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "image",
  "inventory",
@@ -2598,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "image",
  "inventory",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2620,7 +2620,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "image",
  "inventory",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "image",
  "inventory",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=94e688c778385efe23f21cf7c6a8b748b23713d7#94e688c778385efe23f21cf7c6a8b748b23713d7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8b2746e56a93d10416a305c80bd862204619c943#8b2746e56a93d10416a305c80bd862204619c943"
 dependencies = [
  "image",
  "inventory",
@@ -2974,7 +2974,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -412,6 +412,9 @@ fn resolved_data_dir() -> PathBuf {
 
 /// Directory containing the Python `scene_worker` package + requirements: the
 /// bundled resource in a packaged app, the repo copy during development.
+///
+/// Only used to launch the Python worker, which macOS no longer spawns (sc-3492).
+#[cfg(not(target_os = "macos"))]
 fn worker_src_dir(app: &AppHandle) -> PathBuf {
     if let Ok(resources) = app.path().resource_dir() {
         let bundled = resources.join("python-src");
@@ -428,6 +431,9 @@ fn worker_src_dir(app: &AppHandle) -> PathBuf {
 /// (scene_worker depends on it at startup). Bundled: it's staged into python-src
 /// alongside scene_worker. Development: it lives in the repo's packages/shared.
 /// Mirrors the Docker worker's `PYTHONPATH=...:/app/packages/shared`.
+///
+/// Only used to launch the Python worker, which macOS no longer spawns (sc-3492).
+#[cfg(not(target_os = "macos"))]
 fn shared_parent_dir(app: &AppHandle) -> PathBuf {
     if let Ok(resources) = app.path().resource_dir() {
         let bundled = resources.join("python-src");
@@ -886,13 +892,17 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         // The catalog's install-state detection resolves the HF cache from this;
         // it must match the worker's download root or every model reads "missing".
         .env("HF_HOME", huggingface_home().to_string_lossy().to_string());
-    // Epic 3482 (Python Eradication) — macOS "MLX-required" mode is wired through the API
-    // (`Settings.mlx_required` ← `SCENEWORKS_MLX_REQUIRED`, sc-3483): the MPS worker never
-    // claims an MLX-eligible job and a job no live `mlx` worker takes fails `mlx_unavailable`
-    // instead of running on MPS. It ships default OFF (observe) so nothing is set here yet;
-    // the final cutover (sc-3492) flips it on for macOS at exactly this point —
-    //     #[cfg(target_os = "macos")] { command = command.env("SCENEWORKS_MLX_REQUIRED", "1"); }
-    // — once every Mac Python surface is ported or UI-gated.
+    // Epic 3482 (Python Eradication) final cutover (sc-3492) — macOS runs MLX-only.
+    // `Settings.mlx_required` ← `SCENEWORKS_MLX_REQUIRED` (sc-3483): the MPS/torch worker
+    // never claims an MLX-eligible job, and an MLX-eligible job that no live `mlx` worker
+    // takes fails `mlx_unavailable` instead of falling back to MPS. Every Mac Python
+    // *inference* surface is now ported to the in-process Rust/MLX worker or UI-gated
+    // (sc-3486), and the Python torch worker is no longer spawned on macOS (see
+    // `gate_window`), so the flag is enforced here.
+    #[cfg(target_os = "macos")]
+    {
+        command = command.env("SCENEWORKS_MLX_REQUIRED", "1");
+    }
     // The in-process utility worker shells out to ffmpeg; point it at the bundled
     // static binary (sc-3767) since the desktop has no system ffmpeg on PATH.
     if let Some(ffmpeg) = resolve_bundled_ffmpeg(app) {
@@ -967,7 +977,9 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
 
 /// Health-gate the window on a background thread: wait for the API's
 /// OS-assigned port, confirm the responder is genuinely SceneWorks, then
-/// navigate and start the Python worker; show an error after the timeout.
+/// navigate and start the platform inference worker(s) — the MLX GPU worker on
+/// macOS (MLX-only, sc-3492), the Python torch worker elsewhere; show an error
+/// after the timeout.
 fn gate_window(app: AppHandle) {
     std::thread::spawn(move || {
         let deadline = Instant::now() + HEALTH_TIMEOUT;
@@ -986,10 +998,12 @@ fn gate_window(app: AppHandle) {
                     }
                     #[cfg(target_os = "macos")]
                     {
-                        supervise_worker(app.clone(), port);
-                        // Apple-Silicon MLX GPU worker (sc-3289): MLX-eligible
-                        // image/video jobs run here on the in-process Rust
-                        // mlx-gen engine instead of the Python torch/MPS path.
+                        // Epic 3482 final cutover (sc-3492): macOS is MLX-only — the
+                        // Python torch/MPS worker is no longer spawned. Only the
+                        // Apple-Silicon MLX GPU worker (sc-3289) runs, executing
+                        // MLX-eligible image/video jobs on the in-process Rust mlx-gen
+                        // engine. Any MLX-ineligible job fails `mlx_unsupported` /
+                        // `mlx_unavailable` (never MPS) per `Settings.mlx_required`.
                         supervise_mlx_worker(app, port);
                     }
                     #[cfg(not(target_os = "macos"))]
@@ -1009,6 +1023,11 @@ fn gate_window(app: AppHandle) {
 /// Spawn and supervise the Python inference worker on a background thread,
 /// restarting it with exponential backoff if it dies unexpectedly while the app
 /// is open. Output is appended to worker.log.
+///
+/// Not compiled on macOS: the MLX-only cutover (sc-3492) never spawns the Python
+/// torch/MPS worker there — only `supervise_mlx_worker` runs. (The venv strip is
+/// sc-3493.)
+#[cfg(not(target_os = "macos"))]
 fn supervise_worker(app: AppHandle, api_port: u16) {
     std::thread::spawn(move || {
         let log_path = logs_dir().join("worker.log");
@@ -1335,6 +1354,9 @@ fn record_api_pid(app: &AppHandle, pid: u32) {
     write_sidecar_pidfile(&pids);
 }
 
+/// Only used by `supervise_worker`, which macOS no longer spawns (sc-3492); the
+/// `WorkerPids.worker` field it writes stays for Windows/Linux + crash recovery.
+#[cfg(not(target_os = "macos"))]
 fn record_worker_pid(app: &AppHandle, pid: Option<u32>) {
     let state = app.state::<Managed>();
     let mut pids = state.pids.lock().expect("pids lock");

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,6 +68,13 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# Rev 8b2746e (mlx-gen main, merged PR #379): exposes the SAM2 reverse-tracking entry point
+# `Sam2VideoPredictor::propagate_reverse` (sc-4750, verified reverse video propagation), plus a
+# repo cleanup/maintenance sweep (F-160..F-178: rename `mean_count_gt`->`count_gt`, drop the
+# trivial `JoyCaption::normalized_request` wrapper, relocate the LyCORIS LoKr/LoHa generators into
+# `tools/`, namespace the dump scripts, force `RUST_TEST_THREADS=1`, README/doc refreshes) — none
+# of which touch the public mlx-gen API the SceneWorks worker consumes. The mlx-rs pin is unchanged
+# (e59ffd88) so MLX core rebuilds nothing. On top of:
 # Rev 94e688c (mlx-gen main, merged PR #368, epic 3090 / sc-4568 + sc-4733): the native-MLX Kolors
 # LoRA/LoKr **trainer** (`mlx-gen-kolors/src/training.rs` — `KolorsTrainer` + `load_trainer` +
 # `TrainerRegistration` under id `"kolors"`; SDXL-UNet trainer core with the ChatGLM3-6B encoder,
@@ -113,7 +120,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -121,60 +128,60 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c7783
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -183,7 +190,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -191,7 +198,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "94e688c778385efe23f21cf7c6a8b748b23713d7" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8b2746e56a93d10416a305c80bd862204619c943" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Two changes that finish the macOS MLX migration's runtime flip.

### 1. sc-3492 — MLX-only runtime cutover (macOS)
Epic 3482 (Python Eradication) final runtime flip, in `apps/desktop/src/setup.rs`:
- `spawn_api` sets `SCENEWORKS_MLX_REQUIRED=1` on macOS — enables the enforcement built in sc-3483: the MPS/torch worker never claims an MLX-eligible job, and an MLX-eligible job that no live `mlx` worker takes fails `mlx_unavailable` instead of falling back to MPS.
- `gate_window` no longer spawns `supervise_worker` (the Python torch worker) on macOS — only `supervise_mlx_worker`. The now-macOS-dead spawn machinery (`supervise_worker` + its exclusive helpers `worker_src_dir` / `shared_parent_dir` / `record_worker_pid`) is `#[cfg(not(target_os = "macos"))]`-gated so clippy `-D warnings` stays clean.

Windows / Linux / Docker are unchanged: the flag is absent and the Python worker is still spawned.

### 2. Bump mlx-gen pin `94e688c` → `8b2746e` (latest main, PR #379)
All 16 `mlx-gen-*` git deps in `crates/sceneworks-worker/Cargo.toml`. The `pmetal-mlx-rs` pin is unchanged (`e59ffd88`), so MLX core rebuilds nothing — only the engine family crates. Delta = SAM2 `Sam2VideoPredictor::propagate_reverse` (sc-4750) + the F-160..F-178 cleanup sweep (`mean_count_gt`→`count_gt` rename, drop `JoyCaption::normalized_request`, relocate LyCORIS generators, etc.). None of the renamed/dropped symbols are referenced by the worker (grep-verified). `Cargo.lock` churn is the 16 source-rev swaps + a benign `num_enum_derive` proc-macro-crate consolidation (both versions already in tree).

## Verification
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p sceneworks-desktop --all-targets -- -D warnings` (macOS target) — clean, no dead-code cascade.
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` — clean; worker compiles against `8b2746e` (MLX core cached, ~6s incremental).

## Static confirmation (sc-3492 bullet 3)
No torch/MPS **execution** path remains reachable on macOS: the Python worker (all torch image/video adapters + Lens) is no longer spawned; advanced-video torch paths become unreachable automatically; routing enforcement is unit-tested green from sc-3483.

## Follow-ups (not in this PR)
- **sc-3493** — strip the venv / sidecar / requirements from the Mac build. This flip exposes two provisioning residuals that are now installed-but-unused on macOS: the main venv, and the **Lens torch venv** (`provision_lens_venv` still pulls `torch>=2.11`). Plus the vestigial `SCENEWORKS_PYTHON` env wiring (its consumer was retired in sc-3240). Burn-down list captured on sc-3493.
- **Owed for sc-3492 before Done:** real-Mac enforce-mode E2E — eligible job + `mlx` worker down → `mlx_unavailable` in System → Logs (never MPS); transient `mlx` restart inside the grace window → job survives; torch-only / UI-gated model → `mlx_unsupported`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)