### PR TITLE
sc-5099: candle per-engine labeling + Python fallback hardening + live-smoke runbook

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3147,7 +3147,30 @@ fn image_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
     if has_poses {
         return false;
     }
+    // On-the-fly quantization (`advanced.mlxQuantize` > 0) → torch. The candle providers advertise
+    // `supported_quants: &[]` (dense bf16/fp16 only), so an explicit quant request can't be honored
+    // here — route it to Python rather than silently running dense (sc-5099, no dropped controls).
+    if candle_request_wants_quant(payload) {
+        return false;
+    }
     true
+}
+
+/// Whether the request explicitly asks for on-the-fly quantization the candle backend can't do.
+/// `advanced.mlxQuantize` is an optional advanced override (the web UI doesn't send it; the MLX path
+/// otherwise defaults quant from the manifest) — so a payload-level value `> 0` is a deliberate quant
+/// request. `<= 0` (dense) and absent both leave candle on its native dense path (sc-5099).
+fn candle_request_wants_quant(payload: &Map<String, Value>) -> bool {
+    payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("mlxQuantize"))
+        .and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .is_some_and(|bits| bits > 0)
 }
 
 /// The video models the candle (Windows/CUDA) lane serves (epic 5095, sc-5097): the base txt2video
@@ -3203,6 +3226,10 @@ fn video_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
         .and_then(Value::as_array)
         .is_some_and(|loras| !loras.is_empty())
     {
+        return false;
+    }
+    // On-the-fly quantization → torch (the candle video providers are dense; sc-5099).
+    if candle_request_wants_quant(payload) {
         return false;
     }
     true
@@ -4125,6 +4152,33 @@ mod candle_routing_tests {
                 "{model} conditioning shape must fall back to torch: {payload}"
             );
         }
