### PR TITLE
Cache parity job Python and Rust dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,12 +33,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: ".github/workflows/check.yml"
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy,rustfmt
+      - uses: Swatinem/rust-cache@v2
       - name: Install contract test dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- enable pip caching for the parity job setup-python step
- key the pip cache to check.yml because the parity pip dependencies are installed inline there
- add Swatinem/rust-cache@v2 after the parity Rust toolchain setup

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/check.yml"); puts "check.yml YAML parsed"'\n- git diff --check