### PR TITLE
sc-5035: bump worker candle-gen-sdxl pin 5d7071a → f5abb03 (gen-core 95cd5c6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,23 +436,25 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d7071ab152a759f4cdcb1cef020226f03ddb2c3#5d7071ab152a759f4cdcb1cef020226f03ddb2c3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f5abb03325658ee17c9981f205805686469a7758#f5abb03325658ee17c9981f205805686469a7758"
 dependencies = [
  "candle-core",
  "candle-nn",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5d7071ab152a759f4cdcb1cef020226f03ddb2c3#5d7071ab152a759f4cdcb1cef020226f03ddb2c3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f5abb03325658ee17c9981f205805686469a7758#f5abb03325658ee17c9981f205805686469a7758"
 dependencies = [
  "candle-gen",
  "candle-transformers",
  "hf-hub",
  "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
  "tokenizers 0.22.2",
 ]
 
@@ -3058,7 +3060,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3880,7 +3882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4872,17 +4874,6 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8355152a79d6d328d3798c19a2b5a37bb8468622#8355152a79d6d328d3798c19a2b5a37bb8468622"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
@@ -4959,7 +4950,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",
@@ -7080,7 +7071,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -314,14 +314,13 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5
 # mlx providers). OPTIONAL + behind the `backend-candle` feature: its `cuda` feature compiles
 # candle-kernels for the target arch via nvcc, which must NOT run on the plain Desktop (Windows)
 # installer build — only the dedicated candle CI lane (sc-3676) opts in. Pinned to candle-gen
-# `5d7071a` (PR #2), whose `sceneworks-gen-core` pin is `8355152…`. NOTE: the worker's gen-core pin
-# moved to `95cd5c6` (sc-5012) while this candle pin still resolves `8355152`. The default skew gate
-# (`cargo tree` with no `--features backend-candle`) does NOT see this `optional` Windows-only dep, so
-# it stays green; but the candle lane (with `backend-candle`) WOULD split the gen-core registry until
-# candle-gen is re-pinned to `95cd5c6` and this rev bumped in lockstep — tracked as sc-5035 so it
-# isn't silently shipped on the Windows/CUDA lane.
+# `f5abb03` (PR #10, sc-5035), whose `sceneworks-gen-core` pin is `95cd5c6` — the SAME rev this
+# worker pins (sc-5012) — so the candle lane (`--features backend-candle`) resolves EXACTLY ONE
+# `sceneworks-gen-core` and the gen_core inventory registry no longer splits. This rev also carries
+# `set_flash_attn` (candle-gen `5143dd9`, sc-3674), which the `image_jobs/base.rs` call depends on;
+# the prior `5d7071a` pin predated it and broke the `backend-candle` compile.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5d7071ab152a759f4cdcb1cef020226f03ddb2c3", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f5abb03325658ee17c9981f205805686469a7758", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## sc-5035: align the worker's candle-gen-sdxl pin to gen-core `95cd5c6`

Worker-side companion to candle-gen [#10](https://github.com/michaeltrefry/candle-gen/pull/10) (merged). Bumps `candle-gen-sdxl` `5d7071a → f5abb03` and rewrites the deferral comment.

### Why
`candle-gen f5abb03` pins `sceneworks-gen-core` at `95cd5c6` — the **same** rev this worker already pins via `mlx-gen` ([sc-5012](https://app.shortcut.com/trefry/story/5012) / epic 3090). The old `5d7071a` pin pulled gen-core `8355152`, so under `--features backend-candle` the build resolved **two** distinct gen-core revs → the `inventory` registry split → "no generator registered" at runtime on the candle backend.

`f5abb03` also carries `set_flash_attn` (candle-gen `5143dd9`, [sc-3674](https://app.shortcut.com/trefry/story/3674)), which `image_jobs/base.rs` calls — the prior `5d7071a` predated it and broke the `backend-candle` **compile** (flagged during sc-3678).

### Verification
- `cargo tree -p sceneworks-worker --target all --features backend-candle`: **exactly one** `sceneworks-gen-core` (`95cd5c6`); the old `8355152` subtree dropped out of `Cargo.lock`.
- `scripts/check-gen-core-skew.sh` (default gate): OK, single resolution.

cuda/fatbin compile of the candle lane runs on the dedicated CI lane ([sc-3676](https://app.shortcut.com/trefry/story/3676)) / Windows box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
