### PR TITLE
sc-5105: cut Lens / Lens-Turbo to native Rust mlx-gen-lens on Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ source = "git+https://github.com/michaeltrefry/candle-gen?rev=f5abb03325658ee17c
 dependencies = [
  "candle-core",
  "candle-nn",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260)",
  "thiserror 2.0.18",
 ]
 
@@ -3056,11 +3056,11 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63)",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3080,7 +3080,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3133,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "image",
  "inventory",
@@ -3143,9 +3143,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-lens"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "mlx-gen-flux2",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "image",
  "inventory",
@@ -3157,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3169,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3179,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3188,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3197,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "image",
  "inventory",
@@ -3210,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3221,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3232,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "image",
  "inventory",
@@ -3246,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
 dependencies = [
  "image",
  "inventory",
@@ -4874,6 +4886,17 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63#4db50b24fd0b1ee27e8ebe1f16292436b9767b63"
+dependencies = [
+ "inventory",
+ "safetensors 0.4.5",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
 dependencies = [
  "inventory",
@@ -4935,6 +4958,7 @@ dependencies = [
  "mlx-gen-instantid",
  "mlx-gen-joycaption",
  "mlx-gen-kolors",
+ "mlx-gen-lens",
  "mlx-gen-ltx",
  "mlx-gen-pulid",
  "mlx-gen-qwen-image",
@@ -4950,7 +4974,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=4db50b24fd0b1ee27e8ebe1f16292436b9767b63)",
  "serde",
  "serde_json",
  "sha2",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -2725,8 +2725,8 @@ async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
             { "id": "z_image_turbo", "name": "Z-Image-Turbo", "family": "z-image", "type": "image",
               "adapter": "z_image_diffusers", "capabilities": ["text_to_image"], "downloads": [],
               "paths": {}, "defaults": {}, "limits": {}, "loraCompatibility": { "families": [], "types": [] }, "ui": {} },
-            { "id": "lens", "name": "Lens", "family": "lens", "type": "image",
-              "adapter": "lens_turbo", "capabilities": ["text_to_image"], "downloads": [],
+            { "id": "unported_image_model", "name": "Unported", "family": "unported", "type": "image",
+              "adapter": "procedural_preview", "capabilities": ["text_to_image"], "downloads": [],
               "paths": {}, "defaults": {}, "limits": {}, "loraCompatibility": { "families": [], "types": [] }, "ui": {} },
             { "id": "svd", "name": "SVD", "family": "svd", "type": "video",
               "adapter": "svd_video", "capabilities": ["image_to_video"], "downloads": [],
@@ -2752,15 +2752,15 @@ async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
             .cloned()
             .unwrap_or(Value::Null)
     };
-    // Torch-only image model → unsupported on Mac, names its port epic. (Kolors base T2I — sc-3875
-    // — and PuLID-FLUX — sc-3344 — are now MLX-routed, so neither is a torch-only example anymore;
-    // the `lens` family is still torch-only, epic 3164.)
-    let torch_only = by_id("lens");
+    // Unported image model (no Rust/MLX engine) → unsupported on Mac, with a gap reason. No real
+    // image model is torch-only anymore: every family was ported to MLX — Kolors (sc-3875),
+    // PuLID-FLUX (sc-3344), and finally Lens / Lens-Turbo (epic 3164 / sc-5105, the last one) — so
+    // the torch-only gating is demonstrated with a synthetic unported id, which has no dedicated
+    // port epic (suggestedEpic absent → "needs an epic", epic 3482 policy).
+    let torch_only = by_id("unported_image_model");
     assert_eq!(torch_only["macSupport"]["supported"], false);
-    assert_eq!(
-        torch_only["macSupport"]["reason"]["suggestedEpic"],
-        "epic 3164"
-    );
+    assert!(torch_only["macSupport"]["reason"].is_object());
+    assert!(torch_only["macSupport"]["reason"]["suggestedEpic"].is_null());
     // MLX-routed family → supported, stays in the picker.
     assert_eq!(by_id("z_image_turbo")["macSupport"]["supported"], true);
     // SVD is now MLX-routed (sc-3523: `svd`→`svd_xt`, image→video only) → supported.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2392,27 +2392,17 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
 /// unported model gets its own port epic + is dropped on Mac until it lands). `None` = a
 /// model we don't have a port epic for yet, which the oracle reports as "needs an epic".
 /// Keep in sync with `docs/mac-rust-gaps.md` §1.
-fn torch_only_image_model_epic(model: &str) -> Option<&'static str> {
-    match model {
-        // Kolors base T2I was ported to MLX (epic 3090 / sc-3875) — it is now in
-        // `MLX_ROUTED_MODELS`, so it never reaches this whole-model torch-only classifier. Its
-        // not-yet-wired advanced modes (img2img / IP-Adapter / pose) are named per-feature in
-        // `classify_image_gap`, not as a whole-model gap.
-        // InstantID (instantid_realvisxl) was ported to MLX (epic 3109 engine / sc-3345) — it is
-        // now in `MLX_ROUTED_MODELS`, so it never reaches this torch-only classifier. Its
-        // remaining gaps (pose-library mode, face-restore) are named per-feature in
-        // `classify_image_gap`, not as a whole-model gap.
-        // PuLID-FLUX (pulid_flux_dev) was ported to MLX (epic 3069 engine / sc-3344) — it is now in
-        // `MLX_ROUTED_MODELS`, so it never reaches this torch-only classifier. A reference-less /
-        // non-character job has no PuLID path and is named per-feature in `classify_image_gap`.
-        // z_image_edit was ported to MLX (epic 3529 / sc-3923) — it is now in
-        // `MLX_ROUTED_MODELS`, so it never reaches this torch-only gap classifier.
-        m if m.starts_with("lens") => Some("epic 3164"),
-        // Chroma (chroma1_*, epic 3531 / sc-3843) and SenseNova-U1 (sensenova_u1_8b[_fast],
-        // epic 3180 / sc-3900) were ported to MLX — they are now in `MLX_ROUTED_MODELS`, so
-        // neither reaches this torch-only gap classifier.
-        _ => None,
-    }
+///
+/// **No whole-model torch-only image families remain.** Each was ported to MLX and moved into
+/// `MLX_ROUTED_MODELS`, so it never reaches this classifier: Kolors (epic 3090 / sc-3875), InstantID
+/// (epic 3109 / sc-3345), PuLID-FLUX (epic 3069 / sc-3344), z_image_edit (epic 3529 / sc-3923),
+/// Chroma (epic 3531 / sc-3843), SenseNova-U1 (epic 3180 / sc-3900), and finally Lens / Lens-Turbo
+/// (epic 3164 / sc-5105 — the LAST one). Models with a partial surface (e.g. InstantID pose-library,
+/// PuLID reference-less) are named per-feature in `classify_image_gap`, not here. This function is
+/// retained for the generic "unported model → needs a port epic" path and as the seam for any future
+/// torch-only image model: add a `match _model { "<id>" => Some("epic NNNN"), _ => None }` arm here.
+fn torch_only_image_model_epic(_model: &str) -> Option<&'static str> {
+    None
 }
 
 /// Name the precise gap for an ineligible `image_generate` / `image_edit` job: a torch-only
@@ -2937,6 +2927,14 @@ const MLX_ROUTED_MODELS: &[&str] = &[
     // img2img (sc-4765), the IP-Adapter-Plus reference (sc-4767) and the strict-pose tier (sc-4766 /
     // engine sc-5012, the combined pose-ControlNet + IP-Adapter-identity + img2img pass).
     "kolors",
+    // Microsoft Lens / Lens-Turbo (epic 3164 engine / sc-5105 cutover): pure T2I on the native
+    // `mlx-gen-lens` engine (gpt-oss-20b MoE encoder + dual-stream MMDiT + Flux.2 VAE), retiring the
+    // Python `/opt/lens-venv` transformers-5 sidecar on Mac. Both ids are always MLX-eligible
+    // (`lens_mlx_eligible` — no conditioning surface to gate). Lens was the LAST whole-model
+    // torch-only image family; with it routed, every image model here is MLX (`torch_only_image_model_epic`
+    // now matches nothing).
+    "lens",
+    "lens_turbo",
 ];
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
@@ -2994,6 +2992,7 @@ fn image_request_mlx_eligible(model: &str, payload: &Map<String, Value>) -> bool
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => chroma_mlx_eligible(payload),
         "sensenova_u1_8b" | "sensenova_u1_8b_fast" => sensenova_mlx_eligible(payload),
         "kolors" => kolors_mlx_eligible(payload),
+        "lens" | "lens_turbo" => lens_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
         _ => false,
     }
@@ -3327,6 +3326,19 @@ fn sensenova_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// LoKr apply on the SDXL-family loader (epic 3641), so a LoRA never forces torch.
 fn kolors_mlx_eligible(_payload: &Map<String, Value>) -> bool {
     true
+}
+
+/// Lens / Lens-Turbo (epic 3164 / sc-5105) is a pure T2I family — the `mlx-gen-lens` descriptor
+/// advertises no conditioning (no img2img / ControlNet / IP), and the base + turbo ids share the
+/// architecture/weights tree, differing only in their step/guidance defaults. Every non-edit
+/// `image_generate` job routes to the in-process Rust `mlx-gen-lens` worker on Mac. An `edit_image`
+/// mode — which Lens has no path for on any platform (`supportsEdit=false`) — stays off MLX so it is
+/// never silently run as plain T2I against a dropped source image (defensive; the UI never offers
+/// edit for Lens). Mirrors [`chroma_mlx_eligible`]. (LoRA/LoKr apply at load on the DiT — sc-3174 —
+/// so a LoRA never forces torch; training stays Python via the `lens_lora` kernel, a recorded
+/// non-goal.)
+fn lens_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 
 /// Video models the in-process Rust MLX worker generates today (sc-3034 Wan2.2,

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1981,39 +1981,25 @@ fn mac_capabilities_features_agree_with_the_rust_oracle() {
 }
 
 #[test]
-fn mac_rust_supported_names_torch_only_image_model_with_its_port_epic() {
+fn mac_rust_supported_flags_an_unported_image_model_as_needing_a_port_epic() {
     let store = store("oracle-torch-model");
-    // Each torch-only model points at its dedicated MLX-porting epic (epic 3482 policy),
-    // not the generic done feasibility epic.
-    // (z_image_edit was ported to MLX, epic 3529 / sc-3923 — no longer torch-only.)
-    // (Kolors base T2I was ported to MLX, epic 3090 / sc-3875 — no longer wholly torch-only; its
-    // not-yet-wired advanced modes are per-feature gaps, covered by `kolors_*` tests below.)
-    let cases = [
-        // (pulid_flux_dev was ported to MLX, epic 3069 / sc-3344 — no longer torch-only; runs on
-        // the native mlx-gen `pulid_flux` worker target for character_image.)
-        // instantid_realvisxl is NO LONGER wholly torch-only (sc-3345: identity + angle set run on
-        // MLX); its remaining per-feature gaps are covered by
-        // `mac_rust_supported_instantid_identity_ok_but_pose_and_facerestore_gapped`.
-        // SenseNova-U1 (sensenova_u1_8b[_fast]) was likewise ported to MLX (epic 3180 / sc-3900
-        // image modes, sc-3905 VQA + interleave): all of its surface is now MLX-routed, so it is no
-        // longer a torch-only image model (and its understanding job types are MLX-supported too).
-        ("lens_turbo", "epic 3164"),
-    ];
-    for (model, epic) in cases {
-        let job = job_of(
-            &store,
-            JobType::ImageGenerate,
-            json!({ "model": model, "prompt": "p" }),
-        );
-        let reason = mac_rust_supported(&job).unwrap_err();
-        assert_eq!(reason.model.as_deref(), Some(model));
-        assert_eq!(
-            reason.suggested_epic.as_deref(),
-            Some(epic),
-            "{model} → {epic}"
-        );
-        assert!(reason.error_message().starts_with("mlx_unsupported:"));
-    }
+    // Every shipping image model now has a Rust/MLX engine and is in `MLX_ROUTED_MODELS`, so none
+    // reaches the whole-model torch-only classifier anymore: z_image_edit (epic 3529 / sc-3923),
+    // Kolors (epic 3090 / sc-3875), pulid_flux_dev (epic 3069 / sc-3344), instantid_realvisxl
+    // (sc-3345), SenseNova-U1 (epic 3180 / sc-3900 + sc-3905), and finally Lens / Lens-Turbo
+    // (epic 3164 / sc-5105) — the LAST whole-model torch-only image family. The torch-only gap path
+    // now only fires for a hypothetical *unported* model id; lacking a dedicated port epic, the
+    // oracle flags it `mlx_unsupported` and reports "needs an epic" (suggested_epic None — epic 3482
+    // policy: file a porting epic + drop on Mac until it lands).
+    let job = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "unported_image_model", "prompt": "p" }),
+    );
+    let reason = mac_rust_supported(&job).unwrap_err();
+    assert_eq!(reason.model.as_deref(), Some("unported_image_model"));
+    assert_eq!(reason.suggested_epic.as_deref(), None);
+    assert!(reason.error_message().starts_with("mlx_unsupported:"));
 }
 
 #[test]
