### PR TITLE
Fix Image Studio Text/Variations pickers to filter by capability (sc-5549)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -443,7 +443,15 @@ export function ImageStudio() {
           // character's identity from one reference; gate the picker to them.
           return caps.includes("character_image");
         }
-        return item.type === "image";
+        if (mode === "style_variations") {
+          return caps.includes("style_variations");
+        }
+        // text_to_image: only models that declare a real sourceless T2I path (sc-5549).
+        // Without this gate the Text tab leaked edit-only models (run a degraded
+        // sourceless edit) and reference-only identity models (MLX-ineligible without a
+        // reference → strand on "Waiting for an available worker"); both classes lack
+        // text_to_image. Mirrors the per-capability gating the other three modes use.
+        return caps.includes("text_to_image");
       }),
     [macImageModels, mode],
   );

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -437,3 +437,67 @@ describe("ImageStudio edit source picker", () => {
     expect(createImageJob).toHaveBeenCalledWith(expect.objectContaining({ mode: "edit_image", sourceAssetId: "uploaded-source" }));
   });
 });
+
+describe("ImageStudio model picker capability gating", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  // One model per capability class so each mode's picker can be checked in isolation.
+  const T2I = { ...Z_IMAGE, id: "t2i_only", name: "T2I Only", capabilities: ["text_to_image"] };
+  const VARIATIONS = {
+    ...Z_IMAGE,
+    id: "variations_model",
+    name: "Variations Model",
+    capabilities: ["text_to_image", "style_variations"],
+  };
+  const EDIT_ONLY = { ...Z_IMAGE, id: "edit_only", name: "Edit Only", capabilities: ["edit_image", "image_to_image"] };
+  const CHARACTER_ONLY = { ...Z_IMAGE, id: "character_only", name: "Character Only", capabilities: ["character_image"] };
+
+  const modelOptionValues = () => [...field(container, "Model").options].map((option) => option.value);
+
+  it("Text tab lists only text_to_image models, excluding edit-only and character-only (sc-5549)", async () => {
+    await render(baseContext({ imageModels: [EDIT_ONLY, T2I, VARIATIONS, CHARACTER_ONLY] }));
+
+    const options = modelOptionValues();
+    expect(options).toContain("t2i_only");
+    expect(options).toContain("variations_model"); // declares text_to_image
+    expect(options).not.toContain("edit_only");
+    expect(options).not.toContain("character_only");
+  });
+
+  it("Variations tab lists only style_variations models (sc-5549)", async () => {
+    await render(baseContext({ imageModels: [EDIT_ONLY, T2I, VARIATIONS, CHARACTER_ONLY] }));
+    await click([...container.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "Variations"));
+
+    const options = modelOptionValues();
+    expect(options).toContain("variations_model");
+    expect(options).not.toContain("t2i_only"); // text_to_image but no style_variations
+    expect(options).not.toContain("edit_only");
+    expect(options).not.toContain("character_only");
+  });
+});


### PR DESCRIPTION
## What

Fixes [sc-5549](https://app.shortcut.com/trefry/story/5549): the Image Studio **Text** tab model picker wasn't capability-filtered, so it listed every image model — including ones that don't declare `text_to_image`:

- **Edit-only** (`qwen_image_edit_2511`, `qwen_image_edit_2511_lightning`, `z_image_edit`) → ran a degraded sourceless edit ("generates T2I but looks bad").
- **Reference-only identity** (`pulid_flux_dev`, `instantid_realvisxl`) → reference-less job is MLX-ineligible → strands on "Waiting for an available worker." on the Mac build.

## Root cause

`apps/web/src/screens/ImageStudio.jsx` `availableModels` gated the Edit and Character tabs by capability but fell through to `item.type === "image"` for everything else, so any model without `text_to_image` leaked into the Text picker.

## Fix

Each mode now gates by its own capability, mirroring the existing Edit/Character pattern:

| Mode | Gate |
|------|------|
| `edit_image` | `edit_image` \|\| `image_edit` (unchanged) |
| `character_image` | `character_image` (unchanged) |
| `style_variations` | `style_variations` (**new**) |
| `text_to_image` | `text_to_image` (**the story's fix**) |

**Scope note:** the shared `else` branch served *two* tabs — Text (`text_to_image`) **and** Variations (`style_variations`). The Variations tab had the identical defect (it also listed the five problem models), and the story's literal one-liner would have left it half-gated. So both get their own capability gate. Verified against `config/manifests/builtin.models.jsonc`: every `style_variations` model also declares `text_to_image`, so the Variations tab stays well-populated; the five problem models declare neither and are excluded from both tabs.

## Tests

Adds `describe("ImageStudio model picker capability gating")` in `ImageStudio.test.jsx` with Text-tab and Variations-tab cases asserting the picker `<option>`s exclude an edit-only and a character-only model while keeping the right ones. Proven to **fail** against the pre-fix code and **pass** after.

- `ImageStudio.test.jsx`: 8/8 green.
- ESLint on both files: 0 errors (only pre-existing exhaustive-deps warnings, none from this change).

## Acceptance (met)

- Text tab shows only `text_to_image`-capable models; Qwen-Image-Edit ×2, Z-Image-Edit, PuLID-FLUX, InstantID all absent.
- `z_image_turbo` and the other genuine T2I models remain.
- Regression test mirroring the edit/character filter tests included.

Pairs with sc-5545 (backend fail-fast) so any reference-less job reaching the queue via another path still fails fast instead of stranding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)