### PR TITLE
sc-5097: candle video dispatch + wire the candle video generators (wan, ltx)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-ltx"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+dependencies = [
+ "candle-gen",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
@@ -494,6 +506,18 @@ dependencies = [
  "candle-gen",
  "candle-transformers",
  "hf-hub",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
+name = "candle-gen-wan"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+dependencies = [
+ "candle-gen",
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
@@ -4974,8 +4998,10 @@ dependencies = [
  "axum",
  "candle-gen-flux",
  "candle-gen-flux2",
+ "candle-gen-ltx",
  "candle-gen-qwen-image",
  "candle-gen-sdxl",
+ "candle-gen-wan",
  "candle-gen-z-image",
  "futures-util",
  "glob",
@@ -7126,7 +7152,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3150,6 +3150,64 @@ fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
     true
 }
 
+/// The video models the candle (Windows/CUDA) lane serves (epic 5095, sc-5097): the base txt2video
+/// engines only — `wan_2_2` (→ candle `wan2_2_ti2v_5b`) and `ltx_2_3` (→ candle `ltx_2_3_distilled`).
+/// Mirrors the worker's `video_jobs::candle_video_engine_id`. The 14B Wan MoE, SVD, and `ltx_2_3_eros`
+/// have no candle provider; every conditioned mode + LoRA stays on the Python torch worker.
+const CANDLE_VIDEO_ROUTED_MODELS: &[&str] = &["wan_2_2", "ltx_2_3"];
+
+/// Does this video job belong on the candle **txt2video-only** lane (sc-5097)? The candle wan/ltx
+/// providers drive plain text-to-video only — no image-to-video / first-last-frame / extend / bridge /
+/// replace (the advanced job types), no source/reference/mask conditioning, and no LoRAs. Every other
+/// shape must fall back to the Python torch worker, so the candle worker refuses it here.
+fn video_job_is_candle_eligible(job: &JobSnapshot) -> bool {
+    // Only the base `video_generate` job type — the advanced types (VideoExtend/VideoBridge/
+    // PersonReplace) are conditioned modes the candle lane doesn't serve.
+    if !matches!(job.job_type, JobType::VideoGenerate) {
+        return false;
+    }
+    let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
+        return false;
+    };
+    video_request_candle_eligible(model, &job.payload)
+}
+
+/// Per-model candle txt2video-eligibility, factored out so the routing tests can probe it with
+/// synthetic payloads (parity with `image_request_candle_eligible`).
+fn video_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
+    if !CANDLE_VIDEO_ROUTED_MODELS.contains(&model) {
+        return false;
+    }
+    // txt2video only: the base `video_generate` mode defaults to `image_to_video`, so require an
+    // explicit `text_to_video`. Every conditioned mode (i2v / first_last_frame / extend / bridge /
+    // replace) is thereby excluded.
+    if payload.get("mode").and_then(Value::as_str) != Some("text_to_video") {
+        return false;
+    }
+    let has_nonempty_id = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    // Any conditioning asset (img2vid source, reference, inpaint mask) → torch.
+    if has_nonempty_id("sourceAssetId")
+        || has_nonempty_id("referenceAssetId")
+        || has_nonempty_id("maskAssetId")
+    {
+        return false;
+    }
+    // LoRAs are not in the candle video lane (the providers advertise none).
+    if payload
+        .get("loras")
+        .and_then(Value::as_array)
+        .is_some_and(|loras| !loras.is_empty())
+    {
+        return false;
+    }
+    true
+}
+
 /// InstantID (`instantid_realvisxl`) MLX-routing conditions. The native `mlx-gen-instantid`
 /// provider now serves the FULL surface on Mac: single-identity `character_image`, the 11-view
 /// Character-Studio angle set (sc-3345), AND pose-library mode + face-restore (sc-3381, on the
@@ -3646,18 +3704,30 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
             return false;
         }
     }
