### PR TITLE
Allow HF-cache base model in the real LoRA training run

### DIFF
--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1234,15 +1234,16 @@ fn normalize_app_managed_path(
     ensure_path_under(path, &[data_dir], label)
 }
 
-/// The training base model is a read-only weights source the rust-api resolves
-/// (`resolve_base_model_path`) from either the app data dir *or* the shared
+/// A model's weights are a read-only source the rust-api resolves (e.g.
+/// `resolve_base_model_path`) from either the app data dir *or* the shared
 /// Hugging Face hub cache — the default `HF_HOME` the desktop injects points the
 /// cache at `~/.cache/huggingface`, outside `data_dir`. Unlike output dirs and
-/// dataset roots (write targets, confined to `data_dir`), the base model may
-/// legitimately live in that cache, so it is allowed under either root. Without
-/// this, training an HF-cache-resident base model (e.g. z_image_turbo) fails the
-/// data-dir-only check even though the install/resolve gates accepted it.
-fn normalize_base_model_path(
+/// dataset roots (write targets, confined to `data_dir`), model weights may
+/// legitimately live in that cache, so they are allowed under either root. Used
+/// for the training base model and every other read-only model dir (captioner,
+/// image/InstantID). Without this, an HF-cache-resident model (e.g. z_image_turbo)
+/// fails the data-dir-only check even though the install/resolve gates accepted it.
+fn normalize_app_managed_model_path(
     settings: &Settings,
     raw_path: &str,
     label: &str,
@@ -1296,7 +1297,7 @@ fn resolve_app_managed_model_dir(
             "{label} snapshot is not cached for {model_name_or_path}."
         )));
     }
-    let path = normalize_app_managed_path(settings, model_name_or_path, label)?;
+    let path = normalize_app_managed_model_path(settings, model_name_or_path, label)?;
     if path.is_dir() {
         return Ok(path);
     }

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -89,7 +89,7 @@ fn validate_training_plan(settings: &Settings, plan: &TrainingPlan) -> WorkerRes
             "Training plan dataset has no items to train on.".to_owned(),
         ));
     }
-    normalize_base_model_path(
+    normalize_app_managed_model_path(
         settings,
         &plan.target.base_model_path,
         "Training baseModelPath",
@@ -181,7 +181,7 @@ async fn run_training_dry_run(
 /// The dry-run completion summary (keys mirror the Python `dry_run_training_summary`
 /// so the Training Studio reads an identical shape regardless of which worker runs it).
 fn dry_run_summary(settings: &Settings, plan: &TrainingPlan) -> JsonObject {
-    let base_model_installed = normalize_base_model_path(
+    let base_model_installed = normalize_app_managed_model_path(
         settings,
         &plan.target.base_model_path,
         "Training baseModelPath",
@@ -954,6 +954,48 @@ mod tests {
         assert!(
             result.is_ok(),
             "HF-cache base model should validate: {result:?}"
+        );
+    }
+
+    /// The REAL training run (`run_training_execution`) resolves the base model
+    /// weights via `resolve_app_managed_model_dir`, a path separate from the
+    /// dry-run validator. It must also accept an HF-cache-resident model dir, or
+    /// the dry run passes while the real run fails with "must be inside an
+    /// app-managed directory" (the z_image_turbo regression: dry run completed,
+    /// real run rejected the same `~/.cache/huggingface` snapshot).
+    #[test]
+    fn resolve_app_managed_model_dir_accepts_hf_cache_snapshot() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().expect("env lock");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let hf_cache = tempfile::tempdir().expect("hf cache tempdir");
+        let settings = test_settings(dir.path());
+
+        // A real, existing snapshot dir under the HF hub cache (outside data_dir),
+        // exactly what `resolve_base_model_path` hands the worker.
+        let snapshot = hf_cache
+            .path()
+            .join("models--Tongyi-MAI--Z-Image-Turbo")
+            .join("snapshots")
+            .join("abc123");
+        std::fs::create_dir_all(&snapshot).expect("snapshot dir");
+
+        let prior = std::env::var("HF_HUB_CACHE").ok();
+        std::env::set_var("HF_HUB_CACHE", hf_cache.path());
+        let resolved = resolve_app_managed_model_dir(
+            &settings,
+            &snapshot.display().to_string(),
+            "Training baseModelPath",
+        );
+        match prior {
+            Some(value) => std::env::set_var("HF_HUB_CACHE", value),
+            None => std::env::remove_var("HF_HUB_CACHE"),
+        }
+
+        assert!(
+            resolved.is_ok(),
+            "HF-cache model dir should resolve for the real run: {resolved:?}"
         );
     }
 


### PR DESCRIPTION
## Problem

Starting a **real** z-image-turbo LoRA training failed with:

> lora train: Training baseModelPath must be inside an app-managed directory (/Users/.../SceneWorks/data).

…even though the **dry run** of the same training **passed**. Ground truth from the jobs database — same `baseModelPath` (`~/.cache/huggingface/hub/models--Tongyi-MAI--Z-Image-Turbo/snapshots/…`):

| Job | dryRun | status |
|---|---|---|
| `job_4d7e47…` | true | **completed** |
| `job_a513e2…` | false | **failed** (single-root base-model error) |

## Cause

The training base-model path is validated in **three** places. #604 fixed two of them — `validate_training_plan` and `dry_run_summary` — both on the dry-run side. But the real run (`run_training_execution`) resolves the weights directory through a separate function, `resolve_app_managed_model_dir`, which still used the single-root `normalize_app_managed_path` check and rejected the `~/.cache/huggingface` snapshot.

That's why the dry run accepted the HF-cache model while the real run rejected it — and why earlier rebuilds appeared not to "take": they *were* fixing the dry-run path, just never the real one.

## Fix

- Generalized the HF-cache-tolerant helper: `normalize_base_model_path` → `normalize_app_managed_model_path`. It's a read-only **model-weights** check (data dir *or* the HF hub cache), not base-model-specific.
- Used it in `resolve_app_managed_model_dir`, replacing the single-root check. That resolver is also shared by the captioner and the image/InstantID model-path resolvers — all read-only model dirs that correctly become HF-cache-tolerant too. No regression: a model under `data_dir/models` still passes (data_dir is the first root).
- Output dirs and dataset roots keep their strict `data_dir`-only confinement (unchanged).

## Verification

- New test `resolve_app_managed_model_dir_accepts_hf_cache_snapshot` covers the real-run path (fails on old code, passes now).
- `cargo test -p sceneworks-worker --lib` (validate_* + the new test) pass; `cargo fmt --check` and `cargo clippy -p sceneworks-worker` clean.
- **Runtime-confirmed**: with the fixed binary installed, the real z-image-turbo training passes validation and is training (`job_e60a23…` status `running`, no error).

## Note

Follow-up to #604 and #611. This completes base-model HF-cache tolerance across all three validation sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)