### PR TITLE
sc-5228: bump worker candle-gen pin 8a3974a -> c032f16 (align gen-core to 1a97909)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,18 +436,22 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
  "candle-core",
  "candle-nn",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=e9c569c211b77fb9061aa3968dfd03bd02804109)",
+ "image",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "safetensors 0.7.0",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -461,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -475,7 +479,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -486,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -498,7 +502,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -512,21 +516,25 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
+ "candle-core",
  "candle-gen",
+ "candle-nn",
  "candle-transformers",
  "hf-hub",
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
+ "safetensors 0.7.0",
  "tokenizers 0.22.2",
+ "tracing",
 ]
 
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -538,13 +546,16 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a3974acebd6d6d394b8bfeb91c0bdb01093c27a#8a3974acebd6d6d394b8bfeb91c0bdb01093c27a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c032f16acdee5559664e41a8e65ffa238645a57a#c032f16acdee5559664e41a8e65ffa238645a57a"
 dependencies = [
+ "candle-core",
  "candle-gen",
+ "candle-nn",
  "candle-transformers",
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
+ "safetensors 0.7.0",
  "tokenizers 0.22.2",
 ]
 
@@ -3146,7 +3157,7 @@ source = "git+https://github.com/michaeltrefry/mlx-gen?rev=1a97909902c73ff8cc02e
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=1a97909902c73ff8cc02e94c689bd1e86d9e8280)",
+ "sceneworks-gen-core",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -4993,17 +5004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=e9c569c211b77fb9061aa3968dfd03bd02804109#e9c569c211b77fb9061aa3968dfd03bd02804109"
-dependencies = [
- "inventory",
- "safetensors 0.4.5",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5080,7 +5080,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=1a97909902c73ff8cc02e94c689bd1e86d9e8280)",
+ "sceneworks-gen-core",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -126,8 +126,9 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # (none of #416–#426 touch the mlx-rs/engine ABI), so the direct `mlx-rs` pin below is unchanged and
 # MLX rebuilds only the new `mlx-gen-seedvr2` crate. gen-core is byte-identical to `e9c569c` EXCEPT the
 # additive `softness` field, so the default `check-gen-core-skew.sh` gate stays green (one rev); the
-# Windows `backend-candle` lane needs a matching candle-gen gen-core re-pin to this rev (sc-5228, the
-# sc-5176/sc-5035 pattern). On top of:
+# Windows `backend-candle` lane's matching candle-gen gen-core re-pin to this rev landed in sc-5228
+# (candle-gen PR #33 — see the candle-gen dep block below), so that lane also resolves a single rev.
+# On top of:
 # Rev e9c569c (mlx-gen main, merged PR #415, epic 3164 / sc-5148): adds the native-MLX Lens
 # LoRA/LoKr TRAINING kernel (`mlx-gen-lens/src/training.rs`, `LensTrainer` registered under `lens`),
 # unblocking the worker `lens_lora` training cutover (sc-5180 — the training sibling of sc-5105's
@@ -401,26 +402,34 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1a9
 # this worker's MLX pin (bumped by sc-5180 / mlx-gen-lens). That re-pin is the key: without it the
 # `--features backend-candle` graph resolved TWO gen-core revs (worker mlx-gen `e9c569c2` vs candle-gen
 # `95cd5c6`) -> the inventory skew trap. With `8a3974a` the candle lane resolves EXACTLY ONE
-# `sceneworks-gen-core` (`e9c569c2`, == the mlx-gen pin) again. ALL candle deps below MUST share this rev.
+# `sceneworks-gen-core` (`e9c569c2`, == the mlx-gen pin) again.
+#
+# sc-5228 bumps `8a3974a` -> `c032f16` (candle-gen main, PR #33): re-pins candle-gen's
+# `sceneworks-gen-core` `e9c569c2` -> `1a97909` to MATCH this worker's MLX pin after sc-4816 (#647)
+# bumped it `e9c569c2` -> `1a97909` (mlx-gen #422, the SeedVR2 `softness` field). Same skew-trap reason:
+# without it the `--features backend-candle` graph resolved worker `1a97909` vs candle-gen `e9c569c2`;
+# with `c032f16` the candle lane resolves EXACTLY ONE `sceneworks-gen-core` (`1a97909`, == the mlx-gen
+# pin) again, and this also LINKS candle-gen's Wan2.2 14B T2V/I2V providers (sc-5174, candle-gen #23)
+# that the sc-5175 worker wiring routes to. ALL candle deps below MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a3974acebd6d6d394b8bfeb91c0bdb01093c27a", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c032f16acdee5559664e41a8e65ffa238645a57a", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## What

Bump the worker's 8 `candle-gen-*` deps `8a3974a` → `c032f16` (candle-gen main, [PR #33](https://github.com/michaeltrefry/candle-gen/pull/33)), which re-pins candle-gen's internal `sceneworks-gen-core` `e9c569c2` → `1a97909`. Step 2 of [sc-5228](https://app.shortcut.com/trefry/story/5228) (step 1 = candle-gen #33).

## Why

The worker's direct `sceneworks-gen-core` pin moved `e9c569c2`→`1a97909` (sc-4816 / #647 — mlx-gen #422's SeedVR2 `softness` field), but candle-gen was still on `e9c569c2`. So `--features backend-candle` resolved **two** `sceneworks-gen-core` revs — the inventory-skew trap (providers register into one registry, the worker queries the other → runtime "engine not found"). This bump re-aligns them: the candle lane now resolves **exactly one** `sceneworks-gen-core` (`1a97909`, == the mlx-gen pin).

It also **links candle-gen's Wan2.2 14B T2V/I2V providers** (sc-5174, candle-gen #23, in the `c032f16` history) that the [sc-5175](https://app.shortcut.com/trefry/story/5175) worker wiring (#648) routes to — so the 14B candle video lane is now wired end to end.

## Changes
- `crates/sceneworks-worker/Cargo.toml`: 8 `candle-gen-*` deps `8a3974a`→`c032f16` + the pin-lineage comments.
- `Cargo.lock` regenerated — the stale `e9c569c2` gen-core rev drops out.

## Validation (MSVC 14.44 / CUDA 12.9, sm_120)
- default `check-gen-core-skew.sh` ✅ (single rev `1a97909`)
- `cargo tree --features backend-candle` resolves a **single** `sceneworks-gen-core` rev `1a97909` ✅
- `cargo check -p sceneworks-worker --features backend-candle` ✅ clean
- zero `e9c569c` references left in `Cargo.lock` ✅

Recompile-only re-pin: the gen-core delta `e9c569c2..1a97909` is exactly the additive optional `GenerationRequest.softness` field, which candle-gen consumes none of. The candle-gen side passed its CPU CI (#33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
