### PR TITLE
Default compose API publish to loopback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,12 @@
 # API bind address and exposed port. The binary defaults to 127.0.0.1 (loopback)
-# so it is not LAN-reachable until you opt in. In Docker, keep the bind host at
-# 0.0.0.0 (set here) so the published host port can reach the container; pair it
-# with SCENEWORKS_ACCESS_TOKEN below for access control.
+# so it is not LAN-reachable until you opt in. In Docker, keep the container bind
+# host at 0.0.0.0 (set here) so the published host port can reach the container.
+# Compose publishes that port on host loopback by default; set
+# SCENEWORKS_API_PUBLISH_HOST=0.0.0.0 only when intentionally exposing the API to
+# your LAN, and pair that with SCENEWORKS_ACCESS_TOKEN below for access control.
 # Default port is 8010 (8000 commonly collides with ComfyUI on the same machine).
 SCENEWORKS_API_HOST=0.0.0.0
+SCENEWORKS_API_PUBLISH_HOST=127.0.0.1
 SCENEWORKS_API_PORT=8010
 
 # Docker API image. The Rust API is the only supported backend runtime.
@@ -11,7 +14,8 @@ SCENEWORKS_API_PORT=8010
 # Vite dev server port exposed by docker-compose.
 SCENEWORKS_WEB_PORT=5173
 
-# Leave blank for local open access, or set a private token for shared-machine/LAN use.
+# Leave blank for local loopback-only access, or set a private token for
+# shared-machine/LAN use.
 SCENEWORKS_ACCESS_TOKEN=
 
 # Comma-separated browser origins allowed to call the API. Add LAN hostnames or

--- a/README.md
+++ b/README.md
@@ -157,10 +157,12 @@ access from another machine), set `SCENEWORKS_API_HOST=0.0.0.0` **and** set
 `SCENEWORKS_ACCESS_TOKEN` — without a token, every endpoint (project file reads,
 credential writes, job creation, large model uploads) is reachable unauthenticated,
 and the API logs a warning on startup. Inside Docker, `SCENEWORKS_API_HOST=0.0.0.0`
-is set by `docker-compose.yml` so the published host port can reach the container;
-control access with `SCENEWORKS_ACCESS_TOKEN` and the published-port boundary, and
-extend `SCENEWORKS_CORS_ORIGINS` with LAN hostnames or IP origins when the web app is
-opened from another machine.
+is set by `docker-compose.yml` so the published host port can reach the container,
+but the host-side publish defaults to `SCENEWORKS_API_PUBLISH_HOST=127.0.0.1`.
+Set `SCENEWORKS_API_PUBLISH_HOST=0.0.0.0` only when intentionally exposing Docker
+Compose to the LAN; control access with `SCENEWORKS_ACCESS_TOKEN` and extend
+`SCENEWORKS_CORS_ORIGINS` with LAN hostnames or IP origins when the web app is opened
+from another machine.
 
 For offline development or deterministic Rust API tests, set `SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1` to skip live Hugging Face model size lookups. The catalog still returns the same fields with unknown sizes.
 

--- a/apps/rust-api/README.md
+++ b/apps/rust-api/README.md
@@ -7,9 +7,10 @@ The API uses these compose contracts:
 
 - `SCENEWORKS_API_HOST` and `SCENEWORKS_API_PORT` control the bind address. The
   binary defaults `SCENEWORKS_API_HOST` to `127.0.0.1` (loopback); compose sets it to
-  `0.0.0.0` so the published host port can reach the container. A non-loopback bind
-  with no `SCENEWORKS_ACCESS_TOKEN` serves every endpoint unauthenticated and logs a
-  startup warning.
+  `0.0.0.0` so the published host port can reach the container, while
+  `SCENEWORKS_API_PUBLISH_HOST` defaults the host-side publish to `127.0.0.1`. A
+  non-loopback bind or publish with no `SCENEWORKS_ACCESS_TOKEN` serves every endpoint
+  unauthenticated and logs a startup warning.
 - `SCENEWORKS_DATA_DIR=/sceneworks/data` maps to `${SCENEWORKS_DATA_BIND:-./data}`.
 - `SCENEWORKS_CONFIG_DIR=/sceneworks/config` maps writable to `${SCENEWORKS_CONFIG_BIND:-./config}` for user manifests.
 - `SCENEWORKS_JOBS_DB_PATH=/sceneworks/data/cache/jobs.db` stores queue state on the existing data bind mount.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
     ports:
