### PR TITLE
sc-5176/5189/5194: bump worker candle-gen pin → 8a3974a (VAE OOM + JoyCaption prompt + gen-core re-pin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,18 +436,18 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-core",
  "candle-nn",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -498,7 +498,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ba7d8b6b2ec575b430d93cfaed07106506bfeba#5ba7d8b6b2ec575b430d93cfaed07106506bfeba"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -3146,7 +3146,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9c569c211b77fb9061aa
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=e9c569c211b77fb9061aa3968dfd03bd02804109)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -4973,17 +4973,6 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=95cd5c692b974ecaafa57c0af437f085b052e260#95cd5c692b974ecaafa57c0af437f085b052e260"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9c569c211b77fb9061aa3968dfd03bd02804109#e9c569c211b77fb9061aa3968dfd03bd02804109"
 dependencies = [
  "inventory",
@@ -5068,7 +5057,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=e9c569c211b77fb9061aa3968dfd03bd02804109)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -359,30 +359,37 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "e9c569
 # `set_flash_attn` (candle-gen `5143dd9`, sc-3674), which the `image_jobs/base.rs` call depends on;
 # the prior `5d7071a` pin predated it and broke the `backend-candle` compile.
 #
-# sc-5096 (epic 5095) bumps the pin `f5abb03` -> `5ba7d8b` (candle-gen main, PR #17): adds the
+# sc-5096 (epic 5095) bumped the pin `f5abb03` -> `5ba7d8b` (candle-gen main, PR #17): adds the
 # z-image / flux / flux2 / qwen-image image providers AND the wan / ltx video + joycaption captioner
-# providers (the latter three wired by sc-5097/sc-5098). `5ba7d8b` still pins `sceneworks-gen-core`
-# at `95cd5c6` (the SAME rev this worker pins), so the skew gate (`--features backend-candle`) stays
-# green: one gen-core resolution, one inventory registry. ALL candle deps below MUST share this rev.
+# providers (the latter three wired by sc-5097/sc-5098).
+#
+# sc-5176/sc-5189/sc-5194 bump `5ba7d8b` -> `8a3974a` (candle-gen main, PRs #18/#19/#20), found by the
+# live deployed-worker smoke: #18 streams the Wan VAE decode per frame (fixes the video OOM — decode
+# ~41GB vs ~97GB), #19 builds the JoyCaption prompt from the caption options when none is supplied
+# (MLX parity), and #20 re-pins candle-gen's `sceneworks-gen-core` `95cd5c6` -> `e9c569c2` to MATCH
+# this worker's MLX pin (bumped by sc-5180 / mlx-gen-lens). That re-pin is the key: without it the
+# `--features backend-candle` graph resolved TWO gen-core revs (worker mlx-gen `e9c569c2` vs candle-gen
+# `95cd5c6`) -> the inventory skew trap. With `8a3974a` the candle lane resolves EXACTLY ONE
+# `sceneworks-gen-core` (`e9c569c2`, == the mlx-gen pin) again. ALL candle deps below MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ba7d8b6b2ec575b430d93cfaed07106506bfeba", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Outcome
Bumps the worker's candle-gen pin `5ba7d8b → 8a3974a` (candle-gen main) to pick up the three fixes the **live deployed-worker smoke** (epic 5095 / sc-5099) surfaced, and — critically — to **re-close the gen-core skew** the candle lane currently has on `main`.

## What lands
- **[candle-gen #18](https://github.com/michaeltrefry/candle-gen/pull/18) (sc-5176)** — per-frame Wan **VAE decode streaming**, fixing the video OOM. Live-validated: decode peaks **~41 GB vs ~97 GB** (OOM) on a 320²×17 clip; the wan clip renders end-to-end.
- **[candle-gen #19](https://github.com/michaeltrefry/candle-gen/pull/19) (sc-5189)** — JoyCaption **builds its prompt from the caption type/length options** when none is supplied (the normal flow), mirroring mlx-gen.
- **[candle-gen #20](https://github.com/michaeltrefry/candle-gen/pull/20) (sc-5194)** — candle-gen re-pins `sceneworks-gen-core` `95cd5c6 → e9c569c2` to match this worker's MLX pin (moved by **sc-5180** / mlx-gen-lens).

## Why the re-pin is load-bearing
`main` currently has a **latent candle gen-core skew**: the worker's mlx-gen is on `e9c569c2` (sc-5180) but candle-gen was on `95cd5c6`, so `--features backend-candle` resolved **two** `sceneworks-gen-core` revs → the inventory skew trap ("engine not found" at runtime). The default CI gate misses it (candle isn't pulled without the feature). This bump (with #20 in candle-gen) restores a single gen-core rev.

## Verification
- ✅ gen-core skew gate **with `--features backend-candle`**: exactly one `sceneworks-gen-core` (`e9c569c2`); default skew gate likewise.
- ✅ Default Windows build green.
- ✅ `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` clean (MSVC 14.44 / CUDA 12.9, sm_120).
- ✅ Live re-smoke: candle `wan_2_2` video renders to a real mp4 (no OOM) with this candle-gen.

Production routing unchanged unless `backend_candle_enabled` (default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)