### PR TITLE
Fix flaky HF_HUB_CACHE training-validation tests (share one poison-resistant ENV_LOCK)

### DIFF
--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -702,6 +702,14 @@ async fn run_training_execution(
 mod tests {
     use super::*;
 
+    /// Serializes every test that mutates the process-global `HF_HUB_CACHE` env
+    /// var. Must be a SINGLE module-level mutex: per-function `static`s are
+    /// distinct locks and do not serialize against each other, so under parallel
+    /// test execution one test's `set_var`/`remove_var` races another's
+    /// validation read (the intermittent "must be inside an app-managed
+    /// directory" flake on the macOS nax-worker CI lane).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn test_settings(data_dir: &Path) -> Settings {
         Settings {
             api_url: "http://127.0.0.1".to_owned(),
@@ -916,8 +924,10 @@ mod tests {
     /// mutation can't race other env-reading tests.
     #[test]
     fn validate_accepts_base_model_in_hf_cache_outside_data_dir() {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        // Recover from poisoning: a panic in another env-mutating test must not
+        // cascade into a spurious failure here — we only need the mutual
+        // exclusion, not the guarded data.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let dir = tempfile::tempdir().expect("tempdir");
         let hf_cache = tempfile::tempdir().expect("hf cache tempdir");
@@ -965,8 +975,7 @@ mod tests {
     /// real run rejected the same `~/.cache/huggingface` snapshot).
     #[test]
     fn resolve_app_managed_model_dir_accepts_hf_cache_snapshot() {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let dir = tempfile::tempdir().expect("tempdir");
         let hf_cache = tempfile::tempdir().expect("hf cache tempdir");


### PR DESCRIPTION
## Problem

Two unit tests in `crates/sceneworks-worker/src/training_jobs.rs` intermittently failed on the macOS `nax-worker` CI lane:

- `training_jobs::tests::validate_accepts_base_model_in_hf_cache_outside_data_dir`
- `training_jobs::tests::resolve_app_managed_model_dir_accepts_hf_cache_snapshot`

Both panicked with `Training baseModelPath must be inside an app-managed directory (...)`. They passed locally and on earlier CI runs, then began failing intermittently — a flake introduced by #617 and observed on #618 (sc-3722 pin-bump).

## Root cause

Each test mutates the process-global `HF_HUB_CACHE` env var (`set_var`/`remove_var`), guarded only by a `static ENV_LOCK: Mutex<()>` declared **inside each function**. Two functions → two distinct mutexes → no mutual exclusion. The worker crate runs tests in parallel (it doesn't force `RUST_TEST_THREADS=1`), so one test's `set_var`/restore raced the other's validation read, and validation saw the wrong cache root and rejected a valid path.

## Fix

- Hoist a **single module-level** `static ENV_LOCK` shared by both tests so every `HF_HUB_CACHE`-mutating test serializes against each other.
- Recover from poisoning (`lock().unwrap_or_else(|e| e.into_inner())`) so a panic in one env-mutating test can't cascade into a spurious failure in the other — only the mutual exclusion matters, not the guarded `()`.

Chose the targeted lock fix over forcing `RUST_TEST_THREADS=1` crate-wide, which would needlessly serialize all 244 tests.

## Verification

- 5× full `cargo test -p sceneworks-worker --lib`: 244 passed, 0 failed each run.
- 10× targeted runs of just the two `hf_cache` tests under contention: all green.
- 3× full re-run after the poison-resistance change: still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)