+    }
+
+    #[test]
+    fn explicit_quantization_falls_back_to_torch_image_and_video() {
+        // sc-5099: the candle providers are dense (supported_quants: &[]); an explicit
+        // `advanced.mlxQuantize > 0` must route to Python rather than silently running dense.
+        assert!(!image_request_candle_eligible(
+            "sdxl",
+            &object(json!({ "advanced": { "mlxQuantize": 8 } }))
+        ));
+        assert!(!image_request_candle_eligible(
+            "qwen_image",
+            &object(json!({ "advanced": { "mlxQuantize": 4 } }))
+        ));
+        assert!(!video_request_candle_eligible(
+            "wan_2_2",
+            &object(json!({ "mode": "text_to_video", "advanced": { "mlxQuantize": 8 } }))
+        ));
+        // Dense (<= 0) or absent quant leaves candle on its native dense path → still eligible.
+        assert!(image_request_candle_eligible(
+            "sdxl",
+            &object(json!({ "advanced": { "mlxQuantize": 0 } }))
+        ));
+        assert!(image_request_candle_eligible(
+            "sdxl",
+            &object(json!({ "advanced": { "steps": 30 } }))
+        ));
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1084,3 +1084,59 @@ async fn consume_gen_events(
 // `z_image_turbo_control` variant. One image per pose, each driven by a DWPose
 // skeleton rendered from the pose's keypoints (see `openpose_skeleton`).
 // ---------------------------------------------------------------------------
+
+// Candle image lane labeling + engine-gate unit tests (sc-5099). Windows/candle-gated (the functions
+// only exist on that build); pure string maps, no GPU.
+#[cfg(all(test, target_os = "windows", feature = "backend-candle"))]
+mod candle_label_tests {
+    use super::*;
+
+    #[test]
+    fn candle_image_adapter_labels_are_per_family() {
+        assert_eq!(candle_adapter_label("z_image_turbo"), "candle_z_image");
+        assert_eq!(candle_adapter_label("flux_schnell"), "candle_flux");
+        assert_eq!(candle_adapter_label("flux_dev"), "candle_flux");
+        assert_eq!(candle_adapter_label("flux2_klein_9b"), "candle_flux2");
+        assert_eq!(candle_adapter_label("qwen_image"), "candle_qwen");
+        assert_eq!(candle_adapter_label("sdxl"), "candle_sdxl");
+        assert_eq!(candle_adapter_label("realvisxl"), "candle_sdxl");
+        // Every wired engine carries a `candle_`-prefixed label, distinct from the `mlx_` labels.
+        for model in [
+            "z_image_turbo",
+            "flux_schnell",
+            "flux_dev",
+            "flux2_klein_9b",
+            "qwen_image",
+            "sdxl",
+            "realvisxl",
+        ] {
+            assert!(candle_adapter_label(model).starts_with("candle_"));
+        }
+    }
+
+    #[test]
+    fn is_candle_engine_covers_only_the_wired_txt2img_families() {
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "z_image_turbo",
+            "flux_schnell",
+            "flux_dev",
+            "flux2_klein_9b",
+            "qwen_image",
+        ] {
+            assert!(is_candle_engine(model), "{model} should be a candle engine");
+        }
+        // Non-candle families + non-base variants (edit ids, the kv distill) are not in the lane.
+        for model in [
+            "chroma1_hd",
+            "kolors",
+            "z_image_edit",
+            "qwen_image_edit",
+            "flux2_klein_9b_kv",
+            "wan_2_2",
+        ] {
+            assert!(!is_candle_engine(model), "{model} must not be a candle engine");
+        }
+    }
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5343,3 +5343,32 @@ mod tests {
             .unwrap_or(false)
     }
 }
+
+// Candle video lane labeling + engine-mapping unit tests (sc-5099). Windows/candle-gated; pure maps.
+#[cfg(all(test, target_os = "windows", feature = "backend-candle"))]
+mod candle_video_label_tests {
+    use super::*;
+
+    #[test]
+    fn candle_video_engine_ids_map_base_txt2video_only() {
+        assert_eq!(candle_video_engine_id("wan_2_2"), Some("wan2_2_ti2v_5b"));
+        // ltx maps to the candle distilled id, not the MLX `ltx_2_3`.
+        assert_eq!(candle_video_engine_id("ltx_2_3"), Some("ltx_2_3_distilled"));
+        // The 14B Wan MoE, SVD, and the eros LTX have no candle provider.
+        for model in ["wan_2_2_t2v_14b", "wan_2_2_i2v_14b", "svd", "ltx_2_3_eros"] {
+            assert_eq!(candle_video_engine_id(model), None, "{model}");
+            assert!(!is_candle_video_engine(model));
+        }
+        assert!(is_candle_video_engine("wan_2_2"));
+        assert!(is_candle_video_engine("ltx_2_3"));
+    }
+
+    #[test]
+    fn candle_video_adapter_labels_are_per_family() {
+        assert_eq!(candle_video_adapter_label("wan2_2_ti2v_5b"), "candle_wan");
+        assert_eq!(
+            candle_video_adapter_label("ltx_2_3_distilled"),
+            "candle_ltx"
+        );
+    }
+}

--- a/docs/sc-5099/candle-lane-smoke.md
+++ b/docs/sc-5099/candle-lane-smoke.md
@@ -1,0 +1,74 @@
+# sc-5099 — candle (Windows/CUDA) worker lane: labeling, Python fallback, and live smoke
+
+Epic 5095 wired seven candle-gen providers into the worker beyond SDXL:
+**z-image, flux, flux2, qwen-image** (sc-5096, image), **wan, ltx** (sc-5097, video), and
+**joycaption** (sc-5098, caption). This story (sc-5099) closes the labeling + Python-fallback surface
+and defines the live deployed-worker smoke.
+
+## Two-level gating (unchanged)
+
+1. **Build feature** `backend-candle` — pulls the optional `candle-gen-*` provider crates (CUDA). Off
+   by default so the Desktop/non-CUDA builds never touch candle/cudarc/nvcc.
+2. **Runtime flag** `SCENEWORKS_BACKEND_CANDLE_ENABLED=1` (`Settings.backend_candle_enabled`) — until
+   set, the worker links the providers but routes nothing to them (production routing unchanged).
+
+Build the worker with the **VS2022 BuildTools MSVC 14.44** toolset (CUDA 12.9 rejects the newer
+VS18/14.51), `CUDA_COMPUTE_CAP=120` for Blackwell sm_120. See the build-toolchain note.
+
+## What runs on candle vs Python (the fallback matrix)
+
+The candle lane is **txt2img / txt2video-only** + JoyCaption. The router
+(`jobs_store::worker_supports_job` via the `candle` marker capability) confines the candle worker to
+the advertised surface; everything else falls back to the co-resident Python torch worker, with **no
+silently-dropped controls**.
+
+| Job | Candle-eligible | Falls back to Python |
+| --- | --- | --- |
+| `image_generate` | `sdxl`, `realvisxl`, `z_image_turbo`, `flux_schnell`, `flux_dev`, `flux2_klein_9b`, `qwen_image` — plain txt2img | `edit_image` / `sourceAssetId` / `referenceAssetId` / `maskAssetId` / `advanced.poses` / `loras` / **`advanced.mlxQuantize > 0`**; any non-listed model id (incl. `*_edit`, `flux2_klein_9b_kv`, chroma, kolors, sensenova) |
+| `video_generate` | `wan_2_2` (→ `wan2_2_ti2v_5b`), `ltx_2_3` (→ `ltx_2_3_distilled`) — `mode=text_to_video` | any other mode (i2v / first_last_frame / extend / bridge / replace), source/reference/mask, `loras`, `mlxQuantize > 0`; `wan_2_2_t2v_14b` / `wan_2_2_i2v_14b` / `svd` / `ltx_2_3_eros`; the advanced video job types |
+| `training_caption` | `captioner=joy_caption` | any other captioner |
+
+Per-asset backend labels (`candle_<family>`, distinct from the MLX `mlx_<family>`):
+`candle_sdxl`, `candle_z_image`, `candle_flux`, `candle_flux2`, `candle_qwen` (image);
+`candle_wan`, `candle_ltx` (video). Caption records `captioner=joy_caption` + `modelNameOrPath`.
+
+The candle descriptors advertise `supported_quants: &[]` (dense bf16/fp16) and no LoRA/conditioning,
+so the gates above mirror the descriptor surface 1:1.
+
+## Live deployed-worker smoke (run on the Windows/CUDA box)
+
+Goal: one real job per modality through the **deployed** worker (not a local `cargo run --example`),
+confirming `assetWrites` streaming, progress, and mid-generation cancellation on the production path.
+
+### Prerequisites
+- Worker built `--features backend-candle` (MSVC 14.44 / CUDA 12.9) and deployed.
+- `SCENEWORKS_BACKEND_CANDLE_ENABLED=1` in the worker environment.
+- Model weights present in the HF cache (download via Model Manager):
+  - image: `stabilityai/stable-diffusion-xl-base-1.0` (or any one wired image repo)
+  - video: `Wan-AI/Wan2.2-TI2V-5B-Diffusers` **or** `Lightricks/LTX-2.3` (+ `google/gemma-3-12b-it`
+    for LTX; the worker sets `LTX_GEMMA_DIR` from that snapshot, else honors an explicit override)
+  - caption: `fancyfeast/llama-joycaption-beta-one-hf-llava`
+
+### Steps (pick one engine per modality)
+1. **Image** — submit a plain txt2img job for a candle model (e.g. `sdxl`, prompt only, no
+   conditioning/LoRA/quant). Expect: streamed `assetWrites` (PNG lands in the gallery), step progress
+   with backend `candle`, asset `adapter = candle_sdxl`. Re-run and cancel mid-denoise → job ends
+   `Canceled`, no partial asset indexed.
+2. **Video** — submit a `text_to_video` job for `wan_2_2` (or `ltx_2_3`). Expect: a playable mp4
+   asset, step progress (backend `candle`), `adapter = candle_wan` (`candle_ltx`). Cancel mid-denoise
+   → `Canceled`.
+3. **Caption** — submit a `training_caption` job with `captioner=joy_caption` over a small dataset.
+   Expect: per-item progress, caption sidecars persisted, result `captioner=joy_caption`. Cancel
+   mid-run → `Canceled`.
+4. **Fallback spot-check** — submit one unsupported shape (e.g. an `sdxl` `edit_image`, or a
+   `qwen_image` with `advanced.poses`, or `mlxQuantize: 8`) and confirm it runs on the **Python torch
+   worker** (not the candle worker) and produces the expected torch-labeled asset — i.e. the control
+   was honored, not dropped.
+
+### Pass criteria
+- One image, one video, and one caption engine each complete end-to-end on candle with correct
+  `candle_<x>` labeling, streamed assetWrites, progress, and honored cancellation.
+- The fallback spot-check runs on Python with the control honored.
+
+> Status: code + routing + labeling + unit/routing tests landed in sc-5099. The **live GPU smoke is
+> executed on the deployed Windows/CUDA box** (hardware lane) — record the run results here when done.


### PR DESCRIPTION
## Outcome

Final story of [epic 5095](https://app.shortcut.com/trefry/epic/5095). The candle (Windows/CUDA) worker lane now has a complete, tested per-engine **labeling + Python-fallback** surface across all seven wired engines, and a documented **live deployed-worker smoke** runbook.

Story: [sc-5099](https://app.shortcut.com/trefry/story/5099)

## Context

The per-engine `candle_<x>` labeling and the Python-fallback routing were built incrementally across sc-5096 (image), sc-5097 (video), and sc-5098 (caption) — each shipped its own routing gate + labels. This story closes the one remaining **silently-dropped control**, locks the whole surface with tests, and defines the live smoke.

## What changed

- **`jobs_store.rs`** — reject explicit on-the-fly quantization on the candle lane. The candle providers advertise `supported_quants: &[]` (dense bf16/fp16), so an `advanced.mlxQuantize > 0` request now routes to the Python torch worker instead of silently running dense (new `candle_request_wants_quant`, applied to both image and video eligibility). Dense (`<= 0`) / absent quant stays on candle. The web UI doesn't send `mlxQuantize` (it's an advanced override; MLX otherwise defaults it from the manifest), so this only catches deliberate quant requests — the normal lane is unaffected.
- **Tests** — a quant-fallback test (image + video) plus candle-gated worker unit tests locking the `candle_<family>` adapter labels and the engine gates (`is_candle_engine`; `candle_video_engine_id` incl. the `ltx_2_3 → ltx_2_3_distilled` mapping). Together with the existing per-story routing tests this asserts the full matrix: each engine's advertised shape → candle, every unsupported shape → Python, with correct labels and no dropped controls.
- **`docs/sc-5099/candle-lane-smoke.md`** — the fallback matrix + the live deployed-worker smoke runbook (enable flags, weights / `LTX_GEMMA_DIR`, per-modality steps, pass criteria).

## Fallback matrix (recap)

| Job | Candle | → Python torch |
| --- | --- | --- |
| `image_generate` | sdxl, realvisxl, z_image_turbo, flux_schnell, flux_dev, flux2_klein_9b, qwen_image — plain txt2img | edit/source/reference/mask/poses/loras/**mlxQuantize>0**; any other model id |
| `video_generate` | wan_2_2, ltx_2_3 — text_to_video | other modes, conditioning, loras, mlxQuantize>0; 14B Wan / svd / ltx_2_3_eros; advanced video job types |
| `training_caption` | joy_caption | any other captioner |

Per-asset labels: `candle_sdxl/z_image/flux/flux2/qwen` (image), `candle_wan/ltx` (video) — distinct from the MLX `mlx_<x>`.

## Validation

- ✅ fmt + core (12 candle routing tests) + default Windows build green.
- ✅ `cargo clippy --features backend-candle -- -D warnings` of the worker green; candle label/engine unit tests pass (image + video) on MSVC 14.44 / CUDA 12.9 (sm_120).

## Live smoke — hardware lane

The **live deployed-worker smoke** (one real job per modality: image / video / caption, confirming assetWrites + progress + cancellation on the production path) runs on the Windows/CUDA box per the runbook in `docs/sc-5099/candle-lane-smoke.md`. Code + routing + labeling + unit/routing tests are landed; the GPU smoke execution + result capture is the remaining hardware-lane step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)