### PR TITLE
Allow project-scoped output dir for LoRA training

### DIFF
--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1319,7 +1319,17 @@ fn resolve_training_output_dir(
 ) -> WorkerResult<PathBuf> {
     let path = normalize_app_managed_path(settings, output_dir, label)?;
     let data_dir = normalized_data_dir(settings)?;
-    let allowed_roots = [data_dir.join("loras"), data_dir.join("models")];
+    // Global-scope outputs land in `<data>/loras` (or `<data>/models` for full
+    // fine-tunes); project-scope outputs — the default — land in the owning
+    // project's tree, `<data>/projects/<slug>.sceneworks/loras/<lora_id>`, which
+    // `resolve_training_output_location` computes API-side from trusted inputs.
+    // All three stay inside the app data dir, so allow the projects tree too
+    // rather than rejecting every project-scoped run.
+    let allowed_roots = [
+        data_dir.join("loras"),
+        data_dir.join("models"),
+        data_dir.join("projects"),
+    ];
     ensure_path_under(path, &allowed_roots, label)
 }
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -976,6 +976,40 @@ mod tests {
         assert!(error.to_string().contains("Training outputDir"));
     }
 
+    /// Project-scoped training (the default) writes to the owning project's tree,
+    /// `<data>/projects/<slug>.sceneworks/loras/<lora_id>`, which is under the app
+    /// data dir but not under `<data>/loras` or `<data>/models`. The worker must
+    /// accept it (regression for the "Training outputDir must be inside an
+    /// app-managed directory" failure on project-scoped runs).
+    #[test]
+    fn validate_accepts_project_scoped_output_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let dataset_root = dir.path().join("datasets").join("ds-1");
+        std::fs::create_dir_all(&dataset_root).expect("dataset root");
+        let image = dataset_root.join("image.png");
+        std::fs::write(&image, b"png").expect("image");
+        let mut value = plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        );
+        value["output"]["outputDir"] = json!(dir
+            .path()
+            .join("projects")
+            .join("my-character.sceneworks")
+            .join("loras")
+            .join("lora-1")
+            .display()
+            .to_string());
+        assert!(
+            validate_training_plan(&settings, &parse(value)).is_ok(),
+            "project-scoped output dir should validate"
+        );
+    }
+
     #[test]
     fn dry_run_summary_carries_plan_facts() {
         let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Problem

Starting a project-scoped LoRA training (the **default** scope) fails worker validation with:

> lora train: Training outputDir must be inside an app-managed directory (/Users/.../SceneWorks/data/loras, /Users/.../SceneWorks/data/models).

The rust-api's `resolve_training_output_location` writes project-scoped LoRA outputs into the owning project's tree — `<data>/projects/<slug>.sceneworks/loras/<lora_id>`. But the worker's `resolve_training_output_dir` only allowed `<data>/loras` and `<data>/models`, so every project-scoped run was rejected.

This is the follow-up validator that surfaced after the base-model HF-cache fix merged in #604. Same class of bug: the rust-api computes a legitimate path that the worker's defense-in-depth check then rejected.

## Fix

Add `<data>/projects` to the allowed output roots. All three locations (`<data>/loras` for global scope, `<data>/models` for full fine-tunes, `<data>/projects/...` for project scope) live inside the app data dir, so this keeps confinement within app-managed data.

### Why the projects *tree* rather than the specific project dir

`resolve_lora_import_target` (elsewhere in this file) resolves the exact project path via `project_path_for_payload` because its `targetDir` is **user-supplied**. Here, `output_dir` is fully **server-computed** by `resolve_training_output_location` from trusted inputs (scope + project id + lora id) and stamped into the plan — it is never client-controlled. The validator (`validate_training_plan`) also receives only the resolved `TrainingPlan`, which does not carry the owning project id, so per-project resolution would mean threading the job payload through the validator and its 9 call sites. Given the trusted-input nature of the path, allowing the app-managed `projects` tree is the proportionate, minimal fix.

## Changes

`crates/sceneworks-worker/`:
- `src/lib.rs` — `resolve_training_output_dir` adds `<data>/projects` to `allowed_roots`.
- `src/training_jobs.rs` — new regression test `validate_accepts_project_scoped_output_dir`. The existing `validate_rejects_output_dir_outside_app_lora_or_model_roots` (rejecting an arbitrary path outside the app data dir) still passes, so confinement isn't lost.

## Verification

- `cargo test -p sceneworks-worker --lib validate_` → 9/9 pass
- `cargo fmt --all --check` clean
- `cargo clippy -p sceneworks-worker` clean

## Reviewer notes

- Needs a worker rebuild to take effect, then the z-image-turbo project-scoped training should get past validation and start.
- There is one more validated path in `validate_training_plan` — `resolve_dataset_item_path` confines dataset images to the plan's `rootPath` (also API-computed) — which should be fine; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)