### PR TITLE
sc-3722: bump mlx-gen pins to 810a9ff (sampler/weights-metadata split, epic 3720)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2522,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "image",
  "inventory",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "image",
  "inventory",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "image",
  "inventory",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "image",
  "inventory",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "image",
  "inventory",
@@ -2975,7 +2975,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4165,6 +4165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4206,9 +4216,10 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=f0aa634996a0760e6a0ca4483f1c43eaef5acd41#f0aa634996a0760e6a0ca4483f1c43eaef5acd41"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=810a9ff6170690e0f01c1410730d8e5528c40e65#810a9ff6170690e0f01c1410730d8e5528c40e65"
 dependencies = [
  "inventory",
+ "safetensors",
  "thiserror 2.0.18",
  "tokenizers",
 ]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -68,6 +68,17 @@ tower = { version = "0.5", features = ["util"] }
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# Rev 810a9ff (mlx-gen main, merged PR #381, epic 3720 / sc-3722): the sampler-policy + weights-
+# metadata split. The schedule/coefficient math (per-step affine `StepCoeffs`, the FlowMatch/LCM/TCD/
+# Lightning policies, the `AlphaSchedule`/sigma builders) and the safetensors header/byte-view reader
+# (`CheckpointMeta`) + LoRA/LoKr/LoHa/kohya string parsing move into `sceneworks-gen-core`; mlx-gen
+# keeps only the tensor `apply_step` and re-exports every sampler type + `mlx_gen::adapters::loader`
+# helper at the old paths. NO public mlx-gen signature changed (the worker import surface, Appendix C,
+# is identical) and the byte-parity rule keeps flow-match/FLUX golden output bit-for-bit unchanged, so
+# this bump has ZERO worker source diff — only the rev + lock. One behavior change exists upstream but
+# is not worker-visible: stochastic accel samplers (LCM/TCD η>0, SDXL-only) now draw seeded per-step
+# re-noise (D6). New transitive build dep `safetensors` enters gen-core's subgraph (serde-only, no
+# tensor lib). The mlx-rs pin is unchanged (e59ffd88) so MLX core rebuilds nothing. On top of:
 # Rev f0aa634 (mlx-gen main, merged PR #380, epic 3720 / sc-3721): Phase-0 of the backend-neutral
 # gen-core extraction. Adds a new workspace member `sceneworks-gen-core` (lib `gen_core`, zero tensor
 # deps) holding the Generator/Trainer/Captioner/Transform contracts, request/output/registry types,
@@ -133,7 +144,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (epic 3040), JoyCaption captioner (epic 3550), and the XLabs FLUX IP-Adapter (epic 3621).
 # One shared rev so MLX builds once with the unchanged mlx-rs pin (e59ffd88, identical across
 # the bump -> no MLX rebuild).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -141,60 +152,60 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "e59ffd88014340e6a49b26de95446b8b76a57932" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -203,7 +214,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa63
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -211,7 +222,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f0aa634996a0760e6a0ca4483f1c43eaef5acd41" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "810a9ff6170690e0f01c1410730d8e5528c40e65" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Pin-bump following mlx-gen [#381](https://github.com/michaeltrefry/mlx-gen/pull/381) (sc-3722, epic 3720 Phase 0). Branched fresh off `main` (`7ba5bd6`).

## What changed
- All **16** mlx-gen git-dep revs bumped `f0aa634` → `810a9ff` in `crates/sceneworks-worker/Cargo.toml`, plus the pin-history comment and `Cargo.lock`.
- mlx-rs pin (`e59ffd88`) **unchanged** → MLX core rebuilds nothing.
- New transitive build dep `safetensors 0.4` enters gen-core's subgraph (serde-only, no tensor lib).

## Why zero worker source diff
mlx-gen #381 moved the sampler schedule/coefficient math (`StepCoeffs` + FlowMatch/LCM/TCD/Lightning policies + `AlphaSchedule`/sigma builders) and the safetensors metadata/key-map parsing (`CheckpointMeta` + LoRA/LoKr/LoHa/kohya string parsing) into backend-neutral **gen-core**, keeping mlx-gen's tensor `apply_step` and re-exporting every sampler type and `mlx_gen::adapters::loader` helper at the old paths. No public signature changed (Appendix C import surface identical), and the §3.3 byte-parity rule keeps flow-match/FLUX golden output bit-for-bit identical. The one upstream behavior change (seeded per-step re-noise for SDXL-only LCM/TCD η>0 accel, D6) is not worker-visible.

## Verification (local, Apple-Silicon macOS)
- `cargo build -p sceneworks-worker` ✅ (clean, 11s — only mlx-gen crates + worker recompiled)
- `cargo test -p sceneworks-worker --no-run` ✅ (lib + `nax_guard` test targets compile against 810a9ff)

Diff is rev + lock only — the predicted "none" worker source change holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)