### PR TITLE
sc-5096: wire candle image generators (z-image, flux, flux2, qwen-image) into the worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,8 +409,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+source = "git+https://github.com/huggingface/candle?rev=65ecb58c11d2244a7e60c71bdcdb19b15b0a4343#65ecb58c11d2244a7e60c71bdcdb19b15b0a4343"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -419,6 +418,7 @@ dependencies = [
  "float8",
  "gemm 0.19.0",
  "half",
+ "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -430,13 +430,13 @@ dependencies = [
  "thiserror 2.0.18",
  "tokenizers 0.22.2",
  "yoke 0.8.2",
- "zip 7.2.0",
+ "zip 8.6.0",
 ]
 
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f5abb03325658ee17c9981f205805686469a7758#f5abb03325658ee17c9981f205805686469a7758"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -445,9 +445,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-flux"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+dependencies = [
+ "candle-gen",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
+name = "candle-gen-flux2"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+dependencies = [
+ "candle-gen",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
+name = "candle-gen-qwen-image"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+dependencies = [
+ "candle-gen",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f5abb03325658ee17c9981f205805686469a7758#f5abb03325658ee17c9981f205805686469a7758"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -459,10 +501,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-z-image"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+dependencies = [
+ "candle-gen",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742e2ac226b777134436e9e692f44e77c278b8a7abb1554dc10e44dc911b349f"
+source = "git+https://github.com/huggingface/candle?rev=65ecb58c11d2244a7e60c71bdcdb19b15b0a4343#65ecb58c11d2244a7e60c71bdcdb19b15b0a4343"
 dependencies = [
  "cudaforge",
 ]
@@ -470,8 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+source = "git+https://github.com/huggingface/candle?rev=65ecb58c11d2244a7e60c71bdcdb19b15b0a4343#65ecb58c11d2244a7e60c71bdcdb19b15b0a4343"
 dependencies = [
  "candle-core",
  "half",
@@ -486,8 +539,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+source = "git+https://github.com/huggingface/candle?rev=65ecb58c11d2244a7e60c71bdcdb19b15b0a4343#65ecb58c11d2244a7e60c71bdcdb19b15b0a4343"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -505,8 +557,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
+source = "git+https://github.com/huggingface/candle?rev=65ecb58c11d2244a7e60c71bdcdb19b15b0a4343#65ecb58c11d2244a7e60c71bdcdb19b15b0a4343"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -1392,9 +1443,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -4921,7 +4972,11 @@ name = "sceneworks-worker"
 version = "0.2.0"
 dependencies = [
  "axum",
+ "candle-gen-flux",
+ "candle-gen-flux2",
+ "candle-gen-qwen-image",
  "candle-gen-sdxl",
+ "candle-gen-z-image",
  "futures-util",
  "glob",
  "image",
@@ -7907,18 +7962,6 @@ dependencies = [
  "memchr",
  "thiserror 2.0.18",
  "zopfli",
-]
-
-[[package]]
-name = "zip"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
-dependencies = [
- "crc32fast",
- "indexmap 2.14.0",
- "memchr",
- "typed-path",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4028,11 +4028,20 @@ mod candle_routing_tests {
         // The four sc-5096 families are txt2img-only on candle: any conditioning shape defers to torch
         // (the worker advertises none of these, so this is the no-silently-dropped-control boundary).
         let cases = [
-            ("z_image_turbo", json!({ "mode": "edit_image", "sourceAssetId": "a" })),
+            (
+                "z_image_turbo",
+                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+            ),
             ("flux_dev", json!({ "referenceAssetId": "a" })),
             ("flux_schnell", json!({ "loras": [{ "name": "x" }] })),
-            ("qwen_image", json!({ "advanced": { "poses": [{ "id": "pose_1" }] } })),
-            ("flux2_klein_9b", json!({ "mode": "edit_image", "sourceAssetId": "a" })),
+            (
+                "qwen_image",
+                json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),
+            ),
+            (
+                "flux2_klein_9b",
+                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+            ),
         ];
         for (model, payload) in cases {
             assert!(
@@ -4075,7 +4084,13 @@ mod candle_routing_tests {
     fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         let candle = gpu_worker(CANDLE_CAPS);
         // Claims the lane — SDXL plus the sc-5096 image families, all plain txt2img.
-        for model in ["sdxl", "realvisxl", "z_image_turbo", "flux_dev", "qwen_image"] {
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "z_image_turbo",
+            "flux_dev",
+            "qwen_image",
+        ] {
             assert!(
                 worker_supports_job(
                     &candle,

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3058,11 +3058,22 @@ fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
 }
 
-/// The models the candle (Windows/CUDA) SDXL lane can serve (epic 3672, sc-3678). Mirrors the
-/// worker's `image_jobs::is_candle_engine`: the SDXL family only — `realvisxl` shares the candle
-/// `"sdxl"` engine via a weights swap. Deliberately narrow: candle is a gated txt2img-only lane,
-/// and everything outside it falls back to the Python torch worker.
-const CANDLE_ROUTED_MODELS: &[&str] = &["sdxl", "realvisxl"];
+/// The models the candle (Windows/CUDA) lane can serve (epic 3672 sc-3678 for SDXL; epic 5095
+/// sc-5096 adds the four image families). Mirrors the worker's `image_jobs::is_candle_engine`:
+/// SDXL/RealVisXL (`realvisxl` shares the candle `"sdxl"` engine via a weights swap), plus
+/// z-image-turbo, FLUX.1 schnell/dev, FLUX.2-klein-9B, and Qwen-Image — the base **txt2img** ids
+/// only. Deliberately narrow: candle is a gated txt2img-only lane, so every conditioning shape AND
+/// every non-base weight variant (e.g. `flux2_klein_9b_kv`, `qwen_image_edit`) falls back to the
+/// Python torch worker.
+const CANDLE_ROUTED_MODELS: &[&str] = &[
+    "sdxl",
+    "realvisxl",
+    "z_image_turbo",
+    "flux_schnell",
+    "flux_dev",
+    "flux2_klein_9b",
+    "qwen_image",
+];
 
 /// Whether `worker` is the candle (Windows/CUDA) SDXL worker — identified by the `candle` marker
 /// capability it self-advertises (`gpu::with_candle_capabilities`), mirroring the `nvidia` marker
@@ -3983,7 +3994,8 @@ mod candle_routing_tests {
     const TORCH_CAPS: &[&str] = &["gpu", "image_generate", "image_edit", "image_detail"];
 
     #[test]
-    fn sdxl_and_realvisxl_plain_txt2img_are_candle_eligible() {
+    fn candle_routed_models_plain_txt2img_are_eligible() {
+        // SDXL/RealVisXL (sc-3678) + the four image families wired in sc-5096 — every base txt2img id.
         for model in CANDLE_ROUTED_MODELS {
             assert!(
                 image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
@@ -3993,17 +4005,39 @@ mod candle_routing_tests {
     }
 
     #[test]
-    fn non_sdxl_families_are_never_candle_eligible() {
+    fn non_candle_families_and_variants_are_never_candle_eligible() {
+        // Families with no candle provider (chroma/kolors/sensenova) AND the non-base weight/shape
+        // variants of wired families (edit ids, the kv distill) all stay on the Python torch worker.
         for model in [
-            "flux_dev",
-            "qwen_image",
-            "z_image_turbo",
             "chroma1_hd",
             "kolors",
+            "sensenova_u1_8b",
+            "z_image_edit",
+            "qwen_image_edit",
+            "flux2_klein_9b_kv",
         ] {
             assert!(
                 !image_request_candle_eligible(model, &object(json!({ "prompt": "p" }))),
                 "{model} must fall back to the Python worker"
+            );
+        }
+    }
+
+    #[test]
+    fn new_candle_families_conditioning_shapes_fall_back_to_torch() {
+        // The four sc-5096 families are txt2img-only on candle: any conditioning shape defers to torch
+        // (the worker advertises none of these, so this is the no-silently-dropped-control boundary).
+        let cases = [
+            ("z_image_turbo", json!({ "mode": "edit_image", "sourceAssetId": "a" })),
+            ("flux_dev", json!({ "referenceAssetId": "a" })),
+            ("flux_schnell", json!({ "loras": [{ "name": "x" }] })),
+            ("qwen_image", json!({ "advanced": { "poses": [{ "id": "pose_1" }] } })),
+            ("flux2_klein_9b", json!({ "mode": "edit_image", "sourceAssetId": "a" })),
+        ];
+        for (model, payload) in cases {
+            assert!(
+                !image_request_candle_eligible(model, &object(payload.clone())),
+                "{model} conditioning shape must fall back to torch: {payload}"
             );
         }
     }
@@ -4038,21 +4072,30 @@ mod candle_routing_tests {
     }
 
     #[test]
-    fn candle_worker_claims_sdxl_txt2img_but_refuses_unsupported_shapes() {
+    fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         let candle = gpu_worker(CANDLE_CAPS);
-        // Claims the lane.
-        assert!(worker_supports_job(
-            &candle,
-            &image_generate_job(json!({ "model": "sdxl", "prompt": "a red fox" }))
-        ));
-        assert!(worker_supports_job(
-            &candle,
-            &image_generate_job(json!({ "model": "realvisxl", "prompt": "p" }))
-        ));
-        // Refuses a non-SDXL family and an SDXL img2img — both defer to torch.
+        // Claims the lane — SDXL plus the sc-5096 image families, all plain txt2img.
+        for model in ["sdxl", "realvisxl", "z_image_turbo", "flux_dev", "qwen_image"] {
+            assert!(
+                worker_supports_job(
+                    &candle,
+                    &image_generate_job(json!({ "model": model, "prompt": "a red fox" }))
+                ),
+                "candle worker should claim {model} plain txt2img"
+            );
+        }
+        // Refuses a family with no candle provider, and a conditioning shape on a wired family —
+        // both defer to torch.
         assert!(!worker_supports_job(
             &candle,
-            &image_generate_job(json!({ "model": "flux_dev", "prompt": "p" }))
+            &image_generate_job(json!({ "model": "chroma1_hd", "prompt": "p" }))
+        ));
+        assert!(!worker_supports_job(
+            &candle,
+            &image_generate_job(json!({
+                "model": "qwen_image",
+                "advanced": { "poses": [{ "id": "pose_1" }] }
+            }))
         ));
         assert!(!worker_supports_job(
             &candle,
@@ -4069,9 +4112,17 @@ mod candle_routing_tests {
         // The co-resident Python torch worker (no `candle` marker) is ungated here: it claims the
         // shapes the candle worker refused, so nothing is stranded.
         let torch = gpu_worker(TORCH_CAPS);
+        // A family with no candle provider, and a conditioning shape on a wired family.
         assert!(worker_supports_job(
             &torch,
-            &image_generate_job(json!({ "model": "flux_dev", "prompt": "p" }))
+            &image_generate_job(json!({ "model": "chroma1_hd", "prompt": "p" }))
+        ));
+        assert!(worker_supports_job(
+            &torch,
+            &image_generate_job(json!({
+                "model": "qwen_image",
+                "advanced": { "poses": [{ "id": "pose_1" }] }
+            }))
         ));
         assert!(worker_supports_job(
             &torch,

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -74,7 +74,18 @@ inventory = "0.3"
 # candle Windows CI lane (sc-3676) builds with `--features backend-candle`. Linking the crate does
 # NOT enable it at runtime — that is the separate `backend_candle_enabled` setting, read by
 # `engines::registry_capabilities`. Two-level gating: build feature + runtime setting.
-backend-candle = ["dep:candle-gen-sdxl"]
+# sc-5096 (epic 5095) widens the lane beyond SDXL: the four candle image generators
+# (z-image, flux, flux2, qwen-image) are pulled in here too (each with its `cuda` feature) so the
+# Windows/CUDA worker links + force-links their `inventory::submit!` registrations. Their engine ids
+# (`z_image_turbo` / `flux1_schnell` / `flux1_dev` / `flux2_klein_9b` / `qwen_image`) already have
+# `MODEL_TABLE` rows, so `engines::registry_capabilities` advertises them with no further change.
+backend-candle = [
+    "dep:candle-gen-sdxl",
+    "dep:candle-gen-z-image",
+    "dep:candle-gen-flux",
+    "dep:candle-gen-flux2",
+    "dep:candle-gen-qwen-image",
+]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # DWPose whole-body pose detection in Rust (epic 3482, sc-3487): RTMW (yolox_m +
@@ -319,8 +330,22 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5
 # `sceneworks-gen-core` and the gen_core inventory registry no longer splits. This rev also carries
 # `set_flash_attn` (candle-gen `5143dd9`, sc-3674), which the `image_jobs/base.rs` call depends on;
 # the prior `5d7071a` pin predated it and broke the `backend-candle` compile.
+#
+# sc-5096 (epic 5095) bumps the pin `f5abb03` -> `5ba7d8b` (candle-gen main, PR #17): adds the
+# z-image / flux / flux2 / qwen-image image providers AND the wan / ltx video + joycaption captioner
+# providers (the latter three wired by sc-5097/sc-5098). `5ba7d8b` still pins `sceneworks-gen-core`
+# at `95cd5c6` (the SAME rev this worker pins), so the skew gate (`--features backend-candle`) stays
+# green: one gen-core resolution, one inventory registry. ALL candle deps below MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f5abb03325658ee17c9981f205805686469a7758", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+# Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
+# self-registers its engine id into the shared gen_core inventory registry; force-linked in
+# `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
+# Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -300,13 +300,24 @@ pub(crate) const TRAINER_IDS: &[&str] = &[
 /// view the image path reads. The row supplies the worker-side defaults; the descriptor
 /// supplies the capability surface (`supports_guidance` / `supports_negative_prompt` /
 /// `backend`) so a row can never drift from the engine's own advertisement (sc-3723).
-#[cfg(target_os = "macos")]
+///
+/// Compiled on the macOS MLX path AND the Windows candle lane (sc-5096): the join is purely
+/// backend-neutral (`MODEL_TABLE` row + whichever provider crate registered the engine id), so the
+/// candle `generate_candle_stream` reuses it exactly like the MLX `generate_stream` — `cfg(target_os)`
+/// only decides which provider crate registered the descriptor, not how it is resolved.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 pub(crate) struct ResolvedModel {
     pub row: &'static ModelRow,
     pub descriptor: gen_core::ModelDescriptor,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 impl ResolvedModel {
     pub fn engine_id(&self) -> &'static str {
         self.row.engine_id
@@ -320,6 +331,13 @@ impl ResolvedModel {
     pub fn default_guidance(&self) -> f32 {
         self.row.default_guidance
     }
+    // The MLX adapter label (`mlx_<family>`). The candle lane reports `candle_<family>` via the free
+    // `image_jobs::candle_adapter_label` instead, so this accessor is MLX-path-only — silence the
+    // dead-code lint on the candle-only build where the macOS dispatch is cfg'd out.
+    #[cfg_attr(
+        all(target_os = "windows", feature = "backend-candle"),
+        allow(dead_code)
+    )]
     pub fn adapter_label(&self) -> &'static str {
         self.row.adapter_label
     }
@@ -341,7 +359,14 @@ impl ResolvedModel {
 /// The engine-backed family for a SceneWorks model id, if any — the row joined with its
 /// linked gen_core descriptor. `None` when the id is not in [`MODEL_TABLE`] or no provider
 /// crate registered its engine id (keeps the existing fail-loud-when-not-MLX behavior).
-#[cfg(target_os = "macos")]
+///
+/// Backend-neutral despite the `mlx_` name (sc-5096): on the Windows candle lane the registry holds
+/// the candle descriptors, so this resolves the candle engine for `request.model` the same way it
+/// resolves the MLX engine on macOS — the candle `generate_candle_stream` calls it directly.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 pub(crate) fn mlx_model(sceneworks_id: &str) -> Option<ResolvedModel> {
     let row = MODEL_TABLE
         .iter()

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -69,6 +69,18 @@ use mlx_gen_z_image as _;
 // actually USED at runtime is the separate `backend_candle_enabled` setting, not this link anchor.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_sdxl as _;
+// The four candle image families wired in sc-5096 (epic 5095). Same force-link anchor pattern as the
+// SDXL crate above + the mlx providers: each self-registers its engine id (`z_image_turbo` /
+// `flux1_schnell` + `flux1_dev` / `flux2_klein_9b` / `qwen_image`) into the shared gen_core inventory
+// registry, and the `as _;` keeps the MSVC release linker from GC-ing the `inventory::submit!`.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_flux as _;
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_flux2 as _;
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_qwen_image as _;
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_z_image as _;
 // CARVE-OUT(epic 3720): backend-specific; absorbed by FaceEmbedder in Phase 3.
 // InstantID (sc-3345) is a bespoke provider, not an inventory-registered `Generator`, so it is
 // referenced by name (`InstantId::load`) rather than anchored with `as _;` — and the native face
@@ -99,8 +111,13 @@ const MAX_JOB_LORAS: usize = 3;
 // The engine dispatch table + its `ModelRow`/`mlx_model` join moved to the all-targets
 // `engines` module (sc-3723); the two descriptor-duplicating flags it used to carry
 // (`supports_guidance`/`supports_negative_prompt`) are now read from the linked gen_core
-// descriptor via `ResolvedModel`. The lookup stays macOS-gated (every caller is).
-#[cfg(target_os = "macos")]
+// descriptor via `ResolvedModel`. Shared by the macOS MLX path and the Windows candle lane
+// (sc-5096) — the join is backend-neutral, so `generate_candle_stream` resolves repo/steps/guidance
+// through the same `mlx_model` lookup the MLX path uses.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use crate::engines::{mlx_model, ResolvedModel};
 /// Dispatch handler for `JobType::ImageGenerate`: generate, save, and stream image
 /// assets through the Rust GPU worker.
@@ -581,14 +598,14 @@ fn adapter_id(request: &ImageRequest) -> &'static str {
     if let Some(model) = mlx_model(&request.model) {
         return model.adapter_label();
     }
-    // Windows/CUDA candle lane (sc-3678): report the candle adapter for the SDXL family so the
-    // generation-set fact matches the per-asset `adapter` the candle path already writes, instead
-    // of falling through to the procedural-stub label. Routing (`worker_supports_job`) only lets
-    // candle-eligible SDXL txt2img jobs reach this worker, so `is_candle_engine` here implies the
+    // Windows/CUDA candle lane (sc-3678, per-engine in sc-5096): report the candle adapter for the
+    // wired family so the generation-set fact matches the per-asset `adapter` the candle path writes,
+    // instead of falling through to the procedural-stub label. Routing (`worker_supports_job`) only
+    // lets candle-eligible txt2img jobs reach this worker, so `is_candle_engine` here implies the
     // candle path ran.
     #[cfg(all(target_os = "windows", feature = "backend-candle"))]
     if is_candle_engine(&request.model) {
-        return CANDLE_ADAPTER;
+        return candle_adapter_label(&request.model);
     }
     let _ = request;
     STUB_ADAPTER

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -78,8 +78,11 @@ fn grouped_edit_image_count(request: &ImageRequest) -> u32 {
 }
 
 /// The HuggingFace repo for the model: the manifest entry's `repo` wins, else the
-/// family default.
-#[cfg(target_os = "macos")]
+/// family default. Shared by the MLX path and the candle lane (sc-5096).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
     request
         .model_manifest_entry
@@ -154,7 +157,11 @@ fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
 }
 
 /// Resolve denoise steps: `advanced.steps` (clamped 1..=80) else the family default.
-#[cfg(target_os = "macos")]
+/// Shared by the MLX path and the candle lane (sc-5096).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn resolve_steps(request: &ImageRequest, model: &ResolvedModel) -> u32 {
     request
         .advanced
@@ -171,7 +178,13 @@ fn resolve_steps(request: &ImageRequest, model: &ResolvedModel) -> u32 {
 /// Resolve the guidance scale. Distilled variants (z-image-turbo, flux schnell) take
 /// no guidance — the engine rejects `Some(_)` on them — so this returns `None`. For a
 /// guided variant (flux dev) it is `advanced.guidanceScale` else the family default.
-#[cfg(target_os = "macos")]
+/// Shared by the MLX path and the candle lane (sc-5096); the descriptor's `supports_guidance` is the
+/// candle descriptor on the Windows lane, so a distilled candle family (z-image, flux schnell) still
+/// gets `None` and a guided one (flux dev, flux2, qwen, sdxl) gets the scale.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn resolve_guidance(request: &ImageRequest, model: &ResolvedModel) -> Option<f32> {
     if !model.supports_guidance() {
         return None;
@@ -195,7 +208,10 @@ fn resolve_guidance(request: &ImageRequest, model: &ResolvedModel) -> Option<f32
 /// guidance-distilled families (`z_image_turbo`, `flux_schnell`) are `false`/`false` (no CFG at
 /// all), and the `guidance`-scalar families (qwen / sdxl / flux2 …) are `true`/*. For a true-CFG
 /// family the worker forwards `advanced.guidanceScale` as `true_cfg`, not `guidance`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn uses_true_cfg(model: &ResolvedModel) -> bool {
     !model.supports_guidance() && model.supports_negative_prompt()
 }
@@ -203,7 +219,11 @@ fn uses_true_cfg(model: &ResolvedModel) -> bool {
 /// Resolve the true-CFG scale for a true-CFG family (Chroma). `None` for every other family
 /// (their CFG, if any, flows through [`resolve_guidance`]). The scale is `advanced.guidanceScale`
 /// (the same user knob) else the family default — forwarded to the engine as `GenerationRequest.true_cfg`.
-#[cfg(target_os = "macos")]
+/// Shared by the MLX path and the candle lane (sc-5096).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn resolve_true_cfg(request: &ImageRequest, model: &ResolvedModel) -> Option<f32> {
     if !uses_true_cfg(model) {
         return None;
@@ -224,7 +244,12 @@ fn resolve_true_cfg(request: &ImageRequest, model: &ResolvedModel) -> Option<f32
 /// The negative prompt to pass to the engine. `None` for variants without true CFG
 /// (the engine rejects `negative_prompt` on the distilled families) and for an empty
 /// prompt (the true-CFG engines fall back to their own neutral negative).
-#[cfg(target_os = "macos")]
+/// Shared by the MLX path and the candle lane (sc-5096); on the Windows lane `supports_negative_prompt`
+/// is the candle descriptor, so distilled candle families (z-image, flux schnell) get `None`.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn resolve_negative_prompt(request: &ImageRequest, model: &ResolvedModel) -> Option<String> {
     if !model.supports_negative_prompt() {
         return None;
@@ -717,19 +742,54 @@ async fn generate_stream(
     .await
 }
 
-/// Whether `model` is served by the candle (Windows/CUDA) backend (sc-3675): the SDXL family only
-/// (`realvisxl` shares the candle `"sdxl"` engine). A tiny routing match — candle registers one engine.
+/// Whether `model` is served by the candle (Windows/CUDA) backend's **txt2img** lane. SDXL/RealVisXL
+/// (sc-3675) plus the four image families wired in sc-5096 — z-image, flux schnell/dev, flux2-klein,
+/// qwen-image. `realvisxl` shares the candle `"sdxl"` engine via a weights swap; every other id maps
+/// 1:1 to its `MODEL_TABLE` engine id. Edit/control/reference shapes and the non-base weight variants
+/// stay on the Python torch worker (the router's `image_request_candle_eligible` enforces the same
+/// boundary), so this gate is intentionally the base-id set only.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 fn is_candle_engine(model: &str) -> bool {
-    matches!(model, "sdxl" | "realvisxl")
+    matches!(
+        model,
+        "sdxl"
+            | "realvisxl"
+            | "z_image_turbo"
+            | "flux_schnell"
+            | "flux_dev"
+            | "flux2_klein_9b"
+            | "qwen_image"
+    )
 }
 
-/// Windows/CUDA candle execution path (sc-3675, epic 3672). The macOS dispatch is MLX-bound; candle
-/// is a narrow **txt2img-only** lane, so this is a trimmed sibling of [`generate_stream`] that drives
-/// the SAME neutral streaming harness (`start_cached_gen_stream` → `generate_one` →
-/// `consume_gen_events`) against the registry-resolved candle generator (`gen_core::load("sdxl", …)`).
-/// No reference/img2img/LoRA — the descriptor advertises none, so those never route here. Reached
-/// only when `backend_candle_enabled` (default off → production routing unchanged until parity).
+/// The per-asset `adapter` id recorded for a candle image engine (`candle_<family>`), the candle
+/// sibling of the `MODEL_TABLE` `mlx_<family>` labels. Used both per-asset (`generate_candle_stream`)
+/// and at the generation-set level (`adapter_id`) so the sidecar + result agree on the backend.
+/// (sc-5099 extends this same labeling to the video + caption engines.)
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn candle_adapter_label(model: &str) -> &'static str {
+    match model {
+        "z_image_turbo" => "candle_z_image",
+        "flux_schnell" | "flux_dev" => "candle_flux",
+        "flux2_klein_9b" => "candle_flux2",
+        "qwen_image" => "candle_qwen",
+        // sdxl / realvisxl share the candle "sdxl" engine.
+        _ => CANDLE_ADAPTER,
+    }
+}
+
+/// Windows/CUDA candle execution path (sc-3675 SDXL, generalized in sc-5096). The macOS dispatch is
+/// MLX-bound; candle is a narrow **txt2img-only** lane, so this is a trimmed sibling of
+/// [`generate_stream`] that drives the SAME neutral streaming harness (`start_cached_gen_stream` →
+/// `generate_one` → `consume_gen_events`) against the registry-resolved candle generator.
+///
+/// Backend-neutral resolution (sc-5096): the per-engine repo / steps / guidance / negative prompt all
+/// come from the shared [`mlx_model`] join (`MODEL_TABLE` row + the linked candle descriptor), exactly
+/// like the MLX path — so adding the four image families needs no new dispatch logic, just their
+/// provider crates linked. Quant + adapters are always empty (the candle descriptors advertise
+/// neither). No reference/img2img/control — those shapes fall back to the Python worker upstream
+/// (`image_request_candle_eligible`). Reached only when `backend_candle_enabled` (default off →
+/// production routing unchanged until parity).
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 async fn generate_candle_stream(
     api: &ApiClient,
@@ -741,65 +801,69 @@ async fn generate_candle_stream(
     asset_writes: &mut Vec<Value>,
 ) -> WorkerResult<()> {
     let request = &plan.request;
-    let adapter_label = CANDLE_ADAPTER;
-    // Report the tensor backend ("candle"), not the gpu-id device label (`_device_backend`), on the
-    // streamed progress + inference events (sc-3678) — parity with the macOS path's
-    // `model.backend()` override, so the worker log + the UI architecture pill clearly attribute the
-    // run to Candle.
-    let backend = "candle";
-    // realvisxl shares the candle "sdxl" engine + a weights swap (sc-3677 verifies its layout).
-    let repo = match request.model.as_str() {
-        "realvisxl" => "SG161222/RealVisXL_V5.0",
-        _ => "stabilityai/stable-diffusion-xl-base-1.0",
+    let adapter_label = candle_adapter_label(&request.model);
+    // Join the MODEL_TABLE row with the linked candle descriptor (same resolver the MLX path uses).
+    // `None` means the candle provider crate for this id wasn't linked/registered — fail loud rather
+    // than silently stubbing.
+    let model = mlx_model(&request.model).ok_or_else(|| {
+        WorkerError::Engine(format!(
+            "candle backend not linked for model {} (no registered generator)",
+            request.model
+        ))
+    })?;
+    let engine_id = model.engine_id();
+    // Report the descriptor's tensor backend ("candle"), not the gpu-id device label
+    // (`_device_backend`), on the streamed progress + inference events (sc-3678) — parity with the
+    // macOS path's `model.backend()` override, so the worker log + the UI architecture pill clearly
+    // attribute the run to Candle.
+    let backend = if model.backend().is_empty() {
+        "candle"
+    } else {
+        model.backend()
     };
-    let weights_dir = huggingface_snapshot_dir(&settings.data_dir, repo).ok_or_else(|| {
-        WorkerError::InvalidPayload(format!("candle sdxl weights snapshot not found for {repo}"))
+    let repo = model_repo(request, &model);
+    let weights_dir = huggingface_snapshot_dir(&settings.data_dir, &repo).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
     })?;
 
-    // SDXL production defaults (the candle descriptor's wired surface): 30 steps, CFG 7.0.
-    let steps = request
-        .advanced
-        .get("steps")
-        .and_then(|v| v.as_u64().or_else(|| v.as_str()?.trim().parse().ok()))
-        .map(|s| (s as u32).clamp(1, 80))
-        .unwrap_or(30);
-    let guidance = Some(
-        request
-            .advanced
-            .get("guidanceScale")
-            .and_then(|v| v.as_f64().or_else(|| v.as_str()?.trim().parse().ok()))
-            .map(|g| g as f32)
-            .unwrap_or(7.0),
-    );
-    let negative_prompt = {
-        let trimmed = request.negative_prompt.trim();
-        (!trimmed.is_empty()).then(|| trimmed.to_owned())
-    };
+    // Descriptor-derived denoise/guidance surface (distilled families → no guidance/negative; guided
+    // families → the scale + negative prompt). Identical to the MLX path; quant + LoRA are omitted.
+    let steps = resolve_steps(request, &model);
+    let guidance = resolve_guidance(request, &model);
+    let true_cfg = resolve_true_cfg(request, &model);
+    let negative_prompt = resolve_negative_prompt(request, &model);
 
-    // Per-payload flash-attention (sc-3674): the UI Advanced toggle sends `advanced.flashAttn`
+    // Per-payload flash/accel-attention (sc-3674): the UI Advanced toggle sends `advanced.flashAttn`
     // (default on). Process-global toggle, set before the generator loads (the candle pipeline reads
-    // it at load) — race-free because the worker runs image jobs sequentially. No effect unless the
-    // crate was built `--features flash-attn` (it is, on the Windows CUDA worker).
+    // it at load) — race-free because the worker runs image jobs sequentially. The providers expose
+    // the runtime knob under different names (SDXL `set_flash_attn`, Z-Image `set_accel_attn`); the
+    // diffusion-transformer families (flux/flux2/qwen) bake it via the build feature with no runtime
+    // toggle. No effect unless the crate was built with its flash/accel feature.
     let flash_attn = request
         .advanced
         .get("flashAttn")
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
-    candle_gen_sdxl::set_flash_attn(flash_attn);
+    match request.model.as_str() {
+        "sdxl" | "realvisxl" => candle_gen_sdxl::set_flash_attn(flash_attn),
+        "z_image_turbo" => candle_gen_z_image::set_accel_attn(flash_attn),
+        _ => {}
+    }
 
     let count = request.count as usize;
     let seeds: Vec<i64> = (0..count).map(|index| resolve_seed(request, index)).collect();
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
-    let raw_settings = mlx_raw_settings(request, repo, steps, None, guidance);
+    // Record the effective CFG knob (guidance for guided families, else true_cfg) in the recipe.
+    let raw_settings = mlx_raw_settings(request, &repo, steps, None, guidance.or(true_cfg));
     let spec = load_spec(weights_dir, None, Vec::new(), None);
 
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
-        "sdxl",
+        engine_id,
         0,
         spec,
-        "candle sdxl load failed".to_owned(),
+        format!("candle {engine_id} load failed"),
         move |generator, tx, cancel| {
             drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
                 let (out_w, out_h, pixels) = generate_one(
@@ -812,7 +876,7 @@ async fn generate_candle_stream(
                     guidance,
                     negative_prompt.clone(),
                     None,
-                    None,
+                    true_cfg,
                     &cancel,
                     on_progress,
                 )?;


### PR DESCRIPTION
## Outcome

Widens the candle (Windows/CUDA) worker lane beyond SDXL (sc-3675) to the four image families ported in epic 3692 — **z-image, flux (FLUX.1 schnell/dev), flux2 (FLUX.2-klein-9B), and qwen-image** — reachable end-to-end through the existing backend-neutral `gen_core` seam with **no candle-specific dispatch**. First story of [epic 5095](https://app.shortcut.com/trefry/epic/5095).

Story: [sc-5096](https://app.shortcut.com/trefry/story/5096)

## What changed

- **`Cargo.toml`** — bump the candle-gen pin `f5abb03 → 5ba7d8b` (candle-gen main, PR #17) and add `candle-gen-{z-image,flux,flux2,qwen-image}` deps (each `cuda`, `optional`) behind the existing **`backend-candle`** feature. `5ba7d8b` still pins `sceneworks-gen-core` at `95cd5c6` — the worker's pin — so the skew gate stays single-rev (one gen-core, one inventory registry).
- **`image_jobs.rs`** — force-link the four providers (`use candle_gen_<x> as _;`) so the MSVC release linker keeps their `inventory::submit!` registrations; broaden the `mlx_model`/`ResolvedModel` import to the candle lane; per-engine candle adapter label at the set level.
- **`image_jobs/base.rs`** — generalize `generate_candle_stream` + `is_candle_engine`. Repo/steps/guidance/negative-prompt now resolve through the shared `mlx_model`/`ResolvedModel` join (the backend-neutral `MODEL_TABLE`-row + linked-descriptor view the MLX path uses), so the four families need **no new dispatch logic** — only their crates linked. Quant + LoRA stay empty (the candle descriptors advertise neither). Per-engine flash/accel toggle (SDXL `set_flash_attn`, Z-Image `set_accel_attn`; flux/flux2/qwen bake via the build feature). Per-asset `candle_<family>` labels.
- **`engines.rs`** — broaden the backend-neutral registry-join helpers (`ResolvedModel`, `mlx_model`) to compile on the candle lane; `adapter_label` accessor annotated as MLX-path-only on the candle-only build.
- **`jobs_store.rs`** (core) — extend `CANDLE_ROUTED_MODELS` to the four base txt2img ids. The existing `image_request_candle_eligible` shape checks (edit / reference / mask / LoRA / strict-pose → Python torch) apply per-model unchanged. Routing tests updated for the widened lane.

Capability advertisement needs no change: the four engine ids already have `MODEL_TABLE` rows, so `engines::registry_capabilities` derives `image_generate` for candle automatically once the crates link.

## Why no candle-specific routing

The four engine ids (`z_image_turbo` / `flux1_schnell` / `flux1_dev` / `flux2_klein_9b` / `qwen_image`) already map onto `MODEL_TABLE` rows, and `generate_candle_stream` resolves everything off the registry descriptor. So this is purely "link the providers + let the registry advertise + reuse the neutral harness" — the same shape sc-3675 established for SDXL.

## Validation

- ✅ Default Windows build + `sceneworks-worker`/`sceneworks-core` tests (incl. the 7 candle routing tests + 4 engines registry-derivation tests).
- ✅ gen-core skew gate green **with `--features backend-candle`** — exactly one `sceneworks-gen-core` resolution.
- ✅ `cargo check` **and** `cargo clippy -- -D warnings` of the worker `--features backend-candle` → **0 warnings**; all 5 candle providers + worker compile. Built with the VS2022 BuildTools **MSVC 14.44** toolset + CUDA 12.9 (`CUDA_COMPUTE_CAP=120`, sm_120); the default VS18 14.51 toolset is rejected by CUDA 12.9.

Production routing is unchanged unless candle is explicitly enabled (`backend_candle_enabled`, default off).

## Not in this PR

- Live GPU generation per engine on the deployed Windows worker → the smoke in **sc-5099**.
- Video (wan/ltx) → **sc-5097**; JoyCaption → **sc-5098**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)