### PR TITLE
sc-4482: version-skew guard — exactly one gen-core in the build graph (epic 3720)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,6 +55,14 @@ jobs:
         run: |
           npm run check
           npm run check:compose
+      - name: Guard against gen-core version skew (sc-4482, epic 3720)
+        # Fails if more than one distinct `sceneworks-gen-core` rev resolves in the worker's
+        # build graph (the inventory skew trap => runtime "engine not found"). `--target all`
+        # resolves the macOS-only mlx-gen transitive gen-core even on this Linux lane. The
+        # self-test proves the gate fires without a deliberately-broken pin checked in.
+        run: |
+          bash scripts/check-gen-core-skew.sh --self-test
+          bash scripts/check-gen-core-skew.sh
       - name: Run Rust workspace checks
         run: npm run rust:check
       - name: Build Rust API before contract tests

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -441,6 +441,14 @@ pub async fn run() -> WorkerResult<()> {
 }
 
 pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
+    // sc-4482 (epic 3720): log the resolved backend-neutral gen-core contract version at startup
+    // so a pin skew that slips past the CI guard (`scripts/check-gen-core-skew.sh`) is
+    // diagnosable from one log line. One shared contract version backs every linked backend.
+    println!(
+        "rust_worker gen-core contract version {} (gpu_id={})",
+        gen_core::VERSION,
+        settings.gpu_id
+    );
     let gpu = discover_gpu(&settings).await;
     let api = ApiClient::new(&settings);
     let http_client = reqwest::Client::new();

