### PR TITLE
[codex] Fix character reference cleanup on asset purge

### DIFF
--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -443,6 +443,38 @@ impl<'a> CharacterStore<'a> {
         hydrate_character(project_id, &self.project_path, character)
     }
 
+    pub fn remove_asset_references(&self, asset_id: &str) -> ProjectStoreResult<u32> {
+        validate_required_text(asset_id, "assetId")?;
+        let mut connection = connect_project_db(&self.project_path)?;
+        let transaction = connection.transaction()?;
+        let mut changed_count = 0;
+
+        for sidecar_path in character_sidecars(&self.project_path)? {
+            let Ok(mut character) = read_json(&sidecar_path) else {
+                continue;
+            };
+            if !remove_asset_references_from_character(&mut character, asset_id)? {
+                continue;
+            }
+            value_object_mut(&mut character, "Character sidecar")?
+                .insert("updatedAt".to_owned(), Value::String(utc_now()));
+            write_character_json(&sidecar_path, &character)?;
+            index_character_sidecar_on_connection(
+                &transaction,
+                &self.project_path,
+                &sidecar_path,
+                &character,
+            )?;
+            changed_count += 1;
+        }
+
+        if changed_count > 0 {
+            store_character_index_fingerprint(&transaction, &self.project_path)?;
+        }
+        transaction.commit()?;
+        Ok(changed_count)
+    }
+
     pub fn create_look(
         &self,
         project_id: &str,
@@ -1125,9 +1157,19 @@ fn update_asset_character_link(
     remove: bool,
 ) -> ProjectStoreResult<()> {
     let asset_id = required_str(reference, "assetId")?;
-    let sidecar_path =
+    let Some(sidecar_path) =
         find_asset_sidecar_path_on_connection(connection, project_path, asset_id)?
-            .ok_or_else(|| ProjectStoreError::NotFound("Reference asset not found".to_owned()))?;
+    else {
+        if remove {
+            return Ok(());
+        }
+        return Err(ProjectStoreError::NotFound(
+            "Reference asset not found".to_owned(),
+        ));
+    };
+    if remove && !sidecar_path.exists() {
+        return Ok(());
+    }
     let mut asset = read_json(&sidecar_path)?;
     let metadata = value_object_mut(&mut asset, "Asset sidecar")?
         .entry("metadata".to_owned())
@@ -1155,6 +1197,44 @@ fn update_asset_character_link(
     metadata.insert("characterReferences".to_owned(), Value::Array(links));
     write_json(&sidecar_path, &asset)?;
     index_asset_on_connection(connection, project_path, &asset, Some(&sidecar_path))
+}
+
+fn remove_asset_references_from_character(
+    character: &mut Value,
+    asset_id: &str,
+) -> ProjectStoreResult<bool> {
+    let object = value_object_mut(character, "Character sidecar")?;
+    let mut changed = false;
+
+    if let Some(references) = object.get_mut("references") {
+        let references = references.as_array_mut().ok_or_else(|| {
+            ProjectStoreError::BadRequest("Character references must be an array".to_owned())
+        })?;
+        let before = references.len();
+        references.retain(|item| item.get("assetId").and_then(Value::as_str) != Some(asset_id));
+        changed |= references.len() != before;
+    }
+
+    if let Some(looks) = object.get_mut("looks") {
+        let looks = looks.as_array_mut().ok_or_else(|| {
+            ProjectStoreError::BadRequest("Character looks must be an array".to_owned())
+        })?;
+        for look in looks {
+            let Some(reference_ids) = look.get_mut("approvedReferenceIds") else {
+                continue;
+            };
+            let reference_ids = reference_ids.as_array_mut().ok_or_else(|| {
+                ProjectStoreError::BadRequest(
+                    "Character look approvedReferenceIds must be an array".to_owned(),
+                )
+            })?;
+            let before = reference_ids.len();
+            reference_ids.retain(|item| item.as_str() != Some(asset_id));
+            changed |= reference_ids.len() != before;
+        }
+    }
+
+    Ok(changed)
 }
 
 /// Thin DB-prep wrapper over the shared resolver in `asset_index` (sc-4272).

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -2030,6 +2030,8 @@ impl ProjectStore {
                 .and_then(Value::as_str)
                 .unwrap_or_default(),
         );
+        CharacterStore::new(&self.data_dir, project_path.clone())
+            .remove_asset_references(asset_id)?;
         if media_path.exists() && media_path.is_file() {
             fs::remove_file(media_path)?;
         }

--- a/crates/sceneworks-core/tests/character_store.rs
+++ b/crates/sceneworks-core/tests/character_store.rs
@@ -260,6 +260,175 @@ fn references_sync_asset_metadata_and_character_reference_table() {
 }
 
 #[test]
+fn remove_character_reference_tolerates_purged_asset_record() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+    let project = store
+        .create_project("Stale References")
+        .expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+    let source = temp_dir.path().join("reference.png");
+    fs::write(&source, b"png-bytes").expect("source writes");
+    let asset = store
+        .import_asset(
+            &project.id,
+            UploadAsset {
+                filename: "reference.png".to_owned(),
+                content_type: Some("image/png".to_owned()),
+                source_path: source,
+                source_asset_id: None,
+                provenance: None,
+            },
+        )
+        .expect("asset imports");
+    let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+    let character = store
+        .create_character(
+            &project.id,
+            CharacterCreateInput {
+                name: "Mira".to_owned(),
+                character_type: "person".to_owned(),
+                description: String::new(),
+            },
+        )
+        .expect("character creates");
+    let character_id = character["id"].as_str().expect("character id").to_owned();
+
+    store
+        .add_character_reference(
+            &project.id,
+            &character_id,
+            CharacterReferenceInput {
+                asset_id: asset_id.clone(),
+                approved: true,
+                role: "reference".to_owned(),
+                notes: String::new(),
+            },
+        )
+        .expect("reference adds");
+
+    let sidecar_path = project_path.join(
+        asset["sidecarPath"]
+            .as_str()
+            .expect("sidecar path")
+            .replace('/', std::path::MAIN_SEPARATOR_STR),
+    );
+    fs::remove_file(&sidecar_path).expect("asset sidecar removed");
+    let connection = Connection::open(project_path.join("project.db")).expect("db opens");
+    connection
+        .execute("delete from assets where id = ?1", params![asset_id])
+        .expect("asset index row removed");
+
+    let updated = store
+        .remove_character_reference(&project.id, &character_id, &asset_id)
+        .expect("stale reference removes");
+    assert!(updated["references"]
+        .as_array()
+        .expect("references")
+        .is_empty());
+
+    let remaining: i64 = connection
+        .query_row(
+            "select count(*) from character_references where character_id = ?1 and asset_id = ?2",
+            params![character_id, asset_id],
+            |row| row.get(0),
+        )
+        .expect("reference count reads");
+    assert_eq!(remaining, 0);
+}
+
+#[test]
+fn purge_asset_removes_character_references_and_look_ids() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+    let project = store
+        .create_project("Purge References")
+        .expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+    let source = temp_dir.path().join("reference.png");
+    fs::write(&source, b"png-bytes").expect("source writes");
+    let asset = store
+        .import_asset(
+            &project.id,
+            UploadAsset {
+                filename: "reference.png".to_owned(),
+                content_type: Some("image/png".to_owned()),
+                source_path: source,
+                source_asset_id: None,
+                provenance: None,
+            },
+        )
+        .expect("asset imports");
+    let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+    let character = store
+        .create_character(
+            &project.id,
+            CharacterCreateInput {
+                name: "Mira".to_owned(),
+                character_type: "person".to_owned(),
+                description: String::new(),
+            },
+        )
+        .expect("character creates");
+    let character_id = character["id"].as_str().expect("character id").to_owned();
+
+    store
+        .add_character_reference(
+            &project.id,
+            &character_id,
+            CharacterReferenceInput {
+                asset_id: asset_id.clone(),
+                approved: true,
+                role: "reference".to_owned(),
+                notes: String::new(),
+            },
+        )
+        .expect("reference adds");
+    store
+        .create_character_look(
+            &project.id,
+            &character_id,
+            CharacterLookInput {
+                name: "Hero".to_owned(),
+                description: String::new(),
+                approved_reference_ids: vec![asset_id.clone()],
+                recipe_settings: Map::new(),
+            },
+        )
+        .expect("look creates");
+
+    store
+        .purge_asset(&project.id, &asset_id)
+        .expect("asset purges");
+
+    let character = store
+        .get_character(&project.id, &character_id)
+        .expect("character reads");
+    assert!(character["references"]
+        .as_array()
+        .expect("references")
+        .is_empty());
+    assert!(character["approvedReferences"]
+        .as_array()
+        .expect("approved references")
+        .is_empty());
+    assert!(character["looks"][0]["approvedReferenceIds"]
+        .as_array()
+        .expect("look reference ids")
+        .is_empty());
+
+    let connection = Connection::open(project_path.join("project.db")).expect("db opens");
+    let remaining: i64 = connection
+        .query_row(
+            "select count(*) from character_references where character_id = ?1 and asset_id = ?2",
+            params![character_id, asset_id],
+            |row| row.get(0),
+        )
+        .expect("reference count reads");
+    assert_eq!(remaining, 0);
+}
+
+#[test]
 fn looks_loras_and_reindex_are_persisted() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");


### PR DESCRIPTION
## Summary
- Remove stale Character Studio references when an asset is purged from the Assets page.
- Allow the existing Remove action to unlink references whose asset sidecar/index row is already gone.
- Clean saved look approved reference IDs when their asset is purged.

## Root Cause
Character reference removal tried to update the linked asset metadata even when the asset had already been purged, which returned `Reference asset not found` before the character sidecar could be cleaned up. Asset purge also deleted the asset record without removing character-side references.

## Validation
- `cargo test -p sceneworks-core --test character_store`
- `cargo test -p sceneworks-rust-api project_and_asset_routes_persist_contract_state`