@@ -2261,19 +2247,29 @@ fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
 
 #[test]
 fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
-    // sc-3486: the picker-gating view of the same routing predicates. Torch-only image
-    // models are unsupported (hidden/disabled on Mac) and carry their port epic. (`lens` is the
-    // remaining torch-only image family; pulid_flux_dev — formerly this example — is MLX-routed
-    // after sc-3344, asserted below.)
-    let torch_only = model_mac_support("lens", "image");
+    // sc-3486: the picker-gating view of the same routing predicates. An *unported* image model (no
+    // Rust/MLX engine, not in `MLX_ROUTED_MODELS`) is unsupported — hidden/disabled on Mac — and,
+    // lacking a dedicated port epic, reports "needs an epic" (suggested_epic None). No real image
+    // model is torch-only anymore: Lens — formerly this example — is MLX-routed after epic 3164 /
+    // sc-5105 (asserted below), as is pulid_flux_dev after sc-3344.
+    let torch_only = model_mac_support("unported_image_model", "image");
     assert!(!torch_only.supported);
+    assert!(torch_only.reason.is_some());
     assert_eq!(
         torch_only
             .reason
             .as_ref()
             .and_then(|r| r.suggested_epic.as_deref()),
-        Some("epic 3164")
+        None
     );
+    // Lens / Lens-Turbo (epic 3164 / sc-5105) are MLX-routed now — pure T2I, so both are supported
+    // and in the picker with no gap reason. The edit-mode gating (Lens has no edit path) is asserted
+    // in `model_mac_support_feature_flags_mirror_routing_without_over_gating`.
+    for id in ["lens", "lens_turbo"] {
+        let lens = model_mac_support(id, "image");
+        assert!(lens.supported, "{id} should be MLX-supported");
+        assert!(lens.reason.is_none(), "{id} should carry no gap reason");
+    }
     // PuLID-FLUX (sc-3344) is MLX-routed now — it stays in the picker as a supported face-ID
     // backbone (character_image reference), no longer a torch-only port-epic gap.
     let pulid = model_mac_support("pulid_flux_dev", "image");
