### PR TITLE
sc-5552: route the macOS worker's prompt_refine job to the native MLX twin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=152974d7d462cb7efeb90311885189ad75befc73#152974d7d462cb7efeb90311885189ad75befc73"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3289,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3345,9 +3345,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-prompt-refine"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
+dependencies = [
+ "inventory",
+ "mlx-gen",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3359,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3369,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3378,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3387,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3400,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3411,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3422,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3433,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -3447,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "image",
  "inventory",
@@ -5075,7 +5086,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=fa0f75bfdfe264164aff4c867d0e2100a55c92e7#fa0f75bfdfe264164aff4c867d0e2100a55c92e7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76#d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76"
 dependencies = [
  "inventory",
  "safetensors 0.4.5",
@@ -5152,6 +5163,7 @@ dependencies = [
  "mlx-gen-kolors",
  "mlx-gen-lens",
  "mlx-gen-ltx",
+ "mlx-gen-prompt-refine",
  "mlx-gen-pulid",
  "mlx-gen-qwen-image",
  "mlx-gen-sam2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-prompt-refine"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "candle-transformers",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6af4ce02db2953d02cf018cef1ecfc13568994a1#6af4ce02db2953d02cf018cef1ecfc13568994a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=6e919c2972e9fb4e68814aa0c50cbb021a405ef3#6e919c2972e9fb4e68814aa0c50cbb021a405ef3"
 dependencies = [
  "candle-core",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1961,8 +1961,10 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
     }
     let model = job.payload.get("model").and_then(Value::as_str);
     match job.job_type {
-        // MLX-agnostic job types: metadata/utility work, ffmpeg, and prompt refine run
-        // in-process on macOS with no Python torch dependency.
+        // In-process macOS job types with no Python torch dependency: MLX-agnostic metadata/utility
+        // work + ffmpeg, plus prompt refine — now served by the native MLX `prompt_refine` TextLlm
+        // provider (sc-5552, the mlx twin of the candle sc-5525 cutover), so the worker advertises +
+        // claims it and this `Ok` is backed by a real capability (no longer the pre-sc-5552 strand).
         JobType::Placeholder
         | JobType::ModelDownload
         | JobType::ModelImport

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -39,7 +39,13 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle-gen pin in the macOS block is re-pinned in LOCKSTEP to a candle-gen rev whose gen-core is
 # fa0f75b too (candle-gen #55), so the `--features backend-candle` lane also resolves one gen-core rev.
 # mlx-gen's internal mlx-rs rev is unchanged (44929a0), so the direct `mlx-rs` pin below stays put.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+# Rev d3ec5e5 (mlx-gen main, sc-5552): bumps every mlx-gen crate fa0f75b -> d3ec5e5 to pick up the new
+# additive `mlx-gen-prompt-refine` crate (the native MLX `prompt_refine` TextLlm; mlx-gen #457). gen-core
+# + gen-core-testkit are BYTE-IDENTICAL fa0f75b -> d3ec5e5 (the merge only ADDS a provider crate), so
+# the worker's import surface is unchanged → skew gate stays green at one rev. The candle-gen pin in the
+# macOS block is re-pinned in LOCKSTEP to candle-gen #57 (gen-core d3ec5e5) so the
+# `--features backend-candle` lane resolves the same single gen-core rev. mlx-rs unchanged (44929a0).
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -281,7 +287,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -293,55 +299,55 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe
 # internal pin (the Lens engine PRs #407–#414 did not move it; nor did the seedvr2 engine #416/#419/
 # #421 or the softness PR #422, so the 1a97909 bump above leaves mlx-rs at 44929a0).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "44929a001ab8a8837403a71c65cf064224de0cdc" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -350,12 +356,12 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -364,7 +370,7 @@ mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -372,7 +378,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "f
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -383,7 +389,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -394,7 +400,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f7
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -409,7 +415,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75
 # converted in-memory at load (no Python); the precomputed neg-prompt embedding is bundled in-crate. No
 # LoRA/guidance/CFG (one-step). 3B fp16 only here — 7B (sc-5197) + int8 (sc-5198) are engine-side and
 # unwired. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -420,7 +426,17 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0f75bfdfe264164aff4c867d0e2100a55c92e7" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
+# Prompt-refine provider (sc-5552, the MLX twin of candle-gen-prompt-refine / sc-5500). An
+# inventory-registered `TextLlm` under id `prompt_refine` (`backend="mlx"`, `mac_only`): a native MLX
+# Llama-3.2-3B-Instruct that rewrites a user's prompt, replacing the Python `prompt_refine.py`
+# (`AutoModelForCausalLM` + `model.generate`) on Mac. The worker reaches it through the registry
+# (`gen_core::load_textllm("prompt_refine")` → `.generate`), so prompt_refine_jobs.rs must force-link
+# the crate (`use mlx_gen_prompt_refine as _;`) or the linker drops the `TextLlmRegistration` (the "no
+# textllm registered" trap). Weights = a stock Llama-3.2-3B-Instruct HF snapshot (config.json +
+# tokenizer.json + model-*.safetensors; default `huihui-ai/Llama-3.2-3B-Instruct-abliterated`). Same
+# git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
+mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d3ec5e5e97ba3c0e71a49a001f2b8a975451bb76" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -482,30 +498,39 @@ mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "fa0
 # `_fast` sm_120 CPU distill-LoRA merge fix) with sc-5551's `fa0f75b` re-pin — plus LINKS the candle
 # Kolors (`kolors`) + SenseNova-U1 (`sensenova_u1_8b` / `_fast`) image providers wired below. ALL candle
 # deps MUST share this rev.
+#
+# sc-5552 bumps both: the candle pin `152974d` -> `6af4ce0` (candle-gen #57), which re-pins candle-gen's
+# `sceneworks-gen-core` -> `d3ec5e5` to MATCH the mlx-gen pin above after sc-5552 bumped it `fa0f75b` ->
+# `d3ec5e5` (to add the `mlx-gen-prompt-refine` crate). `git diff fa0f75b..d3ec5e5 -- gen-core/` is EMPTY
+# (the merge only ADDS the mlx prompt-refine provider crate), so candle-gen's re-pin is a pure rev-string
+# bump. With `6af4ce0` the candle lane resolves EXACTLY ONE `sceneworks-gen-core` (`d3ec5e5`, == the
+# mlx-gen pin). ⚠️ `6af4ce0` is an UNMERGED candle-gen branch commit (PR #57); flip it to the merged
+# candle-gen rev when #57 lands (the mlx pins already point at merged mlx-gen main `d3ec5e5`). ALL candle
+# deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -514,25 +539,25 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
 # #54's sm_120 fix). Unified Qwen3-MoT backbone + flow-matching head; pure T2I (edit / VQA / interleave
 # stay on Python). Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "152974d7d462cb7efeb90311885189ad75befc73", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -499,38 +499,36 @@ mlx-gen-prompt-refine = { git = "https://github.com/michaeltrefry/mlx-gen", rev 
 # Kolors (`kolors`) + SenseNova-U1 (`sensenova_u1_8b` / `_fast`) image providers wired below. ALL candle
 # deps MUST share this rev.
 #
-# sc-5552 bumps both: the candle pin `152974d` -> `6af4ce0` (candle-gen #57), which re-pins candle-gen's
-# `sceneworks-gen-core` -> `d3ec5e5` to MATCH the mlx-gen pin above after sc-5552 bumped it `fa0f75b` ->
-# `d3ec5e5` (to add the `mlx-gen-prompt-refine` crate). `git diff fa0f75b..d3ec5e5 -- gen-core/` is EMPTY
-# (the merge only ADDS the mlx prompt-refine provider crate), so candle-gen's re-pin is a pure rev-string
-# bump. With `6af4ce0` the candle lane resolves EXACTLY ONE `sceneworks-gen-core` (`d3ec5e5`, == the
-# mlx-gen pin). ⚠️ `6af4ce0` is an UNMERGED candle-gen branch commit (PR #57); flip it to the merged
-# candle-gen rev when #57 lands (the mlx pins already point at merged mlx-gen main `d3ec5e5`). ALL candle
-# deps MUST share this rev.
+# sc-5552 bumps both: the candle pin `152974d` -> `6e919c2` (candle-gen #57, merged), which re-pins
+# candle-gen's `sceneworks-gen-core` -> `d3ec5e5` to MATCH the mlx-gen pin above after sc-5552 bumped it
+# `fa0f75b` -> `d3ec5e5` (to add the `mlx-gen-prompt-refine` crate). `git diff fa0f75b..d3ec5e5 -- gen-core/`
+# is EMPTY (the merge only ADDS the mlx prompt-refine provider crate), so candle-gen's re-pin is a pure
+# rev-string bump. With `6e919c2` the candle lane resolves EXACTLY ONE `sceneworks-gen-core` (`d3ec5e5`,
+# == the mlx-gen pin). ALL candle deps MUST share this rev.
 [target.'cfg(target_os = "windows")'.dependencies]
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b`; ltx registers `ltx_2_3_distilled` (txt2video first slice — no conditioning/audio/
 # LoRA/quant). Force-linked in video_jobs.rs (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098) — Windows/CUDA sibling of mlx-gen-joycaption. Registers the
 # captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava` (image->text). Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -539,25 +537,25 @@ candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle prompt-refine LLM provider (sc-5500 phase 2 / sc-5525) — Windows/CUDA sibling with NO mlx
 # twin (greenfield). Self-registers the `prompt_refine` `TextLlm` (Llama-3.2-3B-Instruct, the gen-core
 # `TextLlm` contract from sc-5500) into the shared inventory registry; the worker resolves it via
 # `gen_core::load_textllm("prompt_refine", …)`. Force-linked in prompt_refine_jobs.rs
 # (`use candle_gen_prompt_refine as _;`). Same rev as the other candle crates (one candle build,
 # single gen-core pin == the mlx-gen pin fa0f75b).
-candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-prompt-refine = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle Kolors provider (sc-5576, epic 3692) — Windows/CUDA sibling of mlx-gen-kolors. Self-registers
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
 # #54's sm_120 fix). Unified Qwen3-MoT backbone + flow-matching head; pure T2I (edit / VQA / interleave
 # stay on Python). Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6af4ce02db2953d02cf018cef1ecfc13568994a1", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6e919c2972e9fb4e68814aa0c50cbb021a405ef3", features = ["cuda"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -513,11 +513,13 @@ pub(crate) fn registry_capabilities(
     }) {
         push(Cap::TrainingCaption, &mut caps);
     }
-    // Prompt-refinement TextLlm (sc-5500 contract / sc-5525 cutover): the candle prompt-refine
-    // provider registers a `TextLlm` under id `prompt_refine`. Advertise `prompt_refine` when its
-    // backend is enabled — off-Mac this is the candle Llama-3.2-3B path. There is NO mlx twin
-    // (greenfield), so the macOS `mlx` worker never lights this up; the Python torch `PromptRefiner`
-    // stays the fallback there + on the candle-less Desktop installer (sc-5525 keeps it).
+    // Prompt-refinement TextLlm (sc-5500 contract / sc-5525 candle cutover / sc-5552 mlx twin): a
+    // prompt-refine provider registers a `TextLlm` under id `prompt_refine`. Advertise `prompt_refine`
+    // when its backend is enabled — the native MLX Llama-3.2-3B path on macOS (sc-5552) and the candle
+    // Llama-3.2-3B path on the Windows candle build (sc-5525). The Python torch `PromptRefiner` stays
+    // the fallback on platforms with neither (e.g. the candle-less Desktop installer). The derivation
+    // is backend-agnostic, so no change here was needed to light up the mlx twin — only force-linking
+    // `mlx_gen_prompt_refine` in prompt_refine_jobs.rs.
     if gen_core::registry::textllms().any(|r| {
         let d = (r.descriptor)();
         backends.contains(&d.backend) && d.id == "prompt_refine"
@@ -663,15 +665,35 @@ mod tests {
             on.contains(&Cap::PromptRefine),
             "an enabled candle backend should derive prompt_refine from its TextLlm descriptor"
         );
-        // mlx-only ⇒ the candle TextLlm is filtered out, and there is no mlx prompt_refine twin.
+        // both off ⇒ nothing (neither the candle stub nor — on macOS — the real mlx twin is enabled).
+        let off = registry_capabilities(&settings_with_backends(false, false));
+        assert!(!off.contains(&Cap::PromptRefine));
+    }
+
+    // Off-macOS no real mlx prompt_refine provider is linked (only the candle stub above), so an
+    // mlx-only worker must not advertise prompt_refine.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn mlx_only_does_not_advertise_prompt_refine_without_the_mlx_twin() {
         let mlx_only = registry_capabilities(&settings_with_backends(true, false));
         assert!(
             !mlx_only.contains(&Cap::PromptRefine),
-            "prompt_refine has no mlx twin, so an mlx-only worker must not advertise it"
+            "off-macOS there is no mlx prompt_refine provider, so an mlx-only worker must not \
+             advertise it"
         );
-        // both off ⇒ nothing.
-        let off = registry_capabilities(&settings_with_backends(false, false));
-        assert!(!off.contains(&Cap::PromptRefine));
+    }
+
+    // On macOS the native mlx prompt_refine provider (sc-5552, force-linked in prompt_refine_jobs.rs)
+    // is in the registry, so an mlx-only worker DOES advertise prompt_refine — the MLX twin of the
+    // candle path (sc-5525).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mlx_only_advertises_prompt_refine_via_the_mlx_twin() {
+        let mlx_only = registry_capabilities(&settings_with_backends(true, false));
+        assert!(
+            mlx_only.contains(&Cap::PromptRefine),
+            "the sc-5552 mlx prompt_refine twin should light up prompt_refine on an mlx-only worker"
+        );
     }
 
     // Off-macOS the registry holds ONLY these three stubs (no real provider crate is linked), so

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -1,11 +1,12 @@
-//! Native candle prompt refinement (epic 5095, sc-5525).
+//! Native prompt refinement (epic 5095): candle on Windows/CUDA (sc-5525) + MLX on macOS (sc-5552).
 //!
-//! Routes the `prompt_refine` job to the candle `TextLlm` provider (Llama-3.2-3B-Instruct,
-//! `backend="candle"`) on the Windows/CUDA worker, through the backend-neutral `gen_core::load_textllm`
-//! seam (the sc-5500 contract). There is NO mlx twin (greenfield), so this is candle-only off-Mac; the
-//! Python torch `PromptRefiner` (`apps/worker/scene_worker/prompt_refine.py`) stays the fallback for
-//! the Mac path and the default, candle-less Desktop installer until the candle provider is the default
-//! everywhere off-Mac (the physical deletion of `prompt_refine.py` waits on that — see sc-5525).
+//! Routes the `prompt_refine` job to a native `TextLlm` provider (Llama-3.2-3B-Instruct) through the
+//! backend-neutral `gen_core::load_textllm` seam (the sc-5500 contract): the candle provider
+//! (`backend="candle"`, `candle-gen-prompt-refine`) on the Windows candle build, and the MLX twin
+//! (`backend="mlx"`, `mlx-gen-prompt-refine`) on macOS. The Python torch `PromptRefiner`
+//! (`apps/worker/scene_worker/prompt_refine.py`) stays the fallback only on platforms with neither
+//! native provider (e.g. the candle-less Desktop installer); its physical deletion waits on the candle
+//! provider being the default everywhere off-Mac (see sc-5525).
 //!
 //! The `TextLlm` contract is generic (`system` + `prompt` + sampling → text), so the
 //! prompt-refinement PRODUCT logic that lived in `prompt_refine.py` moves here caller-side: the
@@ -17,32 +18,56 @@
 
 use super::*;
 
-// Candle prompt-refine provider force-link anchor (sc-5525): keeps its `inventory::submit!` `TextLlm`
-// registration (id `prompt_refine`, backend `candle`) from being dropped by the MSVC release linker.
-// Mirrors the `candle_gen_joycaption` anchor in caption_jobs.rs.
+// Prompt-refine provider force-link anchors: keep each backend's `inventory::submit!` `TextLlm`
+// registration (id `prompt_refine`) from being dropped by the release linker. sc-5552 adds the native
+// MLX twin (`mlx_gen_prompt_refine`, backend `mlx`) alongside sc-5525's candle anchor; mirrors the
+// dual JoyCaption anchors in caption_jobs.rs.
 #[cfg(all(target_os = "windows", feature = "backend-candle"))]
 use candle_gen_prompt_refine as _;
+#[cfg(target_os = "macos")]
+use mlx_gen_prompt_refine as _;
 
-// The registry id the candle provider registers under (`candle_gen_prompt_refine::prompt::
-// PROMPT_REFINE_ID`); kept as a local literal so the shared dispatch names no backend-specific symbol.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+// The registry id both providers register under (`prompt::PROMPT_REFINE_ID`); kept as a local literal
+// so the shared dispatch names no backend-specific symbol. `gen_core::load_textllm` resolves the MLX
+// twin on macOS and the candle provider on the Windows candle build.
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const PROMPT_REFINE_ENGINE_ID: &str = "prompt_refine";
 // Default refinement checkpoint — the small abliterated Llama-3.2-3B instruction model, parity with
 // the Python `DEFAULT_REFINE_MODEL`. Overridable per-job via `payload.model`.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const DEFAULT_REFINE_MODEL: &str = "huihui-ai/Llama-3.2-3B-Instruct-abliterated";
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 const CANCEL_MESSAGE: &str = "Prompt refinement canceled by user.";
+// Architecture-pill label for the streamed progress (mirrors the candle image/video paths): the MLX
+// twin on macOS, candle on the Windows candle build.
+#[cfg(target_os = "macos")]
+const REFINE_BACKEND: &str = "mlx";
+#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+const REFINE_BACKEND: &str = "candle";
 
 // ----------------------------------------------------------------------------------------------
-// Product logic (pure, platform-independent) — ported from `prompt_refine.py` so the candle worker
-// owns the prompt assembly + reply cleanup the generic `TextLlm` contract does not. Compiled in the
-// default `cargo test` gate (so the unit tests below run on every lane) and on the candle build.
+// Product logic (pure, platform-independent) — ported from `prompt_refine.py` so the native worker
+// (candle + MLX) owns the prompt assembly + reply cleanup the generic `TextLlm` contract does not.
+// Compiled in the default `cargo test` gate (so the unit tests below run on every lane) and on the
+// macOS + candle builds.
 // ----------------------------------------------------------------------------------------------
 
 /// The base rewrite rules with the `{medium}` placeholders filled (`image` / `video`). Verbatim port
 /// of the Python `_BASE_RULES.format(medium=…)`.
-#[cfg(any(test, all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn base_rules(medium: &str) -> String {
     [
         format!("You are a prompt rewriter for a generative {medium} model."),
@@ -77,7 +102,11 @@ fn base_rules(medium: &str) -> String {
 
 /// Build the `system` message for the refiner: the rewrite rules (medium chosen from the workflow)
 /// plus the model's prompt guide when one is supplied. Port of the Python `build_system_prompt`.
-#[cfg(any(test, all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn build_refine_system_prompt(guide: Option<&str>, workflow: Option<&str>) -> String {
     let medium = if workflow
         .map(|w| w.trim().eq_ignore_ascii_case("video"))
@@ -99,7 +128,11 @@ fn build_refine_system_prompt(guide: Option<&str>, workflow: Option<&str>) -> St
 /// Strip `<think>…</think>` reasoning blocks, a wrapping code fence, and matching surrounding quotes
 /// from the model reply. Port of the Python `clean_output` (regex-free: the tags are ASCII, matched
 /// case-insensitively without lowercasing the whole — Unicode-safe — string).
-#[cfg(any(test, all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn clean_refine_output(text: &str) -> String {
     let mut text = strip_think_blocks(text.trim()).trim().to_owned();
     // An orphan closing tag (no matching open): keep only what follows the last one.
@@ -130,7 +163,11 @@ fn clean_refine_output(text: &str) -> String {
 
 /// Remove every `<think>…</think>` pair (case-insensitive, spanning newlines). An unmatched open tag
 /// leaves the remainder untouched — matching the Python non-greedy regex, which simply does not match.
-#[cfg(any(test, all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn strip_think_blocks(input: &str) -> String {
     const OPEN: &str = "<think>";
     const CLOSE: &str = "</think>";
@@ -159,7 +196,11 @@ fn strip_think_blocks(input: &str) -> String {
 
 /// Byte offset of the first case-insensitive occurrence of an ASCII `needle`. Offsets land on ASCII
 /// tag boundaries, so callers can slice safely even when the surrounding text is Unicode.
-#[cfg(any(test, all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn first_ci(haystack: &str, needle: &str) -> Option<usize> {
     let (h, n) = (haystack.as_bytes(), needle.as_bytes());
     if n.is_empty() || n.len() > h.len() {
@@ -169,7 +210,11 @@ fn first_ci(haystack: &str, needle: &str) -> Option<usize> {
 }
 
 /// Byte offset of the last case-insensitive occurrence of an ASCII `needle`.
-#[cfg(any(test, all(target_os = "windows", feature = "backend-candle")))]
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn last_ci(haystack: &str, needle: &str) -> Option<usize> {
     let (h, n) = (haystack.as_bytes(), needle.as_bytes());
     if n.is_empty() || n.len() > h.len() {
@@ -181,10 +226,15 @@ fn last_ci(haystack: &str, needle: &str) -> Option<usize> {
 }
 
 // ----------------------------------------------------------------------------------------------
-// Job handler (candle-only — there is no mlx twin).
+// Job handler — native MLX on macOS (sc-5552) and candle on the Windows candle build (sc-5525). The
+// body is backend-agnostic: `gen_core::load_textllm("prompt_refine", …)` resolves whichever provider
+// is force-linked above. The Python torch `PromptRefiner` remains the fallback on other platforms.
 // ----------------------------------------------------------------------------------------------
 
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 pub(crate) async fn run_prompt_refine_job(
     api: &ApiClient,
     settings: &Settings,
@@ -230,9 +280,9 @@ pub(crate) async fn run_prompt_refine_job(
 
     let system = build_refine_system_prompt(guide.as_deref(), workflow.as_deref());
     let weights_dir = resolve_app_managed_model_dir(settings, &model, "prompt-refine model path")?;
-    // Attribute the run to Candle on the streamed progress + UI architecture pill (mirrors the candle
-    // image/video paths), not the gpu-id device label.
-    let backend = "candle";
+    // Attribute the run to the active backend (MLX on macOS, candle off-Mac) on the streamed progress
+    // + UI architecture pill (mirrors the image/video paths), not the gpu-id device label.
+    let backend = REFINE_BACKEND;
 
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     update_job(
@@ -265,9 +315,7 @@ pub(crate) async fn run_prompt_refine_job(
             PROMPT_REFINE_ENGINE_ID,
             &LoadSpec::new(WeightsSource::Dir(weights_dir)),
         )
-        .map_err(|error| {
-            WorkerError::Engine(format!("candle prompt-refine load failed: {error}"))
-        })?;
+        .map_err(|error| WorkerError::Engine(format!("prompt-refine load failed: {error}")))?;
         emit_event(
             "prompt_refine_load_complete",
             json!({ "jobId": job_id, "engine": engine_label }),
@@ -294,7 +342,7 @@ pub(crate) async fn run_prompt_refine_job(
         let output = refiner
             .generate(&request, &mut on_progress)
             .map_err(|error| {
-                WorkerError::Engine(format!("candle prompt-refine generation failed: {error}"))
+                WorkerError::Engine(format!("prompt-refine generation failed: {error}"))
             })?;
         Ok(output.text)
     });
@@ -364,24 +412,30 @@ pub(crate) async fn run_prompt_refine_job(
     Ok(())
 }
 
-/// Off the Windows candle build there is no native prompt-refine provider (no mlx twin), so the
-/// capability is never advertised and this arm is unreachable in practice — the Python torch
-/// `PromptRefiner` serves `prompt_refine`. Kept so the `run_utility_job` dispatch compiles on all
-/// targets.
-#[cfg(not(all(target_os = "windows", feature = "backend-candle")))]
+/// On platforms with no native prompt-refine provider (neither the macOS MLX twin nor the Windows
+/// candle build — e.g. Linux, or the candle-less Desktop installer), the capability is never
+/// advertised and this arm is unreachable in practice — the Python torch `PromptRefiner` serves
+/// `prompt_refine`. Kept so the `run_utility_job` dispatch compiles on all targets.
+#[cfg(not(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+)))]
 pub(crate) async fn run_prompt_refine_job(
     _api: &ApiClient,
     _settings: &Settings,
     _job: &JobSnapshot,
 ) -> WorkerResult<()> {
     Err(WorkerError::InvalidPayload(
-        "Native prompt refinement needs the Windows candle backend; use the Python torch prompt \
-         refiner on this platform."
+        "Native prompt refinement needs the macOS MLX worker or the Windows candle backend; use the \
+         Python torch prompt refiner on this platform."
             .to_owned(),
     ))
 }
 
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn refine_progress(
     status: JobStatus,
     stage: ProgressStage,
@@ -408,7 +462,10 @@ fn refine_progress(
 }
 
 /// The `prompt_refine` result payload, parity with the Python `run_prompt_refine_job`.
-#[cfg(all(target_os = "windows", feature = "backend-candle"))]
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "windows", feature = "backend-candle")
+))]
 fn refine_result(original_prompt: &str, refined_prompt: &str) -> JsonObject {
     let mut result = JsonObject::new();
     result.insert("originalPrompt".to_owned(), json!(original_prompt));

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -549,12 +549,15 @@ fn mlx_gpu_capability_set_matches_expected_full_set() {
     let expected: BTreeSet<_> = [
         // seed
         WorkerCapability::Gpu,
-        // 5 registry-derived
+        // 6 registry-derived
         WorkerCapability::ImageGenerate,
         WorkerCapability::VideoGenerate,
         WorkerCapability::LoraTrain,
         WorkerCapability::LoraTrainExecute,
         WorkerCapability::TrainingCaption,
+        // sc-5552: the native MLX `prompt_refine` TextLlm provider (mlx-gen-prompt-refine) is
+        // force-linked on macOS, so the registry now derives PromptRefine from its descriptor.
+        WorkerCapability::PromptRefine,
         // carve-outs
         WorkerCapability::ImageEdit,
         WorkerCapability::ImageDetail,


### PR DESCRIPTION
The **MLX half of the `prompt_refine` worker cutover** — the macOS counterpart to sc-5525's candle path (now on `main`). On macOS the worker now advertises + claims `prompt_refine` and runs it through the **native MLX Llama-3.2-3B provider** (`mlx-gen-prompt-refine`, [mlx-gen #457](https://github.com/michaeltrefry/mlx-gen/pull/457), merged as `d3ec5e5`), retiring the Python `prompt_refine.py` 120s dead-poll (epic 3482). Fixes the sc-5552 symptom: *"Prompt refinement timed out. Is the refinement runtime running?"*

## What it does
- **`prompt_refine_jobs.rs`** — broaden the candle-only gating to `any(target_os="macos", all(windows, backend-candle))` (mirrors `caption_jobs.rs`), force-link `mlx_gen_prompt_refine` on macOS, label the run `"mlx"` vs `"candle"` via a per-platform `REFINE_BACKEND`. The job body is **backend-agnostic** — `gen_core::load_textllm("prompt_refine")` resolves the MLX twin on macOS and the candle provider off-Mac — so the product logic (system-prompt assembly + reply cleanup) and `{originalPrompt, refinedPrompt}` result shape are shared unchanged.
- **`engines.rs`** — the `PromptRefine` derivation was already backend-agnostic (`backends.contains(&d.backend) && d.id=="prompt_refine"`), so force-linking the mlx provider lights it up with **no derivation change**. Refresh the stale "no mlx twin" comment; split the cap test so the mlx-only assertion is per-platform (off-macOS ⇒ not advertised; on macOS the real twin IS linked ⇒ advertised), mirroring the file's existing `#[cfg(not(target_os="macos"))]` isolation pattern.
- **`jobs_store.rs`** — `mac_rust_supported`'s `Ok` for `PromptRefine` is now backed by a real capability (was the pre-sc-5552 strand the bug describes); comment refreshed. **No `Err` interim guard** — the story is explicit the stopgap is not the resolution.
- **`Cargo.toml`** — add the `mlx-gen-prompt-refine` macOS dep + bump **both lanes in lockstep** to pick up the new crate: mlx-gen `fa0f75b → d3ec5e5` (the merged #457 main rev) and candle-gen `008d38f → 6af4ce0` ([candle-gen #57](https://github.com/michaeltrefry/candle-gen/pull/57), whose gen-core re-pins to `d3ec5e5`). gen-core is **byte-identical** `fa0f75b → d3ec5e5` (the merge only adds a provider crate), so the **skew gate resolves a single `sceneworks-gen-core` rev (`d3ec5e5`) across both lanes**.

## Validation (Apple Silicon)
- Worker **compiles** on the macOS host target.
- Worker **unit tests green**, incl. **`engines::tests::mlx_only_advertises_prompt_refine_via_the_mlx_twin`** — proves the force-link registers the real MLX provider and the cap derivation advertises `prompt_refine` on an mlx-only worker — plus the candle-derivation + product-logic tests.
- `cargo fmt` + `clippy --lib -D warnings` clean.
- **Engine-level real-weights proof** is in [mlx-gen #457](https://github.com/michaeltrefry/mlx-gen/pull/457) (merged): TextLlm conformance PASSED + an on-guide rewrite, zero Python.

## Merge order (one small follow-up)
The mlx pins point at **merged** mlx-gen `main` (`d3ec5e5`). The candle pin (`6af4ce0`) is candle-gen #57's **branch** tip (its gen-core already resolves to `d3ec5e5`, so the skew gate is green now). Clean order: merge **[candle-gen #57](https://github.com/michaeltrefry/candle-gen/pull/57)**, flip this PR's candle pin `6af4ce0` → the merged candle-gen rev, then merge this.

Remaining runtime validation (post-merge): a live `prompt_refine` job through the running worker needs the Llama-3.2-3B snapshot staged in the app-managed model dir (same provisioning as the candle side); the engine itself is already proven on real weights in #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)