### PR TITLE
Bump mlx-gen db08076 → fa0f75b + candle-gen lockstep (video-gen cancel, sc-5551)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8#008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "image",
  "inventory",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "image",
  "inventory",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "image",
  "inventory",
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "image",
  "inventory",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3333,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "image",
  "inventory",
@@ -3374,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3407,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "image",
  "inventory",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "image",
  "inventory",
@@ -3728,7 +3728,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=db08076c1195f4a648ad336252f680e62d04716b#db08076c1195f4a648ad336252f680e62d04716b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -30,13 +30,16 @@ sceneworks-core = { path = "../sceneworks-core" }
 # The rev MUST stay identical to the `mlx-gen` pin in the macOS block: two gen-core revs would mean
 # two distinct `inventory` registries (one for the worker's derivation, one the provider crates
 # register into) and the runtime would see "engine not found". Bump both together.
-# Rev db08076 (mlx-gen main, sc-5540): bumps every mlx-gen crate 41c95a1 -> db08076 (44 commits) to
-# pick up the per-step `eval` cancel fix across the image families — chroma (#445/sc-5514) +
-# flux/flux2/lens/z-image/sensenova (#450/sc-5522) — so a mid-render cancel interrupts within ~a step
-# (epic 5391 / sc-5399). gen-core delta over the range is additive (new textllm/weightsmeta/registry;
-# the worker's import surface is unchanged → skew gate stays green at one rev). mlx-gen's internal
-# mlx-rs rev is unchanged (44929a0), so the direct `mlx-rs` pin below stays put.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+# Rev fa0f75b (mlx-gen main, sc-5551): bumps every mlx-gen crate db08076 -> fa0f75b to pick up the
+# per-step cancel-flag check in Wan/LTX video *generation* (#456/sc-5551) — the video sibling of the
+# image per-step cancel — so a mid-clip video cancel interrupts within ~a step (the worker-side
+# defer-terminal fix sc-5516 / #662 is already merged; this pin makes its video path responsive).
+# gen-core delta over the range is EMPTY (the range touched only the wan/ltx + scail2 provider crates,
+# not gen-core), so the worker's import surface is unchanged → skew gate stays green at one rev. The
+# candle-gen pin in the macOS block is re-pinned in LOCKSTEP to a candle-gen rev whose gen-core is
+# fa0f75b too (candle-gen #55), so the `--features backend-candle` lane also resolves one gen-core rev.
+# mlx-gen's internal mlx-rs rev is unchanged (44929a0), so the direct `mlx-rs` pin below stays put.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -272,7 +275,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -284,55 +287,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c119
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -341,12 +344,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db0807
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -355,7 +358,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db0807
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -363,7 +366,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -374,7 +377,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -385,7 +388,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db080
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -400,7 +403,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db0807
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -411,7 +414,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db0
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db08076c1195f4a648ad336252f680e62d04716b" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -455,39 +458,40 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db0
 # pin) again, and this LINKS `candle-gen-lens` (registers `lens` + `lens_turbo`, the sc-5126 cutover
 # target). ALL candle deps below MUST share this rev.
 #
-# sc-5525 bumps the candle pin to `398395a` (candle-gen PR #53, off candle-gen main HEAD `099d4d4`)
-# which re-pins candle-gen's `sceneworks-gen-core` -> `db08076` to MATCH this worker's MLX pin after
-# sc-5540 (mlx-gen #..., per-step cancel) bumped it `41c95a1` -> `db08076`. `git diff
-# af190c7..db08076 -- gen-core/` is EMPTY (the delta is mlx-gen engine code), so candle-gen's re-pin is
-# a pure rev-string bump. Same skew-trap reason: without it the `--features backend-candle` graph
-# resolved worker `db08076` vs candle-gen `41c95a1`; with `398395a` the candle lane resolves EXACTLY
-# ONE `sceneworks-gen-core` (`db08076`, == the mlx-gen pin) again, and this LINKS
-# `candle-gen-prompt-refine` (registers the `prompt_refine` `TextLlm`, the sc-5525 cutover target). ALL
-# candle deps below MUST share this rev.
+# sc-5525 bumped the candle pin to candle-gen PR #53 (candle-gen main `77c70be`) which LINKS
+# `candle-gen-prompt-refine` (registers the `prompt_refine` `TextLlm`, the sc-5525 cutover target) and
+# re-pinned candle-gen's `sceneworks-gen-core` in lockstep with this worker's MLX pin (then `db08076`).
+# sc-5551 bumps both: the candle pin -> `008d38f` (candle-gen #55), which re-pins candle-gen's
+# `sceneworks-gen-core` -> `fa0f75b` to MATCH the mlx-gen pin above after sc-5551 bumped it `db08076`
+# -> `fa0f75b`. `git diff db08076..fa0f75b -- gen-core/` is EMPTY (the delta is mlx-gen engine code:
+# wan/ltx + scail2), so candle-gen's re-pin is a pure rev-string bump. Skew-trap: without it the
+# `--features backend-candle` graph would resolve worker `fa0f75b` vs candle-gen `db08076`; with
+# `008d38f` the candle lane resolves EXACTLY ONE `sceneworks-gen-core` (`fa0f75b`, == the mlx-gen pin)
+# again. ALL candle deps below MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -496,14 +500,14 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
-# single gen-core pin == the mlx-gen pin db08076).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+# single gen-core pin == the mlx-gen pin fa0f75b).
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "008d38f84eda1bbee1d9c59930e5bb77bf9e1cc8", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## What
Rebased onto main **after #661 landed**. Activates the engine-side video-cancel fix (mlx-gen [#456](https://github.com/michaeltrefry/mlx-gen/pull/456) / sc-5551): the Wan/LTX video **generation** denoise loops now check the cancel flag per step, so a mid-clip cancel interrupts within ~a step. Pairs with the merged worker-side defer-terminal fix (sc-5516 / [#662](https://github.com/michaeltrefry/SceneWorks/pull/662)).

- **Worker mlx-gen + sceneworks-gen-core** (24 deps): db08076 → **fa0f75b**.
- **candle-gen** (11 deps): 77c70be → **008d38f** (candle-gen [#55](https://github.com/michaeltrefry/candle-gen/pull/55)) — re-pins candle-gen's own `sceneworks-gen-core` to fa0f75b in **lockstep**, so the `--features backend-candle` lane resolves **one** gen-core rev (fa0f75b == the mlx-gen pin). Without this co-bump, #664 would re-skew the candle lane that #661 just aligned (worker fa0f75b vs candle-gen db08076).

## Safety
gen-core is **byte-identical** across db08076/fa0f75b (the delta is mlx-gen engine code: wan/ltx + scail2), so both re-pins are pure rev-string alignment. Verified:
- **Skew gate green on BOTH** the default and `--features backend-candle --target all` graphs (exactly one `sceneworks-gen-core` @ fa0f75b).
- mlx-gen's internal **mlx-rs unchanged** (44929a0) → worker mlx-rs pin stays put.
- Worker builds + **275 unit tests pass** (includes #661's 5 new prompt-refine tests).
- Lock side-effect: `num_enum_derive`'s build-time `proc-macro-crate` consolidates 1.3.1 → 2.0.2 (already present via glib-macros); benign, no runtime impact.

## ⚠️ Merge order
Depends on candle-gen **[#55](https://github.com/michaeltrefry/candle-gen/pull/55)** (the gen-core lockstep re-pin). Merge **#55 first**, then this — `008d38f` becomes an ancestor of candle-gen main so the pin stays valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)