### PR TITLE
sc-4906: gate training/caption advertisement per-backend + pin mlx-gen 8355152 (epic 3720)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -2522,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "image",
  "inventory",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "image",
  "inventory",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "image",
  "inventory",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "image",
  "inventory",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "image",
  "inventory",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ea08d47f0346a12988a5e94abd20899fa011aa72#ea08d47f0346a12988a5e94abd20899fa011aa72"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "safetensors",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -30,7 +30,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # The rev MUST stay identical to the `mlx-gen` pin in the macOS block: two gen-core revs would mean
 # two distinct `inventory` registries (one for the worker's derivation, one the provider crates
 # register into) and the runtime would see "engine not found". Bump both together.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -82,6 +82,13 @@ inventory = "0.3"
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# Rev 8355152 (mlx-gen, PR #385, epic 3720 / sc-4906): adds `backend: &'static str` to
+# TrainerDescriptor/CaptionerDescriptor/TransformDescriptor (mirroring `ModelDescriptor.backend`),
+# letting the worker gate training/caption capability advertisement per-backend (engines.rs
+# `registry_capabilities`) instead of on "any enabled backend". All existing descriptors are
+# `backend: "mlx"`, so macOS advertisement is unchanged. The delta vs ea08d47 is ONLY the
+# descriptor field — no engine/mlx-rs change (mlx-rs pin stays b6e4e56), so MLX rebuilds nothing.
+# On top of:
 # Rev ea08d47 (mlx-gen main HEAD, merged PR #384, epic 3720 / sc-4481; bundles #382 sc-4874 +
 # #383 sc-4886/4887): the z-image LoRA OOM training fix PLUS the typed-cancellation contract.
 # Training fix (#382+#383): #382 adds the opt-in `TrainingConfig.gradient_checkpointing` field +
@@ -176,7 +183,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -184,60 +191,60 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f034
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs). Tracks the mlx-gen #382 mlx-rs bump (b6e4e56).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "b6e4e56930d3b639e4989d51be0abface5addf58" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -246,7 +253,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d4
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -254,7 +261,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ea08d47f0346a12988a5e94abd20899fa011aa72" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -405,22 +405,23 @@ pub(crate) fn registry_capabilities(
         }
     }
 
-    // Trainers/captioners have no `backend` field at this gen_core rev (Phase-0 limitation),
-    // so gate them on "any enabled backend" + a matching registration rather than a per-item
-    // backend. `lora_train` (dry-run plan validation) and `lora_train_execute` (real run) are
-    // both served in-process by the same trainer registry, so they light up together.
-    if !backends.is_empty()
-        && gen_core::registry::trainers().any(|r| TRAINER_IDS.contains(&(r.descriptor)().id))
-    {
+    // Trainers/captioners now carry `backend` (sc-4906), so gate them per-backend exactly like the
+    // generators above — a candle-only trainer no longer lights up under `backend_mlx_enabled`
+    // alone, and vice versa. `lora_train` (dry-run plan validation) and `lora_train_execute` (real
+    // run) are both served in-process by the same trainer registry, so they light up together.
+    if gen_core::registry::trainers().any(|r| {
+        let d = (r.descriptor)();
+        backends.contains(&d.backend) && TRAINER_IDS.contains(&d.id)
+    }) {
         push(Cap::LoraTrain, &mut caps);
         push(Cap::LoraTrainExecute, &mut caps);
     }
     // The JoyCaption captioner registers under the HF repo id (mlx-gen `JOY_CAPTION_MODEL_ID`),
     // not a short name.
-    if !backends.is_empty()
-        && gen_core::registry::captioners()
-            .any(|r| (r.descriptor)().id == "fancyfeast/llama-joycaption-beta-one-hf-llava")
-    {
+    if gen_core::registry::captioners().any(|r| {
+        let d = (r.descriptor)();
+        backends.contains(&d.backend) && d.id == "fancyfeast/llama-joycaption-beta-one-hf-llava"
+    }) {
         push(Cap::TrainingCaption, &mut caps);
     }
     caps


### PR DESCRIPTION
Completes the worker half of [sc-4906](https://app.shortcut.com/trefry/story/4906) now that the gen-core descriptors carry `backend` ([mlx-gen#385](https://github.com/michaeltrefry/mlx-gen/pull/385), merged).

## Changes
- **Pin bump** `ea08d47 → 8355152` (mlx-gen + `sceneworks-gen-core`, kept skew-aligned). `8355152` is the sc-4906 commit, now an ancestor of mlx-gen main. The delta vs `ea08d47` is **only** the descriptor `backend` field — no engine/mlx-rs change (mlx-rs stays `b6e4e56`), so MLX rebuilds nothing.
- **`engines.rs::registry_capabilities`**: gates `LoraTrain`/`LoraTrainExecute`/`TrainingCaption` per-backend (`backends.contains(&descriptor.backend)`), matching the generator path, instead of on "any enabled backend". Removes the Phase-0 limitation from sc-3723/sc-3724.

## Behavior
No macOS change: every existing trainer/captioner descriptor is `backend: "mlx"`, so with mlx enabled (default) the derived capability set is unchanged (cap-set parity test still passes). A candle-only trainer/captioner now correctly does **not** light up under `backend_mlx_enabled` alone (and vice versa) — the point of the change.

## Verified
Full workspace `rust:check` green (fmt + `clippy -D warnings` + tests + build, 0 failures); skew gate green (both pins at `8355152`).

Note on the pin: `8355152` is the actual sc-4906 commit (now on main via #385's merge), not #385's merge commit `f461303` — a deliberate choice to avoid a needless mlx-gen recompile, since cargo keys git deps by rev and the two are tree-identical. Both resolve on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)