### PR TITLE
Defer terminal Canceled for image jobs until generation stops (sc-5515)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -733,6 +733,46 @@ pub(crate) fn backend_label(gpu_id: &str) -> &str {
     }
 }
 
+/// First-detection handling for the in-loop image cancel poller (sc-5515): trip the
+/// engine `CancelFlag` and post a NON-terminal "Cancelling…" update (indeterminate
+/// progress; any completed thumbnails stay via the streamed result). The terminal
+/// `Canceled` is posted only after the blocking generation actually stops (see
+/// `consume_gen_events`), so the worker row — and therefore the next queued job — is
+/// not freed until the GPU is genuinely idle, and the UI honestly shows "Cancelling…"
+/// until completion. Best-effort: a failed status update here is non-fatal because the
+/// post-run terminal write is what ultimately frees the worker.
+//
+// Gated to where `consume_gen_events` (its only caller) and the `CancelFlag` import live — the
+// `include!`d `base.rs` block — so it isn't compiled (referencing the cfg-gated `CancelFlag`) on
+// non-macOS / non-candle builds.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
+async fn begin_image_cancel(
+    api: &ApiClient,
+    job_id: &str,
+    cancel: &CancelFlag,
+    plan: &ImagePlan,
+    asset_writes: &[Value],
+    backend: &str,
+) {
+    cancel.cancel();
+    let _ = update_job(
+        api,
+        job_id,
+        image_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.0,
+            "Cancelling — finishing the current image…",
+            Some(streaming_result(plan, asset_writes)),
+            backend,
+        ),
+    )
+    .await;
+}
+
 /// Deterministic placeholder pixels: a vertical gradient from a per-seed base colour
 /// to white, exactly `width * height * 3` RGB8 bytes.
 fn stub_rgb8(width: u32, height: u32, seed: i64) -> Vec<u8> {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1078,8 +1078,11 @@ async fn consume_gen_events(
                 mark_started(index);
                 if last_cancel_check.elapsed() >= Duration::from_secs(2) {
                     last_cancel_check = Instant::now();
-                    if cancel_requested(api, &job.id, "Image generation canceled by user.").await {
-                        cancel.cancel();
+                    if cancel_requested_peek(api, &job.id).await {
+                        // Trip the flag + show "Cancelling…", but stay non-terminal until the
+                        // in-flight image actually stops (terminal Canceled posted after the
+                        // blocking run returns) — sc-5515.
+                        begin_image_cancel(api, &job.id, &cancel, plan, asset_writes, backend).await;
                         canceled = true;
                         continue;
                     }
@@ -1162,8 +1165,8 @@ async fn consume_gen_events(
                 heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
                 if !canceled && last_cancel_check.elapsed() >= Duration::from_secs(2) {
                     last_cancel_check = Instant::now();
-                    if cancel_requested(api, &job.id, "Image generation canceled by user.").await {
-                        cancel.cancel();
+                    if cancel_requested_peek(api, &job.id).await {
+                        begin_image_cancel(api, &job.id, &cancel, plan, asset_writes, backend).await;
                         canceled = true;
                     }
                 }
@@ -1175,11 +1178,28 @@ async fn consume_gen_events(
         .await
         .map_err(|error| task_join_error("generation task join", error))?;
     if canceled {
-        // check_cancel already posted the Canceled update; treat the (likely) generate
-        // error as the clean cancel.
-        return Err(WorkerError::Canceled(
-            "Image generation canceled by user.".to_owned(),
-        ));
+        // The generation has now actually stopped, so post the TERMINAL Canceled here
+        // (not at the earlier cancel poll, which only tripped the flag + showed
+        // "Cancelling…"). This terminal write is what frees the worker row
+        // (`jobs_store::update_job_progress`), so it lands exactly as the worker process
+        // returns to its claim loop — the next queued job waits only until the GPU is
+        // genuinely free, and the UI shows "Cancelling…" until completion (sc-5515).
+        // result=None lets `coalesce` keep any partial images already streamed.
+        let message = "Image generation canceled by user.";
+        update_job(
+            api,
+            &job.id,
+            image_progress(
+                JobStatus::Canceled,
+                ProgressStage::Canceled,
+                1.0,
+                message,
+                None,
+                backend,
+            ),
+        )
+        .await?;
+        return Err(WorkerError::Canceled(message.to_owned()));
     }
     task_result
 }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -920,6 +920,30 @@ async fn cancel_requested(api: &ApiClient, job_id: &str, message: &str) -> bool 
     }
 }
 
+/// Check-only cancel poll (sc-5515): returns `true` when the user requested
+/// cancellation, WITHOUT posting any status. Unlike [`check_cancel`] /
+/// [`cancel_requested`] this never writes the terminal `Canceled`. In-loop
+/// generation pollers that sit in front of a long, un-interruptible compute use
+/// this so the job stays non-terminal ("Cancelling…") until the in-flight work
+/// actually stops; they post the terminal `Canceled` themselves only once it does.
+/// Posting terminal at acknowledgement time frees the worker row
+/// (`jobs_store::update_job_progress`) while the worker process is still busy, so
+/// the next queued job is told a worker is free that isn't — deferring the
+/// terminal write to actual-stop keeps the two in sync. Transient GET failures are
+/// tolerated (read as "not canceled", retried on the next poll), matching
+/// [`cancel_requested`]'s policy (sc-4174).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+async fn cancel_requested_peek(api: &ApiClient, job_id: &str) -> bool {
+    let outcome: WorkerResult<JobSnapshot> = api.get_json(&format!("/api/v1/jobs/{job_id}")).await;
+    match outcome {
+        Ok(job) => job.cancel_requested,
+        Err(error) => {
+            eprintln!("cancel_poll_failed jobId={job_id}: {error}; retrying on the next poll");
+            false
+        }
+    }
+}
+
 async fn update_job(
     api: &ApiClient,
     job_id: &str,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -41,13 +41,13 @@ use super::supervisor::{
     utility_worker_specs, SupervisedChild, WorkerSpec,
 };
 use super::{
-    allow_pattern_matches, bounded_tail, cancel_requested, cleanup_uploaded_import_source,
-    copy_lora_source, fresh_asset_id, import_lora_source_file_as, import_lora_source_path,
-    now_rfc3339, parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
-    safe_download_dir, safe_project_path, value_f64, wan_moe_pair_filenames,
-    write_model_install_marker, CredentialScheme, JsonObject, SafetensorsHeaderError, Settings,
-    WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
-    DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+    allow_pattern_matches, bounded_tail, cancel_requested, cancel_requested_peek,
+    cleanup_uploaded_import_source, copy_lora_source, fresh_asset_id, import_lora_source_file_as,
+    import_lora_source_path, now_rfc3339, parse_credentials_env, resolve_model_convert_output,
+    resolve_model_import_target, safe_download_dir, safe_project_path, value_f64,
+    wan_moe_pair_filenames, write_model_install_marker, CredentialScheme, JsonObject,
+    SafetensorsHeaderError, Settings, WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES,
+    DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
 };
 
 fn write_safetensors_with_keys(path: &std::path::Path, keys: &[String]) {
@@ -2526,6 +2526,46 @@ async fn cancel_poll_continues_when_no_cancel_requested() {
     })
     .await;
     assert!(!canceled);
+}
+
+/// sc-5515 — the in-loop image cancel poller uses a CHECK-ONLY peek that reads
+/// `cancel_requested` without posting any terminal status. The terminal Canceled
+/// is posted by `consume_gen_events` only after the blocking generation actually
+/// stops, so the worker row isn't freed (and the next queued job isn't misled)
+/// while the in-flight image is still rendering. `post_status` is wired to fail
+/// here to prove the peek never touches the progress route.
+async fn cancel_peek_with(get_status: AxumStatusCode, cancel_requested: bool) -> bool {
+    let base_url = spawn_cancel_poll_stub(CancelPollStubState {
+        get_status,
+        cancel_requested,
+        post_status: AxumStatusCode::INTERNAL_SERVER_ERROR,
+    })
+    .await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url;
+    let api = ApiClient::new(&settings);
+    cancel_requested_peek(&api, "job-1").await
+}
+
+#[tokio::test]
+async fn cancel_peek_reports_confirmed_cancel_without_posting() {
+    assert!(
+        cancel_peek_with(AxumStatusCode::OK, true).await,
+        "a confirmed cancel request must be reported by the check-only peek"
+    );
+}
+
+#[tokio::test]
+async fn cancel_peek_false_when_not_requested() {
+    assert!(!cancel_peek_with(AxumStatusCode::OK, false).await);
+}
+
+#[tokio::test]
+async fn cancel_peek_tolerates_transient_get_errors() {
+    assert!(
+        !cancel_peek_with(AxumStatusCode::INTERNAL_SERVER_ERROR, true).await,
+        "a transient GET failure must not read as a user cancel"
+    );
 }
 
 /// sc-4176 — on macOS an MLX-routed model whose weights don't resolve must


### PR DESCRIPTION
## What
Cancelling a running image job now keeps it non-terminal ("Cancelling…") until generation actually stops, instead of marking it terminal `Canceled` the moment the worker acknowledges the request.

## Why
`check_cancel` posted terminal `Canceled` at acknowledgement time, which also frees the worker row (`jobs_store::update_job_progress`) — while the worker process was still grinding the in-flight image. So the UI flipped to "Cancelled" and hid progress while the GPU was still busy, and the next queued job stayed stranded with no indication a worker would free. (sc-5399.)

## Change
`consume_gen_events` (`crates/sceneworks-worker/src/image_jobs/base.rs`):
- check-only `cancel_requested_peek` (no terminal post) + `begin_image_cancel` (trip the `CancelFlag` + post a non-terminal "Cancelling — finishing the current image…" update).
- terminal `Canceled` posted only after `blocking.await` returns — so the worker row frees exactly as the process returns to its claim loop; the next job waits only until the GPU is genuinely free, and the UI honestly shows "Cancelling…" until done.
- `active_gpu_job_exists` stays status-based/conservative on purpose (do not weaken — would let a 2nd job start while the GPU is still occupied).

## Verification
- `cargo check -p sceneworks-worker` clean.
- `cargo test -p sceneworks-worker cancel_p` → **7 passed** (3 new `cancel_peek_*` + 4 existing `cancel_poll_*`).

## Scope / related
- Image path only (reported surface). Frontend already renders non-terminal `running`+`cancelRequested` correctly → no UI change.
- Pairs with mlx-gen sc-5514 (per-step eval), which makes the "Cancelling…" window sub-second for chroma; this PR is the system-wide correctness / UI-honesty fix.
- Video/training share the in-loop pattern → sc-5516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)