### PR TITLE
sc-5437: drop stale "torch-only" label from Mac video-mode gating message

### DIFF
--- a/apps/web/src/macGating.js
+++ b/apps/web/src/macGating.js
@@ -85,7 +85,11 @@ export function macVideoModeBlock(model, caps, mode) {
   if (modes && modes[mode] === false) {
     return {
       blocked: true,
-      text: `${label(caps)} — this mode is a torch-only advanced video mode.`,
+      // On Mac the runtime is MLX-only (epic 3482) — there is no torch fallback, so a
+      // blocked mode simply isn't served for this model here (some modes have no MLX path
+      // on this engine; others, like Bernini's editing/reference modes, are MLX-only and
+      // exclusive to another model). Don't call it "torch-only".
+      text: `${label(caps)} — the selected model doesn't support this mode on macOS.`,
     };
   }
   return null;

--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -107,10 +107,13 @@ describe("macGating helpers", () => {
     expect(macTrainingKernelBlocked(gating, "z_image_lora")).toBe(false);
   });
 
-  it("blocks a torch-only video mode by per-model eligibility", () => {
+  it("blocks an MLX-unsupported video mode by per-model eligibility", () => {
     const video = { id: "wan_2_2", macSupport: { features: { videoModes: { image_to_video: true, replace_person: false } } } };
     expect(macVideoModeBlock(video, gating, "image_to_video")).toBeNull();
-    expect(macVideoModeBlock(video, gating, "replace_person")?.blocked).toBe(true);
+    const block = macVideoModeBlock(video, gating, "replace_person");
+    expect(block?.blocked).toBe(true);
+    // The message must not claim "torch-only" — on Mac the runtime is MLX-only (epic 3482).
+    expect(block?.text).not.toMatch(/torch/i);
   });
 
   it("gates the clip-conditioning modes per-model (sc-3773 / sc-3357)", () => {


### PR DESCRIPTION
Surfaced during the [sc-4703](https://app.shortcut.com/trefry/story/4703) / [sc-4709](https://app.shortcut.com/trefry/story/4709) Torch-reference cleanup ([sc-5437](https://app.shortcut.com/trefry/story/5437)).

`macVideoModeBlock` (`apps/web/src/macGating.js`) showed *"… — this mode is a **torch-only** advanced video mode."* when a video mode is disabled for the selected model on Mac. On Mac the runtime is MLX-only (epic 3482 — no torch fallback), so the label is stale for every gated mode, and **doubly wrong for Bernini's editing/reference modes** ([sc-4703](https://app.shortcut.com/trefry/story/4703)), which are MLX-only and Bernini-exclusive (no torch path at all).

## Change
- **`macGating.js`** — reword to `"… — the selected model doesn't support this mode on macOS."` (accurate for every gated mode; no behavior change — same `{blocked: true}`).
- **`macGating.test.js`** — rename the test off "torch-only" and assert the message contains no "torch".
- **Left as-is:** the comments at `macGating.js:56/75/109` describe things that genuinely *are* torch off-Mac (un-ported models, per-model torch features, the dropped aura-sr upscaler) — accurate, not Bernini.

## Verification
- `apps/web` vitest: 413 passed (incl. `macGating.test.js`), eslint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)