### PR TITLE
sc-3678: candle SDXL lane — Python fallback + backend labeling

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7571,6 +7571,14 @@ label {
   border-color: transparent;
 }
 
+/* Candle (Windows/CUDA Rust SDXL lane, sc-3678): a warm tone distinct from the generic
+   cuda/torch pill so a Candle-backed run is visually unmistakable. */
+.worker-progress-card__pill.arch.arch-candle {
+  background: color-mix(in oklch, #d97706 18%, var(--surface));
+  color: color-mix(in oklch, #b45309 85%, var(--text));
+  border-color: transparent;
+}
+
 .worker-progress-card__meters {
   display: grid;
   grid-template-columns: 1fr;

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3043,6 +3043,87 @@ fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
 }
 
+/// The models the candle (Windows/CUDA) SDXL lane can serve (epic 3672, sc-3678). Mirrors the
+/// worker's `image_jobs::is_candle_engine`: the SDXL family only — `realvisxl` shares the candle
+/// `"sdxl"` engine via a weights swap. Deliberately narrow: candle is a gated txt2img-only lane,
+/// and everything outside it falls back to the Python torch worker.
+const CANDLE_ROUTED_MODELS: &[&str] = &["sdxl", "realvisxl"];
+
+/// Whether `worker` is the candle (Windows/CUDA) SDXL worker — identified by the `candle` marker
+/// capability it self-advertises (`gpu::with_candle_capabilities`), mirroring the `nvidia` marker
+/// the Rust GPU worker already emits. The candle worker runs on a real CUDA gpu index, not the
+/// `mlx` sentinel, so it can't be recognized by `gpu_id`; the marker is the seam. When candle is
+/// disabled the worker never advertises the marker, so this is always `false` and routing is
+/// unchanged.
+fn worker_is_candle(worker: &WorkerSnapshot) -> bool {
+    worker
+        .capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "candle")
+}
+
+/// Does this image job belong on the candle SDXL **txt2img-only** lane (epic 3672, sc-3678)? The
+/// candle generator (`image_jobs::generate_candle_stream`) drives plain text-to-image only — no
+/// img2img/edit (`mode == "edit_image"` + `sourceAssetId`), no reference/IP-Adapter
+/// (`referenceAssetId`), no masked inpaint/outpaint (`maskAssetId`), no strict-pose ControlNet
+/// (`advanced.poses`), and no LoRAs. Every one of those shapes must fall back to the Python torch
+/// worker, so the candle worker refuses them here. The conditioning signals mirror the worker's
+/// `sdxl_sub_mode` / `pose_entries` exactly, so the router and worker agree on the lane boundary.
+fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
+    if !matches!(job.job_type, JobType::ImageGenerate) {
+        return false;
+    }
+    let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
+        return false;
+    };
+    image_request_candle_eligible(model, &job.payload)
+}
+
+/// Per-model candle txt2img-eligibility, factored out of [`image_job_is_candle_eligible`] so the
+/// routing tests can probe it with synthetic payloads (parity with `image_request_mlx_eligible`).
+fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
+    if !CANDLE_ROUTED_MODELS.contains(&model) {
+        return false;
+    }
+    // img2img / inpaint / outpaint all arrive as `mode == "edit_image"` (+ a source); reject the
+    // whole edit family up front (the worker's `sdxl_sub_mode` keys off the same mode).
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    let has_nonempty_id = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    // Any conditioning asset (img2img source, IP-Adapter reference, or inpaint mask) → torch.
+    if has_nonempty_id("sourceAssetId")
+        || has_nonempty_id("referenceAssetId")
+        || has_nonempty_id("maskAssetId")
+    {
+        return false;
+    }
+    // LoRAs are not in the candle lane (the descriptor advertises none).
+    if payload
+        .get("loras")
+        .and_then(Value::as_array)
+        .is_some_and(|loras| !loras.is_empty())
+    {
+        return false;
+    }
+    // Strict-pose ControlNet (`advanced.poses`, object-shaped entries) → torch.
+    let has_poses = payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty());
+    if has_poses {
+        return false;
+    }
+    true
+}
+
 /// InstantID (`instantid_realvisxl`) MLX-routing conditions. The native `mlx-gen-instantid`
 /// provider now serves the FULL surface on Mac: single-identity `character_image`, the 11-view
 /// Character-Studio angle set (sc-3345), AND pose-library mode + face-restore (sc-3381, on the
@@ -3520,6 +3601,19 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
             return false;
         }
     }
