### PR TITLE
sc-4220: cache MLX generators across jobs

### DIFF
--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -1,0 +1,207 @@
+use std::path::PathBuf;
+use std::sync::{mpsc, OnceLock};
+use std::thread;
+
+use mlx_gen::{
+    AdapterKind, AdapterSpec, Generator, LoadSpec, MoeExpert, Precision, Quant, WeightsSource,
+};
+use tokio::sync::oneshot;
+
+use crate::{WorkerError, WorkerResult};
+
+type GeneratorJob = Box<dyn FnOnce(&mut GeneratorCache) + Send + 'static>;
+
+static GENERATOR_WORKER: OnceLock<mpsc::Sender<GeneratorJob>> = OnceLock::new();
+
+struct GeneratorCache {
+    entry: Option<GeneratorCacheEntry>,
+}
+
+struct GeneratorCacheEntry {
+    key: GeneratorCacheKey,
+    generator: Box<dyn Generator>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct GeneratorCacheKey {
+    engine_id: String,
+    weights: CacheWeightsSource,
+    quantize: Option<Quant>,
+    precision: Precision,
+    control: Option<CacheWeightsSource>,
+    extra_controls: Vec<CacheWeightsSource>,
+    ip_adapter: Option<CacheWeightsSource>,
+    adapters: Vec<CacheAdapterSpec>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CacheWeightsSource {
+    Dir(PathBuf),
+    File(PathBuf),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CacheAdapterSpec {
+    path: PathBuf,
+    scale_bits: u32,
+    kind: AdapterKind,
+    pass_scale_bits: Option<Vec<u32>>,
+    moe_expert: Option<MoeExpert>,
+}
+
+impl GeneratorCacheKey {
+    pub(crate) fn from_load_spec(engine_id: &str, spec: &LoadSpec) -> Self {
+        Self {
+            engine_id: engine_id.to_owned(),
+            weights: CacheWeightsSource::from(&spec.weights),
+            quantize: spec.quantize,
+            precision: spec.precision,
+            control: spec.control.as_ref().map(CacheWeightsSource::from),
+            extra_controls: spec
+                .extra_controls
+                .iter()
+                .map(CacheWeightsSource::from)
+                .collect(),
+            ip_adapter: spec.ip_adapter.as_ref().map(CacheWeightsSource::from),
+            adapters: spec.adapters.iter().map(CacheAdapterSpec::from).collect(),
+        }
+    }
+}
+
+impl From<&WeightsSource> for CacheWeightsSource {
+    fn from(source: &WeightsSource) -> Self {
+        match source {
+            WeightsSource::Dir(path) => Self::Dir(path.clone()),
+            WeightsSource::File(path) => Self::File(path.clone()),
+        }
+    }
+}
+
+impl From<&AdapterSpec> for CacheAdapterSpec {
+    fn from(spec: &AdapterSpec) -> Self {
+        Self {
+            path: spec.path.clone(),
+            scale_bits: spec.scale.to_bits(),
+            kind: spec.kind,
+            pass_scale_bits: spec
+                .pass_scales
+                .as_ref()
+                .map(|scales| scales.iter().map(|scale| scale.to_bits()).collect()),
+            moe_expert: spec.moe_expert,
+        }
+    }
+}
+
+impl GeneratorCache {
+    fn new() -> Self {
+        Self { entry: None }
+    }
+
+    fn with_generator<R>(
+        &mut self,
+        key: GeneratorCacheKey,
+        spec: LoadSpec,
+        load_error_context: String,
+        run: impl FnOnce(&dyn Generator) -> WorkerResult<R>,
+    ) -> WorkerResult<R> {
+        if self.entry.as_ref().map_or(true, |entry| entry.key != key) {
+            self.entry = None;
+            let generator = mlx_gen::load(&key.engine_id, &spec)
+                .map_err(|error| WorkerError::Engine(format!("{load_error_context}: {error}")))?;
+            self.entry = Some(GeneratorCacheEntry {
+                key: key.clone(),
+                generator,
+            });
+        }
+
+        let generator = self
+            .entry
+            .as_ref()
+            .expect("cache entry populated")
+            .generator
+            .as_ref();
+        run(generator)
+    }
+}
+
+fn generator_worker() -> &'static mpsc::Sender<GeneratorJob> {
+    GENERATOR_WORKER.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<GeneratorJob>();
+        thread::Builder::new()
+            .name("sceneworks-mlx-generator-cache".to_owned())
+            .spawn(move || {
+                let mut cache = GeneratorCache::new();
+                while let Ok(job) = rx.recv() {
+                    job(&mut cache);
+                }
+            })
+            .expect("start MLX generator cache worker");
+        tx
+    })
+}
+
+pub(crate) async fn with_cached_generator<R>(
+    engine_id: &'static str,
+    spec: LoadSpec,
+    load_error_context: impl Into<String>,
+    run: impl FnOnce(&dyn Generator) -> WorkerResult<R> + Send + 'static,
+) -> WorkerResult<R>
+where
+    R: Send + 'static,
+{
+    let key = GeneratorCacheKey::from_load_spec(engine_id, &spec);
+    let load_error_context = load_error_context.into();
+    let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
+    let job = Box::new(move |cache: &mut GeneratorCache| {
+        let result = cache.with_generator(key, spec, load_error_context, run);
+        let _ = reply_tx.send(result);
+    });
+    generator_worker()
+        .send(job)
+        .map_err(|_| WorkerError::Engine("MLX generator cache worker stopped".to_owned()))?;
+    reply_rx.await.map_err(|_| {
+        WorkerError::Engine("MLX generator cache worker dropped the job result".to_owned())
+    })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_includes_adapter_fingerprint() {
+        let base = LoadSpec::new(WeightsSource::Dir(PathBuf::from("/models/base")));
+        let mut with_adapter = base.clone();
+        with_adapter.adapters = vec![AdapterSpec::new(
+            PathBuf::from("/loras/style.safetensors"),
+            0.8,
+            AdapterKind::Lora,
+        )];
+        let mut different_scale = with_adapter.clone();
+        different_scale.adapters[0].scale = 0.9;
+
+        assert_ne!(
+            GeneratorCacheKey::from_load_spec("z_image_turbo", &base),
+            GeneratorCacheKey::from_load_spec("z_image_turbo", &with_adapter)
+        );
+        assert_ne!(
+            GeneratorCacheKey::from_load_spec("z_image_turbo", &with_adapter),
+            GeneratorCacheKey::from_load_spec("z_image_turbo", &different_scale)
+        );
+    }
+
+    #[test]
+    fn cache_key_includes_control_and_ip_components() {
+        let mut control = LoadSpec::new(WeightsSource::Dir(PathBuf::from("/models/base")));
+        control.control = Some(WeightsSource::File(PathBuf::from(
+            "/controls/pose.safetensors",
+        )));
+        let mut ip = LoadSpec::new(WeightsSource::Dir(PathBuf::from("/models/base")));
+        ip.ip_adapter = Some(WeightsSource::Dir(PathBuf::from("/ip-adapter")));
+
+        assert_ne!(
+            GeneratorCacheKey::from_load_spec("sdxl", &control),
+            GeneratorCacheKey::from_load_spec("sdxl", &ip)
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1026,6 +1026,53 @@ where
     (cancel, rx, blocking)
 }
 
+#[cfg(target_os = "macos")]
+fn start_cached_gen_stream<D>(
+    job_id: String,
+    engine_id: &'static str,
+    adapter_count: usize,
+    spec: LoadSpec,
+    load_error_context: String,
+    drive: D,
+) -> (
+    CancelFlag,
+    tokio::sync::mpsc::Receiver<GenEvent>,
+    tokio::task::JoinHandle<WorkerResult<()>>,
+)
+where
+    D: FnOnce(&dyn Generator, tokio::sync::mpsc::Sender<GenEvent>, CancelFlag) -> WorkerResult<()>
+        + Send
+        + 'static,
+{
+    let cancel = CancelFlag::new();
+    let (tx, rx) = tokio::sync::mpsc::channel::<GenEvent>(64);
+    let blocking_cancel = cancel.clone();
+    let blocking = tokio::spawn(async move {
+        emit_load_event(
+            "image_pipeline_load_start",
+            &job_id,
+            engine_id,
+            adapter_count,
+        );
+        crate::generator_cache::with_cached_generator(
+            engine_id,
+            spec,
+            load_error_context,
+            move |generator| {
+                emit_load_event(
+                    "image_pipeline_load_complete",
+                    &job_id,
+                    engine_id,
+                    adapter_count,
+                );
+                drive(generator, tx, blocking_cancel)
+            },
+        )
+        .await
+    });
+    (cancel, rx, blocking)
+}
+
 /// True when this job can run real in-process inference: the model is a linked,
 /// engine-backed family and its weights resolve locally.
 /// Fail-loud gate for the stub fallback (sc-4176): Some(message) when the
@@ -1392,7 +1439,7 @@ fn mlx_raw_settings(
 }
 
 /// Load the generator for `engine_id` (heavy; once per job).
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", test))]
 fn mlx_load(
     engine_id: &str,
     weights_dir: PathBuf,
@@ -1402,17 +1449,13 @@ fn mlx_load(
     mlx_load_with_ip(engine_id, weights_dir, quant, adapters, None)
 }
 
-/// As [`mlx_load`], but optionally installing an IP-Adapter from `ip_adapter_dir`
-/// (`LoadSpec::with_ip_adapter`). Used by the FLUX.1 XLabs IP-Adapter reference path
-/// (epic 3621): the engine then treats a `Conditioning::Reference` as the image prompt.
 #[cfg(target_os = "macos")]
-fn mlx_load_with_ip(
-    engine_id: &str,
+fn mlx_load_spec(
     weights_dir: PathBuf,
     quant: Option<Quant>,
     adapters: Vec<AdapterSpec>,
     ip_adapter_dir: Option<PathBuf>,
-) -> WorkerResult<Box<dyn Generator>> {
+) -> LoadSpec {
     let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir));
     if let Some(quant) = quant {
         spec = spec.with_quant(quant);
@@ -1423,6 +1466,21 @@ fn mlx_load_with_ip(
     if let Some(dir) = ip_adapter_dir {
         spec = spec.with_ip_adapter(WeightsSource::Dir(dir));
     }
+    spec
+}
+
+/// As [`mlx_load`], but optionally installing an IP-Adapter from `ip_adapter_dir`
+/// (`LoadSpec::with_ip_adapter`). Used by the FLUX.1 XLabs IP-Adapter reference path
+/// (epic 3621): the engine then treats a `Conditioning::Reference` as the image prompt.
+#[cfg(all(target_os = "macos", test))]
+fn mlx_load_with_ip(
+    engine_id: &str,
+    weights_dir: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+    ip_adapter_dir: Option<PathBuf>,
+) -> WorkerResult<Box<dyn Generator>> {
+    let spec = mlx_load_spec(weights_dir, quant, adapters, ip_adapter_dir);
     mlx_gen::load(engine_id, &spec)
         .map_err(|error| WorkerError::Engine(format!("{engine_id} load failed: {error}")))
 }
@@ -1693,15 +1751,17 @@ async fn generate_mlx_stream(
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
-    let (cancel, rx, blocking) = start_gen_stream(
+    let spec = mlx_load_spec(weights_dir, quant, adapters, flux_ip_dir);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
         adapter_count,
-        move || mlx_load_with_ip(engine_id, weights_dir, quant, adapters, flux_ip_dir),
+        spec,
+        format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
             drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
                 let (out_w, out_h, pixels) = mlx_generate_one(
-                    generator.as_ref(),
+                    generator,
                     &prompt,
                     width,
                     height,
@@ -2029,12 +2089,12 @@ fn parse_poses(request: &ImageRequest) -> Vec<PoseInput> {
 
 /// Load the Z-Image Fun-Controlnet-Union generator (base snapshot + control overlay).
 #[cfg(target_os = "macos")]
-fn zimage_control_load(
+fn zimage_control_spec(
     weights_dir: PathBuf,
     control_weights: PathBuf,
     quant: Option<Quant>,
     adapters: Vec<AdapterSpec>,
-) -> WorkerResult<Box<dyn Generator>> {
+) -> LoadSpec {
     let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
         .with_control(WeightsSource::File(control_weights));
     if let Some(quant) = quant {
@@ -2043,6 +2103,17 @@ fn zimage_control_load(
     if !adapters.is_empty() {
         spec = spec.with_adapters(adapters);
     }
+    spec
+}
+
+#[cfg(all(target_os = "macos", test))]
+fn zimage_control_load(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> WorkerResult<Box<dyn Generator>> {
+    let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
     mlx_gen::load(ZIMAGE_CONTROL_ENGINE_ID, &spec)
         .map_err(|error| WorkerError::Engine(format!("Z-Image control load failed: {error}")))
 }
@@ -2181,11 +2252,13 @@ async fn generate_zimage_control_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let (cancel, rx, blocking) = start_gen_stream(
+    let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         ZIMAGE_CONTROL_ENGINE_ID,
         adapter_count,
-        move || zimage_control_load(weights_dir, control_weights, quant, adapters),
+        spec,
+        "Z-Image control load failed".to_owned(),
         move |generator, tx, cancel| {
             let identity_init = identity_init.as_ref();
             drive_gen_items(tx, poses, move |_index, pose, on_progress| {
@@ -2203,7 +2276,7 @@ async fn generate_zimage_control_stream(
                     pixels: skeleton.into_raw(),
                 };
                 let (out_w, out_h, pixels) = zimage_control_generate_one(
-                    generator.as_ref(),
+                    generator,
                     &prompt,
                     width,
                     height,
@@ -2846,11 +2919,13 @@ async fn generate_flux2_edit_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let (cancel, rx, blocking) = start_gen_stream(
+    let spec = mlx_load_spec(weights_dir, quant, adapters, None);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
         adapter_count,
-        move || mlx_load(engine_id, weights_dir, quant, adapters),
+        spec,
+        format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
             drive_gen_items(
                 tx,
@@ -2883,7 +2958,7 @@ async fn generate_flux2_edit_stream(
                         None => build_edit_conditioning(&references),
                     };
                     let (out_w, out_h, pixels) = flux2_edit_generate_one(
-                        generator.as_ref(),
+                        generator,
                         &prompt,
                         width,
                         height,
@@ -2952,12 +3027,12 @@ fn resolve_qwen_control_weights(request: &ImageRequest, settings: &Settings) -> 
 
 /// Load the Qwen-Image ControlNet-Union generator (base snapshot + InstantX control overlay).
 #[cfg(target_os = "macos")]
-fn qwen_control_load(
+fn qwen_control_spec(
     weights_dir: PathBuf,
     control_weights: PathBuf,
     quant: Option<Quant>,
     adapters: Vec<AdapterSpec>,
-) -> WorkerResult<Box<dyn Generator>> {
+) -> LoadSpec {
     let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
         .with_control(WeightsSource::File(control_weights));
     if let Some(quant) = quant {
@@ -2966,6 +3041,17 @@ fn qwen_control_load(
     if !adapters.is_empty() {
         spec = spec.with_adapters(adapters);
     }
+    spec
+}
+
+#[cfg(all(target_os = "macos", test))]
+fn qwen_control_load(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> WorkerResult<Box<dyn Generator>> {
+    let spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
     mlx_gen::load(QWEN_CONTROL_ENGINE_ID, &spec).map_err(|error| {
         WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
     })
@@ -3097,11 +3183,13 @@ async fn generate_qwen_control_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let (cancel, rx, blocking) = start_gen_stream(
+    let spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         QWEN_CONTROL_ENGINE_ID,
         adapter_count,
-        move || qwen_control_load(weights_dir, control_weights, quant, adapters),
+        spec,
+        "Qwen strict-pose control load failed".to_owned(),
         move |generator, tx, cancel| {
             drive_gen_items(tx, poses, move |_index, pose, on_progress| {
                 let skeleton = crate::openpose_skeleton::draw_wholebody(
@@ -3118,7 +3206,7 @@ async fn generate_qwen_control_stream(
                     pixels: skeleton.into_raw(),
                 };
                 let (out_w, out_h, pixels) = qwen_control_generate_one(
-                    generator.as_ref(),
+                    generator,
                     &prompt,
                     negative_prompt.clone(),
                     width,
@@ -3572,11 +3660,13 @@ async fn generate_qwen_edit_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let (cancel, rx, blocking) = start_gen_stream(
+    let spec = mlx_load_spec(weights_dir, quant, adapters, None);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
         adapter_count,
-        move || mlx_load(engine_id, weights_dir, quant, adapters),
+        spec,
+        format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
             drive_gen_items(
                 tx,
@@ -3610,7 +3700,7 @@ async fn generate_qwen_edit_stream(
                         None => build_edit_conditioning(&references),
                     };
                     let (out_w, out_h, pixels) = qwen_edit_generate_one(
-                        generator.as_ref(),
+                        generator,
                         &prompt,
                         negative_prompt.clone(),
                         width,
@@ -3914,18 +4004,20 @@ async fn generate_sensenova_edit_stream(
         raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
     }
 
-    let (cancel, rx, blocking) = start_gen_stream(
+    let spec = mlx_load_spec(weights_dir, quant, Vec::new(), None);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
         0,
-        move || mlx_load(engine_id, weights_dir, quant, Vec::new()),
+        spec,
+        format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
             drive_gen_items(
                 tx,
                 seeds.into_iter().zip(prompts),
                 move |_index, (seed, prompt), on_progress| {
                     let (w, h, pixels) = sensenova_edit_generate_one(
-                        generator.as_ref(),
+                        generator,
                         &prompt,
                         out_w,
                         out_h,
@@ -4092,16 +4184,16 @@ fn engine_image_to_rgb(image: Image) -> WorkerResult<image::RgbImage> {
         .ok_or_else(|| WorkerError::InvalidPayload("image buffer size mismatch".to_owned()))
 }
 
-/// Load the SDXL generator for an advanced job. `ip_adapter_dir` (Some only in IP mode) adds
-/// the decoupled cross-attn weights at load — the engine then treats a `Reference` as the
-/// image prompt rather than an img2img init. Loaded per job (no persistent cache).
+/// Build the SDXL generator spec for an advanced job. `ip_adapter_dir` (Some only in IP mode)
+/// adds the decoupled cross-attn weights at load — the engine then treats a `Reference` as the
+/// image prompt rather than an img2img init.
 #[cfg(target_os = "macos")]
-fn sdxl_advanced_load(
+fn sdxl_advanced_spec(
     weights_dir: PathBuf,
     quant: Option<Quant>,
     adapters: Vec<AdapterSpec>,
     ip_adapter_dir: Option<PathBuf>,
-) -> WorkerResult<Box<dyn Generator>> {
+) -> LoadSpec {
     let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir));
     if let Some(quant) = quant {
         spec = spec.with_quant(quant);
@@ -4112,8 +4204,7 @@ fn sdxl_advanced_load(
     if !adapters.is_empty() {
         spec = spec.with_adapters(adapters);
     }
-    mlx_gen::load("sdxl", &spec)
-        .map_err(|error| WorkerError::Engine(format!("sdxl advanced load failed: {error}")))
+    spec
 }
 
 /// Generate one SDXL image conditioned on `conditioning` (Reference[/Mask]). SDXL is true-CFG
@@ -4380,15 +4471,17 @@ async fn generate_sdxl_advanced_stream(
     let prompt = request.prompt.clone();
     let negative_prompt = negative_prompt.clone();
     let adapter_count = adapters.len();
-    let (cancel, rx, blocking) = start_gen_stream(
+    let spec = sdxl_advanced_spec(weights_dir, quant, adapters, ip_adapter_dir);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         "sdxl",
         adapter_count,
-        move || sdxl_advanced_load(weights_dir, quant, adapters, ip_adapter_dir),
+        spec,
+        "sdxl advanced load failed".to_owned(),
         move |generator, tx, cancel| {
             drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
                 let (out_w, out_h, pixels) = sdxl_advanced_generate_one(
-                    generator.as_ref(),
+                    generator,
                     &prompt,
                     negative_prompt.clone(),
                     width,
@@ -5324,20 +5417,15 @@ fn detail_feather(tile_w: u32, tile_h: u32, overlap: u32) -> Vec<f32> {
     out
 }
 
-/// Load the SDXL generator with the tile ControlNet overlay (per job, no cache).
+/// Build the SDXL generator spec with the tile ControlNet overlay.
 #[cfg(target_os = "macos")]
-fn detail_load(
-    weights_dir: PathBuf,
-    control_file: PathBuf,
-    quant: Option<Quant>,
-) -> WorkerResult<Box<dyn Generator>> {
+fn detail_spec(weights_dir: PathBuf, control_file: PathBuf, quant: Option<Quant>) -> LoadSpec {
     let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
         .with_control(WeightsSource::File(control_file));
     if let Some(quant) = quant {
         spec = spec.with_quant(quant);
     }
-    mlx_gen::load("sdxl", &spec)
-        .map_err(|error| WorkerError::Engine(format!("sdxl detail load failed: {error}")))
+    spec
 }
 
 /// Refine one tile (already sized to engine-valid `eng_w`×`eng_h`): img2img on the tile
@@ -5673,18 +5761,20 @@ pub(crate) async fn run_image_detail_job(
     let blocking = {
         let params_ref = params.clone();
         let cancel = cancel.clone();
-        tokio::task::spawn_blocking(move || -> WorkerResult<(image::RgbImage, usize)> {
-            let generator = detail_load(weights_dir, control_file, quant)?;
-            let mut on_tile = |done: usize, total: usize| {
-                let _ = tx.blocking_send((done, total));
-            };
-            refine_tiled_detail(
-                generator.as_ref(),
-                &source,
-                &params_ref,
-                &cancel,
-                &mut on_tile,
+        let spec = detail_spec(weights_dir, control_file, quant);
+        tokio::spawn(async move {
+            crate::generator_cache::with_cached_generator(
+                "sdxl",
+                spec,
+                "sdxl detail load failed",
+                move |generator| {
+                    let mut on_tile = |done: usize, total: usize| {
+                        let _ = tx.blocking_send((done, total));
+                    };
+                    refine_tiled_detail(generator, &source, &params_ref, &cancel, &mut on_tile)
+                },
             )
+            .await
         })
     };
 

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -39,6 +39,8 @@ use uuid::Uuid;
 #[cfg(target_os = "macos")]
 mod advanced;
 mod api_client;
+#[cfg(target_os = "macos")]
+mod generator_cache;
 use api_client::*;
 mod gpu;
 use gpu::*;

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -32,8 +32,9 @@ use crate::media_jobs::{run_ffmpeg, FfmpegContext};
 use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
 #[cfg(target_os = "macos")]
 use mlx_gen::{
-    AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Image,
-    LoadSpec, MoeExpert, Precision, Progress, Quant, ReplacementMode, WeightsSource,
+    AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
+    Generator, Image, LoadSpec, MoeExpert, Precision, Progress, Quant, ReplacementMode,
+    WeightsSource,
 };
 #[cfg(target_os = "macos")]
 use mlx_gen_ltx as _;
@@ -1489,28 +1490,30 @@ impl Default for VideoGenInput {
     }
 }
 
-/// Load a video model and run one generation to a [`DecodedVideo`] (RGB8 frames + fps +
-/// optional audio), streaming denoise progress via `on_progress` and honoring `cancel`.
-/// Synchronous + blocking (the `Box<dyn Generator>` is `!Send`); the caller runs it on a
-/// blocking thread. The engine fills the audio track (LTX) or leaves it `None` (Wan).
 #[cfg(target_os = "macos")]
-fn run_video_generation(
-    input: VideoGenInput,
-    cancel: &CancelFlag,
-    on_progress: &mut dyn FnMut(Progress),
-) -> WorkerResult<DecodedVideo> {
-    let spec = LoadSpec {
-        weights: WeightsSource::Dir(input.model_dir),
+fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
+    LoadSpec {
+        weights: WeightsSource::Dir(input.model_dir.clone()),
         quantize: input.quant,
         precision: Precision::Bf16,
         control: None,
         // MultiControlNet (sc-3378) is image-only; video providers ignore it.
         extra_controls: Vec::new(),
         ip_adapter: None,
-        adapters: input.adapters,
-    };
-    let generator = mlx_gen::load(input.engine_id, &spec)
-        .map_err(|error| WorkerError::Engine(format!("video load failed: {error}")))?;
+        adapters: input.adapters.clone(),
+    }
+}
+
+/// Run one generation to a [`DecodedVideo`] (RGB8 frames + fps + optional audio) against an already
+/// loaded video generator, streaming denoise progress via `on_progress` and honoring `cancel`.
+/// The engine fills the audio track (LTX) or leaves it `None` (Wan).
+#[cfg(target_os = "macos")]
+fn run_loaded_video_generation(
+    generator: &dyn Generator,
+    input: VideoGenInput,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<DecodedVideo> {
     let req = GenerationRequest {
         prompt: input.prompt,
         negative_prompt: input.negative_prompt,
@@ -1561,6 +1564,32 @@ fn run_video_generation(
     }
 }
 
+#[cfg(all(target_os = "macos", test))]
+fn load_video_generation_for_tests(input: &VideoGenInput) -> WorkerResult<Box<dyn Generator>> {
+    let spec = LoadSpec {
+        weights: WeightsSource::Dir(input.model_dir.clone()),
+        quantize: input.quant,
+        precision: Precision::Bf16,
+        control: None,
+        // MultiControlNet (sc-3378) is image-only; video providers ignore it.
+        extra_controls: Vec::new(),
+        ip_adapter: None,
+        adapters: input.adapters.clone(),
+    };
+    mlx_gen::load(input.engine_id, &spec)
+        .map_err(|error| WorkerError::Engine(format!("video load failed: {error}")))
+}
+
+#[cfg(all(target_os = "macos", test))]
+fn run_video_generation(
+    input: VideoGenInput,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<DecodedVideo> {
+    let generator = load_video_generation_for_tests(&input)?;
+    run_loaded_video_generation(generator.as_ref(), input, cancel, on_progress)
+}
+
 /// Drive a `run_video_generation` on a blocking thread, forwarding its streamed denoise
 /// progress to the async worker (Generating stage ~0.25..0.58) + polling cancel ~every 2s.
 /// The shared blocking + mpsc + cancel plumbing for Wan and LTX.
@@ -1576,11 +1605,21 @@ async fn generate_video(
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Progress>(64);
     let blocking = {
         let cancel = cancel.clone();
-        tokio::task::spawn_blocking(move || -> WorkerResult<DecodedVideo> {
-            let mut on_progress = |progress: Progress| {
-                let _ = tx.blocking_send(progress);
-            };
-            run_video_generation(input, &cancel, &mut on_progress)
+        let spec = video_load_spec(&input);
+        let engine_id = input.engine_id;
+        tokio::spawn(async move {
+            crate::generator_cache::with_cached_generator(
+                engine_id,
+                spec,
+                "video load failed",
+                move |generator| {
+                    let mut on_progress = |progress: Progress| {
+                        let _ = tx.blocking_send(progress);
+                    };
+                    run_loaded_video_generation(generator, input, &cancel, &mut on_progress)
+                },
+            )
+            .await
         })
     };
 


### PR DESCRIPTION
## Summary
- Adds a macOS MLX generator cache worker that keeps a single resident generator on one dedicated thread and keys it by engine id plus the full LoadSpec fingerprint.
- Routes generic image, image-detail, and video MLX generation through the cached worker so back-to-back jobs with the same model/spec avoid reloading weights and reapplying adapters.
- Keeps direct load wrappers scoped to real-weight tests and leaves the bespoke InstantID concrete provider path unchanged.

## Validation
- cargo fmt --check
- cargo check -p sceneworks-worker --all-targets
- cargo test -p sceneworks-worker generator_cache -- --nocapture
- cargo test -p sceneworks-worker -- --nocapture
- cargo clippy -p sceneworks-worker --all-targets -- -D warnings

Note: the full worker test suite passed with the existing expected simulated poisoned-lock panic output from person_segment tests.