### PR TITLE
sc-5576: wire candle Kolors + SenseNova-U1 into the worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -503,9 +503,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-kolors"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
+dependencies = [
+ "candle-gen",
+ "candle-transformers",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -518,7 +531,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -530,7 +543,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -541,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -555,7 +568,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -571,9 +584,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-sensenova"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
+dependencies = [
+ "candle-gen",
+ "inventory",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -586,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c70be98abe3b5c1f502438082bbf98612fa529#77c70be98abe3b5c1f502438082bbf98612fa529"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e58ff493e16f7019b11889123803ab3a26ddcf9f#e58ff493e16f7019b11889123803ab3a26ddcf9f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -5101,11 +5127,13 @@ dependencies = [
  "candle-gen-flux",
  "candle-gen-flux2",
  "candle-gen-joycaption",
+ "candle-gen-kolors",
  "candle-gen-lens",
  "candle-gen-ltx",
  "candle-gen-prompt-refine",
  "candle-gen-qwen-image",
  "candle-gen-sdxl",
+ "candle-gen-sensenova",
  "candle-gen-wan",
  "candle-gen-z-image",
  "futures-util",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3127,10 +3127,12 @@ fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
 }
 
 /// The models the candle (Windows/CUDA) lane can serve (epic 3672 sc-3678 for SDXL; epic 5095
-/// sc-5096 adds the four image families; sc-5126 adds Lens / Lens-Turbo). Mirrors the worker's
+/// sc-5096 adds the four image families; sc-5126 adds Lens / Lens-Turbo; sc-5484 + sc-5576 add Chroma,
+/// Kolors, and SenseNova-U1). Mirrors the worker's
 /// `image_jobs::is_candle_engine`: SDXL/RealVisXL (`realvisxl` shares the candle `"sdxl"` engine via a
-/// weights swap), plus z-image-turbo, FLUX.1 schnell/dev, FLUX.2-klein-9B, Qwen-Image, and
-/// `lens`/`lens_turbo` — the base **txt2img** ids only. Deliberately narrow: candle is a gated
+/// weights swap), plus z-image-turbo, FLUX.1 schnell/dev, FLUX.2-klein-9B, Qwen-Image,
+/// `lens`/`lens_turbo`, `chroma1_hd`/`_base`/`_flash`, `kolors`, and `sensenova_u1_8b`/`_fast` —
+/// the base **txt2img** ids only. Deliberately narrow: candle is a gated
 /// txt2img-only lane, so every conditioning shape AND every non-base weight variant (e.g.
 /// `flux2_klein_9b_kv`, `qwen_image_edit`) falls back to the Python torch worker. Lens is pure T2I
 /// (no conditioning at all) but — unlike the others — DOES advertise quant + LoRA/LoKr, so it is also
@@ -3145,6 +3147,16 @@ const CANDLE_ROUTED_MODELS: &[&str] = &[
     "qwen_image",
     "lens",
     "lens_turbo",
+    // epic 3692 candle image families. Chroma's worker lane (#658) shipped without this router half, so
+    // chroma jobs never reached the candle worker — added here with Kolors + SenseNova-U1 (sc-5576). All
+    // pure **txt2img** on candle: their edit / IP-reference / pose-control / VQA shapes are rejected
+    // below (`image_request_candle_eligible`) and fall back to the Python torch worker.
+    "chroma1_hd",
+    "chroma1_base",
+    "chroma1_flash",
+    "kolors",
+    "sensenova_u1_8b",
+    "sensenova_u1_8b_fast",
 ];
 
 /// The candle image families that advertise on-the-fly Q4/Q8 quant AND LoRA/LoKr adapters — Lens /
@@ -4305,12 +4317,11 @@ mod candle_routing_tests {
 
     #[test]
     fn non_candle_families_and_variants_are_never_candle_eligible() {
-        // Families with no candle provider (chroma/kolors/sensenova) AND the non-base weight/shape
+        // A family with no candle provider at all (`bernini_image`) AND the non-base weight/shape
         // variants of wired families (edit ids, the kv distill) all stay on the Python torch worker.
+        // (chroma / kolors / sensenova ARE candle-routed now — sc-5484 / sc-5576 — for txt2img.)
         for model in [
-            "chroma1_hd",
-            "kolors",
-            "sensenova_u1_8b",
+            "bernini_image",
             "z_image_edit",
             "qwen_image_edit",
             "flux2_klein_9b_kv",
@@ -4324,7 +4335,7 @@ mod candle_routing_tests {
 
     #[test]
     fn new_candle_families_conditioning_shapes_fall_back_to_torch() {
-        // The four sc-5096 families are txt2img-only on candle: any conditioning shape defers to torch
+        // Every candle image family is txt2img-only on candle: any conditioning shape defers to torch
         // (the worker advertises none of these, so this is the no-silently-dropped-control boundary).
         let cases = [
             (
@@ -4341,6 +4352,26 @@ mod candle_routing_tests {
                 "flux2_klein_9b",
                 json!({ "mode": "edit_image", "sourceAssetId": "a" }),
             ),
+            // sc-5484 / sc-5576: Chroma / Kolors / SenseNova-U1 are pure T2I on candle. Their MLX-only
+            // conditioning shapes (Kolors edit / IP-reference / pose-control; SenseNova edit) defer.
+            (
+                "chroma1_hd",
+                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+            ),
+            (
+                "kolors",
+                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+            ),
+            ("kolors", json!({ "referenceAssetId": "a" })),
+            (
+                "kolors",
+                json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),
+            ),
+            (
+                "sensenova_u1_8b",
+                json!({ "mode": "edit_image", "sourceAssetId": "a" }),
+            ),
+            ("sensenova_u1_8b_fast", json!({ "referenceAssetId": "a" })),
         ];
         for (model, payload) in cases {
             assert!(
@@ -4459,13 +4490,17 @@ mod candle_routing_tests {
     #[test]
     fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         let candle = gpu_worker(CANDLE_CAPS);
-        // Claims the lane — SDXL plus the sc-5096 image families, all plain txt2img.
+        // Claims the lane — SDXL plus every wired candle image family, all plain txt2img.
         for model in [
             "sdxl",
             "realvisxl",
             "z_image_turbo",
             "flux_dev",
             "qwen_image",
+            "chroma1_hd",
+            "kolors",
+            "sensenova_u1_8b",
+            "sensenova_u1_8b_fast",
         ] {
             assert!(
                 worker_supports_job(
@@ -4479,7 +4514,15 @@ mod candle_routing_tests {
         // both defer to torch.
         assert!(!worker_supports_job(
             &candle,
-            &image_generate_job(json!({ "model": "chroma1_hd", "prompt": "p" }))
+            &image_generate_job(json!({ "model": "bernini_image", "prompt": "p" }))
+        ));
+        assert!(!worker_supports_job(
+            &candle,
+            &image_generate_job(json!({
+                "model": "kolors",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1"
+            }))
         ));
         assert!(!worker_supports_job(
             &candle,
@@ -4506,7 +4549,15 @@ mod candle_routing_tests {
         // A family with no candle provider, and a conditioning shape on a wired family.
         assert!(worker_supports_job(
             &torch,
-            &image_generate_job(json!({ "model": "chroma1_hd", "prompt": "p" }))
+            &image_generate_job(json!({ "model": "bernini_image", "prompt": "p" }))
+        ));
+        assert!(worker_supports_job(
+            &torch,
+            &image_generate_job(json!({
+                "model": "kolors",
+                "mode": "edit_image",
+                "sourceAssetId": "asset_1"
+            }))
         ));
         assert!(worker_supports_job(
             &torch,

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -97,6 +97,12 @@ backend-candle = [
     "dep:candle-gen-qwen-image",
     # sc-5484 (epic 3692): the candle Chroma image provider (chroma1_hd / chroma1_base / chroma1_flash).
     "dep:candle-gen-chroma",
+    # sc-5576 (epic 3692): the candle Kolors image provider (`kolors` — SDXL UNet + ChatGLM3-6B
+    # encoder) and the candle SenseNova-U1 NEO-Unify image provider (`sensenova_u1_8b` +
+    # `sensenova_u1_8b_fast`). Both pure T2I; their `MODEL_TABLE` rows already exist (MLX families), so
+    # `engines::registry_capabilities` advertises them off-Mac with no further change.
+    "dep:candle-gen-kolors",
+    "dep:candle-gen-sensenova",
     # sc-5126 (epic 5107): the candle Lens / Lens-Turbo image provider — gpt-oss-20b MoE encoder +
     # 48-layer MMDiT + Flux.2 VAE. The first candle family with Q4/Q8 quant + LoRA/LoKr; pure T2I.
     "dep:candle-gen-lens",
@@ -464,30 +470,37 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "db0
 # ONE `sceneworks-gen-core` (`db08076`, == the mlx-gen pin) again, and this LINKS
 # `candle-gen-prompt-refine` (registers the `prompt_refine` `TextLlm`, the sc-5525 cutover target). ALL
 # candle deps below MUST share this rev.
+#
+# sc-5576 bumps the candle pin `77c70be` -> `e58ff49` (candle-gen main HEAD): a PURE candle-side bump.
+# `e58ff49` keeps the SAME `sceneworks-gen-core` pin (`db08076`, == this worker's mlx-gen pin), so the
+# `--features backend-candle` graph still resolves exactly one gen-core rev (no skew) and NO mlx-gen
+# bump is needed. It adds candle-gen #54 (the SenseNova `_fast` sm_120 CPU distill-LoRA merge fix) and
+# LINKS the candle Kolors (`kolors`) + SenseNova-U1 (`sensenova_u1_8b` / `_fast`) image providers wired
+# below. ALL candle deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -496,14 +509,25 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin db08076).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c70be98abe3b5c1f502438082bbf98612fa529", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
+# Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
+# the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
+# by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
+# Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
+# Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
+# mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
+# distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
+# #54's sm_120 fix). Unified Qwen3-MoT backbone + flow-matching head; pure T2I (edit / VQA / interleave
+# stay on Python). Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e58ff493e16f7019b11889123803ab3a26ddcf9f", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -100,6 +100,14 @@ use candle_gen_qwen_image as _;
 // shared gen_core inventory; the `as _;` keeps the MSVC release linker from GC-ing the registrations.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_chroma as _;
+// Candle Kolors (sc-5576, epic 3692): the `kolors` T2I id self-registers into the shared gen_core
+// inventory; `as _;` keeps the MSVC release linker from GC-ing the registration.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_kolors as _;
+// Candle SenseNova-U1 (sc-5576, epic 3692): `sensenova_u1_8b` + `sensenova_u1_8b_fast` self-register
+// into the shared gen_core inventory; force-linked so the registrations survive linker GC.
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+use candle_gen_sensenova as _;
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_z_image as _;
 // Lens / Lens-Turbo (epic 5107 engine / sc-5126 cutover) — the candle Windows/CUDA sibling of the

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -847,6 +847,9 @@ fn is_candle_engine(model: &str) -> bool {
             | "chroma1_flash"
             | "lens"
             | "lens_turbo"
+            | "kolors"
+            | "sensenova_u1_8b"
+            | "sensenova_u1_8b_fast"
     )
 }
 
@@ -863,6 +866,8 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "qwen_image" => "candle_qwen",
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => "candle_chroma",
         "lens" | "lens_turbo" => "candle_lens",
+        "kolors" => "candle_kolors",
+        "sensenova_u1_8b" | "sensenova_u1_8b_fast" => "candle_sensenova",
         // sdxl / realvisxl share the candle "sdxl" engine.
         _ => CANDLE_ADAPTER,
     }
@@ -1232,6 +1237,12 @@ mod candle_label_tests {
         assert_eq!(candle_adapter_label("chroma1_flash"), "candle_chroma");
         assert_eq!(candle_adapter_label("lens"), "candle_lens");
         assert_eq!(candle_adapter_label("lens_turbo"), "candle_lens");
+        assert_eq!(candle_adapter_label("kolors"), "candle_kolors");
+        assert_eq!(candle_adapter_label("sensenova_u1_8b"), "candle_sensenova");
+        assert_eq!(
+            candle_adapter_label("sensenova_u1_8b_fast"),
+            "candle_sensenova"
+        );
         assert_eq!(candle_adapter_label("sdxl"), "candle_sdxl");
         assert_eq!(candle_adapter_label("realvisxl"), "candle_sdxl");
         // Every wired engine carries a `candle_`-prefixed label, distinct from the `mlx_` labels.
@@ -1246,6 +1257,9 @@ mod candle_label_tests {
             "chroma1_flash",
             "lens",
             "lens_turbo",
+            "kolors",
+            "sensenova_u1_8b",
+            "sensenova_u1_8b_fast",
             "sdxl",
             "realvisxl",
         ] {
@@ -1268,12 +1282,16 @@ mod candle_label_tests {
             "chroma1_flash",
             "lens",
             "lens_turbo",
+            "kolors",
+            "sensenova_u1_8b",
+            "sensenova_u1_8b_fast",
         ] {
             assert!(is_candle_engine(model), "{model} should be a candle engine");
         }
         // Non-candle families + non-base variants (edit ids, the kv distill) are not in the lane.
+        // (kolors / sensenova ARE candle engines now — sc-5576 — for their base txt2img shape.)
         for model in [
-            "kolors",
+            "bernini_image",
             "z_image_edit",
             "qwen_image_edit",
             "flux2_klein_9b_kv",

--- a/docs/sc-5576/candle-kolors-sensenova-worker-wiring.md
+++ b/docs/sc-5576/candle-kolors-sensenova-worker-wiring.md
@@ -1,0 +1,81 @@
+# sc-5576 — Wire candle Kolors + SenseNova-U1 into the worker
+
+Epic 3692 (Candle Windows model-family expansion). Worker counterpart of the candle-gen provider
+ports **sc-5485 (Kolors)** and **sc-5486 (SenseNova-U1)**, mirroring the Chroma worker wiring
+(sc-5484 / [#658]). Makes the two families actually routable + executable on the Windows/CUDA candle
+lane.
+
+## Why this wasn't sc-5525
+
+The kolors/sensenova provider stories deferred their worker wiring to a follow-up that memory had
+attributed to "sc-5525". That story turned out to be the unrelated `prompt_refine` → candle `TextLlm`
+cutover (merged, [#661]). This story (sc-5576) is the real worker wiring.
+
+## Premise: additive, not a cutover
+
+The gen-core cutover already happened. candle-gen main (`e58ff49`) and the worker both pin gen-core
+**`db08076`**. So this is a pure candle-side pin bump plus link/route/advertise wiring — no mlx-gen
+bump, no gen-core move.
+
+## Changes
+
+### 1. candle-gen pin bump (`crates/sceneworks-worker/Cargo.toml`)
+- All `candle-gen-*` deps `77c70be` → `e58ff49` (candle-gen main HEAD). Same `sceneworks-gen-core`
+  pin (`db08076`), so `--features backend-candle` still resolves exactly one gen-core rev (no skew),
+  and no mlx-gen bump is needed. `e58ff49` adds candle-gen #54 — the SenseNova `_fast` **sm_120**
+  CPU distill-LoRA merge fix (reading the I32 `alpha` through an F32 VarBuilder hit a missing
+  on-device I32→F32 cast on Blackwell; the LoRA is now merged on CPU and the delta moved to the
+  weight's device).
+- New optional deps `candle-gen-kolors` + `candle-gen-sensenova` (`features=["cuda"]`), added to the
+  `backend-candle` feature list.
+
+### 2. Force-link (`crates/sceneworks-worker/src/image_jobs.rs`)
+`use candle_gen_kolors as _;` + `use candle_gen_sensenova as _;` (Windows + `backend-candle`), so the
+MSVC release linker keeps each provider's `inventory::submit!` registration.
+
+### 3. Routing (`crates/sceneworks-worker/src/image_jobs/base.rs`)
+- `is_candle_engine`: + `kolors`, `sensenova_u1_8b`, `sensenova_u1_8b_fast`.
+- `candle_adapter_label`: `kolors` → `candle_kolors`; `sensenova_u1_8b` / `_fast` → `candle_sensenova`.
+
+### 4. Router eligibility (`crates/sceneworks-core/src/jobs_store.rs`)
+`CANDLE_ROUTED_MODELS` += `chroma1_hd`/`_base`/`_flash`, `kolors`, `sensenova_u1_8b`/`_fast`. Without
+this a candle worker **refuses** the job (`worker_supports_job`) and it never reaches the candle lane.
+
+> **Also fixes a Chroma gap:** sc-5484 / [#658] wired Chroma into the *worker* (`is_candle_engine`)
+> but never added it to `CANDLE_ROUTED_MODELS`, so the router never let a candle worker claim a Chroma
+> job — the Chroma candle lane was unreachable. Added here alongside kolors/sensenova (same one-list
+> change, same default-off gate).
+
+### 5. Capability
+No code change: `engines::registry_capabilities` derives `image_generate` from any linked descriptor
+whose `backend` is enabled. The `kolors` / `sensenova_u1_8b` / `_fast` `MODEL_TABLE` rows already
+exist (MLX families), so linking the candle providers + `backend_candle_enabled` advertises them.
+
+## T2I-only confinement
+
+Both families are multi-shape on MLX (Kolors: edit / IP-reference / pose-control; SenseNova: edit /
+VQA / interleave) but the candle providers are **pure T2I**. Confinement is router-enforced:
+`image_request_candle_eligible` rejects `edit_image` mode, any source/reference/mask asset, poses,
+and (for non-quant/LoRA families) loras/quant — so only base txt2img reaches the candle worker; every
+conditioning shape falls back to the Python torch worker. The MLX-only `KolorsControl` /
+`SensenovaEdit` dispatch routes never run on Windows.
+
+## Safety
+
+`backend_candle_enabled` is **default-off**, so production routing is unchanged until the lane is
+explicitly turned on — the GPU smoke is exactly that opt-in. Providers were already real-weights
+GPU-validated (SenseNova base + `_fast` in sc-5486; Kolors conformance is the remaining provider
+smoke). Single gen-core rev (`db08076`) across worker + candle-gen.
+
+## Validation
+
+- Default lane: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`
+  (`sceneworks-core` + `sceneworks-worker`) green.
+- Candle lane: `cargo check -p sceneworks-worker --features backend-candle` (MSVC 14.44 vcvars +
+  `CUDA_COMPUTE_CAP=120`) clean.
+- Skew gate: `scripts/check-gen-core-skew.sh` (+ `--features backend-candle`) resolves one
+  `sceneworks-gen-core` (`db08076`).
+- Remaining: deployed-worker GPU job-routing smoke on the Blackwell box.
+
+[#658]: https://github.com/michaeltrefry/SceneWorks/pull/658
+[#661]: https://github.com/michaeltrefry/SceneWorks/pull/661


### PR DESCRIPTION
Worker wiring for the two epic-3692 candle image families whose providers are merged but not yet routable: **Kolors** (sc-5485, candle-gen #50) and **SenseNova-U1** (sc-5486, candle-gen #52/#54). Mirrors the Chroma worker wiring (sc-5484 / #658). Doc: `docs/sc-5576/candle-kolors-sensenova-worker-wiring.md`.

### Premise — additive, not a cutover
The gen-core cutover already happened (sc-5525). candle-gen main (`e58ff49`) **and** the worker both pin gen-core **`db08076`**, so this is a pure candle-side pin bump + link/route/advertise wiring. No mlx-gen bump, no gen-core move.

### Changes
- **Pin bump** — worker `candle-gen-*` `77c70be` → `e58ff49` (candle-gen main HEAD). Same `sceneworks-gen-core` (`db08076`) ⇒ `--features backend-candle` resolves exactly one gen-core rev (no skew). Picks up candle-gen #54 (the SenseNova `_fast` **sm_120** CPU distill-LoRA merge fix).
- **Deps + feature** — `candle-gen-kolors` + `candle-gen-sensenova` (`features=["cuda"]`), added to `backend-candle`; force-linked in `image_jobs.rs`.
- **Routing** — `is_candle_engine` + `candle_adapter_label`: `kolors` → `candle_kolors`; `sensenova_u1_8b`/`_fast` → `candle_sensenova`.
- **Router eligibility** — `CANDLE_ROUTED_MODELS` += `kolors`, `sensenova_u1_8b`/`_fast`.
- **Capability** — no code change: `engines::registry_capabilities` auto-derives `image_generate` (the `MODEL_TABLE` rows already exist for the MLX families).

### ⚠️ Also fixes a Chroma router gap (sc-5484 / #658)
#658 wired Chroma into the **worker** (`is_candle_engine`) but never added it to `CANDLE_ROUTED_MODELS`, so `worker_supports_job` had a candle worker **refuse** every chroma job — the candle Chroma lane was unreachable. Added `chroma1_hd`/`_base`/`_flash` here alongside kolors/sensenova (same one-list change). Contained by the default-off gate.

### T2I-only confinement
Kolors (edit / IP-reference / pose-control) and SenseNova (edit / VQA / interleave) are multi-shape on MLX but **pure T2I** on candle. Confinement is router-enforced (`image_request_candle_eligible` rejects edit mode, source/reference/mask assets, poses, loras/quant) — only base txt2img reaches the candle worker; every conditioning shape falls back to the Python torch worker. The MLX-only `KolorsControl`/`SensenovaEdit` dispatch routes never run on Windows.

### Safety
`backend_candle_enabled` is **default-off** → production routing unchanged until the lane is explicitly enabled (the GPU smoke is that opt-in). Providers already real-weights GPU-validated (SenseNova base + `_fast` in sc-5486; Kolors conformance pending). Single gen-core rev (`db08076`) across worker + candle-gen.

### Validation
- Default lane: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` (`sceneworks-core` 124 + worker) green. (The lone worker clippy finding is a pre-existing **Windows-only** unused `terminating_signal` import — its sole user is a `#[cfg(unix)]` test — clean on the Linux CI; not touched here.)
- Candle lane (MSVC 14.44 vcvars + `CUDA_COMPUTE_CAP=120`): `cargo check` + `cargo clippy` + `candle_label_tests` under `--features backend-candle` green.
- Skew gate: `scripts/check-gen-core-skew.sh` + `cargo tree --features backend-candle` resolve one `sceneworks-gen-core` (`db08076`).
- Remaining: deployed-worker GPU job-routing smoke on the Blackwell box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)