-    // Candle (Windows/CUDA) SDXL lane (epic 3672, sc-3678): the candle worker advertises only
-    // `image_generate` and serves a gated, narrow SDXL/RealVisXL **txt2img-only** lane. It must
-    // refuse every other `image_generate` shape — a non-SDXL family, or an SDXL img2img / inpaint /
-    // outpaint / reference / strict-pose / LoRA request — so those transparently fall back to the
-    // Python torch worker that co-resides on the box. Identified by the `candle` marker capability
-    // (not `gpu_id`, which is a real CUDA index here). When candle is disabled the marker is absent
-    // and this is inert, so production routing is unchanged until the lane is turned on.
-    if worker_is_candle(worker)
-        && matches!(job.job_type, JobType::ImageGenerate)
-        && !image_job_is_candle_eligible(job)
-    {
-        return false;
+    // Candle (Windows/CUDA) lane (epic 3672 image sc-3678; epic 5095 image families sc-5096 + video
+    // sc-5097): the candle worker advertises `image_generate` (+ `video_generate` once video engines
+    // are wired) and serves gated, narrow **txt2img / txt2video-only** lanes. It must refuse every
+    // other shape — a non-candle family, or a conditioned (img2img/edit/reference/inpaint/pose/
+    // i2v/extend/bridge/replace) / LoRA request — so those transparently fall back to the Python torch
+    // worker that co-resides on the box. Identified by the `candle` marker capability (not `gpu_id`,
+    // which is a real CUDA index here). When candle is disabled the marker is absent and this is inert,
+    // so production routing is unchanged until the lane is turned on.
+    if worker_is_candle(worker) {
+        if matches!(job.job_type, JobType::ImageGenerate) && !image_job_is_candle_eligible(job) {
+            return false;
+        }
+        // The candle worker advertises only the base `video_generate` (txt2video); refuse the
+        // advanced video job types and every non-eligible `video_generate` shape.
+        if matches!(
+            job.job_type,
+            JobType::VideoGenerate
+                | JobType::VideoExtend
+                | JobType::VideoBridge
+                | JobType::PersonReplace
+        ) && !video_job_is_candle_eligible(job)
+        {
+            return false;
+        }
     }
     let advertises = |capability: &str| {
         worker
@@ -4146,6 +4216,104 @@ mod candle_routing_tests {
                 "mode": "edit_image",
                 "sourceAssetId": "asset_1"
             }))
