### PR TITLE
Allow HF-cache base model path for LoRA training

### DIFF
--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1234,6 +1234,29 @@ fn normalize_app_managed_path(
     ensure_path_under(path, &[data_dir], label)
 }
 
+/// The training base model is a read-only weights source the rust-api resolves
+/// (`resolve_base_model_path`) from either the app data dir *or* the shared
+/// Hugging Face hub cache — the default `HF_HOME` the desktop injects points the
+/// cache at `~/.cache/huggingface`, outside `data_dir`. Unlike output dirs and
+/// dataset roots (write targets, confined to `data_dir`), the base model may
+/// legitimately live in that cache, so it is allowed under either root. Without
+/// this, training an HF-cache-resident base model (e.g. z_image_turbo) fails the
+/// data-dir-only check even though the install/resolve gates accepted it.
+fn normalize_base_model_path(
+    settings: &Settings,
+    raw_path: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    let raw_path = raw_path.trim();
+    if raw_path.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!("{label} is required.")));
+    }
+    let data_dir = normalized_data_dir(settings)?;
+    let hf_cache = normalize_absolute_path(&huggingface_hub_cache_dir(&settings.data_dir))?;
+    let path = normalize_absolute_path(Path::new(raw_path))?;
+    ensure_path_under(path, &[data_dir, hf_cache], label)
+}
+
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn looks_like_huggingface_repo(value: &str) -> bool {
     let value = value.trim();

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -89,7 +89,7 @@ fn validate_training_plan(settings: &Settings, plan: &TrainingPlan) -> WorkerRes
             "Training plan dataset has no items to train on.".to_owned(),
         ));
     }
-    normalize_app_managed_path(
+    normalize_base_model_path(
         settings,
         &plan.target.base_model_path,
         "Training baseModelPath",
@@ -181,7 +181,7 @@ async fn run_training_dry_run(
 /// The dry-run completion summary (keys mirror the Python `dry_run_training_summary`
 /// so the Training Studio reads an identical shape regardless of which worker runs it).
 fn dry_run_summary(settings: &Settings, plan: &TrainingPlan) -> JsonObject {
-    let base_model_installed = normalize_app_managed_path(
+    let base_model_installed = normalize_base_model_path(
         settings,
         &plan.target.base_model_path,
         "Training baseModelPath",
@@ -906,6 +906,55 @@ mod tests {
         let error = validate_training_plan(&settings, &parse(value))
             .expect_err("outside base model rejected");
         assert!(error.to_string().contains("Training baseModelPath"));
+    }
+
+    /// The base model is a read-only weights source the rust-api resolves from the
+    /// shared Hugging Face hub cache, which the desktop points outside `data_dir`
+    /// via `HF_HOME`. Such a path must be accepted even though it is not under the
+    /// app data dir (regression for the z_image_turbo "must be inside an
+    /// app-managed directory" training failure). Serialized so the `HF_HUB_CACHE`
+    /// mutation can't race other env-reading tests.
+    #[test]
+    fn validate_accepts_base_model_in_hf_cache_outside_data_dir() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().expect("env lock");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let hf_cache = tempfile::tempdir().expect("hf cache tempdir");
+        let settings = test_settings(dir.path());
+        let dataset_root = dir.path().join("datasets").join("ds-1");
+        std::fs::create_dir_all(&dataset_root).expect("dataset root");
+        let image = dataset_root.join("image.png");
+        std::fs::write(&image, b"png").expect("image");
+
+        // The base model lives under the HF hub cache (outside data_dir), exactly
+        // as `resolve_base_model_path` returns for an HF-cache-resident model.
+        let base_model = hf_cache
+            .path()
+            .join("models--Tongyi-MAI--Z-Image-Turbo")
+            .join("snapshots")
+            .join("abc123");
+        let mut value = plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        );
+        value["target"]["baseModelPath"] = json!(base_model.display().to_string());
+
+        let prior = std::env::var("HF_HUB_CACHE").ok();
+        std::env::set_var("HF_HUB_CACHE", hf_cache.path());
+        let result = validate_training_plan(&settings, &parse(value));
+        match prior {
+            Some(value) => std::env::set_var("HF_HUB_CACHE", value),
+            None => std::env::remove_var("HF_HUB_CACHE"),
+        }
+
+        assert!(
+            result.is_ok(),
+            "HF-cache base model should validate: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two related fixes for LoRA training validation on the Rust worker. Both are cases where the rust-api resolves a legitimate path that the worker's defense-in-depth validator then rejected, blocking the job.

## 1. Base model in the HF cache (commit 1)

Starting a z-image-turbo LoRA training failed with:

> lora train: Training baseModelPath must be inside an app-managed directory (/Users/.../SceneWorks/data).

The base model (`Tongyi-MAI/Z-Image-Turbo`) is installed in the shared Hugging Face hub cache (`~/.cache/huggingface/hub/...`). The desktop injects `HF_HOME=~/.cache/huggingface` into the worker by default, so that cache is outside the data dir. The rust-api `resolve_base_model_path` and `training_base_model_installed` both accept the HF cache, so the job submitted — then the worker rejected it because `normalize_app_managed_path` required `data_dir` only.

The base model is a read-only weights source, not a write target. Added `normalize_base_model_path`, which allows the path under either `data_dir` **or** `huggingface_hub_cache_dir(data_dir)`.

## 2. Project-scoped output dir (commit 2)

After fix #1, the same run then failed with:

> lora train: Training outputDir must be inside an app-managed directory (.../data/loras, .../data/models).

Project-scoped training (the **default** scope) writes its LoRA to the owning project's tree — `resolve_training_output_location` returns `<data>/projects/<slug>.sceneworks/loras/<lora_id>`. But the worker's `resolve_training_output_dir` only allowed `<data>/loras` and `<data>/models`, so every project-scoped run was rejected. Added `<data>/projects` to the allowed output roots. All three stay inside the app data dir.

## Changes

All in `crates/sceneworks-worker/`:
- `src/lib.rs` — new `normalize_base_model_path`; `<data>/projects` added to `resolve_training_output_dir`'s allowed roots. `normalize_app_managed_path` (dataset roots) unchanged.
- `src/training_jobs.rs` — base-model validation uses the new helper; two new regression tests (`validate_accepts_base_model_in_hf_cache_outside_data_dir`, `validate_accepts_project_scoped_output_dir`). Existing negative tests still pass, so confinement isn't lost.

## Verification

- `cargo test -p sceneworks-worker --lib validate_` → 9/9 pass
- `cargo fmt --all --check` clean
- `cargo clippy -p sceneworks-worker` clean

## Reviewer notes

- User confirmed fix #1 works after an app rebuild (the base-model error is gone, surfacing the output-dir error fix #2 addresses). Fix #2 not yet validated live end-to-end — needs another worker rebuild.
- The HF-cache test mutates `HF_HUB_CACHE`, serialized with a local mutex and restoring the prior value; the only other non-ignored HF-env reader asserts on the repo slug `file_name`, independent of the cache root, so no cross-test interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)