### PR TITLE
Kolors full-surface MLX cutover: img2img + IP-Adapter + strict-pose (sc-4765/4766/4767/4768)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d7071ab152a759f4c
 dependencies = [
  "candle-core",
  "candle-nn",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622)",
  "thiserror 2.0.18",
 ]
 
@@ -3054,11 +3054,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3099,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3121,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "image",
  "inventory",
@@ -3143,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "image",
  "inventory",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "image",
  "inventory",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3209,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "image",
  "inventory",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "image",
  "inventory",
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "mlx-internal-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=b6e4e56930d3b639e4989d51be0abface5addf58#b6e4e56930d3b639e4989d51be0abface5addf58"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
 dependencies = [
  "darling 0.21.3",
  "itertools 0.14.0",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "mlx-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=b6e4e56930d3b639e4989d51be0abface5addf58#b6e4e56930d3b639e4989d51be0abface5addf58"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-rs"
 version = "0.25.8"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=b6e4e56930d3b639e4989d51be0abface5addf58#b6e4e56930d3b639e4989d51be0abface5addf58"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
 dependencies = [
  "dyn-clone",
  "half",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-sys"
 version = "0.2.4"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=b6e4e56930d3b639e4989d51be0abface5addf58#b6e4e56930d3b639e4989d51be0abface5addf58"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=44929a001ab8a8837403a71c65cf064224de0cdc#44929a001ab8a8837403a71c65cf064224de0cdc"
 dependencies = [
  "bindgen",
  "cc",
@@ -4860,6 +4860,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+dependencies = [
+ "inventory",
+ "safetensors 0.4.5",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -4925,7 +4936,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260)",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2485,33 +2485,9 @@ fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
             "InstantID runs on MLX for character_image with a referenceAssetId (single identity, the 11-view angle set, pose-library mode, and face-restore); a non-character / reference-less job has no InstantID path.",
             None,
         ),
-        // Kolors (sc-3875): plain T2I runs on MLX; the advanced conditioning modes — img2img
-        // (`edit_image`), the IP-Adapter-Plus reference, and the strict-pose ControlNet tier —
-        // are not yet wired in the Rust worker and stay on the torch `KolorsDiffusersAdapter`
-        // (dropped on Mac under the gating flag) until their epic-3090 cutover slices land.
-        "kolors" => {
-            let has_poses = payload
-                .get("advanced")
-                .and_then(Value::as_object)
-                .and_then(|advanced| advanced.get("poses"))
-                .and_then(Value::as_array)
-                .is_some_and(|poses| !poses.is_empty());
-            if has_poses {
-                UnsupportedReason::new(
-                    Some(model),
-                    "strict pose (ControlNet)",
-                    "Kolors ControlNet-pose is not yet wired in the Rust worker; it stays on the Python torch path until its cutover slice lands.",
-                    Some("epic 3090"),
-                )
-            } else {
-                UnsupportedReason::new(
-                    Some(model),
-                    "img2img / reference (IP-Adapter)",
-                    "Kolors img2img (edit_image) and the IP-Adapter-Plus reference are not yet wired in the Rust worker; they stay on the Python torch path until their cutover slices land.",
-                    Some("epic 3090"),
-                )
-            }
-        }
+        // Kolors (epic 3090) runs its full surface on MLX now — T2I (sc-3875), img2img (sc-4765),
+        // the IP-Adapter-Plus reference (sc-4767) and the strict-pose tier (sc-4766 / engine sc-5012)
+        // — so a kolors job is never gap-classified; any residual falls to the defensive arm below.
         // flux2 / sdxl / realvisxl only fall out via LyCORIS (handled above) — defensive.
         _ => UnsupportedReason::new(
             Some(model),
@@ -2943,8 +2919,9 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     "chroma1_flash",
     "sensenova_u1_8b",
     "sensenova_u1_8b_fast",
-    // Kolors (sc-3875): plain T2I is wired to the Rust `kolors` engine model; the advanced
-    // conditioning modes stay torch via `kolors_mlx_eligible` until later epic-3090 slices.
+    // Kolors (epic 3090): the full surface runs on the Rust `kolors` engine model — T2I (sc-3875),
+    // img2img (sc-4765), the IP-Adapter-Plus reference (sc-4767) and the strict-pose tier (sc-4766 /
+    // engine sc-5012, the combined pose-ControlNet + IP-Adapter-identity + img2img pass).
     "kolors",
 ];
 
@@ -3224,35 +3201,17 @@ fn sensenova_mlx_eligible(payload: &Map<String, Value>) -> bool {
     }
 }
 
-/// Kolors (sc-3875, epic 3090) MLX-routing conditions. The engine `kolors` model (an SDXL-family
-/// U-Net under a ChatGLM3-6B encoder) supports the full surface — img2img / ControlNet-pose /
-/// IP-Adapter-Plus / Q8/Q4 / LoRA/LoKr — but the SceneWorks worker has wired only the **plain T2I**
-/// base path so far (the `kolors` row in `MlxModel`s + `generate_mlx_stream`). So this gate admits
-/// T2I only; the advanced conditioning modes (`edit_image` img2img, a reference IP-Adapter image,
-/// the strict-pose `advanced.poses` tier) stay on the torch `KolorsDiffusersAdapter` until their
-/// dedicated worker streams land (subsequent epic-3090 cutover slices — see [`classify_image_gap`]).
-/// Third-party LyCORIS / peft LoKr apply on the SDXL-family loader (epic 3641), so a LoRA never
-/// forces torch.
-fn kolors_mlx_eligible(payload: &Map<String, Value>) -> bool {
-    let has_poses = payload
-        .get("advanced")
-        .and_then(Value::as_object)
-        .and_then(|advanced| advanced.get("poses"))
-        .and_then(Value::as_array)
-        .is_some_and(|poses| !poses.is_empty());
-    let has_reference = payload
-        .get("referenceAssetId")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().is_empty());
-    let has_source = payload
-        .get("sourceAssetId")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().is_empty());
-    if has_poses || has_reference || has_source {
-        return false;
-    }
-    // Only plain text-to-image (no edit_image conditioning) routes to MLX in this slice.
-    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
+/// Kolors (epic 3090) MLX-routing conditions. The engine `kolors` model (an SDXL-family U-Net under
+/// a ChatGLM3-6B encoder) now runs the **full surface** on the in-process Rust worker: plain T2I
+/// (sc-3875), img2img (`edit_image` + `sourceAssetId`, sc-4765), the IP-Adapter-Plus reference
+/// (`referenceAssetId`, sc-4767) — all via the base `Reference` path — and the strict-pose tier
+/// (`advanced.poses` + a reference, the combined pose-ControlNet + IP-Adapter-identity + img2img pass:
+/// engine sc-5012 + the worker `generate_kolors_control_stream`, sc-4766). A pose set without a
+/// reference is not the pose tier (torch `_pose_entries` ignores it) and falls through to the base
+/// path as plain T2I — same as torch — so every Kolors job is MLX-eligible. Third-party LyCORIS / peft
+/// LoKr apply on the SDXL-family loader (epic 3641), so a LoRA never forces torch.
+fn kolors_mlx_eligible(_payload: &Map<String, Value>) -> bool {
+    true
 }
 
 /// Video models the in-process Rust MLX worker generates today (sc-3034 Wan2.2,

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2271,13 +2271,14 @@ fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
             .and_then(|r| r.suggested_epic.as_deref()),
         Some("epic 3069")
     );
