### PR TITLE
Remove duplicate AuraSR upscaler path

### DIFF
--- a/apps/worker/scene_worker/upscalers.py
+++ b/apps/worker/scene_worker/upscalers.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import importlib
 import re
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any
 
 from PIL import Image
 
@@ -16,18 +16,6 @@ class UpscaleJob:
     engine: str = "real_esrgan"
     tile_size: int = 512
     tile_pad: int = 16
-
-
-class UpscalerEngine(Protocol):
-    id: str
-
-    def upscale(
-        self,
-        image: Image.Image,
-        *,
-        job: UpscaleJob,
-        settings: Any,
-    ) -> Image.Image: ...
 
 
 @dataclass(frozen=True)
@@ -49,15 +37,6 @@ def tile_slices(width: int, height: int, tile_size: int) -> list[TileSlice]:
         for x0 in range(0, width, tile_size):
             tiles.append(TileSlice(x0, y0, min(x0 + tile_size, width), min(y0 + tile_size, height)))
     return tiles
-
-
-def create_upscaler_engine(engine: str | None = None) -> UpscalerEngine:
-    engine_id = (engine or "real_esrgan").strip().lower().replace("-", "_")
-    if engine_id in {"real_esrgan", "realesrgan"}:
-        return RealESRGANUpscaler()
-    if engine_id in {"aura_sr", "aurasr"}:
-        return AuraSRUpscaler()
-    raise RuntimeError(f"Unsupported upscaler engine: {engine}.")
 
 
 class RealESRGANUpscaler:
@@ -152,38 +131,6 @@ class RealESRGANUpscaler:
         tile_pad: int,
     ) -> Image.Image:
         return _run_tiled(torch, model, image, factor=factor, device=device, dtype=dtype, tile_size=tile_size, tile_pad=tile_pad)
-
-
-class AuraSRUpscaler:
-    id = "aura_sr"
-
-    def upscale(
-        self,
-        image: Image.Image,
-        *,
-        job: UpscaleJob,
-        settings: Any,
-    ) -> Image.Image:
-        if job.factor != 4:
-            raise RuntimeError("AuraSR upscaling supports only 4x output.")
-        if not job.weights_path.exists():
-            raise RuntimeError(f"AuraSR weights are missing: {job.weights_path}")
-
-        torch = importlib.import_module("torch")
-        aura_sr = importlib.import_module("aura_sr")
-        from .image_adapters import activate_torch_device, select_torch_device
-
-        device = select_torch_device(torch, getattr(settings, "gpu_id", None))
-        activate_torch_device(torch, device)
-        model = aura_sr.AuraSR.from_pretrained(str(job.weights_path), use_safetensors=True)
-        upsampler = getattr(model, "upsampler", None)
-        if upsampler is not None and hasattr(upsampler, "to"):
-            upsampler.to(device)
-        if upsampler is not None and hasattr(upsampler, "eval"):
-            upsampler.eval()
-        if job.tile_pad > 0 and hasattr(model, "upscale_4x_overlapped"):
-            return model.upscale_4x_overlapped(image.convert("RGB"))
-        return model.upscale_4x(image.convert("RGB"))
 
 
 def _load_state_dict(torch: Any, weights_path: Path) -> dict[str, Any]:

--- a/tests/test_worker_image_adapters.py
+++ b/tests/test_worker_image_adapters.py
@@ -2552,6 +2552,87 @@ def test_aurasr_upscaler_rejects_non_4x_request(monkeypatch):
             cancel_requested=lambda: False,
         )
 
+def test_aurasr_upscaler_caches_loaded_model_and_threads_batch_size(tmp_path, monkeypatch):
+    weights = tmp_path / "model.safetensors"
+    weights.write_bytes(b"stub")
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+
+    class FakeTorch:
+        class cuda:
+            @staticmethod
+            def is_available():
+                return False
+
+        class backends:
+            mps = None
+
+    seen: dict[str, Any] = {"loads": 0, "calls": []}
+
+    class FakeUpsampler:
+        def __init__(self):
+            self.device = None
+            self.evaluated = False
+
+        def to(self, device):
+            self.device = device
+
+        def eval(self):
+            self.evaluated = True
+
+    class FakeAuraModel:
+        def __init__(self):
+            self.upsampler = FakeUpsampler()
+
+        def upscale_4x_overlapped(self, image, max_batch_size=16):
+            seen["calls"].append(max_batch_size)
+            return image.resize((image.width * 4, image.height * 4))
+
+    class FakeAuraSR:
+        @staticmethod
+        def from_pretrained(model_id, use_safetensors=True):
+            seen["loads"] += 1
+            seen["model_id"] = model_id
+            seen["use_safetensors"] = use_safetensors
+            model = FakeAuraModel()
+            seen["upsampler"] = model.upsampler
+            return model
+
+    fake_aura_module = SimpleNamespace(AuraSR=FakeAuraSR)
+    imports: list[str] = []
+
+    def fake_import_module(name):
+        imports.append(name)
+        if name == "torch":
+            return FakeTorch
+        if name == "aura_sr":
+            return fake_aura_module
+        return importlib.import_module(name)
+
+    monkeypatch.setattr("scene_worker.image_adapters.importlib.import_module", fake_import_module)
+    request = image_request_from_job(
+        {
+            "payload": {
+                "projectId": "p",
+                "upscale": {"enabled": True, "factor": 4, "engine": "aura-sr"},
+                "advanced": {"auraSrModelPath": str(weights), "auraSrMaxBatchSize": 3},
+            }
+        }
+    )
+    upscaler = AuraSrUpscaler(settings=SimpleNamespace(gpu_id="cpu"))
+
+    first = upscaler.upscale(Image.new("RGB", (3, 4), "white"), request=request, cancel_requested=lambda: False)
+    second = upscaler.upscale(Image.new("RGB", (2, 5), "white"), request=request, cancel_requested=lambda: False)
+
+    assert first.size == (12, 16)
+    assert second.size == (8, 20)
+    assert imports == ["torch", "aura_sr"]
+    assert seen["loads"] == 1
+    assert seen["model_id"] == str(weights)
+    assert seen["use_safetensors"] is True
+    assert seen["calls"] == [3, 3]
+    assert seen["upsampler"].device == "cpu"
+    assert seen["upsampler"].evaluated is True
+
 def test_image_asset_writer_retains_original_and_adds_upscaled_variant(monkeypatch, tmp_path):
     class FakeUpscaler:
         id = "real-esrgan"