-      - "${SCENEWORKS_API_PORT:-8010}:${SCENEWORKS_API_PORT:-8010}"
+      - "${SCENEWORKS_API_PUBLISH_HOST:-127.0.0.1}:${SCENEWORKS_API_PORT:-8010}:${SCENEWORKS_API_PORT:-8010}"
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
       - ${SCENEWORKS_HF_CACHE_BIND:-${USERPROFILE:-$HOME}/.cache/huggingface}:/sceneworks/data/cache/huggingface

--- a/scripts/check-compose-config.mjs
+++ b/scripts/check-compose-config.mjs
@@ -46,19 +46,32 @@ function assertWritableMount(service, target, label) {
   }
 }
 
+function assertPublishedPort(service, target, expectedHostIp, expectedPublished, label) {
+  const ports = service?.ports ?? [];
+  const port = ports.find((item) => Number(item?.target) === target);
+  if (!port) {
+    throw new Error(`${label}: expected published port for target ${target}`);
+  }
+  assertEqual(port.host_ip, expectedHostIp, `${label} API host publish IP`);
+  assertEqual(String(port.published), String(expectedPublished), `${label} API published port`);
+}
+
 function assertMissing(object, key, label) {
   if (Object.prototype.hasOwnProperty.call(object ?? {}, key)) {
     throw new Error(`${label}: expected ${key} to be absent`);
   }
 }
 
-function assertRuntimeDefaults(config, label) {
+function assertRuntimeDefaults(config, label, options = {}) {
+  const apiPublishHost = options.apiPublishHost ?? "127.0.0.1";
+  const apiPort = options.apiPort ?? "8010";
   const api = config.services?.api;
   const worker = config.services?.worker;
   const rustWorker = config.services?.["rust-worker"];
   // Split the removed key so the story's cleanup grep does not report this assertion as a live reference.
   const removedRuntimeKey = ["SCENEWORKS_API", "RUNTIME"].join("_");
   assertEqual(api?.build?.dockerfile, "docker/rust.Dockerfile", `${label} api dockerfile`);
+  assertPublishedPort(api, Number(apiPort), apiPublishHost, apiPort, `${label} api`);
   assertMissing(api?.environment, removedRuntimeKey, `${label} api runtime switch`);
   assertWritableMount(api, "/sceneworks/config", `${label} api config mount`);
   assertMissing(worker?.environment, "SCENEWORKS_UTILITY_JOBS", `${label} python utility jobs`);
@@ -76,11 +89,21 @@ function assertRuntimeDefaults(config, label) {
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "sceneworks-compose-config-"));
 const emptyEnv = path.join(tempRoot, "empty.env");
+const lanEnv = path.join(tempRoot, "lan.env");
 
 try {
   await writeFile(emptyEnv, "", "utf8");
+  await writeFile(
+    lanEnv,
+    "SCENEWORKS_API_PUBLISH_HOST=0.0.0.0\nSCENEWORKS_API_PORT=18010\n",
+    "utf8",
+  );
   assertRuntimeDefaults(await composeConfig(emptyEnv), "compose defaults");
   assertRuntimeDefaults(await composeConfig(".env.example"), ".env.example");
+  assertRuntimeDefaults(await composeConfig(lanEnv), "compose LAN override", {
+    apiPublishHost: "0.0.0.0",
+    apiPort: "18010",
+  });
   console.log("SceneWorks compose config check passed.");
 } finally {
   await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- default the Docker Compose API host port publish to `127.0.0.1` via `SCENEWORKS_API_PUBLISH_HOST`
- document the explicit `SCENEWORKS_API_PUBLISH_HOST=0.0.0.0` LAN override and token requirement
- extend the compose config check to assert the loopback default and the explicit LAN override

## Validation
- `npm run check:compose`
- direct `docker compose config --format json` spot-check shows API `host_ip: 127.0.0.1`
- `npm run check`
- `git diff --check`

Shortcut: sc-4223