### PR TITLE
sc-5175: wire the candle Wan2.2 14B (T2V + I2V) video generators into the candle lane

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3225,16 +3225,27 @@ fn candle_request_wants_quant(payload: &Map<String, Value>) -> bool {
         .is_some_and(|bits| bits > 0)
 }
 
-/// The video models the candle (Windows/CUDA) lane serves (epic 5095, sc-5097): the base txt2video
-/// engines only — `wan_2_2` (→ candle `wan2_2_ti2v_5b`) and `ltx_2_3` (→ candle `ltx_2_3_distilled`).
-/// Mirrors the worker's `video_jobs::candle_video_engine_id`. The 14B Wan MoE, SVD, and `ltx_2_3_eros`
-/// have no candle provider; every conditioned mode + LoRA stays on the Python torch worker.
-const CANDLE_VIDEO_ROUTED_MODELS: &[&str] = &["wan_2_2", "ltx_2_3"];
+/// The video models the candle (Windows/CUDA) lane serves: the base txt2video engines `wan_2_2`
+/// (→ candle `wan2_2_ti2v_5b`) and `ltx_2_3` (→ candle `ltx_2_3_distilled`) (epic 5095, sc-5097),
+/// plus the Wan2.2 **14B** MoE pair `wan_2_2_t2v_14b` (text-only) and `wan_2_2_i2v_14b` (image→video)
+/// (sc-5175). Mirrors the worker's `video_jobs::candle_video_engine_id`. SVD and `ltx_2_3_eros` still
+/// have no candle provider; every conditioned mode + LoRA stays on the Python torch worker. Note the
+/// 14B I2V is image→video, NOT txt2video — see [`CANDLE_VIDEO_I2V_ROUTED_MODELS`].
+const CANDLE_VIDEO_ROUTED_MODELS: &[&str] =
+    &["wan_2_2", "ltx_2_3", "wan_2_2_t2v_14b", "wan_2_2_i2v_14b"];
 
-/// Does this video job belong on the candle **txt2video-only** lane (sc-5097)? The candle wan/ltx
-/// providers drive plain text-to-video only — no image-to-video / first-last-frame / extend / bridge /
-/// replace (the advanced job types), no source/reference/mask conditioning, and no LoRAs. Every other
-/// shape must fall back to the Python torch worker, so the candle worker refuses it here.
+/// The candle video models that run **image→video** (a source image is required), not txt2video. Only
+/// the Wan2.2 14B I2V MoE (sc-5175): its candle provider conditions on a source frame, so its
+/// eligibility gate requires `mode=image_to_video` + a non-empty `sourceAssetId` — the inverse of the
+/// txt2video-only gate the 5B / T2V-14B / ltx ids use. Every other candle video id is txt2video-only.
+const CANDLE_VIDEO_I2V_ROUTED_MODELS: &[&str] = &["wan_2_2_i2v_14b"];
+
+/// Does this video job belong on the candle video lane (sc-5097 txt2video; sc-5175 adds the Wan2.2
+/// 14B I2V image→video)? The candle wan/ltx providers drive plain text-to-video, plus the 14B I2V's
+/// single source-image conditioning — but no first-last-frame / extend / bridge / replace (the
+/// advanced job types), no reference/mask conditioning, and no LoRAs. Every other shape must fall back
+/// to the Python torch worker, so the candle worker refuses it here. The per-model shape gate is
+/// [`video_request_candle_eligible`].
 fn video_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     // Only the base `video_generate` job type — the advanced types (VideoExtend/VideoBridge/
     // PersonReplace) are conditioned modes the candle lane doesn't serve.
@@ -3253,23 +3264,35 @@ fn video_request_candle_eligible(model: &str, payload: &Map<String, Value>) -> b
     if !CANDLE_VIDEO_ROUTED_MODELS.contains(&model) {
         return false;
     }