@@ -2981,38 +3062,6 @@ def test_gpu_memory_snapshot_reports_allocated_and_reserved_bytes():
 
     assert snapshot == {"device": "cuda:0", "allocatedMb": 50.0, "reservedMb": 60.0}
 
-def test_upscaler_engine_selection_is_import_safe_without_torch(monkeypatch):
-    imported: list[str] = []
-
-    def fail_torch_import(name):
-        imported.append(name)
-        if name == "torch":
-            raise AssertionError("torch must not be imported while selecting an upscaler")
-        return importlib.import_module(name)
-
-    monkeypatch.setattr("scene_worker.upscalers.importlib.import_module", fail_torch_import)
-
-    engine = create_upscaler_engine("real-esrgan")
-
-    assert isinstance(engine, RealESRGANUpscaler)
-    assert imported == []
-
-def test_aurasr_engine_selection_is_import_safe_without_torch(monkeypatch):
-    imported: list[str] = []
-
-    def fail_torch_import(name):
-        imported.append(name)
-        if name == "torch":
-            raise AssertionError("torch must not be imported while selecting an upscaler")
-        return importlib.import_module(name)
-
-    monkeypatch.setattr("scene_worker.upscalers.importlib.import_module", fail_torch_import)
-
-    engine = create_upscaler_engine("aura-sr")
-
-    assert isinstance(engine, AuraSRUpscaler)
-    assert imported == []
-
 def test_upscaler_tile_slices_cover_edges_without_overlap_gaps():
     assert tile_slices(5, 3, 2) == [
         TileSlice(0, 0, 2, 2),
@@ -3079,62 +3128,6 @@ def test_real_esrgan_upscale_lazily_imports_torch_and_reuses_device_helpers(tmp_
         "dtype": "float32",
         "tile_size": 64,
         "tile_pad": 4,
-    }
-
-def test_aurasr_upscale_lazily_imports_torch_and_uses_local_weight_file(tmp_path, monkeypatch):
-    weights = tmp_path / "model.safetensors"
-    weights.write_bytes(b"stub")
-    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
-
-    class FakeTorch:
-        class cuda:
-            @staticmethod
-            def is_available():
-                return False
-
-        class backends:
-            mps = None
-
-    seen: dict[str, Any] = {}
-
-    class FakeAuraModel:
-        def upscale_4x_overlapped(self, image, max_batch_size=16, weight_type="checkboard"):
-            seen.update({"method": "overlapped", "max_batch_size": max_batch_size, "weight_type": weight_type})
-            return image.resize((image.width * 4, image.height * 4))
-
-    class FakeAuraSR:
-        @staticmethod
-        def from_pretrained(model_id, use_safetensors=True):
-            seen.update({"model_id": model_id, "use_safetensors": use_safetensors})
-            return FakeAuraModel()
-
-    fake_aura_module = SimpleNamespace(AuraSR=FakeAuraSR)
-    imports: list[str] = []
-
-    def fake_import_module(name):
-        imports.append(name)
-        if name == "torch":
-            return FakeTorch
-        if name == "aura_sr":
-            return fake_aura_module
-        return importlib.import_module(name)
-
-    monkeypatch.setattr("scene_worker.upscalers.importlib.import_module", fake_import_module)
-
-    result = AuraSRUpscaler().upscale(
-        Image.new("RGB", (3, 4), "white"),
-        job=UpscaleJob(factor=4, weights_path=weights, tile_pad=16),
-        settings=SimpleNamespace(gpu_id="cpu"),
-    )
-
-    assert result.size == (12, 16)
-    assert imports == ["torch", "aura_sr"]
-    assert seen == {
-        "model_id": str(weights),
-        "use_safetensors": True,
-        "method": "overlapped",
-        "max_batch_size": 16,
-        "weight_type": "checkboard",
     }
 
 def test_pipeline_component_devices_inspects_known_submodules():

--- a/tests/worker_runtime_shared.py
+++ b/tests/worker_runtime_shared.py
@@ -80,12 +80,10 @@ from scene_worker.image_adapters import (
 )
 
 from scene_worker.upscalers import (
-    AuraSRUpscaler,
     RealESRGANUpscaler,
     TileSlice,
     UpscaleJob,
     _load_state_dict,
-    create_upscaler_engine,
     tile_slices,
 )
 


### PR DESCRIPTION
## Summary
- delete the unused `create_upscaler_engine` factory and duplicate `upscalers.AuraSRUpscaler` implementation
- keep the live image-adapter AuraSR path as the single AuraSR wrapper
- replace dead-path tests with a production AuraSR regression proving model caching and batch-size threading

## Validation
- `/Users/michael/Library/Application Support/SceneWorks/python/venv/bin/python -m pytest -q tests/test_worker_image_adapters.py` -> 173 passed
- `/Users/michael/Library/Application Support/SceneWorks/python/venv/bin/python -m pytest -q tests/ -m "not e2e and not parity" --strict-markers` -> 548 passed, 17 deselected
- `npm run check`
- `npm run check:compose`
- `git diff --check`

Shortcut: sc-4234