+        ));
+    }
+
+    // ---- Candle video lane (sc-5097) ----
+
+    /// A queued `video_generate` job carrying `payload`.
+    fn video_generate_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_v",
+            "type": "video_generate",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-13T00:00:00Z",
+            "updatedAt": "2026-06-13T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    // The candle worker on the video lane advertises `video_generate` + the `candle` marker.
+    const CANDLE_VIDEO_CAPS: &[&str] = &["gpu", "video_generate", "candle"];
+    const TORCH_VIDEO_CAPS: &[&str] = &["gpu", "video_generate"];
+
+    #[test]
+    fn candle_routed_video_models_txt2video_are_eligible() {
+        for model in CANDLE_VIDEO_ROUTED_MODELS {
+            assert!(
+                video_request_candle_eligible(
+                    model,
+                    &object(json!({ "mode": "text_to_video", "prompt": "a river at dawn" }))
+                ),
+                "{model} text_to_video should be candle-eligible"
+            );
+        }
+    }
+
+    #[test]
+    fn non_candle_video_models_and_conditioned_shapes_fall_back() {
+        // Models with no candle video provider stay on torch even for text_to_video.
+        for model in ["wan_2_2_t2v_14b", "wan_2_2_i2v_14b", "svd", "ltx_2_3_eros"] {
+            assert!(
+                !video_request_candle_eligible(model, &object(json!({ "mode": "text_to_video" }))),
+                "{model} must fall back to the Python worker"
+            );
+        }
+        // A wired model in any conditioned shape (default/i2v mode, a source, or a LoRA) → torch.
+        let cases = [
+            json!({ "prompt": "p" }), // no mode → defaults to i2v
+            json!({ "mode": "image_to_video", "sourceAssetId": "a" }),
+            json!({ "mode": "first_last_frame" }),
+            json!({ "mode": "text_to_video", "sourceAssetId": "a" }), // txt mode but conditioned
+            json!({ "mode": "text_to_video", "loras": [{ "name": "x" }] }),
+        ];
+        for case in cases {
+            assert!(
+                !video_request_candle_eligible("wan_2_2", &object(case.clone())),
+                "wan_2_2 shape must fall back to torch: {case}"
+            );
+        }
+    }
+
+    #[test]
+    fn candle_worker_claims_txt2video_but_refuses_other_video_shapes() {
+        let candle = gpu_worker(CANDLE_VIDEO_CAPS);
+        // Claims wan + ltx plain txt2video.
+        for model in ["wan_2_2", "ltx_2_3"] {
+            assert!(
+                worker_supports_job(
+                    &candle,
+                    &video_generate_job(json!({ "model": model, "mode": "text_to_video" }))
+                ),
+                "candle worker should claim {model} txt2video"
+            );
+        }
+        // Refuses a non-candle video model and a conditioned (i2v) shape on a wired model.
+        assert!(!worker_supports_job(
+            &candle,
+            &video_generate_job(json!({ "model": "svd", "mode": "text_to_video" }))
+        ));
+        assert!(!worker_supports_job(
+            &candle,
+            &video_generate_job(
+                json!({ "model": "wan_2_2", "mode": "image_to_video", "sourceAssetId": "a" })
+            )
+        ));
+        // The co-resident torch worker claims everything the candle worker defers.
+        let torch = gpu_worker(TORCH_VIDEO_CAPS);
+        assert!(worker_supports_job(
+            &torch,
+            &video_generate_job(
+                json!({ "model": "wan_2_2", "mode": "image_to_video", "sourceAssetId": "a" })
+            )
         ));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -79,12 +79,18 @@ inventory = "0.3"
 # Windows/CUDA worker links + force-links their `inventory::submit!` registrations. Their engine ids
 # (`z_image_turbo` / `flux1_schnell` / `flux1_dev` / `flux2_klein_9b` / `qwen_image`) already have
 # `MODEL_TABLE` rows, so `engines::registry_capabilities` advertises them with no further change.
+# sc-5097 (epic 5095) adds the two candle VIDEO providers (wan, ltx) behind the same feature, wired
+# through the new worker candle-video dispatch (`GenerationOutput::Video`). ltx registers the engine id
+# `ltx_2_3_distilled` (not the MLX `ltx_2_3`); it needs the Gemma-3-12B encoder snapshot via
+# `LTX_GEMMA_DIR` (resolved by the worker).
 backend-candle = [
     "dep:candle-gen-sdxl",
     "dep:candle-gen-z-image",
     "dep:candle-gen-flux",
     "dep:candle-gen-flux2",
     "dep:candle-gen-qwen-image",
+    "dep:candle-gen-wan",
+    "dep:candle-gen-ltx",
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -346,6 +352,11 @@ candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
 candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
 candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+# Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
+# `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
+# LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -279,6 +279,10 @@ pub(crate) const VIDEO_ENGINE_IDS: &[&str] = &[
     "wan2_2_t2v_14b",
     "wan2_2_i2v_14b",
     "ltx_2_3",
+    // The candle LTX provider registers a distinct engine id (`ltx_2_3_distilled`, not the MLX
+    // `ltx_2_3`); listed here so the registry-derived `video_generate` advertisement
+    // ([`registry_capabilities`]) picks up the candle LTX descriptor too (sc-5097).
+    "ltx_2_3_distilled",
     "svd_xt",
 ];
 

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -34,23 +34,49 @@ use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
 // `as _;` provider links below stay mlx-gen-specific (they register the video engines into the
 // registry). `cfg(target_os)` decides which backend crates link, not which contract types this
 // module names.
-#[cfg(target_os = "macos")]
+// Backend-neutral contract types shared by the macOS MLX video path AND the Windows candle video
+// lane (sc-5097): the streaming driver (`generate_video`), the output decode
+// (`run_loaded_video_generation`), and `VideoGenInput`/`video_load_spec` are all backend-neutral, so
+// these types compile on both lanes. `cfg(target_os)` decides which provider crate registered the
+// video engine, not which contract types this module names.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use gen_core::{
-    AdapterKind, AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
-    Generator, Image, LoadSpec, MoeExpert, Precision, Progress, Quant, ReplacementMode,
-    WeightsSource,
+    AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Generator,
+    LoadSpec, Precision, Progress, Quant, WeightsSource,
 };