+    // Candle (Windows/CUDA) SDXL lane (epic 3672, sc-3678): the candle worker advertises only
+    // `image_generate` and serves a gated, narrow SDXL/RealVisXL **txt2img-only** lane. It must
+    // refuse every other `image_generate` shape — a non-SDXL family, or an SDXL img2img / inpaint /
+    // outpaint / reference / strict-pose / LoRA request — so those transparently fall back to the
+    // Python torch worker that co-resides on the box. Identified by the `candle` marker capability
+    // (not `gpu_id`, which is a real CUDA index here). When candle is disabled the marker is absent
+    // and this is inert, so production routing is unchanged until the lane is turned on.
+    if worker_is_candle(worker)
+        && matches!(job.job_type, JobType::ImageGenerate)
+        && !image_job_is_candle_eligible(job)
+    {
+        return false;
+    }
     let advertises = |capability: &str| {
         worker
             .capabilities
@@ -3798,6 +3892,161 @@ mod active_statuses_sql_tests {
                 "active status {status:?} missing from SQL list"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod candle_routing_tests {
+    //! Candle (Windows/CUDA) SDXL lane routing (epic 3672, sc-3678): the candle worker serves a
+    //! gated, narrow SDXL/RealVisXL **txt2img-only** lane and must defer every other shape to the
+    //! Python torch worker. These tests pin the lane boundary (`image_request_candle_eligible`) and
+    //! the full claim gate (`worker_supports_job` via the `candle` marker capability).
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn object(value: Value) -> Map<String, Value> {
+        value.as_object().expect("test value is an object").clone()
+    }
+
+    /// A queued `image_generate` job carrying `payload`, built via serde so the test never has to
+    /// spell out the full `JobSnapshot` field set.
+    fn image_generate_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_1",
+            "type": "image_generate",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-12T00:00:00Z",
+            "updatedAt": "2026-06-12T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    /// A worker on a real CUDA gpu index advertising `capabilities` (string ids). The candle worker
+    /// carries the `candle` marker; the torch worker on the same box does not.
+    fn gpu_worker(capabilities: &[&str]) -> WorkerSnapshot {
+        serde_json::from_value(json!({
+            "id": "worker_1",
+            "gpuId": "0",
+            "status": "idle",
+            "capabilities": capabilities,
+            "loadedModels": [],
+            "registeredAt": "2026-06-12T00:00:00Z",
+            "lastSeenAt": "2026-06-12T00:00:00Z",
+        }))
+        .expect("valid WorkerSnapshot")
+    }
+
+    const CANDLE_CAPS: &[&str] = &["gpu", "image_generate", "candle"];
+    // The Python torch worker advertises the broad image surface but no `candle` marker.
+    const TORCH_CAPS: &[&str] = &["gpu", "image_generate", "image_edit", "image_detail"];
+
+    #[test]
+    fn sdxl_and_realvisxl_plain_txt2img_are_candle_eligible() {
+        for model in CANDLE_ROUTED_MODELS {
+            assert!(
+                image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
+                "{model} plain txt2img should be candle-eligible"
+            );
+        }
+    }
+
+    #[test]
+    fn non_sdxl_families_are_never_candle_eligible() {
+        for model in [
+            "flux_dev",
+            "qwen_image",
+            "z_image_turbo",
+            "chroma1_hd",
+            "kolors",
+        ] {
+            assert!(
+                !image_request_candle_eligible(model, &object(json!({ "prompt": "p" }))),
+                "{model} must fall back to the Python worker"
+            );
+        }
+    }
+
+    #[test]
+    fn sdxl_advanced_shapes_fall_back_to_torch() {
+        // Every conditioning shape the txt2img candle lane can't honor must be ineligible.
+        let cases = [
+            json!({ "mode": "edit_image", "sourceAssetId": "asset_1" }), // img2img / inpaint / outpaint
+            json!({ "referenceAssetId": "asset_1" }),                    // IP-Adapter reference
+            json!({ "mode": "edit_image", "sourceAssetId": "a", "maskAssetId": "m" }), // inpaint
+            json!({ "loras": [{ "name": "x" }] }),                       // LoRA
+            json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),    // strict-pose ControlNet
+        ];
+        for case in cases {
+            assert!(
+                !image_request_candle_eligible("sdxl", &object(case.clone())),
+                "sdxl shape must fall back to torch: {case}"
+            );
+        }
+    }
+
+    #[test]
+    fn blank_conditioning_ids_are_treated_as_absent() {
+        // Whitespace/empty ids are not real conditioning → still plain txt2img → eligible.
+        assert!(image_request_candle_eligible(
+            "sdxl",
+            &object(
+                json!({ "referenceAssetId": "  ", "sourceAssetId": "", "advanced": { "poses": [] } })
+            )
+        ));
+    }
+
+    #[test]
+    fn candle_worker_claims_sdxl_txt2img_but_refuses_unsupported_shapes() {
+        let candle = gpu_worker(CANDLE_CAPS);
+        // Claims the lane.
+        assert!(worker_supports_job(
+            &candle,
+            &image_generate_job(json!({ "model": "sdxl", "prompt": "a red fox" }))
+        ));
+        assert!(worker_supports_job(
+            &candle,
+            &image_generate_job(json!({ "model": "realvisxl", "prompt": "p" }))
+        ));
+        // Refuses a non-SDXL family and an SDXL img2img — both defer to torch.
+        assert!(!worker_supports_job(
+            &candle,
+            &image_generate_job(json!({ "model": "flux_dev", "prompt": "p" }))
+        ));
+        assert!(!worker_supports_job(
+            &candle,
+            &image_generate_job(json!({
+                "model": "sdxl",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1"
+            }))
+        ));
+    }
+
+    #[test]
+    fn torch_worker_claims_everything_the_candle_worker_defers() {
+        // The co-resident Python torch worker (no `candle` marker) is ungated here: it claims the
+        // shapes the candle worker refused, so nothing is stranded.
+        let torch = gpu_worker(TORCH_CAPS);
+        assert!(worker_supports_job(
+            &torch,
+            &image_generate_job(json!({ "model": "flux_dev", "prompt": "p" }))
+        ));
+        assert!(worker_supports_job(
+            &torch,
+            &image_generate_job(json!({
+                "model": "sdxl",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1"
+            }))
+        ));
     }
 }
 

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -22,12 +22,46 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
         return gpu;
     }
     let gpus = discover_gpus().await;
