### PR TITLE
sc-5484: wire candle Chroma into the worker (force-link + routing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -445,13 +445,28 @@ dependencies = [
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
  "sceneworks-gen-core",
+ "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-gen-chroma"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
+dependencies = [
+ "candle-gen",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+ "tokenizers 0.22.2",
 ]
 
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -465,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -479,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -490,7 +505,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -503,7 +518,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -515,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -529,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -547,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -560,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f366f4009126f268256ca6ce5cfbe86408bb8456#f366f4009126f268256ca6ce5cfbe86408bb8456"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4ca699e4e22b3cc4eaa62071e1f6bf5570df2560#4ca699e4e22b3cc4eaa62071e1f6bf5570df2560"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -5070,6 +5085,7 @@ name = "sceneworks-worker"
 version = "0.2.0"
 dependencies = [
  "axum",
+ "candle-gen-chroma",
  "candle-gen-flux",
  "candle-gen-flux2",
  "candle-gen-joycaption",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -89,6 +89,8 @@ backend-candle = [
     "dep:candle-gen-flux",
     "dep:candle-gen-flux2",
     "dep:candle-gen-qwen-image",
+    # sc-5484 (epic 3692): the candle Chroma image provider (chroma1_hd / chroma1_base / chroma1_flash).
+    "dep:candle-gen-chroma",
     # sc-5126 (epic 5107): the candle Lens / Lens-Turbo image provider — gpt-oss-20b MoE encoder +
     # 48-layer MMDiT + Flux.2 VAE. The first candle family with Q4/Q8 quant + LoRA/LoKr; pure T2I.
     "dep:candle-gen-lens",
@@ -444,24 +446,29 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "41c
 # pin) again, and this LINKS `candle-gen-lens` (registers `lens` + `lens_turbo`, the sc-5126 cutover
 # target). ALL candle deps below MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
+# Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
+# THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
+# guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
+# (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -470,7 +477,7 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f366f4009126f268256ca6ce5cfbe86408bb8456", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4ca699e4e22b3cc4eaa62071e1f6bf5570df2560", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -96,6 +96,10 @@ use candle_gen_flux as _;
 use candle_gen_flux2 as _;
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_qwen_image as _;
+// Candle Chroma (sc-5484, epic 3692): chroma1_hd / chroma1_base / chroma1_flash self-register into the
+// shared gen_core inventory; the `as _;` keeps the MSVC release linker from GC-ing the registrations.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_chroma as _;
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_z_image as _;
 // Lens / Lens-Turbo (epic 5107 engine / sc-5126 cutover) — the candle Windows/CUDA sibling of the

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -842,6 +842,9 @@ fn is_candle_engine(model: &str) -> bool {
             | "flux_dev"
             | "flux2_klein_9b"
             | "qwen_image"
+            | "chroma1_hd"
+            | "chroma1_base"
+            | "chroma1_flash"
             | "lens"
             | "lens_turbo"
     )
@@ -858,6 +861,7 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "flux_schnell" | "flux_dev" => "candle_flux",
         "flux2_klein_9b" => "candle_flux2",
         "qwen_image" => "candle_qwen",
+        "chroma1_hd" | "chroma1_base" | "chroma1_flash" => "candle_chroma",
         "lens" | "lens_turbo" => "candle_lens",
         // sdxl / realvisxl share the candle "sdxl" engine.
         _ => CANDLE_ADAPTER,
@@ -1203,6 +1207,9 @@ mod candle_label_tests {
         assert_eq!(candle_adapter_label("flux_dev"), "candle_flux");
         assert_eq!(candle_adapter_label("flux2_klein_9b"), "candle_flux2");
         assert_eq!(candle_adapter_label("qwen_image"), "candle_qwen");
+        assert_eq!(candle_adapter_label("chroma1_hd"), "candle_chroma");
+        assert_eq!(candle_adapter_label("chroma1_base"), "candle_chroma");
+        assert_eq!(candle_adapter_label("chroma1_flash"), "candle_chroma");
         assert_eq!(candle_adapter_label("lens"), "candle_lens");
         assert_eq!(candle_adapter_label("lens_turbo"), "candle_lens");
         assert_eq!(candle_adapter_label("sdxl"), "candle_sdxl");
@@ -1214,6 +1221,9 @@ mod candle_label_tests {
             "flux_dev",
             "flux2_klein_9b",
             "qwen_image",
+            "chroma1_hd",
+            "chroma1_base",
+            "chroma1_flash",
             "lens",
             "lens_turbo",
             "sdxl",
@@ -1233,6 +1243,9 @@ mod candle_label_tests {
             "flux_dev",
             "flux2_klein_9b",
             "qwen_image",
+            "chroma1_hd",
+            "chroma1_base",
+            "chroma1_flash",
             "lens",
             "lens_turbo",
         ] {
@@ -1240,7 +1253,6 @@ mod candle_label_tests {
         }
         // Non-candle families + non-base variants (edit ids, the kv distill) are not in the lane.
         for model in [
-            "chroma1_hd",
             "kolors",
             "z_image_edit",
             "qwen_image_edit",


### PR DESCRIPTION
Worker half of [sc-5484](https://app.shortcut.com/trefry/story/5484) (epic [3692](https://app.shortcut.com/trefry/epic/3692)) — wires the merged candle Chroma provider ([candle-gen#47](https://github.com/michaeltrefry/candle-gen/pull/47)) into the Windows/CUDA worker lane.

## Changes
- **Pin bump** `f366f40 → 4ca699e` across all candle-gen providers (candle-gen `main` post-#47). Pulls sc-5147 (Lens e2e notes), sc-5374 (LoRA-alpha fix), and the Chroma provider. **gen-core stays `41c95a1`**, so the `--features backend-candle` graph resolves a single gen-core rev (no skew with the worker's MLX gen-core).
- Add the **`candle-gen-chroma`** dep + `backend-candle` feature entry; force-link it in `image_jobs.rs` (`use candle_gen_chroma as _;`) so the MSVC release linker keeps the `inventory::submit!` registrations.
- Route `chroma1_hd` / `chroma1_base` / `chroma1_flash` through the candle lane: added to `is_candle_engine` + `candle_adapter_label` (→ `candle_chroma`), with their unit tests updated (moved from the non-candle list to the candle list).

The `chroma1_*` rows already exist in `engines.rs` `MODEL_TABLE` (from the MLX side), so repo/steps/guidance resolve through the same backend-neutral `mlx_model` join the other candle families use — no new dispatch logic.

## Gating & verification
- Gated behind **`backend_candle_enabled` (default off)** → production routing is unchanged until parity is accepted.
- **Non-candle `cargo check -p sceneworks-worker` green**; `Cargo.lock` updated (candle-gen-chroma @ 4ca699e + bumped revs).
- The candle-path edits are all `cfg(windows + backend-candle)`-gated; the **`--features backend-candle` compile is covered by the candle Windows CI lane (sc-3676)**. A local cold CUDA build / deployed-worker GPU smoke is the remaining manual acceptance (RTX PRO 6000 box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)