### PR TITLE
Constrain worker asset media paths to project root

### DIFF
--- a/apps/worker/scene_worker/image_adapters.py
+++ b/apps/worker/scene_worker/image_adapters.py
@@ -25,6 +25,7 @@ from sceneworks_shared import (
     find_project_path as shared_find_project_path,
     index_asset,
     read_json,
+    resolve_project_relative_path,
     safe_int,
     slugify,
     utc_now,
@@ -5585,7 +5586,10 @@ def find_asset_media_path(project_path: Path, asset_id: str) -> Path:
     sidecar_path = find_asset_sidecar_path(project_path, asset_id)
     if sidecar_path is not None:
         asset = read_json(sidecar_path)
-        media_path = project_path / asset.get("file", {}).get("path", "")
+        media_path_ref = str(asset.get("file", {}).get("path", "") or "")
+        media_path = resolve_project_relative_path(project_path, media_path_ref)
+        if media_path is None:
+            raise RuntimeError(f"Source image file path is outside the project for asset {asset_id}.")
         if media_path.exists():
             return media_path
         raise RuntimeError(f"Source image file is missing for asset {asset_id}.")

--- a/apps/worker/scene_worker/video_adapters.py
+++ b/apps/worker/scene_worker/video_adapters.py
@@ -23,6 +23,7 @@ from sceneworks_shared import (
     find_project_path,
     index_asset,
     read_json,
+    resolve_project_relative_path,
     safe_float,
     safe_int,
     slugify,
@@ -2352,7 +2353,9 @@ def source_asset_media_path(project_path: Path, asset_id: str | None) -> Path | 
         return None
     payload = read_json(sidecar_path)
     media_rel = payload.get("file", {}).get("path", "")
-    media_path = project_path / media_rel
+    media_path = resolve_project_relative_path(project_path, str(media_rel or ""))
+    if media_path is None:
+        return None
     return media_path if media_path.exists() else None
 
 
@@ -2379,8 +2382,8 @@ def load_source_frame(project_path: Path, asset_id: str | None, timestamp: float
     if sidecar_path is None:
         return None
     payload = read_json(sidecar_path)
-    media_path = project_path / payload.get("file", {}).get("path", "")
-    if not media_path.exists():
+    media_path = resolve_project_relative_path(project_path, str(payload.get("file", {}).get("path", "") or ""))
+    if media_path is None or not media_path.exists():
         return None
 
     image = load_seekable_image_frame(media_path, timestamp, payload.get("file", {}).get("duration"))
@@ -2400,7 +2403,9 @@ def load_source_video_frames(project_path: Path, asset_id: str | None, width: in
     if sidecar_path is None:
         raise RuntimeError(f"Source clip asset not found: {asset_id}.")
     payload = read_json(sidecar_path)
-    media_path = project_path / payload.get("file", {}).get("path", "")
+    media_path = resolve_project_relative_path(project_path, str(payload.get("file", {}).get("path", "") or ""))
+    if media_path is None:
+        raise RuntimeError(f"Source clip file path is outside the project for asset {asset_id}.")
     if not media_path.exists():
         raise RuntimeError(f"Source clip file is missing for asset {asset_id}.")
 

--- a/packages/shared/sceneworks_shared/__init__.py
+++ b/packages/shared/sceneworks_shared/__init__.py
@@ -7,6 +7,7 @@ from .project_db import (
     index_asset,
     purge_asset,
     reindex_project,
+    resolve_project_relative_path,
 )
 from .utils import (
     ProjectNotFound,
@@ -35,6 +36,7 @@ __all__ = [
     "purge_asset",
     "read_json",
     "reindex_project",
+    "resolve_project_relative_path",
     "safe_float",
     "safe_int",
     "slugify",

--- a/packages/shared/sceneworks_shared/project_db.py
+++ b/packages/shared/sceneworks_shared/project_db.py
@@ -199,6 +199,18 @@ def find_asset_sidecar_path(project_path: Path, asset_id: str) -> Path | None:
     return _find_asset_sidecar_by_glob(project_path, asset_id)
 
 
+def resolve_project_relative_path(project_path: Path, relative_path: str) -> Path | None:
+    if not relative_path:
+        return None
+    try:
+        project_root = project_path.resolve()
+        resolved = (project_root / relative_path).resolve()
+        resolved.relative_to(project_root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved
+
+
 def _find_asset_sidecar_by_glob(project_path: Path, asset_id: str) -> Path | None:
     for folder in ASSET_FOLDERS:
         for sidecar_path in (project_path / folder).rglob(ASSET_SIDECAR_PATTERN):

--- a/tests/test_worker_image_adapters.py
+++ b/tests/test_worker_image_adapters.py
@@ -2,6 +2,34 @@ from __future__ import annotations
 
 from worker_runtime_shared import *
 
+def _write_asset_sidecar(project_path, folder, asset_id, media_path):
+    sidecar_path = project_path / folder / f"{asset_id}.sceneworks.json"
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text(
+        json.dumps({"id": asset_id, "file": {"path": media_path}}),
+        encoding="utf-8",
+    )
+    return sidecar_path
+
+def test_find_asset_media_path_rejects_sidecar_paths_outside_project(tmp_path):
+    from scene_worker.image_adapters import find_asset_media_path
+
+    in_project_media = tmp_path / "assets" / "images" / "source.png"
+    in_project_media.parent.mkdir(parents=True, exist_ok=True)
+    in_project_media.write_bytes(b"not-a-real-png")
+    _write_asset_sidecar(tmp_path, "assets/images", "asset_inside", "assets/images/source.png")
+
+    assert find_asset_media_path(tmp_path, "asset_inside") == in_project_media.resolve()
+
+    outside_media = tmp_path.parent / f"{tmp_path.name}-outside.png"
+    outside_media.write_bytes(b"outside")
+    _write_asset_sidecar(tmp_path, "assets/images", "asset_absolute_escape", str(outside_media))
+    _write_asset_sidecar(tmp_path, "assets/images", "asset_relative_escape", f"../{outside_media.name}")
+
+    for asset_id in ("asset_absolute_escape", "asset_relative_escape"):
+        with pytest.raises(RuntimeError, match="outside the project"):
+            find_asset_media_path(tmp_path, asset_id)
+
 def test_run_image_upscale_writes_single_child_asset(tmp_path, monkeypatch):
     # sc-2431: standalone upscale of an existing asset. Mock the engine so the
     # orchestration (source resolve → one child asset + lineage) is exercised
@@ -4021,4 +4049,3 @@ def test_load_state_dict_requires_weights_only(tmp_path):
 
     with pytest.raises(RuntimeError, match="weights_only"):
         _load_state_dict(_AncientTorch(), weights)
-

--- a/tests/test_worker_video_adapters.py
+++ b/tests/test_worker_video_adapters.py
@@ -2,6 +2,35 @@ from __future__ import annotations
 
 from worker_runtime_shared import *
 
+def _write_video_asset_sidecar(project_path, asset_id, media_path):
+    sidecar_path = project_path / "assets" / "videos" / f"{asset_id}.sceneworks.json"
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text(
+        json.dumps({"id": asset_id, "file": {"path": media_path}}),
+        encoding="utf-8",
+    )
+    return sidecar_path
+
+def test_video_source_asset_media_path_rejects_sidecar_paths_outside_project(tmp_path):
+    from scene_worker.video_adapters import load_source_video_frames, source_asset_media_path
+
+    in_project_media = tmp_path / "assets" / "videos" / "clip.mp4"
+    in_project_media.parent.mkdir(parents=True, exist_ok=True)
+    in_project_media.write_bytes(b"not-a-real-video")
+    _write_video_asset_sidecar(tmp_path, "asset_inside", "assets/videos/clip.mp4")
+
+    assert source_asset_media_path(tmp_path, "asset_inside") == in_project_media.resolve()
+
+    outside_media = tmp_path.parent / f"{tmp_path.name}-outside.mp4"
+    outside_media.write_bytes(b"outside")
+    _write_video_asset_sidecar(tmp_path, "asset_absolute_escape", str(outside_media))
+    _write_video_asset_sidecar(tmp_path, "asset_relative_escape", f"../{outside_media.name}")
+
+    assert source_asset_media_path(tmp_path, "asset_absolute_escape") is None
+    assert source_asset_media_path(tmp_path, "asset_relative_escape") is None
+    with pytest.raises(RuntimeError, match="outside the project"):
+        load_source_video_frames(tmp_path, "asset_absolute_escape", 64, 64, 1)
+
 def test_ltx_mps_gating_leaves_cuda_path_untouched():
     gating = ltx_mps_gating(cuda_available=True, device_str="cuda")
     assert gating == {
@@ -1894,4 +1923,3 @@ def test_replace_person_video_result_carries_lineage_facts():
     # No real masked-control path ran here, so the worker reports no
     # replacementStatus; the Rust builder fills the honest false defaults.
     assert "replacementStatus" not in fact
-


### PR DESCRIPTION
## Summary
- add a shared project-relative path resolver that rejects absolute or traversal paths escaping the project root
- apply the guard to image asset media resolution and video source media/frame/clip resolution
- add regression coverage for in-project media, absolute escapes, and relative traversal escapes

## Validation
- `/Users/michael/Library/Application Support/SceneWorks/python/venv/bin/python -m pytest -q tests/test_worker_image_adapters.py tests/test_worker_video_adapters.py` -> 233 passed
- `/Users/michael/Library/Application Support/SceneWorks/python/venv/bin/python -m pytest -q tests/ -m "not e2e and not parity" --strict-markers` -> 550 passed, 17 deselected
- `npm run check`
- `npm run check:compose`
- `git diff --check`

Shortcut: sc-4233