### PR TITLE
sc-4926: SAM3 text-concept person segmenter (replace SAM2 box-prompt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,11 +3069,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3136,7 +3136,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3146,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "image",
  "inventory",
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "image",
  "inventory",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3180,7 +3180,16 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
+dependencies = [
+ "mlx-gen",
+ "pmetal-mlx-rs",
+]
+
+[[package]]
+name = "mlx-gen-sam3"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3189,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "image",
  "inventory",
@@ -3202,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3213,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3224,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "image",
  "inventory",
@@ -3238,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "image",
  "inventory",
@@ -3545,7 +3554,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4866,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7#6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -4877,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679#ec1838a8c2ef19f9b3e6010e0bab2d9631795679"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -4941,6 +4950,7 @@ dependencies = [
  "mlx-gen-ltx",
  "mlx-gen-qwen-image",
  "mlx-gen-sam2",
+ "mlx-gen-sam3",
  "mlx-gen-sdxl",
  "mlx-gen-sensenova",
  "mlx-gen-svd",
@@ -4951,7 +4961,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7)",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=ec1838a8c2ef19f9b3e6010e0bab2d9631795679)",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -30,7 +30,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # The rev MUST stay identical to the `mlx-gen` pin in the macOS block: two gen-core revs would mean
 # two distinct `inventory` registries (one for the worker's derivation, one the provider crates
 # register into) and the runtime would see "engine not found". Bump both together.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -206,7 +206,16 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # z-image encoder-free sc-4952, the sc-4986 pre-flight denoise guard, sc-4895 typed
 # cancellation) — all additive / internal to the engine; no consumed public API was
 # removed (verified by building the worker against this rev).
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+#
+# Rev ec1838a (mlx-gen main, merged PR #402, sc-4925/SAM3-G): adds SAM3 whole-model Q8/Q4
+# affine quant — `Sam3VideoModel::quantize(bits)` — so the person-track SAM3 segmenter runs
+# at ~0.9 GB (Q8, near-lossless: engine image Q8 IoU 0.9988) instead of F32 ~3.2 GB
+# (person_segment_sam3.rs calls `.quantize()`). The #401 -> #402 diff touches ONLY the
+# `mlx-gen-sam3` crate (every linear routed through `AdaptableLinear`, dense path = the same
+# fused `addmm` so the F32 path stays parity-preserving) — root Cargo.toml / mlx-rs rev /
+# gen-core are byte-identical to #401, so this bump rebuilds nothing outside sam3 and the
+# direct `mlx-rs` pin below stays 44929a00.
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -216,60 +225,69 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72
 # #382 e59ffd88 -> b6e4e56, then sc-5009 (PR #401 / mlx-rs PR #10) b6e4e56 -> 44929a00
 # (recoverable Metal command-buffer error).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
+# SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
+# (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
+# builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
+# (`propagate(frames, "person")`) to produce temporally-consistent multi-person masks with no
+# manual box prompt, replacing the SAM2 box-prompt segmenter in the macOS person-track flow.
+# Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
+# `Sam3VideoModel::quantize(8)` (sc-4925, on this rev) for a ~0.9 GB Q8 footprint vs F32 ~3.2 GB.
+# Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -278,7 +296,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f90
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -286,7 +304,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6c0f904ec72fd0d5f5b2fffef2d0461e8d29f3f7" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ec1838a8c2ef19f9b3e6010e0bab2d9631795679" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -118,6 +118,11 @@ mod person_track;
 // Windows/Linux backend.
 #[cfg(target_os = "macos")]
 mod person_segment;
+// SAM3 text-concept (PCS) person segmenter — the box-prompt-free upgrade of `person_segment`
+// (epic 4910, sc-4926). macOS-only like its SAM2 sibling. The Python SAM2 path stays the
+// Windows/Linux backend until a parallel candle backport (cf. epic 3792).
+#[cfg(target_os = "macos")]
+mod person_segment_sam3;
 use downloads::*;
 #[cfg(target_os = "macos")]
 use kps_jobs::*;

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -633,6 +633,37 @@ pub(crate) fn frame_seek_timestamp(timestamp: f64, duration: f64) -> f64 {
     timestamp.min((duration - FRAME_SEEK_GUARD_SECONDS).max(0.0))
 }
 
+/// The native-MLX person segmenter used by the macOS person-track masking pass.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PersonSegmenter {
+    /// SAM3 text-concept (PCS) — the box-prompt-free default (sc-4926).
+    Sam3,
+    /// Legacy SAM2 box-prompt video predictor (epic 3704) — kept for A/B parity + fallback.
+    Sam2,
+}
+
+#[cfg(target_os = "macos")]
+impl PersonSegmenter {
+    /// The sidecar `tracker_meta.segmenter` id for this backend.
+    fn meta_label(self) -> &'static str {
+        match self {
+            PersonSegmenter::Sam3 => "sam3",
+            PersonSegmenter::Sam2 => "sam2.1_hiera_large",
+        }
+    }
+}
+
+/// Select the person segmenter: SAM3 PCS by default, the legacy SAM2 box-prompt path under
+/// `SCENEWORKS_PERSON_SEGMENTER=sam2` (A/B parity validation + cutover fallback, sc-4926).
+#[cfg(target_os = "macos")]
+fn person_segmenter_kind() -> PersonSegmenter {
+    match std::env::var("SCENEWORKS_PERSON_SEGMENTER").ok().as_deref() {
+        Some("sam2") => PersonSegmenter::Sam2,
+        _ => PersonSegmenter::Sam3,
+    }
+}
+
 /// The real (model-backed) outcome of `assemble_real_person_track`: the resampled track frames
 /// plus the metadata `run_person_track` folds into the sidecar.
 struct RealPersonTrack {
@@ -778,7 +809,7 @@ async fn assemble_real_person_track(
             "device": device,
             "model": "yolo11m",
             "tracker": "sort_bytetrack",
-            "segmenter": if segment_enabled { "sam2.1_hiera_large" } else { "disabled" },
+            "segmenter": if segment_enabled { person_segmenter_kind().meta_label() } else { "disabled" },
         }),
     })
 }
@@ -817,21 +848,15 @@ async fn segment_assembly_frames(
         return Ok("missing");
     }
 