-    // txt2video only: the base `video_generate` mode defaults to `image_to_video`, so require an
-    // explicit `text_to_video`. Every conditioned mode (i2v / first_last_frame / extend / bridge /
-    // replace) is thereby excluded.
-    if payload.get("mode").and_then(Value::as_str) != Some("text_to_video") {
-        return false;
-    }
     let has_nonempty_id = |key: &str| {
         payload
             .get(key)
             .and_then(Value::as_str)
             .is_some_and(|value| !value.trim().is_empty())
     };
-    // Any conditioning asset (img2vid source, reference, inpaint mask) → torch.
-    if has_nonempty_id("sourceAssetId")
-        || has_nonempty_id("referenceAssetId")
-        || has_nonempty_id("maskAssetId")
-    {
+    if CANDLE_VIDEO_I2V_ROUTED_MODELS.contains(&model) {
+        // Wan 14B I2V is image→video ONLY (sc-5175): require the `image_to_video` mode + a source
+        // image. A txt2video shape (no source) is rejected so a mis-picked text job stays on torch.
+        if payload.get("mode").and_then(Value::as_str) != Some("image_to_video") {
+            return false;
+        }
+        if !has_nonempty_id("sourceAssetId") {
+            return false;
+        }
+    } else {
+        // txt2video only: the base `video_generate` mode defaults to `image_to_video`, so require an
+        // explicit `text_to_video`. Every conditioned mode (i2v / first_last_frame / extend / bridge /
+        // replace) is thereby excluded, as is a stray source image.
+        if payload.get("mode").and_then(Value::as_str) != Some("text_to_video") {
+            return false;
+        }
+        if has_nonempty_id("sourceAssetId") {
+            return false;
+        }
+    }
+    // Reference / inpaint-mask conditioning is never in the candle video lane (i2v needs only the
+    // single source image; reference + mask are the character / inpaint shapes that stay on torch).
+    if has_nonempty_id("referenceAssetId") || has_nonempty_id("maskAssetId") {
         return false;
     }
     // LoRAs are not in the candle video lane (the providers advertise none).
@@ -4401,8 +4424,9 @@ mod candle_routing_tests {
     const TORCH_VIDEO_CAPS: &[&str] = &["gpu", "video_generate"];
 
     #[test]
-    fn candle_routed_video_models_txt2video_are_eligible() {
-        for model in CANDLE_VIDEO_ROUTED_MODELS {
+    fn candle_routed_video_models_are_eligible_in_their_native_shape() {
+        // txt2video lane: the 5B, ltx, and the 14B T2V (text-only) are eligible for text_to_video.
+        for model in ["wan_2_2", "ltx_2_3", "wan_2_2_t2v_14b"] {
             assert!(
                 video_request_candle_eligible(
                     model,
@@ -4411,18 +4435,28 @@ mod candle_routing_tests {
                 "{model} text_to_video should be candle-eligible"
             );
         }
+        // image→video lane: the 14B I2V is eligible only with the i2v mode + a source image (sc-5175).
+        assert!(
+            video_request_candle_eligible(
+                "wan_2_2_i2v_14b",
+                &object(
+                    json!({ "mode": "image_to_video", "sourceAssetId": "asset_1", "prompt": "p" })
+                )
+            ),
+            "wan_2_2_i2v_14b image_to_video with a source should be candle-eligible"
+        );
     }
 
     #[test]
     fn non_candle_video_models_and_conditioned_shapes_fall_back() {
         // Models with no candle video provider stay on torch even for text_to_video.
-        for model in ["wan_2_2_t2v_14b", "wan_2_2_i2v_14b", "svd", "ltx_2_3_eros"] {
+        for model in ["svd", "ltx_2_3_eros"] {
             assert!(
                 !video_request_candle_eligible(model, &object(json!({ "mode": "text_to_video" }))),
                 "{model} must fall back to the Python worker"
             );
         }
-        // A wired model in any conditioned shape (default/i2v mode, a source, or a LoRA) → torch.
+        // A txt2video model in any conditioned shape (default/i2v mode, a source, or a LoRA) → torch.
         let cases = [
             json!({ "prompt": "p" }), // no mode → defaults to i2v
             json!({ "mode": "image_to_video", "sourceAssetId": "a" }),
@@ -4436,13 +4470,34 @@ mod candle_routing_tests {
                 "wan_2_2 shape must fall back to torch: {case}"
             );
         }
+        // The 14B T2V is text-only: any image_to_video / sourced shape falls back to torch (sc-5175).
+        for case in [
+            json!({ "mode": "image_to_video", "sourceAssetId": "a" }),
+            json!({ "mode": "text_to_video", "sourceAssetId": "a" }),
+        ] {
+            assert!(
+                !video_request_candle_eligible("wan_2_2_t2v_14b", &object(case.clone())),
+                "wan_2_2_t2v_14b conditioned shape must fall back to torch: {case}"
+            );
+        }
+        // The 14B I2V is image→video only: a txt2video shape, an i2v with no source, or a LoRA → torch.
+        for case in [
+            json!({ "mode": "text_to_video", "prompt": "p" }),
+            json!({ "mode": "image_to_video" }), // i2v but no source image
+            json!({ "mode": "image_to_video", "sourceAssetId": "a", "loras": [{ "name": "x" }] }),
+        ] {
+            assert!(
+                !video_request_candle_eligible("wan_2_2_i2v_14b", &object(case.clone())),
+                "wan_2_2_i2v_14b non-i2v / LoRA shape must fall back to torch: {case}"
+            );
+        }
     }
 
     #[test]
     fn candle_worker_claims_txt2video_but_refuses_other_video_shapes() {
         let candle = gpu_worker(CANDLE_VIDEO_CAPS);
-        // Claims wan + ltx plain txt2video.
-        for model in ["wan_2_2", "ltx_2_3"] {
+        // Claims wan + ltx + the 14B T2V plain txt2video.
+        for model in ["wan_2_2", "ltx_2_3", "wan_2_2_t2v_14b"] {
             assert!(
                 worker_supports_job(
                     &candle,
@@ -4451,7 +4506,20 @@ mod candle_routing_tests {
                 "candle worker should claim {model} txt2video"
             );
         }
-        // Refuses a non-candle video model and a conditioned (i2v) shape on a wired model.
+        // Claims the 14B I2V in its image→video shape (with a source image) (sc-5175).
+        assert!(
+            worker_supports_job(
+                &candle,
+                &video_generate_job(json!({
+                    "model": "wan_2_2_i2v_14b",
+                    "mode": "image_to_video",
+                    "sourceAssetId": "a"
+                }))
+            ),
+            "candle worker should claim wan_2_2_i2v_14b image_to_video"
+        );
+        // Refuses a non-candle video model, a conditioned (i2v) shape on a txt2video model, and the
+        // 14B I2V in a txt2video shape (it is image→video only).
         assert!(!worker_supports_job(
             &candle,
             &video_generate_job(json!({ "model": "svd", "mode": "text_to_video" }))
@@ -4461,6 +4529,10 @@ mod candle_routing_tests {
             &video_generate_job(
                 json!({ "model": "wan_2_2", "mode": "image_to_video", "sourceAssetId": "a" })
             )
+        ));
+        assert!(!worker_supports_job(
+            &candle,
+            &video_generate_job(json!({ "model": "wan_2_2_i2v_14b", "mode": "text_to_video" }))
         ));
         // The co-resident torch worker claims everything the candle worker defers.
         let torch = gpu_worker(TORCH_VIDEO_CAPS);

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -566,6 +566,50 @@ fn step_fraction(index: usize, current: u32, total: u32, count: u32) -> f64 {
     (0.1 + per * (index as f64 + within)).min(0.95)
 }
 
+/// Resolve a reference/source asset id to an in-memory RGB8 image (the engine VAE-encodes + resizes
+/// it). Uses the indexed `ProjectStore::get_asset` → `file.path`. Shared by the MLX image/video
+/// conditioning paths and the candle video i2v conditioning (sc-5175), so it lives here (both lanes)
+/// rather than in a macOS-only include.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
+pub(crate) fn load_reference_image(
+    data_dir: &Path,
+    project_id: &str,
+    asset_id: &str,
+    project_path: &Path,
+) -> WorkerResult<Image> {
+    let asset = ProjectStore::new(data_dir.to_path_buf(), "worker")
+        .get_asset(project_id, asset_id)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("reference asset {asset_id}: {error}"))
+        })?;
+    let rel = asset
+        .get("file")
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!("reference asset {asset_id} has no media path"))
+        })?;
+    // The asset's file.path comes from an on-disk sidecar the user can edit, so
+    // route it through safe_project_path (rejects `..`/absolute components) rather
+    // than a bare join — matching the media-jobs reads and keeping a poisoned
+    // sidecar from reading an arbitrary file as the reference (sc-4278 / F-MLXW-14).
+    let path = crate::safe_project_path(project_path, rel)?;
+    let decoded = image::open(&path)
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("reference image {}: {error}", path.display()))
+        })?
+        .to_rgb8();
+    Ok(Image {
+        width: decoded.width(),
+        height: decoded.height(),
+        pixels: decoded.into_raw(),
+    })
+}
+
 /// Real MLX generation: load once on a blocking thread, generate each image, and
 /// stream step/decode/image events back to the async worker (which saves PNGs, emits
 /// `assetWrites`, and polls cancel). MLX runs entirely on the blocking thread (the

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -153,44 +153,6 @@ fn flux2_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
         && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
-/// Resolve a reference/source asset id to an in-memory RGB8 image (the engine VAE-
-/// encodes + resizes it). Uses the indexed `ProjectStore::get_asset` → `file.path`.
-pub(crate) fn load_reference_image(
-    data_dir: &Path,
-    project_id: &str,
-    asset_id: &str,
-    project_path: &Path,
-) -> WorkerResult<Image> {
-    let asset = ProjectStore::new(data_dir.to_path_buf(), "worker")
-        .get_asset(project_id, asset_id)
-        .map_err(|error| {
-            WorkerError::InvalidPayload(format!("reference asset {asset_id}: {error}"))
-        })?;
-    let rel = asset
-        .get("file")
-        .and_then(|file| file.get("path"))
-        .and_then(Value::as_str)
-        .filter(|path| !path.trim().is_empty())
-        .ok_or_else(|| {
-            WorkerError::InvalidPayload(format!("reference asset {asset_id} has no media path"))
-        })?;
-    // The asset's file.path comes from an on-disk sidecar the user can edit, so
-    // route it through safe_project_path (rejects `..`/absolute components) rather
-    // than a bare join — matching the media-jobs reads and keeping a poisoned
-    // sidecar from reading an arbitrary file as the reference (sc-4278 / F-MLXW-14).
-    let path = crate::safe_project_path(project_path, rel)?;
-    let decoded = image::open(&path)
-        .map_err(|error| {
-            WorkerError::InvalidPayload(format!("reference image {}: {error}", path.display()))
-        })?
-        .to_rgb8();
-    Ok(Image {
-        width: decoded.width(),
-        height: decoded.height(),
-        pixels: decoded.into_raw(),
-    })
-}
-
 /// One `Reference` (single) or one `MultiReference` (N) edit conditioning from the
 /// resolved reference images (cloned per output).
 fn build_edit_conditioning(references: &[Image]) -> Vec<Conditioning> {

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -307,7 +307,7 @@ pub(crate) async fn run_video_generate_job(
     let (decoded, adapter, raw_settings, replacement_status) =
         if settings.backend_candle_enabled && is_candle_video_engine(&request.model) {
             let (decoded, adapter, raw_settings) =
-                generate_candle_video(api, settings, job, &request, backend).await?;
+                generate_candle_video(api, settings, job, &request, &project_path, backend).await?;
             (decoded, adapter, raw_settings, None::<Value>)
         } else {
             (
@@ -2402,10 +2402,15 @@ const CANDLE_WAN_ADAPTER: &str = "candle_wan";
 const CANDLE_LTX_ADAPTER: &str = "candle_ltx";
 
 /// Default HuggingFace repos the candle video providers load (overridable via the manifest `repo`).
-/// The candle wan provider reads a Wan2.2-TI2V-5B diffusers snapshot; ltx reads the LTX-2.3 checkpoint
-/// plus a separate Gemma-3-12B encoder snapshot (`LTX_GEMMA_DIR`).
+/// The candle wan providers read a Wan2.2 diffusers snapshot — the TI2V-5B, or the T2V-A14B /
+/// I2V-A14B 14B MoE (sc-5175); ltx reads the LTX-2.3 checkpoint plus a separate Gemma-3-12B encoder
+/// snapshot (`LTX_GEMMA_DIR`).
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
-const CANDLE_WAN_REPO: &str = "Wan-AI/Wan2.2-TI2V-5B-Diffusers";
+const CANDLE_WAN_5B_REPO: &str = "Wan-AI/Wan2.2-TI2V-5B-Diffusers";
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_WAN_T2V_14B_REPO: &str = "Wan-AI/Wan2.2-T2V-A14B-Diffusers";
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const CANDLE_WAN_I2V_14B_REPO: &str = "Wan-AI/Wan2.2-I2V-A14B-Diffusers";
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 const CANDLE_LTX_REPO: &str = "Lightricks/LTX-2.3";
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
@@ -2413,11 +2418,15 @@ const CANDLE_LTX_GEMMA_REPO: &str = "google/gemma-3-12b-it";
 
 /// SceneWorks video model id → candle registry engine id, or `None` for an id the candle video lane
 /// does not serve. Note ltx maps to `ltx_2_3_distilled` (the candle provider's id), not the MLX
-/// `ltx_2_3`. Only the base txt2video ids — the 14B Wan MoE, SVD, and `ltx_2_3_eros` stay on torch.
+/// `ltx_2_3`. Covers the base txt2video ids (5B + ltx) plus the Wan2.2 **14B** dual-expert MoE pair
+/// (sc-5174 / sc-5175): `wan_2_2_t2v_14b` (text→video) and `wan_2_2_i2v_14b` (image→video). SVD and
+/// `ltx_2_3_eros` have no candle provider and stay on torch.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 fn candle_video_engine_id(model: &str) -> Option<&'static str> {
     match model {
         "wan_2_2" => Some("wan2_2_ti2v_5b"),
+        "wan_2_2_t2v_14b" => Some("wan2_2_t2v_14b"),
+        "wan_2_2_i2v_14b" => Some("wan2_2_i2v_14b"),
         "ltx_2_3" => Some("ltx_2_3_distilled"),
         _ => None,
     }
@@ -2438,22 +2447,30 @@ fn candle_video_adapter_label(engine_id: &str) -> &'static str {
     }
 }
 
+/// The candle default weights repo for a video engine id (the per-variant Wan2.2 diffusers snapshot,
+/// or the LTX-2.3 checkpoint). Used when the manifest entry omits `repo`.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn candle_video_default_repo(engine_id: &str) -> &'static str {
+    match engine_id {
+        "ltx_2_3_distilled" => CANDLE_LTX_REPO,
+        "wan2_2_t2v_14b" => CANDLE_WAN_T2V_14B_REPO,
+        "wan2_2_i2v_14b" => CANDLE_WAN_I2V_14B_REPO,
+        // `wan2_2_ti2v_5b` (and any other wan id) → the 5B TI2V snapshot.
+        _ => CANDLE_WAN_5B_REPO,
+    }
+}
+
 /// The candle weights repo for a video engine: the manifest `repo` wins, else the candle default repo
 /// for the engine.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 fn candle_video_repo(request: &VideoRequest, engine_id: &str) -> String {
-    let default_repo = if engine_id == "ltx_2_3_distilled" {
-        CANDLE_LTX_REPO
-    } else {
-        CANDLE_WAN_REPO
-    };
     request
         .model_manifest_entry
         .get("repo")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(default_repo)
+        .unwrap_or_else(|| candle_video_default_repo(engine_id))
         .to_owned()
 }
 
@@ -2496,15 +2513,57 @@ fn candle_video_raw_settings(request: &VideoRequest, repo: &str) -> Value {
     Value::Object(raw)
 }
 
-/// Windows/CUDA candle txt2video path (sc-5097). Resolves the engine + weights, provisions the LTX
-/// Gemma encoder, builds a txt2video `VideoGenInput`, and runs it through the shared
-/// [`generate_video`] streaming driver. Returns the decoded clip + the candle adapter label.
+/// Per-request conditioning for a candle video generation. Only the Wan2.2 **14B I2V** engine is
+/// conditioned (sc-5174 / sc-5175): it requires a source image, loaded to a single
+/// [`Conditioning::Reference`] — the channel-concat first frame the provider VAE-encodes into its
+/// `y` (`in_dim=36`). The candle analog of the MLX Wan i2v conditioning ([`resolve_wan_conditioning`]).
+/// Every other candle video engine (5B, T2V-14B, ltx) is txt2video-only, so this returns an empty set.
+/// The router's `video_request_candle_eligible` already guarantees the i2v shape carries a source and
+/// the txt2video ids do not, but the source is required here too so a mis-routed job fails clearly.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+fn resolve_candle_video_conditioning(
+    settings: &Settings,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &str,
+) -> WorkerResult<Vec<Conditioning>> {
+    if engine_id != "wan2_2_i2v_14b" {
+        return Ok(Vec::new());
+    }
+    let asset_id = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "wan_2_2_i2v_14b: image-to-video requires a source image (sourceAssetId)."
+                    .to_owned(),
+            )
+        })?;
+    let image = crate::image_jobs::load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        asset_id,
+        project_path,
+    )?;
+    Ok(vec![Conditioning::Reference {
+        image,
+        strength: None,
+    }])
+}
+
+/// Windows/CUDA candle video path (sc-5097 txt2video; sc-5175 adds the Wan2.2 14B MoE T2V + I2V).
+/// Resolves the engine + weights, provisions the LTX Gemma encoder, resolves any i2v source-image
+/// conditioning, builds a `VideoGenInput`, and runs it through the shared [`generate_video`] streaming
+/// driver. Returns the decoded clip + the candle adapter label.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 async fn generate_candle_video(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
     request: &VideoRequest,
