### PR TITLE
Run desktop crate checks in Windows CI

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -50,6 +50,12 @@ jobs:
         run: npm ci --prefix apps/web
       - name: Install desktop dependencies
         run: npm ci --prefix apps/desktop
+      - name: Stage desktop test sidecar placeholders
+        run: node apps/desktop/scripts/stage-test-sidecars.mjs
+      - name: Run desktop Rust tests
+        run: cargo test -p sceneworks-desktop
+      - name: Check desktop Rust lint
+        run: npm run desktop:check
       # `tauri build` runs the beforeBuildCommand (build-sidecar/fetch-uv/
       # stage-python), then compiles the Tauri shell and packages the NSIS
       # installer. --bundles nsis pins the release pipeline to NSIS (the .exe

--- a/apps/desktop/scripts/stage-test-sidecars.mjs
+++ b/apps/desktop/scripts/stage-test-sidecars.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Stages minimal files required by Tauri's build-script resource validation for
+// desktop crate tests/lints. `tauri build` still runs the real beforeBuildCommand.
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const desktopDir = resolve(scriptDir, "..");
+
+const triple = execFileSync("rustc", ["-vV"], { encoding: "utf8" }).match(
+  /host:\s*(\S+)/,
+)?.[1];
+
+if (!triple) {
+  console.error("stage-test-sidecars: could not determine host target triple");
+  process.exit(1);
+}
+
+const exe = triple.includes("windows") ? ".exe" : "";
+const binariesDir = join(desktopDir, "binaries");
+mkdirSync(binariesDir, { recursive: true });
+
+for (const name of ["sceneworks-api", "uv"]) {
+  const path = join(binariesDir, `${name}-${triple}${exe}`);
+  writeFileSync(
+    path,
+    `SceneWorks CI placeholder for ${name}; replaced by tauri beforeBuildCommand during packaging.\n`,
+  );
+  if (!exe) {
+    chmodSync(path, 0o755);
+  }
+  console.log(`stage-test-sidecars: staged ${path}`);
+}
+
+for (const dir of ["python-src", "onnxruntime", "ffmpeg"]) {
+  const path = join(desktopDir, dir);
+  mkdirSync(path, { recursive: true });
+  writeFileSync(
+    join(path, "README.txt"),
+    "SceneWorks CI placeholder for desktop crate tests/lints; packaging stages real resources.\n",
+  );
+  console.log(`stage-test-sidecars: staged ${path}`);
+}


### PR DESCRIPTION
## Summary
- add explicit Windows CI steps for `cargo test -p sceneworks-desktop` and `npm run desktop:check`
- stage minimal Tauri sidecar/resource placeholders for test/lint validation so the desktop build script can run before the real installer build
- keep the existing `tauri build` packaging path unchanged; it still runs the real beforeBuild sidecar/resource staging

## Validation
- `node --check apps/desktop/scripts/stage-test-sidecars.mjs`
- `node apps/desktop/scripts/stage-test-sidecars.mjs`
- `cargo test -p sceneworks-desktop` (4 passed)
- `npm run desktop:check`
- `git diff --check`

Shortcut: sc-4222