### PR TITLE
sc-4997: default Wan 5B to 832×480 fast path + 5B timing harness

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -448,7 +448,10 @@ export const fallbackModels = [
     name: "Wan2.2",
     type: "video",
     capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
-    defaults: { duration: 5, fps: 24, resolution: "1280x720", quality: "balanced" },
+    // Default to 832x480 for a sane out-of-the-box time on the Mac MLX path (sc-4997): measured
+    // 5B @ 832x480/121f/20-step/CFG = ~5 min vs ~20 min at 1280x720 (the z48 VAE decode dominates
+    // at high res). 1280x720 stays user-selectable via `limits.resolutions` for those who accept it.
+    defaults: { duration: 5, fps: 24, resolution: "832x480", quality: "balanced" },
     limits: {
       durations: [4, 5, 6, 7, 8],
       recommendedMaxDuration: 7,

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -4354,6 +4354,88 @@ mod tests {
             .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize));
     }
 
+    /// Real-weight perf probe for the TI2V-5B (sc-4997): measures the load / DiT-denoise /
+    /// VAE-decode wall-clock split at a configurable resolution, frame count, step count, and
+    /// CFG — to ground the "under 10 min" target on real numbers instead of estimates. Env-driven
+    /// so configs run without recompiling. MUST be `--release` (debug MLX timing is meaningless):
+    ///   SCENEWORKS_MLX_WAN5B_DIR=~/.cache/mlx-gen-models/wan_2_2_ti2v_5b_mlx_bf16 \
+    ///   WAN_TIMING_W=1280 WAN_TIMING_H=720 WAN_TIMING_FRAMES=121 WAN_TIMING_STEPS=20 WAN_TIMING_CFG=on \
+    ///   cargo test -p sceneworks-worker --release --lib wan_5b_timing -- --ignored --nocapture
+    /// CFG: `off`/`1` ⇒ guide 1.0 (no CFG); a number ⇒ that scale; `on`/unset ⇒ engine default (5.0).
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "real-weight perf probe; needs the converted TI2V-5B snapshot + a Metal device"]
+    fn wan_5b_timing() {
+        use std::time::Instant;
+        let Some(model_dir) = wan_5b_dir() else {
+            eprintln!("skipping wan_5b_timing: no converted TI2V-5B dir found");
+            return;
+        };
+        let env_u32 = |k: &str, d: u32| {
+            std::env::var(k)
+                .ok()
+                .and_then(|s| s.trim().parse().ok())
+                .unwrap_or(d)
+        };
+        let width = env_u32("WAN_TIMING_W", 1280);
+        let height = env_u32("WAN_TIMING_H", 720);
+        let frames = env_u32("WAN_TIMING_FRAMES", 121);
+        let steps = env_u32("WAN_TIMING_STEPS", 20);
+        let guidance = match std::env::var("WAN_TIMING_CFG")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+        {
+            Some("off") | Some("1") | Some("1.0") => Some(1.0_f32),
+            Some("on") | Some("") | None => None,
+            Some(other) => other.parse().ok(),
+        };
+        let input = VideoGenInput {
+            engine_id: "wan2_2_ti2v_5b",
+            model_dir,
+            prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
+            width,
+            height,
+            frames,
+            fps: 24,
+            steps: Some(steps),
+            guidance,
+            seed: 7,
+            ..VideoGenInput::default()
+        };
+        let cancel = CancelFlag::new();
+        let start = Instant::now();
+        let mut first_step: Option<Instant> = None;
+        let mut last_step: Option<Instant> = None;
+        let mut decode_at: Option<Instant> = None;
+        let mut on_progress = |progress: Progress| match progress {
+            Progress::Step { .. } => {
+                let now = Instant::now();
+                first_step.get_or_insert(now);
+                last_step = Some(now);
+            }
+            Progress::Decoding => {
+                decode_at.get_or_insert(Instant::now());
+            }
+        };
+        let decoded =
+            run_video_generation(input, &cancel, &mut on_progress).expect("5B generation");
+        let end = Instant::now();
+        let secs = |a: Instant, b: Instant| b.duration_since(a).as_secs_f64();
+        let fs = first_step.unwrap_or(start);
+        let dec = decode_at.or(last_step).unwrap_or(end);
+        eprintln!(
+            "WAN5B_TIMING {width}x{height} frames={frames} steps={steps} cfg={} => \
+             total={:.1}s load={:.1}s dit={:.1}s vae={:.1}s out_frames={}",
+            guidance.map_or_else(|| "5.0(default)".to_owned(), |g| format!("{g}")),
+            secs(start, end),
+            secs(start, fs),
+            secs(fs, dec),
+            secs(dec, end),
+            decoded.frames.len(),
+        );
+    }
+
     /// LTX model-id → engine-id mapping (both base + eros load the one engine model).
     #[cfg(target_os = "macos")]
     #[test]


### PR DESCRIPTION
## What & why

Follow-up to [sc-4997](https://app.shortcut.com/trefry/story/4997) (merged [#636](https://github.com/michaeltrefry/SceneWorks/pull/636)). The goal Michael set: the 5B must finish in **under 10 min** (40 min was unacceptable). I measured the converted TI2V-5B on the Mac (M5 Max, real weights, each config run alone) to ground the fix in data instead of estimates:

| config (121f ≈5s, 20-step, CFG on) | total | load | DiT | z48 VAE |
|---|---|---|---|---|
| 1280×720 (the old default) | **19.7 min** | 28s | 11.0 min | **8.3 min** |
| **832×480** | **5.1 min** | 10s | 3.5 min | 1.5 min |

**832×480 lands under 10 min with the same 20-step + CFG recipe** (no quality-cliff few-step needed). 1280×720 can't be brought under 10 by the worker — the z48 VAE decode alone is ~8 min there, and that's an engine optimization ([sc-5089](https://app.shortcut.com/trefry/story/5089)), not a sampler-config problem.

## Changes
- **`apps/web/constants.js`** — default the Wan2.2 (5B) studio resolution to **832×480**. 1280×720 stays user-selectable via `limits.resolutions` (labelled in the comment as the slow/high-res option).
- **`crates/sceneworks-worker` `wan_5b_timing`** — an `#[ignore]`d, env-driven real-weight perf probe that splits **load / DiT / VAE** wall-clock via the engine's `Progress::Decoding` boundary. This is the harness that produced the table above; kept for future tuning (matches the existing `wan_5b_real_weights` ignored test).

## Notes for the reviewer
- **No engine pin bump in this PR.** The measurement used a local bump to the VAE-memory-fix rev (sc-4998/5039); shipping that bump needs a coordinated candle-gen `sceneworks-gen-core` alignment (two-step cross-repo), so it's folded into the [sc-5089](https://app.shortcut.com/trefry/story/5089) engine work rather than done standalone. This PR is dependency-free.
- The timing harness uses only pre-existing worker APIs, so it compiles against the current pin.
- Open question that bounds 1280×720 expectations: whether the user's 3–4 min ComfyUI 1280×720 run is on this Mac or NVIDIA — if NVIDIA, the ~8-min Apple-GPU VAE decode is partly just the hardware delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)