--- a/scripts/check-gen-core-skew.sh
+++ b/scripts/check-gen-core-skew.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# sc-4482 (epic 3720): version-skew guard for the backend-neutral gen-core contract.
+#
+# THE TRAP: everything is git-SHA-pinned. If `mlx-gen` (macOS) resolves `sceneworks-gen-core`
+# at rev A while the worker's direct dep resolves rev B, cargo silently builds BOTH. The
+# provider crates (linked `as _`, no type contact with worker code) register into rev A's
+# `inventory` registry while the worker queries rev B's. The symptom is "engine not found" at
+# RUNTIME, not a compile error.
+#
+# This gate fails the build if more than one distinct `sceneworks-gen-core` resolution exists in
+# the root package's dependency graph. It is reusable: pass the root package as $1 (default
+# `sceneworks-worker`); the candle-gen repo wires this same script against its own worker package
+# (epic 3672). `--target all` is REQUIRED so the macOS-only `mlx-gen` transitive gen-core is
+# resolved even when this runs on a Linux CI lane (otherwise the skew is invisible off-macOS).
+#
+# Self-test: `check-gen-core-skew.sh --self-test` exercises the verdict logic on canned input
+# (one-resolution => pass, two-resolutions => fail) so CI proves the gate actually fires without
+# needing a deliberately-broken pin checked in.
+set -euo pipefail
+
+CRATE="sceneworks-gen-core"
+
+# Decide from a newline-delimited list of distinct resolution lines on stdin.
+# Exit 0 iff exactly one resolution; otherwise print the skew explanation and exit 1.
+evaluate() {
+  local pkg="$1"
+  local lines=()
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] && lines+=("$line")
+  done
+  local count=${#lines[@]}
+
+  if [ "$count" -eq 1 ]; then
+    echo "OK: exactly one ${CRATE} in ${pkg}'s build graph: ${lines[0]}"
+    return 0
+  fi
+
+  if [ "$count" -eq 0 ]; then
+    echo "ERROR (sc-4482): ${CRATE} was not found in ${pkg}'s build graph at all." >&2
+    echo "Expected the worker to depend on ${CRATE} (the backend-neutral gen-core contract)." >&2
+    return 1
+  fi
+
+  {
+    echo "ERROR (sc-4482 version skew): found ${count} distinct ${CRATE} resolutions in ${pkg}'s build graph:"
+    printf '  %s\n' "${lines[@]}"
+    cat <<'MSG'
+
+Two gen-core revs => provider crates register into ONE inventory registry while the worker
+queries ANOTHER => the engine is "not found" at RUNTIME (not a compile error, because provider
+crates link `as _` and their types never meet the worker). Align the pins: the `mlx-gen` git rev
+and the direct `sceneworks-gen-core` git rev in crates/sceneworks-worker/Cargo.toml MUST be
+identical (and any candle-gen pin must match too). Bump them together.
+MSG
+  } >&2
+  return 1
+}
+
+self_test() {
+  local rc=0
+  echo "self-test: single resolution should PASS"
+  if printf '%s\n' "sceneworks-gen-core v0.1.0 (git+https://example/repo?rev=AAA#AAA)" \
+      | evaluate "self-test" >/dev/null; then
+    echo "  ok"
+  else
+    echo "  FAIL: single resolution was rejected"; rc=1
+  fi
+
+  echo "self-test: two distinct resolutions should FAIL"
+  if printf '%s\n%s\n' \
+      "sceneworks-gen-core v0.1.0 (git+https://example/repo?rev=AAA#AAA)" \
+      "sceneworks-gen-core v0.1.0 (git+https://example/repo?rev=BBB#BBB)" \
+      | evaluate "self-test" >/dev/null 2>&1; then
+    echo "  FAIL: skew was NOT detected"; rc=1
+  else
+    echo "  ok"
+  fi
+
+  echo "self-test: zero resolutions should FAIL"
+  if printf '' | evaluate "self-test" >/dev/null 2>&1; then
+    echo "  FAIL: missing dependency was NOT detected"; rc=1
+  else
+    echo "  ok"
+  fi
+
+  if [ "$rc" -eq 0 ]; then echo "self-test: PASS"; else echo "self-test: FAIL"; fi
+  return "$rc"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+PKG="${1:-sceneworks-worker}"
+
+# Flatten the tree (`--prefix none`), strip the ` (*)` dedupe marker cargo appends to repeated
+# nodes, keep only the contract crate, and unique-sort. Each unique (version + source) line is one
+# distinct resolution; two revs differ in the `#<rev>` source fragment.
+cargo tree -p "$PKG" --target all --prefix none 2>/dev/null \
+  | sed 's/ (\*)$//' \
+  | grep -E "^${CRATE} v" \
+  | sort -u \
+  | evaluate "$PKG"

--- a/scripts/check-gen-core-skew.sh
+++ b/scripts/check-gen-core-skew.sh
@@ -98,7 +98,13 @@ PKG="${1:-sceneworks-worker}"
 # Flatten the tree (`--prefix none`), strip the ` (*)` dedupe marker cargo appends to repeated
 # nodes, keep only the contract crate, and unique-sort. Each unique (version + source) line is one
 # distinct resolution; two revs differ in the `#<rev>` source fragment.
-cargo tree -p "$PKG" --target all --prefix none 2>/dev/null \
+#
+# `--color never` overrides CI's `CARGO_TERM_COLOR=always` (which would otherwise wrap the ` (*)`
+# marker in ANSI codes so the `(*)$` strip misses it and a deduped node looks "distinct" — a false
+# skew). The ESC-strip sed is a portable backstop (works on BSD + GNU sed).
+esc=$(printf '\033')
+cargo tree -p "$PKG" --target all --color never --prefix none 2>/dev/null \
+  | sed "s/${esc}\\[[0-9;]*m//g" \
   | sed 's/ (\*)$//' \
   | grep -E "^${CRATE} v" \
   | sort -u \


### PR DESCRIPTION
**Epic 3720 Phase 0** — structurally prevents the `inventory` version-skew trap. ([sc-4482](https://app.shortcut.com/trefry/story/4482))

**The trap:** everything is git-SHA-pinned. If `mlx-gen` (macOS) resolves `sceneworks-gen-core` at rev A while the worker's direct dep resolves rev B, cargo builds **both** — provider crates (linked `as _`, no type contact with worker code) register into rev A's `inventory` registry while the worker queries rev B's. The symptom is **"engine not found" at runtime**, not a compile error.

## Changes
- **`scripts/check-gen-core-skew.sh`** — fails if >1 distinct `sceneworks-gen-core` resolution exists in the worker's build graph, printing the disagreeing pins + the skew explanation. Uses `cargo tree --target all` so the **macOS-only `mlx-gen` transitive gen-core is resolved even on the Linux CI lane** (otherwise the skew is invisible off-macOS — the key subtlety). Reusable: takes the root package as `$1` (default `sceneworks-worker`) so the candle-gen repo wires the same gate (epic 3672).
- **`--self-test` mode** — proves the gate actually fires (one resolution → pass, two → fail, zero → fail) without a deliberately-broken pin checked in. CI runs the self-test before the real gate.
- **`check.yml` (parity lane)** — new step runs `--self-test` then the real gate before the Rust workspace checks.
- **Worker startup log** — `run_worker_loop` logs `gen_core::VERSION` so a skew that slips past CI is diagnosable from one log line (the runtime belt-and-braces half; the registry's not-found error embeds the version engine-side).

## Acceptance
- ✅ A deliberately mismatched pin would fail CI with the explanatory message — demonstrated reproducibly by the `--self-test` two-resolution case (exit 1) rather than committing a broken pin.
- ✅ Worker startup logs the resolved gen-core version.
- ✅ Gate passes on the current aligned tree (one gen-core rev, shared by mlx-gen + the direct dep — the invariant #620 established); full `rust:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)