+    project_path: &Path,
     backend: &str,
 ) -> WorkerResult<(DecodedVideo, &'static str, Value)> {
     let engine_id = candle_video_engine_id(&request.model).ok_or_else(|| {
@@ -2518,9 +2577,13 @@ async fn generate_candle_video(
     if is_ltx {
         ensure_ltx_gemma_dir(settings);
     }
-    // Descriptor-narrowed sampling surface: wan takes guidance + a negative prompt; the distilled ltx
-    // takes neither (single-stage, no CFG). Steps/guidance default to the provider's own constants
-    // when the request omits them.
+    // Wan 14B I2V conditions on a source image (`Conditioning::Reference`); every other candle video
+    // engine is txt2video-only (empty conditioning).
+    let conditioning =
+        resolve_candle_video_conditioning(settings, request, project_path, engine_id)?;
+    // Descriptor-narrowed sampling surface: wan (5B + 14B) takes guidance + a negative prompt; the
+    // distilled ltx takes neither (single-stage, no CFG). Steps/guidance default to the provider's own
+    // constants when the request omits them.
     let steps = advanced_opt_u32(request, "steps");
     let (guidance, negative_prompt) = if is_ltx {
         (None, None)
@@ -2539,6 +2602,7 @@ async fn generate_candle_video(
     let input = VideoGenInput {
         engine_id,
         model_dir,
+        conditioning,
         prompt: request.prompt.clone(),
         negative_prompt,
         width: request.width,
@@ -5866,25 +5930,93 @@ mod candle_video_label_tests {
     use super::*;
 
     #[test]
-    fn candle_video_engine_ids_map_base_txt2video_only() {
+    fn candle_video_engine_ids_map_5b_ltx_and_14b() {
         assert_eq!(candle_video_engine_id("wan_2_2"), Some("wan2_2_ti2v_5b"));
+        // The Wan2.2 14B dual-expert MoE pair (sc-5175): T2V (text→video) + I2V (image→video).
+        assert_eq!(
+            candle_video_engine_id("wan_2_2_t2v_14b"),
+            Some("wan2_2_t2v_14b")
+        );
+        assert_eq!(
+            candle_video_engine_id("wan_2_2_i2v_14b"),
+            Some("wan2_2_i2v_14b")
+        );
         // ltx maps to the candle distilled id, not the MLX `ltx_2_3`.
         assert_eq!(candle_video_engine_id("ltx_2_3"), Some("ltx_2_3_distilled"));
-        // The 14B Wan MoE, SVD, and the eros LTX have no candle provider.
-        for model in ["wan_2_2_t2v_14b", "wan_2_2_i2v_14b", "svd", "ltx_2_3_eros"] {
+        // SVD and the eros LTX have no candle provider.
+        for model in ["svd", "ltx_2_3_eros"] {
             assert_eq!(candle_video_engine_id(model), None, "{model}");
             assert!(!is_candle_video_engine(model));
         }
-        assert!(is_candle_video_engine("wan_2_2"));
-        assert!(is_candle_video_engine("ltx_2_3"));
+        for model in ["wan_2_2", "wan_2_2_t2v_14b", "wan_2_2_i2v_14b", "ltx_2_3"] {
+            assert!(is_candle_video_engine(model), "{model}");
+        }
     }
 
     #[test]
     fn candle_video_adapter_labels_are_per_family() {
-        assert_eq!(candle_video_adapter_label("wan2_2_ti2v_5b"), "candle_wan");
+        // Every wan engine (5B + 14B T2V/I2V) reports the shared `candle_wan` adapter.
+        for engine_id in ["wan2_2_ti2v_5b", "wan2_2_t2v_14b", "wan2_2_i2v_14b"] {
+            assert_eq!(
+                candle_video_adapter_label(engine_id),
+                "candle_wan",
+                "{engine_id}"
+            );
+        }
         assert_eq!(
             candle_video_adapter_label("ltx_2_3_distilled"),
             "candle_ltx"
+        );
+    }
+
+    #[test]
+    fn candle_video_default_repos_are_per_engine() {
+        assert_eq!(
+            candle_video_default_repo("wan2_2_ti2v_5b"),
+            "Wan-AI/Wan2.2-TI2V-5B-Diffusers"
+        );
+        assert_eq!(
+            candle_video_default_repo("wan2_2_t2v_14b"),
+            "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+        );
+        assert_eq!(
+            candle_video_default_repo("wan2_2_i2v_14b"),
+            "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+        );
+        assert_eq!(
+            candle_video_default_repo("ltx_2_3_distilled"),
+            "Lightricks/LTX-2.3"
+        );
+    }
+
+    #[test]
+    fn candle_video_conditioning_only_for_i2v() {
+        let settings = crate::Settings::from_env();
+        let project_path = std::path::Path::new("");
+        // txt2video engines never build conditioning (even if a stray source asset is present).
+        for engine_id in ["wan2_2_ti2v_5b", "wan2_2_t2v_14b", "ltx_2_3_distilled"] {
+            let payload = json!({ "sourceAssetId": "asset_1" });
+            let request = VideoRequest::from_payload(payload.as_object().expect("object"));
+            let conditioning =
+                resolve_candle_video_conditioning(&settings, &request, project_path, engine_id)
+                    .expect("txt2video conditioning resolves");
+            assert!(
+                conditioning.is_empty(),
+                "{engine_id} must be txt2video-only"
+            );
+        }
+        // The 14B I2V requires a source image — a request without one errors before touching disk.
+        let payload = json!({ "mode": "image_to_video" });
+        let no_source = VideoRequest::from_payload(payload.as_object().expect("object"));
+        assert!(
+            resolve_candle_video_conditioning(
+                &settings,
+                &no_source,
+                project_path,
+                "wan2_2_i2v_14b"
+            )
+            .is_err(),
+            "i2v without a source image must error"
         );
     }
 }


### PR DESCRIPTION
## What

Wire the candle **Wan2.2 14B** T2V + I2V video generators into the worker candle lane — the worker analog of [sc-5097](https://app.shortcut.com/trefry/story/5097), which wired only the 5B (`wan_2_2` → `wan2_2_ti2v_5b`). Story: [sc-5175](https://app.shortcut.com/trefry/story/5175) (epic 5095). Depends on [sc-5174](https://app.shortcut.com/trefry/story/5174) (the candle Wan 14B provider, merged in candle-gen [#23](https://github.com/michaeltrefry/candle-gen/pull/23)).

## Changes

- **Routing** (`sceneworks-core/jobs_store.rs`, all-targets): `CANDLE_VIDEO_ROUTED_MODELS` gains `wan_2_2_t2v_14b` + `wan_2_2_i2v_14b`. `video_request_candle_eligible` now branches — the **14B I2V is image→video only** (requires `mode=image_to_video` + a `sourceAssetId`, via the new `CANDLE_VIDEO_I2V_ROUTED_MODELS` set), while the 5B / T2V-14B / ltx ids stay txt2video-only. Reference/mask conditioning + LoRA + on-the-fly quant still fall back to the Python torch worker.
- **Dispatch + labeling** (`sceneworks-worker/video_jobs.rs`, candle lane): `candle_video_engine_id` maps the two 14B ids to the candle registry ids; per-engine default repos (`Wan-AI/Wan2.2-T2V-A14B-Diffusers` / `...-I2V-A14B-Diffusers`); `candle_video_adapter_label` already reports `candle_wan` for every wan engine.
- **New seam — candle I2V conditioning**: `resolve_candle_video_conditioning` loads the i2v_14b source image to a single `Conditioning::Reference` — exactly what the sc-5174 provider reads (the channel-concat first frame it VAE-encodes into `y`, `in_dim=36`). The candle analog of the MLX Wan i2v conditioning. T2V needs only the routing extension.
- **Reuse**: `load_reference_image` moves from the macOS-only `image_jobs/flux2.rs` into both-lanes `image_jobs/base.rs`, so the candle i2v path reuses the exact loader the MLX conditioning paths use (no duplication, no path change for the ~20 macOS callers).
- `engines.rs` `VIDEO_ENGINE_IDS` already lists the 14B ids, so `registry_capabilities` lights up `video_generate` for `backend="candle"` once the providers link.

## Scope boundary — pins (sc-5228)

This PR is **code-only**, per the story ("Force-link is already covered; just the routing/dispatch/labeling"). The candle-gen pin bump that actually links sc-5174's 14B provider **and** aligns gen-core (`e9c569c`→`1a97909`) so the `--features backend-candle` skew gate is green is owned by **[sc-5228](https://app.shortcut.com/trefry/story/5228)** (the candle-gen gen-core re-pin). Until sc-5228 lands, these ids have no linked candle provider and correctly fall back to torch — and the **default** skew gate stays green (it runs without `--features backend-candle`). The end-to-end 14B render acceptance is gated on sc-5228.

## Validation

- `sceneworks-core` lib: **164 tests** incl. **17 candle routing tests** ✅
- worker default Windows `cargo check` ✅
- worker `cargo check --features backend-candle` ✅ + `cargo clippy --features backend-candle -- -D warnings` ✅ + the **4 candle video tests** ✅ (MSVC 14.44 / CUDA 12.9, sm_120)
- `cargo fmt --check` ✅; default `check-gen-core-skew.sh` ✅ (one rev)
- macOS build not run (Windows box) — the only macOS-affecting change is the mechanical `load_reference_image` relocation; all callers resolve `crate::image_jobs::load_reference_image` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