+// MLX-only contract types (LoRA classification, MoE experts, ControlNet/VACE conditioning, Wan-VACE
+// replacement) — the candle txt2video first slice uses none of these.
+#[cfg(target_os = "macos")]
+use gen_core::{AdapterKind, Image, MoeExpert, ReplacementMode};
 #[cfg(target_os = "macos")]
 use mlx_gen_ltx as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_svd as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_wan as _;
+// Candle (Windows/CUDA) video providers (sc-5097) — force-link anchors so their `inventory::submit!`
+// registrations (`wan2_2_ti2v_5b` / `ltx_2_3_distilled`) survive the MSVC release linker, mirroring
+// the image providers in image_jobs.rs.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_ltx as _;
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_wan as _;
 #[cfg(target_os = "macos")]
 use sceneworks_core::character_store::CharacterStore;
-#[cfg(target_os = "macos")]
+// Frame-count stride coercion (Wan needs frames ≡ 1 mod 4; LTX snaps to 8k+1) — used by the MLX path
+// and the candle entry (sc-5097).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use sceneworks_core::video_request::{ltx_frame_count, wan_frame_count};
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use std::time::{Duration, Instant};
 
 /// Stub adapter id recorded on generated assets — matches the Python
@@ -270,7 +296,29 @@ pub(crate) async fn run_video_generate_job(
             None,
         )
     };
