### PR TITLE
sc-5425: Bernini multi-source video modes (mv2v + ads2v)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -515,14 +515,25 @@ pub(crate) struct VideoJobRequest {
     pub(crate) last_frame_asset_id: Option<String>,
     #[serde(default)]
     pub(crate) source_clip_asset_id: Option<String>,
+    /// Multiple source clips for Bernini's multi-source-video edit mode
+    /// (`multi_video_to_video` / mv2v, sc-5425). The worker pushes one
+    /// `Conditioning::VideoClip` per clip; v2v/rv2v/ads2v use the single
+    /// `source_clip_asset_id` instead.
+    #[serde(default)]
+    pub(crate) source_clip_asset_ids: Vec<String>,
     #[serde(default)]
     pub(crate) bridge_right_clip_asset_id: Option<String>,
     /// Subject reference images for Bernini's reference-driven video modes
-    /// (`reference_to_video` / `reference_video_to_video`, sc-4703). Carried as a
-    /// list so r2v/rv2v can supply multiple references; the worker VAE/ViT-encodes
-    /// each into the planner's `MultiReference` conditioning.
+    /// (`reference_to_video` / `reference_video_to_video` / `ads2v`, sc-4703 /
+    /// sc-5425). Carried as a list so the mode can supply multiple references; the
+    /// worker VAE/ViT-encodes each into the planner's `MultiReference` conditioning.
     #[serde(default)]
     pub(crate) reference_asset_ids: Vec<String>,
+    /// The reference *video* slot for Bernini's `ads2v` mode (sc-5425): a second
+    /// source video distinct from `source_clip_asset_id` (the clip being edited).
+    /// The worker pushes it as a second `Conditioning::VideoClip`.
+    #[serde(default)]
+    pub(crate) reference_clip_asset_id: Option<String>,
     #[serde(default = "default_requested_gpu")]
     pub(crate) requested_gpu: String,
     #[serde(default)]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1814,6 +1814,10 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         "video_to_video",
         "reference_to_video",
         "reference_video_to_video",
+        // Bernini multi-source-video modes (sc-5425): mv2v (multiple source clips)
+        // and ads2v (source video + reference video + reference images).
+        "multi_video_to_video",
+        "ads2v",
     ]
     .contains(&payload.mode.as_str())
     {
@@ -1826,6 +1830,15 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
     {
         return Err(ApiError::bad_request(
             "referenceAssetIds must not contain blank ids",
+        ));
+    }
+    if payload
+        .source_clip_asset_ids
+        .iter()
+        .any(|id| id.trim().is_empty())
+    {
+        return Err(ApiError::bad_request(
+            "sourceClipAssetIds must not contain blank ids",
         ));
     }
     let duration = payload
@@ -1885,6 +1898,22 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         "reference_video_to_video" if payload.reference_asset_ids.is_empty() => Err(
             ApiError::bad_request("Reference + Video requires at least one reference image."),
         ),
+        // Bernini multi-source-video modes (sc-5425): mv2v blends multiple source clips;
+        // ads2v edits a source clip using a reference video + reference images. Each
+        // requires its full media set so the worker never falls through to an
+        // unconditioned render.
+        "multi_video_to_video" if payload.source_clip_asset_ids.len() < 2 => Err(
+            ApiError::bad_request("Multi-Clip → Video requires at least two source clips."),
+        ),
+        "ads2v" if payload.source_clip_asset_id.is_none() => Err(ApiError::bad_request(
+            "Source + Reference Video requires a source clip.",
+        )),
+        "ads2v" if payload.reference_clip_asset_id.is_none() => Err(ApiError::bad_request(
+            "Source + Reference Video requires a reference video.",
+        )),
+        "ads2v" if payload.reference_asset_ids.is_empty() => Err(ApiError::bad_request(
+            "Source + Reference Video requires at least one reference image.",
+        )),
         _ => Ok(()),
     }
 }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3102,7 +3102,7 @@ async fn bernini_video_modes_validate_required_media() {
 
     // A complete reference_video_to_video request carries both the clip and the refs.
     let (status, rv2v_job) = request(
-        app,
+        app.clone(),
         "POST",
         "/api/v1/video/jobs",
         json!({
@@ -3119,6 +3119,102 @@ async fn bernini_video_modes_validate_required_media() {
     assert_eq!(rv2v_job["type"], "video_generate");
     assert_eq!(rv2v_job["payload"]["referenceAssetIds"][0], "ref-1");
     assert_eq!(rv2v_job["payload"]["referenceAssetIds"][1], "ref-2");
+
+    // multi_video_to_video (sc-5425) needs at least two source clips.
+    for clips in [json!([]), json!(["clip-a"])] {
+        let (status, _) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/video/jobs",
+            json!({
+                "projectId": "project-1",
+                "model": "bernini",
+                "mode": "multi_video_to_video",
+                "prompt": "blend the takes",
+                "sourceClipAssetIds": clips
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    // Blank source-clip ids are rejected.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "multi_video_to_video",
+            "prompt": "blend the takes",
+            "sourceClipAssetIds": ["clip-a", "  "]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // A complete multi_video_to_video request carries the clip array.
+    let (status, mv2v_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "multi_video_to_video",
+            "prompt": "blend the takes",
+            "sourceClipAssetIds": ["clip-a", "clip-b"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(mv2v_job["type"], "video_generate");
+    assert_eq!(mv2v_job["payload"]["sourceClipAssetIds"][0], "clip-a");
+    assert_eq!(mv2v_job["payload"]["sourceClipAssetIds"][1], "clip-b");
+
+    // ads2v (sc-5425) needs a source clip, a reference video, AND >=1 reference image.
+    let ads2v_incomplete = [
+        json!({ "referenceClipAssetId": "clip-ref", "referenceAssetIds": ["ref-1"] }),
+        json!({ "sourceClipAssetId": "clip-src", "referenceAssetIds": ["ref-1"] }),
+        json!({ "sourceClipAssetId": "clip-src", "referenceClipAssetId": "clip-ref" }),
+    ];
+    for extra in ads2v_incomplete {
+        let mut body = json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "ads2v",
+            "prompt": "drive the edit with the reference clip"
+        });
+        let object = body.as_object_mut().unwrap();
+        for (key, value) in extra.as_object().unwrap() {
+            object.insert(key.clone(), value.clone());
+        }
+        let (status, _) = request(app.clone(), "POST", "/api/v1/video/jobs", body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    // A complete ads2v request carries the source clip, reference video, and references.
+    let (status, ads2v_job) = request(
+        app,
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "ads2v",
+            "prompt": "drive the edit with the reference clip",
+            "sourceClipAssetId": "clip-src",
+            "referenceClipAssetId": "clip-ref",
+            "referenceAssetIds": ["ref-1"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(ads2v_job["type"], "video_generate");
+    assert_eq!(ads2v_job["payload"]["sourceClipAssetId"], "clip-src");
+    assert_eq!(ads2v_job["payload"]["referenceClipAssetId"], "clip-ref");
+    assert_eq!(ads2v_job["payload"]["referenceAssetIds"][0], "ref-1");
 }
 
 #[tokio::test]

--- a/apps/web/public/prompt-guides/bernini.md
+++ b/apps/web/public/prompt-guides/bernini.md
@@ -21,16 +21,21 @@ Video Studio shows the right inputs for each, and the prompt always describes th
 | **Video → Video** | Re-renders a source clip to follow your prompt (restyle, relight, change the setting) while keeping its motion and timing. | Source clip + prompt |
 | **Reference → Video** | Generates a clip whose subject matches one or more reference images (identity / look), driven by the prompt. | 1+ reference images + prompt |
 | **Reference + Video** | Edits a source clip so its subject matches your reference images — reference-driven video editing. | Source clip + 1+ reference images + prompt |
+| **Multi-Clip → Video** | Blends/edits several source clips into one result clip following your prompt. | 2+ source clips + prompt |
+| **Clip + Ref Video** | Edits a source clip guided by a separate reference video *and* reference images. | Source clip + reference video + 1+ reference images + prompt |
 
 Tips per mode:
 
-- **Video → Video / Reference + Video:** the source clip sets the motion and framing, so write the
-  prompt about *what changes* (the new style, lighting, wardrobe, or setting), not the motion the clip
-  already has.
-- **Reference → Video / Reference + Video:** use clean, well-lit reference images of the subject. More
-  than one reference (different angles) helps the planner hold identity across the clip. Then describe
-  the action and scene you want the subject placed into.
-- All modes share the same length / fps / resolution limits — keep clips short; the source clip is
+- **Video → Video / Reference + Video / Multi-Clip → Video / Clip + Ref Video:** the source clip(s) set
+  the motion and framing, so write the prompt about *what changes* (the new style, lighting, wardrobe,
+  or setting), not the motion the clip already has.
+- **Reference → Video / Reference + Video / Clip + Ref Video:** use clean, well-lit reference images of
+  the subject. More than one reference (different angles) helps the planner hold identity across the
+  clip. Then describe the action and scene you want the subject placed into.
+- **Multi-Clip → Video:** supply two or more clips; the planner conditions on all of them in the order
+  you pick. **Clip + Ref Video** adds a separate reference video on top of the source clip and images —
+  use it when a second clip (not just stills) should drive the edit.
+- All modes share the same length / fps / resolution limits — keep clips short; source clips are
   resampled to the output length.
 
 ## Prompt Shape

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -229,8 +229,13 @@ export function VideoStudio() {
   const [sourceClipAssetId, setSourceClipAssetId] = useState(selectedAsset?.type === "video" ? selectedAsset.id : "");
   const [bridgeRightClipAssetId, setBridgeRightClipAssetId] = useState("");
   // Subject reference images for Bernini's reference-driven video modes
-  // (reference_to_video / reference_video_to_video, sc-4703). 1–N images.
+  // (reference_to_video / reference_video_to_video / ads2v, sc-4703 / sc-5425). 1–N images.
   const [referenceAssetIds, setReferenceAssetIds] = useState([]);
+  // Multiple source clips for Bernini's multi-source-video edit (multi_video_to_video, sc-5425).
+  const [sourceClipAssetIds, setSourceClipAssetIds] = useState([]);
+  // Reference video for Bernini's ads2v mode (sc-5425): a second source clip distinct from the
+  // edited source clip (sourceClipAssetId).
+  const [referenceClipAssetId, setReferenceClipAssetId] = useState("");
   const [characterId, setCharacterId] = useState("");
   const [characterLookId, setCharacterLookId] = useState("");
   const [personTrackId, setPersonTrackId] = useState("");
@@ -269,6 +274,8 @@ export function VideoStudio() {
     "video_to_video",
     "reference_to_video",
     "reference_video_to_video",
+    "multi_video_to_video",
+    "ads2v",
   ].includes(mode);
   const {
     availablePresets,
@@ -602,12 +609,15 @@ export function VideoStudio() {
     ["extend_clip", "Extend"],
     ["video_bridge", "Bridge"],
     ["replace_person", "Replace person"],
-    // Bernini planner editing / reference-driven video modes (sc-4703). Enabled only
-    // on models whose capabilities include them (today: Bernini); disabled elsewhere,
-    // the same per-model gating as Replace person / the LTX clip modes.
+    // Bernini planner editing / reference-driven video modes (sc-4703) + multi-source
+    // modes (sc-5425). Enabled only on models whose capabilities include them (today:
+    // Bernini); disabled elsewhere, the same per-model gating as Replace person / the
+    // LTX clip modes.
     ["video_to_video", "Video → Video"],
     ["reference_to_video", "Reference → Video"],
     ["reference_video_to_video", "Reference + Video"],
+    ["multi_video_to_video", "Multi-Clip → Video"],
+    ["ads2v", "Clip + Ref Video"],
   ];
   // Mac UI gating (sc-3486, sc-3773): every video mode is disabled per-model via the selected
   // model's `macSupport.features.videoModes` — FLF on the non-Keyframe Wan MoE engines,
@@ -641,7 +651,11 @@ export function VideoStudio() {
     // Bernini editing / reference-driven modes (sc-4703).
     (mode === "video_to_video" && sourceClipAssetId) ||
     (mode === "reference_to_video" && referenceAssetIds.length > 0) ||
-    (mode === "reference_video_to_video" && sourceClipAssetId && referenceAssetIds.length > 0);
+    (mode === "reference_video_to_video" && sourceClipAssetId && referenceAssetIds.length > 0) ||
+    // Bernini multi-source modes (sc-5425): mv2v needs >=2 clips; ads2v needs a source
+    // clip, a reference video, and >=1 reference image.
+    (mode === "multi_video_to_video" && sourceClipAssetIds.length >= 2) ||
+    (mode === "ads2v" && sourceClipAssetId && referenceClipAssetId && referenceAssetIds.length > 0);
   // Don't let Replace Person queue a job the readiness endpoint says no live
   // worker can run — that would sit unclaimable instead of honoring the gate.
   const replaceReady = mode !== "replace_person" || personReadiness?.replace?.ready !== false;
@@ -706,14 +720,25 @@ export function VideoStudio() {
         characterLookId: characterLookId || null,
         sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,
         lastFrameAssetId: mode === "first_last_frame" ? lastFrameAssetId || null : null,
-        sourceClipAssetId: ["extend_clip", "replace_person", "video_bridge", "video_to_video", "reference_video_to_video"].includes(
-          mode,
-        )
+        sourceClipAssetId: [
+          "extend_clip",
+          "replace_person",
+          "video_bridge",
+          "video_to_video",
+          "reference_video_to_video",
+          "ads2v",
+        ].includes(mode)
           ? sourceClipAssetId || null
           : null,
+        // Bernini multi-source clips (sc-5425) — only mv2v carries the array.
+        sourceClipAssetIds: mode === "multi_video_to_video" ? sourceClipAssetIds : [],
         bridgeRightClipAssetId: mode === "video_bridge" ? bridgeRightClipAssetId || null : null,
-        // Bernini subject references (sc-4703) — only the reference-driven modes carry them.
-        referenceAssetIds: ["reference_to_video", "reference_video_to_video"].includes(mode) ? referenceAssetIds : [],
+        // Bernini subject references (sc-4703 / sc-5425) — the reference-driven modes + ads2v carry them.
+        referenceAssetIds: ["reference_to_video", "reference_video_to_video", "ads2v"].includes(mode)
+          ? referenceAssetIds
+          : [],
+        // Bernini ads2v reference video (sc-5425).
+        referenceClipAssetId: mode === "ads2v" ? referenceClipAssetId || null : null,
         personTrackId: mode === "replace_person" ? personTrackId || null : null,
         replacementMode: mode === "replace_person" ? replacementMode : "face_only",
         loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
@@ -935,7 +960,7 @@ export function VideoStudio() {
               </>
             ) : null}
 
-            {["video_to_video", "reference_video_to_video"].includes(mode) ? (
+            {["video_to_video", "reference_video_to_video", "ads2v"].includes(mode) ? (
               <AssetPickerField
                 assets={videoAssets}
                 buttonLabel="Select clip"
@@ -946,7 +971,31 @@ export function VideoStudio() {
               />
             ) : null}
 
-            {["reference_to_video", "reference_video_to_video"].includes(mode) ? (
+            {mode === "multi_video_to_video" ? (
+              <AssetPickerField
+                assets={videoAssets}
+                buttonLabel="Select clips"
+                changeLabel="Edit clips"
+                emptyLabel="No source clips selected"
+                label="Source clips"
+                multiple
+                onChange={setSourceClipAssetIds}
+                values={sourceClipAssetIds}
+              />
+            ) : null}
+
+            {mode === "ads2v" ? (
+              <AssetPickerField
+                assets={videoAssets}
+                buttonLabel="Select clip"
+                emptyLabel="No reference video selected"
+                label="Reference video"
+                onChange={setReferenceClipAssetId}
+                value={referenceClipAssetId}
+              />
+            ) : null}
+
+            {["reference_to_video", "reference_video_to_video", "ads2v"].includes(mode) ? (
               <AssetPickerField
                 assets={imageAssets}
                 buttonLabel="Select images"

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -258,7 +258,14 @@ describe("VideoStudio Bernini task modes", () => {
     name: "Bernini",
     type: "video",
     family: "bernini",
-    capabilities: ["text_to_video", "video_to_video", "reference_to_video", "reference_video_to_video"],
+    capabilities: [
+      "text_to_video",
+      "video_to_video",
+      "reference_to_video",
+      "reference_video_to_video",
+      "multi_video_to_video",
+      "ads2v",
+    ],
     defaults: { duration: 5, resolution: "848x480", fps: 16 },
     limits: { durations: [3, 4, 5], fps: [16], resolutions: ["848x480", "480x848"] },
     quantization: {},
@@ -267,6 +274,8 @@ describe("VideoStudio Bernini task modes", () => {
   };
 
   const clip = { id: "vid_src", type: "video", projectId: "project_1", displayName: "Source Clip" };
+  const clip2 = { id: "vid_src_2", type: "video", projectId: "project_1", displayName: "Source Clip Two" };
+  const refClip = { id: "vid_ref", type: "video", projectId: "project_1", displayName: "Reference Clip" };
   const refA = { id: "img_ref_a", type: "image", projectId: "project_1", displayName: "Reference A" };
   const refB = { id: "img_ref_b", type: "image", projectId: "project_1", displayName: "Reference B" };
 
@@ -317,6 +326,18 @@ describe("VideoStudio Bernini task modes", () => {
 
     await click(modeButton("Reference + Video"));
     expect(pickerLabels()).toEqual(expect.arrayContaining(["Source clip", "Reference images"]));
+
+    // mv2v: a single multi-clip picker, no single "Source clip" or reference images.
+    await click(modeButton("Multi-Clip → Video"));
+    expect(pickerLabels()).toContain("Source clips");
+    expect(pickerLabels()).not.toContain("Source clip");
+    expect(pickerLabels()).not.toContain("Reference images");
+
+    // ads2v: source clip + reference video + reference images.
+    await click(modeButton("Clip + Ref Video"));
+    expect(pickerLabels()).toEqual(
+      expect.arrayContaining(["Source clip", "Reference video", "Reference images"]),
+    );
   });
 
   it("keeps Render disabled until the required reference image is selected", async () => {
@@ -387,6 +408,77 @@ describe("VideoStudio Bernini task modes", () => {
       sourceClipAssetId: "vid_src",
     });
     expect(payload.referenceAssetIds).toEqual(["img_ref_a"]);
+  });
+
+  it("requires at least two clips before submitting multi_video_to_video", async () => {
+    const context = baseContext({ videoModels: [BERNINI], assets: [clip, clip2], selectedAsset: clip });
+    await render(context);
+    await click(modeButton("Multi-Clip → Video"));
+
+    // One clip auto-selected from selectedAsset isn't enough — mv2v needs >=2.
+    expect(buttonWithText(container, "Render clip").disabled).toBe(true);
+
+    await click(buttonWithText(container, "Select clips"));
+    const modal = document.querySelector(".asset-picker-modal");
+    for (const name of ["Source Clip", "Source Clip Two"]) {
+      const option = [...modal.querySelectorAll('[role="option"]')].find((el) => el.textContent.includes(name));
+      await click(option);
+    }
+    await click(buttonWithText(modal, "Use Selection"));
+
+    expect(buttonWithText(container, "Render clip").disabled).toBe(false);
+    await click(buttonWithText(container, "Render clip"));
+
+    expect(context.createVideoJob).toHaveBeenCalledTimes(1);
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload.mode).toBe("multi_video_to_video");
+    expect(payload.sourceClipAssetIds).toEqual(["vid_src", "vid_src_2"]);
+    expect(payload.sourceClipAssetId).toBeNull();
+    expect(payload.referenceAssetIds).toEqual([]);
+  });
+
+  it("submits source clip, reference video, and references for ads2v", async () => {
+    const context = baseContext({
+      videoModels: [BERNINI],
+      assets: [clip, refClip, refA],
+      selectedAsset: clip,
+    });
+    await render(context);
+    await click(modeButton("Clip + Ref Video"));
+
+    // Source clip auto-selected; reference video + a reference image still required.
+    expect(buttonWithText(container, "Render clip").disabled).toBe(true);
+
+    // The source clip picker shows "Change" (auto-selected), so the first "Select clip"
+    // button in document order is the empty reference-video picker.
+    await click(buttonWithText(container, "Select clip"));
+    let modal = document.querySelector(".asset-picker-modal");
+    const refClipOption = [...modal.querySelectorAll('[role="option"]')].find((el) =>
+      el.textContent.includes("Reference Clip"),
+    );
+    await click(refClipOption);
+    await click(buttonWithText(modal, "Use Selection"));
+
+    // Pick a reference image.
+    await click(buttonWithText(container, "Select images"));
+    modal = document.querySelector(".asset-picker-modal");
+    const refImageOption = [...modal.querySelectorAll('[role="option"]')].find((el) =>
+      el.textContent.includes("Reference A"),
+    );
+    await click(refImageOption);
+    await click(buttonWithText(modal, "Use Selection"));
+
+    expect(buttonWithText(container, "Render clip").disabled).toBe(false);
+    await click(buttonWithText(container, "Render clip"));
+
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      mode: "ads2v",
+      sourceClipAssetId: "vid_src",
+      referenceClipAssetId: "vid_ref",
+    });
+    expect(payload.referenceAssetIds).toEqual(["img_ref_a"]);
+    expect(payload.sourceClipAssetIds).toEqual([]);
   });
 
   it("disables an editing mode on a model that does not support it", async () => {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2249,9 +2249,10 @@
     // (`assemble_bernini_snapshot`, ~93 GB bf16) and published as the turnkey
     // `SceneWorks/bernini-mlx` repo, downloaded on first use (no in-app conversion
     // — engine quantizes to Q8 at load). This entry covers the planner video task
-    // surface — text_to_video plus the editing (`video_to_video`) and reference-driven
-    // (`reference_to_video` / `reference_video_to_video`) modes (sc-4703). The t2i/i2i
-    // image companion is a separate image-typed catalog id (tracked under epic 4699).
+    // surface — text_to_video plus the editing (`video_to_video`), reference-driven
+    // (`reference_to_video` / `reference_video_to_video`, sc-4703), and multi-source
+    // (`multi_video_to_video` / `ads2v`, sc-5425) modes. The t2i/i2i image companion is
+    // a separate image-typed catalog id (tracked under epic 4699).
     {
       "id": "bernini",
       "name": "Bernini",
@@ -2262,7 +2263,9 @@
         "text_to_video",
         "video_to_video",
         "reference_to_video",
-        "reference_video_to_video"
+        "reference_video_to_video",
+        "multi_video_to_video",
+        "ads2v"
       ],
       "downloads": [
         {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2242,12 +2242,15 @@ const VIDEO_UI_MODES: &[&str] = &[
     "extend_clip",
     "video_bridge",
     "replace_person",
-    // Bernini editing / reference-driven video modes (sc-4703): only `bernini` is
-    // eligible (see `video_mode_is_mlx_eligible`); they surface disabled on the other
-    // models, the same per-model gating as `replace_person` / the LTX clip modes.
+    // Bernini editing / reference-driven video modes (sc-4703) + multi-source modes
+    // (sc-5425: `multi_video_to_video` / `ads2v`): only `bernini` is eligible (see
+    // `video_mode_is_mlx_eligible`); they surface disabled on the other models, the same
+    // per-model gating as `replace_person` / the LTX clip modes.
     "video_to_video",
     "reference_to_video",
     "reference_video_to_video",
+    "multi_video_to_video",
+    "ads2v",
 ];
 
 fn video_model_mac_support(model: &str) -> ModelMacSupport {
@@ -3620,12 +3623,19 @@ fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
     // editing + reference-driven video tasks (sc-4703): `video_to_video` (v2v — a
     // source-clip edit, `Conditioning::VideoClip`), `reference_to_video` (r2v —
     // subject reference images, `MultiReference`), and `reference_video_to_video`
-    // (rv2v — source clip + reference images). The engine selects the matching
-    // guidance mode from `video_mode` + the supplied conditioning.
+    // (rv2v — source clip + reference images); plus the multi-source modes (sc-5425):
+    // `multi_video_to_video` (mv2v — several source clips) and `ads2v` (source video +
+    // reference video + reference images). The engine selects the matching guidance
+    // mode from `video_mode` + the supplied conditioning.
     if model == "bernini" {
         return matches!(
             mode,
-            "text_to_video" | "video_to_video" | "reference_to_video" | "reference_video_to_video"
+            "text_to_video"
+                | "video_to_video"
+                | "reference_to_video"
+                | "reference_video_to_video"
+                | "multi_video_to_video"
+                | "ads2v"
         );
     }
     match mode {
@@ -5029,13 +5039,16 @@ mod mlx_routing_tests {
             assert!(!video_mode_is_mlx_eligible("svd", mode));
         }
         // Bernini serves text_to_video + the planner editing/reference video modes (sc-4703:
-        // video_to_video / reference_to_video / reference_video_to_video). It has no classic
-        // still-image-to-video / FLF / replace_person (its renderer is Wan2.2-T2V).
+        // video_to_video / reference_to_video / reference_video_to_video) + the multi-source
+        // modes (sc-5425: multi_video_to_video / ads2v). It has no classic still-image-to-video
+        // / FLF / replace_person (its renderer is Wan2.2-T2V).
         for mode in [
             "text_to_video",
             "video_to_video",
             "reference_to_video",
             "reference_video_to_video",
+            "multi_video_to_video",
+            "ads2v",
         ] {
             assert!(
                 video_mode_is_mlx_eligible("bernini", mode),
@@ -5055,7 +5068,8 @@ mod mlx_routing_tests {
                 "bernini should not serve {mode}"
             );
         }
-        // The editing/reference modes are Bernini-only — every other routed model rejects them.
+        // The editing/reference + multi-source modes are Bernini-only — every other routed
+        // model rejects them.
         for model in VIDEO_MLX_ROUTED_MODELS {
             if *model == "bernini" {
                 continue;
@@ -5064,6 +5078,8 @@ mod mlx_routing_tests {
                 "video_to_video",
                 "reference_to_video",
                 "reference_video_to_video",
+                "multi_video_to_video",
+                "ads2v",
             ] {
                 assert!(
                     !video_mode_is_mlx_eligible(model, mode),

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -270,17 +270,21 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         // Bernini (epic 4699) is a Wan2.2-T2V-A14B renderer + Qwen2.5-VL semantic
         // planner whose engine descriptor is `Modality::Both` with conditioning
         // `[Reference, MultiReference, VideoClip]`. The video task surface maps onto
-        // SceneWorks modes (sc-4703): `text_to_video` (t2v), `video_to_video` (v2v —
-        // a source clip edit), `reference_to_video` (r2v — subject reference images →
-        // video), and `reference_video_to_video` (rv2v — source clip + reference
-        // images). Bernini has no classic still-image-to-video (its renderer is T2V,
-        // not I2V). The t2i/i2i image companion is a separate image-typed catalog id
-        // (tracked under epic 4699), not declared here.
+        // SceneWorks modes (sc-4703 / sc-5425): `text_to_video` (t2v), `video_to_video`
+        // (v2v — a source clip edit), `reference_to_video` (r2v — subject reference
+        // images → video), `reference_video_to_video` (rv2v — source clip + reference
+        // images), `multi_video_to_video` (mv2v — multiple source clips), and `ads2v`
+        // (source video + reference video + reference images). Bernini has no classic
+        // still-image-to-video (its renderer is T2V, not I2V). The t2i/i2i image
+        // companion is a separate image-typed catalog id (tracked under epic 4699), not
+        // declared here.
         ("video", "bernini") => vec![
             "text_to_video",
             "video_to_video",
             "reference_to_video",
             "reference_video_to_video",
+            "multi_video_to_video",
+            "ads2v",
         ],
         _ => Vec::new(),
     }
@@ -1387,9 +1391,10 @@ mod tests {
     #[test]
     fn bernini_family_maps_to_bernini_adapter_and_full_video_task_surface() {
         assert_eq!(model_adapter_for_family("bernini"), Some("bernini"));
-        // sc-4703: the full Bernini video task surface — t2v + the editing
-        // (`video_to_video`) and reference-driven (`reference_to_video` /
-        // `reference_video_to_video`) modes. No still-image-to-video (renderer is T2V).
+        // sc-4703 / sc-5425: the full Bernini video task surface — t2v + the editing
+        // (`video_to_video`), reference-driven (`reference_to_video` /
+        // `reference_video_to_video`), and multi-source (`multi_video_to_video` /
+        // `ads2v`) modes. No still-image-to-video (renderer is T2V).
         assert_eq!(
             model_capabilities_for_type_and_family("video", "bernini"),
             vec![
@@ -1397,6 +1402,8 @@ mod tests {
                 "video_to_video",
                 "reference_to_video",
                 "reference_video_to_video",
+                "multi_video_to_video",
+                "ads2v",
             ],
         );
     }

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -56,11 +56,21 @@ pub struct VideoRequest {
     pub replacement_mode: String,
     pub last_frame_asset_id: Option<String>,
     pub source_clip_asset_id: Option<String>,
+    /// Multiple source clips for Bernini's multi-source-video edit mode
+    /// (`multi_video_to_video` / mv2v, sc-5425). `generate_bernini` pushes one
+    /// `Conditioning::VideoClip` per clip; the single-clip modes use
+    /// `source_clip_asset_id` instead.
+    pub source_clip_asset_ids: Vec<String>,
     pub bridge_right_clip_asset_id: Option<String>,
     /// Subject reference images for Bernini's reference-driven video modes
-    /// (`reference_to_video` / `reference_video_to_video`, sc-4703). Consumed by the
-    /// MLX `generate_bernini` path as the planner's `MultiReference` conditioning.
+    /// (`reference_to_video` / `reference_video_to_video` / `ads2v`, sc-4703 /
+    /// sc-5425). Consumed by the MLX `generate_bernini` path as the planner's
+    /// `MultiReference` conditioning.
     pub reference_asset_ids: Vec<String>,
+    /// The reference *video* slot for Bernini's `ads2v` mode (sc-5425): a second
+    /// source video distinct from `source_clip_asset_id`. `generate_bernini` pushes
+    /// it as a second `Conditioning::VideoClip` after the source clip.
+    pub reference_clip_asset_id: Option<String>,
     /// Per-model advanced knobs (steps, guidanceScale, imageConditioningStrength,
     /// timelineContext, …), passed through.
     pub advanced: JsonObject,
@@ -94,8 +104,10 @@ impl VideoRequest {
             replacement_mode: string_or(payload, "replacementMode", DEFAULT_REPLACEMENT_MODE),
             last_frame_asset_id: optional_id(payload, "lastFrameAssetId"),
             source_clip_asset_id: optional_id(payload, "sourceClipAssetId"),
+            source_clip_asset_ids: string_list(payload, "sourceClipAssetIds"),
             bridge_right_clip_asset_id: optional_id(payload, "bridgeRightClipAssetId"),
             reference_asset_ids: string_list(payload, "referenceAssetIds"),
+            reference_clip_asset_id: optional_id(payload, "referenceClipAssetId"),
             advanced: object_or_empty(payload, "advanced"),
             model_manifest_entry: object_or_empty(payload, "modelManifestEntry"),
         }
@@ -362,6 +374,34 @@ mod tests {
         // Absent → empty, never a panic.
         let bare = VideoRequest::from_payload(&payload(json!({ "projectId": "p" })));
         assert!(bare.reference_asset_ids.is_empty());
+    }
+
+    #[test]
+    fn parses_mv2v_and_ads2v_multi_source_fields() {
+        // mv2v: multiple source clips, blanks/non-strings dropped.
+        let mv2v = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p",
+            "mode": "multi_video_to_video",
+            "sourceClipAssetIds": ["clip-a", "  ", "clip-b", 7]
+        })));
+        assert_eq!(mv2v.source_clip_asset_ids, vec!["clip-a", "clip-b"]);
+
+        // ads2v: source clip + reference clip + reference images.
+        let ads2v = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p",
+            "mode": "ads2v",
+            "sourceClipAssetId": "clip-src",
+            "referenceClipAssetId": "clip-ref",
+            "referenceAssetIds": ["ref-1"]
+        })));
+        assert_eq!(ads2v.source_clip_asset_id.as_deref(), Some("clip-src"));
+        assert_eq!(ads2v.reference_clip_asset_id.as_deref(), Some("clip-ref"));
+        assert_eq!(ads2v.reference_asset_ids, vec!["ref-1"]);
+
+        // Absent → empty / None, never a panic.
+        let bare = VideoRequest::from_payload(&payload(json!({ "projectId": "p" })));
+        assert!(bare.source_clip_asset_ids.is_empty());
+        assert!(bare.reference_clip_asset_id.is_none());
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2698,14 +2698,15 @@ async fn generate_wan(
 }
 
 // ---------------------------------------------------------------------------
-// Real MLX Bernini generation (macOS, via mlx-gen-bernini, epic 4699 / sc-4707 + sc-4703): the full
-// Qwen2.5-VL semantic planner + Wan2.2-T2V-A14B dual-expert renderer. Serves the planner video task
-// surface: text_to_video (t2v), video_to_video (v2v — source-clip edit), reference_to_video (r2v —
-// subject references → video), reference_video_to_video (rv2v — source clip + references). The
-// SceneWorks mode maps to the engine `video_mode` task string and the source media is resolved into
-// the planner's `VideoClip` / `MultiReference` conditioning. Q4 default / Q8 opt-in at load. The
-// turnkey `SceneWorks/bernini-mlx` snapshot is self-contained. (t2i/i2i image companion = a separate
-// image-typed catalog id, tracked under epic 4699.)
+// Real MLX Bernini generation (macOS, via mlx-gen-bernini, epic 4699 / sc-4707 + sc-4703 + sc-5425):
+// the full Qwen2.5-VL semantic planner + Wan2.2-T2V-A14B dual-expert renderer. Serves the planner
+// video task surface: text_to_video (t2v), video_to_video (v2v — source-clip edit),
+// reference_to_video (r2v — subject references → video), reference_video_to_video (rv2v — source clip
+// + references), multi_video_to_video (mv2v — multiple source clips), ads2v (source video + reference
+// video + references). The SceneWorks mode maps to the engine `video_mode` task string and the source
+// media is resolved into the planner's `VideoClip` / `MultiReference` conditioning. Q4 default / Q8
+// opt-in at load. The turnkey `SceneWorks/bernini-mlx` snapshot is self-contained. (t2i/i2i image
+// companion = a separate image-typed catalog id, tracked under epic 4699.)
 // ---------------------------------------------------------------------------
 
 /// Adapter id recorded on a real MLX Bernini asset.
@@ -2789,16 +2790,26 @@ fn bernini_engine_video_mode(mode: &str) -> &'static str {
         "video_to_video" => "v2v",
         "reference_to_video" => "r2v",
         "reference_video_to_video" => "rv2v",
+        // Multi-source-video modes (sc-5425): mv2v (multiple source clips) and ads2v
+        // (source video + reference video + reference images). Both resolve to the
+        // engine's `V2vApg` guidance via `task_to_vit_mode`; they differ only in the
+        // supplied media.
+        "multi_video_to_video" => "mv2v",
+        "ads2v" => "ads2v",
         _ => "t2v",
     }
 }
 
 /// Resolve the source media for a Bernini editing/reference request into the planner conditioning:
-/// the source clip → [`Conditioning::VideoClip`] (the edit structure, VAE/ViT-encoded by the engine)
-/// and the subject reference images → [`Conditioning::MultiReference`]. `text_to_video` needs none.
-/// Each mode's required media is enforced here (defense in depth — the API validates the same), so a
-/// mis-built request fails loudly instead of silently rendering an unconditioned clip. The source
-/// clip is decoded to the output frame count (the engine resamples to its `target_fps` grid).
+/// source clips → [`Conditioning::VideoClip`] (the edit structure, VAE/ViT-encoded by the engine)
+/// and subject reference images → [`Conditioning::MultiReference`]. `text_to_video` needs none.
+/// The single-clip modes (v2v / rv2v / ads2v) use `sourceClipAssetId`; mv2v supplies several via
+/// `sourceClipAssetIds`; ads2v additionally appends the reference video (`referenceClipAssetId`) as a
+/// second clip after the source clip (sc-5425). Clips are emitted videos-first, in submission order,
+/// then images — matching the engine's `collect_conditioning` / `assign_source_ids` ordering. Each
+/// mode's required media is enforced here (defense in depth — the API validates the same), so a
+/// mis-built request fails loudly instead of silently rendering an unconditioned clip. Every clip is
+/// decoded to the output frame count (the engine resamples to its `target_fps` grid).
 #[cfg(target_os = "macos")]
 async fn resolve_bernini_conditioning(
     api: &ApiClient,
@@ -2807,23 +2818,44 @@ async fn resolve_bernini_conditioning(
     request: &VideoRequest,
     project_path: &Path,
 ) -> WorkerResult<Vec<Conditioning>> {
-    let needs_clip = matches!(
-        request.mode.as_str(),
-        "video_to_video" | "reference_video_to_video"
-    );
-    let needs_refs = matches!(
-        request.mode.as_str(),
-        "reference_to_video" | "reference_video_to_video"
-    );
-    let mut conditioning = Vec::new();
+    let mode = request.mode.as_str();
 
-    if needs_clip {
-        let clip_id = request.source_clip_asset_id.as_deref().ok_or_else(|| {
-            WorkerError::InvalidPayload(format!(
-                "bernini {} requires a source clip (sourceClipAssetId).",
-                request.mode.replace('_', " ")
-            ))
+    // Source video clips, in the order the engine assigns source ids (videos first; for ads2v the
+    // source clip leads the reference video).
+    let mut clip_ids: Vec<&str> = Vec::new();
+    match mode {
+        "video_to_video" | "reference_video_to_video" | "ads2v" => {
+            let clip_id = request.source_clip_asset_id.as_deref().ok_or_else(|| {
+                WorkerError::InvalidPayload(format!(
+                    "bernini {} requires a source clip (sourceClipAssetId).",
+                    request.mode.replace('_', " ")
+                ))
+            })?;
+            clip_ids.push(clip_id);
+        }
+        "multi_video_to_video" => {
+            if request.source_clip_asset_ids.len() < 2 {
+                return Err(WorkerError::InvalidPayload(
+                    "bernini multi video to video requires at least two source clips \
+                     (sourceClipAssetIds)."
+                        .to_owned(),
+                ));
+            }
+            clip_ids.extend(request.source_clip_asset_ids.iter().map(String::as_str));
+        }
+        _ => {}
+    }
+    if mode == "ads2v" {
+        let ref_clip_id = request.reference_clip_asset_id.as_deref().ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "bernini ads2v requires a reference video (referenceClipAssetId).".to_owned(),
+            )
         })?;
+        clip_ids.push(ref_clip_id);
+    }
+
+    let mut conditioning = Vec::new();
+    for clip_id in clip_ids {
         let frames = extract_clip_frames(
             api,
             settings,
@@ -2843,6 +2875,11 @@ async fn resolve_bernini_conditioning(
         });
     }
 
+    // Subject reference images → MultiReference (r2v / rv2v / ads2v).
+    let needs_refs = matches!(
+        mode,
+        "reference_to_video" | "reference_video_to_video" | "ads2v"
+    );
     if needs_refs {
         if request.reference_asset_ids.is_empty() {
             return Err(WorkerError::InvalidPayload(format!(
@@ -2865,12 +2902,13 @@ async fn resolve_bernini_conditioning(
     Ok(conditioning)
 }
 
-/// Real MLX Bernini video generation (epic 4699 / sc-4707 + sc-4703): build the `VideoGenInput` and
-/// run the shared `generate_video` path. The SceneWorks mode resolves to the engine `video_mode` task
-/// ([`bernini_engine_video_mode`]) and the source media into the planner conditioning
-/// ([`resolve_bernini_conditioning`]) — empty for t2v, a `VideoClip` for v2v/rv2v, `MultiReference`
-/// for r2v/rv2v. No LoRA (the engine reports `supports_lora=false`); steps/guidance stay at the engine
-/// defaults. Frame count uses the Wan 1-mod-4 stride coercion (the renderer is Wan).
+/// Real MLX Bernini video generation (epic 4699 / sc-4707 + sc-4703 + sc-5425): build the
+/// `VideoGenInput` and run the shared `generate_video` path. The SceneWorks mode resolves to the
+/// engine `video_mode` task ([`bernini_engine_video_mode`]) and the source media into the planner
+/// conditioning ([`resolve_bernini_conditioning`]) — empty for t2v, one or more `VideoClip`s for
+/// v2v/mv2v/rv2v/ads2v, and `MultiReference` for r2v/rv2v/ads2v. No LoRA (the engine reports
+/// `supports_lora=false`); steps/guidance stay at the engine defaults. Frame count uses the Wan
+/// 1-mod-4 stride coercion (the renderer is Wan).
 #[cfg(target_os = "macos")]
 async fn generate_bernini(
     api: &ApiClient,
@@ -5185,15 +5223,20 @@ mod tests {
             bernini_engine_video_mode("reference_video_to_video"),
             "rv2v"
         );
+        // Multi-source modes (sc-5425).
+        assert_eq!(bernini_engine_video_mode("multi_video_to_video"), "mv2v");
+        assert_eq!(bernini_engine_video_mode("ads2v"), "ads2v");
         // Unknown / unset falls back to plain text-to-video.
         assert_eq!(bernini_engine_video_mode("image_to_video"), "t2v");
         assert_eq!(bernini_engine_video_mode(""), "t2v");
     }
 
-    /// Real in-process Bernini editing/reference video modes through the engine (sc-4703 / sc-4709):
-    /// drive v2v (synthetic source clip → `VideoClip`), r2v (synthetic reference → `MultiReference`),
-    /// and rv2v (both), asserting each mode loads, consumes its conditioning, and streams RGB8 frames.
-    /// `#[ignore]` — weights live outside CI; run on a Mac with the `SceneWorks/bernini-mlx` snapshot.
+    /// Real in-process Bernini editing/reference/multi-source video modes through the engine
+    /// (sc-4703 / sc-4709 / sc-5425): drive v2v (synthetic source clip → `VideoClip`), r2v
+    /// (synthetic reference → `MultiReference`), rv2v (both), mv2v (two source clips), and ads2v
+    /// (source clip + reference clip + reference), asserting each mode loads, consumes its
+    /// conditioning, and streams RGB8 frames. `#[ignore]` — weights live outside CI; run on a Mac
+    /// with the `SceneWorks/bernini-mlx` snapshot.
     #[cfg(target_os = "macos")]
     #[ignore = "loads the real Bernini snapshot; run manually on a Mac with SceneWorks/bernini-mlx present"]
     #[test]
@@ -5208,19 +5251,18 @@ mod tests {
             height: h,
             pixels: vec![shade; (w * h * 3) as usize],
         };
-        // A 5-frame synthetic source clip and one synthetic subject reference.
+        // Two 5-frame synthetic source clips and one synthetic subject reference.
         let clip: Vec<Image> = (0..5).map(|i| frame(60 + i * 12)).collect();
+        let clip_b: Vec<Image> = (0..5).map(|i| frame(40 + i * 16)).collect();
         let reference = frame(150);
+        let video_clip = |frames: Vec<Image>| Conditioning::VideoClip {
+            frames,
+            frame_idx: 0,
+            strength: 1.0,
+        };
 
         let cases: &[(&str, Vec<Conditioning>)] = &[
-            (
-                "v2v",
-                vec![Conditioning::VideoClip {
-                    frames: clip.clone(),
-                    frame_idx: 0,
-                    strength: 1.0,
-                }],
-            ),
+            ("v2v", vec![video_clip(clip.clone())]),
             (
                 "r2v",
                 vec![Conditioning::MultiReference {
@@ -5230,11 +5272,23 @@ mod tests {
             (
                 "rv2v",
                 vec![
-                    Conditioning::VideoClip {
-                        frames: clip.clone(),
-                        frame_idx: 0,
-                        strength: 1.0,
+                    video_clip(clip.clone()),
+                    Conditioning::MultiReference {
+                        images: vec![reference.clone()],
                     },
+                ],
+            ),
+            // mv2v: two source clips, no references.
+            (
+                "mv2v",
+                vec![video_clip(clip.clone()), video_clip(clip_b.clone())],
+            ),
+            // ads2v: source clip + reference clip + reference image (videos first, then images).
+            (
+                "ads2v",
+                vec![
+                    video_clip(clip.clone()),
+                    video_clip(clip_b.clone()),
                     Conditioning::MultiReference {
                         images: vec![reference.clone()],
                     },

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2616,10 +2616,12 @@
       "prompt": "hero walks through rain",
       "quality": "balanced",
       "referenceAssetIds": [],
+      "referenceClipAssetId": null,
       "replacementMode": "face_only",
       "seed": null,
       "sourceAssetId": null,
       "sourceClipAssetId": "asset-video",
+      "sourceClipAssetIds": [],
       "width": 768
     },
     "progress": 0.0,


### PR DESCRIPTION
Follow-on to [sc-4703](https://app.shortcut.com/trefry/story/4703) (PR #651). Wires Bernini's two remaining engine-supported video tasks end-to-end as SceneWorks modes, coherently — the worker serves exactly what the UI submits.

[sc-5425](https://app.shortcut.com/trefry/story/5425) · epic [4699](https://app.shortcut.com/trefry/epic/4699)

## Modes
- **`multi_video_to_video`** (mv2v): ≥2 source clips → one `Conditioning::VideoClip` each.
- **`ads2v`**: source video + reference video + reference images → 2 `VideoClip`s (source then reference) + `MultiReference`, videos-first to match the engine's `collect_conditioning` / `assign_source_ids` ordering.

Both resolve to the engine's `V2vApg` guidance via `task_to_vit_mode` and differ only in supplied media. Verified data-ready at the pinned rev `41c95a1`: `validate_request` checks conditioning *kind* not count, and `collect_conditioning` loops over N `VideoClip`s. Names: `multi_video_to_video` gets the verbose form like the other modes; `ads2v` keeps the engine token (no clean English expansion) with descriptive UI labels.

## Layers
- **Contract** (`dto.rs`, `video_request.rs`): `sourceClipAssetIds: Vec<String>` (mv2v) + `referenceClipAssetId: Option<String>` (ads2v reference video, distinct from the edited source clip).
- **API validation** (`lib.rs`): admit both modes; mv2v ≥2 clips; ads2v source clip + reference video + ≥1 reference image; `sourceClipAssetIds` blank-id guard.
- **Worker** (`video_jobs.rs`): `bernini_engine_video_mode` mapping + `resolve_bernini_conditioning` rewritten (one `VideoClip` per source clip then `MultiReference`); per-mode media errors.
- **Routing/caps** (`lora_family.rs`, `jobs_store.rs`): bernini caps + `VIDEO_UI_MODES` + `video_mode_is_mlx_eligible` (Bernini-only; disabled on other models).
- **UI** (`VideoStudio.jsx`): two mode buttons, multi-clip + reference-video pickers, validation/disabled states, payload.
- **Manifest / guide / parity snapshot**: capabilities, task-modes doc, new snapshot keys.

## Validation
- `cargo fmt` + `clippy -D warnings` clean.
- Rust: core **169**, API **110** (extended `bernini_video_modes_validate_required_media`), worker mode-mapping test.
- Web vitest: **415** (new mv2v/ads2v slot + submit tests).
- Python parity lane `test_rust_api_contract_snapshots.py`: **12/12** (confirms the hand-edited snapshot matches Rust serialization).
- Real-weight smoke `bernini_editing_reference_modes_real_weights` extended with mv2v + ads2v cases (`#[ignore]`, Mac-gated). **Pending a clean-Mac run** — an attempt this session was OOM-killed during the *established* v2v/r2v modes (not the new code) due to a concurrent MLX session monopolizing memory/GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)