### PR TITLE
sc-5098: wire the candle JoyCaption captioner into the worker caption job path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-joycaption"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+dependencies = [
+ "candle-gen",
+ "inventory",
+ "rand 0.9.4",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
 source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
@@ -4998,6 +5009,7 @@ dependencies = [
  "axum",
  "candle-gen-flux",
  "candle-gen-flux2",
+ "candle-gen-joycaption",
  "candle-gen-ltx",
  "candle-gen-qwen-image",
  "candle-gen-sdxl",
@@ -7152,7 +7164,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3728,6 +3728,12 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         {
             return false;
         }
+        // Dataset captioning (sc-5098): the candle worker serves only JoyCaption (the candle
+        // captioner provider). A non-`joy_caption` caption job stays on the Python torch worker.
+        // Eligibility is backend-neutral (captioner == joy_caption), so reuse the mlx gate.
+        if matches!(job.job_type, JobType::TrainingCaption) && !caption_job_is_mlx_eligible(job) {
+            return false;
+        }
     }
     let advertises = |capability: &str| {
         worker
@@ -4314,6 +4320,48 @@ mod candle_routing_tests {
             &video_generate_job(
                 json!({ "model": "wan_2_2", "mode": "image_to_video", "sourceAssetId": "a" })
             )
+        ));
+    }
+
+    // ---- Candle caption lane (sc-5098) ----
+
+    /// A queued `training_caption` job carrying `payload`.
+    fn caption_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_c",
+            "type": "training_caption",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-06-13T00:00:00Z",
+            "updatedAt": "2026-06-13T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    #[test]
+    fn candle_worker_claims_joycaption_but_refuses_other_captioners() {
+        let candle = gpu_worker(&["gpu", "training_caption", "candle"]);
+        // Claims a JoyCaption job.
+        assert!(worker_supports_job(
+            &candle,
+            &caption_job(json!({ "captioner": "joy_caption", "datasetId": "ds_1" }))
+        ));
+        // Refuses a non-JoyCaption captioner → falls back to the Python torch worker.
+        assert!(!worker_supports_job(
+            &candle,
+            &caption_job(json!({ "captioner": "blip2", "datasetId": "ds_1" }))
+        ));
+        let torch = gpu_worker(&["gpu", "training_caption"]);
+        assert!(worker_supports_job(
+            &torch,
+            &caption_job(json!({ "captioner": "blip2", "datasetId": "ds_1" }))
         ));
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -91,6 +91,9 @@ backend-candle = [
     "dep:candle-gen-qwen-image",
     "dep:candle-gen-wan",
     "dep:candle-gen-ltx",
+    # sc-5098 (epic 5095): the candle JoyCaption captioner (image->text), wired into the worker's
+    # caption job path via the neutral `gen_core::load_captioner` seam.
+    "dep:candle-gen-joycaption",
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -357,6 +360,10 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
 candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
 candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+# Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
+# captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
+# caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -1,29 +1,49 @@
-//! Native MLX dataset captioning (epic 3550, sc-3556).
+//! Native dataset captioning (epic 3550, sc-3556 MLX; epic 5095 sc-5098 candle).
 //!
 //! SceneWorks keeps the existing `training_caption` job contract and result shape,
-//! but the macOS `mlx` worker can now serve `captioner=joy_caption` in-process via
-//! mlx-gen's JoyCaption provider. The Python torch captioner remains the
-//! Windows/Linux path and the explicit non-MLX fallback.
+//! but the in-process Rust worker can serve `captioner=joy_caption` through the
+//! backend-neutral `gen_core::load_captioner` seam: the macOS `mlx` worker via mlx-gen's
+//! JoyCaption provider, and the Windows/CUDA candle worker via candle-gen-joycaption
+//! (`--features backend-candle`). `cfg(target_os)` only decides which provider crate registers the
+//! captioner; the job flow below is identical. The Python torch captioner remains the explicit
+//! non-MLX/non-candle fallback (and the default Windows/Linux path).
 
 use super::*;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const JOY_CAPTION_MODEL: &str = "fancyfeast/llama-joycaption-beta-one-hf-llava";
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const CANCEL_MESSAGE: &str = "Training captioning canceled by user.";
 
 // epic 3720 (sc-3724): the backend-neutral captioner contract types come from `gen_core`; the
 // `as _;` provider link below stays mlx-gen-specific (it registers the JoyCaption captioner into
 // the registry).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 use gen_core::{
     CancelFlag, CaptionOptions, CaptionRequest, CaptionSampling, Image, LoadSpec, Progress,
     WeightsSource,
 };
 #[cfg(target_os = "macos")]
 use mlx_gen_joycaption as _;
+// Candle JoyCaption captioner force-link anchor (sc-5098): keeps its `inventory::submit!` captioner
+// registration (`fancyfeast/llama-joycaption-beta-one-hf-llava`, backend `candle`) from being dropped
+// by the MSVC release linker. Mirrors the mlx anchor above.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_joycaption as _;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 #[derive(Clone, Debug)]
 struct CaptionItem {
     item_id: String,
@@ -31,14 +51,20 @@ struct CaptionItem {
     trigger_words: Vec<String>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 #[derive(Clone, Debug)]
 struct CaptionJobOptions {
     options: CaptionOptions,
     sampling: CaptionSampling,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 #[derive(Debug)]
 enum CaptionEvent {
     Step {
@@ -54,7 +80,10 @@ enum CaptionEvent {
     },
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 pub(crate) async fn run_training_caption_job(
     api: &ApiClient,
     settings: &Settings,
@@ -175,11 +204,10 @@ pub(crate) async fn run_training_caption_job(
                 .map_err(|error| {
                     WorkerError::Engine(format!("JoyCaption MLX generation failed: {error}"))
                 })?;
-            // epic 3720: JoyCaption trigger-word string helper stays mlx-gen-local until lifted to gen_core::caption.
-            let text = mlx_gen::caption::joycaption::apply_trigger_words(
-                &output.text,
-                &item.trigger_words,
-            );
+            // Prepend any missing trigger words to the caption. Backend-neutral worker-local helper
+            // (sc-5098) — the same logic mlx-gen + candle-gen each ship locally — so the shared path
+            // names no backend-specific symbol.
+            let text = apply_trigger_words(&output.text, &item.trigger_words);
             tx.blocking_send(CaptionEvent::Captioned {
                 index,
                 item_id: item.item_id,
@@ -300,19 +328,26 @@ pub(crate) async fn run_training_caption_job(
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+)))]
 pub(crate) async fn run_training_caption_job(
     _api: &ApiClient,
     _settings: &Settings,
     _job: &JobSnapshot,
 ) -> WorkerResult<()> {
     Err(WorkerError::InvalidPayload(
-        "The Rust JoyCaption worker is macOS/MLX-only; use the Python torch captioner on this platform."
+        "The in-process JoyCaption worker needs the macOS MLX backend or the Windows candle backend; \
+         use the Python torch captioner on this platform."
             .to_owned(),
     ))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn caption_progress(
     status: JobStatus,
     stage: ProgressStage,
@@ -338,7 +373,10 @@ fn caption_progress(
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn caption_result(
     model_name_or_path: &str,
     dataset_id: &str,
@@ -368,7 +406,10 @@ fn caption_result(
     result
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn caption_items(settings: &Settings, payload: &JsonObject) -> WorkerResult<Vec<CaptionItem>> {
     let dataset_root = payload
         .get("datasetRoot")
@@ -439,7 +480,10 @@ fn caption_items(settings: &Settings, payload: &JsonObject) -> WorkerResult<Vec<
         .collect()
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn caption_job_options(payload: &JsonObject) -> CaptionJobOptions {
     let options = payload
         .get("options")
@@ -483,7 +527,10 @@ fn caption_job_options(payload: &JsonObject) -> CaptionJobOptions {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn option_string(options: &JsonObject, key: &str, default: &str) -> String {
     options
         .get(key)
@@ -492,7 +539,10 @@ fn option_string(options: &JsonObject, key: &str, default: &str) -> String {
         .to_owned()
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn resolve_caption_weights_dir(
     settings: &Settings,
     model_name_or_path: &str,
@@ -500,7 +550,10 @@ fn resolve_caption_weights_dir(
     resolve_app_managed_model_dir(settings, model_name_or_path, "JoyCaption model path")
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn load_caption_image(path: &Path) -> WorkerResult<Image> {
     let decoded = image::open(path)
         .map_err(|error| {
@@ -514,7 +567,10 @@ fn load_caption_image(path: &Path) -> WorkerResult<Image> {
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn caption_step_progress(index: usize, current: u32, total: u32, item_count: usize) -> f64 {
     let item_count = item_count.max(1) as f64;
     let within = if total > 0 {
@@ -525,7 +581,39 @@ fn caption_step_progress(index: usize, current: u32, total: u32, item_count: usi
     (0.12 + 0.76 * ((index as f64 + within) / item_count)).min(0.9)
 }
 
-#[cfg(all(test, target_os = "macos"))]
+/// Prepend the trigger words that are not already present (case-insensitive substring) to the
+/// captioner's text, comma-joined, with the cleaned caption last. Backend-neutral copy of the
+/// identical helper both `mlx-gen` and `candle-gen` ship locally (the comment in the engines noted it
+/// should be lifted out of the provider) — keeping it here means the shared caption path names no
+/// backend-specific symbol (sc-5098). Matches the engine behavior 1:1, including the empty-caption
+/// case (just the missing trigger words).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
+fn apply_trigger_words(caption: &str, trigger_words: &[String]) -> String {
+    let cleaned = caption.split_whitespace().collect::<Vec<_>>().join(" ");
+    let lower_caption = cleaned.to_lowercase();
+    let mut parts: Vec<String> = trigger_words
+        .iter()
+        .map(|word| word.trim())
+        .filter(|word| !word.is_empty())
+        .filter(|word| !lower_caption.contains(&word.to_lowercase()))
+        .map(ToOwned::to_owned)
+        .collect();
+    if !cleaned.is_empty() {
+        parts.push(cleaned);
+    }
+    parts.join(", ")
+}
+
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        all(target_os = "windows", feature = "backend-candle")
+    )
+))]
 mod tests {
     use super::*;
 
@@ -578,6 +666,20 @@ mod tests {
         assert_eq!(options.sampling.temperature, 0.5);
         assert_eq!(options.sampling.top_p, 0.8);
         assert_eq!(options.sampling.max_new_tokens, 128);
+    }
+
+    #[test]
+    fn apply_trigger_words_prepends_only_missing() {
+        let triggers = vec!["mika_token".to_owned(), "hat".to_owned()];
+        // "hat" already appears in the caption → dropped; "mika_token" prepended.
+        assert_eq!(
+            apply_trigger_words("A portrait of Mika wearing a hat.", &triggers),
+            "mika_token, A portrait of Mika wearing a hat."
+        );
+        // Empty/whitespace caption → just the (whitespace-normalized) trigger words.
+        assert_eq!(apply_trigger_words("   ", &triggers), "mika_token, hat");
+        // No triggers → the cleaned caption unchanged.
+        assert_eq!(apply_trigger_words("  a  cat ", &[]), "a cat");
     }
 
     #[test]


### PR DESCRIPTION
## Outcome

Training-dataset caption jobs now route through the candle **JoyCaption** captioner on Windows/CUDA (epic 5095, builds on sc-5096 #638 + sc-5097 #639) — the candle analog of the MLX wiring in sc-3556.

Story: [sc-5098](https://app.shortcut.com/trefry/story/5098)

## Context

JoyCaption is a `gen_core::Captioner` (image → text), **not** a `Generator`, so it does not flow through the generate path the other six families use. It resolves via `gen_core::load_captioner("fancyfeast/llama-joycaption-beta-one-hf-llava", spec)` and is driven by `Captioner::caption(req, on_progress)`. The worker's caption flow was already backend-neutral, so this is mostly a lane-broadening.

## What changed

- **`Cargo.toml`** — add `candle-gen-joycaption` (`cuda`, `optional`) behind the `backend-candle` feature, same pin (`5ba7d8b`).
- **`caption_jobs.rs`** — broaden the whole JoyCaption caption flow from macOS-only to the candle lane (it already resolves through `gen_core::load_captioner` + `Captioner::caption`). Force-link `candle_gen_joycaption`; the non-macOS stub now fires only off *both* backends. The one backend-specific call (`mlx_gen::caption::joycaption::apply_trigger_words`) is replaced by a **neutral worker-local `apply_trigger_words`** (the identical logic both engines ship locally — the engine comment noted it should be lifted out), so the shared path names no backend-specific symbol. Caption type/length, custom prompt, sampling, `max_new_tokens`, and the typed pre-cancellation flow are unchanged.
- **`jobs_store.rs`** — gate `training_caption` on the candle worker: only `joy_caption` jobs are claimed; any other captioner falls back to the Python torch worker. Eligibility is backend-neutral (`captioner == joy_caption`), so it reuses `caption_job_is_mlx_eligible`. Routing test added.

Capability advertisement needs no change: `engines::registry_capabilities` already derives `training_caption` for any enabled backend with a registered JoyCaption descriptor, so the candle descriptor (backend `candle`) lights it up.

## Validation

- ✅ Default Windows build unchanged (caption → stub off both native backends); core routing tests green (incl. the candle caption gate).
- ✅ `cargo clippy --features backend-candle -- -D warnings` of the worker → **0 warnings**; candle-gen-joycaption compiled.
- ✅ Candle caption unit tests pass **4/4** under the feature (incl. `apply_trigger_words`), MSVC 14.44 / CUDA 12.9 (sm_120).

Production routing is unchanged unless candle is explicitly enabled (`backend_candle_enabled`, default off).

## Not in this PR

- Live caption smoke on the deployed Windows worker → the smoke in **sc-5099** (the final epic story: per-engine labeling + Python-fallback hardening + live e2e across image/video/caption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)