-    #[cfg(not(target_os = "macos"))]
+    // Windows/CUDA candle video lane (sc-5097): a real wan/ltx txt2video job runs through
+    // `generate_candle_video` (the same neutral encode/mux path as MLX + the stub); anything the
+    // candle lane doesn't serve stubs exactly as before. Gated on `backend_candle_enabled` (default
+    // off → routing unchanged until parity). Conditioning shapes never reach here — the router's
+    // `video_job_is_candle_eligible` confines the candle worker to txt2video.
+    #[cfg(all(target_os = "windows", feature = "backend-candle"))]
+    let (decoded, adapter, raw_settings, replacement_status) =
+        if settings.backend_candle_enabled && is_candle_video_engine(&request.model) {
+            let (decoded, adapter, raw_settings) =
+                generate_candle_video(api, settings, job, &request, backend).await?;
+            (decoded, adapter, raw_settings, None::<Value>)
+        } else {
+            (
+                generate_stub_video(&request, seed),
+                STUB_ADAPTER,
+                stub_raw_settings(&request),
+                None::<Value>,
+            )
+        };
+    #[cfg(not(any(
+        target_os = "macos",
+        all(target_os = "windows", feature = "backend-candle")
+    )))]
     let (decoded, adapter, raw_settings, replacement_status) = (
         generate_stub_video(&request, seed),
         STUB_ADAPTER,
@@ -1447,7 +1495,11 @@ fn resolve_wan_quant(request: &VideoRequest) -> Option<Quant> {
 const WAN5B_INTERIM_STEPS: u32 = 20;
 
 /// An optional positive-integer `advanced` knob (`steps`); accepts a number or a numeric string.
-#[cfg(target_os = "macos")]
+/// Shared by the MLX path and the candle video lane (sc-5097).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn advanced_opt_u32(request: &VideoRequest, key: &str) -> Option<u32> {
     request.advanced.get(key).and_then(|value| {
         value
@@ -1458,7 +1510,11 @@ fn advanced_opt_u32(request: &VideoRequest, key: &str) -> Option<u32> {
 }
 
 /// An optional float `advanced` knob (`guidanceScale`); accepts a number or a numeric string.
-#[cfg(target_os = "macos")]
+/// Shared by the MLX path and the candle video lane (sc-5097).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn advanced_opt_f32(request: &VideoRequest, key: &str) -> Option<f32> {
     request.advanced.get(key).and_then(|value| {
         value
@@ -1489,7 +1545,10 @@ fn wan_sampling(engine_id: &str, request: &VideoRequest) -> (Option<u32>, Option
 /// Wan (sc-3034) and LTX (sc-3035) — split out so the engine call is unit-testable on real
 /// weights without the API/job plumbing. The LTX-only knobs (`video_mode` no_audio,
 /// prompt-enhance) default off for Wan; the Wan-only `moe_expert` rides on `adapters`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 struct VideoGenInput {
     engine_id: &'static str,
     model_dir: PathBuf,
@@ -1522,7 +1581,10 @@ struct VideoGenInput {
     conditioning_fps: Option<u32>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 impl Default for VideoGenInput {
     fn default() -> Self {
         Self {
@@ -1554,7 +1616,10 @@ impl Default for VideoGenInput {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
     LoadSpec {
         weights: WeightsSource::Dir(input.model_dir.clone()),
@@ -1571,7 +1636,10 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
 /// Run one generation to a [`DecodedVideo`] (RGB8 frames + fps + optional audio) against an already
 /// loaded video generator, streaming denoise progress via `on_progress` and honoring `cancel`.
 /// The engine fills the audio track (LTX) or leaves it `None` (Wan).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn run_loaded_video_generation(
     generator: &dyn Generator,
     input: VideoGenInput,
@@ -1660,7 +1728,10 @@ fn run_video_generation(
 /// error instead of heartbeating indefinitely. Tuned well above any legitimate single load or
 /// step on the current video models; override via `SCENEWORKS_VIDEO_STALL_SECS` for an
 /// unusually large/slow model or disk.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const VIDEO_STALL_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Grace period granted after a stall is detected and engine cancellation is requested, before
@@ -1668,19 +1739,28 @@ const VIDEO_STALL_TIMEOUT: Duration = Duration::from_secs(600);
 /// within this window (the manual-cancel path proves it honors the flag); the abandon escape
 /// only matters for a hard Metal wedge that never re-checks cancel, and keeps the watchdog from
 /// itself re-hanging on the join.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const VIDEO_STALL_GRACE: Duration = Duration::from_secs(60);
 
 /// The effective forward-progress stall timeout: `SCENEWORKS_VIDEO_STALL_SECS` (a positive
 /// integer number of seconds) when set, else [`VIDEO_STALL_TIMEOUT`].
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn video_stall_timeout() -> Duration {
     parse_stall_timeout(std::env::var("SCENEWORKS_VIDEO_STALL_SECS").ok())
 }
 
 /// Parse the `SCENEWORKS_VIDEO_STALL_SECS` override (a positive integer number of seconds),
 /// falling back to [`VIDEO_STALL_TIMEOUT`] when unset, blank, non-numeric, or zero.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn parse_stall_timeout(raw: Option<String>) -> Duration {
     raw.and_then(|raw| raw.trim().parse::<u64>().ok())
         .filter(|secs| *secs > 0)
@@ -1692,7 +1772,10 @@ fn parse_stall_timeout(raw: Option<String>) -> Duration {
 /// progress to the async worker (Generating stage ~0.25..0.58) + polling cancel ~every 2s.
 /// The shared blocking + mpsc + cancel plumbing for Wan and LTX. A forward-progress watchdog
 /// ([`video_stall_timeout`]) fails a wedged job loudly rather than letting it look alive forever.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 async fn generate_video(
     api: &ApiClient,
     settings: &Settings,
@@ -1849,6 +1932,176 @@ async fn generate_video(
         return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
     }
     result
+}
+
+// ---------------------------------------------------------------------------
+// Candle (Windows/CUDA) video lane (sc-5097, epic 5095). The candle wan/ltx providers serve a narrow
+// **txt2video-only** first slice (no image/VACE conditioning, audio, LoRA, or quant). This is the
+// video sibling of the candle image lane (image_jobs.rs `generate_candle_stream`): it builds a
+// `VideoGenInput` and drives the SAME neutral streaming harness (`generate_video` →
+// `run_loaded_video_generation` → the registry-resolved candle generator), reusing the shared
+// encode/mux/poster path. Reached only when `backend_candle_enabled` (default off).
+// ---------------------------------------------------------------------------
+
+/// Per-asset adapter ids for the candle video engines (`candle_<family>`), the candle siblings of
+/// the MLX `mlx_wan` / `mlx_ltx` labels (sc-5097).
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_WAN_ADAPTER: &str = "candle_wan";
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_LTX_ADAPTER: &str = "candle_ltx";
+
+/// Default HuggingFace repos the candle video providers load (overridable via the manifest `repo`).
+/// The candle wan provider reads a Wan2.2-TI2V-5B diffusers snapshot; ltx reads the LTX-2.3 checkpoint
+/// plus a separate Gemma-3-12B encoder snapshot (`LTX_GEMMA_DIR`).
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_WAN_REPO: &str = "Wan-AI/Wan2.2-TI2V-5B-Diffusers";
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_LTX_REPO: &str = "Lightricks/LTX-2.3";
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_LTX_GEMMA_REPO: &str = "google/gemma-3-12b-it";
+
+/// SceneWorks video model id → candle registry engine id, or `None` for an id the candle video lane
+/// does not serve. Note ltx maps to `ltx_2_3_distilled` (the candle provider's id), not the MLX
+/// `ltx_2_3`. Only the base txt2video ids — the 14B Wan MoE, SVD, and `ltx_2_3_eros` stay on torch.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn candle_video_engine_id(model: &str) -> Option<&'static str> {
+    match model {
+        "wan_2_2" => Some("wan2_2_ti2v_5b"),
+        "ltx_2_3" => Some("ltx_2_3_distilled"),
+        _ => None,
+    }
+}
+
+/// Whether `model` is served by the candle video lane (sc-5097).
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn is_candle_video_engine(model: &str) -> bool {
+    candle_video_engine_id(model).is_some()
+}
+
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn candle_video_adapter_label(engine_id: &str) -> &'static str {
+    if engine_id == "ltx_2_3_distilled" {
+        CANDLE_LTX_ADAPTER
+    } else {
+        CANDLE_WAN_ADAPTER
+    }
+}
+
+/// The candle weights repo for a video engine: the manifest `repo` wins, else the candle default repo
+/// for the engine.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn candle_video_repo(request: &VideoRequest, engine_id: &str) -> String {
+    let default_repo = if engine_id == "ltx_2_3_distilled" {
+        CANDLE_LTX_REPO
+    } else {
+        CANDLE_WAN_REPO
+    };
+    request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default_repo)
+        .to_owned()
+}
+
+/// Resolve the candle weights snapshot dir for `repo`. Errors loudly (no procedural-stub fallback)
+/// when the snapshot is absent, so a missing model surfaces a re-download error.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn candle_video_snapshot_dir(settings: &Settings, repo: &str) -> WorkerResult<PathBuf> {
+    huggingface_snapshot_dir(&settings.data_dir, repo).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "candle video weights snapshot not found for {repo}"
+        ))
+    })
+}
+
+/// Point the candle LTX provider at the Gemma-3-12B encoder snapshot via `LTX_GEMMA_DIR` (the env var
+/// the provider reads; it otherwise falls back to `<checkpoint>/text_encoder`). Best-effort: if the
+/// Gemma snapshot isn't in the HF cache we leave `LTX_GEMMA_DIR` unset so the provider tries its
+/// `<root>/text_encoder` fallback and emits its own clear "set LTX_GEMMA_DIR …" error. The worker runs
+/// video jobs sequentially, so the process-global env set is race-free.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn ensure_ltx_gemma_dir(settings: &Settings) {
+    if std::env::var_os("LTX_GEMMA_DIR").is_some() {
+        return; // honor an explicit operator override.
+    }
+    if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, CANDLE_LTX_GEMMA_REPO) {
+        std::env::set_var("LTX_GEMMA_DIR", dir);
+    }
+}
+
+/// Raw-settings recorded on a candle video asset (mirrors `wan_raw_settings`, trimmed to the
+/// txt2video surface): the request `advanced` knobs plus the real-inference markers.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn candle_video_raw_settings(request: &VideoRequest, repo: &str) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("frameCount".to_owned(), json!(request.frame_count()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    Value::Object(raw)
+}
+
+/// Windows/CUDA candle txt2video path (sc-5097). Resolves the engine + weights, provisions the LTX
+/// Gemma encoder, builds a txt2video `VideoGenInput`, and runs it through the shared
+/// [`generate_video`] streaming driver. Returns the decoded clip + the candle adapter label.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+async fn generate_candle_video(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    backend: &str,
+) -> WorkerResult<(DecodedVideo, &'static str, Value)> {
+    let engine_id = candle_video_engine_id(&request.model).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!("{} is not a candle video engine", request.model))
+    })?;
+    let adapter = candle_video_adapter_label(engine_id);
+    let repo = candle_video_repo(request, engine_id);
+    let model_dir = candle_video_snapshot_dir(settings, &repo)?;
+    // ltx needs the separate Gemma-3-12B encoder (its only conditioning input).
+    let is_ltx = engine_id == "ltx_2_3_distilled";
+    if is_ltx {
+        ensure_ltx_gemma_dir(settings);
+    }
+    // Descriptor-narrowed sampling surface: wan takes guidance + a negative prompt; the distilled ltx
+    // takes neither (single-stage, no CFG). Steps/guidance default to the provider's own constants
+    // when the request omits them.
+    let steps = advanced_opt_u32(request, "steps");
+    let (guidance, negative_prompt) = if is_ltx {
+        (None, None)
+    } else {
+        let guidance = advanced_opt_f32(request, "guidanceScale");
+        let trimmed = request.negative_prompt.trim();
+        let negative = (!trimmed.is_empty()).then(|| trimmed.to_owned());
+        (guidance, negative)
+    };
+    // Coerce the requested frame count onto each engine's temporal stride (wan: ≡1 mod 4; ltx: 8k+1).
+    let frames = if is_ltx {
+        ltx_frame_count(request.raw_frame_count())
+    } else {
+        wan_frame_count(request.raw_frame_count())
+    };
+    let input = VideoGenInput {
+        engine_id,
+        model_dir,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames,
+        fps: request.fps,
+        steps,
+        guidance,
+        seed: resolve_video_seed(request) as u64,
+        ..VideoGenInput::default()
+    };
+    let raw_settings = candle_video_raw_settings(request, &repo);
+    let decoded = generate_video(api, settings, job, backend, input).await?;
+    Ok((decoded, adapter, raw_settings))
 }
 
 /// Resolve a Wan request into a [`VideoGenInput`] and run it (sc-3034).