-    // Kolors base T2I is MLX-routed now (sc-3875), so it stays in the picker as a supported model
-    // whose advanced conditioning features are individually gated off.
+    // Kolors runs its full surface on MLX (epic 3090): T2I (sc-3875), img2img (sc-4765), the
+    // IP-Adapter-Plus reference (sc-4767) and the strict-pose tier (sc-4766 / engine sc-5012), so all
+    // three advanced features are enabled.
     let kolors = model_mac_support("kolors", "image");
     assert!(kolors.supported);
-    assert!(!kolors.features.edit);
-    assert!(!kolors.features.pose);
-    assert!(!kolors.features.reference);
+    assert!(kolors.features.edit);
+    assert!(kolors.features.pose);
+    assert!(kolors.features.reference);
     // An MLX-routed base family stays in the picker.
     let z_image = model_mac_support("z_image_turbo", "image");
     assert!(z_image.supported);
@@ -2679,15 +2680,15 @@ fn active_mlx_image_edit_blocks_mps_image_edit_claim() {
     assert_eq!(claimed_mlx.id, mlx_job.id);
     assert_eq!(claimed_mlx.assigned_gpu.as_deref(), Some("mlx"));
 
-    // A kolors edit_image job is the MPS job: kolors base T2I is MLX-routed (sc-3875) but its
-    // img2img/edit path is not yet wired to MLX (`kolors_mlx_eligible` rejects edit_image), so it
-    // stays on the torch worker, exercising the shared-GPU exclusion without being soft-deferred.
+    // A PuLID job is the MPS job: PuLID is torch-only on Mac (epic 3069, not in MLX_ROUTED_MODELS),
+    // so it stays on the torch worker — exercising the shared-GPU exclusion without being
+    // soft-deferred. (Kolors is fully MLX now — epic 3090 — so it's no longer a torch example.)
     let mps_job = store
-        .create_job(image_edit_job_with(
+        .create_job(image_job_with(
             json!({
-                "model": "kolors",
-                "mode": "edit_image",
-                "sourceAssetId": "asset_2",
+                "model": "pulid_flux_dev",
+                "mode": "character_image",
+                "referenceAssetId": "asset_2",
                 "prompt": "p"
             }),
             "auto",
@@ -2717,14 +2718,14 @@ fn active_mps_image_edit_blocks_mlx_image_edit_claim() {
     register_gpu_worker(&store, "worker-mps", "mps", image_edit_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
-    // A kolors edit_image job is the MPS job (kolors img2img isn't wired to MLX yet, so it isn't
-    // soft-deferred to the mlx worker).
+    // A PuLID job is the MPS job (PuLID is torch-only on Mac — epic 3069 — so it isn't soft-deferred
+    // to the mlx worker).
     let mps_job = store
-        .create_job(image_edit_job_with(
+        .create_job(image_job_with(
             json!({
-                "model": "kolors",
-                "mode": "edit_image",
-                "sourceAssetId": "asset_1",
+                "model": "pulid_flux_dev",
+                "mode": "character_image",
+                "referenceAssetId": "asset_1",
                 "prompt": "p"
             }),
             "auto",
@@ -2794,20 +2795,19 @@ fn routing_decision_reports_claimed_by_mlx_for_image_edit() {
 }
 
 #[test]
-fn torch_only_image_edit_model_stays_on_torch() {
-    let store = store("mlx-routing-image-edit-torch-only");
+fn torch_only_image_model_stays_on_torch() {
+    let store = store("mlx-routing-image-torch-only");
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
-    // kolors base T2I is MLX-routed (sc-3875), but its edit/img2img path is not yet wired to MLX
-    // (`kolors_mlx_eligible` rejects edit_image), so a kolors edit stays on the Python torch path
-    // and the mlx worker must refuse it. (z_image_edit WAS ported to MLX — epic 3529 / sc-3923 — so
-    // it is no longer a valid torch-only example; see `z_image_edit_routes_to_mlx`.)
+    // PuLID is torch-only on Mac (epic 3069, not in MLX_ROUTED_MODELS), so it stays on the Python
+    // torch path and the mlx worker must refuse it. (Every ported image family — incl. Kolors' full
+    // surface, epic 3090 — is MLX now, so a torch-only example must come from an unported model.)
     let job = store
-        .create_job(image_edit_job_with(
+        .create_job(image_job_with(
             json!({
-                "model": "kolors",
-                "mode": "edit_image",
-                "sourceAssetId": "asset_1",
+                "model": "pulid_flux_dev",
+                "mode": "character_image",
+                "referenceAssetId": "asset_1",
                 "prompt": "p"
             }),
             "auto",
@@ -2829,7 +2829,7 @@ fn torch_only_image_edit_model_stays_on_torch() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mps"));
     assert!(
         decision.is_none(),
-        "a torch-only edit model is routing-neutral (no mlx_route_decision)"
+        "a torch-only image model is routing-neutral (no mlx_route_decision)"
     );
 }
 
@@ -3611,6 +3611,55 @@ fn kolors_txt2img_routes_to_mlx_worker() {
         .expect("mlx claims kolors txt2img");
     assert_eq!(claimed.id, job.id);
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+}
+
+#[test]
+fn kolors_advanced_modes_route_to_mlx() {
+    // epic 3090: kolors runs its full surface on MLX — img2img (sc-4765, `edit_image` +
+    // `sourceAssetId`), the IP-Adapter-Plus reference (sc-4767, `referenceAssetId`) and the
+    // strict-pose tier (sc-4766 / engine sc-5012, `advanced.poses` + a reference) — all defer to the
+    // idle mlx worker.
+    for (index, payload) in [
+        json!({
+            "model": "kolors",
+            "mode": "edit_image",
+            "sourceAssetId": "asset_1",
+            "prompt": "p"
+        }),
+        json!({
+            "model": "kolors",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "prompt": "p"
+        }),
+        json!({
+            "model": "kolors",
+            "mode": "character_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "poses": [{ "keypoints": [] }] },
+            "prompt": "p"
+        }),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let store = store(&format!("mlx-routing-kolors-advanced-{index}"));
+        register_gpu_worker(&store, "worker-torch", "mps", image_edit_caps());
+        register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
+        let job = store
+            .create_job(image_edit_job_with(payload, "auto"))
+            .expect("job creates");
+        assert!(store
+            .claim_next_job("worker-torch")
+            .expect("torch claim ok")
+            .is_none());
+        let claimed = store
+            .claim_next_job("worker-mlx")
+            .expect("mlx claim ok")
+            .expect("mlx claims kolors advanced job");
+        assert_eq!(claimed.id, job.id);
+        assert_eq!(claimed.assigned_gpu.as_deref(), Some("mlx"));
+    }
 }
 
 #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -30,7 +30,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # The rev MUST stay identical to the `mlx-gen` pin in the macOS block: two gen-core revs would mean
 # two distinct `inventory` registries (one for the worker's derivation, one the provider crates
 # register into) and the runtime would see "engine not found". Bump both together.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -93,12 +93,20 @@ backend-candle = ["dep:candle-gen-sdxl"]
 # desktop packager (build-sidecar.mjs) has a dylib to stage and dev runs work.
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# Rev 95cd5c6 (mlx-gen main, merged PR #403, epic 3090 / sc-5012): adds the combined
+# Kolors ControlNet-pose + IP-Adapter + img2img pass (`Kolors::denoise_controlnet_ip_latents` /
+# `generate_controlnet_ip` + the relaxed registry validate guard), unblocking the Kolors strict-pose
+# worker cutover (sc-4766). Bundles the intervening main merges since 8355152 (#398 SAM3 video PCS,
+# #400 SAM3 geometry/exemplar encoder, #401, #402 SAM3 quant+API) — none touched by the worker's
+# image path. ⚠️ mlx-rs moved b6e4e56 → 44929a0 across these (mlx-gen main's internal pin); the direct
+# `mlx-rs` pin below moves in lockstep or the worker links two incompatible `Array`/`Error` types.
+# On top of:
 # Rev 8355152 (mlx-gen, PR #385, epic 3720 / sc-4906): adds `backend: &'static str` to
 # TrainerDescriptor/CaptionerDescriptor/TransformDescriptor (mirroring `ModelDescriptor.backend`),
 # letting the worker gate training/caption capability advertisement per-backend (engines.rs
 # `registry_capabilities`) instead of on "any enabled backend". All existing descriptors are
 # `backend: "mlx"`, so macOS advertisement is unchanged. The delta vs ea08d47 is ONLY the
-# descriptor field — no engine/mlx-rs change (mlx-rs pin stays b6e4e56), so MLX rebuilds nothing.
+# descriptor field — no engine/mlx-rs change (mlx-rs pin was b6e4e56), so MLX rebuilds nothing.
 # On top of:
 # Rev ea08d47 (mlx-gen main HEAD, merged PR #384, epic 3720 / sc-4481; bundles #382 sc-4874 +
 # #383 sc-4886/4887): the z-image LoRA OOM training fix PLUS the typed-cancellation contract.
@@ -194,68 +202,69 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
 # and the DFL/anchor decode. Pinned to the SAME rev mlx-gen uses so MLX builds once
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
-# guard test (tests/nax_guard.rs). Tracks the mlx-gen #382 mlx-rs bump (b6e4e56).
-mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "b6e4e56930d3b639e4989d51be0abface5addf58" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+# guard test (tests/nax_guard.rs). Tracks mlx-gen main's internal mlx-rs pin, last moved
+# b6e4e56 → 44929a0 alongside the mlx-gen 8355152 → 95cd5c6 bump (epic 3090 / sc-5012, PR #403).
+mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -264,7 +273,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "835515
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -272,7 +281,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355152a79d6d328d3798c19a2b5a37bb8468622" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -280,9 +289,12 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8355
 # mlx providers). OPTIONAL + behind the `backend-candle` feature: its `cuda` feature compiles
 # candle-kernels for the target arch via nvcc, which must NOT run on the plain Desktop (Windows)
 # installer build — only the dedicated candle CI lane (sc-3676) opts in. Pinned to candle-gen
-# `5d7071a` (PR #2), whose `sceneworks-gen-core` pin is `8355152…` — the SAME rev this worker pins —
-# so the inventory registry is single. A drift here trips the skew gate (two gen-core builds split
-# the registry → "no generator registered" at runtime). Bump in lockstep with the mlx-gen pin above.
+# `5d7071a` (PR #2), whose `sceneworks-gen-core` pin is `8355152…`. NOTE: the worker's gen-core pin
+# moved to `95cd5c6` (sc-5012) while this candle pin still resolves `8355152`. The default skew gate
+# (`cargo tree` with no `--features backend-candle`) does NOT see this `optional` Windows-only dep, so
+# it stays green; but the candle lane (with `backend-candle`) WOULD split the gen-core registry until
+# candle-gen is re-pinned to `95cd5c6` and this rev bumped in lockstep — tracked as sc-5035 so it
+# isn't silently shipped on the Windows/CUDA lane.
 [target.'cfg(target_os = "windows")'.dependencies]
 candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d7071ab152a759f4cdcb1cef020226f03ddb2c3", features = ["cuda"], optional = true }
 

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -175,6 +175,20 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::KolorsControl => {
+                // Kolors strict-pose (advanced.poses + a reference) → the combined pose ControlNet
+                // + IP-Adapter identity + img2img pass (sc-4766 / engine sc-5012), one image per pose.
+                generate_kolors_control_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::Flux2Edit => {
                 // FLUX.2-klein edit/reference (mode edit_image or a reference) → edit variant.
                 generate_flux2_edit_stream(
@@ -644,6 +658,9 @@ include!("image_jobs/sensenova.rs");
 #[cfg(target_os = "macos")]
 // SDXL advanced routing.
 include!("image_jobs/sdxl.rs");
+#[cfg(target_os = "macos")]
+// Kolors advanced conditioning (img2img + IP-Adapter-Plus reference).
+include!("image_jobs/kolors.rs");
 #[cfg(target_os = "macos")]
 // InstantID native routing.
 include!("image_jobs/instantid.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -7,6 +7,7 @@ fn mlx_available(request: &ImageRequest, settings: &Settings) -> bool {
 enum ImageRoute {
     ZImageControl,
     QwenControl,
+    KolorsControl,
     Flux2Edit,
     QwenEdit,
     InstantId,
@@ -20,6 +21,8 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         Some(ImageRoute::ZImageControl)
     } else if qwen_control_available(request, settings) {
         Some(ImageRoute::QwenControl)
+    } else if kolors_control_available(request, settings) {
+        Some(ImageRoute::KolorsControl)
     } else if flux2_edit_available(request, settings) {
         Some(ImageRoute::Flux2Edit)
     } else if qwen_edit_available(request, settings) {
@@ -40,9 +43,9 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
 impl ImageRoute {
     fn image_count(self, request: &ImageRequest, settings: &Settings) -> u32 {
         match self {
-            ImageRoute::ZImageControl | ImageRoute::QwenControl => {
-                pose_entries(request).len() as u32
-            }
+            ImageRoute::ZImageControl
+            | ImageRoute::QwenControl
+            | ImageRoute::KolorsControl => pose_entries(request).len() as u32,
             ImageRoute::Flux2Edit | ImageRoute::QwenEdit => grouped_edit_image_count(request),
             ImageRoute::InstantId => instantid_image_count(request, settings),
             ImageRoute::SensenovaEdit => match flux2_grouping(request) {
@@ -559,10 +562,12 @@ async fn generate_stream(
         .map(|index| resolve_seed(request, index))
         .collect();
     // Reference conditioning for the base MLX path, resolved once (constant across the set):
-    //  • Z-Image reference-identity img2img-init (sc-3619), and
+    //  • Z-Image reference-identity img2img-init (sc-3619),
     //  • FLUX.1 XLabs IP-Adapter (epic 3621 — both schnell + dev; `strength = ipAdapterScale`, plus
-    //    real CFG via `trueCfgScale` on dev). Qwen/SDXL reference divert to their own advanced
-    //    branches before reaching here.
+    //    real CFG via `trueCfgScale` on dev), and
+    //  • Kolors img2img (sc-4765, `edit_image` + `sourceAssetId`) + the IP-Adapter-Plus reference
+    //    (sc-4767, `referenceAssetId` → image prompt at `ipAdapterScale`). Qwen/SDXL reference
+    //    divert to their own advanced branches before reaching here.
     let has_reference = request
         .reference_asset_id
         .as_deref()
@@ -612,6 +617,19 @@ async fn generate_stream(
             )
         });
         (Some((image, scale)), Some(ip_dir), true_cfg)
+    } else if request.model == "kolors" && request.mode == "edit_image" {
+        // Kolors img2img (sc-4765): `sourceAssetId` + `strength` → the engine's `Reference`
+        // (img2img init, no IP-Adapter loaded). Kolors carries CFG through `guidance` + negative
+        // prompt (resolved above), not `true_cfg`.
+        let init = resolve_kolors_edit_init(request, settings, project_path)?;
+        (init, None, None)
+    } else if request.model == "kolors" && has_reference {
+        // Kolors IP-Adapter-Plus reference (sc-4767): `referenceAssetId` → the IP image prompt at
+        // `ipAdapterScale`. `with_ip_adapter` makes the engine treat the `Reference` as the image
+        // prompt (decoupled cross-attn) rather than an img2img init.
+        let (image, scale) = resolve_kolors_ip_reference(request, settings, project_path)?;
+        let ip_dir = resolve_kolors_ip_adapter_dir(settings)?;
+        (Some((image, scale)), Some(ip_dir), None)
     } else {
         (None, None, None)
     };

--- a/crates/sceneworks-worker/src/image_jobs/kolors.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors.rs
@@ -1,0 +1,411 @@
+// ---------------------------------------------------------------------------
+// Kolors advanced conditioning (macOS, epic 3090): img2img (sc-4765) + the
+// IP-Adapter-Plus reference (sc-4767). Both ride the base `generate_stream`
+// `Reference` conditioning — the engine's single `kolors` model handles img2img
+// (a `Reference` with no IP-Adapter loaded) and the IP image prompt (a `Reference`
+// once `with_ip_adapter` installs the decoupled-attn weights), so this module only
+// resolves the per-mode init image + the IP snapshot dir. Kolors is a guidance/CFG
+// family (negative prompt + guidance 5.0), so the CFG flows through `guidance` (not
+// `true_cfg`) on the base path. The strict-pose tier (sc-4766) is a combined
+// ControlNet + IP-Adapter + img2img pass that the pinned engine does not yet
+// support (sc-5012) and lands as a dedicated stream once that engine feature does.
+// ---------------------------------------------------------------------------
+
+/// The Kolors IP-Adapter-Plus snapshot repo: a CLIP-ViT-L/14-336 image encoder under
+/// `image_encoder/` + the `ip_adapter_plus_general.safetensors` weights (the `image_proj`
+/// Resampler + decoupled-attn K/V pairs). The torch `KolorsDiffusersAdapter` downloads it at
+/// `refs/pr/4`; the MLX path reuses the same HF-cache snapshot (no new weight to ship).
+const KOLORS_IP_ADAPTER_REPO: &str = "Kwai-Kolors/Kolors-IP-Adapter-Plus";
+/// IP-Adapter scale when the request omits `ipAdapterScale` — the torch
+/// `KolorsDiffusersAdapter._ip_adapter_scale` default 0.6.
+const KOLORS_IP_SCALE: f32 = 0.6;
+/// img2img strength for a Kolors edit when the request omits `strength` — the torch
+/// `KolorsImg2ImgPipeline` default 0.6, forwarded verbatim to the engine's
+/// `init_time_step(steps, strength)`.
+const KOLORS_EDIT_STRENGTH: f32 = 0.6;
+
+/// Resolve the Kolors img2img init for `mode == "edit_image"` (sc-4765): `Some((source, strength))`
+/// decoding `sourceAssetId` and pre-fitting it to the output W×H (crop/pad/outpaint via
+/// [`should_fit_edit_source`]/[`fit_engine_image`] — never stretch an off-aspect source, epic 2551);
+/// `None` when not an edit job or no source asset (the base path then falls back to plain txt2img).
+/// `strength` is the torch `advanced.strength` (default 0.6) forwarded verbatim to the engine's
+/// `Reference` (img2img init) — its `init_time_step(steps, strength)` matches the diffusers
+/// `KolorsImg2ImgPipeline` start step.
+fn resolve_kolors_edit_init(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<Option<(Image, f32)>> {
+    if request.mode != "edit_image" {
+        return Ok(None);
+    }
+    let Some(asset_id) = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let source = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        asset_id,
+        project_path,
+    )?;
+    let image = if should_fit_edit_source(request) {
+        fit_engine_image(source, request.width, request.height, &request.fit_mode)?
+    } else {
+        source
+    };
+    let strength =
+        advanced::f32_clamped(&request.advanced, "strength", KOLORS_EDIT_STRENGTH, 0.05..=1.0);
+    Ok(Some((image, strength)))
+}
+
+/// Resolve the Kolors IP-Adapter-Plus reference image prompt (sc-4767): `(image, scale)` decoding
+/// `referenceAssetId` + the IP scale (`advanced.ipAdapterScale`, default 0.6). Once the IP-Adapter
+/// is installed via [`resolve_kolors_ip_adapter_dir`] + `LoadSpec::with_ip_adapter`, the engine
+/// treats this `Reference` as the image prompt (decoupled cross-attn) rather than an img2img init.
+fn resolve_kolors_ip_reference(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<(Image, f32)> {
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Kolors IP-Adapter requires a reference image".to_owned())
+        })?;
+    let image = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+    let scale =
+        advanced::f32_clamped(&request.advanced, "ipAdapterScale", KOLORS_IP_SCALE, 0.0..=1.0);
+    Ok((image, scale))
+}
+
+/// Resolve the Kolors IP-Adapter-Plus snapshot directory the engine loads (`image_encoder/`
+/// CLIP-ViT-L/14-336 + `ip_adapter_plus_general.safetensors`). Errors loudly if the snapshot or
+/// either required file is absent — the model-download flow fetches the repo (`refs/pr/4`) ahead of
+/// generation, like the base weights; mirrors the SDXL/FLUX IP-Adapter dir resolvers.
+fn resolve_kolors_ip_adapter_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    let missing = || {
+        WorkerError::InvalidPayload(format!(
+            "Kolors IP-Adapter weights not found (download {KOLORS_IP_ADAPTER_REPO})."
+        ))
+    };
+    let snapshot = huggingface_snapshot_dir(&settings.data_dir, KOLORS_IP_ADAPTER_REPO)
+        .ok_or_else(missing)?;
+    if !snapshot.join("ip_adapter_plus_general.safetensors").exists()
+        || !snapshot.join("image_encoder").join("model.safetensors").exists()
+    {
+        return Err(missing());
+    }
+    Ok(snapshot)
+}
+
+// ---------------------------------------------------------------------------
+// Kolors strict-pose tier (macOS, sc-4766 / engine sc-5012): the Character-Studio
+// pose-locked character variations. One image per library pose, each driven by a
+// DWPose skeleton (the pose ControlNet, `Kwai-Kolors/Kolors-ControlNet-Pose`) + the
+// IP-Adapter-Plus identity reference + an img2img init from that same reference — all
+// in ONE combined engine pass (`Kolors::denoise_controlnet_ip_latents`). Faithful port
+// of the torch `KolorsDiffusersAdapter._run_pose` / `_generate_pose_set`. Mirrors
+// `generate_zimage_control_stream` (one image per pose, shared seed, streamed events),
+// but loads base + ControlNet + IP-Adapter in one `LoadSpec` and passes Control +
+// Reference together (the combined tier the engine gained in sc-5012).
+// ---------------------------------------------------------------------------
+
+/// The official Kolors pose ControlNet checkpoint (a diffusers `ControlNetModel` snapshot dir with
+/// `diffusion_pytorch_model.safetensors`). Loaded via `LoadSpec::with_control(Dir(..))` — the engine
+/// expects a directory, not a single file.
+const KOLORS_CONTROLNET_REPO: &str = "Kwai-Kolors/Kolors-ControlNet-Pose";
+/// Pose ControlNet conditioning scale when the request omits `openPoseScale` — the torch
+/// `KolorsDiffusersAdapter._openpose_scale` default 0.7 (clamp [0, 2]).
+const KOLORS_POSE_CONTROL_SCALE: f32 = 0.7;
+/// img2img init strength for the pose tier — the torch `_run_pose` default 1.0 (at full strength the
+/// reference init only seeds latent dimensions; identity rides the IP-Adapter, structure the pose).
+const KOLORS_POSE_IMG2IMG_STRENGTH: f32 = 1.0;
+
+/// True when this is a Kolors strict-pose job: `kolors` + ≥1 `advanced.poses` + a `referenceAssetId`
+/// (the identity) whose base weights resolve. Routed to the combined control stream rather than the
+/// base path. Mirrors the torch `_pose_entries` gate (poses ONLY with a reference). The ControlNet /
+/// IP-Adapter checkpoints are validated in the stream so a missing one errors loudly.
+fn kolors_control_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == "kolors"
+        && !pose_entries(request).is_empty()
+        && request
+            .reference_asset_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty())
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
+}
+
+/// Resolve the Kolors pose ControlNet snapshot directory (`diffusion_pytorch_model.safetensors`
+/// inside). Errors loudly if absent — the model-download flow fetches it ahead of generation.
+fn resolve_kolors_controlnet_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    let missing = || {
+        WorkerError::InvalidPayload(format!(
+            "Kolors pose ControlNet weights not found (download {KOLORS_CONTROLNET_REPO})."
+        ))
+    };
+    let snapshot = huggingface_snapshot_dir(&settings.data_dir, KOLORS_CONTROLNET_REPO)
+        .ok_or_else(missing)?;
+    if !snapshot.join("diffusion_pytorch_model.safetensors").exists() {
+        return Err(missing());
+    }
+    Ok(snapshot)
+}
+
+/// Pose ControlNet lock strength: `advanced.openPoseScale` (default 0.7, clamp [0, 2]) — the torch
+/// `_openpose_scale` knob.
+fn kolors_pose_control_scale(request: &ImageRequest) -> f32 {
+    advanced::f32_clamped(
+        &request.advanced,
+        "openPoseScale",
+        KOLORS_POSE_CONTROL_SCALE,
+        0.0..=2.0,
+    )
+}
+
+/// The combined Kolors `LoadSpec`: base snapshot + the pose ControlNet (`with_control`) + the
+/// IP-Adapter-Plus (`with_ip_adapter`) + quant + LoRA. The engine's `kolors` model routes a request
+/// carrying both `Control` and `Reference` to its combined pose pass (sc-5012).
+fn kolors_control_spec(
+    weights_dir: PathBuf,
+    control_dir: PathBuf,
+    ip_dir: PathBuf,
+    quant: Option<Quant>,
+    adapters: Vec<AdapterSpec>,
+) -> LoadSpec {
+    let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
+        .with_control(WeightsSource::Dir(control_dir))
+        .with_ip_adapter(WeightsSource::Dir(ip_dir));
+    if let Some(quant) = quant {
+        spec = spec.with_quant(quant);
+    }
+    if !adapters.is_empty() {
+        spec = spec.with_adapters(adapters);
+    }
+    spec
+}
+
+/// Generate one Kolors pose image: the `control` skeleton locks the pose, the `reference` drives
+/// identity via the IP-Adapter (scale `ip_scale`) AND seeds the img2img init (strength
+/// `img2img_strength`). Kolors is true-CFG (negative prompt + guidance). The reference is shared
+/// across the pose set (identity is constant; only the per-pose skeleton changes).
+#[allow(clippy::too_many_arguments)]
+fn kolors_control_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    negative_prompt: Option<String>,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: Option<f32>,
+    control: Image,
+    control_scale: f32,
+    reference: &Image,
+    ip_scale: f32,
+    img2img_strength: f32,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let conditioning = vec![
+        Conditioning::Control {
+            image: control,
+            kind: ControlKind::Pose,
+            scale: control_scale,
+        },
+        Conditioning::Reference {
+            image: reference.clone(),
+            strength: Some(ip_scale),
+        },
+    ];
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        negative_prompt,
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        guidance,
+        strength: Some(img2img_strength),
+        conditioning,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&request, on_progress)
+        .map_err(|error| WorkerError::Engine(format!("kolors pose generation failed: {error}")))?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::Engine("kolors pose generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::Engine(
+            "kolors pose generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn kolors_control_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: Option<f32>,
+    control_scale: f32,
+    ip_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = mlx_raw_settings(request, repo, steps, quant_bits, guidance);
+    raw.insert("controlNetPose".to_owned(), json!(KOLORS_CONTROLNET_REPO));
+    raw.insert("openPoseScale".to_owned(), json!(control_scale));
+    raw.insert("ipAdapterScale".to_owned(), json!(ip_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw
+}
+
+/// Real Kolors strict-pose generation: one image per pose, each conditioned on a DWPose skeleton
+/// (pose ControlNet) + the shared IP-Adapter identity reference + an img2img init from that
+/// reference, in one combined engine pass (sc-5012). Mirrors [`generate_zimage_control_stream`]'s
+/// blocking-thread + streamed-events shape, reusing [`consume_gen_events`].
+async fn generate_kolors_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let kolors = mlx_model("kolors")
+        .ok_or_else(|| WorkerError::InvalidPayload("kolors model row missing".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Kolors weights not found".to_owned()))?;
+    let control_dir = resolve_kolors_controlnet_dir(settings)?;
+    let ip_dir = resolve_kolors_ip_adapter_dir(settings)?;
+
+    // The identity reference: the IP-Adapter image prompt AND the img2img init, shared across the
+    // pose set (`kolors_control_available` guarantees a non-empty referenceAssetId).
+    let reference_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload("Kolors pose tier requires a reference image".to_owned())
+        })?;
+    let reference = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+
+    let (quant, quant_bits) = resolve_quant(request);
+    let steps = resolve_steps(request, &kolors);
+    let guidance = resolve_guidance(request, &kolors);
+    let negative_prompt = resolve_negative_prompt(request, &kolors);
+    let control_scale = kolors_pose_control_scale(request);
+    let ip_scale =
+        advanced::f32_clamped(&request.advanced, "ipAdapterScale", KOLORS_IP_SCALE, 0.0..=1.0);
+    let adapters = resolve_adapters(request)?;
+    let repo = model_repo(request, &kolors);
+    let poses = parse_poses(request);
+    let count = poses.len();
+    let raw_settings = kolors_control_raw_settings(
+        request,
+        &repo,
+        steps,
+        quant_bits,
+        guidance,
+        control_scale,
+        ip_scale,
+        count,
+    );
+    // The pose set shares one seed so noise-derived attributes stay constant while only the pose
+    // changes (torch `_generate_pose_set` shares `set_seed`).
+    let seed = resolve_seed(request, 0);
+
+    let prompt = request.prompt.clone();
+    let (width, height) = (request.width, request.height);
+    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+    let adapter_count = adapters.len();
+    let spec = kolors_control_spec(weights_dir, control_dir, ip_dir, quant, adapters);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
+        job.id.clone(),
+        "kolors",
+        adapter_count,
+        spec,
+        "Kolors pose ControlNet load failed".to_owned(),
+        move |generator, tx, cancel| {
+            let reference = &reference;
+            let negative_prompt = negative_prompt.clone();
+            drive_gen_items(tx, poses, move |_index, pose, on_progress| {
+                let skeleton = crate::openpose_skeleton::draw_wholebody(
+                    width,
+                    height,
+                    &pose.keypoints,
+                    pose.hands.as_deref(),
+                    pose.face.as_deref(),
+                    stickwidth,
+                );
+                let control = Image {
+                    width,
+                    height,
+                    pixels: skeleton.into_raw(),
+                };
+                let (out_w, out_h, pixels) = kolors_control_generate_one(
+                    generator,
+                    &prompt,
+                    negative_prompt.clone(),
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
+                    control,
+                    control_scale,
+                    reference,
+                    ip_scale,
+                    KOLORS_POSE_IMG2IMG_STRENGTH,
+                    &cancel,
+                    on_progress,
+                )?;
+                Ok(Some((seed, out_w, out_h, pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        kolors.adapter_label(),
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Completes the **inference half of epic 3090** — every Kolors mode now runs in-process on the Rust MLX worker on Mac. Depends on the engine combined-pass [mlx-gen#403](https://github.com/michaeltrefry/mlx-gen/pull/403) (sc-5012, merged), pinned here.

## Slices

- **sc-4765 img2img** — kolors `edit_image` + `sourceAssetId` → the engine `Reference` (img2img init) on the base path, with epic-2551 fit_mode (crop/pad/outpaint). `strength` default 0.6.
- **sc-4767 IP-Adapter-Plus reference** — kolors `referenceAssetId` → `LoadSpec::with_ip_adapter` (`Kwai-Kolors/Kolors-IP-Adapter-Plus`) + the reference as the IP image prompt at `ipAdapterScale` (0.6). Resolved the sc-3875 open item: Kolors does **not** participate in Character-Studio angle orchestration (no angle path in `KolorsDiffusersAdapter`), so plain reference covers its `character_image`.
- **sc-4766 strict-pose** — `generate_kolors_control_stream`: one image per library pose, each a **combined** pose-ControlNet (skeleton) + IP-Adapter identity + img2img-init pass via the engine's combined method (sc-5012). Loads base + control + IP in one `LoadSpec`; new `ImageRoute::KolorsControl`. Maps torch `_run_pose` exactly: `openPoseScale` 0.7, `ipAdapterScale` 0.6, `strength` 1.0; ControlNet loads as `with_control(Dir(<snapshot>))`.
- **sc-4768 flip + retire** — `kolors_mlx_eligible` → full surface; `model_mac_support` features `edit`/`pose`/`reference` all true; dropped the kolors gap arm. The torch `KolorsDiffusersAdapter` is retired from the **Mac routing** (kept for Win/Linux, per the sc-3032/sc-3843 family-cutover pattern; Mac is MLX-only at runtime since sc-3492). Repurposed the torch-only routing fixtures to **PuLID** (the remaining torch-only image model).

## Engine pin bump

mlx-gen `8355152 → 95cd5c6` across all provider deps (bundles the sc-5012 combined pass + the intervening SAM3 main merges) + the direct **mlx-rs** pin `b6e4e56 → 44929a0` in lockstep (mlx-gen main's internal pin moved — or the worker links two incompatible `Array` types). gen-core **skew gate green** (one resolution at 95cd5c6). The optional Windows-only `candle-gen-sdxl` still transitively pins the old gen-core; it's not in the default skew graph (`optional`, no `--features backend-candle`), so the gate stays green — tracked as **sc-5035** for the candle lane.

## Validation

- fmt + `clippy --all-targets -D warnings` clean; **full workspace tests green** (core 149, rust-api 109, worker 255).
- The combined pose pass is real-weight validated in mlx-gen#403 (`control=0,ip=0` byte-identical to img2img; both scales on perturb + render coherently).
- New core routing coverage: `kolors_advanced_modes_route_to_mlx` (edit / reference / pose all → MLX).

## Remaining for sc-4768 Done
Real-Mac per-mode E2E (worker-integration parity for T2I / img2img / pose / IP-Adapter) — the final acceptance gate, as with the other family cutovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)