### PR TITLE
Defer terminal Canceled for video/training/detail jobs until work stops (sc-5516)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -421,11 +421,34 @@ pub(crate) async fn run_image_detail_job(
     };
 
     let mut last_cancel_check = Instant::now();
+    let mut canceled = false;
     while let Some((done, total)) = rx.recv().await {
+        if canceled {
+            continue; // drain so the blocking sender never blocks; terminal posts after stop.
+        }
         if last_cancel_check.elapsed() >= Duration::from_secs(2) {
             last_cancel_check = Instant::now();
-            if cancel_requested(api, &job.id, "Detail enhancement canceled by user.").await {
+            if cancel_requested_peek(api, &job.id).await {
+                // Trip the engine flag and show a NON-terminal "Cancelling…" (indeterminate bar);
+                // the terminal Canceled is deferred to after the blocking refinement actually
+                // stops so the worker row isn't freed while it's still grinding the current tile
+                // (sc-5516; mirrors the image path sc-5515). Best-effort update.
                 cancel.cancel();
+                let _ = update_job(
+                    api,
+                    &job.id,
+                    image_progress(
+                        JobStatus::Running,
+                        ProgressStage::Generating,
+                        0.0,
+                        "Cancelling — finishing the current tile…",
+                        None,
+                        backend,
+                    ),
+                )
+                .await;
+                canceled = true;
+                continue;
             }
         }
         update_job(
@@ -444,9 +467,31 @@ pub(crate) async fn run_image_detail_job(
         heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     }
 
-    let (refined, tiles) = blocking
+    let join = blocking
         .await
-        .map_err(|error| task_join_error("detail task join", error))??;
+        .map_err(|error| task_join_error("detail task join", error))?;
+    if canceled {
+        // Refinement has actually stopped now — post the TERMINAL Canceled here. This terminal
+        // write frees the worker row (`jobs_store::update_job_progress`) exactly as the worker
+        // returns to its claim loop, so the next queued job waits only until the GPU is genuinely
+        // free (sc-5516). The engine's own early return (`join`) is discarded as the clean cancel.
+        let message = "Detail enhancement canceled by user.";
+        update_job(
+            api,
+            &job.id,
+            image_progress(
+                JobStatus::Canceled,
+                ProgressStage::Canceled,
+                1.0,
+                message,
+                None,
+                backend,
+            ),
+        )
+        .await?;
+        return Err(WorkerError::Canceled(message.to_owned()));
+    }
+    let (refined, tiles) = join?;
     let (out_w, out_h) = (refined.width(), refined.height());
     let media_path = project_path.join(&media_rel);
     let temp_path = media_path.with_extension("tmp.png");

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -900,38 +900,18 @@ async fn check_cancel(api: &ApiClient, job_id: &str, message: &str) -> WorkerRes
     Ok(())
 }
 
-/// In-band cancel poll for long-running generation/training loops. Returns
-/// true only when the user actually requested cancellation (check_cancel's
-/// `WorkerError::Canceled`). Any other failure — a transient HTTP/API hiccup on
-/// the GET, or a failed Canceled-status POST — is tolerated and retried on the
-/// next poll instead of being misread as a user cancel that aborts a
-/// multi-minute run and strands the job in Running (sc-4174).
-// In-band polling call sites are inside macOS-gated generation paths; the
-// helper itself stays unit-tested on every platform.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-async fn cancel_requested(api: &ApiClient, job_id: &str, message: &str) -> bool {
-    match check_cancel(api, job_id, message).await {
-        Ok(()) => false,
-        Err(WorkerError::Canceled(_)) => true,
-        Err(error) => {
-            eprintln!("cancel_poll_failed jobId={job_id}: {error}; retrying on the next poll");
-            false
-        }
-    }
-}
-
 /// Check-only cancel poll (sc-5515): returns `true` when the user requested
-/// cancellation, WITHOUT posting any status. Unlike [`check_cancel`] /
-/// [`cancel_requested`] this never writes the terminal `Canceled`. In-loop
-/// generation pollers that sit in front of a long, un-interruptible compute use
-/// this so the job stays non-terminal ("Cancelling…") until the in-flight work
-/// actually stops; they post the terminal `Canceled` themselves only once it does.
+/// cancellation, WITHOUT posting any status. Unlike [`check_cancel`] this never
+/// writes the terminal `Canceled`. In-loop generation/training pollers that sit in
+/// front of a long, un-interruptible compute use this so the job stays non-terminal
+/// ("Cancelling…") until the in-flight work actually stops; they post the terminal
+/// `Canceled` themselves only once it does (sc-5515 image, sc-5516 video/training/detail).
 /// Posting terminal at acknowledgement time frees the worker row
 /// (`jobs_store::update_job_progress`) while the worker process is still busy, so
 /// the next queued job is told a worker is free that isn't — deferring the
 /// terminal write to actual-stop keeps the two in sync. Transient GET failures are
-/// tolerated (read as "not canceled", retried on the next poll), matching
-/// [`cancel_requested`]'s policy (sc-4174).
+/// tolerated (read as "not canceled", retried on the next poll) so an API hiccup
+/// never aborts a multi-minute run by being misread as a user cancel (sc-4174).
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 async fn cancel_requested_peek(api: &ApiClient, job_id: &str) -> bool {
     let outcome: WorkerResult<JobSnapshot> = api.get_json(&format!("/api/v1/jobs/{job_id}")).await;

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -41,13 +41,13 @@ use super::supervisor::{
     utility_worker_specs, SupervisedChild, WorkerSpec,
 };
 use super::{
-    allow_pattern_matches, bounded_tail, cancel_requested, cancel_requested_peek,
-    cleanup_uploaded_import_source, copy_lora_source, fresh_asset_id, import_lora_source_file_as,
-    import_lora_source_path, now_rfc3339, parse_credentials_env, resolve_model_convert_output,
-    resolve_model_import_target, safe_download_dir, safe_project_path, value_f64,
-    wan_moe_pair_filenames, write_model_install_marker, CredentialScheme, JsonObject,
-    SafetensorsHeaderError, Settings, WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES,
-    DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+    allow_pattern_matches, bounded_tail, cancel_requested_peek, cleanup_uploaded_import_source,
+    copy_lora_source, fresh_asset_id, import_lora_source_file_as, import_lora_source_path,
+    now_rfc3339, parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
+    safe_download_dir, safe_project_path, value_f64, wan_moe_pair_filenames,
+    write_model_install_marker, CredentialScheme, JsonObject, SafetensorsHeaderError, Settings,
+    WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
+    DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
 };
 
 fn write_safetensors_with_keys(path: &std::path::Path, keys: &[String]) {
@@ -2468,66 +2468,6 @@ async fn spawn_cancel_poll_stub(state: CancelPollStubState) -> String {
     format!("http://{address}")
 }
 
-async fn cancel_poll_with(state: CancelPollStubState) -> bool {
-    let base_url = spawn_cancel_poll_stub(state).await;
-    let mut settings = test_settings(base_url.clone(), None);
-    settings.api_url = base_url;
-    let api = ApiClient::new(&settings);
-    cancel_requested(&api, "job-1", "canceled by user").await
-}
-
-#[tokio::test]
-async fn cancel_poll_tolerates_transient_get_errors() {
-    let canceled = cancel_poll_with(CancelPollStubState {
-        get_status: AxumStatusCode::INTERNAL_SERVER_ERROR,
-        cancel_requested: false,
-        post_status: AxumStatusCode::OK,
-    })
-    .await;
-    assert!(
-        !canceled,
-        "a transient GET failure must not read as a user cancel"
-    );
-}
-
-#[tokio::test]
-async fn cancel_poll_cancels_on_confirmed_user_cancel() {
-    let canceled = cancel_poll_with(CancelPollStubState {
-        get_status: AxumStatusCode::OK,
-        cancel_requested: true,
-        post_status: AxumStatusCode::OK,
-    })
-    .await;
-    assert!(canceled, "a confirmed cancel request must cancel the run");
-}
-
-#[tokio::test]
-async fn cancel_poll_retries_when_cancel_ack_post_fails() {
-    // cancel_requested=true but the Canceled-status POST fails: don't treat it
-    // as canceled yet — the next 2s poll retries the acknowledgement.
-    let canceled = cancel_poll_with(CancelPollStubState {
-        get_status: AxumStatusCode::OK,
-        cancel_requested: true,
-        post_status: AxumStatusCode::INTERNAL_SERVER_ERROR,
-    })
-    .await;
-    assert!(
-        !canceled,
-        "a failed cancel acknowledgement must be retried, not assumed"
-    );
-}
-
-#[tokio::test]
-async fn cancel_poll_continues_when_no_cancel_requested() {
-    let canceled = cancel_poll_with(CancelPollStubState {
-        get_status: AxumStatusCode::OK,
-        cancel_requested: false,
-        post_status: AxumStatusCode::OK,
-    })
-    .await;
-    assert!(!canceled);
-}
-
 /// sc-5515 — the in-loop image cancel poller uses a CHECK-ONLY peek that reads
 /// `cancel_requested` without posting any terminal status. The terminal Canceled
 /// is posted by `consume_gen_events` only after the blocking generation actually
@@ -2565,6 +2505,120 @@ async fn cancel_peek_tolerates_transient_get_errors() {
     assert!(
         !cancel_peek_with(AxumStatusCode::INTERNAL_SERVER_ERROR, true).await,
         "a transient GET failure must not read as a user cancel"
+    );
+}
+
+// sc-5516 — the in-loop video/training/detail cancel pollers DEFER the terminal `Canceled`
+// to actual-stop: at acknowledgement they only trip the engine flag and post a NON-terminal
+// "Cancelling…" update (so the worker row isn't freed while the in-flight step is still
+// running). This stub captures every progress POST body so a test can assert the
+// acknowledgement status is `running`, not the terminal `canceled`.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
+async fn spawn_progress_capture_stub() -> (String, std::sync::Arc<std::sync::Mutex<Vec<Value>>>) {
+    use std::sync::{Arc, Mutex};
+    type Posts = Arc<Mutex<Vec<Value>>>;
+    async fn job_route(axum::extract::Path(job_id): axum::extract::Path<String>) -> Response {
+        Json(job_snapshot_json(&job_id, true)).into_response()
+    }
+    async fn progress_route(
+        State(posts): State<Posts>,
+        axum::extract::Path(job_id): axum::extract::Path<String>,
+        Json(body): Json<Value>,
+    ) -> Response {
+        posts.lock().expect("posts lock").push(body);
+        Json(job_snapshot_json(&job_id, true)).into_response()
+    }
+    let posts: Posts = Arc::new(Mutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/api/v1/jobs/:job_id", get(job_route))
+        .route("/api/v1/jobs/:job_id/progress", post(progress_route))
+        .with_state(posts.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+    (format!("http://{address}"), posts)
+}
+
+/// sc-5516 — `begin_video_cancel` trips the engine cancel flag and posts the
+/// cancel acknowledgement as a NON-terminal `running` "Cancelling…" update. The
+/// terminal `Canceled` (which frees the worker row) is posted by `generate_video`
+/// only after the blocking generation actually stops, so the next queued job waits
+/// until the GPU is genuinely free.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
+#[tokio::test]
+async fn begin_video_cancel_trips_flag_and_stays_non_terminal() {
+    let (base_url, posts) = spawn_progress_capture_stub().await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url;
+    let api = ApiClient::new(&settings);
+    let cancel = gen_core::CancelFlag::new();
+    crate::video_jobs::begin_video_cancel(&api, "job-1", &cancel, "mlx").await;
+    assert!(
+        cancel.is_cancelled(),
+        "begin_video_cancel must trip the engine cancel flag"
+    );
+    let posts = posts.lock().expect("posts lock");
+    assert_eq!(
+        posts.len(),
+        1,
+        "exactly one acknowledgement update is posted"
+    );
+    assert_eq!(
+        posts[0]["status"], "running",
+        "the cancel acknowledgement must stay NON-terminal — the terminal Canceled is \
+         deferred to actual-stop (sc-5516)"
+    );
+    assert!(
+        posts[0]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Cancelling"),
+        "the acknowledgement message should read as Cancelling…"
+    );
+}
+
+/// sc-5516 — the training sibling of the above: `begin_training_cancel` trips the
+/// flag and acknowledges with a NON-terminal `running` update; the terminal
+/// `Canceled` is posted by `consume_training_events` after training stops.
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn begin_training_cancel_trips_flag_and_stays_non_terminal() {
+    let (base_url, posts) = spawn_progress_capture_stub().await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url;
+    let api = ApiClient::new(&settings);
+    let cancel = gen_core::CancelFlag::new();
+    crate::training_jobs::begin_training_cancel(&api, "job-1", &cancel, "mlx").await;
+    assert!(
+        cancel.is_cancelled(),
+        "begin_training_cancel must trip the engine cancel flag"
+    );
+    let posts = posts.lock().expect("posts lock");
+    assert_eq!(
+        posts.len(),
+        1,
+        "exactly one acknowledgement update is posted"
+    );
+    assert_eq!(
+        posts[0]["status"], "running",
+        "the cancel acknowledgement must stay NON-terminal (sc-5516)"
+    );
+    assert!(
+        posts[0]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Cancelling"),
+        "the acknowledgement message should read as Cancelling…"
     );
 }
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -554,6 +554,37 @@ async fn run_training_execution(
     .await
 }
 
+/// First-detection handling for the in-loop training cancel poller (sc-5516): trip the engine
+/// `CancelFlag` and post a NON-terminal "Cancelling…" update (indeterminate progress bar —
+/// `running` + fraction 0.0 renders the "Working" animation, not a backward jump). The terminal
+/// `Canceled` is posted only after the blocking training actually stops (see
+/// `consume_training_events`), so the worker row — and therefore the next queued job — is not freed
+/// until the GPU is genuinely idle, and the UI honestly shows "Cancelling…" until completion.
+/// Best-effort: a failed status update here is non-fatal because the post-run terminal write is
+/// what ultimately frees the worker. Mirrors the image path's `begin_image_cancel` (sc-5515).
+#[cfg(target_os = "macos")]
+pub(crate) async fn begin_training_cancel(
+    api: &ApiClient,
+    job_id: &str,
+    cancel: &CancelFlag,
+    backend: &str,
+) {
+    cancel.cancel();
+    let _ = update_job(
+        api,
+        job_id,
+        training_progress(
+            JobStatus::Running,
+            ProgressStage::Training,
+            0.0,
+            "Cancelling — finishing the current step…",
+            None,
+            backend,
+        ),
+    )
+    .await;
+}
+
 /// Consume training events from the blocking thread: stream staged progress, poll
 /// cancel ~every 2s (draining after a cancel so the blocking sender never blocks),
 /// and on the final `Done` event report completion with the result the UI shows.
@@ -585,8 +616,8 @@ async fn consume_training_events(
                     && last_cancel_check.elapsed() >= Duration::from_secs(2)
                 {
                     last_cancel_check = Instant::now();
-                    if cancel_requested(api, &job.id, "LoRA training canceled by user.").await {
-                        cancel.cancel();
+                    if cancel_requested_peek(api, &job.id).await {
+                        begin_training_cancel(api, &job.id, &cancel, backend).await;
                         canceled = true;
                         continue;
                     }
@@ -627,11 +658,26 @@ async fn consume_training_events(
         .await
         .map_err(|error| task_join_error("training task join", error))?;
     if canceled {
-        // check_cancel already posted the Canceled update; treat the engine's
-        // early return as the clean cancel.
-        return Err(WorkerError::Canceled(
-            "LoRA training canceled by user.".to_owned(),
-        ));
+        // Training has actually stopped now, so post the TERMINAL Canceled here (not at the
+        // earlier cancel poll, which only tripped the flag + showed "Cancelling…"). This terminal
+        // write is what frees the worker row (`jobs_store::update_job_progress`), so it lands as
+        // the worker returns to its claim loop — the next queued job waits only until the GPU is
+        // genuinely free (sc-5516; mirrors the image path sc-5515).
+        let message = "LoRA training canceled by user.";
+        update_job(
+            api,
+            &job.id,
+            training_progress(
+                JobStatus::Canceled,
+                ProgressStage::Canceled,
+                1.0,
+                message,
+                None,
+                backend,
+            ),
+        )
+        .await?;
+        return Err(WorkerError::Canceled(message.to_owned()));
     }
     task_result
 }

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2250,6 +2250,40 @@ fn parse_stall_timeout(raw: Option<String>) -> Duration {
         .unwrap_or(VIDEO_STALL_TIMEOUT)
 }
 
+/// First-detection handling for the in-loop video cancel poller (sc-5516): trip the engine
+/// `CancelFlag` and post a NON-terminal "Cancelling…" update (indeterminate progress bar —
+/// `running` + fraction 0.0 renders the "Working" animation, not a backward jump). The terminal
+/// `Canceled` is posted only after the blocking generation actually stops (see `generate_video`),
+/// so the worker row — and therefore the next queued job — is not freed until the GPU is genuinely
+/// idle, and the UI honestly shows "Cancelling…" until completion. Best-effort: a failed status
+/// update here is non-fatal because the post-run terminal write is what ultimately frees the
+/// worker. Mirrors the image path's `begin_image_cancel` (sc-5515).
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
+pub(crate) async fn begin_video_cancel(
+    api: &ApiClient,
+    job_id: &str,
+    cancel: &CancelFlag,
+    backend: &str,
+) {
+    cancel.cancel();
+    let _ = update_job(
+        api,
+        job_id,
+        video_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.0,
+            "Cancelling — finishing the current step…",
+            None,
+            backend,
+        ),
+    )
+    .await;
+}
+
 /// Drive a `run_video_generation` on a blocking thread, forwarding its streamed denoise
 /// progress to the async worker (Generating stage ~0.25..0.58) + polling cancel ~every 2s.
 /// The shared blocking + mpsc + cancel plumbing for Wan and LTX. A forward-progress watchdog
@@ -2320,8 +2354,8 @@ async fn generate_video(
                 }
         if last_cancel.elapsed() >= Duration::from_secs(2) {
             last_cancel = Instant::now();
-            if cancel_requested(api, &job.id, CANCEL_MESSAGE).await {
-                cancel.cancel();
+            if cancel_requested_peek(api, &job.id).await {
+                begin_video_cancel(api, &job.id, &cancel, backend).await;
                 canceled = true;
                 continue;
             }
@@ -2352,8 +2386,8 @@ async fn generate_video(
                 heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
                 if !canceled && last_cancel.elapsed() >= Duration::from_secs(2) {
                     last_cancel = Instant::now();
-                    if cancel_requested(api, &job.id, CANCEL_MESSAGE).await {
-                        cancel.cancel();
+                    if cancel_requested_peek(api, &job.id).await {
+                        begin_video_cancel(api, &job.id, &cancel, backend).await;
                         canceled = true;
                     }
                 }
@@ -2411,6 +2445,25 @@ async fn generate_video(
         )));
     }
     if canceled {
+        // Reached only on a genuine user cancel — the stall/abandon watchdog returns above.
+        // Generation has actually stopped now, so post the TERMINAL Canceled here (not at the
+        // earlier cancel poll, which only tripped the flag + showed "Cancelling…"). This terminal
+        // write is what frees the worker row (`jobs_store::update_job_progress`), so it lands as
+        // the worker returns to its claim loop — the next queued job waits only until the GPU is
+        // genuinely free (sc-5516; mirrors the image path sc-5515).
+        update_job(
+            api,
+            &job.id,
+            video_progress(
+                JobStatus::Canceled,
+                ProgressStage::Canceled,
+                1.0,
+                CANCEL_MESSAGE,
+                None,
+                backend,
+            ),
+        )
+        .await?;
         return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
     }
     result


### PR DESCRIPTION
## What

Follow-up sibling of the image-path fix **sc-5515**. The same "post terminal `Canceled` at *acknowledgement*, not at *actual stop*" anti-pattern lived in every in-loop cancel poller that sits in front of a long, un-interruptible engine step:

- **video** — `video_jobs.rs::generate_video` (the progress-branch poll at `:2323` and the interval-branch poll at `:2355`)
- **training** — `training_jobs.rs::consume_training_events` (the per-step poll at `:588`, plus the now-stale comment at `:630`)
- **detail** — `image_jobs/detail.rs::run_image_detail_job` (the per-tile poll). Same defect class, **not listed on the story** but found while auditing — it was the last remaining caller of the immediate-terminal helper and was actually *worse* (it re-posted a `Running` update after the terminal `Canceled`).

All of these called `cancel_requested` → `check_cancel`, which posts terminal `Canceled` the instant it sees `cancelRequested=1`. `jobs_store::update_job_progress` frees the worker row on **any** terminal write — so the worker was freed in the DB while the worker *process* was still grinding the in-flight step (single-threaded; can't reach the claim loop until `blocking.await` returns). Result: the UI flips to "Cancelled" and hides progress while the GPU is still busy, and the next queued job stays stranded — the sc-5399 bug, for these paths.

## How

Each poll site now uses the check-only `cancel_requested_peek` (no terminal post) plus a small `begin_*_cancel` helper that:
1. trips the engine `CancelFlag`, and
2. posts a **non-terminal** `running` "Cancelling…" update (fraction `0.0` → the indeterminate "Working" bar, not a backward jump).

The terminal `Canceled` is posted **only after the blocking task actually returns**, so the worker row — and therefore the next queued job — is freed exactly when the GPU is genuinely free.

The now-orphaned immediate-terminal in-loop helper `cancel_requested` is **removed** along with the four tests that exclusively covered it (the `cancel_requested_peek` tests already cover the equivalent transient-error tolerance). `check_cancel` — the checkpoint-style `.await?` abort used at phase boundaries (downloads / media / model / caption) — is intentionally left unchanged, per the story (those abort immediately, so terminal-at-checkpoint is correct there).

## Tests

- New `begin_video_cancel_*` / `begin_training_cancel_*` (capturing-stub) tests assert each helper trips the flag and posts a **non-terminal `running`** status (terminal deferred).
- All 7 cancel tests pass; full worker unit suite (270) green; `clippy -D warnings` clean; `cargo fmt --all --check` clean.

## ⚠️ Separate engine gap found (filed, not in this PR)

While verifying, I confirmed the **Wan/LTX video *generation* denoise loops eval per step but never check the cancel flag** (`is_cancelled` exists only in their `training.rs`). So the worker's `cancel.cancel()` is a no-op for video generation — the engine runs the full clip before stopping.

- This PR still **removes the stranding** for video regardless (worker freed only at true stop).
- Cancel is **fully responsive** for **training** (engine checks per step) and **detail/image** (engine honors cancel — sc-5514/sc-5522).
- Video cancel **responsiveness** needs the engine sibling: add a per-step `is_cancelled()` check to the Wan/LTX denoise loops (the video analog of sc-5514/sc-5522). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)