### PR TITLE
sc-3724: single backend-neutral worker paths (generate/train/caption) + named carve-outs (epic 3720)

### DIFF
--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -12,8 +12,11 @@ const JOY_CAPTION_MODEL: &str = "fancyfeast/llama-joycaption-beta-one-hf-llava";
 #[cfg(target_os = "macos")]
 const CANCEL_MESSAGE: &str = "Training captioning canceled by user.";
 
+// epic 3720 (sc-3724): the backend-neutral captioner contract types come from `gen_core`; the
+// `as _;` provider link below stays mlx-gen-specific (it registers the JoyCaption captioner into
+// the registry).
 #[cfg(target_os = "macos")]
-use mlx_gen::{
+use gen_core::{
     CancelFlag, CaptionOptions, CaptionRequest, CaptionSampling, Image, LoadSpec, Progress,
     WeightsSource,
 };
@@ -131,7 +134,7 @@ pub(crate) async fn run_training_caption_job(
                 "engine": JOY_CAPTION_MODEL,
             }),
         );
-        let captioner = mlx_gen::load_captioner(
+        let captioner = gen_core::load_captioner(
             JOY_CAPTION_MODEL,
             &LoadSpec::new(WeightsSource::Dir(weights_dir)),
         )
@@ -172,6 +175,7 @@ pub(crate) async fn run_training_caption_job(
                 .map_err(|error| {
                     WorkerError::Engine(format!("JoyCaption MLX generation failed: {error}"))
                 })?;
+            // epic 3720: JoyCaption trigger-word string helper stays mlx-gen-local until lifted to gen_core::caption.
             let text = mlx_gen::caption::joycaption::apply_trigger_words(
                 &output.text,
                 &item.trigger_words,

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -22,7 +22,7 @@
 pub(crate) struct ModelRow {
     /// SceneWorks model id (the job payload `model`).
     pub sceneworks_id: &'static str,
-    /// mlx-gen registry id passed to `mlx_gen::load`.
+    /// registry id passed to `gen_core::load`.
     pub engine_id: &'static str,
     /// Default HuggingFace repo when the manifest entry omits `repo`.
     pub default_repo: &'static str,
@@ -195,7 +195,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // Python `MODEL_TARGETS` / `KolorsDiffusersAdapter` parity: 25 steps, guidance 5.0. The engine
     // `kolors` model (sc-3874) supports the full surface — img2img / ControlNet-pose /
     // IP-Adapter-Plus / Q8/Q4 / LoRA/LoKr — but this base row drives plain T2I (+ quant + LoRA)
-    // through `generate_mlx_stream`; the advanced conditioning modes are gated to torch by
+    // through `generate_stream`; the advanced conditioning modes are gated to torch by
     // `kolors_mlx_eligible` until their dedicated streams land (subsequent epic-3090 slices).
     ModelRow {
         sceneworks_id: "kolors",
@@ -246,7 +246,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // image-guidance via `true_cfg` (edit ≈ 1.0 / character ≈ 1.5) — so it is NOT a
     // [`uses_true_cfg`] family (which is for engines that read the *single* CFG knob from
     // `true_cfg`). The descriptor advertises no negative prompt. Plain T2I rides
-    // [`generate_mlx_stream`]; edit (`Reference`) + Character Studio (`MultiReference`) divert to
+    // [`generate_stream`]; edit (`Reference`) + Character Studio (`MultiReference`) divert to
     // [`generate_sensenova_edit_stream`] where the dual CFG + reference conditioning are built.
     // `_fast` is the same base weights with the 8-step distill LoRA merged internally at load
     // (`load_fast`); the worker only selects the engine id, the engine resolves + merges the

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::{mpsc, OnceLock};
 use std::thread;
 
-use mlx_gen::{
+use gen_core::{
     AdapterKind, AdapterSpec, Generator, LoadSpec, MoeExpert, Precision, Quant, WeightsSource,
 };
 use tokio::sync::oneshot;
@@ -106,7 +106,7 @@ impl GeneratorCache {
     ) -> WorkerResult<R> {
         if self.entry.as_ref().map_or(true, |entry| entry.key != key) {
             self.entry = None;
-            let generator = mlx_gen::load(&key.engine_id, &spec)
+            let generator = gen_core::load(&key.engine_id, &spec)
                 .map_err(|error| WorkerError::Engine(format!("{load_error_context}: {error}")))?;
             self.entry = Some(GeneratorCacheEntry {
                 key: key.clone(),
@@ -202,6 +202,166 @@ mod tests {
         assert_ne!(
             GeneratorCacheKey::from_load_spec("sdxl", &control),
             GeneratorCacheKey::from_load_spec("sdxl", &ip)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Backend-neutral acceptance seam (epic 3720, sc-3724). A pure-`gen_core`
+    // `Generator` registered into the same `inventory` registry the real provider crates use
+    // (with a UNIQUE id so it never collides with a real engine or the engines.rs derivation
+    // stubs). It links NO tensor backend, so these tests run on Linux/Windows AND macOS, proving
+    // the load→progress→cancel→output contract that `with_cached_generator` is the production seam
+    // for. Mirrors the inventory pattern at engines.rs.
+    struct StubGenerator {
+        descriptor: gen_core::ModelDescriptor,
+    }
+
+    impl Generator for StubGenerator {
+        fn descriptor(&self) -> &gen_core::ModelDescriptor {
+            &self.descriptor
+        }
+
+        fn validate(&self, _req: &gen_core::GenerationRequest) -> gen_core::Result<()> {
+            Ok(())
+        }
+
+        fn generate(
+            &self,
+            req: &gen_core::GenerationRequest,
+            on_progress: &mut dyn FnMut(gen_core::Progress),
+        ) -> gen_core::Result<gen_core::GenerationOutput> {
+            on_progress(gen_core::Progress::Step {
+                current: 1,
+                total: 2,
+            });
+            if req.cancel.is_cancelled() {
+                return Err(gen_core::Error::Canceled);
+            }
+            on_progress(gen_core::Progress::Step {
+                current: 2,
+                total: 2,
+            });
+            Ok(gen_core::GenerationOutput::Images(vec![gen_core::Image {
+                width: 2,
+                height: 2,
+                pixels: vec![0u8; 12],
+            }]))
+        }
+    }
+
+    fn stub_descriptor() -> gen_core::ModelDescriptor {
+        gen_core::ModelDescriptor {
+            id: "sc3724_stub",
+            family: "test",
+            backend: "stub",
+            modality: gen_core::Modality::Image,
+            capabilities: gen_core::Capabilities::default(),
+        }
+    }
+
+    fn stub_load(_spec: &gen_core::LoadSpec) -> gen_core::Result<Box<dyn Generator>> {
+        Ok(Box::new(StubGenerator {
+            descriptor: stub_descriptor(),
+        }))
+    }
+
+    inventory::submit! {
+        gen_core::registry::ModelRegistration { descriptor: stub_descriptor, load: stub_load }
+    }
+
+    // load → progress → asset: drive the production cache seam end to end with a backend-neutral
+    // generator. Collect progress, take the produced image, write a PNG, and build a minimal
+    // asset-fact JSON — the same shape (load → generate → persist) the macOS image path follows.
+    #[tokio::test]
+    async fn cached_generator_loads_progresses_and_writes_asset() {
+        let weights = tempfile::tempdir().expect("weights tempdir");
+        let spec = LoadSpec::new(WeightsSource::Dir(weights.path().to_path_buf()));
+        let assets = tempfile::tempdir().expect("asset tempdir");
+        let png_path = assets.path().join("stub.png");
+        let png_path_for_run = png_path.clone();
+
+        let fact = with_cached_generator("sc3724_stub", spec, "stub load", move |generator| {
+            let req = gen_core::GenerationRequest {
+                width: 2,
+                height: 2,
+                ..Default::default()
+            };
+            let mut steps: Vec<gen_core::Progress> = Vec::new();
+            let output = generator
+                .generate(&req, &mut |progress| steps.push(progress))
+                .map_err(|error| WorkerError::Engine(error.to_string()))?;
+            let image = match output {
+                gen_core::GenerationOutput::Images(mut images) => images.remove(0),
+                other => {
+                    return Err(WorkerError::Engine(format!(
+                        "expected images, got {other:?}"
+                    )))
+                }
+            };
+            let buffer = image::RgbImage::from_raw(image.width, image.height, image.pixels)
+                .ok_or_else(|| WorkerError::Engine("stub image buffer size mismatch".to_owned()))?;
+            buffer
+                .save(&png_path_for_run)
+                .map_err(|error| WorkerError::Engine(error.to_string()))?;
+            let step_count = steps
+                .iter()
+                .filter(|p| matches!(p, gen_core::Progress::Step { .. }))
+                .count();
+            Ok(serde_json::json!({
+                "assetId": uuid::Uuid::new_v4().to_string(),
+                "path": png_path_for_run.display().to_string(),
+                "steps": step_count,
+            }))
+        })
+        .await
+        .expect("stub generate succeeds");
+
+        assert!(
+            fact.get("steps")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0)
+                >= 1,
+            "expected at least one Progress::Step"
+        );
+        assert!(png_path.exists(), "expected the PNG asset to be written");
+        assert!(
+            fact.get("assetId")
+                .and_then(serde_json::Value::as_str)
+                .is_some(),
+            "expected the asset fact to carry an asset id"
+        );
+    }
+
+    // cancel honored: a pre-tripped CancelFlag makes the generator return `Error::Canceled`, which
+    // the seam maps to `WorkerError::Canceled` (the typed cancellation the worker distinguishes
+    // from generic failure).
+    #[tokio::test]
+    async fn cached_generator_honors_cancel() {
+        let weights = tempfile::tempdir().expect("weights tempdir");
+        let spec = LoadSpec::new(WeightsSource::Dir(weights.path().to_path_buf()));
+
+        let result = with_cached_generator("sc3724_stub", spec, "stub load", move |generator| {
+            let cancel = gen_core::runtime::CancelFlag::new();
+            cancel.cancel();
+            let req = gen_core::GenerationRequest {
+                width: 2,
+                height: 2,
+                cancel,
+                ..Default::default()
+            };
+            generator
+                .generate(&req, &mut |_progress| {})
+                .map(|_| ())
+                .map_err(|error| match error {
+                    gen_core::Error::Canceled => WorkerError::Canceled(error.to_string()),
+                    other => WorkerError::Engine(other.to_string()),
+                })
+        })
+        .await;
+
+        assert!(
+            matches!(result, Err(WorkerError::Canceled(_))),
+            "expected the cancel flag to map to WorkerError::Canceled, got {result:?}"
         );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -20,8 +20,12 @@ use sceneworks_core::image_request::ImageRequest;
 // Force each provider crate to link so its `inventory::submit!` registration survives
 // linker GC. Each per-family story adds its provider dep + a matching `use … as _;`.
 // See mlx-gen-z-image/tests/registry.rs ("the SceneWorks worker").
+// epic 3720 (sc-3724): the backend-neutral contract types come from `gen_core` (the registry
+// contract layer mlx-gen re-exports). The `as _;` provider links below stay mlx-gen-specific —
+// `cfg(target_os)` decides which backend crates register into the registry, not which contract
+// types the worker names.
 #[cfg(target_os = "macos")]
-use mlx_gen::{
+use gen_core::{
     AdapterKind, AdapterSpec, CancelFlag, Conditioning, ControlKind, GenerationOutput,
     GenerationRequest, Generator, Image, LoadSpec, Progress, Quant, WeightsSource,
 };
@@ -41,10 +45,13 @@ use mlx_gen_sdxl as _;
 use mlx_gen_sensenova as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_z_image as _;
+// CARVE-OUT(epic 3720): backend-specific; absorbed by FaceEmbedder in Phase 3.
 // InstantID (sc-3345) is a bespoke provider, not an inventory-registered `Generator`, so it is
 // referenced by name (`InstantId::load`) rather than anchored with `as _;` — and the native face
 // stack it composes (`mlx-gen-face`, SCRFD + ArcFace) rides in transitively but is anchored here so
-// the direct dep the story adds is meaningful + survives any future unused-crate lint.
+// the direct dep the story adds is meaningful + survives any future unused-crate lint. The
+// `mlx_gen::weights::Weights` loader and the `mlx_gen_instantid` API stay mlx-gen-typed until the
+// bespoke face stack is lifted onto a neutral FaceEmbedder contract.
 #[cfg(target_os = "macos")]
 use mlx_gen::weights::Weights;
 #[cfg(target_os = "macos")]
@@ -230,7 +237,7 @@ pub(crate) async fn run_image_generate_job(
                 .await?;
             }
             ImageRoute::Mlx => {
-                generate_mlx_stream(
+                generate_stream(
                     api,
                     settings,
                     job,
@@ -517,7 +524,7 @@ fn resolve_family(request: &ImageRequest) -> String {
     }
     #[cfg(target_os = "macos")]
     {
-        if let Some(family) = mlx_gen::registry::generators()
+        if let Some(family) = gen_core::registry::generators()
             .find(|registration| (registration.descriptor)().id == request.model)
             .map(|registration| (registration.descriptor)().family)
         {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -322,18 +322,7 @@ fn mlx_raw_settings(
     raw
 }
 
-/// Load the generator for `engine_id` (heavy; once per job).
-#[cfg(all(target_os = "macos", test))]
-fn mlx_load(
-    engine_id: &str,
-    weights_dir: PathBuf,
-    quant: Option<Quant>,
-    adapters: Vec<AdapterSpec>,
-) -> WorkerResult<Box<dyn Generator>> {
-    mlx_load_with_ip(engine_id, weights_dir, quant, adapters, None)
-}
-
-fn mlx_load_spec(
+fn load_spec(
     weights_dir: PathBuf,
     quant: Option<Quant>,
     adapters: Vec<AdapterSpec>,
@@ -352,19 +341,22 @@ fn mlx_load_spec(
     spec
 }
 
-/// As [`mlx_load`], but optionally installing an IP-Adapter from `ip_adapter_dir`
-/// (`LoadSpec::with_ip_adapter`). Used by the FLUX.1 XLabs IP-Adapter reference path
-/// (epic 3621): the engine then treats a `Conditioning::Reference` as the image prompt.
+/// Registry-only generator load (epic 3720, sc-3724): resolve `engine_id` through the
+/// backend-neutral `gen_core::load` seam and return a `Box<dyn gen_core::Generator>`. Optionally
+/// installs an IP-Adapter from `ip_adapter_dir` (`LoadSpec::with_ip_adapter`) — the FLUX.1 XLabs
+/// IP-Adapter reference path (epic 3621), after which the engine treats a `Conditioning::Reference`
+/// as the image prompt. `cfg(target_os)` decides which provider crate registered the engine, not
+/// this call.
 #[cfg(all(target_os = "macos", test))]
-fn mlx_load_with_ip(
+fn load_engine(
     engine_id: &str,
     weights_dir: PathBuf,
     quant: Option<Quant>,
     adapters: Vec<AdapterSpec>,
     ip_adapter_dir: Option<PathBuf>,
 ) -> WorkerResult<Box<dyn Generator>> {
-    let spec = mlx_load_spec(weights_dir, quant, adapters, ip_adapter_dir);
-    mlx_gen::load(engine_id, &spec)
+    let spec = load_spec(weights_dir, quant, adapters, ip_adapter_dir);
+    gen_core::load(engine_id, &spec)
         .map_err(|error| WorkerError::Engine(format!("{engine_id} load failed: {error}")))
 }
 
@@ -430,7 +422,7 @@ fn resolve_flux_ip_adapter_dir(settings: &Settings) -> WorkerResult<PathBuf> {
 
 /// Emit an `image_pipeline_load_{start,complete}` event from inside a blocking
 /// generation closure (sc-3450), parity with the Python worker's pipeline-load
-/// events. On the MLX path `mlx_gen::load` is a single atomic call that also fuses
+/// events. On the backend path `gen_core::load` is a single atomic call that also fuses
 /// any distill LoRA and applies user LoRAs (`spec.with_adapters`), so there is no
 /// separable fuse/apply step to bracket: the adapter total (`adapter_count` =
 /// distill + user) is reported here instead of via the torch worker's separate
@@ -455,7 +447,7 @@ pub(crate) fn emit_load_event(event: &str, job_id: &str, engine: &str, adapter_c
 /// (no-ControlNet) Z-Image reference-without-pose path, reusing the same engine img2img the
 /// strict-pose tier already drives. `None` → plain txt2img.
 #[allow(clippy::too_many_arguments)]
-fn mlx_generate_one(
+fn generate_one(
     generator: &dyn Generator,
     prompt: &str,
     width: u32,
@@ -522,7 +514,7 @@ fn step_fraction(index: usize, current: u32, total: u32, count: u32) -> f64 {
 /// `assetWrites`, and polls cancel). MLX runs entirely on the blocking thread (the
 /// `Box<dyn Generator>` is `!Send` and the MLX device is single-thread).
 #[allow(clippy::too_many_arguments)]
-async fn generate_mlx_stream(
+async fn generate_stream(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
@@ -631,7 +623,7 @@ async fn generate_mlx_stream(
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
-    let spec = mlx_load_spec(weights_dir, quant, adapters, flux_ip_dir);
+    let spec = load_spec(weights_dir, quant, adapters, flux_ip_dir);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
@@ -640,7 +632,7 @@ async fn generate_mlx_stream(
         format!("{engine_id} load failed"),
         move |generator, tx, cancel| {
             drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
-                let (out_w, out_h, pixels) = mlx_generate_one(
+                let (out_w, out_h, pixels) = generate_one(
                     generator,
                     &prompt,
                     width,
@@ -680,7 +672,7 @@ async fn generate_mlx_stream(
 /// Consume the streamed generation events (step / decoding / image) from the blocking
 /// thread: write each finished image as an asset fact, stream progress, and poll cancel
 /// ~every 2s (draining the channel after a cancel so the blocking sender never blocks).
-/// Shared by the base txt2img path ([`generate_mlx_stream`]) and the Z-Image strict-pose
+/// Shared by the base txt2img path ([`generate_stream`]) and the Z-Image strict-pose
 /// control path ([`generate_zimage_control_stream`]). `total` is the number of images
 /// the job produces (the request count, or the pose count).
 #[allow(clippy::too_many_arguments)]

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -276,7 +276,7 @@ fn flux2_edit_raw_settings(
 }
 
 /// Real FLUX.2 edit generation: load the edit variant once, then `count` outputs each
-/// conditioned on the shared reference set. Mirrors [`generate_mlx_stream`]'s blocking-
+/// conditioned on the shared reference set. Mirrors [`generate_stream`]'s blocking-
 /// thread + streamed-events shape and reuses [`consume_gen_events`].
 async fn generate_flux2_edit_stream(
     api: &ApiClient,
@@ -393,7 +393,7 @@ async fn generate_flux2_edit_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let spec = mlx_load_spec(weights_dir, quant, adapters, None);
+    let spec = load_spec(weights_dir, quant, adapters, None);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -45,7 +45,7 @@ fn qwen_control_load(
     adapters: Vec<AdapterSpec>,
 ) -> WorkerResult<Box<dyn Generator>> {
     let spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
-    mlx_gen::load(QWEN_CONTROL_ENGINE_ID, &spec).map_err(|error| {
+    gen_core::load(QWEN_CONTROL_ENGINE_ID, &spec).map_err(|error| {
         WorkerError::Engine(format!("Qwen strict-pose control load failed: {error}"))
     })
 }
@@ -640,7 +640,7 @@ async fn generate_qwen_edit_stream(
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    let spec = mlx_load_spec(weights_dir, quant, adapters, None);
+    let spec = load_spec(weights_dir, quant, adapters, None);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
@@ -720,7 +720,7 @@ async fn generate_qwen_edit_stream(
 // ---------------------------------------------------------------------------
 // SenseNova-U1 it2i (macOS, sc-3900 / epic 3180): instruction edit + Character Studio on the
 // unified `sensenova_u1_8b` / `sensenova_u1_8b_fast` ids. The same model does T2I (the base
-// `generate_mlx_stream` path) and it2i here; a `Conditioning::Reference` (single, edit_image) or
+// `generate_stream` path) and it2i here; a `Conditioning::Reference` (single, edit_image) or
 // `Conditioning::MultiReference` (N, character_image incl. the angle set) drives the
 // understanding-path vision encoder. SenseNova uses BOTH CFG knobs: the text CFG via `guidance`
 // (`advanced.guidanceScale`, default 4.0 base / 1.0 fast) AND the image-guidance via `true_cfg`

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -9,7 +9,7 @@ const SDXL_INPAINT_STRENGTH: f32 = 0.85;
 const SDXL_IP_SCALE: f32 = 0.7;
 
 /// Which advanced SDXL path a request maps onto (or `None` for plain txt2img, which stays
-/// on [`generate_mlx_stream`]). Outpaint wins over a plain mask when `fit_mode == outpaint`
+/// on [`generate_stream`]). Outpaint wins over a plain mask when `fit_mode == outpaint`
 /// (the torch path checks outpaint first, then unions any user mask into the border).
 enum SdxlSubMode {
     /// Reference image-prompt via IP-Adapter (txt2img + decoupled cross-attn).
@@ -85,11 +85,11 @@ fn load_mask_asset_image(
 
 /// Composite `source` contained (long edge fits) + centered on a black `width`×`height`
 /// canvas, using the **engine's** `contain_box` so the padded source lines up pixel-for-pixel
-/// with [`mlx_gen::image::outpaint_border_mask`] (both derive the same kept rect).
+/// with [`gen_core::imageops::outpaint_border_mask`] (both derive the same kept rect).
 fn sdxl_outpaint_canvas(source: &image::RgbImage, width: u32, height: u32) -> Image {
     use image::imageops::FilterType::Lanczos3;
     let (new_w, new_h, left, top) =
-        mlx_gen::image::contain_box(source.width(), source.height(), width, height);
+        gen_core::imageops::contain_box(source.width(), source.height(), width, height);
     let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
     let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
     image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
@@ -343,7 +343,7 @@ async fn generate_sdxl_advanced_stream(
             let (src_w, src_h) = (source.width(), source.height());
             let canvas = sdxl_outpaint_canvas(&source, width, height);
             // White = generate (the padded border), black = keep (the centered source).
-            let mut mask = mlx_gen::image::outpaint_border_mask(src_w, src_h, width, height);
+            let mut mask = gen_core::imageops::outpaint_border_mask(src_w, src_h, width, height);
             if non_empty(&request.mask_asset_id) {
                 // Union the user edit region with the border (white wins) — pad-fit the user
                 // mask onto the same contained geometry first.
@@ -351,7 +351,7 @@ async fn generate_sdxl_advanced_stream(
                 let user_mask =
                     load_mask_asset_image(settings, &request.project_id, mask_id, project_path)?;
                 let user_mask = fit_engine_image(user_mask, width, height, "pad")?;
-                mask = mlx_gen::image::union_masks(&mask, &user_mask).map_err(|error| {
+                mask = gen_core::imageops::union_masks(&mask, &user_mask).map_err(|error| {
                     WorkerError::Engine(format!("outpaint mask union failed: {error}"))
                 })?;
             }

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -243,7 +243,7 @@ async fn generate_sensenova_edit_stream(
         raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
     }
 
-    let spec = mlx_load_spec(weights_dir, quant, Vec::new(), None);
+    let spec = load_spec(weights_dir, quant, Vec::new(), None);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
@@ -296,7 +296,7 @@ async fn generate_sensenova_edit_stream(
 // ---------------------------------------------------------------------------
 // SDXL advanced conditioning (macOS, epic 3041 / sc-3060): reference (IP-Adapter),
 // img2img edit, masked inpaint, and outpaint on the `sdxl` engine model. The plain
-// txt2img + LoRA path stays on `generate_mlx_stream`; this branch handles every SDXL
+// txt2img + LoRA path stays on `generate_stream`; this branch handles every SDXL
 // shape that used to fall through to the Python torch `SdxlDiffusersAdapter`. The
 // engine selects the path from the loaded weights (`ip_adapter`) + conditioning combo
 // (mlx-gen-sdxl PRs #137/#138); we just build the right `LoadSpec` + `Conditioning`.

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -122,7 +122,7 @@ fn backend_label_defaults_empty_to_cpu() {
 #[cfg(target_os = "macos")]
 #[test]
 fn quant_mapping_defaults_to_q8_and_maps_bits() {
-    use mlx_gen::Quant;
+    use gen_core::Quant;
     let default = request(json!({ "projectId": "p" }));
     assert!(matches!(
         resolve_quant(&default),
@@ -335,19 +335,20 @@ fn sensenova_edit_available_needs_a_reference() {
 #[ignore = "needs real SenseNova-U1-8B-MoT weights (~35GB) + Metal device"]
 fn sensenova_it2i_real_weights_generates_one_image() {
     let snapshot = hf_snapshot("models--sensenova--SenseNova-U1-8B-MoT");
-    let generator = mlx_load(
+    let generator = load_engine(
         mlx_model("sensenova_u1_8b").unwrap().engine_id(),
         snapshot,
-        Some(mlx_gen::Quant::Q8),
+        Some(gen_core::Quant::Q8),
         Vec::new(),
+        None,
     )
     .unwrap();
-    let reference = mlx_gen::Image {
+    let reference = gen_core::Image {
         width: 512,
         height: 512,
         pixels: stub_rgb8(512, 512, 7),
     };
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let (w, h, pixels) = sensenova_edit_generate_one(
         generator.as_ref(),
@@ -362,7 +363,7 @@ fn sensenova_it2i_real_weights_generates_one_image() {
         build_edit_conditioning(std::slice::from_ref(&reference)),
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -466,7 +467,7 @@ fn adapter_id_reports_per_family_mlx_label() {
 #[cfg(target_os = "macos")]
 #[test]
 fn mlx_engine_registry_links_image_families() {
-    let ids: Vec<&str> = mlx_gen::registry::generators()
+    let ids: Vec<&str> = gen_core::registry::generators()
         .map(|reg| (reg.descriptor)().id)
         .collect();
     for id in [
@@ -511,17 +512,18 @@ fn smoke_generate_one(
     negative_prompt: Option<String>,
 ) {
     let model = mlx_model(sceneworks_id).unwrap();
-    let generator = mlx_load(
+    let generator = load_engine(
         model.engine_id(),
         snapshot,
-        Some(mlx_gen::Quant::Q8),
+        Some(gen_core::Quant::Q8),
         Vec::new(),
+        None,
     )
     .unwrap();
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let steps = model.default_steps();
-    let (w, h, pixels) = mlx_generate_one(
+    let (w, h, pixels) = generate_one(
         generator.as_ref(),
         "a serene mountain lake at dawn",
         512,
@@ -534,7 +536,7 @@ fn smoke_generate_one(
         None,
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -886,7 +888,7 @@ fn instantid_angle_kps_real_weights_fills_frame_and_holds_identity() {
 
 /// Load + generate one small image for a TRUE-CFG family (Chroma): the CFG scale rides
 /// `true_cfg` (not the distilled `guidance` scalar the engine rejects), mirroring
-/// [`generate_mlx_stream`]'s wiring. Sibling of [`smoke_generate_one`].
+/// [`generate_stream`]'s wiring. Sibling of [`smoke_generate_one`].
 #[cfg(target_os = "macos")]
 fn smoke_generate_one_true_cfg(
     sceneworks_id: &str,
@@ -895,17 +897,18 @@ fn smoke_generate_one_true_cfg(
     negative_prompt: Option<String>,
 ) {
     let model = mlx_model(sceneworks_id).unwrap();
-    let generator = mlx_load(
+    let generator = load_engine(
         model.engine_id(),
         snapshot,
-        Some(mlx_gen::Quant::Q8),
+        Some(gen_core::Quant::Q8),
         Vec::new(),
+        None,
     )
     .unwrap();
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let steps = model.default_steps();
-    let (w, h, pixels) = mlx_generate_one(
+    let (w, h, pixels) = generate_one(
         generator.as_ref(),
         "a serene mountain lake at dawn",
         512,
@@ -918,7 +921,7 @@ fn smoke_generate_one_true_cfg(
         true_cfg,
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -1060,7 +1063,7 @@ fn qwen_control_raw_settings_records_control_recipe() {
 /// sc-3031 A/B dump (NOT a CI test): generate ONE image through the **real new-adapter
 /// path** — the production resolvers (`model_repo` / `resolve_steps` / `resolve_guidance` /
 /// `resolve_negative_prompt` / `resolve_quant` / `resolve_adapters` / `resolve_weights_dir` /
-/// `resolve_seed`) + the `mlx_load` + `mlx_generate_one` core that `generate_mlx_stream`
+/// `resolve_seed`) + the `load_engine` + `generate_one` core that `generate_stream`
 /// drives — and write it to `$SC3031_OUT` for head-to-head comparison against the Python
 /// `Mlx*Adapter` output. Covers the txt2img families (z-image / flux / qwen / flux2 / sdxl).
 /// Env: `SC3031_PAYLOAD` (job-payload JSON object), `SC3031_OUT` (.png path); set
@@ -1089,10 +1092,10 @@ fn sc3031_ab_dump_txt2img() {
         .expect("weights in HF cache");
     let adapters = resolve_adapters(&req).expect("adapters");
     let seed = resolve_seed(&req, 0);
-    let generator = mlx_load(model.engine_id(), weights, quant, adapters).expect("load");
+    let generator = load_engine(model.engine_id(), weights, quant, adapters, None).expect("load");
 
     let cancel = CancelFlag::new();
-    let (w, h, pixels) = mlx_generate_one(
+    let (w, h, pixels) = generate_one(
         generator.as_ref(),
         &req.prompt,
         req.width,
@@ -1303,7 +1306,7 @@ fn zimage_control_real_weights_generates_one_pose() {
     .expect("control weights file");
 
     let generator =
-        zimage_control_load(base, control, Some(mlx_gen::Quant::Q8), Vec::new()).unwrap();
+        zimage_control_load(base, control, Some(gen_core::Quant::Q8), Vec::new()).unwrap();
 
     // A minimal standing skeleton at 512².
     let kp = crate::openpose_skeleton::normalize_keypoints(&json!([
@@ -1334,13 +1337,13 @@ fn zimage_control_real_weights_generates_one_pose() {
         None,
         crate::openpose_skeleton::body_stickwidth(512, 512),
     );
-    let control = mlx_gen::Image {
+    let control = gen_core::Image {
         width: 512,
         height: 512,
         pixels: skeleton.into_raw(),
     };
 
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let (w, h, pixels) = zimage_control_generate_one(
         generator.as_ref(),
@@ -1354,7 +1357,7 @@ fn zimage_control_real_weights_generates_one_pose() {
         None,
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -1383,7 +1386,8 @@ fn qwen_control_real_weights_generates_one_pose() {
         "Qwen control weights missing: {control:?}"
     );
 
-    let generator = qwen_control_load(base, control, Some(mlx_gen::Quant::Q8), Vec::new()).unwrap();
+    let generator =
+        qwen_control_load(base, control, Some(gen_core::Quant::Q8), Vec::new()).unwrap();
 
     let kp = crate::openpose_skeleton::normalize_keypoints(&json!([
         [0.5, 0.2],
@@ -1413,13 +1417,13 @@ fn qwen_control_real_weights_generates_one_pose() {
         None,
         crate::openpose_skeleton::body_stickwidth(512, 512),
     );
-    let control = mlx_gen::Image {
+    let control = gen_core::Image {
         width: 512,
         height: 512,
         pixels: skeleton.into_raw(),
     };
 
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let (w, h, pixels) = qwen_control_generate_one(
         generator.as_ref(),
@@ -1434,7 +1438,7 @@ fn qwen_control_real_weights_generates_one_pose() {
         0.9,
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -1495,17 +1499,17 @@ fn flux2_edit_reference_ids_prefers_reference_then_source() {
 #[cfg(target_os = "macos")]
 #[test]
 fn build_edit_conditioning_single_vs_multi() {
-    let img = |seed| mlx_gen::Image {
+    let img = |seed| gen_core::Image {
         width: 8,
         height: 8,
         pixels: stub_rgb8(8, 8, seed),
     };
     match build_edit_conditioning(std::slice::from_ref(&img(1))).as_slice() {
-        [mlx_gen::Conditioning::Reference { .. }] => {}
+        [gen_core::Conditioning::Reference { .. }] => {}
         other => panic!("expected one Reference, got {other:?}"),
     }
     match build_edit_conditioning(&[img(1), img(2)]).as_slice() {
-        [mlx_gen::Conditioning::MultiReference { images }] => assert_eq!(images.len(), 2),
+        [gen_core::Conditioning::MultiReference { images }] => assert_eq!(images.len(), 2),
         other => panic!("expected MultiReference, got {other:?}"),
     }
 }
@@ -1519,19 +1523,20 @@ fn build_edit_conditioning_single_vs_multi() {
 #[ignore = "needs real FLUX.2-klein-9b weights + Metal device"]
 fn flux2_edit_real_weights_generates_one_image() {
     let snapshot = hf_snapshot("models--black-forest-labs--FLUX.2-klein-9b");
-    let generator = mlx_load(
+    let generator = load_engine(
         "flux2_klein_9b_edit",
         snapshot,
-        Some(mlx_gen::Quant::Q8),
+        Some(gen_core::Quant::Q8),
         Vec::new(),
+        None,
     )
     .unwrap();
-    let reference = mlx_gen::Image {
+    let reference = gen_core::Image {
         width: 512,
         height: 512,
         pixels: stub_rgb8(512, 512, 7),
     };
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let (w, h, pixels) = flux2_edit_generate_one(
         generator.as_ref(),
@@ -1544,7 +1549,7 @@ fn flux2_edit_real_weights_generates_one_image() {
         build_edit_conditioning(std::slice::from_ref(&reference)),
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -1949,19 +1954,20 @@ fn resolve_qwen_edit_guidance_reads_true_cfg_scale_not_guidance_scale() {
 #[ignore = "needs real Qwen-Image-Edit-2511 weights + Metal device"]
 fn qwen_edit_real_weights_generates_one_image() {
     let snapshot = hf_snapshot("models--Qwen--Qwen-Image-Edit-2511");
-    let generator = mlx_load(
+    let generator = load_engine(
         "qwen_image_edit",
         snapshot,
-        Some(mlx_gen::Quant::Q8),
+        Some(gen_core::Quant::Q8),
         Vec::new(),
+        None,
     )
     .unwrap();
-    let reference = mlx_gen::Image {
+    let reference = gen_core::Image {
         width: 512,
         height: 512,
         pixels: stub_rgb8(512, 512, 7),
     };
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let (w, h, pixels) = qwen_edit_generate_one(
         generator.as_ref(),
@@ -1976,7 +1982,7 @@ fn qwen_edit_real_weights_generates_one_image() {
         build_edit_conditioning(std::slice::from_ref(&reference)),
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -2012,19 +2018,20 @@ fn qwen_edit_lightning_real_weights_generates_one_image() {
     );
 
     let snapshot = hf_snapshot("models--Qwen--Qwen-Image-Edit-2511");
-    let generator = mlx_load(
+    let generator = load_engine(
         "qwen_image_edit",
         snapshot,
-        Some(mlx_gen::Quant::Q8),
+        Some(gen_core::Quant::Q8),
         vec![AdapterSpec::new(lora_path, 1.0, AdapterKind::Lora)],
+        None,
     )
     .unwrap();
-    let reference = mlx_gen::Image {
+    let reference = gen_core::Image {
         width: 512,
         height: 512,
         pixels: stub_rgb8(512, 512, 7),
     };
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let (w, h, pixels) = qwen_edit_generate_one(
         generator.as_ref(),
@@ -2040,7 +2047,7 @@ fn qwen_edit_lightning_real_weights_generates_one_image() {
         build_edit_conditioning(std::slice::from_ref(&reference)),
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -2063,11 +2070,12 @@ fn qwen_edit_lightning_real_weights_generates_one_image() {
 #[ignore = "needs real FLUX.2-klein-9b weights + Metal device"]
 fn flux2_pose_tier_real_weights_generates_one_image() {
     let snapshot = hf_snapshot("models--black-forest-labs--FLUX.2-klein-9b");
-    let generator = mlx_load(
+    let generator = load_engine(
         "flux2_klein_9b_edit",
         snapshot,
-        Some(mlx_gen::Quant::Q8),
+        Some(gen_core::Quant::Q8),
         Vec::new(),
+        None,
     )
     .unwrap();
     // A minimal standing skeleton (body only — the best-effort tier uses no
@@ -2100,20 +2108,20 @@ fn flux2_pose_tier_real_weights_generates_one_image() {
         None,
         crate::openpose_skeleton::body_stickwidth(512, 512),
     );
-    let skeleton_img = mlx_gen::Image {
+    let skeleton_img = gen_core::Image {
         width: 512,
         height: 512,
         pixels: skeleton.into_raw(),
     };
-    let reference = mlx_gen::Image {
+    let reference = gen_core::Image {
         width: 512,
         height: 512,
         pixels: stub_rgb8(512, 512, 7),
     };
-    let conditioning = vec![mlx_gen::Conditioning::MultiReference {
+    let conditioning = vec![gen_core::Conditioning::MultiReference {
         images: vec![skeleton_img, reference],
     }];
-    let cancel = mlx_gen::CancelFlag::new();
+    let cancel = gen_core::CancelFlag::new();
     let mut steps_seen = 0u32;
     let (w, h, pixels) = flux2_edit_generate_one(
         generator.as_ref(),
@@ -2126,7 +2134,7 @@ fn flux2_pose_tier_real_weights_generates_one_image() {
         conditioning,
         &cancel,
         &mut |p| {
-            if let mlx_gen::Progress::Step { current, .. } = p {
+            if let gen_core::Progress::Step { current, .. } = p {
                 steps_seen = steps_seen.max(current);
             }
         },
@@ -2214,7 +2222,7 @@ fn detail_feather_ramps_over_overlap() {
 
 /// sc-3625 real-Mac E2E (epic 3621): drive the WORKER's FLUX.1 XLabs IP-Adapter reference path
 /// end to end on real weights — `resolve_flux_ip_adapter_dir` staging from the real HF cache +
-/// `mlx_load_with_ip` + a real `Conditioning::Reference` dev `true_cfg` render against the
+/// `load_engine` + a real `Conditioning::Reference` dev `true_cfg` render against the
 /// pinned mlx-gen engine. Guards the worker plumbing the engine-side A/B can't: the staged-dir
 /// contract + the dev reference render NOT regressing to the pre-#173 saturation (which
 /// collapsed `true_cfg=4` to a near-uniform white frame). Run (needs FLUX.1-dev +
@@ -2269,8 +2277,8 @@ fn flux_ip_reference_worker_e2e() {
         .expect("flux_dev in MODEL_TABLE")
         .engine_id();
     let flux_dev = hf_snapshot("black-forest-labs/FLUX.1-dev", "transformer");
-    let generator = mlx_load_with_ip(engine_id, flux_dev, None, vec![], Some(staged))
-        .unwrap_or_else(|e| panic!("mlx_load_with_ip {engine_id} + ip: {e}"));
+    let generator = load_engine(engine_id, flux_dev, None, vec![], Some(staged))
+        .unwrap_or_else(|e| panic!("load_engine {engine_id} + ip: {e}"));
 
     // (3) Reference render through the dev `true_cfg` path (white-dot garbage pre-#173).
     let reference = {

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -121,7 +121,7 @@ fn zimage_control_load(
     adapters: Vec<AdapterSpec>,
 ) -> WorkerResult<Box<dyn Generator>> {
     let spec = zimage_control_spec(weights_dir, control_weights, quant, adapters);
-    mlx_gen::load(ZIMAGE_CONTROL_ENGINE_ID, &spec)
+    gen_core::load(ZIMAGE_CONTROL_ENGINE_ID, &spec)
         .map_err(|error| WorkerError::Engine(format!("Z-Image control load failed: {error}")))
 }
 
@@ -209,7 +209,7 @@ fn zimage_control_raw_settings(
 
 /// Real Z-Image strict-pose generation: one image per pose, each conditioned on a DWPose
 /// skeleton rendered from the pose keypoints + locked by the Fun-Controlnet-Union branch.
-/// Mirrors [`generate_mlx_stream`]'s blocking-thread + streamed-events shape (the MLX
+/// Mirrors [`generate_stream`]'s blocking-thread + streamed-events shape (the MLX
 /// generator is `!Send` + single-thread), reusing [`consume_gen_events`].
 async fn generate_zimage_control_stream(
     api: &ApiClient,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -39,7 +39,12 @@ use uuid::Uuid;
 #[cfg(target_os = "macos")]
 mod advanced;
 mod api_client;
-#[cfg(target_os = "macos")]
+// Backend-neutral generator load/run cache (epic 3720, sc-3724). Typed entirely against
+// `gen_core::*` (no tensor types leak), so it links on ALL targets — the production load seam
+// (`with_cached_generator`) is reached only from the macOS image/video paths, but the all-targets
+// stub test exercises the load→progress→cancel→output contract with no backend linked. Off macOS
+// the production caller is cfg'd out, so allow dead_code there (the engines.rs precedent).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod generator_cache;
 use api_client::*;
 // Backend-neutral engine dispatch table + registry-derived capability advertisement

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -209,7 +209,7 @@ pub(crate) fn kolors_tokenizer_overlay_dest(repo: &str, snapshot_dir: &Path) -> 
 }
 
 /// After a Kolors base-model download, overlay the derived `tokenizer.json` (sc-4764) from the
-/// SceneWorks tokenizer repo into the snapshot's `tokenizer/` dir, so `mlx_gen::load("kolors", …)`
+/// SceneWorks tokenizer repo into the snapshot's `tokenizer/` dir, so `gen_core::load("kolors", …)`
 /// and `load_trainer("kolors", …)` can construct (they read only `tokenizer/tokenizer.json`, which
 /// upstream omits). No-op for any other repo; idempotent — skips when the file is already present
 /// (a re-install, or a snapshot that already shipped it). Reuses the standard HF resolve + download
@@ -274,6 +274,7 @@ fn convert_flux2_klein_diffusers(
     base_dir: &Path,
     out_dir: &Path,
 ) -> Result<(), String> {
+    // CARVE-OUT(epic 3720): backend-specific weight converter; not a registry contract.
     mlx_gen_flux2::convert_and_assemble(source_file, base_dir, out_dir)
         .map(|_| ())
         .map_err(|error| error.to_string())
@@ -305,6 +306,7 @@ fn convert_wan_native(
     out_dir: &Path,
     quant: Option<(i32, i32)>,
 ) -> Result<(), String> {
+    // CARVE-OUT(epic 3720): backend-specific weight converter; not a registry contract.
     use mlx_gen_wan::convert::{convert_i2v_14b, convert_t2v_14b, convert_ti2v_5b};
     match kind {
         "wan_ti2v_5b" => convert_ti2v_5b(checkpoint_dir, out_dir).map(|_| ()),
@@ -340,6 +342,7 @@ fn convert_ltx_native(
     out_dir: &Path,
     bits: i32,
 ) -> Result<(), String> {
+    // CARVE-OUT(epic 3720): backend-specific weight converter; not a registry contract.
     let opts = mlx_gen_ltx::LtxConvertOpts::audio_quant(bits);
     mlx_gen_ltx::convert_and_assemble(source_file, Some(upscaler_dir), out_dir, &opts)
         .map(|_| ())

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -38,6 +38,7 @@ use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use image::RgbImage;
 use serde_json::{json, Value};
 
+// CARVE-OUT(epic 3720): backend-specific; absorbed by Detector in Phase 6.
 use mlx_gen::nn::{conv2d, silu, upsample_nearest};
 use mlx_gen::weights::Weights;
 use mlx_gen::Result as MlxResult;

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -5,6 +5,7 @@
 //! when the fused MLX weights + fixtures are staged in the app cache.
 
 use super::*;
+// CARVE-OUT(epic 3720): backend-specific; absorbed by Detector in Phase 6.
 use mlx_gen::weights::Weights;
 use mlx_rs::Array;
 use std::path::PathBuf;

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -22,6 +22,7 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
+// CARVE-OUT(epic 3720): backend-specific; absorbed by Segmenter in Phase 6.
 use mlx_gen::weights::Weights;
 use mlx_gen_sam2::{Sam2ModelSize, Sam2VideoPredictor};
 

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -29,6 +29,13 @@ use super::*;
 #[cfg(target_os = "macos")]
 use sceneworks_core::image_request::ImageRequest;
 
+// CARVE-OUT(epic 3720): backend-specific; absorbed by TextLlm in Phase 5.
+// VQA + Document-Studio interleave bypass the `Generator` registry and drive the concrete
+// `mlx_gen_sensenova::T2iModel` directly (text / text+images output the neutral `GenerationOutput`
+// contract can't express). The whole module stays mlx-gen-typed — `Image`, `TextTokenizer`,
+// `resize_bicubic_u8`, and `decoded_to_image` (which operates on a backend tensor and MUST stay
+// mlx-gen-local) are kept on the `mlx_gen::` paths to protect byte-identical VQA/interleave
+// decode — until the understanding path is lifted onto a neutral TextLlm contract.
 #[cfg(target_os = "macos")]
 use mlx_gen::image::{decoded_to_image, resize_bicubic_u8};
 #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -2,8 +2,8 @@
 //! [`image_jobs`](crate::image_jobs)/[`video_jobs`](crate::video_jobs).
 //!
 //! Parses a `lora_train` job into the Rust-resolved [`TrainingPlan`], then either
-//! validates it (dry run) or maps it onto an [`mlx_gen::TrainingRequest`] and drives
-//! `mlx_gen::load_trainer(id, &LoadSpec).train(req, on_progress)` — exactly as the
+//! validates it (dry run) or maps it onto a [`gen_core::TrainingRequest`] and drives
+//! `gen_core::load_trainer(id, &LoadSpec).train(req, on_progress)` — exactly as the
 //! image path maps `ImageRequest` → `GenerationRequest` and calls `Generator::generate`.
 //! The engine writes the adapter to the plan's `output.outputDir`; the API registers
 //! it from the staged `manifestEntry` + the files on disk (apps/rust-api jobs.rs
@@ -22,12 +22,14 @@
 use super::*;
 use sceneworks_core::training::{TrainingPlan, TRAINING_PLAN_VERSION};
 
+// epic 3720 (sc-3724): the backend-neutral training contract types come from `gen_core`.
 // Force each trainer-provider crate to link so its `inventory::submit!` trainer
 // registration survives linker GC and `load_trainer` can find it. The same crates
 // are referenced by image_jobs/video_jobs for generation; re-stating the training
-// dependency here keeps it explicit and independent of those modules.
+// dependency here keeps it explicit and independent of those modules. `cfg(target_os)`
+// decides which backend crates register, not which contract types this module names.
 #[cfg(target_os = "macos")]
-use mlx_gen::{
+use gen_core::{
     CancelFlag, LoadSpec, LrSchedule, NetworkType, TrainingConfig, TrainingItem, TrainingOutput,
     TrainingProgress, TrainingRequest, WeightsSource,
 };
@@ -319,7 +321,7 @@ fn advanced_u32(advanced: &JsonObject, key: &str, default: u32) -> u32 {
 }
 
 /// Map the SceneWorks `TrainingConfig` (plan `config` + its free-form `advanced`
-/// bag) onto the engine's typed [`mlx_gen::TrainingConfig`]. The optimizer string is
+/// bag) onto the engine's typed [`gen_core::TrainingConfig`]. The optimizer string is
 /// passed verbatim — the engine normalizes aliases (`adamw8bit`→`adamw`,
 /// `prodigyopt`→`prodigy`). An empty `loraTargetModules` lets the family trainer use
 /// its default target set.
@@ -372,7 +374,7 @@ enum TrainEvent {
 }
 
 /// Execute a real training run on the in-process mlx-gen engine. Loads the (frozen)
-/// base model via a [`LoadSpec`] (exactly as inference's `mlx_load`), runs the
+/// base model via a [`LoadSpec`] (exactly as inference's `load_engine`), runs the
 /// family trainer on a blocking thread, streams staged progress, honors cancellation
 /// via the engine's [`CancelFlag`], and reports the produced adapter. The adapter is
 /// written by the engine into the plan's `output.outputDir`; the API registers it
@@ -449,10 +451,10 @@ async fn run_training_execution(
         let cancel = cancel.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<()> {
             let mut trainer =
-                mlx_gen::load_trainer(engine_id, &LoadSpec::new(WeightsSource::Dir(weights_dir)))
+                gen_core::load_trainer(engine_id, &LoadSpec::new(WeightsSource::Dir(weights_dir)))
                     .map_err(|error| {
-                    WorkerError::Engine(format!("{engine_id} trainer load failed: {error}"))
-                })?;
+                        WorkerError::Engine(format!("{engine_id} trainer load failed: {error}"))
+                    })?;
             let request = TrainingRequest {
                 items,
                 config,
@@ -1253,7 +1255,7 @@ mod tests {
         };
 
         let mut trainer =
-            mlx_gen::load_trainer("kolors", &LoadSpec::new(WeightsSource::Dir(snapshot)))
+            gen_core::load_trainer("kolors", &LoadSpec::new(WeightsSource::Dir(snapshot)))
                 .expect("kolors trainer loads (tokenizer.json present)");
         trainer
             .validate(&request)

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -14,7 +14,7 @@
 //! synchronized tone for the LTX family, mirroring the engine: LTX emits audio, Wan
 //! does not). The real in-process MLX video models — Wan2.2 (sc-3034) and LTX-2.3 +
 //! audio (sc-3035) — link the `mlx-gen-wan` / `mlx-gen-ltx` provider crates and decode
-//! `mlx_gen::GenerationOutput::Video { frames, fps, audio }` into the same
+//! `gen_core::GenerationOutput::Video { frames, fps, audio }` into the same
 //! [`DecodedVideo`], so the encode/mux/poster path below is unchanged for them.
 
 use std::f32::consts::PI;
@@ -30,8 +30,12 @@ use crate::media_jobs::{run_ffmpeg, FfmpegContext};
 // the same link-time pattern as the image families in `image_jobs.rs`).
 #[cfg(target_os = "macos")]
 use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
+// epic 3720 (sc-3724): the backend-neutral generation contract types come from `gen_core`; the
+// `as _;` provider links below stay mlx-gen-specific (they register the video engines into the
+// registry). `cfg(target_os)` decides which backend crates link, not which contract types this
+// module names.
 #[cfg(target_os = "macos")]
-use mlx_gen::{
+use gen_core::{
     AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
     Generator, Image, LoadSpec, MoeExpert, Precision, Progress, Quant, ReplacementMode,
     WeightsSource,
@@ -55,7 +59,7 @@ const STUB_ADAPTER: &str = "procedural_video";
 const CANCEL_MESSAGE: &str = "Video generation canceled by user.";
 
 /// Decoded video ready for muxing — the worker-side shape both the procedural stub
-/// (sc-3033) and the real engine output (`mlx_gen::GenerationOutput::Video`,
+/// (sc-3033) and the real engine output (`gen_core::GenerationOutput::Video`,
 /// sc-3034/3035) feed into [`encode_media`]. Mirrors the engine contract: `frames`
 /// are RGB8, `audio` is `Some` for LTX (a synchronized track) and `None` for Wan.
 /// The frames are held in memory (the engine returns them that way); the duration
@@ -1576,7 +1580,7 @@ fn load_video_generation_for_tests(input: &VideoGenInput) -> WorkerResult<Box<dy
         ip_adapter: None,
         adapters: input.adapters.clone(),
     };
-    mlx_gen::load(input.engine_id, &spec)
+    gen_core::load(input.engine_id, &spec)
         .map_err(|error| WorkerError::Engine(format!("video load failed: {error}")))
 }
 
@@ -1625,7 +1629,7 @@ async fn generate_video(
 
     let mut canceled = false;
     let mut last_cancel = Instant::now();
-    // Interval arm so the cold model-load phase (mlx_gen::load emits no progress)
+    // Interval arm so the cold model-load phase (gen_core::load emits no progress)
     // still heartbeats and polls cancel, instead of looking dead to the API's
     // staleness check until the first denoise step (sc-4276 / F-MLXW-12; mirrors
     // the caption-job select!-with-interval).
@@ -2657,7 +2661,7 @@ fn replacement_mode_from(value: &str) -> ReplacementMode {
 }
 
 /// Whether `dir` is a load-ready assembled Wan-VACE snapshot — the diffusers VACE
-/// `transformer/` plus the shared base-Wan UMT5/VAE/tokenizer that `mlx_gen::load("wan_vace")`
+/// `transformer/` plus the shared base-Wan UMT5/VAE/tokenizer that `gen_core::load("wan_vace")`
 /// reads (sc-3467 `assemble_wan_vace_snapshot` layout).
 #[cfg(target_os = "macos")]
 fn wan_vace_dir_is_complete(dir: &Path) -> bool {
@@ -2713,6 +2717,7 @@ fn resolve_wan_vace_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
                     .to_owned(),
             )
         })?;
+    // CARVE-OUT(epic 3720): backend-specific weight converter; not a registry contract.
     mlx_gen_wan::convert::assemble_wan_vace_snapshot(&out_dir, &transformer_dir, &base_wan, true)
         .map_err(|error| {
         WorkerError::InvalidPayload(format!(
@@ -4291,7 +4296,7 @@ mod tests {
             steps: Some(2),
             seed: 7,
             conditioning: vec![Conditioning::Reference {
-                image: mlx_gen::Image {
+                image: Image {
                     width: w,
                     height: h,
                     pixels,


### PR DESCRIPTION
**Epic 3720 Phase 0** — collapses the worker's generation/training/caption paths onto **one backend-neutral contract** typed against `gen_core::*`, so `cfg(target_os)` decides only which provider crates link `as _`. Builds directly on sc-3723 (#620). ([sc-3724](https://app.shortcut.com/trefry/story/3724))

**No macOS behavior change:** every repoint targets the *same* item `mlx_gen` already re-exports from `gen_core` (mlx-gen/src/lib.rs:41-89) — an identifier swap with identical codegen.

## Changes
- **Repoint `mlx_gen::` → `gen_core::`** across the registry-driven paths (Generator/GenerationRequest/Output/Conditioning/Image/LoadSpec/Progress/Quant/CancelFlag/AdapterSpec/WeightsSource + `load`/`load_trainer`/`load_captioner`/`registry`/`imageops`): `generator_cache`, `image_jobs` (+ base/sdxl/qwen/zimage/flux2/sensenova/tests), `video_jobs`, `training_jobs`, `caption_jobs`.
- **Renames** (`image_jobs/base.rs`): `mlx_load_with_ip`→`load_engine` (registry-only via `gen_core::load`; flux IP-adapter staging stays a separate neutral step), `mlx_load` folded in, `mlx_load_spec`→`load_spec`, `mlx_generate_one`→`generate_one`, `generate_mlx_stream`→`generate_stream`. (No `generate_candle_stream` existed — "one path" = the rename + the single `gen_core::load` seam.)
- **Named carve-outs** keep their `mlx_gen` typing, each tagged `// CARVE-OUT(epic 3720): …`: InstantID (FaceEmbedder, P3), SenseNova VQA/interleave (TextLlm, P5 — whole module kept mlx-gen-local to protect byte-identical VQA decode), SAM2 (Segmenter, P6), YOLO (Detector, P6), torch→MLX converters.
- **`generator_cache` un-gated to all-targets** (`cfg_attr(not(macos), allow(dead_code))`, engines.rs precedent) — now tensor-free (gen_core/std/tokio), making `with_cached_generator` (the production load seam for image **and** video) Linux-compilable.
- **Acceptance test** (`generator_cache`): a pure-`gen_core` stub `Generator` registered via `inventory` drives the real `with_cached_generator` seam — load → `Progress` → write PNG asset fact — and a tripped `CancelFlag` → `Error::Canceled` → `WorkerError::Canceled`. No mlx linked; runs on Linux + macOS.

## Acceptance boundary
Every remaining `mlx_gen::` ref is either a tagged carve-out or an Appendix-C-sanctioned host escape (`apply_trigger_words` / `Weights` / `decoded_to_image`). No contract-path `mlx_gen::` logic remains. `cargo check`/`clippy -D warnings`/full `rust:check` green; 251 worker lib tests pass.

## Scope notes (surfaced, not buried)
- The full async `generate_stream`/`consume_gen_events`/asset-write job path is macOS-cfg-gated (it **is** the MLX worker) and stays covered by the macOS tests + macos-mlx lane after the renames; the Linux stub test proves the backend-neutral **contract seam**. Un-gating the async/ApiClient orchestration to Linux belongs to Phase 1 (candle), not this story.
- **N/A (binding determinations):** transform/upscale — there is no `gen_core::Transform` path in the worker today (upscale is pure ONNX/ort), so the spec's "transform → gen_core::Transform" task is not applicable here. `kps_jobs` (bespoke face module, not a registry contract) left unchanged.

## Follow-up worth a story
Add a `backend` field to `Trainer`/`Captioner`/`Transform` descriptors in gen-core (removes sc-3723's Phase-0 "any enabled backend" gating; enables true per-backend gating for these contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)