-    // Resolve/download the SAM2 weights once; any failure degrades to box masks.
+    // Resolve/download the segmenter weights once; any failure degrades to box masks.
     let download_context = DownloadContext {
         api,
         client: http_client,
         settings,
         job_id: &job.id,
-        cancel_message: "Person segmentation canceled while fetching SAM2 weights.",
+        cancel_message: "Person segmentation canceled while fetching segmenter weights.",
         fresh_download: false,
     };
-    let weights =
-        match crate::person_segment::ensure_segmenter_weights(settings, &download_context).await {
-            Ok(path) => path,
-            Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
-            Err(_) => return Ok("degraded"),
-        };
     let masks_dir = project_path
         .join("person-tracks")
         .join(track_id)
@@ -871,16 +896,54 @@ async fn segment_assembly_frames(
     )
     .await?;
 
-    let weights_for_task = weights.clone();
-    let masks = match tokio::task::spawn_blocking(move || {
-        crate::person_segment::propagate_track_blocking(weights_for_task, clip_paths, anchors)
-    })
-    .await
-    {
-        Ok(Ok(masks)) => masks,
-        // Propagation failure degrades to box masks (handled by the replacement loader); a track
-        // that already located the person is never failed by the mask pass.
-        _ => return Ok("degraded"),
+    // Dispatch to the active segmenter (sc-4926): SAM3 text-concept PCS by default, the legacy
+    // SAM2 box-prompt path under `SCENEWORKS_PERSON_SEGMENTER=sam2` (kept for A/B parity +
+    // fallback during the cutover). Both return one binary mask per clip frame; either path's
+    // failure degrades to box masks (handled by the replacement loader) — a track that already
+    // located the person is never failed by the mask pass.
+    let masks = match person_segmenter_kind() {
+        PersonSegmenter::Sam3 => {
+            let (model, tokenizer) = match crate::person_segment_sam3::ensure_segmenter_weights(
+                settings,
+                &download_context,
+            )
+            .await
+            {
+                Ok(pair) => pair,
+                Err(WorkerError::Canceled(message)) => return Err(WorkerError::Canceled(message)),
+                Err(_) => return Ok("degraded"),
+            };
+            match tokio::task::spawn_blocking(move || {
+                crate::person_segment_sam3::segment_track_blocking(
+                    model, tokenizer, clip_paths, anchors,
+                )
+            })
+            .await
+            {
+                Ok(Ok(masks)) => masks,
+                _ => return Ok("degraded"),
+            }
+        }
+        PersonSegmenter::Sam2 => {
+            let weights =
+                match crate::person_segment::ensure_segmenter_weights(settings, &download_context)
+                    .await
+                {
+                    Ok(path) => path,
+                    Err(WorkerError::Canceled(message)) => {
+                        return Err(WorkerError::Canceled(message))
+                    }
+                    Err(_) => return Ok("degraded"),
+                };
+            match tokio::task::spawn_blocking(move || {
+                crate::person_segment::propagate_track_blocking(weights, clip_paths, anchors)
+            })
+            .await
+            {
+                Ok(Ok(masks)) => masks,
+                _ => return Ok("degraded"),
+            }
+        }
     };
 
     // Write every clip frame's non-empty mask (detected + gap) and set its sidecar `mask`. All the
@@ -2518,6 +2581,244 @@ mod person_track_e2e_tests {
             assert_eq!(
                 mask_state, "active",
                 "all detected frames masked → maskState=active"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+
+    /// SAM3 cutover E2E (sc-4926): the same detect → track → assemble flow as the SAM2 test
+    /// above, then segment the selected person with the **SAM3 text-concept (PCS)** path
+    /// (`person_segment_sam3::segment_track_blocking`, prompt `"person"`, **no box prompt**) and
+    /// the legacy **SAM2 box-prompt** path on the identical clip + anchors, and compare. Proves
+    /// the box-free pipeline produces an `active` mask track end-to-end and reports SAM3-vs-SAM2
+    /// mask agreement (the "parity/quality vs the SAM2 baseline" acceptance).
+    ///
+    /// ```text
+    /// SCENEWORKS_SAM3_WEIGHTS=<facebook/sam3 snapshot dir> \  # or omit to download SceneWorks/sam3-mlx
+    /// SCENEWORKS_PERSON_E2E_VIDEO=/path/to/person_clip.mp4 \
+    /// SCENEWORKS_PERSON_E2E_DURATION=4 \
+    ///   cargo test -p sceneworks-worker --lib person_track_e2e_sam3 -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "real Mac E2E: SAM3 + SAM2 weights; set SCENEWORKS_PERSON_E2E_VIDEO; Apple Silicon only"]
+    fn person_track_e2e_sam3_segments_and_matches_sam2_baseline() {
+        let Some(video) = staged_video() else {
+            eprintln!(
+                "skipping: set SCENEWORKS_PERSON_E2E_VIDEO to a short clip containing a person"
+            );
+            return;
+        };
+        let scratch = std::env::temp_dir().join("sw-person-track-e2e-sam3");
+        let _ = std::fs::remove_dir_all(&scratch);
+        let data_dir = scratch.join("data");
+        let frames_dir = scratch.join("frames");
+        std::fs::create_dir_all(&frames_dir).expect("frames dir");
+        std::env::set_var("SCENEWORKS_DATA_DIR", &data_dir);
+        let settings = crate::Settings::from_env();
+        let timestamps = crate::person_track::sample_timestamps(staged_duration());
+        assert!(!timestamps.is_empty(), "sample cadence produced no frames");
+
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            let http = reqwest::Client::new();
+            let api = ApiClient::new(&settings);
+            let download_context = DownloadContext {
+                api: &api,
+                client: &http,
+                settings: &settings,
+                job_id: "person-track-e2e-sam3",
+                cancel_message: "person track e2e (sam3) canceled while fetching weights",
+                fresh_download: false,
+            };
+
+            // detect → track → assemble (identical to the SAM2 E2E above).
+            let det_weights =
+                crate::person_jobs::ensure_detector_weights(&settings, &download_context)
+                    .await
+                    .expect("yolo11 weights provisioned");
+            let mut per_frame: Vec<(f64, Vec<(crate::person_track::NormalizedBox, f64)>)> =
+                Vec::with_capacity(timestamps.len());
+            let mut frame_paths: Vec<PathBuf> = Vec::with_capacity(timestamps.len());
+            for (index, &timestamp) in timestamps.iter().enumerate() {
+                let frame_path = frames_dir.join(format!("frame_{index:04}.png"));
+                render_frame_png(
+                    "ffmpeg",
+                    &video,
+                    &frame_path,
+                    frame_seek_timestamp(timestamp, staged_duration()),
+                    1280,
+                    720,
+                    None,
+                )
+                .await
+                .expect("ffmpeg renders the sample frame");
+                let w = det_weights.clone();
+                let f = frame_path.clone();
+                let result =
+                    tokio::task::spawn_blocking(move || {
+                        crate::person_jobs::detect_people_blocking(w, f, 0.25)
+                    })
+                    .await
+                    .expect("detect task joins")
+                    .expect("yolo11 detection runs");
+                let boxes = result
+                    .detections
+                    .iter()
+                    .map(|d| {
+                        (
+                            crate::person_track::xyxy_to_normalized(
+                                d.x1 as f64,
+                                d.y1 as f64,
+                                d.x2 as f64,
+                                d.y2 as f64,
+                                result.width,
+                                result.height,
+                            ),
+                            d.score as f64,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                per_frame.push((timestamp, boxes));
+                frame_paths.push(frame_path);
+            }
+            let (selected_timestamp, selected_box, _) = per_frame
+                .iter()
+                .flat_map(|(t, boxes)| boxes.iter().map(move |b| (*t, b.0, b.1)))
+                .max_by(|a, b| a.2.partial_cmp(&b.2).expect("finite conf"))
+                .expect("at least one detection");
+            let observations = crate::person_track::observe(per_frame);
+            let assembly = crate::person_track::assemble_track(
+                &observations,
+                selected_box,
+                selected_timestamp,
+                &timestamps,
+            );
+            assert!(
+                assembly.target_track_id.is_some(),
+                "tracker failed to lock onto the selected person"
+            );
+            let detected_total = assembly.frames.iter().filter(|f| f.detected).count();
+            assert!(detected_total > 0, "no detected target frames to segment");
+            let first = assembly
+                .frames
+                .iter()
+                .position(|f| f.detected)
+                .expect("a detected frame exists");
+            let last = assembly
+                .frames
+                .iter()
+                .rposition(|f| f.detected)
+                .unwrap_or(first);
+            let mut clip_paths = Vec::new();
+            let mut anchors = Vec::new();
+            for (frame, path) in assembly.frames[first..=last]
+                .iter()
+                .zip(&frame_paths[first..=last])
+            {
+                clip_paths.push(path.clone());
+                anchors.push(frame.detected.then(|| {
+                    let b = &frame.box_;
+                    (b.x, b.y, b.width, b.height)
+                }));
+            }
+
+            // SAM3 text-concept segmentation (no box prompt) — the path under test.
+            let (sam3_model, sam3_tok) =
+                crate::person_segment_sam3::ensure_segmenter_weights(&settings, &download_context)
+                    .await
+                    .expect("sam3 weights provisioned");
+            let (cp3, an3) = (clip_paths.clone(), anchors.clone());
+            let sam3 = tokio::task::spawn_blocking(move || {
+                crate::person_segment_sam3::segment_track_blocking(sam3_model, sam3_tok, cp3, an3)
+            })
+            .await
+            .expect("sam3 task joins")
+            .expect("sam3 segmentation runs");
+            assert_eq!(sam3.len(), last - first + 1, "one SAM3 mask per clip frame");
+            let mut sam3_generated = 0usize;
+            for (i, px) in sam3.iter().enumerate() {
+                let idx = first + i;
+                assert_eq!(px.len(), 1280 * 720, "SAM3 mask must match the frame size");
+                if assembly.frames[idx].detected {
+                    assert!(
+                        px.iter().any(|&p| p > 127),
+                        "SAM3 frame {idx} has no foreground — concept segmentation lost the person"
+                    );
+                    sam3_generated += 1;
+                }
+            }
+            let sam3_state = crate::person_segment::rollup_mask_state(sam3_generated, detected_total);
+            // SAM3 masking every detected frame is the hard acceptance gate for the cutover.
+            assert_eq!(
+                sam3_state, "active",
+                "every detected frame masked by SAM3 → maskState=active"
+            );
+
+            // SAM2 box-prompt baseline on the identical clip + anchors. Provisioning the SAM2
+            // video-predictor weights needs the download API (or a `SCENEWORKS_SAM2_WEIGHTS` pin);
+            // when it is unavailable the comparison is skipped — the SAM3 gate above still holds.
+            let sam2_weights =
+                match crate::person_segment::ensure_segmenter_weights(&settings, &download_context)
+                    .await
+                {
+                    Ok(path) => path,
+                    Err(e) => {
+                        eprintln!(
+                            "SAM3 E2E: sam3_state={sam3_state} sam3_generated={sam3_generated}; \
+                             SAM2 baseline skipped (weights unavailable: {e}). Pin \
+                             SCENEWORKS_SAM2_WEIGHTS to run the parity comparison."
+                        );
+                        return;
+                    }
+                };
+            let (cp2, an2) = (clip_paths.clone(), anchors.clone());
+            let sam2 = tokio::task::spawn_blocking(move || {
+                crate::person_segment::propagate_track_blocking(sam2_weights, cp2, an2)
+            })
+            .await
+            .expect("sam2 task joins")
+            .expect("sam2 propagation runs");
+
+            // Per-detected-frame mask IoU between the two segmenters.
+            let mut ious = Vec::new();
+            for i in 0..sam3.len() {
+                if !assembly.frames[first + i].detected {
+                    continue;
+                }
+                let (a, b) = (&sam3[i], &sam2[i]);
+                if a.is_empty() || b.is_empty() {
+                    continue;
+                }
+                let (mut inter, mut union) = (0u64, 0u64);
+                for k in 0..a.len() {
+                    let (pa, pb) = (a[k] > 127, b[k] > 127);
+                    if pa || pb {
+                        union += 1;
+                        if pa && pb {
+                            inter += 1;
+                        }
+                    }
+                }
+                if union > 0 {
+                    ious.push(inter as f64 / union as f64);
+                }
+            }
+            let mean_iou = if ious.is_empty() {
+                0.0
+            } else {
+                ious.iter().sum::<f64>() / ious.len() as f64
+            };
+            let sam3_cov = sam3.iter().map(|m| m.iter().filter(|&&p| p > 127).count()).sum::<usize>()
+                as f64
+                / (sam3.len() * 1280 * 720) as f64;
+            eprintln!(
+                "SAM3 E2E: detected={detected_total} sam3_generated={sam3_generated} \
+                 sam3_state={sam3_state} meanIoU(sam3,sam2)={mean_iou:.3} sam3_coverage={sam3_cov:.3}"
+            );
+            assert!(
+                mean_iou > 0.5,
+                "SAM3 vs SAM2 mean IoU {mean_iou:.3} below the parity floor (0.5)"
             );
         });
 

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -1,0 +1,532 @@
+//! Native-MLX **SAM3** text-concept person segmentation on the Rust worker (epic 4910, sc-4926).
+//!
+//! The box-prompt-free upgrade of `person_segment` (SAM2). Instead of prompting the segmenter
+//! with the selected person's ByteTrack box, this drives the SAM3 **Promptable Concept
+//! Segmentation (PCS)** video pipeline (`mlx-gen-sam3` `Sam3VideoModel::propagate`) from the text
+//! concept `"person"`: SAM3 detects *every* person on every frame and tracks them across the clip
+//! with its own memory bank + identity bookkeeping, returning per-frame `obj_id → mask`.
+//!
+//! Replace-Person still needs *one* selected person's mask per frame, so the per-frame ByteTrack
+//! box stops being a *prompt* and becomes an *association hint*: we pick the SAM3 object whose
+//! masks best fall inside the selected track's boxes across the span, then emit that object's
+//! per-frame mask. The downstream contract is identical to the SAM2 path — one binary `L` mask
+//! per clip frame, written under `person-tracks/{track_id}/masks/` by the orchestrator in
+//! `media_jobs::segment_assembly_frames` — so the replacement loader and Wan-VACE are unchanged.
+//!
+//! macOS-only, like `person_segment` / `person_jobs`: `mlx-gen-sam3` builds Apple MLX from source
+//! and is meaningless off Apple Silicon. **Cross-platform divergence (surfaced, not silent — cf.
+//! epic 3792):** the Python/torch SAM2 *box-prompt* path stays the Windows/Linux backend until a
+//! parallel SAM3 backport; only the macOS MLX worker gets the text-concept upgrade today.
+//!
+//! Unlike SAM2 (converted `.pt` → MLX), SAM3 loads the **stock `facebook/sam3` checkpoint
+//! directly** (`model.safetensors` + `tokenizer.json`); no conversion step. The model is
+//! affine-quantized after load (`Sam3VideoModel::quantize`, sc-4925) — **Q8 by default**
+//! (~0.9 GB, near-lossless), tunable via `SCENEWORKS_SAM3_QUANT` (`q8`/`q4`/`off`).
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use crate::downloads::{ensure_hf_cached_file, DownloadContext};
+use mlx_gen::weights::Weights;
+use mlx_gen_sam3::{Sam3TextConfig, Sam3Tokenizer, Sam3VideoModel, VideoFrameOutput};
+use mlx_rs::Array;
+
+use crate::{Settings, WorkerError, WorkerResult};
+
+/// SAM3 checkpoint files (loaded stock from `facebook/sam3`, no conversion).
+const MODEL_FILE: &str = "model.safetensors";
+const TOKENIZER_FILE: &str = "tokenizer.json";
+
+/// Download-on-first-use repo: the SAM3 weights mirror owned by SceneWorks. Publishing this
+/// mirror (3.2 GB, Meta SAM License → must ship a LICENSE copy with the Materials) is gated on
+/// sign-off; until then point `SCENEWORKS_SAM3_WEIGHTS` at a local `facebook/sam3` snapshot dir.
+const SEG_REPO: &str = "SceneWorks/sam3-mlx";
+
+/// SAM3 model input is a square 1008×1008 (the processor resizes to a fixed square, not
+/// aspect-preserving — `Sam3VideoProcessor` `size={1008,1008}`, `default_to_square`).
+const INPUT_SIZE: u32 = 1008;
+
+/// SAM3 mask logits come back on a 288×288 low-res grid (`Sam3VideoModel` `LOW_RES`).
+const MASK_GRID: usize = 288;
+
+/// The text concept driving PCS — the whole point of the SAM3 upgrade (no manual box).
+const CONCEPT_PROMPT: &str = "person";
+
+/// A normalized `(x, y, width, height)` box (0..1), the per-frame ByteTrack anchor — used here
+/// only to *associate* a SAM3 object id with the selected track, never as a segmenter prompt.
+pub(crate) type BoxNorm = (f64, f64, f64, f64);
+
+/// Affine-quantization bits for the segmenter, from `SCENEWORKS_SAM3_QUANT`: **Q8 by default**
+/// (`8` — near-lossless, engine image Q8 IoU 0.9988, ~0.9 GB resident vs F32 ~3.2 GB), `q4` for
+/// the smaller/lossier Q4, or `off`/`f32` to keep dense F32. `None` = no quantization.
+fn quant_bits() -> Option<i32> {
+    parse_quant_bits(&std::env::var("SCENEWORKS_SAM3_QUANT").unwrap_or_default())
+}
+
+/// Parse the `SCENEWORKS_SAM3_QUANT` value (split out so the mapping is unit-testable). Unset or
+/// unrecognized → the safe Q8 default.
+fn parse_quant_bits(value: &str) -> Option<i32> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "off" | "f32" | "none" | "0" => None,
+        "q4" | "4" => Some(4),
+        _ => Some(8),
+    }
+}
+
+/// The parsed SAM3 checkpoint is cached process-wide (the 3.2 GB safetensors parse is the
+/// expensive part). A **fresh** `Sam3VideoModel` is assembled from it per clip: the model carries
+/// per-session tracking state (obj ids, memory banks) and exposes no reset, so reusing one across
+/// clips would leak identities. Building from cached weights is cheap (layer assembly over
+/// already-resident arrays). Mirrors the SAM2 predictor cache + poison-recovery idiom.
+static WEIGHTS: OnceLock<Mutex<Option<Weights>>> = OnceLock::new();
+
+/// Resolve already-present SAM3 weights: an explicit env pin (`SCENEWORKS_SAM3_WEIGHTS`, a dir or
+/// the `model.safetensors` inside it), then the app cache `<data_dir>/cache/person-segment-sam3/`,
+/// then the model dir `<data_dir>/models/person-segment-sam3/`. Both `model.safetensors` and
+/// `tokenizer.json` must be present. Returns `(model_path, tokenizer_path)` or `None` (then
+/// `ensure_segmenter_weights` downloads them).
+pub(crate) fn resolve_segmenter_weights(settings: &Settings) -> Option<(PathBuf, PathBuf)> {
+    let pair_in = |dir: &Path| -> Option<(PathBuf, PathBuf)> {
+        let model = dir.join(MODEL_FILE);
+        let tokenizer = dir.join(TOKENIZER_FILE);
+        (model.exists() && tokenizer.exists()).then_some((model, tokenizer))
+    };
+    if let Ok(pinned) = std::env::var("SCENEWORKS_SAM3_WEIGHTS") {
+        let p = PathBuf::from(pinned);
+        let dir = if p.is_file() {
+            p.parent().map(Path::to_path_buf).unwrap_or(p)
+        } else {
+            p
+        };
+        if let Some(pair) = pair_in(&dir) {
+            return Some(pair);
+        }
+    }
+    for sub in ["cache/person-segment-sam3", "models/person-segment-sam3"] {
+        if let Some(pair) = pair_in(&settings.data_dir.join(sub)) {
+            return Some(pair);
+        }
+    }
+    None
+}
+
+/// Resolve the SAM3 weights, downloading `model.safetensors` + `tokenizer.json` from HuggingFace
+/// on first use (into the app cache) with streaming progress/cancel and size-aware resume.
+pub(crate) async fn ensure_segmenter_weights(
+    settings: &Settings,
+    context: &DownloadContext<'_>,
+) -> WorkerResult<(PathBuf, PathBuf)> {
+    if let Some(pair) = resolve_segmenter_weights(settings) {
+        return Ok(pair);
+    }
+    let dir = settings.data_dir.join("cache").join("person-segment-sam3");
+    let model =
+        ensure_hf_cached_file(context, SEG_REPO, "main", MODEL_FILE, &dir.join(MODEL_FILE)).await?;
+    let tokenizer = ensure_hf_cached_file(
+        context,
+        SEG_REPO,
+        "main",
+        TOKENIZER_FILE,
+        &dir.join(TOKENIZER_FILE),
+    )
+    .await?;
+    Ok((model, tokenizer))
+}
+
+/// Preprocess an RGB frame to the SAM3 input tensor: resize to a 1008×1008 square (bilinear,
+/// matching the processor's fixed-square resize — *not* aspect-preserving), rescale to `[0,1]`,
+/// normalize by mean/std `0.5` to `[-1,1]`, packed NCHW `[1,3,1008,1008]` f32.
+fn input_tensor(img: &image::RgbImage) -> Array {
+    let resized = image::imageops::resize(
+        img,
+        INPUT_SIZE,
+        INPUT_SIZE,
+        image::imageops::FilterType::Triangle,
+    );
+    let chw = normalize_chw(resized.as_raw(), INPUT_SIZE as usize);
+    Array::from_slice(&chw, &[1, 3, INPUT_SIZE as i32, INPUT_SIZE as i32])
+}
+
+/// Pack a `size×size` interleaved-RGB `u8` buffer into a channel-major `[3·size·size]` f32 vector
+/// with the SAM3 normalization `(x/255 − 0.5) / 0.5` = `x/127.5 − 1` (mean=std=0.5 → range
+/// `[-1,1]`). Split out so the normalization is unit-testable without an image decode.
+fn normalize_chw(rgb: &[u8], size: usize) -> Vec<f32> {
+    let plane = size * size;
+    let mut out = vec![0f32; 3 * plane];
+    for (p, px) in rgb.chunks_exact(3).enumerate() {
+        for c in 0..3 {
+            out[c * plane + p] = px[c] as f32 / 127.5 - 1.0;
+        }
+    }
+    out
+}
+
+/// Fraction of a SAM3 object's foreground (mask logit `> 0` ⇔ σ `> 0.5`) on the `grid×grid`
+/// low-res mask whose pixel center falls inside the normalized `box_norm`. `0.0` when the mask is
+/// empty. SAM3 masks live in the squashed 1008² space, which maps to the full normalized frame, so
+/// a mask pixel `(mx,my)` has normalized center `((mx+0.5)/grid, (my+0.5)/grid)` — directly
+/// comparable to the ByteTrack box. This is the association score: how much of a candidate object
+/// sits under the selected person's box.
+fn mask_box_containment(mask_logits: &[f32], grid: usize, box_norm: BoxNorm) -> f64 {
+    let (bx, by, bw, bh) = box_norm;
+    let (x1, y1, x2, y2) = (bx, by, bx + bw, by + bh);
+    let (mut fg, mut inside) = (0u64, 0u64);
+    for my in 0..grid {
+        for mx in 0..grid {
+            if mask_logits[my * grid + mx] > 0.0 {
+                fg += 1;
+                let (cx, cy) = (
+                    (mx as f64 + 0.5) / grid as f64,
+                    (my as f64 + 0.5) / grid as f64,
+                );
+                if cx >= x1 && cx < x2 && cy >= y1 && cy < y2 {
+                    inside += 1;
+                }
+            }
+        }
+    }
+    if fg == 0 {
+        0.0
+    } else {
+        inside as f64 / fg as f64
+    }
+}
+
+/// Pick the SAM3 object id that best matches the selected track: for every clip frame with an
+/// anchor box, accumulate each present object's `mask_box_containment`, then take the id with the
+/// greatest total. `None` when no object ever overlaps an anchor (→ degraded to box masks). The
+/// per-frame sum (not a single best frame) rewards an object that stays under the box across the
+/// span, which disambiguates the selected person from nearby people SAM3 also segmented.
+fn select_object(outputs: &[VideoFrameOutput], anchors: &[Option<BoxNorm>]) -> Option<i32> {
+    use std::collections::HashMap;
+    let mut score: HashMap<i32, f64> = HashMap::new();
+    for (frame, anchor) in outputs.iter().zip(anchors) {
+        let Some(box_norm) = anchor else { continue };
+        for (oid, mask) in frame.obj_ids.iter().zip(&frame.masks) {
+            let c = mask_box_containment(mask, MASK_GRID, *box_norm);
+            if c > 0.0 {
+                *score.entry(*oid).or_insert(0.0) += c;
+            }
+        }
+    }
+    // Deterministic tie-break on the object id (BTree-like) so repeated runs agree.
+    score
+        .into_iter()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap().then(b.0.cmp(&a.0)))
+        .map(|(oid, _)| oid)
+}
+
+/// Binarize a `grid×grid` SAM3 mask (logit `> 0`) to a 0/255 buffer, then resize it to
+/// `width×height` (bilinear) and re-threshold to a clean binary `L` mask — the per-clip-frame
+/// output the orchestrator writes. Inverts SAM3's uniform 1008² squash back to the frame aspect.
+fn mask_to_frame(mask_logits: &[f32], grid: usize, width: u32, height: u32) -> Vec<u8> {
+    let bin: Vec<u8> = mask_logits
+        .iter()
+        .map(|&v| if v > 0.0 { 255 } else { 0 })
+        .collect();
+    let Some(small) = image::GrayImage::from_raw(grid as u32, grid as u32, bin) else {
+        return Vec::new();
+    };
+    let resized =
+        image::imageops::resize(&small, width, height, image::imageops::FilterType::Triangle);
+    resized
+        .into_raw()
+        .into_iter()
+        .map(|v| if v > 127 { 255 } else { 0 })
+        .collect()
+}
+
+/// Segment the selected person across a clip with the native-MLX SAM3 **text-concept (PCS) video
+/// pipeline** (sc-4926). `clip_frame_paths` is the contiguous detected span (clip-local frame `0`
+/// = first detected frame); `anchors[i]` is the frame's ByteTrack box in normalized
+/// `(x, y, width, height)` when frame `i` was detected, else `None`. At least one anchor must be
+/// `Some` — it is the association hint, not a prompt.
+///
+/// SAM3 runs once over the whole span (`propagate("person")`), segmenting and tracking *all* people
+/// with its own identities; we then [`select_object`] the id that best overlaps the anchors and
+/// emit that object's per-frame mask (gap frames the detector missed are still covered when SAM3
+/// tracked the person through them — the same "survives weak-detection frames" win the SAM2 video
+/// predictor gave us, now without any box prompt).
+///
+/// Returns one binary mask (row-major `width*height`, `0`/`255`) per clip frame, in clip order; an
+/// empty vec for a frame where the selected object was absent (orchestrator skips empties → box
+/// fallback). The checkpoint parses once and is cached process-wide; run under `spawn_blocking`
+/// (image decode + GPU inference are blocking).
+pub(crate) fn segment_track_blocking(
+    model_path: PathBuf,
+    tokenizer_path: PathBuf,
+    clip_frame_paths: Vec<PathBuf>,
+    anchors: Vec<Option<BoxNorm>>,
+) -> WorkerResult<Vec<Vec<u8>>> {
+    assert_eq!(
+        clip_frame_paths.len(),
+        anchors.len(),
+        "frames/anchors mismatch"
+    );
+    if !anchors.iter().any(Option::is_some) {
+        return Err(WorkerError::InvalidPayload(
+            "person segmentation clip needs at least one detected frame to associate".into(),
+        ));
+    }
+
+    // Decode every clip frame to RGB8 (shared rendered size) and build the SAM3 input tensors.
+    let mut frames: Vec<Array> = Vec::with_capacity(clip_frame_paths.len());
+    let (mut width, mut height) = (0u32, 0u32);
+    for path in &clip_frame_paths {
+        let img = image::open(path)
+            .map_err(|e| WorkerError::InvalidPayload(format!("person frame open: {e}")))?
+            .to_rgb8();
+        if width == 0 {
+            (width, height) = (img.width(), img.height());
+        } else if img.width() != width || img.height() != height {
+            return Err(WorkerError::InvalidPayload(
+                "person clip frames are not all the same size".into(),
+            ));
+        }
+        frames.push(input_tensor(&img));
+    }
+
+    // Cached checkpoint; recover from a poisoned lock by dropping the cached weights and reloading
+    // (mirrors person_segment / sc-4277 F-MLXW-13).
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(&model_path)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    // Fresh model per clip (clean tracking state) + tokenize the concept once.
+    let mut model = Sam3VideoModel::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
+    // Quantize (Q8 default) for a ~0.9 GB footprint vs F32 ~3.2 GB (sc-4925). The dense path is
+    // parity-preserving, so the F32 (`SCENEWORKS_SAM3_QUANT=off`) result is unchanged.
+    if let Some(bits) = quant_bits() {
+        model
+            .quantize(bits)
+            .map_err(|e| WorkerError::Engine(format!("sam3 quantize q{bits}: {e}")))?;
+    }
+    let tokenizer = Sam3Tokenizer::from_file(&tokenizer_path, &Sam3TextConfig::sam3())
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
+    let (input_ids, text_mask) = tokenizer
+        .encode(CONCEPT_PROMPT)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+
+    let outputs = model
+        .propagate(&frames, &input_ids, &text_mask)
+        .map_err(|e| WorkerError::Engine(format!("sam3 propagate: {e}")))?;
+
+    // Associate SAM3's identities to the selected track, then emit that object's per-frame mask.
+    let Some(selected) = select_object(&outputs, &anchors) else {
+        // SAM3 found no "person" overlapping any anchor → no masks (degrade to box fallback).
+        return Ok(vec![Vec::new(); clip_frame_paths.len()]);
+    };
+    let masks = outputs
+        .iter()
+        .map(|frame| {
+            frame
+                .obj_ids
+                .iter()
+                .position(|&o| o == selected)
+                .map(|i| mask_to_frame(&frame.masks[i], MASK_GRID, width, height))
+                .unwrap_or_default()
+        })
+        .collect();
+    Ok(masks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quant_bits_defaults_to_q8_and_honors_overrides() {
+        assert_eq!(parse_quant_bits(""), Some(8), "unset → Q8 default");
+        assert_eq!(parse_quant_bits("q8"), Some(8));
+        assert_eq!(parse_quant_bits("8"), Some(8));
+        assert_eq!(
+            parse_quant_bits(" Q4 "),
+            Some(4),
+            "trimmed + case-insensitive"
+        );
+        assert_eq!(parse_quant_bits("4"), Some(4));
+        assert_eq!(parse_quant_bits("off"), None);
+        assert_eq!(parse_quant_bits("F32"), None);
+        assert_eq!(parse_quant_bits("none"), None);
+        assert_eq!(
+            parse_quant_bits("garbage"),
+            Some(8),
+            "unrecognized → safe Q8"
+        );
+    }
+
+    #[test]
+    fn normalize_maps_to_signed_unit_range_channel_major() {
+        // 2×2 RGB: black, white, and a mid-gray pixel. mean=std=0.5 → x/127.5 − 1.
+        let rgb = [
+            0, 0, 0, // (0,0) black
+            255, 255, 255, // (0,1) white
+            128, 128, 128, // (1,0) ~mid
+            255, 0, 0, // (1,1) red
+        ];
+        let chw = normalize_chw(&rgb, 2);
+        let plane = 4;
+        // Channel-major: R plane first.
+        assert!((chw[0] - (-1.0)).abs() < 1e-6); // R of black
+        assert!((chw[1] - 1.0).abs() < 1e-6); // R of white
+        assert!((chw[plane] - (-1.0)).abs() < 1e-6); // G of black
+        assert!((chw[2 * plane + 3] - (-1.0)).abs() < 1e-6); // B of red pixel = 0 → -1
+        assert!((chw[3] - 1.0).abs() < 1e-6); // R of red pixel = 255 → 1
+    }
+
+    #[test]
+    fn containment_measures_foreground_inside_box() {
+        // 10×10 grid, a 4×4 foreground block at rows/cols 2..6 (logit 1.0 inside, -1.0 outside).
+        let grid = 10;
+        let mut logits = vec![-1.0f32; grid * grid];
+        for my in 2..6 {
+            for mx in 2..6 {
+                logits[my * grid + mx] = 1.0;
+            }
+        }
+        // Box covering the whole block (normalized 0.2..0.6) → containment 1.0.
+        let full = mask_box_containment(&logits, grid, (0.2, 0.2, 0.4, 0.4));
+        assert!((full - 1.0).abs() < 1e-9, "full was {full}");
+        // Box over the empty top-left corner → 0.0.
+        let none = mask_box_containment(&logits, grid, (0.0, 0.0, 0.1, 0.1));
+        assert!(none.abs() < 1e-9, "disjoint was {none}");
+        // Box over the left half of the block → ~half the foreground inside.
+        let half = mask_box_containment(&logits, grid, (0.0, 0.0, 0.4, 1.0));
+        assert!((half - 0.5).abs() < 1e-9, "half was {half}");
+        // Empty mask → 0.0, never divide-by-zero.
+        assert_eq!(
+            mask_box_containment(&vec![-1.0; grid * grid], grid, (0.0, 0.0, 1.0, 1.0)),
+            0.0
+        );
+    }
+
+    /// A small synthetic two-object clip: object 7 sits under the anchor box every frame, object 9
+    /// sits elsewhere. The selector must return 7, aggregating containment across the span.
+    #[test]
+    fn select_object_picks_the_id_overlapping_the_anchor() {
+        let grid = MASK_GRID;
+        let block = |r: std::ops::Range<usize>, c: std::ops::Range<usize>| -> Vec<f32> {
+            let mut m = vec![-1.0f32; grid * grid];
+            for y in r.clone() {
+                for x in c.clone() {
+                    m[y * grid + x] = 1.0;
+                }
+            }
+            m
+        };
+        // obj 7 in the top-left quadrant; obj 9 in the bottom-right.
+        let left = block(0..grid / 2, 0..grid / 2);
+        let right = block(grid / 2..grid, grid / 2..grid);
+        let outputs = vec![
+            VideoFrameOutput {
+                obj_ids: vec![7, 9],
+                masks: vec![left.clone(), right.clone()],
+            },
+            VideoFrameOutput {
+                obj_ids: vec![7, 9],
+                masks: vec![left, right],
+            },
+        ];
+        // Anchor over the top-left quadrant on both frames.
+        let anchors = vec![Some((0.0, 0.0, 0.5, 0.5)), Some((0.0, 0.0, 0.5, 0.5))];
+        assert_eq!(select_object(&outputs, &anchors), Some(7));
+        // No anchors → no selection.
+        assert_eq!(select_object(&outputs, &[None, None]), None);
+    }
+
+    #[test]
+    fn mask_to_frame_binarizes_and_resizes() {
+        // 4×4 grid, top-left 2×2 foreground → resized to 8×8 should keep a top-left fg region.
+        let grid = 4;
+        let mut logits = vec![-1.0f32; grid * grid];
+        for y in 0..2 {
+            for x in 0..2 {
+                logits[y * grid + x] = 1.0;
+            }
+        }
+        let out = mask_to_frame(&logits, grid, 8, 8);
+        assert_eq!(out.len(), 64);
+        assert!(out.iter().all(|&v| v == 0 || v == 255), "output is binary");
+        assert_eq!(out[0], 255, "top-left corner is foreground");
+        assert_eq!(out[63], 0, "bottom-right corner is background");
+    }
+
+    /// Real-weights integration smoke (sc-4926, H4): the whole SceneWorks-side pipe — preprocess →
+    /// `Sam3VideoModel::propagate("person")` → associate to the anchor → emit a per-frame mask —
+    /// against the stock `facebook/sam3` checkpoint. Proves the cutover actually segments a person,
+    /// not just that the pure helpers work. `#[ignore]`d (needs the 3.2 GB weights + GPU); run with:
+    ///   SCENEWORKS_SAM3_WEIGHTS=<facebook/sam3 snapshot dir> \
+    ///   SCENEWORKS_SAM3_SMOKE_IMAGE=<person jpg/png, e.g. ultralytics zidane.jpg 1280×720> \
+    ///   cargo test -p sceneworks-worker --release sam3_real_weights_person_smoke -- --ignored --nocapture
+    #[test]
+    #[ignore = "real SAM3 weights + GPU; set SCENEWORKS_SAM3_WEIGHTS + SCENEWORKS_SAM3_SMOKE_IMAGE"]
+    fn sam3_real_weights_person_smoke() {
+        let snap = std::env::var("SCENEWORKS_SAM3_WEIGHTS")
+            .expect("set SCENEWORKS_SAM3_WEIGHTS to a facebook/sam3 snapshot dir");
+        let dir = {
+            let p = PathBuf::from(&snap);
+            if p.is_file() {
+                p.parent().unwrap().to_path_buf()
+            } else {
+                p
+            }
+        };
+        let model = dir.join(MODEL_FILE);
+        let tokenizer = dir.join(TOKENIZER_FILE);
+        let image = PathBuf::from(
+            std::env::var("SCENEWORKS_SAM3_SMOKE_IMAGE")
+                .expect("set SCENEWORKS_SAM3_SMOKE_IMAGE to a person image"),
+        );
+
+        // Two-frame clip from the same still; an anchor over the prominent foreground person
+        // (zidane.jpg: the central/right player). The mask must mostly fall inside the anchor.
+        let anchor: BoxNorm = (0.40, 0.10, 0.55, 0.88);
+        let masks = segment_track_blocking(
+            model,
+            tokenizer,
+            vec![image.clone(), image],
+            vec![Some(anchor), Some(anchor)],
+        )
+        .expect("segment_track_blocking");
+
+        assert_eq!(masks.len(), 2, "one mask per clip frame");
+        let (w, h) = (1280usize, 720usize);
+        for (i, mask) in masks.iter().enumerate() {
+            assert_eq!(mask.len(), w * h, "frame {i} mask size");
+            let fg = mask.iter().filter(|&&v| v > 127).count();
+            let frac = fg as f64 / (w * h) as f64;
+            // A real person mask covers a non-trivial, non-whole region of the frame.
+            assert!(
+                (0.02..0.80).contains(&frac),
+                "frame {i} foreground fraction {frac:.3} is implausible (empty or whole-frame)"
+            );
+            // Most of the emitted foreground sits inside the anchor box.
+            let (bx, by, bw, bh) = anchor;
+            let (x1, y1, x2, y2) = (bx, by, bx + bw, by + bh);
+            let inside = (0..h)
+                .flat_map(|y| (0..w).map(move |x| (x, y)))
+                .filter(|&(x, y)| mask[y * w + x] > 127)
+                .filter(|&(x, y)| {
+                    let (cx, cy) = ((x as f64 + 0.5) / w as f64, (y as f64 + 0.5) / h as f64);
+                    cx >= x1 && cx < x2 && cy >= y1 && cy < y2
+                })
+                .count();
+            let containment = inside as f64 / fg.max(1) as f64;
+            assert!(
+                containment > 0.5,
+                "frame {i} mask containment in anchor {containment:.3} too low (wrong object?)"
+            );
+            eprintln!("frame {i}: fg_frac={frac:.3} containment={containment:.3}");
+        }
+    }
+}


### PR DESCRIPTION
## What

Phase H of epic 4910 — the SceneWorks cross-repo cutover. Replaces the SAM2 **box-prompt** person segmenter with **SAM3 text-concept Promptable Concept Segmentation** in the macOS person-track / `replace_person` flow.

The per-frame ByteTrack box stops being a *segmenter prompt* and becomes an *association hint*: SAM3 `propagate("person")` segments + tracks **all** people with its own memory-based identities, then the selected track is matched by mask-in-box containment summed across the span, and that object's per-frame mask is emitted. This removes the manual-box dependency while keeping the downstream contract identical (one selected-person mask per frame → `person-tracks/{id}/masks/` → Wan-VACE).

## Changes

- **`Cargo.toml` / `Cargo.lock`**: add `mlx-gen-sam3`; bump all worker `mlx-gen-*` + `sceneworks-gen-core` pins `6c0f904` (#401) → `ec1838a` (#402) to fold in SAM3 Q8/Q4 quant (sc-4925). The `#401→#402` diff is **sam3-crate-only**, so the `mlx-rs` pin (`44929a00`) and `gen-core` are byte-identical — gen-core skew gate stays green, nothing else recompiles semantically.
- **`person_segment_sam3.rs`** (new): loads stock `facebook/sam3` (no conversion), preprocesses to NCHW `[1,3,1008,1008]`, **quantizes Q8 by default** (`SCENEWORKS_SAM3_QUANT` = `q8`/`q4`/`off`; ~0.9 GB vs F32 ~3.2 GB), runs `propagate("person")`, associates the SAM3 object id to the selected track, emits per-frame binarized masks. Weights via `SCENEWORKS_SAM3_WEIGHTS` env pin → cache/model dirs → `SceneWorks/sam3-mlx` download-on-first-use.
- **`media_jobs.rs`**: `segment_assembly_frames` dispatches via `person_segmenter_kind()` — **SAM3 default**, `SCENEWORKS_PERSON_SEGMENTER=sam2` keeps the legacy box-prompt path (A/B + fallback). `tracker_meta.segmenter` now reports `sam3`.
- **`lib.rs`**: register `person_segment_sam3` (macOS-only).

## Cross-platform

macOS MLX only. The Python/torch SAM2 **box-prompt** path stays the Windows/Linux backend until a parallel SAM3 backport — divergence is **surfaced** in code + the dep comment (cf. epic 3792), not silent.

## Weights

Published a redistribution mirror → public [`SceneWorks/sam3-mlx`](https://huggingface.co/SceneWorks/sam3-mlx): stock `facebook/sam3` `model.safetensors` (byte-identical) + `tokenizer.json` + the Meta **SAM `LICENSE`** (included per the license) + model card.

## Verification (Apple Silicon)

- `cargo fmt --check` + `clippy -D warnings` clean; gen-core skew gate green (single `ec1838a` resolution).
- **260 worker lib tests pass** + 4 new unit tests (normalize / containment / select / mask-resize / quant-parse).
- 2 new `#[ignore]` real-weight tests:
  - `sam3_real_weights_person_smoke`: fg 0.16 / containment 0.95.
  - `person_track_e2e_sam3_segments_and_matches_sam2_baseline` (real YOLO11 → ByteTrack → SAM3 vs SAM2 on a 4 s person clip, default Q8): **`detected=8 sam3_generated=8 maskState=active meanIoU(sam3,sam2)=0.909`** — identical to F32 (Q8 near-lossless).

## Reviewer notes

- Run the real-weight tests with `SCENEWORKS_SAM3_WEIGHTS` (a `facebook/sam3` snapshot dir or the published mirror), `SCENEWORKS_PERSON_E2E_VIDEO`, and a `ffmpeg` on PATH (`apps/desktop/ffmpeg`).
- The pin bump is consumption-only (SAM3 quant); no other engine path changes between #401 and #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)