-    if requested_gpu_id.is_empty() || requested_gpu_id == "auto" {
-        return gpus.into_iter().next().unwrap_or_else(cpu_gpu);
+    let gpu = if requested_gpu_id.is_empty() || requested_gpu_id == "auto" {
+        gpus.into_iter().next().unwrap_or_else(cpu_gpu)
+    } else {
+        gpus.into_iter()
+            .find(|gpu| gpu.id == requested_gpu_id)
+            .unwrap_or_else(|| fallback_gpu(requested_gpu_id))
+    };
+    with_candle_capabilities(gpu, settings)
+}
+
+/// Light up the Windows/CUDA candle SDXL lane on the discovered nvidia GPU (epic 3672, sc-3678).
+/// When the candle backend is enabled, extend the GPU's advertised capabilities with the
+/// registry-DERIVED core (`engines::registry_capabilities` → `image_generate`, from the linked
+/// candle SDXL descriptor) plus a `candle` marker capability. The marker lets the API routing gate
+/// (`jobs_store::worker_supports_job`) recognize this worker and confine it to the SDXL/RealVisXL
+/// txt2img lane — every other shape falls back to the Python torch worker. Mirrors the macOS
+/// `mlx_gpu` derivation, but bolted onto the real nvidia GPU descriptor rather than a sentinel id.
+///
+/// All-targets signature so `discover_gpu` is uniform; a no-op everywhere except the Windows candle
+/// build with `backend_candle_enabled`, so production routing is unchanged until the lane is on.
+#[cfg_attr(
+    not(all(target_os = "windows", feature = "backend-candle")),
+    allow(unused_mut, unused_variables)
+)]
+fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> DiscoveredGpu {
+    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    if settings.backend_candle_enabled && gpu.capabilities.contains(&WorkerCapability::Gpu) {
+        let derived = crate::engines::registry_capabilities(settings);
+        if !derived.is_empty() {
+            for capability in derived {
+                if !gpu.capabilities.contains(&capability) {
+                    gpu.capabilities.push(capability);
+                }
+            }
+            // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
+            gpu.capabilities
+                .push(WorkerCapability::Unknown("candle".to_owned()));
+        }
     }
-    gpus.into_iter()
-        .find(|gpu| gpu.id == requested_gpu_id)
-        .unwrap_or_else(|| fallback_gpu(requested_gpu_id))
+    gpu
 }
 
 pub(crate) async fn discover_gpus() -> Vec<DiscoveredGpu> {

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -81,6 +81,11 @@ use mlx_gen_instantid::{
 /// The stub adapter id recorded on generated assets (matches the contract fixture
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
 const STUB_ADAPTER: &str = "procedural_preview";
+/// The adapter id recorded on assets produced by the candle (Windows/CUDA) SDXL lane (sc-3678).
+/// Used both per-asset (`generate_candle_stream`) and at the generation-set level (`adapter_id`)
+/// so the sidecar + result agree on which backend produced the image.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_ADAPTER: &str = "candle_sdxl";
 #[cfg(target_os = "macos")]
 const MAX_JOB_LORAS: usize = 3;
 
@@ -554,6 +559,15 @@ fn adapter_id(request: &ImageRequest) -> &'static str {
     #[cfg(target_os = "macos")]
     if let Some(model) = mlx_model(&request.model) {
         return model.adapter_label();
+    }
+    // Windows/CUDA candle lane (sc-3678): report the candle adapter for the SDXL family so the
+    // generation-set fact matches the per-asset `adapter` the candle path already writes, instead
+    // of falling through to the procedural-stub label. Routing (`worker_supports_job`) only lets
+    // candle-eligible SDXL txt2img jobs reach this worker, so `is_candle_engine` here implies the
+    // candle path ran.
+    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    if is_candle_engine(&request.model) {
+        return CANDLE_ADAPTER;
     }
     let _ = request;
     STUB_ADAPTER

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -732,11 +732,16 @@ async fn generate_candle_stream(
     job: &JobSnapshot,
     plan: &ImagePlan,
     project_path: &Path,
-    backend: &str,
+    _device_backend: &str,
     asset_writes: &mut Vec<Value>,
 ) -> WorkerResult<()> {
     let request = &plan.request;
-    let adapter_label = "candle_sdxl";
+    let adapter_label = CANDLE_ADAPTER;
+    // Report the tensor backend ("candle"), not the gpu-id device label (`_device_backend`), on the
+    // streamed progress + inference events (sc-3678) — parity with the macOS path's
+    // `model.backend()` override, so the worker log + the UI architecture pill clearly attribute the
+    // run to Candle.
+    let backend = "candle";
     // realvisxl shares the candle "sdxl" engine + a weights swap (sc-3677 verifies its layout).
     let repo = match request.model.as_str() {
         "realvisxl" => "SG161222/RealVisXL_V5.0",


### PR DESCRIPTION
[sc-3678](https://app.shortcut.com/trefry/story/3678) (epic [3672](https://app.shortcut.com/trefry/epic/3672)). Makes the gated candle (Windows/CUDA) SDXL lane **safe + transparent**: it serves **SDXL/RealVisXL txt2img only**, and every other shape transparently falls back to the Python torch worker. All behind `backend_candle_enabled` (default off) → production routing unchanged until parity is accepted.

## Background
`sc-3675` wired the candle *execution* path but not its *routing*: the Windows/CUDA worker never advertised `image_generate`, and once it did it would have claimed **any** image job (Flux, Qwen, SDXL img2img) and silently run/stubbed it. This closes that gap and labels the lane.

## Changes
**Python fallback (routing safety)**
- `gpu.rs` — `with_candle_capabilities`: on the Windows candle build with `backend_candle_enabled`, extend the discovered GPU's caps with the registry-derived `image_generate` plus a `candle` marker capability (mirrors the existing `nvidia` marker). Gated to real GPU workers.
- `jobs_store.rs::worker_supports_job` — a candle-marked worker refuses any `image_generate` that isn't `image_request_candle_eligible` (sdxl/realvisxl plain txt2img — no edit/img2img, reference, mask, LoRA, or strict-pose), so those defer to the co-resident Python torch worker. Identified by the marker, not `gpu_id` (a real CUDA index here, not the `mlx` sentinel).

**Labeling**
- `image_jobs.rs` — `adapter_id` reports `candle_sdxl` (not `procedural_preview`) for the candle family, matching the per-asset sidecar.
- `base.rs` — `generate_candle_stream` reports backend `"candle"` on progress/inference events (parity with the macOS `model.backend()` override).
- `styles.css` — `.arch-candle` pill so a Candle run is unmistakable in the WorkerProgressCard architecture pill (which already reads `job.backend`).

## Tests
New `candle_routing_tests` module: candle worker claims sdxl/realvisxl txt2img; refuses non-SDXL families + SDXL img2img/reference/mask/LoRA/pose; the torch worker claims everything the candle worker defers. Full `sceneworks-core` suite passes.

## Verification
- ✅ `cargo check -p sceneworks-worker --features backend-candle` compiles clean (validated with a non-stale candle-gen pin; see note below)
- ✅ Default worker build, `cargo fmt --check`, `clippy`, and full `sceneworks-core` tests all green

## ⚠️ Not in this PR — pre-existing pin/skew (sc-5035)
`main`'s `--features backend-candle` build is currently red **independent of this PR**: the worker pins `candle-gen-sdxl@5d7071ab`, which predates `set_flash_attn` (added in candle-gen `5143dd9`/sc-3674) — that call shipped without bumping the pin. Bumping to candle-gen HEAD fixes the compile but leaves a deeper runtime issue: the worker's gen-core pin is `95cd5c6` while candle-gen still pins `8355152`, so the inventory registry splits → runtime "engine not found". The correct pin needs a candle-gen rev re-pinned to gen-core `95cd5c6` (candle-gen + worker bumped in lockstep) — tracked under sc-5035. This PR is deliberately pin-free; the lane can't smoke-test live until sc-5035 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)