@@ -2342,6 +2338,15 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     let qwen_edit = model_mac_support("qwen_image_edit_2511", "image");
     assert!(qwen_edit.features.reference);
     assert!(qwen_edit.features.edit);
+    // Lens / Lens-Turbo (epic 3164 / sc-5105) are pure T2I — no edit path on any platform, so
+    // `edit_image` is gated off (mirrors Chroma / FLUX.1); a lens edit job never silently degrades to
+    // T2I against a dropped source image.
+    for id in ["lens", "lens_turbo"] {
+        assert!(
+            !model_mac_support(id, "image").features.edit,
+            "{id} has no edit path → edit must be gated off"
+        );
+    }
     // Third-party LyCORIS now applies on every MLX provider (epic 3641) → supported.
     assert!(model_mac_support("sdxl", "image").features.lycoris);
     // Video models expose per-mode eligibility.
@@ -2688,14 +2693,14 @@ fn active_mlx_image_edit_blocks_mps_image_edit_claim() {
     assert_eq!(claimed_mlx.id, mlx_job.id);
     assert_eq!(claimed_mlx.assigned_gpu.as_deref(), Some("mlx"));
 
-    // A Lens job is the MPS job: Lens is torch-only on Mac (epic 3164, not in MLX_ROUTED_MODELS),
-    // so it stays on the torch worker — exercising the shared-GPU exclusion without being
-    // soft-deferred. (PuLID-FLUX is fully MLX now — sc-3344 — so it's no longer a torch example,
-    // like Kolors before it.)
+    // An unported image model is the MPS job: not in MLX_ROUTED_MODELS, so it isn't MLX-eligible and
+    // isn't soft-deferred to the mlx worker — it stays on the torch worker, exercising the shared-GPU
+    // exclusion cleanly. (No real image model is torch-only anymore: Lens — formerly this example —
+    // is MLX after epic 3164 / sc-5105, as Kolors/PuLID-FLUX were before it.)
     let mps_job = store
         .create_job(image_job_with(
             json!({
-                "model": "lens",
+                "model": "unported_image_model",
                 "prompt": "p"
             }),
             "auto",
@@ -2725,12 +2730,13 @@ fn active_mps_image_edit_blocks_mlx_image_edit_claim() {
     register_gpu_worker(&store, "worker-mps", "mps", image_edit_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
-    // A Lens job is the MPS job (Lens is torch-only on Mac — epic 3164 — so it isn't soft-deferred
-    // to the mlx worker; PuLID-FLUX is MLX now after sc-3344).
+    // An unported image model is the MPS job (not in MLX_ROUTED_MODELS, so it isn't soft-deferred to
+    // the mlx worker). No real image model is torch-only anymore — Lens, the last one, is MLX after
+    // epic 3164 / sc-5105 (PuLID-FLUX was MLX after sc-3344).
     let mps_job = store
         .create_job(image_job_with(
             json!({
-                "model": "lens",
+                "model": "unported_image_model",
                 "prompt": "p"
             }),
             "auto",
@@ -2804,14 +2810,14 @@ fn torch_only_image_model_stays_on_torch() {
     let store = store("mlx-routing-image-torch-only");
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
-    // Lens is torch-only on Mac (epic 3164, not in MLX_ROUTED_MODELS), so it stays on the Python
-    // torch path and the mlx worker must refuse it. (Every ported image family — incl. Kolors' full
-    // surface (epic 3090) and PuLID-FLUX (sc-3344) — is MLX now, so a torch-only example must come
-    // from an unported model.)
+    // An unported image model (not in MLX_ROUTED_MODELS) stays on the Python torch path and the mlx
+    // worker must refuse it. Every ported image family — incl. Kolors' full surface (epic 3090),
+    // PuLID-FLUX (sc-3344), and Lens (epic 3164 / sc-5105, the last one) — is MLX now, so a
+    // torch-only example must come from an unported model id.
     let job = store
         .create_job(image_job_with(
             json!({
-                "model": "lens",
+                "model": "unported_image_model",
                 "prompt": "p"
             }),
             "auto",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -30,7 +30,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # The rev MUST stay identical to the `mlx-gen` pin in the macOS block: two gen-core revs would mean
 # two distinct `inventory` registries (one for the worker's derivation, one the provider crates
 # register into) and the runtime would see "engine not found". Bump both together.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -206,7 +206,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -214,57 +214,58 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b9
 # (a different rev would compile pmetal-mlx-sys twice). Also exercised by the NAX
 # guard test (tests/nax_guard.rs). Tracks mlx-gen main's internal mlx-rs pin: 44929a0, introduced by
 # mlx-gen 6c0f904 (sc-5009 / SceneWorks #629, the recoverable Metal command-buffer fix) and inherited
-# unchanged by the 95cd5c6 (sc-5012) bump above — kept in lockstep with mlx-gen's internal pin.
+# unchanged by the 4db50b2 (sc-5105 Lens, epic 3164) bump above — kept in lockstep with mlx-gen's
+# internal pin (the Lens engine PRs #407–#414 did not move it).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -273,12 +274,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -287,7 +288,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -295,7 +296,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -306,7 +307,18 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "95cd5c692b974ecaafa57c0af437f085b052e260" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
+# Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
+# inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
+# `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
+# dual-stream MMDiT + the Flux.2 VAE; pure T2I (no img2img/control/IP), standard guidance + negative
+# prompt, Q4/Q8 (encoder MoE + DiT), LoRA + LoKr at load. `mac_only` — there is no torch fallback on
+# the macOS path. The worker reaches it through the registry (`gen_core::load("lens"|"lens_turbo")`
+# → `.generate`), so it must force-link the crate (`use mlx_gen_lens as _;` in image_jobs.rs) or the
+# linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
+# `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
+# + mlx-rs pin as the other mlx-gen crates so MLX builds once.
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4db50b24fd0b1ee27e8ebe1f16292436b9767b63" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -268,6 +268,33 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 1.0,
         adapter_label: "mlx_sensenova",
     },
+    // Microsoft Lens / Lens-Turbo (epic 3164 engine / sc-5105 cutover) — gpt-oss-20b MoE text
+    // encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE. Pure **T2I** (the descriptor advertises
+    // no conditioning — no img2img / ControlNet / IP), so both ids ride the base [`generate_stream`]
+    // path with quant (Q8 default) + LoRA/LoKr. Standard guidance family: `supports_guidance=true` +
+    // `supports_negative_prompt=true` (NOT [`uses_true_cfg`]), so the CFG scale flows through
+    // `guidance` and the negative prompt is forwarded. `mac_only` — there is no torch fallback on the
+    // macOS path (the Python `/opt/lens-venv` sidecar is retired on Mac; Win/Linux/Docker keep it).
+    // The two SceneWorks ids map 1:1 to the engine registry ids of the same name and differ only in
+    // their step/guidance defaults: base `lens` is 20-step / CFG 5.0, distilled `lens_turbo` is
+    // 4-step / guidance 1.0 (≈ no CFG) — Python `MODEL_TARGETS` parity. Each variant resolves its own
+    // `microsoft/Lens` / `microsoft/Lens-Turbo` HF snapshot dir.
+    ModelRow {
+        sceneworks_id: "lens",
+        engine_id: "lens",
+        default_repo: "microsoft/Lens",
+        default_steps: 20,
+        default_guidance: 5.0,
+        adapter_label: "mlx_lens",
+    },
+    ModelRow {
+        sceneworks_id: "lens_turbo",
+        engine_id: "lens_turbo",
+        default_repo: "microsoft/Lens-Turbo",
+        default_steps: 4,
+        default_guidance: 1.0,
+        adapter_label: "mlx_lens",
+    },
 ];
 
 /// The mlx-gen registry ids of the video generators this worker serves (the engine ids

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -46,6 +46,12 @@ use mlx_gen_flux as _;
 use mlx_gen_flux2 as _;
 #[cfg(target_os = "macos")]
 use mlx_gen_kolors as _;
+// Lens / Lens-Turbo (epic 3164 engine / sc-5105) — an inventory-registered `Generator` under the ids
+// `lens` + `lens_turbo`, reached through the generic MODEL_TABLE / `generate_stream` path. Force-link
+// or the linker GCs its `ModelRegistration` and `gen_core::load("lens_turbo")` returns "no generator
+// registered" (the bug that bit Kolors).
+#[cfg(target_os = "macos")]
+use mlx_gen_lens as _;
 // PuLID-FLUX (sc-3344) IS an inventory-registered `Generator` (engine id `pulid_flux`), unlike the
 // bespoke InstantID provider below — so it is force-linked here like the other registry families
 // (its `ModelRegistration` is otherwise dropped by linker GC) and reached via `gen_core::load`. The

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -592,6 +592,13 @@ fn adapter_id_reports_per_family_mlx_label() {
         adapter_id(&request(json!({ "model": "kolors" }))),
         "mlx_kolors"
     );
+    // Lens / Lens-Turbo are MLX-routed (sc-5105) via the MODEL_TABLE registry families → both record
+    // the shared mlx_lens adapter label.
+    assert_eq!(adapter_id(&request(json!({ "model": "lens" }))), "mlx_lens");
+    assert_eq!(
+        adapter_id(&request(json!({ "model": "lens_turbo" }))),
+        "mlx_lens"
+    );
     // PuLID-FLUX (sc-3344) is MLX-routed but via a BESPOKE route (not the MODEL_TABLE registry
     // families), so `adapter_id` — which only resolves MODEL_TABLE rows — reports the stub label;
     // the real per-asset label (`mlx_pulid_flux`) is applied in `generate_pulid_flux_stream` via
@@ -625,6 +632,8 @@ fn mlx_engine_registry_links_image_families() {
         "sensenova_u1_8b",
         "sensenova_u1_8b_fast",
         "kolors",
+        "lens",
+        "lens_turbo",
     ] {
         assert!(ids.contains(&id), "registry missing {id}");
     }
@@ -779,6 +788,78 @@ fn flux2_klein_9b_kv_real_weights_generates_one_image() {
         Some(1.0),
         None,
     );
+}
+
+/// Real-weights smoke: Microsoft Lens base (epic 3164 / sc-5105) — 20-step, standard guidance 5.0 +
+/// a negative prompt (the `mlx-gen-lens` descriptor is `supports_guidance` + `supports_negative_prompt`,
+/// NOT true-CFG). Loads the `microsoft/Lens` snapshot dir (tokenizer/ text_encoder/ transformer/ vae/)
+/// at the Q8 default (encoder MoE + DiT). Needs the HF cache + a Metal device; run on demand:
+/// `cargo test -p sceneworks-worker --lib -- --ignored lens_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs real microsoft/Lens weights + Metal device"]
+fn lens_real_weights_generates_one_image() {
+    smoke_generate_one(
+        "lens",
+        hf_snapshot("models--microsoft--Lens"),
+        Some(5.0),
+        Some("blurry, low quality".to_owned()),
+    );
+}
+
+/// Real-weights smoke: Lens-Turbo (the distilled 4-step / guidance 1.0 variant, ≈ no CFG) — same
+/// architecture/weights tree as base Lens, different defaults. Loads the `microsoft/Lens-Turbo`
+/// snapshot at the Q8 default. Needs the HF cache + a Metal device; run on demand:
+/// `cargo test -p sceneworks-worker --lib -- --ignored lens_turbo_real_weights`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs real microsoft/Lens-Turbo weights + Metal device"]
+fn lens_turbo_real_weights_generates_one_image() {
+    smoke_generate_one(
+        "lens_turbo",
+        hf_snapshot("models--microsoft--Lens-Turbo"),
+        Some(1.0),
+        None,
+    );
+}
+
+/// Real-weights smoke: Lens-Turbo at a **1024 resolution bucket** (sc-5105 acceptance — the Lens port
+/// supports 1024/1440 × 9 ARs; the worker forwards `width`/`height` straight to the engine, which
+/// validates ÷16). Confirms the larger latent + the 20B Q8 encoder run at a real bucket size on Mac,
+/// not just the 512² basic smoke. Run on demand:
+/// `cargo test -p sceneworks-worker --lib -- --ignored lens_turbo_real_weights_bucket`.
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "needs real microsoft/Lens-Turbo weights + Metal device"]
+fn lens_turbo_real_weights_bucket_resolution() {
+    let model = mlx_model("lens_turbo").unwrap();
+    let generator = load_engine(
+        model.engine_id(),
+        hf_snapshot("models--microsoft--Lens-Turbo"),
+        Some(gen_core::Quant::Q8),
+        Vec::new(),
+        None,
+    )
+    .unwrap();
+    let cancel = gen_core::CancelFlag::new();
+    let (w, h, pixels) = generate_one(
+        generator.as_ref(),
+        "a serene mountain lake at dawn",
+        1024,
+        1024,
+        7,
+        model.default_steps(),
+        Some(1.0),
+        None,
+        None,
+        None,
+        &cancel,
+        &mut |_p| {},
+    )
+    .unwrap();
+    assert_eq!((w, h), (1024, 1024));
+    assert_eq!(pixels.len(), 1024 * 1024 * 3);
+    assert!(pixels.windows(2).any(|w| w[0] != w[1]));
 }
 
 /// Real-weights smoke: FLUX.2-klein-9b-true_v2 (wikeeyang undistilled fine-tune,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -614,6 +614,12 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         ("chroma1_flash", false, true),
         ("sensenova_u1_8b", true, false),
         ("sensenova_u1_8b_fast", true, false),
+        // Lens / Lens-Turbo (epic 3164 / sc-5105): the `mlx-gen-lens` descriptor advertises the
+        // norm-rescaled CFG path (`supports_guidance=true`) + a negative prompt
+        // (`supports_negative_prompt=true`) — a standard guidance family (NOT true-CFG), so the worker
+        // forwards the CFG scale via `guidance`. Turbo simply defaults guidance to 1.0 (≈ no CFG).
+        ("lens", true, true),
+        ("lens_turbo", true, true),
     ];
     // Every row is covered by the expectation table (no row added without a flag pair here).
     assert_eq!(MODEL_TABLE.len(), expected.len());

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -54,7 +54,10 @@ Windows/Linux keep the torch path.** Nothing here is a permanent drop. `mac_rust
 |---|---|---|---|
 | `kolors` | kolors (SDXL UNet + ChatGLM3) | 🟡 Base **T2I** ported (sc-3875); img2img / ControlNet-pose / IP-Adapter-Plus stay torch (per-feature gaps) until later epic-3090 slices | epic 3090 |
 | `pulid_flux_dev` | flux (PuLID) | 🔵 Port → drop-on-Mac until then | epic 3069 (engine done; owes SceneWorks routing) |
-| `lens`, `lens_turbo` | lens (Python sidecar `/opt/lens-venv`) | 🔵 Port → drop-on-Mac until then | epic 3164 |
+
+> **No whole-model torch-only image families remain.** `lens` / `lens_turbo` were the last; they
+> are MLX on Mac as of epic 3164 / sc-5105 (see §6). `torch_only_image_model_epic` now names nothing
+> — the gap path fires only for a hypothetical unported model id.
 
 > A torch-only image model with **no** porting epic yet → `torch_only_image_model_epic` returns
 > `None` and the oracle reports "needs a port epic (epic 3482 policy)"; file one + add it to the
@@ -148,6 +151,12 @@ Listed so a reviewer doesn't re-file these. All run in the Rust/MLX flow on Mac.
   in-process via the concrete `T2iModel::{vqa, interleave_gen}` (the `Generator` registry emits
   Images/Video only). Loads dense (no distill LoRA, no quant) for torch parity; the VQA decode is
   bit-identical (no-think primed, sc-3905 engine fix). epic 3180 / sc-3905.
+- Lens / Lens-Turbo text-to-image: `lens` (20-step / CFG 5.0), `lens_turbo` (4-step / guidance 1.0)
+  — gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + Flux.2 VAE; pure T2I, standard
+  guidance + negative prompt, Q4/Q8 (encoder MoE + DiT), LoRA + LoKr at load (`mlx-gen-lens`,
+  `mac_only`). Retires the Python `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker
+  keep the torch path). LoRA/LoKr *training* stays in the Python trainer (`lens_lora`, see §4 /
+  epic 3039 — a recorded non-goal). epic 3164 / sc-5105.
 - SDXL advanced shapes — reference/IP-Adapter, `edit_image`, masked inpaint, outpaint, and
   tile-detail (`image_detail` on `sdxl`/`realvisxl`) — epic 3041 / sc-3060.
 - Z-Image img2img-edit: `z_image_edit` + `z_image_turbo` `edit_image` mode (Turbo weights via the


### PR DESCRIPTION
## What & why

Cuts the SceneWorks worker's `lens` + `lens_turbo` image jobs over from the Python `/opt/lens-venv` (transformers-5 + diffusers) sidecar to the native-MLX `mlx-gen-lens` engine (epic 3164, now complete). This is the production-side counterpart to that engine port — the engine was done but unreachable from production until this cutover.

Lens was the **last whole-model torch-only image family**, so after this every image model on Mac is MLX-routed. Mirrors the Kolors base-T2I precedent (sc-3875); because Lens is pure T2I with no conditioning, the base `generate_stream` path needed **zero new generate code**.

Resolves [sc-5105](https://app.shortcut.com/trefry/story/5105).

## Changes

- **Pin bump** — all `mlx-gen*` + `sceneworks-gen-core` git pins `95cd5c6` → `4db50b2` (origin/main, contains the full Lens crate); added `mlx-gen-lens`. `mlx-rs` unchanged (`44929a0` already matches main, so the MLX C++ core did **not** rebuild). gen-core skew gate green (single resolution).
- **`engines.rs`** — `MODEL_TABLE` rows for `lens` (`microsoft/Lens`, 20-step / CFG 5.0) and `lens_turbo` (`microsoft/Lens-Turbo`, 4-step / guidance 1.0); `adapter_label = mlx_lens`. Standard guidance family (`supports_guidance` + `supports_negative_prompt`, **not** true-CFG), Q8 default, LoRA/LoKr at load.
- **`image_jobs.rs`** — `use mlx_gen_lens as _;` force-link (else `gen_core::load` returns "no generator registered").
- **`jobs_store.rs`** — `lens`/`lens_turbo` → `MLX_ROUTED_MODELS`; `lens_mlx_eligible` mirrors `chroma_mlx_eligible` (every non-`edit_image` job routes to MLX; `edit_image` gated off — Lens has no edit path); removed the `lens*` arm from `torch_only_image_model_epic` (now matches nothing).
- **Tests** — registry-link + adapter-label assertions; `MODEL_TABLE`-count guard 20→22; real-weight smokes for `lens`, `lens_turbo`, and a 1024² resolution bucket; the torch-only image fixtures (core `jobs_store` + `rust-api`) swapped to a synthetic `unported_image_model` id since no real torch-only image model remains.
- **`docs/mac-rust-gaps.md`** — moved `lens`/`lens_turbo` from §1 (torch-only) to §6 (ported).

No tokenizer overlay needed (engine reads `tokenizer/tokenizer.json`; the snapshot ships it — unlike the Kolors special case). No API contract-snapshot regen (the snapshot test's synthetic registry has no Lens model).

## Validation (all green on this Mac)

- `cargo fmt --check`; `clippy --all-targets -D warnings` (worker + core); build; gen-core skew gate.
- Tests: worker lib **260**, core lib **155** + `jobs_store` integration **108** + `training_contracts` **30**, rust-api **109**.
- **Real-weight E2E** (Q8 default, all coherent images): `lens_turbo` 4-step 512² (176s), `lens` 20-step / g5.0 512² (188s), `lens_turbo` 1024² **resolution bucket** (196s).

## Reviewer notes

- **Off-Mac is intentionally untouched.** The Python `LensTurboAdapter` / `lens_runner` / `/opt/lens-venv` provisioning / `INCLUDE_LENS` Docker build are **kept** for Win/Linux/Docker. The engine descriptor is `mac_only`, so deleting them would drop Lens on those platforms — contradicting the epic-3482 "Win/Linux/Docker unaffected" north star and every prior cutover (Chroma/Kolors/SenseNova). The story's "remove the sidecar/Docker" item is pending an explicit product decision (make Lens Mac-only?) and is a clean follow-up if desired. The Mac desktop already provisions no lens venv (`provision_lens_venv` is `#[cfg(not(target_os = "macos"))]`).
- **Training stays Python** (`lens_lora`) — a recorded non-goal; `MLX_ROUTED_TRAINING_KERNELS` and the `classify_training_gap` Lens arm are unchanged.
- **Not exercised:** the LoRA real-weight worker smoke (no Lens LoRA artifact cached). The worker LoRA path is family-agnostic and engine-validated (sc-3174).
- **Non-blocking follow-up:** candle-gen (`backend-candle`, default-off) still pins gen-core at the old rev — same lag as sc-5035; needs a re-pin to `4db50b2` before the candle lane builds off this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