### PR DESCRIPTION
## Outcome

Adds the worker **candle video lane** (epic 5095, builds on sc-5096 #638): real **wan** (Wan2.2 TI2V-5B) and **ltx** (LTX-2.3 distilled) txt2video jobs route through the candle Windows/CUDA backend and emit video assets, reusing the neutral encode/mux/poster path.

Story: [sc-5097](https://app.shortcut.com/trefry/story/5097)

## The new seam

The candle dispatch was txt2img-only (handled `GenerationOutput::Images`). The video providers return `GenerationOutput::Video { frames, fps, audio }`; this story adds the candle video output path — the candle analog of the MLX video path.

## What changed

- **`Cargo.toml`** — add `candle-gen-wan` + `candle-gen-ltx` (each `cuda`, `optional`) behind the `backend-candle` feature, same pin (`5ba7d8b`) as the image providers.
- **`video_jobs.rs`** — force-link the two providers; **broaden the backend-neutral video machinery** (`VideoGenInput`, `video_load_spec`, `run_loaded_video_generation`, the `generate_video` streaming driver + forward-progress stall watchdog, `advanced_opt_*`) to the candle lane, then add a thin **`generate_candle_video`** that resolves the engine + weights, provisions the LTX Gemma-3-12B encoder via `LTX_GEMMA_DIR`, coerces the frame count onto each engine's temporal stride (wan ≡1 mod 4 / ltx 8k+1), and drives the shared driver. `GenerationOutput::Video → DecodedVideo` is the exact decode the MLX path uses, so the encode/mux/poster path is unchanged. Dispatch routes to candle when `backend_candle_enabled`.
- **`engines.rs`** — add `ltx_2_3_distilled` to `VIDEO_ENGINE_IDS` (the candle LTX engine id — **not** the MLX `ltx_2_3`) so `registry_capabilities` derives `video_generate` for candle. wan's `wan2_2_ti2v_5b` was already present.
- **`jobs_store.rs`** — candle video routing: `CANDLE_VIDEO_ROUTED_MODELS` (`wan_2_2` → `wan2_2_ti2v_5b`, `ltx_2_3` → `ltx_2_3_distilled`) + `video_request_candle_eligible` (txt2video only — i2v / first_last_frame / extend / bridge / replace / conditioning / LoRA fall back to the Python torch worker); extend the `worker_supports_job` candle branch to gate `video_generate` and refuse the advanced video job types. Routing tests added.

## LTX Gemma encoder (`LTX_GEMMA_DIR`)

The candle LTX provider reads its Gemma-3-12B text encoder from `LTX_GEMMA_DIR` (else `<checkpoint>/text_encoder`). `ensure_ltx_gemma_dir` points it at the `google/gemma-3-12b-it` HF-cache snapshot before load (honoring an explicit operator override); if the snapshot is absent it leaves the var unset so the provider emits its own clear "set LTX_GEMMA_DIR …" error. Default repos: wan `Wan-AI/Wan2.2-TI2V-5B-Diffusers`, ltx `Lightricks/LTX-2.3` (manifest `repo` overrides).

## Scope

The candle wan/ltx providers are **txt2video first-slice only** — image/VACE conditioning, audio, LoRA, and quant are deferred in the providers and deliberately **not** advertised, so those shapes route to torch.

## Validation

- ✅ Default Windows build + 120 worker / 157 core lib tests (incl. 10 candle routing tests).
- ✅ `cargo clippy --features backend-candle -- -D warnings` of the worker → **0 warnings**; both new video providers compiled (MSVC 14.44 / CUDA 12.9, sm_120).

Production routing is unchanged unless candle is explicitly enabled (`backend_candle_enabled`, default off).

## Not in this PR

- Live GPU render per engine on the deployed Windows worker → the smoke in **sc-5099**.
- JoyCaption captioner → **sc-5098**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)